### PR TITLE
Update kimi-k2-turbo-preview.toml

### DIFF
--- a/providers/moonshotai/models/kimi-k2-turbo-preview.toml
+++ b/providers/moonshotai/models/kimi-k2-turbo-preview.toml
@@ -1,6 +1,6 @@
 name = "Kimi K2 Turbo"
-release_date = "2025-07-14"
-last_updated = "2025-07-14"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
 attachment = false
 reasoning = false
 temperature = true
@@ -14,8 +14,8 @@ output = 10
 cache_read = 0.6
 
 [limit]
-context = 131_072
-output = 16_384
+context = 262_144
+output = 262_144
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
> "Latest release of kimi-k2-0905-preview model, with an expanded 256K context window and enhanced coding capabilities. If you need faster response speed, you can use the kimi-k2-turbo-preview model, which always tracks the latest version of kimi-k2 and maintains the same functionality, but the output speed has been increased to 60tokens/s, with a maximum of 100tokens/s."

https://platform.moonshot.ai/docs/guide/agent-support