### PR TITLE
Update gpt-4o.toml pricing

### DIFF
--- a/providers/openai/models/gpt-4o.toml
+++ b/providers/openai/models/gpt-4o.toml
@@ -1,6 +1,6 @@
 name = "GPT-4o"
-release_date = "2024-05-13"
-last_updated = "2024-05-13"
+release_date = "2024-05-28"
+last_updated = "2024-05-28"
 attachment = true
 reasoning = false
 temperature = true
@@ -9,9 +9,9 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 2.50
-output = 10.00
-cache_read = 1.25
+input = 5.00
+output = 20.00
+cache_read = 2.50
 
 [limit]
 context = 128_000


### PR DESCRIPTION
Updated as per the official docs - https://openai.com/api/pricing/ - as on June 28, 2025.