### PR TITLE
fix: Remove "Air" from OpenRouter GLM 4.5

### DIFF
--- a/providers/openrouter/models/z-ai/glm-4.5.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5.toml
@@ -1,4 +1,4 @@
-name = "GLM 4.5 Air"
+name = "GLM 4.5"
 release_date = "2025-07-28"
 last_updated = "2025-07-28"
 attachment = false


### PR DESCRIPTION
`openrouter/glm-4.5` had the display name of GLM 4.5 **Air**. This PR changes this to the correct display name for this model.

Closes https://github.com/sst/opencode/issues/1397