### PR TITLE
Add cost field to GitHub Models provider models

### DIFF
--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 256_000
 output = 4_096

--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 256_000
 output = 4_096

--- a/providers/github-models/models/cohere/cohere-command-a.toml
+++ b/providers/github-models/models/cohere/cohere-command-a.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/cohere/cohere-command-r-plus.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/cohere/cohere-command-r.toml
+++ b/providers/github-models/models/cohere/cohere-command-r.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/core42/jais-30b-chat.toml
+++ b/providers/github-models/models/core42/jais-30b-chat.toml
@@ -8,6 +8,10 @@ knowledge = "2023-03"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 8_192
 output = 2_048

--- a/providers/github-models/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1-0528.toml
@@ -8,6 +8,10 @@ knowledge = "2024-06"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 65_536
 output = 8_192

--- a/providers/github-models/models/deepseek/deepseek-r1.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1.toml
@@ -8,6 +8,10 @@ knowledge = "2024-06"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 65_536
 output = 8_192

--- a/providers/github-models/models/deepseek/deepseek-v3-0324.toml
+++ b/providers/github-models/models/deepseek/deepseek-v3-0324.toml
@@ -8,6 +8,10 @@ knowledge = "2024-06"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 8_192

--- a/providers/github-models/models/meta/llama-3.2-11b-vision-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.2-11b-vision-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 8_192

--- a/providers/github-models/models/meta/llama-3.2-90b-vision-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.2-90b-vision-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 8_192

--- a/providers/github-models/models/meta/llama-3.3-70b-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.3-70b-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 32_768

--- a/providers/github-models/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
+++ b/providers/github-models/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
@@ -8,6 +8,10 @@ knowledge = "2024-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 8_192

--- a/providers/github-models/models/meta/llama-4-scout-17b-16e-instruct.toml
+++ b/providers/github-models/models/meta/llama-4-scout-17b-16e-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2024-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 8_192

--- a/providers/github-models/models/meta/meta-llama-3-70b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3-70b-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 8_192
 output = 2_048

--- a/providers/github-models/models/meta/meta-llama-3-8b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3-8b-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 8_192
 output = 2_048

--- a/providers/github-models/models/meta/meta-llama-3.1-405b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-405b-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 32_768

--- a/providers/github-models/models/meta/meta-llama-3.1-70b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-70b-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 32_768

--- a/providers/github-models/models/meta/meta-llama-3.1-8b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-8b-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-12"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 32_768

--- a/providers/github-models/models/microsoft/mai-ds-r1.toml
+++ b/providers/github-models/models/microsoft/mai-ds-r1.toml
@@ -8,6 +8,10 @@ knowledge = "2024-06"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 65_536
 output = 8_192

--- a/providers/github-models/models/microsoft/phi-3-medium-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-medium-128k-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-3-medium-4k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-medium-4k-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 4_096
 output = 1_024

--- a/providers/github-models/models/microsoft/phi-3-mini-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-mini-128k-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-3-mini-4k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-mini-4k-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 4_096
 output = 1_024

--- a/providers/github-models/models/microsoft/phi-3-small-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-small-128k-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-3-small-8k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-small-8k-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 8_192
 output = 2_048

--- a/providers/github-models/models/microsoft/phi-3.5-mini-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-mini-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-3.5-moe-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-moe-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-3.5-vision-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-vision-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-4-mini-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-4-mini-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-4-mini-reasoning.toml
+++ b/providers/github-models/models/microsoft/phi-4-mini-reasoning.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-4-multimodal-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-4-multimodal-instruct.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-4-reasoning.toml
+++ b/providers/github-models/models/microsoft/phi-4-reasoning.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 4_096

--- a/providers/github-models/models/microsoft/phi-4.toml
+++ b/providers/github-models/models/microsoft/phi-4.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 16_000
 output = 4_096

--- a/providers/github-models/models/mistral-ai/codestral-2501.toml
+++ b/providers/github-models/models/mistral-ai/codestral-2501.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 32_000
 output = 8_192

--- a/providers/github-models/models/mistral-ai/ministral-3b.toml
+++ b/providers/github-models/models/mistral-ai/ministral-3b.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 8_192

--- a/providers/github-models/models/mistral-ai/mistral-large-2411.toml
+++ b/providers/github-models/models/mistral-ai/mistral-large-2411.toml
@@ -8,6 +8,10 @@ knowledge = "2024-09"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 32_768

--- a/providers/github-models/models/mistral-ai/mistral-medium-2505.toml
+++ b/providers/github-models/models/mistral-ai/mistral-medium-2505.toml
@@ -8,6 +8,10 @@ knowledge = "2024-09"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 32_768

--- a/providers/github-models/models/mistral-ai/mistral-nemo.toml
+++ b/providers/github-models/models/mistral-ai/mistral-nemo.toml
@@ -8,6 +8,10 @@ knowledge = "2024-03"
 tool_call = true
 open_weights = true
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 8_192

--- a/providers/github-models/models/mistral-ai/mistral-small-2503.toml
+++ b/providers/github-models/models/mistral-ai/mistral-small-2503.toml
@@ -8,6 +8,10 @@ knowledge = "2024-09"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 32_768

--- a/providers/github-models/models/openai/gpt-4.1-mini.toml
+++ b/providers/github-models/models/openai/gpt-4.1-mini.toml
@@ -8,6 +8,10 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 16_384

--- a/providers/github-models/models/openai/gpt-4.1-nano.toml
+++ b/providers/github-models/models/openai/gpt-4.1-nano.toml
@@ -8,6 +8,10 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 16_384

--- a/providers/github-models/models/openai/gpt-4.1.toml
+++ b/providers/github-models/models/openai/gpt-4.1.toml
@@ -8,6 +8,10 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 16_384

--- a/providers/github-models/models/openai/gpt-4o-mini.toml
+++ b/providers/github-models/models/openai/gpt-4o-mini.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 16_384

--- a/providers/github-models/models/openai/gpt-4o.toml
+++ b/providers/github-models/models/openai/gpt-4o.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 16_384

--- a/providers/github-models/models/openai/o1-mini.toml
+++ b/providers/github-models/models/openai/o1-mini.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 65_536

--- a/providers/github-models/models/openai/o1-preview.toml
+++ b/providers/github-models/models/openai/o1-preview.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 32_768

--- a/providers/github-models/models/openai/o1.toml
+++ b/providers/github-models/models/openai/o1.toml
@@ -8,6 +8,10 @@ knowledge = "2023-10"
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 200_000
 output = 100_000

--- a/providers/github-models/models/openai/o3-mini.toml
+++ b/providers/github-models/models/openai/o3-mini.toml
@@ -8,6 +8,10 @@ knowledge = "2024-04"
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 200_000
 output = 100_000

--- a/providers/github-models/models/openai/o3.toml
+++ b/providers/github-models/models/openai/o3.toml
@@ -8,6 +8,10 @@ knowledge = "2024-04"
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 200_000
 output = 100_000

--- a/providers/github-models/models/openai/o4-mini.toml
+++ b/providers/github-models/models/openai/o4-mini.toml
@@ -8,6 +8,10 @@ knowledge = "2024-04"
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 200_000
 output = 100_000

--- a/providers/github-models/models/xai/grok-3-mini.toml
+++ b/providers/github-models/models/xai/grok-3-mini.toml
@@ -8,6 +8,10 @@ knowledge = "2024-10"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 8_192

--- a/providers/github-models/models/xai/grok-3.toml
+++ b/providers/github-models/models/xai/grok-3.toml
@@ -8,6 +8,10 @@ knowledge = "2024-10"
 tool_call = true
 open_weights = false
 
+[cost]
+input = 0.00
+output = 0.00
+
 [limit]
 context = 128_000
 output = 8_192


### PR DESCRIPTION
I added the GitHub Models provider [last week](https://github.com/sst/models.dev/pull/30). I left `cost` blank, since the models all have a free tier, but I noticed that actually using `opencode` with this provider shows a constant "could not parse cost field" warning, and the `opencode` GitHub Actions workflow straight up errors out on a missing cost field.

This PR adds a 0.00 cost value to all the models, so they can be used without showing this error.