### PR TITLE
feat: add OpenAI o3-deep-research and o4-mini-deep-research models

### DIFF
--- a/providers/openai/models/o3-deep-research.toml
+++ b/providers/openai/models/o3-deep-research.toml
@@ -1,0 +1,22 @@
+name = "o3-deep-research"
+release_date = "2024-06-26"
+last_updated = "2024-06-26"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-05"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 10.00
+output = 40.00
+cache_read = 2.50
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"] 

--- a/providers/openai/models/o4-mini-deep-research.toml
+++ b/providers/openai/models/o4-mini-deep-research.toml
@@ -1,0 +1,22 @@
+name = "o4-mini-deep-research"
+release_date = "2024-06-26"
+last_updated = "2024-06-26"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-05"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 8.00
+cache_read = 0.50
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"] 


### PR DESCRIPTION
## Add OpenAI Deep Research Models

This PR adds support for the new OpenAI deep research models released on June 26, 2024:

- `o3-deep-research` - Advanced reasoning model for deep research tasks ($10/$40 per M tokens)
- `o4-mini-deep-research` - Faster, more affordable deep research model ($2/$8 per M tokens)

Both models support:
- Text and image inputs
- Text output
- 200,000 token context window
- 100,000 max output tokens
- Reasoning capabilities
- Tool calling
- File attachments

### Changes
- Added `providers/openai/models/o3-deep-research.toml`
- Added `providers/openai/models/o4-mini-deep-research.toml`