### PR TITLE
Add cerebras zai glm 4 6

### DIFF
--- a/providers/cerebras/models/zai-glm-4.6.toml
+++ b/providers/cerebras/models/zai-glm-4.6.toml
@@ -1,6 +1,6 @@
 name = "Z.AI GLM-4.6"
-release_date = "2025-01-15"
-last_updated = "2025-01-15"
+release_date = "2025-11-05"
+last_updated = "2025-11-05"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/cerebras/models/zai-glm-4.6.toml
+++ b/providers/cerebras/models/zai-glm-4.6.toml
@@ -1,0 +1,23 @@
+name = "Z.AI GLM-4.6"
+release_date = "2025-01-15"
+last_updated = "2025-01-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 131_072
+output = 40_960
+
+[modalities]
+input = ["text"]
+output = ["text"]
+


### PR DESCRIPTION
Adding zai-glm-4.6 as a model for Cerebras.

This will go live on Nov. 5th, and replace Qwen 3 Coder, which will be deprecated.