### PR TITLE
Update Copilot Sonnet 4 Model Name

### DIFF
--- a/providers/github-copilot/models/claude-sonnet-4.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.toml
@@ -1,4 +1,4 @@
-name = "Claude Sonnet 4 (Preview)"
+name = "Claude Sonnet 4"
 release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true


### PR DESCRIPTION
Sonnet 4 is not in preview anymore.

See: https://github.blog/changelog/2025-06-25-anthropic-claude-sonnet-4-and-claude-opus-4-are-now-generally-available-in-github-copilot/

![Bildschirmfoto 2025-07-03 um 08 51 45](https://github.com/user-attachments/assets/8b7bfe4a-7f5e-4cdd-9d28-757d833bca92)


