### PR TITLE
Update the minimax M2 model for openrouter

### DIFF
--- a/providers/openrouter/models/minimax/minimax-m2.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.toml
@@ -1,4 +1,4 @@
-name = "MiniMax M2 (free)"
+name = "MiniMax M2"
 attachment = false
 reasoning = true
 tool_call = true
@@ -8,14 +8,14 @@ last_updated = "2025-10-23"
 open_weights = true
 
 [cost]
-input = 0.00
-output = 0.00
-cache_read = 0.00
-cache_write = 0.00
+input = 0.28
+output = 1.15
+cache_read = 0.28
+cache_write = 1.15
 
 [limit]
-context = 204_800
-output = 131_100
+context = 196_600
+output = 118_000
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Update the minimax M2 model for openrouter 
1. Remove Minimax M2 Free that no longer exists
2. Add the paid Minimax M2 model