### PR TITLE
Add grok-4.1-fast model to OpenRouter and xAI

### DIFF
--- a/providers/openrouter/models/x-ai/grok-4.1-fast.toml
+++ b/providers/openrouter/models/x-ai/grok-4.1-fast.toml
@@ -1,0 +1,23 @@
+name = "Grok 4.1 Fast"
+release_date = "2025-11-19"
+last_updated = "2025-11-19"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-11"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.50
+cache_read = 0.05
+cache_write = 0.05
+
+[limit]
+context = 2_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add new grok-4.1-fast model to both OpenRouter and xAI providers
- Model is free for 2 weeks via OpenRouter then standard pricing applies
- xAI version has standard pricing from start
- Includes both reasoning and non-reasoning variants for xAI
- Based on existing grok-4-fast configuration with updated release date of Nov 19, 2025