### PR TITLE
feat: Add Upstage Solar models support

### DIFF
--- a/providers/upstage/models/solar-mini.toml
+++ b/providers/upstage/models/solar-mini.toml
@@ -1,0 +1,21 @@
+name = "solar-mini"
+release_date = "2024-06-12"
+last_updated = "2025-04-22"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-09"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.15
+
+[limit]
+context = 32_768
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"] 

--- a/providers/upstage/models/solar-pro2.toml
+++ b/providers/upstage/models/solar-pro2.toml
@@ -1,0 +1,21 @@
+name = "solar-pro2"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 0.25
+
+[limit]
+context = 65_536
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"] 

--- a/providers/upstage/provider.toml
+++ b/providers/upstage/provider.toml
@@ -1,0 +1,5 @@
+name = "Upstage"
+env = ["UPSTAGE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://developers.upstage.ai/docs/apis/chat"
+api = "https://api.upstage.ai" 


### PR DESCRIPTION
# Add Upstage Solar Models Support 🌟

Introduces support for Upstage's Solar models to models.dev.

## What's New
- **Solar Pro2**: Advanced reasoning capabilities with chain-of-thought support
- **Solar Mini**: Cost-effective model optimized for production workloads  
- Full OpenAI-compatible API integration

## About Upstage
Upstage is the leading AI company in Korea, renowned for their high-performance Solar LLM series. This addition strengthens models.dev's international provider coverage, particularly in the Korean AI ecosystem.

## Technical Details
- Uses `@ai-sdk/openai-compatible` adapter
- Requires `UPSTAGE_API_KEY` environment variable
- Full validation passing with comprehensive TOML configuration
- Follows all project standards and conventions

## Model Specifications
| Model | Context | Output | Price | Reasoning | Tools |
|-------|---------|--------|-------|-----------|-------|
| Solar Pro2 | 65,536 | 8,192 | $0.25/M | ✅ | ✅ |
| Solar Mini | 32,768 | 4,096 | $0.15/M | ❌ | ✅ |


<img width="1899" alt="image" src="https://github.com/user-attachments/assets/64066209-52a9-4274-a312-2e1bd7ae96fa" />


Ready for review! 🚀