### PR TITLE
add chutes' updated qwen3 30b models

### DIFF
--- a/providers/chutes/models/Qwen/Qwen3-30B-A3B-Instruct-2507.toml
+++ b/providers/chutes/models/Qwen/Qwen3-30B-A3B-Instruct-2507.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 30B A3B Instruct 2507"
+release_date = "2025-07-25"
+last_updated = "2025-07-25"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.2
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/chutes/models/Qwen/Qwen3-Coder-30B-A3B-Instruct.toml
+++ b/providers/chutes/models/Qwen/Qwen3-Coder-30B-A3B-Instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 Coder 30B A3B Instruct"
+release_date = "2025-07-25"
+last_updated = "2025-07-25"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds the following two models from chutes:
[Qwen3 Coder 30B A3B Instruct](https://chutes.ai/app/chute/b45bfcdb-7e8e-50c5-93e6-f425688d4b84)
[Qwen3 30B A3B Instruct 2507](https://chutes.ai/app/chute/fa065f66-c8d4-5af0-a6b4-af47e2ef2473)

I wonder if we can make fetching chute's models more automatic though