### PR TITLE
fix (github-copilot): Updated ai-sdk npm package to one that supports codex and `responses` path

### DIFF
--- a/providers/github-copilot/provider.toml
+++ b/providers/github-copilot/provider.toml
@@ -2,4 +2,3 @@ name = "GitHub Copilot"
 env = ["GITHUB_TOKEN"]
 npm = "@opeoginni/github-copilot-openai-compatible"
 doc = "https://docs.github.com/en/copilot"
-api= "https://api.githubcopilot.com"

--- a/providers/github-copilot/provider.toml
+++ b/providers/github-copilot/provider.toml
@@ -1,5 +1,5 @@
 name = "GitHub Copilot"
 env = ["GITHUB_TOKEN"]
-npm = "@ai-sdk/openai-compatible"
+npm = "@opeoginni/github-copilot-openai-compatible"
 doc = "https://docs.github.com/en/copilot"
 api= "https://api.githubcopilot.com"


### PR DESCRIPTION
I ended up creating a custom Provider following the [docs](https://ai-sdk.dev/providers/openai-compatible-providers/custom-providers).

It is [`@opeoginni/github-copilot-openai-compatible`](https://www.npmjs.com/package/@opeoginni/github-copilot-openai-compatible?activeTab=readme) and the repo is [here](https://github.com/OpeOginni/github-copilot-openai-compatible).

This should solve the issue https://github.com/sst/opencode/issues/2758
