### PR TITLE
Add Devstral Models to Openrouter

### DIFF
--- a/providers/openrouter/models/mistralai/devstral-medium-2507.toml
+++ b/providers/openrouter/models/mistralai/devstral-medium-2507.toml
@@ -1,0 +1,21 @@
+name = "Devstral Medium"
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-05"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.40
+output = 2.00
+
+[limit]
+context = 131_072 
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/devstral-small-2505.toml
+++ b/providers/openrouter/models/mistralai/devstral-small-2505.toml
@@ -1,0 +1,21 @@
+name = "Devstral Small"
+release_date = "2025-05-07"
+last_updated = "2025-05-07"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-05"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.12
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/devstral-small-2505:free.toml
+++ b/providers/openrouter/models/mistralai/devstral-small-2505:free.toml
@@ -1,0 +1,21 @@
+name = "Devstral Small (free)"
+release_date = "2025-05-07"
+last_updated = "2025-05-07"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-05"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/devstral-small-2507.toml
+++ b/providers/openrouter/models/mistralai/devstral-small-2507.toml
@@ -1,0 +1,21 @@
+name = "Devstral Small 1.1"
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-05"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+
+[limit]
+context = 131_072 
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
i added newest devstral model through openrouter since i want to try it on opencode referenced from previous open PR:
https://github.com/sst/models.dev/pull/35#issue-3196954124

- devstral small 1.1 (2507)
- devstrall medium (2507)

