### PR TITLE
fix(cohere): switch output tokens for a and a reasoning

### DIFF
--- a/providers/cohere/models/command-a-03-2025.toml
+++ b/providers/cohere/models/command-a-03-2025.toml
@@ -14,7 +14,7 @@ output = 10.00
 
 [limit]
 context = 256_000
-output = 32_000
+output = 8_000
 
 [modalities]
 input = ["text"]

--- a/providers/cohere/models/command-a-reasoning-08-2025 .toml
+++ b/providers/cohere/models/command-a-reasoning-08-2025 .toml
@@ -14,7 +14,7 @@ output = 10.00
 
 [limit]
 context = 256_000
-output = 8_000
+output = 32_000
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
When I initially added Cohere A and A Reasoning I switched the output tokens.

This causes a runtime error when the AI SDK does it's own checks.