### PR TITLE
add: chutes deepseek v3.1 and thinking model, update deepseek provider context

### DIFF
--- a/providers/chutes/models/deepseek-ai/DeepSeek-V3.1.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V3.1.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek V3.1"
+release_date = "2025-08-21"
+last_updated = "2025-08-21"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.8
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/chutes/models/deepseek-ai/DeepSeek-V3.1:THINKING.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V3.1:THINKING.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek V3.1 Reasoning"
+release_date = "2025-08-21"
+last_updated = "2025-08-21"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.8
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/deepseek/models/deepseek-chat.toml
+++ b/providers/deepseek/models/deepseek-chat.toml
@@ -1,21 +1,21 @@
 name = "DeepSeek Chat"
 release_date = "2024-12-26"
-last_updated = "2025-03-24"
+last_updated = "2025-08-21"
 attachment = true
-reasoning = true
+reasoning = false
 temperature = true
 knowledge = "2024-07"
 tool_call = true
 open_weights = false
 
 [cost]
-input = 0.27
-output = 1.10
+input = 0.57
+output = 1.68
 cache_read = 0.07
 
 [limit]
-context = 65_536
-output = 8_192
+context = 128_000
+output = 128_000
 
 [modalities]
 input = ["text"]

--- a/providers/deepseek/models/deepseek-reasoner.toml
+++ b/providers/deepseek/models/deepseek-reasoner.toml
@@ -1,6 +1,6 @@
 name = "DeepSeek Reasoner"
 release_date = "2025-01-20"
-last_updated = "2025-05-29"
+last_updated = "2025-08-21"
 attachment = true
 reasoning = true
 temperature = true
@@ -9,13 +9,13 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.55
-output = 2.19
-cache_read = 0.14
+input = 0.57
+output = 1.68
+cache_read = 0.07
 
 [limit]
-context = 65_536
-output = 8_192
+context = 128_000
+output = 128_000
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
updated based on https://api-docs.deepseek.com/news/news250821 for deepseek provider
deepseek-chat = deepseek v3.1
deepseek-reasoner =  deepseek v3.1 with thinking enabled (not r1 anymore)

as for chutes, they now support 3 ways of enabling thinking on hybrid models, request header, body param and modelname postfix, so added the THINKING one as well for tooling that may not support customizing requests.
