### PR TITLE
feat: Add OpenAI gpt-4o snapshot versions

### DIFF
--- a/providers/openai/models/gpt-4o-2024-05-13.toml
+++ b/providers/openai/models/gpt-4o-2024-05-13.toml
@@ -1,6 +1,6 @@
-name = "GPT-4o"
+name = "GPT-4o (2024-05-13)"
 release_date = "2024-05-13"
-last_updated = "2024-08-06"
+last_updated = "2024-05-13"
 attachment = true
 reasoning = false
 temperature = true
@@ -9,13 +9,12 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 2.50
-output = 10.00
-cache_read = 1.25
+input = 5.00
+output = 15.00
 
 [limit]
 context = 128_000
-output = 16_384
+output = 4_096
 
 [modalities]
 input = ["text", "image"]

--- a/providers/openai/models/gpt-4o-2024-08-06.toml
+++ b/providers/openai/models/gpt-4o-2024-08-06.toml
@@ -1,5 +1,5 @@
-name = "GPT-4o"
-release_date = "2024-05-13"
+name = "GPT-4o (2024-08-06)"
+release_date = "2024-08-06"
 last_updated = "2024-08-06"
 attachment = true
 reasoning = false

--- a/providers/openai/models/gpt-4o-2024-11-20.toml
+++ b/providers/openai/models/gpt-4o-2024-11-20.toml
@@ -1,6 +1,6 @@
-name = "GPT-4o"
-release_date = "2024-05-13"
-last_updated = "2024-08-06"
+name = "GPT-4o (2024-11-20)"
+release_date = "2024-11-20"
+last_updated = "2024-11-20"
 attachment = true
 reasoning = false
 temperature = true


### PR DESCRIPTION
Update OpenAI gpt-4o last updated date
Add all 3 snapshots of gpt-4o available through OpenAI

- [gpt-4o-2024-05-13](https://platform.openai.com/docs/models/gpt-4o?snapshot=gpt-4o-2024-05-13)
- [gpt-4o-2024-08-06](https://platform.openai.com/docs/models/gpt-4o?snapshot=gpt-4o-2024-08-06) (default) - current alias for `gpt-4o`
- [gpt-4o-2024-11-20](https://platform.openai.com/docs/models/gpt-4o?snapshot=gpt-4o-2024-11-20)

GPT 4o (2024-05-13) only supports 4,096 max output, with no cache support, and costs more than the other two snapshots.
<img width="969" height="404" alt="image" src="https://github.com/user-attachments/assets/926abbd7-9c2b-4539-9916-863703958375" />

The 11-20 and 08-06 snapshots are priced the same, with the same limits, and similar features; however, 11-20 does not support fine tuning.

Despite 11-20 being newer, 08-06 is the current default.
<img width="749" height="229" alt="image" src="https://github.com/user-attachments/assets/7034d59b-4d84-4228-a8b6-88c5b9d0b6ea" />