### PR TITLE
feat: add Hugging Face Inference provider

### DIFF
--- a/providers/huggingface/models/deepseek-r1-0528.toml
+++ b/providers/huggingface/models/deepseek-r1-0528.toml
@@ -1,0 +1,22 @@
+id = "deepseek-ai/DeepSeek-R1-0528"
+name = "R1 0528"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-05"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 3
+output = 5
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/huggingface/models/deepseek-r1-0528.toml
+++ b/providers/huggingface/models/deepseek-r1-0528.toml
@@ -1,5 +1,5 @@
 id = "deepseek-ai/DeepSeek-R1-0528"
-name = "R1 0528"
+name = "deepseek-ai/DeepSeek-R1-0528"
 release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false

--- a/providers/huggingface/models/deepseek-r1-0528.toml
+++ b/providers/huggingface/models/deepseek-r1-0528.toml
@@ -1,5 +1,5 @@
 id = "deepseek-ai/DeepSeek-R1-0528"
-name = "deepseek-ai/DeepSeek-R1-0528"
+name = "DeepSeek-R1-0528"
 release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false

--- a/providers/huggingface/models/deepseek-v3-0324.toml
+++ b/providers/huggingface/models/deepseek-v3-0324.toml
@@ -1,0 +1,22 @@
+id = "deepseek-ai/DeepSeek-V3-0324"
+name = "DeepSeek V3 0324"
+release_date = "2025-03-24"
+last_updated = "2025-03-24"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.25
+output = 1.25
+
+[limit]
+context = 16384
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/huggingface/models/deepseek-v3-0324.toml
+++ b/providers/huggingface/models/deepseek-v3-0324.toml
@@ -1,5 +1,5 @@
 id = "deepseek-ai/DeepSeek-V3-0324"
-name = "DeepSeek V3 0324"
+name = "deepseek-ai/DeepSeek-V3-0324"
 release_date = "2025-03-24"
 last_updated = "2025-03-24"
 attachment = false

--- a/providers/huggingface/models/deepseek-v3-0324.toml
+++ b/providers/huggingface/models/deepseek-v3-0324.toml
@@ -1,5 +1,5 @@
 id = "deepseek-ai/DeepSeek-V3-0324"
-name = "deepseek-ai/DeepSeek-V3-0324"
+name = "DeepSeek-V3-0324"
 release_date = "2025-03-24"
 last_updated = "2025-03-24"
 attachment = false

--- a/providers/huggingface/models/kimi-k2-instruct.toml
+++ b/providers/huggingface/models/kimi-k2-instruct.toml
@@ -1,5 +1,5 @@
 id = "moonshotai/Kimi-K2-Instruct:groq"
-name = "Kimi K2 Instruct"
+name = "moonshotai/Kimi-K2-Instruct"
 release_date = "2025-07-14"
 last_updated = "2025-07-14"
 attachment = false

--- a/providers/huggingface/models/kimi-k2-instruct.toml
+++ b/providers/huggingface/models/kimi-k2-instruct.toml
@@ -1,0 +1,22 @@
+id = "moonshotai/Kimi-K2-Instruct:groq"
+name = "Kimi K2 Instruct"
+release_date = "2025-07-14"
+last_updated = "2025-07-14"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = true
+
+[cost]
+input = 1
+output = 3
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/huggingface/models/kimi-k2-instruct.toml
+++ b/providers/huggingface/models/kimi-k2-instruct.toml
@@ -1,5 +1,5 @@
 id = "moonshotai/Kimi-K2-Instruct:groq"
-name = "moonshotai/Kimi-K2-Instruct"
+name = "Kimi-K2-Instruct"
 release_date = "2025-07-14"
 last_updated = "2025-07-14"
 attachment = false

--- a/providers/huggingface/provider.toml
+++ b/providers/huggingface/provider.toml
@@ -1,0 +1,5 @@
+name = "Hugging Face"
+env = ["HF_TOKEN"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://router.huggingface.co/v1"
+doc = "https://huggingface.co/docs/inference-providers"


### PR DESCRIPTION
Would <3 to add Hugging Face to opencode 🚀 

## Summary
- Add Hugging Face Inference as a new provider
- Include 3 popular models available through HF Inference API

## Details
This PR adds support for Hugging Face Inference providers, which offers a unified API platform with access to hundreds of ML models.

### Provider Configuration
- Uses OpenAI-compatible API endpoint
- Authentication via `HF_TOKEN` environment variable
- API endpoint: `https://router.huggingface.co/v1`

### Models Added
1. **moonshotai/Kimi-K2-Instruct** - Reasoning-capable model with 131K context
2. **deepseek-ai/DeepSeek-V3-0324** - Cost-effective model with tool calling support
3. **deepseek-ai/DeepSeek-R1-0528** - Large context (163K) reasoning model

## References
- [Hugging Face Inference Providers Documentation](https://huggingface.co/docs/inference-providers/index)