### PR TITLE
feat(google): add gemini 2.5 pro, flash, and flash lite preview models

### DIFF
--- a/providers/google/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/google/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -1,0 +1,13 @@
+name = "Gemini 2.5 Flash Lite Preview 06-17"
+attachment = true
+reasoning = true
+temperature = true
+
+[cost]
+input = 0.10
+output = 0.40
+cache_read = 0.025
+
+[limit]
+context = 65_536
+output = 65_536

--- a/providers/google/models/gemini-2.5-flash.toml
+++ b/providers/google/models/gemini-2.5-flash.toml
@@ -1,0 +1,13 @@
+name = "Gemini 2.5 Flash"
+attachment = true
+reasoning = true
+temperature = true
+
+[cost]
+input = 0.30
+output = 2.50
+cache_read = 0.075
+
+[limit]
+context = 1_048_576
+output = 65_536

--- a/providers/google/models/gemini-2.5-pro.toml
+++ b/providers/google/models/gemini-2.5-pro.toml
@@ -1,0 +1,13 @@
+name = "Gemini 2.5 Pro"
+attachment = true
+reasoning = true
+temperature = true
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.31
+
+[limit]
+context = 1_048_576
+output = 65_536


### PR DESCRIPTION
## Summary
• Add stable Gemini 2.5 Pro model with same settings and pricing as preview 06-05 version
• Add stable Gemini 2.5 Flash model with updated pricing ($0.30 input, $2.50 output)
• Add new Gemini 2.5 Flash Lite Preview 06-17 model with 65K context/output limits

## Test plan
- [x] Verify model configurations follow existing Google provider patterns
- [x] Confirm pricing and limits are correctly specified
- [x] Test model availability in the web interface

🤖 Generated with [opencode](https://opencode.ai)