### PR TITLE
Add Gemini 3 Pro Preview to GitHub Copilot provider

### DIFF
--- a/providers/github-copilot/models/gemini-3-pro-preview.toml
+++ b/providers/github-copilot/models/gemini-3-pro-preview.toml
@@ -1,0 +1,22 @@
+name = "Gemini 3 Pro Preview"
+release_date = "2025-11-18"
+last_updated = "2025-11-18"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-01"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add Gemini 3 Pro Preview model configuration for GitHub Copilot provider based on Google's implementation