### PR TITLE
fix: deepseek-chat output limit

### DIFF
--- a/providers/deepseek/models/deepseek-chat.toml
+++ b/providers/deepseek/models/deepseek-chat.toml
@@ -15,7 +15,7 @@ cache_read = 0.07
 
 [limit]
 context = 128_000
-output = 128_000
+output = 8_192
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
see deepseek docs: https://api-docs.deepseek.com/quick_start/pricing 

fixes: https://github.com/sst/opencode/issues/2343