### PR TITLE
Fix release and last updated dates in GLM-4.6.toml

### DIFF
--- a/providers/baseten/models/zai-org/GLM-4.6.toml
+++ b/providers/baseten/models/zai-org/GLM-4.6.toml
@@ -1,6 +1,6 @@
 name = "GLM 4.6"
-release_date = "2025-16-09"
-last_updated = "2025-16-09"
+release_date = "2025-09-16"
+last_updated = "2025-09-16"
 attachment = false
 reasoning = false
 temperature = true


### PR DESCRIPTION
This pull request, addresses an issue with incorrect release and last updated dates in the `GLM-4.6.toml` file. The changes rectify the date format from "2025-16-09" to "2025-09-16" for both `release_date` and `last_updated` fields within the `providers/baseten/models/zai-org/GLM-4.6.toml` file.