### PR TITLE
Update OpenAI GPT-4 input/output token pricing

### DIFF
--- a/providers/openai/models/gpt-4.toml
+++ b/providers/openai/models/gpt-4.toml
@@ -9,8 +9,8 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 10.00
-output = 30.00
+input = 30.00
+output = 60.00
 
 [limit]
 context = 8192


### PR DESCRIPTION
This PR updates the price of OpenAI's GPT-4 model to reflect the pricing displayed on their pricing page: https://platform.openai.com/docs/pricing#other-models

### Models Updated
`openai/gpt-4`

### Pricing
Old: `gpt-4`: $10.00 input / $30.00 output per million tokens
New: `gpt-4`: $30.00 input / $60.00 output per million tokens
