### PR TITLE
feat: add github copilot gpt-5-codex

### DIFF
--- a/providers/github-copilot/models/gpt-5-codex.toml
+++ b/providers/github-copilot/models/gpt-5-codex.toml
@@ -1,0 +1,17 @@
+name = "GPT-5-Codex"
+release_date = "2025-09-15"
+last_updated = "2025-09-15"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2024-09-30"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Added github copilot gpt-5-codex, its on vscode now.
Not sure about the context limits, feel free to update it.

cc: @fwang 