### PR TITLE
Add Kwaipilot Kat Coder Pro (free) model from OpenRouter provider

### DIFF
--- a/providers/openrouter/models/kwaipilot/kat-coder-pro:free.toml
+++ b/providers/openrouter/models/kwaipilot/kat-coder-pro:free.toml
@@ -1,0 +1,21 @@
+name = "Kat Coder Pro (free)"
+release_date = "2025-11-10"
+last_updated = "2025-11-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-11"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
- Added kwaipilot/kat-coder-pro:free model configuration
- 256K context window, optimized for agentic coding tasks
- 73.4% SWE-Bench Verified performance
- Free tier model with $0 input/output costs
- Tool-call and temperature parameter support enabled