### PR TITLE
chore(vercel): gpt-5

### DIFF
--- a/providers/vercel/models/openai/gpt-5-mini.toml
+++ b/providers/vercel/models/openai/gpt-5-mini.toml
@@ -1,0 +1,1 @@
+../../../openai/models/gpt-5-mini.toml

--- a/providers/vercel/models/openai/gpt-5-nano.toml
+++ b/providers/vercel/models/openai/gpt-5-nano.toml
@@ -1,0 +1,1 @@
+../../../openai/models/gpt-5-nano.toml

--- a/providers/vercel/models/openai/gpt-5.toml
+++ b/providers/vercel/models/openai/gpt-5.toml
@@ -1,0 +1,1 @@
+../../../openai/models/gpt-5.toml


### PR DESCRIPTION
This pull request adds three new model configuration files to the `providers/vercel/models/openai` directory by linking them to existing model files. These changes help ensure that the Vercel provider has access to the latest OpenAI model configurations.

Model configuration additions:

* Added `gpt-5-mini.toml` by linking to `../../../openai/models/gpt-5-mini.toml`.
* Added `gpt-5-nano.toml` by linking to `../../../openai/models/gpt-5-nano.toml`.
* Added `gpt-5.toml` by linking to `../../../openai/models/gpt-5.toml`.