### PR TITLE
feat: add kimi-k2:free model

### DIFF
--- a/providers/openrouter/models/moonshotai/kimi-k2:free.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2:free.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2 (free)"
+release_date = "2025-07-11"
+last_updated = "2025-07-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 66_000
+output = 66_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This PR adds the model definition for `moonshotai/kimi-k2:free` for OpenRouter. It was also mentioned in: https://github.com/sst/opencode/issues/1002. 