### PR TITLE
feat: add Deepseek v3.1 Terminus

### DIFF
--- a/providers/openrouter/models/deepseek/deepseek-v3.1-terminus.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.1-terminus.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek V3.1 Terminus"
+release_date = "2025-09-22"
+last_updated = "2025-09-22"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.27
+output = 1.00
+
+[limit]
+context = 131_072
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
https://api-docs.deepseek.com/quick_start/pricing

The cut off date is copied from the existing 3.1 model.