### PR TITLE
add OpenAI models for Deep Infra

### DIFF
--- a/providers/deepinfra/models/openai/gpt-oss-120b.toml
+++ b/providers/deepinfra/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,23 @@
+# https://deepinfra.com/openai/gpt-oss-120b
+
+name = "GPT OSS 120B"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.24
+
+[limit]
+context = 131_072
+# https://deepinfra.com/docs/advanced/max_tokens_limit
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/deepinfra/models/openai/gpt-oss-20b.toml
+++ b/providers/deepinfra/models/openai/gpt-oss-20b.toml
@@ -1,0 +1,23 @@
+# https://deepinfra.com/openai/gpt-oss-20b
+
+name = "GPT OSS 20B"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.14
+
+[limit]
+context = 131_072
+# https://deepinfra.com/docs/advanced/max_tokens_limit
+output = 16_384	
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add [GPT OSS 120B](https://deepinfra.com/openai/gpt-oss-120b) and [GPT OSS 20B](https://deepinfra.com/openai/gpt-oss-20b) to Deep Infra models.