### PR TITLE
Add Kimi K2 Instruct model support for Groq

### DIFF
--- a/providers/groq/models/moonshotai/kimi-k2-instruct.toml
+++ b/providers/groq/models/moonshotai/kimi-k2-instruct.toml
@@ -1,7 +1,7 @@
 name = "Kimi K2 Instruct"
 release_date = "2025-07-14"
 last_updated = "2025-07-14"
-attachment = true
+attachment = false
 reasoning = false
 temperature = true
 tool_call = true

--- a/providers/groq/models/moonshotai/kimi-k2-instruct.toml
+++ b/providers/groq/models/moonshotai/kimi-k2-instruct.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2 Instruct"
+release_date = "2025-07-14"
+last_updated = "2025-07-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = true
+
+[cost]
+input = 1
+output = 3
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds moonshotai/kimi-k2-instruct model configuration for Groq provider.
- 131k context and output tokens
- Open source model with tool calling capabilities