### PR TITLE
Vercel: Add GPT OSS models

### DIFF
--- a/providers/vercel/models/openai/gpt-oss-120b.toml
+++ b/providers/vercel/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,20 @@
+name = "GPT OSS 120B"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.50
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vercel/models/openai/gpt-oss-20b.toml
+++ b/providers/vercel/models/openai/gpt-oss-20b.toml
@@ -1,0 +1,20 @@
+name = "GPT OSS 20B"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.30
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This PR adds GPT OSS models to the Vercel AI Gateway provider.

## Models Added
- `openai/gpt-oss-120b` - GPT OSS 120B
- `openai/gpt-oss-20b` - GPT OSS 20B

## Details
- Both models support 131K context window and 32K output tokens
- Pricing based on Vercel's AI Gateway documentation
- Models include support for reasoning and tool calling
- These models are already available through other providers (Groq, Fireworks, OpenRouter, Cerebras)

## Pricing
- GPT OSS 120B: $0.10 input / $0.50 output per million tokens
- GPT OSS 20B: $0.07 input / $0.30 output per million tokens