### PR TITLE
Add multiple model searching

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -147,7 +147,7 @@ document.querySelectorAll("th.sortable").forEach((header) => {
 // Handle Search
 ///////////////////
 function filterTable(value: string) {
-  const lowerCaseValue = value.toLowerCase();
+  const lowerCaseValues = value.toLowerCase().split(",").filter(str => str.trim() !== "");
   const rows = document.querySelectorAll(
     "table tbody tr"
   ) as NodeListOf<HTMLTableRowElement>;
@@ -156,7 +156,8 @@ function filterTable(value: string) {
     const cellTexts = Array.from(row.cells).map((cell) =>
       cell.textContent!.toLowerCase()
     );
-    const isVisible = cellTexts.some((text) => text.includes(lowerCaseValue));
+    const isVisible = lowerCaseValues.length === 0 ||
+     lowerCaseValues.some((lowerCaseValue) => cellTexts.some((text) => text.includes(lowerCaseValue)));
     row.style.display = isVisible ? "" : "none";
   });
 


### PR DESCRIPTION
I was using models.dev and trying to do some quick comparisons across models but since the search only supports one value I was finding it a bit difficult.

This pr adds support for adding multiple search values that are comma-separated

https://github.com/user-attachments/assets/4d4dc3b8-c2aa-45ca-bf3e-8e99c0fdb68b

