### PR TITLE
Add Claude Sonnet, Gemini 2.5 Pro models with special prices >200k tokens

### DIFF
--- a/providers/anthropic/models/claude-sonnet-4-20250514_prompt_greater_than_200k_tokens.toml
+++ b/providers/anthropic/models/claude-sonnet-4-20250514_prompt_greater_than_200k_tokens.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 6.00
+output = 22.50
+reasoning = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/anthropic/models/claude-sonnet-4-5-20250929_prompt_greater_than_200k_tokens.toml
+++ b/providers/anthropic/models/claude-sonnet-4-5-20250929_prompt_greater_than_200k_tokens.toml
@@ -1,0 +1,23 @@
+name = "Claude Sonnet 4.5"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-07-31"
+open_weights = false
+
+[cost]
+input = 6.00
+output = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google/models/gemini-2.5-pro_prompt_greater_than_200k_tokens.toml
+++ b/providers/google/models/gemini-2.5-pro_prompt_greater_than_200k_tokens.toml
@@ -1,0 +1,22 @@
+name = "Gemini 2.5 Pro"
+release_date = "2025-03-20"
+last_updated = "2025-06-05"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.625
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "audio", "video", "pdf"]
+output = ["text"]


### PR DESCRIPTION
There are a couple of major models that have special prices above 200k: 
- Claude Sonnet 4
- Claude Sonnet 4.5
- Gemini 2.5 Pro

<img width="402" height="612" alt="Screenshot 2025-09-30 at 5 50 14 PM" src="https://github.com/user-attachments/assets/c677de93-b257-4226-90f9-e14d28233504" />
<img width="913" height="543" alt="Screenshot 2025-09-30 at 5 50 08 PM" src="https://github.com/user-attachments/assets/a6d88109-5881-416c-8140-d75d7ea7cf2d" />

There are a couple of approaches here:
1. The approach taken by, e.g., [llm-prices.com](https://www.llm-prices.com/), which is to make the 200k models their own row 
<img width="673" height="88" alt="Screenshot 2025-09-30 at 5 51 00 PM" src="https://github.com/user-attachments/assets/cc64f35b-ebab-4a59-8ac4-4863185dd450" />

2. The approach taken by, e.g., LiteLLM, which is to [add columns](https://github.com/BerriAI/litellm/blob/f205b2c0a586dad6403d95a2b627008511065f25/model_prices_and_context_window.json#L563) for the special prices
<img width="447" height="302" alt="Screenshot 2025-09-30 at 5 52 01 PM" src="https://github.com/user-attachments/assets/16ac6e74-5e67-4d86-9585-b0bcd968a87b" />

3. A more comprehensive solution, in which models can have special pricing columns that don't apply to all columns (say, a hash of `special_prices`). 

In this PR, I implemented option 1 since I thought it was the least disruptive. LMK thoughts! 


```
Gemini 2.5 Pro:
  - Input: $1.25 → $2.50
  - Output: $10.00 → $15.00
  - Cache read: $0.31 → $0.625

  Sonnet 4:
  - Input: $3.00 → $6.00
  - Output: $15.00 → $22.50
  - Cache read: $0.30 → $0.60
  - Cache write: $3.75 → $7.50

  Sonnet 4.5:
  - Input: $3.00 → $6.00
  - Output: $15.00 → $22.50
  - Cache read: $0.30 → $0.60
  - Cache write: $3.75 → $7.50
```