### PR TITLE
Update pricing of `openrouter` `openai/gpt-oss-120b`

### DIFF
--- a/providers/openrouter/models/openai/gpt-oss-120b.toml
+++ b/providers/openrouter/models/openai/gpt-oss-120b.toml
@@ -8,8 +8,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.15
-output = 0.60
+input = 0.072
+output = 0.28
 
 [limit]
 context = 131_072


### PR DESCRIPTION
The pricing of `openrouter` `openai/gpt-oss-120b` is incorrect. In this [model page](https://openrouter.ai/openai/gpt-oss-120b) It is mentioned in cheaper price.

<img width="1058" height="151" alt="image" src="https://github.com/user-attachments/assets/90cfcd7e-a65f-4045-b285-a5ac4da51b43" />

Also I did not update the context, in the toml file it is `131072` but in the model page it is `131000`. Should I update that?

I can also add a script to update/verify the pricing of all the openrouter models by fetching the openrouter models api directly. It will also add any new models without manually adding them.