### PR TITLE
Update DeepSeek model costs and last_updated

### DIFF
--- a/providers/deepseek/models/deepseek-chat.toml
+++ b/providers/deepseek/models/deepseek-chat.toml
@@ -1,6 +1,6 @@
 name = "DeepSeek Chat"
 release_date = "2024-12-26"
-last_updated = "2025-08-21"
+last_updated = "2025-09-29"
 attachment = true
 reasoning = false
 temperature = true
@@ -9,9 +9,9 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.57
-output = 1.68
-cache_read = 0.07
+input = 0.28
+output = 0.42
+cache_read = 0.028
 
 [limit]
 context = 128_000

--- a/providers/deepseek/models/deepseek-reasoner.toml
+++ b/providers/deepseek/models/deepseek-reasoner.toml
@@ -1,6 +1,6 @@
 name = "DeepSeek Reasoner"
 release_date = "2025-01-20"
-last_updated = "2025-08-21"
+last_updated = "2025-09-29"
 attachment = true
 reasoning = true
 temperature = true
@@ -9,9 +9,9 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.57
-output = 1.68
-cache_read = 0.07
+input = 0.28
+output = 0.42
+cache_read = 0.028
 
 [limit]
 context = 128_000


### PR DESCRIPTION
Update DeepSeek model costs and last updated
1. models pricing based on https://api-docs.deepseek.com/quick_start/pricing
2. last_updated based on latest news https://api-docs.deepseek.com/news/news250929