### PR TITLE
Add MiniMax-M2 model to NVIDIA provider

### DIFF
--- a/providers/nvidia/models/minimaxai/minimax-m2.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m2.toml
@@ -1,0 +1,21 @@
+name = "MiniMax-M2"
+release_date = "2025-10-27"
+last_updated = "2025-10-31"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add MiniMax-M2 model to NVIDIA provider with proper configuration
- 128K context window and 16K output tokens (NVIDIA NIM specific limits)
- Supports reasoning, tool calling, and temperature control
- Open weights model with MIT license

## Details
The MiniMax-M2 is a compact Mixture-of-Experts (MoE) model with 230B total parameters and 10B active parameters, optimized for coding and agentic tasks. This configuration follows the NVIDIA NIM API specifications and differentiates from other providers by offering specific context/output limits.

## Model Specifications
- **Architecture**: Mixture-of-Experts (MoE) Transformer
- **Context**: 128,000 tokens
- **Output**: 16,384 tokens  
- **Features**: Reasoning, tool calling, temperature control
- **License**: MIT (open weights)
- **Knowledge cutoff**: July 2024

Based on: https://build.nvidia.com/minimaxai/minimax-m2