### PR TITLE
Add `gpt-5-pro` model cards for openai and openrouter providers

### DIFF
--- a/providers/openai/models/gpt-5-pro.toml
+++ b/providers/openai/models/gpt-5-pro.toml
@@ -1,0 +1,21 @@
+name = "GPT-5 Pro"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-09-30"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 15.00
+output = 120.00
+
+[limit]
+context = 400_000
+output = 272_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openai/models/gpt-5-pro.toml
+++ b/providers/openai/models/gpt-5-pro.toml
@@ -1,6 +1,6 @@
 name = "GPT-5 Pro"
-release_date = "2025-08-07"
-last_updated = "2025-08-07"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
 attachment = true
 reasoning = true
 temperature = false

--- a/providers/openrouter/models/openai/gpt-5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5-pro.toml
@@ -1,0 +1,21 @@
+name = "GPT-5 Pro"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-09-30"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 15.00
+output = 120.00
+
+[limit]
+context = 400_000
+output = 272_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5-pro.toml
@@ -1,6 +1,6 @@
 name = "GPT-5 Pro"
-release_date = "2025-08-07"
-last_updated = "2025-08-07"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
 attachment = true
 reasoning = true
 temperature = false


### PR DESCRIPTION
This powerful (but slow and expensive) model brings sota reasoning capabilities, it is crucial in math-heavy fields.

**OpenAI model reference**
https://platform.openai.com/docs/models/gpt-5-pro

**OpenRouter model reference**
https://openrouter.ai/openai/gpt-5-pro

<img width="951" height="245" alt="image" src="https://github.com/user-attachments/assets/b4bd8ae4-1860-4e4d-870b-100db0bb02be" />

<img width="300" height="174" alt="image" src="https://github.com/user-attachments/assets/01e66894-b588-4e54-a521-1b34023c1055" />
