### PR TITLE
Add Embedding Models

### DIFF
--- a/providers/google-vertex/models/gemini-embedding-001.toml
+++ b/providers/google-vertex/models/gemini-embedding-001.toml
@@ -10,6 +10,7 @@ open_weights = false
 
 [cost]
 input = 0.15
+output = 0.00
 
 [limit]
 context = 2_048

--- a/providers/google-vertex/models/gemini-embedding-001.toml
+++ b/providers/google-vertex/models/gemini-embedding-001.toml
@@ -1,0 +1,20 @@
+name = "Gemini Embedding 001"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2025-05"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.15
+
+[limit]
+context = 2_048
+output = 3_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/google/models/gemini-embedding-001.toml
+++ b/providers/google/models/gemini-embedding-001.toml
@@ -10,6 +10,7 @@ open_weights = false
 
 [cost]
 input = 0.15
+output = 0.00
 
 [limit]
 context = 2_048

--- a/providers/google/models/gemini-embedding-001.toml
+++ b/providers/google/models/gemini-embedding-001.toml
@@ -1,0 +1,20 @@
+name = "Gemini Embedding 001"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2025-05"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.15
+
+[limit]
+context = 2_048
+output = 3_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/huggingface/models/Qwen/Qwen3-Embedding-4B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Embedding-4B.toml
@@ -1,0 +1,21 @@
+name = "Qwen 3 Embedding 4B"
+release_date = "2025-01-01"
+last_updated = "2025-01-01"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2024-12"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.00
+
+[limit]
+context = 32_000
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/huggingface/models/Qwen/Qwen3-Embedding-8B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Embedding-8B.toml
@@ -1,0 +1,21 @@
+name = "Qwen 3 Embedding 4B"
+release_date = "2025-01-01"
+last_updated = "2025-01-01"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2024-12"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.00
+
+[limit]
+context = 32_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nvidia/models/nvidia/llama-embed-nemotron-8b.toml
+++ b/providers/nvidia/models/nvidia/llama-embed-nemotron-8b.toml
@@ -1,0 +1,21 @@
+name = "Llama Embed Nemotron 8B"
+release_date = "2025-03-18"
+last_updated = "2025-03-18"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2025-03"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 32_768
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openai/models/text-embedding-3-large.toml
+++ b/providers/openai/models/text-embedding-3-large.toml
@@ -1,0 +1,20 @@
+name = "text-embedding-3-large"
+release_date = "2024-01-25"
+last_updated = "2024-01-25"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2024-01"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.13
+
+[limit]
+context = 8_191
+output = 3_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openai/models/text-embedding-3-large.toml
+++ b/providers/openai/models/text-embedding-3-large.toml
@@ -10,6 +10,7 @@ open_weights = false
 
 [cost]
 input = 0.13
+output = 0.00
 
 [limit]
 context = 8_191

--- a/providers/openai/models/text-embedding-3-small.toml
+++ b/providers/openai/models/text-embedding-3-small.toml
@@ -10,6 +10,7 @@ open_weights = false
 
 [cost]
 input = 0.02
+output = 0.00
 
 [limit]
 context = 8_191

--- a/providers/openai/models/text-embedding-3-small.toml
+++ b/providers/openai/models/text-embedding-3-small.toml
@@ -1,0 +1,20 @@
+name = "text-embedding-3-small"
+release_date = "2024-01-25"
+last_updated = "2024-01-25"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2024-01"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.02
+
+[limit]
+context = 8_191
+output = 1_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openai/models/text-embedding-ada-002.toml
+++ b/providers/openai/models/text-embedding-ada-002.toml
@@ -10,6 +10,7 @@ open_weights = false
 
 [cost]
 input = 0.10
+output = 0.00
 
 [limit]
 context = 8_192

--- a/providers/openai/models/text-embedding-ada-002.toml
+++ b/providers/openai/models/text-embedding-ada-002.toml
@@ -1,0 +1,20 @@
+name = "text-embedding-ada-002"
+release_date = "2022-12-15"
+last_updated = "2022-12-15"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2022-12"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.10
+
+[limit]
+context = 8_192
+output = 1_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Closes: https://github.com/sst/models.dev/issues/304

Adds following models:
- `gemini-embedding-001`
- `Qwen3-Embedding-4B`
- `Qwen3-Embedding-8B`
- `llama-embed-nemotron-8b`
- `text-embedding-3-large`
- `text-embedding-3-small`