### PR TITLE
fix: gh copilot opus 4.1

### DIFF
--- a/providers/github-copilot/models/claude-opus-4.1.toml
+++ b/providers/github-copilot/models/claude-opus-4.1.toml
@@ -4,7 +4,7 @@ last_updated = "2025-08-05"
 attachment = true
 reasoning = true
 temperature = true
-tool_call = true
+tool_call = false
 knowledge = "2025-03-31"
 open_weights = false
 


### PR DESCRIPTION
opus 4.1 in github copilot doesn't support agent mode: https://docs.github.com/en/copilot/reference/ai-models/supported-models#supported-ai-models-in-copilot