### PR TITLE
Add Google Gemini 3 Pro Preview for OpenRouter

### DIFF
--- a/providers/openrouter/models/google/gemini-3-pro-preview.toml
+++ b/providers/openrouter/models/google/gemini-3-pro-preview.toml
@@ -1,0 +1,21 @@
+name = "Gemini 3 Pro Preview"
+release_date = "2025-11-18"
+last_updated = "2025-11"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 12.00
+
+[limit]
+context = 1_050_000
+output = 66_000
+
+[modalities]
+input = ["text", "image", "audio", "video", "pdf"]
+output = ["text"]


### PR DESCRIPTION
Add google/gemini-3-pro-preview model to OpenRouter provider with specifications:
- Input: $2/M tokens, Output: $12/M tokens
- Context window: 1,050,000 tokens
- Max output: 66,000 tokens
- Supports reasoning, tool calling, and multimodal inputs (text, image, audio, video, pdf)
- Knowledge cutoff: January 2025
- Released: November 18, 2025