### PR TITLE
fix: correct invalid dates

### DIFF
--- a/providers/anthropic/models/claude-haiku-4-5-20251001.toml
+++ b/providers/anthropic/models/claude-haiku-4-5-20251001.toml
@@ -5,7 +5,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 open_weights = false
 
 [cost]

--- a/providers/anthropic/models/claude-haiku-4-5.toml
+++ b/providers/anthropic/models/claude-haiku-4-5.toml
@@ -5,7 +5,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 open_weights = false
 
 [cost]

--- a/providers/baseten/models/zai-org/GLM-4.6.toml
+++ b/providers/baseten/models/zai-org/GLM-4.6.toml
@@ -4,7 +4,7 @@ last_updated = "2025-09-16"
 attachment = false
 reasoning = false
 temperature = true
-knowledge = "2025-08"
+knowledge = "2025-08-31"
 tool_call = true
 open_weights = true
 

--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -5,7 +5,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 open_weights = false
 
 [cost]

--- a/providers/google-vertex-anthropic/models/claude-haiku-4-5@20251001.toml
+++ b/providers/google-vertex-anthropic/models/claude-haiku-4-5@20251001.toml
@@ -5,7 +5,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 open_weights = false
 
 [cost]

--- a/providers/opencode/models/claude-haiku-4-5.toml
+++ b/providers/opencode/models/claude-haiku-4-5.toml
@@ -5,7 +5,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-haiku-4.5.toml
@@ -5,7 +5,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 open_weights = false
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -5,7 +5,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 open_weights = false
 
 [cost]

--- a/providers/zenmux/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/zenmux/models/anthropic/claude-haiku-4.5.toml
@@ -5,7 +5,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 open_weights = false
 
 [cost]


### PR DESCRIPTION
corrected invalid knowledge dates '2025-02-31' to '2025-02-28' for a number of claude-haiku 4.5 and GLM 4.6 .toml files
and updated '2025-08' to '2025-08-31' in the baseten/GLM4.6 toml

addresses issue: https://github.com/sst/models.dev/issues/397 