### PR TITLE
feat(openai): add gpt-5.1 model

### DIFF
--- a/providers/openai/models/gpt-5.1.toml
+++ b/providers/openai/models/gpt-5.1.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.1"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-09-30"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.13
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add GPT-5.1 model to OpenAI provider
- Uses same specs as GPT-5 (attachment, reasoning, tool_call enabled, temperature disabled)
- Release date set to 2025-11-13
- Cost, context, and modality specs match GPT-5