### PR TITLE
feat: add Google Vertex AI Anthropic provider with Claude models

### DIFF
--- a/providers/google-vertex-anthropic/models/claude-3-5-haiku@20241022.toml
+++ b/providers/google-vertex-anthropic/models/claude-3-5-haiku@20241022.toml
@@ -1,0 +1,23 @@
+name = "Claude Haiku 3.5"
+release_date = "2024-10-22"
+last_updated = "2024-10-22"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-07-31"
+open_weights = false
+
+[cost]
+input = 0.80
+output = 4.00
+cache_read = 0.08
+cache_write = 1.00
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google-vertex-anthropic/models/claude-3-5-sonnet@20241022.toml
+++ b/providers/google-vertex-anthropic/models/claude-3-5-sonnet@20241022.toml
@@ -1,0 +1,23 @@
+name = "Claude Sonnet 3.5 v2"
+release_date = "2024-10-22"
+last_updated = "2024-10-22"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-04-30"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google-vertex-anthropic/models/claude-3-7-sonnet@20250219.toml
+++ b/providers/google-vertex-anthropic/models/claude-3-7-sonnet@20250219.toml
@@ -1,0 +1,23 @@
+name = "Claude Sonnet 3.7"
+release_date = "2025-02-19"
+last_updated = "2025-02-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-10-31"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google-vertex-anthropic/models/claude-opus-4@20250514.toml
+++ b/providers/google-vertex-anthropic/models/claude-opus-4@20250514.toml
@@ -1,0 +1,23 @@
+name = "Claude Opus 4"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 15.00
+output = 75.00
+cache_read = 1.50
+cache_write = 18.75
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google-vertex-anthropic/models/claude-sonnet-4@20250514.toml
+++ b/providers/google-vertex-anthropic/models/claude-sonnet-4@20250514.toml
@@ -1,0 +1,23 @@
+name = "Claude Sonnet 4"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google-vertex-anthropic/provider.toml
+++ b/providers/google-vertex-anthropic/provider.toml
@@ -1,4 +1,4 @@
-name = "Vertex AI Anthropic"
+name = "Vertex"
 env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]
 npm = "@ai-sdk/google-vertex/anthropic"
 doc = "https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude"

--- a/providers/google-vertex-anthropic/provider.toml
+++ b/providers/google-vertex-anthropic/provider.toml
@@ -1,0 +1,4 @@
+name = "Vertex AI Anthropic"
+env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]
+npm = "@ai-sdk/google-vertex/anthropic"
+doc = "https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude"


### PR DESCRIPTION
## Summary
Adds Google Vertex AI Anthropic provider with Claude models following the established patterns from the existing Vertex Gemini implementation.

## Changes
- ✅ **New Provider**: `google-vertex-anthropic` with correct npm package `@ai-sdk/google-vertex/anthropic`
- ✅ **5 Claude Models Added**:
  - `claude-3-5-sonnet@20241022` - Claude Sonnet 3.5 v2
  - `claude-3-5-haiku@20241022` - Claude Haiku 3.5  
  - `claude-3-7-sonnet@20250219` - Claude Sonnet 3.7
  - `claude-sonnet-4@20250514` - Claude Sonnet 4
  - `claude-opus-4@20250514` - Claude Opus 4

## Technical Details
-  Uses `@YYYYMMDD` suffix format as required by Vercel AI SDK
- Follows existing model schema with pricing, context limits, and modalities
- Matches structure of existing `google-vertex` provider

## Testing
- ✅ All TOML files validated successfully with `bun script/validate.ts`

## References
- Based on PR #23 pattern for Vertex Gemini models
- Vercel AI SDK documentation for Google Vertex Anthropic provider
- Google Cloud Vertex AI Claude models documentation