### PR TITLE
Add new Qwen models and Kimi-K2-Instruct-0905 configuration files

### DIFF
--- a/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen3-Next-80B-A3B-Instruct"
+release_date = "2025-09-11"
+last_updated = "2025-09-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.25
+output = 1.0
+
+[limit]
+context = 262_144
+output = 66_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
@@ -1,0 +1,22 @@
+name = "Qwen3-Next-80B-A3B-Thinking"
+release_date = "2025-09-11"
+last_updated = "2025-09-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.30
+output = 2.00
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]
+

--- a/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
@@ -19,4 +19,3 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
-

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,6 +1,6 @@
-name = "Kimi-K2-Instruct"
-release_date = "2025-07-14"
-last_updated = "2025-07-14"
+name = "Kimi-K2-Instruct-0905"
+release_date = "2025-09-04"
+last_updated = "2025-09-04"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Instruct.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Instruct.toml
@@ -1,6 +1,6 @@
-name = "Kimi-K2-Instruct-0905"
-release_date = "2025-09-04"
-last_updated = "2025-09-04"
+name = "Kimi-K2-Instruct"
+release_date = "2025-07-14"
+last_updated = "2025-07-14"
 attachment = false
 reasoning = false
 temperature = true
@@ -13,7 +13,7 @@ input = 1
 output = 3
 
 [limit]
-context = 262_144
+context = 131_072
 output = 16_384
 
 [modalities]


### PR DESCRIPTION
## Summary
- Add Qwen3-Next-80B-A3B-Instruct model configuration
- Add Qwen3-Next-80B-A3B-Thinking model configuration  
- Rename and update Kimi-K2-Instruct to Kimi-K2-Instruct-0905 with updated release date
