### PR TITLE
fix: correct npm package reference for Google Vertex Anthropic provider

### DIFF
--- a/providers/google-vertex-anthropic/provider.toml
+++ b/providers/google-vertex-anthropic/provider.toml
@@ -1,4 +1,4 @@
 name = "Vertex"
 env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]
-npm = "@ai-sdk/google-vertex/anthropic"
+npm = "@ai-sdk/google-vertex"
 doc = "https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude"


### PR DESCRIPTION
Fix npm package reference from `@ai-sdk/google-vertex/anthropic` to `@ai-sdk/google-vertex` for the Google Vertex Anthropic provider configuration. 