### PR TITLE
Add MiniMax M2 model to vercel

### DIFF
--- a/providers/vercel/models/minimax/minimax-m2.toml
+++ b/providers/vercel/models/minimax/minimax-m2.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2"
+release_date = "2025-10-27"
+last_updated = "2025-10-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 205000
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
model page: https://vercel.com/ai-gateway/models/minimax-m2

i copied most contents from `providers/opencode/models/minimax-m2.toml`, and changed context to 205000 according to the raw data in vercel's page:

```
{
  "slug": "minimax-m2",
  "displayName": "MiniMax M2",
  "creatorOrganization": "minimax",
  "type": "chat",
  "providers": [
    "minimax"
  ],
  "copyString": "minimax/minimax-m2",
  "description": "MiniMax-M2 redefines efficiency for agents. It is a compact, fast, and cost-effective MoE model (230 billion total parameters with 10 billion active parameters) built for elite performance in coding and agentic tasks, all while maintaining powerful general intelligence.",
  "isAggregated": true,
  "contextSize": 205000,
  "inputCost": "0",
  "outputCost": "0",
  "cachedInputCost": "$undefined",
  "cacheCreationInputCost": "$undefined",
  "tags": [
    "reasoning",
    "tool-use"
  ]
}
```