### PR TITLE
fix(requesty): update npm package to openai-compatible

### DIFF
--- a/providers/requesty/provider.toml
+++ b/providers/requesty/provider.toml
@@ -1,4 +1,5 @@
 name = "Requesty"
 env = ["REQUESTY_API_KEY"]
-npm = "@requesty/ai-sdk"
+npm = "@ai-sdk/openai-compatible"
+api = "https://router.requesty.ai/v1"
 doc = "https://requesty.ai/solution/llm-routing/models"


### PR DESCRIPTION
Fix for issue #190 

Alternative fix would be to use the `beta` version of the `@requesty/ai-sdk` as that one uses the V5 of the AI SDK. This should be more of an immediate fix moving to use the openai compatible api.