### PR TITLE
Correct output cost for kimi-k2-thinking on Fireworks.ai

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2-thinking.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2-thinking.toml
@@ -9,7 +9,7 @@ open_weights = true
 
 [cost]
 input = 0.60
-output = 0.60
+output = 2.50
 
 [limit]
 context = 256_000


### PR DESCRIPTION
It has been corrected on their info page: https://app.fireworks.ai/models/fireworks/kimi-k2-thinking