### PR TITLE
Update GPT-5-Chat on Azure with correct info

### DIFF
--- a/providers/azure/models/gpt-5-chat.toml
+++ b/providers/azure/models/gpt-5-chat.toml
@@ -4,8 +4,8 @@ last_updated = "2025-08-07"
 attachment = true
 reasoning = true
 temperature = false
-knowledge = "2024-09-30"
-tool_call = true
+knowledge = "2024-10-24"
+tool_call = false
 open_weights = false
 
 [cost]
@@ -14,8 +14,8 @@ output = 10.00
 cache_read = 0.13
 
 [limit]
-context = 272_000
-output = 128_000
+context = 128_000
+output = 16_384
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
GPT-5-Chat on Azure has lower context window and doesn't support tool calling

Info on Azure [here](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#:~:text=2024-,gpt%2D5%2Dchat%20(2025%2D08%2D07),-Preview)