### PR TITLE
Fix Claude Opus 4.5 cache pricing

### DIFF
--- a/providers/anthropic/models/claude-opus-4-5.toml
+++ b/providers/anthropic/models/claude-opus-4-5.toml
@@ -11,8 +11,8 @@ open_weights = false
 [cost]
 input = 5.00
 output = 25.00
-cache_read = 1.50
-cache_write = 18.75
+cache_read = 0.50
+cache_write = 6.25
 
 [limit]
 context = 200_000


### PR DESCRIPTION
The cache pricing for Claude Opus 4.5 was 3x too high compared to Anthropic's official pricing.

**Current (incorrect):**
- cache_read: $1.50/MTok
- cache_write: $18.75/MTok

**Should be:**
- cache_read: $0.50/MTok
- cache_write: $6.25/MTok

**Source:** https://www.anthropic.com/pricing#anthropic-api

This was causing applications using this data to report 3x inflated cache costs.