### PR TITLE
Update Kimi-K2-Instruct-0905 context length

### DIFF
--- a/providers/synthetic/models/hf:moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K2-Instruct-0905.toml
@@ -13,7 +13,7 @@ input = 1.20
 output = 1.20
 
 [limit]
-context = 128_000
+context = 262_144
 output = 32_768
 
 [modalities]


### PR DESCRIPTION
We support 256k context length for the newest Kimi K2