### PR TITLE
Add grok-4.1-fast models to xAI provider

### DIFF
--- a/providers/xai/models/grok-4.1-fast-non-reasoning.toml
+++ b/providers/xai/models/grok-4.1-fast-non-reasoning.toml
@@ -1,0 +1,22 @@
+name = "Grok 4.1 Fast (Non-Reasoning)"
+release_date = "2025-11-19"
+last_updated = "2025-11-19"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-07"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.50
+cache_read = 0.05
+
+[limit]
+context = 2_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/xai/models/grok-4.1-fast.toml
+++ b/providers/xai/models/grok-4.1-fast.toml
@@ -1,0 +1,22 @@
+name = "Grok 4.1 Fast"
+release_date = "2025-11-19"
+last_updated = "2025-11-19"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-07"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.50
+cache_read = 0.05
+
+[limit]
+context = 2_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary\n- Add grok-4.1-fast and grok-4.1-fast-non-reasoning models to xAI provider\n- Standard pricing applies (no free promotion)\n- Based on existing grok-4-fast configuration with updated release date of Nov 19, 2025