### PR TITLE
Add GLM-4.6 to Hugging Face

### DIFF
--- a/providers/huggingface/models/zai-org/GLM-4.6.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.6.toml
@@ -1,0 +1,22 @@
+name = "GLM-4.6"
+release_date = "2025-09-30"
+last_updated = "2025-09-30"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.60
+output = 2.20
+cache_read = 0.11
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add Hugging Face metadata for zai-org/GLM-4.6 with 200K context window and 128K output tokens based on Z.ai documentation
- mark reasoning and tool capabilities while keeping the knowledge cutoff aligned with prior GLM releases
- set pricing fields to match Z.ai's published GLM-4.6 rates, including cached input pricing
