### PR TITLE
Add Kimi K2 thinking models

### DIFF
--- a/providers/moonshotai-cn/models/kimi-k2-thinking-turbo.toml
+++ b/providers/moonshotai-cn/models/kimi-k2-thinking-turbo.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2 Thinking Turbo"
+release_date = "2025-11-06"
+last_updated = "2025-11-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-08"
+open_weights = true
+
+[cost]
+input = 1.15
+output = 8
+cache_read = 0.15
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/moonshotai-cn/models/kimi-k2-thinking.toml
+++ b/providers/moonshotai-cn/models/kimi-k2-thinking.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2 Thinking"
+release_date = "2025-11-06"
+last_updated = "2025-11-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-08"
+open_weights = true
+
+[cost]
+input = 0.6
+output = 2.5
+cache_read = 0.15
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/moonshotai/models/kimi-k2-thinking-turbo.toml
+++ b/providers/moonshotai/models/kimi-k2-thinking-turbo.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2 Thinking Turbo"
+release_date = "2025-11-06"
+last_updated = "2025-11-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-08"
+open_weights = true
+
+[cost]
+input = 1.15
+output = 8
+cache_read = 0.15
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/moonshotai/models/kimi-k2-thinking.toml
+++ b/providers/moonshotai/models/kimi-k2-thinking.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2 Thinking"
+release_date = "2025-11-06"
+last_updated = "2025-11-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-08"
+open_weights = true
+
+[cost]
+input = 0.6
+output = 2.5
+cache_read = 0.15
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2 Thinking"
+release_date = "2025-11-06"
+last_updated = "2025-11-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-08"
+open_weights = true
+
+[cost]
+input = 0.6
+output = 2.5
+cache_read = 0.15
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds Moonshot AI's new Kimi K2 thinking models released on November 6, 2025.

### Models Added

**Moonshot AI (Global):**
- `kimi-k2-thinking` - Full thinking model
- `kimi-k2-thinking-turbo` - Premium/faster thinking model

**Moonshot AI (China):**
- `kimi-k2-thinking` - Full thinking model  
- `kimi-k2-thinking-turbo` - Premium/faster thinking model

**OpenRouter:**
- `moonshotai/kimi-k2-thinking` - Full thinking model via OpenRouter

### Key Features

- **Reasoning**: Deep multi-step thinking with chain-of-thought capabilities
- **Context**: 256K tokens (262,144) for both input and output
- **Tool Calling**: Native support for function calls and tool orchestration
- **Knowledge Cutoff**: 2024-08
- **Open Weights**: Available as open-source models

### Pricing

- **kimi-k2-thinking**: $0.60/M input, $2.50/M output, $0.15/M cache read
- **kimi-k2-thinking-turbo**: $1.15/M input, $8/M output, $0.15/M cache read

### References

- [HuggingFace Model Card](https://huggingface.co/moonshotai/Kimi-K2-Thinking)
- [Technical Blog](https://moonshotai.github.io/Kimi-K2/thinking.html)