### PR TITLE
Add Audio input/output tokens as special columns, filling in for Gemini 2.5 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ reasoning = 15.00           # Cost per million reasoning tokens (USD)
 cache_read = 0.30           # Cost per million cached read tokens (USD)
 cache_write = 3.75          # Cost per million cached write tokens (USD)
 input_audio = 1.00          # Cost per million audio input tokens (USD)
+output_audio = 10.00        # Cost per million audio output tokens (USD)
 
 [limit]
 context = 200_000           # Maximum context window (tokens)
@@ -157,6 +158,7 @@ Models must conform to the following schema, as defined in `app/schemas.ts`.
 - `cost.cache_read` _(optional)_: Number — Cost per million cached read tokens (USD)
 - `cost.cache_write` _(optional)_: Number — Cost per million cached write tokens (USD)
 - `cost.input_audio` _(optional)_: Number — Cost per million audio input tokens, if billed separately (USD)
+- `cost.output_audio` _(optional)_: Number — Cost per million audio output tokens, if billed separately (USD)
 - `limit.context`: Number — Maximum context window (tokens)
 - `limit.output`: Number — Maximum output tokens
 - `modalities.input`: Array of strings — Supported input modalities (e.g., ["text", "image", "audio", "video", "pdf"])

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ output = 15.00              # Cost per million output tokens (USD)
 reasoning = 15.00           # Cost per million reasoning tokens (USD)
 cache_read = 0.30           # Cost per million cached read tokens (USD)
 cache_write = 3.75          # Cost per million cached write tokens (USD)
+input_audio = 1.00          # Cost per million audio input tokens (USD)
 
 [limit]
 context = 200_000           # Maximum context window (tokens)
@@ -155,6 +156,7 @@ Models must conform to the following schema, as defined in `app/schemas.ts`.
 - `cost.reasoning` _(optional)_: Number — Cost per million reasoning tokens (USD)
 - `cost.cache_read` _(optional)_: Number — Cost per million cached read tokens (USD)
 - `cost.cache_write` _(optional)_: Number — Cost per million cached write tokens (USD)
+- `cost.input_audio` _(optional)_: Number — Cost per million audio input tokens, if billed separately (USD)
 - `limit.context`: Number — Maximum context window (tokens)
 - `limit.output`: Number — Maximum output tokens
 - `modalities.input`: Array of strings — Supported input modalities (e.g., ["text", "image", "audio", "video", "pdf"])

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -41,6 +41,10 @@ export const Model = z
           .number()
           .min(0, "Cache write price cannot be negative")
           .optional(),
+        input_audio_token: z
+          .number()
+          .min(0, "Audio input price cannot be negative")
+          .optional(),
       })
       .optional(),
     limit: z.object({

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -41,7 +41,7 @@ export const Model = z
           .number()
           .min(0, "Cache write price cannot be negative")
           .optional(),
-        input_audio_token: z
+        input_audio: z
           .number()
           .min(0, "Audio input price cannot be negative")
           .optional(),

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -45,6 +45,10 @@ export const Model = z
           .number()
           .min(0, "Audio input price cannot be negative")
           .optional(),
+        output_audio: z
+          .number()
+          .min(0, "Audio output price cannot be negative")
+          .optional(),
       })
       .optional(),
     limit: z.object({

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -287,6 +287,16 @@ export const Rendered = renderToString(
             </div>
           </th>
           <th class="sortable" data-type="number">
+            <div class="header-container">
+              <span class="header-text">
+                Audio Input Cost
+                <br />
+                <span class="desc">per 1M tokens</span>
+              </span>
+              <span class="sort-indicator"></span>
+            </div>
+          </th>
+          <th class="sortable" data-type="number">
             Context Limit <span class="sort-indicator"></span>
           </th>
           <th class="sortable" data-type="number">
@@ -398,6 +408,7 @@ export const Rendered = renderToString(
                   <td>{renderCost(model.cost?.reasoning)}</td>
                   <td>{renderCost(model.cost?.cache_read)}</td>
                   <td>{renderCost(model.cost?.cache_write)}</td>
+                  <td>{renderCost(model.cost?.input_audio_token)}</td>
                   <td>{model.limit.context.toLocaleString()}</td>
                   <td>{model.limit.output.toLocaleString()}</td>
                   <td>{model.temperature ? "Yes" : "No"}</td>

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -297,6 +297,16 @@ export const Rendered = renderToString(
             </div>
           </th>
           <th class="sortable" data-type="number">
+            <div class="header-container">
+              <span class="header-text">
+                Audio Output Cost
+                <br />
+                <span class="desc">per 1M tokens</span>
+              </span>
+              <span class="sort-indicator"></span>
+            </div>
+          </th>
+          <th class="sortable" data-type="number">
             Context Limit <span class="sort-indicator"></span>
           </th>
           <th class="sortable" data-type="number">
@@ -409,6 +419,7 @@ export const Rendered = renderToString(
                   <td>{renderCost(model.cost?.cache_read)}</td>
                   <td>{renderCost(model.cost?.cache_write)}</td>
                   <td>{renderCost(model.cost?.input_audio)}</td>
+                  <td>{renderCost(model.cost?.output_audio)}</td>
                   <td>{model.limit.context.toLocaleString()}</td>
                   <td>{model.limit.output.toLocaleString()}</td>
                   <td>{model.temperature ? "Yes" : "No"}</td>

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -408,7 +408,7 @@ export const Rendered = renderToString(
                   <td>{renderCost(model.cost?.reasoning)}</td>
                   <td>{renderCost(model.cost?.cache_read)}</td>
                   <td>{renderCost(model.cost?.cache_write)}</td>
-                  <td>{renderCost(model.cost?.input_audio_token)}</td>
+                  <td>{renderCost(model.cost?.input_audio)}</td>
                   <td>{model.limit.context.toLocaleString()}</td>
                   <td>{model.limit.output.toLocaleString()}</td>
                   <td>{model.temperature ? "Yes" : "No"}</td>

--- a/providers/google/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/google/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -12,6 +12,7 @@ open_weights = false
 input = 0.10
 output = 0.40
 cache_read = 0.025
+input_audio = 0.30
 
 [limit]
 context = 65_536

--- a/providers/google/models/gemini-2.5-flash.toml
+++ b/providers/google/models/gemini-2.5-flash.toml
@@ -12,7 +12,7 @@ open_weights = false
 input = 0.30
 output = 2.50
 cache_read = 0.075
-input_audio_token = 1.00
+input_audio = 1.00
 
 [limit]
 context = 1_048_576

--- a/providers/google/models/gemini-2.5-flash.toml
+++ b/providers/google/models/gemini-2.5-flash.toml
@@ -12,6 +12,7 @@ open_weights = false
 input = 0.30
 output = 2.50
 cache_read = 0.075
+input_audio_token = 1.00
 
 [limit]
 context = 1_048_576

--- a/providers/google/models/gemini-live-2.5-flash-preview-native-audio.toml
+++ b/providers/google/models/gemini-live-2.5-flash-preview-native-audio.toml
@@ -1,0 +1,24 @@
+name = "Gemini Live 2.5 Flash Preview Native Audio"
+release_date = "2025-06-17"
+last_updated = "2025-09-18"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-01"
+tool_call = true
+open_weights = false
+experimental = true
+
+[cost]
+input = 0.50
+output = 2.00
+input_audio = 3.00
+output_audio = 12.00
+
+[limit]
+context = 131_072
+output = 65_536
+
+[modalities]
+input = ["text", "audio", "video"]
+output = ["text", "audio"]


### PR DESCRIPTION
This PR adds  "Audio input cost" and "audio output cost" as special columns. 

As noted in https://github.com/sst/models.dev/pull/223, Gemini 2.5 Flash (and other models) have special input costs for Audio. This price isn't currently captured in Models.dev.

<img width="2266" height="668" alt="image" src="https://github.com/user-attachments/assets/a3c8ee07-ea9a-4f97-b4ba-882731cb1652" />

This PR proposes adds data for Gemini 2.5 Flash related to special input/output audio tokens, as well as a new model for "Gemini Live 2.5 Flash Preview Native Audio".

This approach is also taken by others such as LiteLLM -- see `input_cost_per_audio_token` in [this file](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json)
