### PR TITLE
Add GLM-4.6 to Synthetic's model listing

### DIFF
--- a/providers/synthetic/models/hf:zai-org/GLM-4.6.toml
+++ b/providers/synthetic/models/hf:zai-org/GLM-4.6.toml
@@ -1,0 +1,21 @@
+name = "GLM 4.6"
+release_date = "2025-09-30"
+last_updated = "2025-09-30"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.55
+output = 2.19
+
+[limit]
+context = 200_000
+output = 96_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds GLM-4.6 to Synthetic's hosting listing. We launched support on Sept 30th, and figured it's time to update models.dev with it.