### PR TITLE
feat(openrouter): add qwen3 max

### DIFF
--- a/providers/openrouter/models/qwen/qwen3-max.toml
+++ b/providers/openrouter/models/qwen/qwen3-max.toml
@@ -1,0 +1,25 @@
+name = "Qwen3 Max"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+# cost at >= 128k context
+# input = 1
+# output = 5
+input = 1.20
+output = 6.00
+
+[limit]
+context = 1_048_576
+output = 65_536
+context = 256_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
https://openrouter.ai/qwen/qwen3-max/providers

Raised a question in the discord about this one, but figured I'd get the PR open anyways for review.

Q: This model has different input/output costs before and after a 128k token cliff, how do you all want to handle that?
