### PR TITLE
Add MiniMax M2 model and enable reasoning for GLM-4.6

### DIFF
--- a/providers/iflowcn/models/glm-4.6.toml
+++ b/providers/iflowcn/models/glm-4.6.toml
@@ -1,8 +1,8 @@
 name = "GLM-4.6"
 release_date = "2024-12-01"
-last_updated = "2024-12-01"
+last_updated = "2025-11-13"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 knowledge = "2024-10"
 tool_call = true

--- a/providers/iflowcn/models/minimax-m2.toml
+++ b/providers/iflowcn/models/minimax-m2.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+cache_read = 0.00
+cache_write = 0.00
+
+[limit]
+context = 204_800
+output = 131_100
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This PR adds the MiniMax M2 model to the iFlowCN provider and enables reasoning for the GLM-4.6 model.