### PR TITLE
feat: add structured_output

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ name = "Model Display Name"
 attachment = true           # or false - supports file attachments
 reasoning = false           # or true - supports reasoning / chain-of-thought
 tool_call = true            # or false - supports tool calling
-structured_output = true    # or false - supports a dedicated structured output feature (optional)
+structured_output = true    # or false - supports a dedicated structured output feature
 temperature = true          # or false - supports temperature control
 knowledge = "2024-04"       # Knowledge-cutoff date
 release_date = "2025-02-19" # First public release date
@@ -150,8 +150,8 @@ Models must conform to the following schema, as defined in `app/schemas.ts`.
 - `attachment`: Boolean — Supports file attachments
 - `reasoning`: Boolean — Supports reasoning / chain-of-thought
 - `tool_call`: Boolean - Supports tool calling
-- `structured_output`: Boolean — Supports structured output feature
-- `temperature`: Boolean — Supports temperature control
+- `structured_output` _(optional)_: Boolean — Supports structured output feature
+- `temperature` _(optional)_: Boolean — Supports temperature control
 - `knowledge` _(optional)_: String — Knowledge-cutoff date in `YYYY-MM` or `YYYY-MM-DD` format
 - `release_date`: String — First public release date in `YYYY-MM` or `YYYY-MM-DD`
 - `last_updated`: String — Most recent update date in `YYYY-MM` or `YYYY-MM-DD`

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ name = "Model Display Name"
 attachment = true           # or false - supports file attachments
 reasoning = false           # or true - supports reasoning / chain-of-thought
 tool_call = true            # or false - supports tool calling
+structured_output = true    # or false - supports a dedicated structured output feature (optional)
 temperature = true          # or false - supports temperature control
 knowledge = "2024-04"       # Knowledge-cutoff date
 release_date = "2025-02-19" # First public release date
@@ -149,6 +150,7 @@ Models must conform to the following schema, as defined in `app/schemas.ts`.
 - `attachment`: Boolean — Supports file attachments
 - `reasoning`: Boolean — Supports reasoning / chain-of-thought
 - `tool_call`: Boolean - Supports tool calling
+- `structured_output`: Boolean — Supports structured output feature
 - `temperature`: Boolean — Supports temperature control
 - `knowledge` _(optional)_: String — Knowledge-cutoff date in `YYYY-MM` or `YYYY-MM-DD` format
 - `release_date`: String — First public release date in `YYYY-MM` or `YYYY-MM-DD`

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -6,9 +6,9 @@ export const Model = z
     name: z.string().min(1, "Model name cannot be empty"),
     attachment: z.boolean(),
     reasoning: z.boolean(),
-    temperature: z.boolean(),
     tool_call: z.boolean(),
     structured_output: z.boolean().optional(),
+    temperature: z.boolean().optional(),
     knowledge: z
       .string()
       .regex(/^\d{4}-\d{2}(-\d{2})?$/, {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -8,6 +8,7 @@ export const Model = z
     reasoning: z.boolean(),
     temperature: z.boolean(),
     tool_call: z.boolean(),
+    structured_output: z.boolean().optional(),
     knowledge: z
       .string()
       .regex(/^\d{4}-\d{2}(-\d{2})?$/, {

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -317,6 +317,9 @@ export const Rendered = renderToString(
             Output Limit <span class="sort-indicator"></span>
           </th>
           <th class="sortable" data-type="boolean">
+            Structured Output <span class="sort-indicator"></span>
+          </th>
+          <th class="sortable" data-type="boolean">
             Temperature <span class="sort-indicator"></span>
           </th>
           <th class="sortable" data-type="text">
@@ -426,6 +429,7 @@ export const Rendered = renderToString(
                   <td>{renderCost(model.cost?.output_audio)}</td>
                   <td>{model.limit.context.toLocaleString()}</td>
                   <td>{model.limit.output.toLocaleString()}</td>
+                  <td>{model.structured_output === undefined ? "-" : model.structured_output ? "Yes" : "No"}</td>
                   <td>{model.temperature ? "Yes" : "No"}</td>
                   <td>{model.open_weights ? "Open" : "Closed"}</td>
                   <td>

--- a/providers/google/models/gemini-2.0-flash-lite.toml
+++ b/providers/google/models/gemini-2.0-flash-lite.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-06"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-2.0-flash.toml
+++ b/providers/google/models/gemini-2.0-flash.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-06"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/google/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-2.5-flash-lite.toml
+++ b/providers/google/models/gemini-2.5-flash-lite.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-2.5-flash-preview-05-20.toml
+++ b/providers/google/models/gemini-2.5-flash-preview-05-20.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/google/models/gemini-2.5-flash-preview-09-2025.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-2.5-flash.toml
+++ b/providers/google/models/gemini-2.5-flash.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/google/models/gemini-2.5-pro-preview-05-06.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/google/models/gemini-2.5-pro-preview-06-05.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-2.5-pro.toml
+++ b/providers/google/models/gemini-2.5-pro.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-flash-latest.toml
+++ b/providers/google/models/gemini-flash-latest.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/google/models/gemini-flash-lite-latest.toml
+++ b/providers/google/models/gemini-flash-lite-latest.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-3.5-turbo.toml
+++ b/providers/openai/models/gpt-3.5-turbo.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2021-09-01"
 tool_call = false
+structured_output = false
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4-turbo.toml
+++ b/providers/openai/models/gpt-4-turbo.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2023-12"
 tool_call = true
+structured_output = false
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4.1-mini.toml
+++ b/providers/openai/models/gpt-4.1-mini.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-04"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4.1-nano.toml
+++ b/providers/openai/models/gpt-4.1-nano.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-04"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4.1.toml
+++ b/providers/openai/models/gpt-4.1.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-04"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4.toml
+++ b/providers/openai/models/gpt-4.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2023-11"
 tool_call = true
+structured_output = false
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4o-2024-05-13.toml
+++ b/providers/openai/models/gpt-4o-2024-05-13.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2023-09"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4o-2024-08-06.toml
+++ b/providers/openai/models/gpt-4o-2024-08-06.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2023-09"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4o-2024-11-20.toml
+++ b/providers/openai/models/gpt-4o-2024-11-20.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2023-09"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4o-mini.toml
+++ b/providers/openai/models/gpt-4o-mini.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2023-09"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-4o.toml
+++ b/providers/openai/models/gpt-4o.toml
@@ -6,6 +6,7 @@ reasoning = false
 temperature = true
 knowledge = "2023-09"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-5-chat-latest.toml
+++ b/providers/openai/models/gpt-5-chat-latest.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-09-30"
 tool_call = false
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-5-codex.toml
+++ b/providers/openai/models/gpt-5-codex.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-5-mini.toml
+++ b/providers/openai/models/gpt-5-mini.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-5-nano.toml
+++ b/providers/openai/models/gpt-5-nano.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-5-pro.toml
+++ b/providers/openai/models/gpt-5-pro.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/gpt-5.toml
+++ b/providers/openai/models/gpt-5.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/o1-mini.toml
+++ b/providers/openai/models/o1-mini.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2023-09"
 tool_call = false
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/o1-pro.toml
+++ b/providers/openai/models/o1-pro.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = false
 knowledge = "2023-09"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/o1.toml
+++ b/providers/openai/models/o1.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2023-09"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/o3-mini.toml
+++ b/providers/openai/models/o3-mini.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-05"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/o3-pro.toml
+++ b/providers/openai/models/o3-pro.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-05"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/o3.toml
+++ b/providers/openai/models/o3.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-05"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openai/models/o4-mini.toml
+++ b/providers/openai/models/o4-mini.toml
@@ -6,6 +6,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-05"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]


### PR DESCRIPTION
Optional boolean representing support for a dedicated structured output feature (e.g., as supported by [OpenAI](https://platform.openai.com/docs/guides/structured-outputs) or [Gemini](https://ai.google.dev/gemini-api/docs/structured-output)).

Here we add the field to the schema, update the readme, and populate on providers `openai` and `google`.

Resolves https://github.com/sst/models.dev/issues/195