### PR TITLE
Added new glm4.6 model to venice

### DIFF
--- a/providers/venice/models/zai-org-glm-4.6.toml
+++ b/providers/venice/models/zai-org-glm-4.6.toml
@@ -1,0 +1,21 @@
+name = "GLM 4.6"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+knowledge = "2024-04"
+release_date = "2025-09-30"
+last_updated = "2025-09-30"
+open_weights = true
+
+[cost]
+input = 0.85
+output = 2.75
+
+[limit]
+context = 202752
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/venice/models/zai-org-glm-4.6.toml
+++ b/providers/venice/models/zai-org-glm-4.6.toml
@@ -13,8 +13,8 @@ input = 0.85
 output = 2.75
 
 [limit]
-context = 202752
-output = 8192
+context = 202_752
+output = 8_192
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Venice has released GLM 4.6, which should be made available.

Heres the x post announcing it
https://x.com/AskVenice/status/1985421776516427802

It is also in the documentation here
https://docs.venice.ai/overview/models

From api
`{
      "created": 1711929600,
      "id": "zai-org-glm-4.6",
      "model_spec": {
        "pricing": {
          "input": {
            "usd": 0.85,
            "diem": 0.85
          },
          "output": {
            "usd": 2.75,
            "diem": 2.75
          }
        },
        "availableContextTokens": 202752,
        "capabilities": {
          "optimizedForCode": false,
          "quantization": "fp8",
          "supportsFunctionCalling": true,
          "supportsReasoning": false,
          "supportsResponseSchema": true,
          "supportsVision": false,
          "supportsWebSearch": true,
          "supportsLogProbs": false
        },
        "constraints": {
          "temperature": {
            "default": 0.7
          },
          "top_p": {
            "default": 0.9
          }
        },
        "name": "GLM 4.6",
        "modelSource": "https://huggingface.co/zai-org/GLM-4.6",
        "offline": false,
        "traits": []
      },
      "object": "model",
      "owned_by": "venice.ai",
      "type": "text"
    },`