### PR TITLE
Remove reasoning prices for Sonnet 4.5

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -11,7 +11,6 @@ open_weights = false
 [cost]
 input = 3.00
 output = 15.00
-reasoning = 15.00
 cache_read = 0.30
 cache_write = 3.75
 

--- a/providers/anthropic/models/claude-sonnet-4-5-20250929.toml
+++ b/providers/anthropic/models/claude-sonnet-4-5-20250929.toml
@@ -11,7 +11,6 @@ open_weights = false
 [cost]
 input = 3.00
 output = 15.00
-reasoning = 15.00
 cache_read = 0.30
 cache_write = 3.75
 

--- a/providers/opencode/models/claude-sonnet-4-5.toml
+++ b/providers/opencode/models/claude-sonnet-4-5.toml
@@ -11,7 +11,6 @@ open_weights = false
 [cost]
 input = 3.00
 output = 15.00
-reasoning = 15.00
 cache_read = 0.30
 cache_write = 3.75
 

--- a/providers/opencode/models/claude-sonnet-4.toml
+++ b/providers/opencode/models/claude-sonnet-4.toml
@@ -11,7 +11,6 @@ open_weights = false
 [cost]
 input = 3.00
 output = 15.00
-reasoning = 15.00
 cache_read = 0.30
 cache_write = 3.75
 


### PR DESCRIPTION
Sonnet 4.5 does not have special pricing for reasoning tokens -- I believe these are incorrect. 
<img width="419" height="626" alt="Screenshot 2025-09-30 at 5 57 34 PM" src="https://github.com/user-attachments/assets/0ad4948f-09c1-4d2c-9f67-0d4e8f4b2e08" />
