### PR TITLE
Added specifications for kimi-k2 free model

### DIFF
--- a/providers/openrouter/models/moonshotai/kimi-k2:free.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2:free.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2 (free)"
+release_date = "2025-07-11"
+last_updated = "2025-07-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
There is a free version from the Kimi-k2 model: [MoonshotAI: Kimi K2 (free)](https://openrouter.ai/moonshotai/kimi-k2:free).