### PR TITLE
Add gemini-2.5-flash-image pricing 

### DIFF
--- a/providers/google/models/gemini-2.5-flash-image-preview.toml
+++ b/providers/google/models/gemini-2.5-flash-image-preview.toml
@@ -1,0 +1,22 @@
+name = "Gemini 2.5 Flash Image (Preview)"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.30
+output = 30
+cache_read = 0.075
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]

--- a/providers/google/models/gemini-2.5-flash-image.toml
+++ b/providers/google/models/gemini-2.5-flash-image.toml
@@ -1,0 +1,22 @@
+name = "Gemini 2.5 Flash Image"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.30
+output = 30
+cache_read = 0.075
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]


### PR DESCRIPTION
Adds support for gemini-2.5-flash-image (recently taken out of preview!)
 
Sources

https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash-image
<img width="797" height="525" alt="gemini-2 5-flash-image" src="https://github.com/user-attachments/assets/39c46869-4fa2-4405-a18d-63877f095883" />

https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-image
<img width="661" height="696" alt="gemini-2 5-flash-image2" src="https://github.com/user-attachments/assets/cbc98900-422b-4392-b19a-b7aa858373fd" />
