### PR TITLE
Update name for GPT-4 in OpenAI provider

### DIFF
--- a/providers/openai/models/gpt-4.toml
+++ b/providers/openai/models/gpt-4.toml
@@ -1,4 +1,4 @@
-name = "GPT-4 Turbo"
+name = "GPT-4"
 release_date = "2023-11-06"
 last_updated = "2024-04-09"
 attachment = true


### PR DESCRIPTION
I think there has been a simple miss here. Both GPT-4 Turbo and GPT-4 share the same name: `GPT-4 Turbo`. 

This PR just changes GPT-4 to have the correct name. 