### PR TITLE
Fixes Azure/Azure Cognitive Services to use @ai-sdk/anthropic

### DIFF
--- a/providers/azure/models/claude-haiku-4-5.toml
+++ b/providers/azure/models/claude-haiku-4-5.toml
@@ -24,4 +24,4 @@ input = ["text", "image"]
 output = ["text"]
 
 [provider]
-npm = "@anthropic-ai/foundry-sdk"
+npm = "@ai-sdk/anthropic"

--- a/providers/azure/models/claude-opus-4-1.toml
+++ b/providers/azure/models/claude-opus-4-1.toml
@@ -24,4 +24,4 @@ input = ["text", "image"]
 output = ["text"]
 
 [provider]
-npm = "@anthropic-ai/foundry-sdk"
+npm = "@ai-sdk/anthropic"

--- a/providers/azure/models/claude-sonnet-4-5.toml
+++ b/providers/azure/models/claude-sonnet-4-5.toml
@@ -24,4 +24,4 @@ input = ["text", "image"]
 output = ["text"]
 
 [provider]
-npm = "@anthropic-ai/foundry-sdk"
+npm = "@ai-sdk/anthropic"


### PR DESCRIPTION
Changes the provider for Foundry providers to @ai-sdk/anthropic which works with baseUrl, but drops @anthropic-ai/foundry-sdk support for Entra ID auth.

For sst/opencode#4474, it would probably be nice to transform the Azure/ACS envs and necessary to adjust how its loaded on Claude requests