### PR TITLE
fix: unique name for Synthetic's Kimi K2 0905

### DIFF
--- a/providers/synthetic/models/hf:moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,4 +1,4 @@
-name = "Kimi K2"
+name = "Kimi K2 0905"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false


### PR DESCRIPTION
# Background 

The two variants of the Kimi K2 model hosted by Synthetic are currently assigned the same `name` "Kimi K2". 

https://github.com/sst/models.dev/blob/2ecca630e6b800397f2d1672966aa95a7734b595/providers/synthetic/models/hf%3Amoonshotai/Kimi-K2-Instruct.toml#L1

https://github.com/sst/models.dev/blob/2ecca630e6b800397f2d1672966aa95a7734b595/providers/synthetic/models/hf%3Amoonshotai/Kimi-K2-Instruct-0905.toml#L1

This naming collision prevents users from selecting the 0905 variant of Kimi K2 in opencode unless they manually configure the model with a different name.

# Fix

Add a version suffix to the more recent Kimi K2 model.