### PR TITLE
Update vercel minimax m2 cost

### DIFF
--- a/providers/vercel/models/minimax/minimax-m2.toml
+++ b/providers/vercel/models/minimax/minimax-m2.toml
@@ -9,8 +9,10 @@ knowledge = "2024-10"
 open_weights = true
 
 [cost]
-input = 0
-output = 0
+input = 0.3
+output = 1.2
+cache_read = 0.03
+cache_write = 0.38
 
 [limit]
 context = 205000


### PR DESCRIPTION
this model is no longer free, i updated the cost according to https://vercel.com/ai-gateway/models/minimax-m2