### PR TITLE
Rename google-vertex-anthropic to avoid conflict with google-vertex

### DIFF
--- a/providers/google-vertex-anthropic/provider.toml
+++ b/providers/google-vertex-anthropic/provider.toml
@@ -1,4 +1,4 @@
-name = "Vertex"
+name = "Vertex (Anthropic)"
 env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]
 npm = "@ai-sdk/google-vertex"
 doc = "https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude"


### PR DESCRIPTION
Related to https://github.com/sst/opencode/pull/2347

Since both google-vertex and google-vertex-anthropic are named `Vertex`, it's tricky for users to tell them apart.

### Side notes

Maybe we should merge google-vertex-anthropic to google-vertex as amazon-bedrock is.