### PR TITLE
Remove preview from GitHub Copilot Gemini Pro 2.5

### DIFF
--- a/providers/github-copilot/models/gemini-2.5-pro.toml
+++ b/providers/github-copilot/models/gemini-2.5-pro.toml
@@ -1,4 +1,4 @@
-name = "Gemini 2.5 Pro (Preview)"
+name = "Gemini 2.5 Pro"
 release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true


### PR DESCRIPTION
Gemini Pro 2.5 via GitHub Copilot is not in preview anymore: https://github.blog/changelog/2025-08-19-gemini-2-5-pro-is-generally-available-in-copilot/