### PR TITLE
Add GitHub Models provider

### DIFF
--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
@@ -1,0 +1,17 @@
+name = "AI21 Jamba 1.5 Large"
+release_date = "2024-08-29"
+last_updated = "2024-08-29"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
@@ -1,0 +1,17 @@
+name = "AI21 Jamba 1.5 Mini"
+release_date = "2024-08-29"
+last_updated = "2024-08-29"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/cohere/cohere-command-a.toml
+++ b/providers/github-models/models/cohere/cohere-command-a.toml
@@ -1,0 +1,17 @@
+name = "Cohere Command A"
+release_date = "2024-11-01"
+last_updated = "2024-11-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
@@ -1,0 +1,17 @@
+name = "Cohere Command R 08-2024"
+release_date = "2024-08-01"
+last_updated = "2024-08-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
@@ -1,0 +1,17 @@
+name = "Cohere Command R+ 08-2024"
+release_date = "2024-08-01"
+last_updated = "2024-08-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/cohere/cohere-command-r-plus.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus.toml
@@ -1,0 +1,17 @@
+name = "Cohere Command R+"
+release_date = "2024-04-04"
+last_updated = "2024-08-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/cohere/cohere-command-r.toml
+++ b/providers/github-models/models/cohere/cohere-command-r.toml
@@ -1,0 +1,17 @@
+name = "Cohere Command R"
+release_date = "2024-03-11"
+last_updated = "2024-08-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/core42/jais-30b-chat.toml
+++ b/providers/github-models/models/core42/jais-30b-chat.toml
@@ -1,0 +1,17 @@
+name = "JAIS 30b Chat"
+release_date = "2023-08-30"
+last_updated = "2023-08-30"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-03"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 8_192
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1-0528.toml
@@ -1,0 +1,17 @@
+name = "DeepSeek-R1-0528"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-06"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 65_536
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/deepseek/deepseek-r1.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1.toml
@@ -1,0 +1,17 @@
+name = "DeepSeek-R1"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-06"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 65_536
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/deepseek/deepseek-v3-0324.toml
+++ b/providers/github-models/models/deepseek/deepseek-v3-0324.toml
@@ -1,0 +1,17 @@
+name = "DeepSeek-V3-0324"
+release_date = "2025-03-24"
+last_updated = "2025-03-24"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-06"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/meta/llama-3.2-11b-vision-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.2-11b-vision-instruct.toml
@@ -1,0 +1,17 @@
+name = "Llama-3.2-11B-Vision-Instruct"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio"]
+output = ["text"]

--- a/providers/github-models/models/meta/llama-3.2-90b-vision-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.2-90b-vision-instruct.toml
@@ -1,0 +1,17 @@
+name = "Llama-3.2-90B-Vision-Instruct"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio"]
+output = ["text"]

--- a/providers/github-models/models/meta/llama-3.3-70b-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.3-70b-instruct.toml
@@ -1,0 +1,17 @@
+name = "Llama-3.3-70B-Instruct"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
+++ b/providers/github-models/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
@@ -1,0 +1,17 @@
+name = "Llama 4 Maverick 17B 128E Instruct FP8"
+release_date = "2025-01-31"
+last_updated = "2025-01-31"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/meta/llama-4-scout-17b-16e-instruct.toml
+++ b/providers/github-models/models/meta/llama-4-scout-17b-16e-instruct.toml
@@ -1,0 +1,17 @@
+name = "Llama 4 Scout 17B 16E Instruct"
+release_date = "2025-01-31"
+last_updated = "2025-01-31"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/meta/meta-llama-3-70b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3-70b-instruct.toml
@@ -1,0 +1,17 @@
+name = "Meta-Llama-3-70B-Instruct"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 8_192
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/meta/meta-llama-3-8b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3-8b-instruct.toml
@@ -1,0 +1,17 @@
+name = "Meta-Llama-3-8B-Instruct"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 8_192
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/meta/meta-llama-3.1-405b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-405b-instruct.toml
@@ -1,0 +1,17 @@
+name = "Meta-Llama-3.1-405B-Instruct"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/meta/meta-llama-3.1-70b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-70b-instruct.toml
@@ -1,0 +1,17 @@
+name = "Meta-Llama-3.1-70B-Instruct"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/meta/meta-llama-3.1-8b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-8b-instruct.toml
@@ -1,0 +1,17 @@
+name = "Meta-Llama-3.1-8B-Instruct"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/mai-ds-r1.toml
+++ b/providers/github-models/models/microsoft/mai-ds-r1.toml
@@ -1,0 +1,17 @@
+name = "MAI-DS-R1"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-06"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 65_536
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-3-medium-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-medium-128k-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-3-medium instruct (128k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-3-medium-4k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-medium-4k-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-3-medium instruct (4k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 4_096
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-3-mini-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-mini-128k-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-3-mini instruct (128k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-3-mini-4k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-mini-4k-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-3-mini instruct (4k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 4_096
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-3-small-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-small-128k-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-3-small instruct (128k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-3-small-8k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-small-8k-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-3-small instruct (8k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 8_192
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-3.5-mini-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-mini-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-3.5-mini instruct (128k)"
+release_date = "2024-08-20"
+last_updated = "2024-08-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-3.5-moe-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-moe-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-3.5-MoE instruct (128k)"
+release_date = "2024-08-20"
+last_updated = "2024-08-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-3.5-vision-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-vision-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-3.5-vision instruct (128k)"
+release_date = "2024-08-20"
+last_updated = "2024-08-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-4-mini-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-4-mini-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-4-mini-instruct"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-4-mini-reasoning.toml
+++ b/providers/github-models/models/microsoft/phi-4-mini-reasoning.toml
@@ -1,0 +1,17 @@
+name = "Phi-4-mini-reasoning"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-4-multimodal-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-4-multimodal-instruct.toml
@@ -1,0 +1,17 @@
+name = "Phi-4-multimodal-instruct"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text", "image", "audio"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-4-reasoning.toml
+++ b/providers/github-models/models/microsoft/phi-4-reasoning.toml
@@ -1,0 +1,17 @@
+name = "Phi-4-Reasoning"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/microsoft/phi-4.toml
+++ b/providers/github-models/models/microsoft/phi-4.toml
@@ -1,0 +1,17 @@
+name = "Phi-4"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 16_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/mistral-ai/codestral-2501.toml
+++ b/providers/github-models/models/mistral-ai/codestral-2501.toml
@@ -1,0 +1,17 @@
+name = "Codestral 25.01"
+release_date = "2025-01-01"
+last_updated = "2025-01-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 32_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/mistral-ai/ministral-3b.toml
+++ b/providers/github-models/models/mistral-ai/ministral-3b.toml
@@ -1,0 +1,17 @@
+name = "Ministral 3B"
+release_date = "2024-10-22"
+last_updated = "2024-10-22"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/mistral-ai/mistral-large-2411.toml
+++ b/providers/github-models/models/mistral-ai/mistral-large-2411.toml
@@ -1,0 +1,17 @@
+name = "Mistral Large 24.11"
+release_date = "2024-11-01"
+last_updated = "2024-11-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-09"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/mistral-ai/mistral-medium-2505.toml
+++ b/providers/github-models/models/mistral-ai/mistral-medium-2505.toml
@@ -1,0 +1,17 @@
+name = "Mistral Medium 3 (25.05)"
+release_date = "2025-05-01"
+last_updated = "2025-05-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-09"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/mistral-ai/mistral-nemo.toml
+++ b/providers/github-models/models/mistral-ai/mistral-nemo.toml
@@ -1,0 +1,17 @@
+name = "Mistral Nemo"
+release_date = "2024-07-18"
+last_updated = "2024-07-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/mistral-ai/mistral-small-2503.toml
+++ b/providers/github-models/models/mistral-ai/mistral-small-2503.toml
@@ -1,0 +1,17 @@
+name = "Mistral Small 3.1"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-09"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/openai/gpt-4.1-mini.toml
+++ b/providers/github-models/models/openai/gpt-4.1-mini.toml
@@ -1,0 +1,17 @@
+name = "GPT-4.1-mini"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/openai/gpt-4.1-nano.toml
+++ b/providers/github-models/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,17 @@
+name = "GPT-4.1-nano"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/openai/gpt-4.1.toml
+++ b/providers/github-models/models/openai/gpt-4.1.toml
@@ -1,0 +1,17 @@
+name = "GPT-4.1"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/openai/gpt-4o-mini.toml
+++ b/providers/github-models/models/openai/gpt-4o-mini.toml
@@ -1,0 +1,17 @@
+name = "GPT-4o mini"
+release_date = "2024-07-18"
+last_updated = "2024-07-18"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image", "audio"]
+output = ["text"]

--- a/providers/github-models/models/openai/gpt-4o.toml
+++ b/providers/github-models/models/openai/gpt-4o.toml
@@ -1,0 +1,17 @@
+name = "GPT-4o"
+release_date = "2024-05-13"
+last_updated = "2024-05-13"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image", "audio"]
+output = ["text"]

--- a/providers/github-models/models/openai/o1-mini.toml
+++ b/providers/github-models/models/openai/o1-mini.toml
@@ -1,0 +1,17 @@
+name = "OpenAI o1-mini"
+release_date = "2024-09-12"
+last_updated = "2024-12-17"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2023-10"
+tool_call = false
+open_weights = false
+
+[limit]
+context = 128_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/openai/o1-preview.toml
+++ b/providers/github-models/models/openai/o1-preview.toml
@@ -1,0 +1,17 @@
+name = "OpenAI o1-preview"
+release_date = "2024-09-12"
+last_updated = "2024-09-12"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2023-10"
+tool_call = false
+open_weights = false
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/openai/o1.toml
+++ b/providers/github-models/models/openai/o1.toml
@@ -1,0 +1,17 @@
+name = "OpenAI o1"
+release_date = "2024-09-12"
+last_updated = "2024-12-17"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2023-10"
+tool_call = false
+open_weights = false
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/openai/o3-mini.toml
+++ b/providers/github-models/models/openai/o3-mini.toml
@@ -1,0 +1,17 @@
+name = "OpenAI o3-mini"
+release_date = "2025-01-31"
+last_updated = "2025-01-31"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2024-04"
+tool_call = false
+open_weights = false
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/openai/o3.toml
+++ b/providers/github-models/models/openai/o3.toml
@@ -1,0 +1,17 @@
+name = "OpenAI o3"
+release_date = "2025-01-31"
+last_updated = "2025-01-31"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2024-04"
+tool_call = false
+open_weights = false
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/openai/o4-mini.toml
+++ b/providers/github-models/models/openai/o4-mini.toml
@@ -1,0 +1,17 @@
+name = "OpenAI o4-mini"
+release_date = "2025-01-31"
+last_updated = "2025-01-31"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2024-04"
+tool_call = false
+open_weights = false
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-models/models/xai/grok-3-mini.toml
+++ b/providers/github-models/models/xai/grok-3-mini.toml
@@ -1,0 +1,17 @@
+name = "Grok 3 Mini"
+release_date = "2024-12-09"
+last_updated = "2024-12-09"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/models/xai/grok-3.toml
+++ b/providers/github-models/models/xai/grok-3.toml
@@ -1,0 +1,17 @@
+name = "Grok 3"
+release_date = "2024-12-09"
+last_updated = "2024-12-09"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/github-models/provider.toml
+++ b/providers/github-models/provider.toml
@@ -1,0 +1,5 @@
+name = "GitHub Models"
+env = ["GITHUB_TOKEN"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://docs.github.com/en/github-models"
+api = "https://models.github.ai/inference"


### PR DESCRIPTION
Hi! This PR adds a new provider for GitHub's inference API, [GitHub Models](https://docs.github.com/en/github-models). I've added every supported model except the embeddings ones.

Let me know if there's anything you'd like me to change, happy to do it 😄 