### PR TITLE
Add openrouter qwen3-next 80b A3b instruct

### DIFF
--- a/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 Next 80B A3B Instruct"
+release_date = "2025-09-11"
+last_updated = "2025-09-11"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.14
+output = 1.40
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Knowledge cutoff is assumed to be the same as qwen3 models, but it's not clearly posted.