### PR TITLE
Add Google/gemini-2.5-flash-lite.toml (separately from preview model)

### DIFF
--- a/providers/google/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/google/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -14,7 +14,7 @@ output = 0.40
 cache_read = 0.025
 
 [limit]
-context = 65_536
+context = 1_048_576
 output = 65_536
 
 [modalities]

--- a/providers/google/models/gemini-2.5-flash-lite.toml
+++ b/providers/google/models/gemini-2.5-flash-lite.toml
@@ -1,0 +1,22 @@
+name = "Gemini 2.5 Flash Lite"
+release_date = "2025-06-17"
+last_updated = "2025-06-17"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.10
+output = 0.40
+cache_read = 0.025
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "audio", "video", "pdf"]
+output = ["text"]


### PR DESCRIPTION
This PR adds `Gemini 2.5 Flash Lite`, as a separate model from `Gemini 2.5 Flash Lite Preview 06-17`

Data referenced from:
- https://cloud.google.com/vertex-ai/generative-ai/pricing
- https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-lite

<img width="899" height="371" alt="Screenshot 2025-09-23 at 10 26 29 PM" src="https://github.com/user-attachments/assets/e252f425-c8bc-4428-a3dd-90ef6ccddea2" />

Notes:
- Gemini 2.5 Flash Lite has special pricing for Audio Input, but don't see a way to represent that. 
- I updated the input context for  `gemini-2.5-flash-lite-preview-06-17.toml` . 
<img width="531" height="62" alt="Screenshot 2025-09-23 at 10 30 35 PM" src="https://github.com/user-attachments/assets/414d7b03-4d28-497e-ad57-3f81d56328cf" />
