### PR TITLE
Reorganize Hugging Face models and fix model id

### DIFF
--- a/providers/huggingface/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen3-Coder-480B-A35B-Instruct"
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 2
+output = 2
+
+[limit]
+context = 262_144
+output = 66_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/huggingface/models/deepseek-ai/deepseek-r1-0528.toml
+++ b/providers/huggingface/models/deepseek-ai/deepseek-r1-0528.toml
@@ -1,12 +1,11 @@
-id = "deepseek-ai/DeepSeek-R1-0528"
 name = "DeepSeek-R1-0528"
 release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
 temperature = true
-knowledge = "2025-05"
 tool_call = true
+knowledge = "2025-05"
 open_weights = true
 
 [cost]

--- a/providers/huggingface/models/deepseek-ai/deepseek-v3-0324.toml
+++ b/providers/huggingface/models/deepseek-ai/deepseek-v3-0324.toml
@@ -1,4 +1,3 @@
-id = "deepseek-ai/DeepSeek-V3-0324"
 name = "DeepSeek-V3-0324"
 release_date = "2025-03-24"
 last_updated = "2025-03-24"

--- a/providers/huggingface/models/moonshotai/kimi-k2-instruct.toml
+++ b/providers/huggingface/models/moonshotai/kimi-k2-instruct.toml
@@ -1,4 +1,3 @@
-id = "moonshotai/Kimi-K2-Instruct:groq"
 name = "Kimi-K2-Instruct"
 release_date = "2025-07-14"
 last_updated = "2025-07-14"


### PR DESCRIPTION
Should fix Hugging Face models not working.

<img width="1394" height="297" alt="image" src="https://github.com/user-attachments/assets/70d0cee3-6804-4cf4-9dac-8364a9ef7dac" />

## Summary
- Moved deepseek models into `deepseek-ai/` subdirectory
- Moved Qwen models into `Qwen/` subdirectory  
- Moved moonshotai models into `moonshotai/` subdirectory

This improves organization of Hugging Face models by grouping them by vendor.