### PR TITLE
chore: copilot/gpt-5 reduce context

### DIFF
--- a/providers/github-copilot/models/gpt-5.toml
+++ b/providers/github-copilot/models/gpt-5.toml
@@ -9,7 +9,7 @@ tool_call = true
 open_weights = false
 
 [limit]
-context = 400_000
+context = 128_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
I received an error when my context was over 128k, updating model.