### PR TITLE
add: chutes' new kimi k2 0905 model

### DIFF
--- a/providers/chutes/models/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,0 +1,20 @@
+name = "Kimi K2 Instruct 0905"
+release_date = "2025-08-01"
+last_updated = "2025-09-05"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.29
+output = 1.18
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds the updated kimi k2 model from chutes.

Chutes has mentioned they've replaced the old 75k model with this one, but the old model id still works, I believe they may be routing requests to the new model but haven't gotten an answer yet.

So the old entry remains since it still works for now.