### PR TITLE
Google provider: Add additional env GEMINI_API_KEY

### DIFF
--- a/providers/google/provider.toml
+++ b/providers/google/provider.toml
@@ -1,4 +1,4 @@
 name = "Google"
-env = ["GOOGLE_GENERATIVE_AI_API_KEY"]
+env = ["GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"]
 npm = "@ai-sdk/google"
 doc = "https://ai.google.dev/gemini-api/docs/pricing"


### PR DESCRIPTION
This is the same env that Gemini CLI uses:

> Option 2: Gemini API Key
> ✨ Best for: Developers who need specific model control or paid tier access
>
> Benefits:
>
> Free tier: 100 requests/day with Gemini 2.5 Pro
> Model selection: Choose specific Gemini models
> Usage-based billing: Upgrade for higher limits when needed
> ```
> # Get your key from https://aistudio.google.com/apikey
> export GEMINI_API_KEY="YOUR_API_KEY"
> gemini
> ```

Source: https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#option-2-gemini-api-key

Inspired by https://github.com/sst/opencode/issues/600