### PR TITLE
Added: MiniMax-M2 from Synthetic.new , update token limits on GLM

### DIFF
--- a/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.toml
+++ b/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.toml
@@ -1,11 +1,11 @@
-name = "GLM 4.6"
-release_date = "2025-09-30"
-last_updated = "2025-09-30"
+name = "Minimax-M2"
+release_date = "2025-10-27"
+last_updated = "2025-10-27"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-04"
+# knowledge = "2025-04" # Not listed on model page.
 open_weights = true
 
 [cost]
@@ -13,7 +13,7 @@ input = 0.55
 output = 2.19
 
 [limit]
-context = 200_000
+context = 196_608
 output = 64_000
 
 [modalities]


### PR DESCRIPTION
Yeppers! This one uses capitals `hf:MiniMaxAI`, unlike the others. See with GET `https://api.synthetic.new/openai/v1/models` (https://dev.synthetic.new/docs/openai/models)

```json
{
  "data": [
    {
      "id": "hf:zai-org/GLM-4.6",
      "object": "model"
    },
    {
      "id": "hf:MiniMaxAI/MiniMax-M2",
      "object": "model"
    },
```

The limits- 64k output on self-hosted models, and 196_608 tokens are directly obtained from 1st party source.
Currently GLM4.6 and Minimax M2 are self hosted.

The output limit isn't yet enforced for M2, but if it will be, this will be the limit

> It's 196608 tokens, which is 192 * 1024 (192 Kibi-tokens), so they're both right  . I think 192k is the more standard notation though

> ah yes, if it's for GLM-4.6, please change to 64k, which is a limit we've added recently to preserve performance for all users. However we don't actually limit non-self-hosted models, so all other models it can be as high as the model is capable of

> we don't actually enforce for MiniMax-M2 yet, but may do in future so fair to set 64k for that as well

quoted from @billycao at Synthetic