### PR TITLE
Change model name to 'GPT OSS 20B' and update costs

### DIFF
--- a/providers/chutes/models/openai/gpt-oss-20b
+++ b/providers/chutes/models/openai/gpt-oss-20b
@@ -1,0 +1,20 @@
+name = "GPT OSS 20B"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Updated model name and cost values for GPT OSS 20B.