### PR TITLE
feat: add ModelScope provider with 8 models

### DIFF
--- a/providers/modelscope/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
+++ b/providers/modelscope/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 235B A22B Instruct 2507"
+release_date = "2025-04-28"
+last_updated = "2025-07-21"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/modelscope/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
+++ b/providers/modelscope/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
@@ -1,0 +1,21 @@
+name = "Qwen3-235B-A22B-Thinking-2507"
+release_date = "2025-07-25"
+last_updated = "2025-07-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/modelscope/models/Qwen/Qwen3-30B-A3B-Instruct-2507.toml
+++ b/providers/modelscope/models/Qwen/Qwen3-30B-A3B-Instruct-2507.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 30B A3B Instruct 2507"
+release_date = "2025-07-30"
+last_updated = "2025-07-30"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/modelscope/models/Qwen/Qwen3-30B-A3B-Thinking-2507.toml
+++ b/providers/modelscope/models/Qwen/Qwen3-30B-A3B-Thinking-2507.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 30B A3B Thinking 2507"
+release_date = "2025-07-30"
+last_updated = "2025-07-30"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/modelscope/models/Qwen/Qwen3-Coder-30B-A3B-Instruct.toml
+++ b/providers/modelscope/models/Qwen/Qwen3-Coder-30B-A3B-Instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 Coder 30B A3B Instruct"
+release_date = "2025-07-31"
+last_updated = "2025-07-31"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/modelscope/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
+++ b/providers/modelscope/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen3-Coder-480B-A35B-Instruct"
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262_144
+output = 66_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/modelscope/models/ZhipuAI/GLM-4.5.toml
+++ b/providers/modelscope/models/ZhipuAI/GLM-4.5.toml
@@ -1,0 +1,21 @@
+name = "GLM-4.5"
+release_date = "2025-07-28"
+last_updated = "2025-07-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131_072
+output = 98_304
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/modelscope/models/moonshotai/Kimi-K2-Instruct.toml
+++ b/providers/modelscope/models/moonshotai/Kimi-K2-Instruct.toml
@@ -1,0 +1,21 @@
+name = "Kimi-K2-Instruct"
+release_date = "2025-07-14"
+last_updated = "2025-07-14"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/modelscope/provider.toml
+++ b/providers/modelscope/provider.toml
@@ -1,0 +1,5 @@
+name = "ModelScope"
+env = ["MODELSCOPE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api-inference.modelscope.cn/v1"
+doc = "https://modelscope.cn/docs/model-service/API-Inference/intro"


### PR DESCRIPTION
- Add new ModelScope provider configuration
- Add 8 models with accurate pricing, context windows, and modalities based on official [ModelScope documentation](https://modelscope.cn/docs/model-service/API-Inference/intro)
- ModelScope provides **free inference with 2K RPD (Requests Per Day)** (if you sign up with a Chinese number or go through a fairly complex process with a non-Chinese number...)

## Models Added
- **Qwen**: Qwen3-Coder-480B-A35B-Instruct, Qwen3-235B-A22B-Thinking-2507, Qwen3-235B-A22B-Instruct-2507, Qwen3-30B-A3B-Instruct-2507, Qwen3-30B-A3B-Thinking-2507, Qwen3-Coder-30B-A3B-Instruct (this one released a [few hours ago](https://x.com/Alibaba_Qwen/status/1950925444057792808))
- **ZhipuAI**: GLM-4.5
- **moonshotai**: Kimi-K2-Instruct