### PR TITLE
fix: correct input types for qwen3-omni-30b-a3b-captioner

### DIFF
--- a/providers/siliconflow/models/qwen-qwen3-omni-30b-a3b-captioner.toml
+++ b/providers/siliconflow/models/qwen-qwen3-omni-30b-a3b-captioner.toml
@@ -17,5 +17,5 @@ context = 66_000
 output = 66_000
 
 [modalities]
-input = ["text", "image"]
+input = ["audio"]
 output = ["text"]


### PR DESCRIPTION
The model was listed as accepting audio+text inputs But actually supports audio-only.
Updated the model configuration to reflect the correct input types.