### PR TITLE
chore(chutes): add zai-org/GLM-4.5-Turbo, deepseek-ai/DeepSeek-V3.1-Turbo

### DIFF
--- a/providers/chutes/models/deepseek-ai/DeepSeek-V3.1-Turbo.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V3.1-Turbo.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek V3.1 Turbo"
+release_date = "2025-08-21"
+last_updated = "2025-08-21"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.00
+output = 3.00
+
+[limit]
+context = 128000
+output = 128000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/chutes/models/zai-org/GLM-4.5-Turbo.toml
+++ b/providers/chutes/models/zai-org/GLM-4.5-Turbo.toml
@@ -1,0 +1,21 @@
+name = "GLM 4.5 Turbo"
+release_date = "2025-07-28"
+last_updated = "2025-07-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 1.00
+output = 3.00
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
<img width="1731" height="256" alt="image" src="https://github.com/user-attachments/assets/1e8d1955-c4ca-46d0-b891-1b7c23ced898" />
<img width="1739" height="225" alt="image" src="https://github.com/user-attachments/assets/1032a8ab-a58c-445e-8d1f-ed54544a9480" />
<img width="788" height="584" alt="image" src="https://github.com/user-attachments/assets/40135884-2ef9-4401-a273-0c00c07b5a6e" />

add model zai-org/GLM-4.5-Turbo, deepseek-ai/DeepSeek-V3.1-Turbo for chutes provider.
This model is hosted by chutes with fast tps