### PR TITLE
Add Kimi K2 0905 model to NVIDIA provider

### DIFF
--- a/providers/nvidia/models/moonshotai/kimi-k2-0905-preview.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k2-0905-preview.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2 0905"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = true
+
+[cost]
+input = 0.6
+output = 2.5
+cache_read = 0.15
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nvidia/models/moonshotai/kimi-k2-0905-preview.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k2-0905-preview.toml
@@ -9,9 +9,8 @@ knowledge = "2024-10"
 open_weights = true
 
 [cost]
-input = 0.6
-output = 2.5
-cache_read = 0.15
+input = 0.0
+output = 0.0
 
 [limit]
 context = 262_144


### PR DESCRIPTION
- Added moonshotai/kimi-k2-0905-preview.toml to NVIDIA provider
- Model is open source and available through NVIDIA's API
- Same specifications as the original MoonshotAI provider version