### PR TITLE
add GLM-4.5-FP8 to chutes provider

### DIFF
--- a/providers/chutes/models/zai-org/GLM-4.5-Air.toml
+++ b/providers/chutes/models/zai-org/GLM-4.5-Air.toml
@@ -1,15 +1,16 @@
 name = "GLM 4.5 Air"
-release_date = "2025-08-01"
-last_updated = "2025-08-01"
+release_date = "2025-07-28"
+last_updated = "2025-07-28"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+knowledge = "2025-04"
+open_weights = true
 
 [limit]
 context = 131_072
-output = 131_072
+output = 98_304
 
 [modalities]
 input = ["text"]

--- a/providers/chutes/models/zai-org/GLM-4.5-FP8.toml
+++ b/providers/chutes/models/zai-org/GLM-4.5-FP8.toml
@@ -1,0 +1,16 @@
+name = "GLM 4.5 FP8"
+release_date = "2025-08-01"
+last_updated = "2025-08-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/chutes/models/zai-org/GLM-4.5-FP8.toml
+++ b/providers/chutes/models/zai-org/GLM-4.5-FP8.toml
@@ -1,15 +1,16 @@
 name = "GLM 4.5 FP8"
-release_date = "2025-08-01"
-last_updated = "2025-08-01"
+release_date = "2025-07-28"
+last_updated = "2025-07-28"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+knowledge = "2025-04"
+open_weights = true
 
 [limit]
 context = 131_072
-output = 131_072
+output = 98_304
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Adds the larger GLM-4.5 model from chutes, wasn't sure about the reasoning, but checked out the model on chutes playground and the API response included reasoning content