### PR TITLE
Add Grok Code Fast 1 Model to xAI Provider

### DIFF
--- a/providers/xai/models/grok-code-fast-1.toml
+++ b/providers/xai/models/grok-code-fast-1.toml
@@ -1,0 +1,22 @@
+name = "Grok Code Fast 1"
+release_date = "2025-08-28"
+last_updated = "2025-08-28"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 1.50
+cache_read = 0.02
+
+[limit]
+context = 256_000
+output = 10_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds `Grok Code Fast 1` model to `xAI` provider. I am not 100% sure about the knowledge cutoff date but that is what the model reports when asked.