### PR TITLE
feat: add LongCat-Flash-Chat-FP8 model to Chutes provider

### DIFF
--- a/providers/chutes/models/meituan-longcat/LongCat-Flash-Chat-FP8.toml
+++ b/providers/chutes/models/meituan-longcat/LongCat-Flash-Chat-FP8.toml
@@ -14,3 +14,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[cost]
+input = 0.25
+output = 1.00

--- a/providers/chutes/models/meituan-longcat/LongCat-Flash-Chat-FP8.toml
+++ b/providers/chutes/models/meituan-longcat/LongCat-Flash-Chat-FP8.toml
@@ -1,0 +1,16 @@
+name = "LongCat Flash Chat FP8"
+release_date = "2025-09-10"
+last_updated = "2025-09-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This PR adds the LongCat-Flash-Chat-FP8 model from the meituan-longcat provider to the Chutes platform configuration.

- Create TOML configuration for meituan-longcat/LongCat-Flash-Chat-FP8 model
- Include proper pricing, context limits, and modality settings
- Validate configuration with bun validate command
- Verify model availability through Chutes API