### PR TITLE
Add OpenRouter free model endpoints (#38)

### DIFF
--- a/providers/openrouter/models/cognitivecomputations/dolphin3.0-mistral-24b.toml
+++ b/providers/openrouter/models/cognitivecomputations/dolphin3.0-mistral-24b.toml
@@ -1,0 +1,16 @@
+id = "cognitivecomputations/dolphin3.0-mistral-24b:free"
+name = "Dolphin3.0 Mistral 24B"
+release_date = "2025-02-13"
+last_updated = "2025-02-13"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 32768, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/cognitivecomputations/dolphin3.0-r1-mistral-24b.toml
+++ b/providers/openrouter/models/cognitivecomputations/dolphin3.0-r1-mistral-24b.toml
@@ -1,0 +1,16 @@
+id = "cognitivecomputations/dolphin3.0-r1-mistral-24b:free"
+name = "Dolphin3.0 R1 Mistral 24B"
+release_date = "2025-02-13"
+last_updated = "2025-02-13"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 32768, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-chat-v3-0324.toml
+++ b/providers/openrouter/models/deepseek/deepseek-chat-v3-0324.toml
@@ -1,0 +1,16 @@
+id = "deepseek/deepseek-chat-v3-0324:free"
+name = "DeepSeek V3 0324"
+release_date = "2025-03-24"
+last_updated = "2025-03-24"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 16384, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-r1-0528-qwen3-8b:free.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-0528-qwen3-8b:free.toml
@@ -1,8 +1,8 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Deepseek R1 0528 Qwen3 8B (free)"
+release_date = "2025-05-29"
+last_updated = "2025-05-29"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 knowledge = "2025-05"
 tool_call = true
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 131_072
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-r1-0528:free.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-0528:free.toml
@@ -1,8 +1,8 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "R1 0528 (free)"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 knowledge = "2025-05"
 tool_call = true
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 163_840
+output = 163_840
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-r1-distill-llama-70b.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-distill-llama-70b.toml
@@ -1,0 +1,16 @@
+id = "deepseek/deepseek-r1-distill-llama-70b:free"
+name = "DeepSeek R1 Distill Llama 70B"
+release_date = "2025-01-23"
+last_updated = "2025-01-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 8192, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-r1-distill-qwen-14b.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-distill-qwen-14b.toml
@@ -1,0 +1,16 @@
+id = "deepseek/deepseek-r1-distill-qwen-14b:free"
+name = "DeepSeek R1 Distill Qwen 14B"
+release_date = "2025-01-29"
+last_updated = "2025-01-29"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 64000, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-r1:free.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "R1 (free)"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-01"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 163_840
+output = 163_840
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-v3-base:free.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3-base:free.toml
@@ -1,11 +1,11 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "DeepSeek V3 Base (free)"
+release_date = "2025-03-29"
+last_updated = "2025-03-29"
 attachment = false
 reasoning = false
 temperature = true
-knowledge = "2025-05"
-tool_call = true
+knowledge = "2025-03"
+tool_call = false
 open_weights = true
 
 [cost]
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 163_840
+output = 163_840
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/featherless/qwerky-72b.toml
+++ b/providers/openrouter/models/featherless/qwerky-72b.toml
@@ -1,0 +1,16 @@
+id = "featherless/qwerky-72b:free"
+name = "Qwerky 72B"
+release_date = "2025-03-20"
+last_updated = "2025-03-20"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 32768, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/google/gemini-2.0-flash-exp:free.toml
+++ b/providers/openrouter/models/google/gemini-2.0-flash-exp:free.toml
@@ -1,0 +1,21 @@
+name = "Gemini 2.0 Flash Experimental (free)"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-12"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 1_048_576
+output = 1_048_576
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/google/gemma-2-9b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-2-9b-it:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Gemma 2 9B (free)"
+release_date = "2024-06-28"
+last_updated = "2024-06-28"
 attachment = false
 reasoning = false
 temperature = true
-knowledge = "2025-05"
+knowledge = "2024-06"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 8_192
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/google/gemma-3-12b-it.toml
+++ b/providers/openrouter/models/google/gemma-3-12b-it.toml
@@ -1,0 +1,16 @@
+id = "google/gemma-3-12b-it:free"
+name = "Gemma 3 12B IT"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 96000, output = 8192 }
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/google/gemma-3-27b-it.toml
+++ b/providers/openrouter/models/google/gemma-3-27b-it.toml
@@ -1,0 +1,16 @@
+id = "google/gemma-3-27b-it:free"
+name = "Gemma 3 27B IT"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 96000, output = 8192 }
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/google/gemma-3n-e4b-it.toml
+++ b/providers/openrouter/models/google/gemma-3n-e4b-it.toml
@@ -1,0 +1,16 @@
+id = "google/gemma-3n-e4b-it:free"
+name = "Gemma 3n E4B IT"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 8192, output = 8192 }
+
+[modalities]
+input = ["text", "image", "audio"]
+output = ["text"]

--- a/providers/openrouter/models/google/gemma-3n-e4b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-3n-e4b-it:free.toml
@@ -1,7 +1,7 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
-attachment = false
+name = "Gemma 3n 4B (free)"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = true
 reasoning = false
 temperature = true
 knowledge = "2025-05"
@@ -13,9 +13,9 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 8_192
+output = 8_192
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "audio"]
 output = ["text"]

--- a/providers/openrouter/models/meta-llama/llama-3.2-11b-vision-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.2-11b-vision-instruct.toml
@@ -1,0 +1,16 @@
+id = "meta-llama/llama-3.2-11b-vision-instruct:free"
+name = "Llama 3.2 11B Vision Instruct"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = false
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 131072, output = 8192 }
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Llama 3.3 70B Instruct (free)"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
 attachment = false
 reasoning = false
 temperature = true
-knowledge = "2025-05"
+knowledge = "2024-12"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 65_536
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/meta-llama/llama-4-scout:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-4-scout:free.toml
@@ -1,0 +1,21 @@
+name = "Llama 4 Scout (free)"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-08"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 64_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/microsoft/mai-ds-r1:free.toml
+++ b/providers/openrouter/models/microsoft/mai-ds-r1:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "MAI DS R1 (free)"
+release_date = "2025-04-21"
+last_updated = "2025-04-21"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 163_840
+output = 163_840
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-7b-instruct:free.toml
+++ b/providers/openrouter/models/mistralai/mistral-7b-instruct:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Mistral 7B Instruct (free)"
+release_date = "2024-05-27"
+last_updated = "2024-05-27"
 attachment = false
 reasoning = false
 temperature = true
-knowledge = "2025-05"
+knowledge = "2024-05"
 tool_call = true
 open_weights = true
 

--- a/providers/openrouter/models/mistralai/mistral-nemo:free.toml
+++ b/providers/openrouter/models/mistralai/mistral-nemo:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Mistral Nemo (free)"
+release_date = "2024-07-19"
+last_updated = "2024-07-19"
 attachment = false
 reasoning = false
 temperature = true
-knowledge = "2025-05"
+knowledge = "2024-07"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 131_072
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-small-3.1-24b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-3.1-24b-instruct.toml
@@ -1,0 +1,16 @@
+id = "mistralai/mistral-small-3.1-24b-instruct:free"
+name = "Mistral Small 3.1 24B Instruct"
+release_date = "2025-03-17"
+last_updated = "2025-03-17"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 128000, output = 8192 }
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-small-3.2-24b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-3.2-24b-instruct.toml
@@ -1,0 +1,16 @@
+id = "mistralai/mistral-small-3.2-24b-instruct:free"
+name = "Mistral Small 3.2 24B Instruct"
+release_date = "2025-06-20"
+last_updated = "2025-06-20"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 96000, output = 8192 }
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-small-3.2-24b-instruct:free.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-3.2-24b-instruct:free.toml
@@ -1,0 +1,21 @@
+name = "Mistral Small 3.2 24B (free)"
+release_date = "2025-06-20"
+last_updated = "2025-06-20"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-06"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 96_000
+output = 96_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/moonshotai/kimi-dev-72b:free.toml
+++ b/providers/openrouter/models/moonshotai/kimi-dev-72b:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Kimi Dev 72b (free)"
+release_date = "2025-06-16"
+last_updated = "2025-06-16"
 attachment = false
 reasoning = false
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-06"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 131_072
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/moonshotai/kimi-k2.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2"
+release_date = "2025-07-11"
+last_updated = "2025-07-11"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = false
+
+[cost]
+input = 0.57
+output = 2.30
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/nousresearch/deephermes-3-llama-3-8b-preview.toml
+++ b/providers/openrouter/models/nousresearch/deephermes-3-llama-3-8b-preview.toml
@@ -1,0 +1,16 @@
+id = "nousresearch/deephermes-3-llama-3-8b-preview:free"
+name = "DeepHermes 3 Llama 3 8B Preview"
+release_date = "2025-02-28"
+last_updated = "2025-02-28"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 131072, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openrouter/cypher-alpha:free.toml
+++ b/providers/openrouter/models/openrouter/cypher-alpha:free.toml
@@ -1,0 +1,21 @@
+name = "Cypher Alpha (free)"
+release_date = "2025-07-01"
+last_updated = "2025-07-01"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-07"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 1_000_000
+output = 1_000_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen-2.5-coder-32b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen-2.5-coder-32b-instruct.toml
@@ -1,0 +1,16 @@
+id = "qwen/qwen-2.5-coder-32b-instruct:free"
+name = "Qwen2.5 Coder 32B Instruct"
+release_date = "2024-11-11"
+last_updated = "2024-11-11"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 32768, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen2.5-vl-32b-instruct:free.toml
+++ b/providers/openrouter/models/qwen/qwen2.5-vl-32b-instruct:free.toml
@@ -1,0 +1,21 @@
+name = "Qwen2.5 VL 32B Instruct (free)"
+release_date = "2025-03-24"
+last_updated = "2025-03-24"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen2.5-vl-72b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen2.5-vl-72b-instruct.toml
@@ -1,0 +1,16 @@
+id = "qwen/qwen2.5-vl-72b-instruct:free"
+name = "Qwen2.5 VL 72B Instruct"
+release_date = "2025-02-01"
+last_updated = "2025-02-01"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 32768, output = 8192 }
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen2.5-vl-72b-instruct:free.toml
+++ b/providers/openrouter/models/qwen/qwen2.5-vl-72b-instruct:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
-attachment = false
+name = "Qwen2.5 VL 72B Instruct (free)"
+release_date = "2025-02-01"
+last_updated = "2025-02-01"
+attachment = true
 reasoning = false
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-02"
 tool_call = true
 open_weights = true
 
@@ -17,5 +17,5 @@ context = 32_768
 output = 32_768
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/openrouter/models/qwen/qwen3-14b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-14b:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Qwen3 14B (free)"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 40_960
+output = 40_960
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/qwen/qwen3-235b-a22b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-235b-a22b:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Qwen3 235B A22B (free)"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 131_072
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/qwen/qwen3-30b-a3b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-30b-a3b:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Qwen3 30B A3B (free)"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 40_960
+output = 40_960
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/qwen/qwen3-32b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-32b:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Qwen3 32B (free)"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 40_960
+output = 40_960
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/qwen/qwen3-8b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-8b:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Qwen3 8B (free)"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
@@ -13,8 +13,8 @@ input = 0.00
 output = 0.00
 
 [limit]
-context = 32_768
-output = 32_768
+context = 40_960
+output = 40_960
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/qwen/qwq-32b:free.toml
+++ b/providers/openrouter/models/qwen/qwq-32b:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "QwQ 32B (free)"
+release_date = "2025-03-05"
+last_updated = "2025-03-05"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-03"
 tool_call = true
 open_weights = true
 

--- a/providers/openrouter/models/rekaai/reka-flash-3.toml
+++ b/providers/openrouter/models/rekaai/reka-flash-3.toml
@@ -1,0 +1,16 @@
+id = "rekaai/reka-flash-3:free"
+name = "Reka Flash 3"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 32768, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/sarvamai/sarvam-m:free.toml
+++ b/providers/openrouter/models/sarvamai/sarvam-m:free.toml
@@ -1,8 +1,8 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "Sarvam-M (free)"
+release_date = "2025-05-25"
+last_updated = "2025-05-25"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/openrouter/models/thudm/glm-z1-32b:free.toml
+++ b/providers/openrouter/models/thudm/glm-z1-32b:free.toml
@@ -1,10 +1,10 @@
-name = "Devstral Small 2505 (free)"
-release_date = "2025-05-21"
-last_updated = "2025-05-21"
+name = "GLM Z1 32B (free)"
+release_date = "2025-04-17"
+last_updated = "2025-04-17"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-05"
+knowledge = "2025-04"
 tool_call = true
 open_weights = true
 

--- a/providers/openrouter/models/tngtech/deepseek-r1t2-chimera:free.toml
+++ b/providers/openrouter/models/tngtech/deepseek-r1t2-chimera:free.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek R1T2 Chimera (free)"
+release_date = "2025-07-08"
+last_updated = "2025-07-08"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Closes #38

This PR adds support for OpenRouter’s free-tier model endpoints, giving users access to a wide range of no-cost LLMs.

Ready for review.

> ⚠️ UX note: 43 new entries may clutter the model picker in Opencode.

FYI: Currently there are 177 free models on openrouter currently. https://openrouter.ai/api/frontend/models

<img width="1624" height="982" alt="Screenshot 2025-07-12 at 10 24 59 AM" src="https://github.com/user-attachments/assets/e981eab4-02f8-4937-b140-35c26a32135a" />
