### PR TITLE
Add Grok 4 Fast models to Vercel Provider

### DIFF
--- a/providers/vercel/models/xai/grok-4-fast-non-reasoning.toml
+++ b/providers/vercel/models/xai/grok-4-fast-non-reasoning.toml
@@ -1,0 +1,1 @@
+../../../xai/models/grok-4-fast-non-reasoning.toml

--- a/providers/vercel/models/xai/grok-4-fast.toml
+++ b/providers/vercel/models/xai/grok-4-fast.toml
@@ -1,0 +1,1 @@
+../../../xai/models/grok-4-fast.toml


### PR DESCRIPTION
Add `Grok 4 Fast` models from `xAI` to `Vercel` provider via symlinks (like the other models).