### PR TITLE
feat: Add support for GLM 4.5 Air (free) model

### DIFF
--- a/providers/openrouter/models/z-ai/glm-45-air:free.toml
+++ b/providers/openrouter/models/z-ai/glm-45-air:free.toml
@@ -1,0 +1,21 @@
+name = "GLM 4.5 Air (free)"
+release_date = "2025-07-28"
+last_updated = "2025-07-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 128_000
+output = 96_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This PR provides support for the GLM 4.5 Air (free) model. Note that this free model doesn't support tool calls.