### PR TITLE
Add Claude Opus 4.5 to GitHub Copilot provider

### DIFF
--- a/providers/github-copilot/models/claude-opus-4-5.toml
+++ b/providers/github-copilot/models/claude-opus-4-5.toml
@@ -13,8 +13,8 @@ input = 0
 output = 0
 
 [limit]
-context = 200_000
-output = 64_000
+context = 128_000
+output = 16_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-opus-4-5.toml
+++ b/providers/github-copilot/models/claude-opus-4-5.toml
@@ -1,0 +1,21 @@
+name = "Claude Opus 4.5"
+release_date = "2025-11-24"
+last_updated = "2025-08-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add Claude Opus 4.5 model to the GitHub Copilot provider, matching the capabilities already available in the Anthropic provider.

## Changes
- Created `providers/github-copilot/models/claude-opus-4-5.toml` with full spec matching the Anthropic version
- Model includes: 200k context, 64k output, reasoning, temperature control, tool calling, and image input support