### PR TITLE
add support for azure cognitive services provider

### DIFF
--- a/providers/azure-cognitive-services/models/codex-mini.toml
+++ b/providers/azure-cognitive-services/models/codex-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/codex-mini.toml

--- a/providers/azure-cognitive-services/models/gpt-3.5-turbo-0125.toml
+++ b/providers/azure-cognitive-services/models/gpt-3.5-turbo-0125.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-3.5-turbo-0125.toml

--- a/providers/azure-cognitive-services/models/gpt-3.5-turbo-0301.toml
+++ b/providers/azure-cognitive-services/models/gpt-3.5-turbo-0301.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-3.5-turbo-0301.toml

--- a/providers/azure-cognitive-services/models/gpt-3.5-turbo-0613.toml
+++ b/providers/azure-cognitive-services/models/gpt-3.5-turbo-0613.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-3.5-turbo-0613.toml

--- a/providers/azure-cognitive-services/models/gpt-3.5-turbo-1106.toml
+++ b/providers/azure-cognitive-services/models/gpt-3.5-turbo-1106.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-3.5-turbo-1106.toml

--- a/providers/azure-cognitive-services/models/gpt-3.5-turbo-instruct.toml
+++ b/providers/azure-cognitive-services/models/gpt-3.5-turbo-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-3.5-turbo-instruct.toml

--- a/providers/azure-cognitive-services/models/gpt-4-32k.toml
+++ b/providers/azure-cognitive-services/models/gpt-4-32k.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-4-32k.toml

--- a/providers/azure-cognitive-services/models/gpt-4-turbo-vision.toml
+++ b/providers/azure-cognitive-services/models/gpt-4-turbo-vision.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-4-turbo-vision.toml

--- a/providers/azure-cognitive-services/models/gpt-4-turbo.toml
+++ b/providers/azure-cognitive-services/models/gpt-4-turbo.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-4-turbo.toml

--- a/providers/azure-cognitive-services/models/gpt-4.1-mini.toml
+++ b/providers/azure-cognitive-services/models/gpt-4.1-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-4.1-mini.toml

--- a/providers/azure-cognitive-services/models/gpt-4.1-nano.toml
+++ b/providers/azure-cognitive-services/models/gpt-4.1-nano.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-4.1-nano.toml

--- a/providers/azure-cognitive-services/models/gpt-4.1.toml
+++ b/providers/azure-cognitive-services/models/gpt-4.1.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-4.1.toml

--- a/providers/azure-cognitive-services/models/gpt-4.toml
+++ b/providers/azure-cognitive-services/models/gpt-4.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-4.toml

--- a/providers/azure-cognitive-services/models/gpt-4o-mini.toml
+++ b/providers/azure-cognitive-services/models/gpt-4o-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-4o-mini.toml

--- a/providers/azure-cognitive-services/models/gpt-4o.toml
+++ b/providers/azure-cognitive-services/models/gpt-4o.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-4o.toml

--- a/providers/azure-cognitive-services/models/gpt-5-chat.toml
+++ b/providers/azure-cognitive-services/models/gpt-5-chat.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5-chat.toml

--- a/providers/azure-cognitive-services/models/gpt-5-codex.toml
+++ b/providers/azure-cognitive-services/models/gpt-5-codex.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5-codex.toml

--- a/providers/azure-cognitive-services/models/gpt-5-mini.toml
+++ b/providers/azure-cognitive-services/models/gpt-5-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5-mini.toml

--- a/providers/azure-cognitive-services/models/gpt-5-nano.toml
+++ b/providers/azure-cognitive-services/models/gpt-5-nano.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5-nano.toml

--- a/providers/azure-cognitive-services/models/gpt-5.1-chat.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.1-chat.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5.1-chat.toml

--- a/providers/azure-cognitive-services/models/gpt-5.1-codex-mini.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.1-codex-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5.1-codex-mini.toml

--- a/providers/azure-cognitive-services/models/gpt-5.1-codex.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.1-codex.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5.1-codex.toml

--- a/providers/azure-cognitive-services/models/gpt-5.1.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.1.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5.1.toml

--- a/providers/azure-cognitive-services/models/gpt-5.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5.toml

--- a/providers/azure-cognitive-services/models/o1-mini.toml
+++ b/providers/azure-cognitive-services/models/o1-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/o1-mini.toml

--- a/providers/azure-cognitive-services/models/o1-preview.toml
+++ b/providers/azure-cognitive-services/models/o1-preview.toml
@@ -1,0 +1,1 @@
+../../azure/models/o1-preview.toml

--- a/providers/azure-cognitive-services/models/o1.toml
+++ b/providers/azure-cognitive-services/models/o1.toml
@@ -1,0 +1,1 @@
+../../azure/models/o1.toml

--- a/providers/azure-cognitive-services/models/o3-mini.toml
+++ b/providers/azure-cognitive-services/models/o3-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/o3-mini.toml

--- a/providers/azure-cognitive-services/models/o3.toml
+++ b/providers/azure-cognitive-services/models/o3.toml
@@ -1,0 +1,1 @@
+../../azure/models/o3.toml

--- a/providers/azure-cognitive-services/models/o4-mini.toml
+++ b/providers/azure-cognitive-services/models/o4-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/o4-mini.toml

--- a/providers/azure-cognitive-services/provider.toml
+++ b/providers/azure-cognitive-services/provider.toml
@@ -1,0 +1,4 @@
+name = "Azure Cognitive Services"
+env = ["AZURE_COGNITIVE_SERVICES_RESOURCE_NAME", "AZURE_COGNITIVE_SERVICES_API_KEY"]
+npm = "@ai-sdk/azure"
+doc = "https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models"


### PR DESCRIPTION
This PR is based on this issue: https://github.com/sst/opencode/issues/4334

I set up an Azure Cognitive Services provider, with envs _AZURE_COGNITIVE_SERVICES_RESOURCES_NAME_ and _AZURE_COGNITIVE_SERVICES_API_KEY_, following the base Azure pattern, and added symlinks to Azure's existing models.

PR in opencode repo for reference: https://github.com/sst/opencode/pull/4397