### PR TITLE
fix: height of github icon

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -128,6 +128,7 @@ header {
 
   a.github {
     flex: 0 0 auto;
+    height: 24px;
     color: var(--color-text-secondary);
 
     svg {


### PR DESCRIPTION
just fixing this little mis-alignment

before
![image](https://github.com/user-attachments/assets/4ba98d22-4fc2-41fc-bc85-31a486d4e591)

after
![image](https://github.com/user-attachments/assets/748a7cd6-4834-4b26-be5c-de6c655ab212)

