### PR TITLE
fix(anthropic): add (latest) flag and correct last_updated for Opus 4.5

### DIFF
--- a/providers/anthropic/models/claude-opus-4-5.toml
+++ b/providers/anthropic/models/claude-opus-4-5.toml
@@ -1,6 +1,6 @@
-name = "Claude Opus 4.5"
+name = "Claude Opus 4.5 (latest)"
 release_date = "2025-11-24"
-last_updated = "2025-08-01"
+last_updated = "2025-11-24"
 attachment = true
 reasoning = true
 temperature = true


### PR DESCRIPTION
Fixes two issues in `claude-opus-4-5.toml`:

1. **Added `(latest)` to name** - This is an alias file (no date suffix), so it should have `(latest)` like all other alias files (`claude-sonnet-4-5.toml`, `claude-opus-4-1.toml`, etc.)

2. **Fixed `last_updated` date** - Changed from `2025-08-01` to `2025-11-24` to match `release_date`, consistent with all other model files in this directory.