### PR TITLE
fix: update baseten npm to openai-compatible

### DIFF
--- a/providers/baseten/provider.toml
+++ b/providers/baseten/provider.toml
@@ -1,5 +1,5 @@
 name = "Baseten"
-npm = "@ai-sdk/provider"
+npm = "@ai-sdk/openai-compatible"
 doc = "https://docs.baseten.co/development/model-apis/overview"
 api = "https://inference.baseten.co/v1"
 env = ["BASETEN_API_KEY"]


### PR DESCRIPTION
Fix validation error by updating npm package to match api field requirement.