### PR TITLE
Add Gemini Live 2.5 Flash

### DIFF
--- a/providers/google/models/gemini-live-2.5-flash.toml
+++ b/providers/google/models/gemini-live-2.5-flash.toml
@@ -1,0 +1,23 @@
+name = "Gemini Live 2.5 Flash"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.50
+output = 2.00
+input_audio = 3.00
+output_audio = 12.00
+
+[limit]
+context = 128_000
+output = 8_000
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text", "audio"]


### PR DESCRIPTION
Adds `gemini-live-2.5-flash-preview`   

(This is my best interpretation of the model specs/pricing, though the specs page contains data for a few `live` models)

Pricing: https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash
<img width="744" height="389" alt="Screenshot 2025-10-03 at 6 20 48 PM" src="https://github.com/user-attachments/assets/9a53aee9-e2cd-44d3-bebd-c90c4ef4b89d" />

Specs: 
https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-live
<img width="722" height="709" alt="Screenshot 2025-10-03 at 6 21 03 PM" src="https://github.com/user-attachments/assets/99394ba6-d96b-469f-b8b2-d69ae1507372" />
