### PR TITLE
feat: add OpenRouter Horizon Alpha model

### DIFF
--- a/providers/openrouter/models/openrouter/horizon-alpha.toml
+++ b/providers/openrouter/models/openrouter/horizon-alpha.toml
@@ -1,0 +1,21 @@
+name = "Horizon Alpha"
+release_date = "2025-07-30"
+last_updated = "2025-07-30"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = true
+knowledge = "2025-07"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
This PR adds support for the Horizon Alpha model from OpenRouter. This is a free model currently in testing phase that supports multimodal input (text +  images) and tool calling.