### PR TITLE
fix: reduce kimi k2 output tokens from 131072 to 16384

### DIFF
--- a/providers/groq/models/moonshotai/kimi-k2-instruct.toml
+++ b/providers/groq/models/moonshotai/kimi-k2-instruct.toml
@@ -14,7 +14,7 @@ output = 3
 
 [limit]
 context = 131_072
-output = 131_072
+output = 16_384
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
This PR reduces the output token limit for the Kimi K2 Instruct model from 131,072 to 16,384 tokens, which appears to be the correct limit based on the model's specifications.

This fixes: https://github.com/sst/opencode/issues/1000

<img width="804" height="891" alt="Screenshot 2025-07-15 at 5 29 12 PM" src="https://github.com/user-attachments/assets/0bb97751-5095-43d9-8ca4-6c483a1cf1ae" />