### PR TITLE
update github copilot model limits to match api

### DIFF
--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -9,7 +9,7 @@ tool_call = true
 open_weights = false
 
 [limit]
-context = 128_000
+context = 144_000
 output = 16_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-sonnet-4.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.toml
@@ -9,7 +9,7 @@ tool_call = true
 open_weights = false
 
 [limit]
-context = 128_000
+context = 216_000
 output = 16_000
 
 [modalities]

--- a/providers/github-copilot/models/gpt-4o.toml
+++ b/providers/github-copilot/models/gpt-4o.toml
@@ -10,7 +10,7 @@ open_weights = false
 
 [limit]
 context = 128_000
-output = 16_384
+output = 4_096
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/gpt-5-mini.toml
+++ b/providers/github-copilot/models/gpt-5-mini.toml
@@ -9,7 +9,7 @@ tool_call = true
 open_weights = false
 
 [limit]
-context = 128_000
+context = 264_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/gpt-5.toml
+++ b/providers/github-copilot/models/gpt-5.toml
@@ -9,7 +9,7 @@ tool_call = true
 open_weights = false
 
 [limit]
-context = 128_000
+context = 264_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/grok-code-fast-1.toml
+++ b/providers/github-copilot/models/grok-code-fast-1.toml
@@ -9,8 +9,8 @@ tool_call = true
 open_weights = false
 
 [limit]
-context = 256_000
-output = 10_000
+context = 128_000
+output = 64_000
 
 [modalities]
 input = ["text"]

--- a/providers/github-copilot/models/o3-mini.toml
+++ b/providers/github-copilot/models/o3-mini.toml
@@ -9,8 +9,8 @@ tool_call = false
 open_weights = false
 
 [limit]
-context = 128_000
-output = 65_536
+context = 200_000
+output = 100_000
 
 [modalities]
 input = ["text"]

--- a/providers/github-copilot/models/o4-mini.toml
+++ b/providers/github-copilot/models/o4-mini.toml
@@ -10,7 +10,7 @@ open_weights = false
 
 [limit]
 context = 128_000
-output = 65_536
+output = 16_384
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Following up on #310

Updated context and output token limits for grok-code-fast-1, o3-mini, o4-mini, gpt-4o, gpt-5/mini, and claude-sonnet-4/4.5 to match  `max_context_window_tokens` and `max_output_tokens` from https://api.githubcopilot.com/models