### PR TITLE
fix: Corrected Cerebras Qwen 3 Coder cost

### DIFF
--- a/providers/cerebras/models/qwen-3-coder-480b.toml
+++ b/providers/cerebras/models/qwen-3-coder-480b.toml
@@ -9,8 +9,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 1
-output = 5
+input = 2
+output = 2
 
 [limit]
 context = 131_000


### PR DESCRIPTION
According to the [docs](https://inference-docs.cerebras.ai/models/qwen-3-480b) the cost is actually $2 input / $2 output