### PR TITLE
Add AWS Bedrock Deepseek v3.1 and Qwen models

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ temperature = true          # or false - supports temperature control
 knowledge = "2024-04"       # Knowledge-cutoff date
 release_date = "2025-02-19" # First public release date
 last_updated = "2025-02-19" # Most recent update date
+open_weights = true         # or false  - model’s trained weights are publicly available
 
 [cost]
 input = 3.00                # Cost per million input tokens (USD)
@@ -152,6 +153,7 @@ Models must conform to the following schema, as defined in `app/schemas.ts`.
 - `knowledge` _(optional)_: String — Knowledge-cutoff date in `YYYY-MM` or `YYYY-MM-DD` format
 - `release_date`: String — First public release date in `YYYY-MM` or `YYYY-MM-DD`
 - `last_updated`: String — Most recent update date in `YYYY-MM` or `YYYY-MM-DD`
+- `open_weights` _(optional)_: Boolean - Indicate the model’s trained weights are publicly available
 - `cost.input` _(optional)_: Number — Cost per million input tokens (USD)
 - `cost.output` _(optional)_: Number — Cost per million output tokens (USD)
 - `cost.reasoning` _(optional)_: Number — Cost per million reasoning tokens (USD)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Models must conform to the following schema, as defined in `app/schemas.ts`.
 - `knowledge` _(optional)_: String — Knowledge-cutoff date in `YYYY-MM` or `YYYY-MM-DD` format
 - `release_date`: String — First public release date in `YYYY-MM` or `YYYY-MM-DD`
 - `last_updated`: String — Most recent update date in `YYYY-MM` or `YYYY-MM-DD`
-- `open_weights` _(optional)_: Boolean - Indicate the model’s trained weights are publicly available
+- `open_weights`: Boolean - Indicate the model's trained weights are publicly available
 - `cost.input` _(optional)_: Number — Cost per million input tokens (USD)
 - `cost.output` _(optional)_: Number — Cost per million output tokens (USD)
 - `cost.reasoning` _(optional)_: Number — Cost per million reasoning tokens (USD)

--- a/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek-V3.1"
+release_date = "2025-09-18"
+last_updated = "2025-09-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.58
+output = 1.68
+
+[limit]
+context = 163_840
+output = 81_920
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 235B A22B 2507"
+release_date = "2025-09-18"
+last_updated = "2025-09-18"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 0.88
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 32B (dense)"
+release_date = "2025-09-18"
+last_updated = "2025-09-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+context = 16_384
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 Coder 30B A3B Instruct"
+release_date = "2025-09-18"
+last_updated = "2025-09-18"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 Coder 480B A35B Instruct"
+release_date = "2025-09-18"
+last_updated = "2025-09-18"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 1.8
+
+[limit]
+context = 131_072
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
AWS Bedrock Qwen models announcement: https://aws.amazon.com/blogs/aws/qwen-models-are-now-available-in-amazon-bedrock/
AWS Bedrock Deepseek model announcement: https://aws.amazon.com/blogs/aws/deepseek-v3-1-now-available-in-amazon-bedrock/

### AWS Bedrock Deepseek
- deepseek.v3-v1:0

### AWS Bedrock Qwen
 - qwen.qwen3-32b-v1:0
 - qwen.qwen3-235b-a22b-2507-v1:0
 - qwen.qwen3-coder-30b-a3b-v1:0
 - qwen.qwen3-coder-480b-a35b-v1:0
 
 ### Readme
 - Added open_weights example to README.md