### PR TITLE
Added GLM 4.5 Air & Fixed GLM 4.5 TOML

### DIFF
--- a/providers/openrouter/models/z-ai/glm-4.5-air.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5-air.toml
@@ -9,8 +9,8 @@ knowledge = "2025-04"
 open_weights = true
 
 [cost]
-input = 0.60
-output = 2.20
+input = 0.20
+output = 1.10
 
 [limit]
 context = 128_000


### PR DESCRIPTION
I checked openrouter, actually it supports reasoning parameter (able to enable reasoning mode), also I saw that the context limit and output limit there was wrong.

- Added GLM 4.5 Air on OpenRouter
- Fix reasoning parameter (to true)
- Fix context & output limit numbers