### PR TITLE
add DeepSeek models to Azure providers

### DIFF
--- a/providers/azure-cognitive-services/models/deepseek-r1-0528.toml
+++ b/providers/azure-cognitive-services/models/deepseek-r1-0528.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek-R1-0528"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 1.35
+output = 5.4
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure-cognitive-services/models/deepseek-r1.toml
+++ b/providers/azure-cognitive-services/models/deepseek-r1.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek-R1"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 1.35
+output = 5.4
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure-cognitive-services/models/deepseek-v3-0324.toml
+++ b/providers/azure-cognitive-services/models/deepseek-v3-0324.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek-V3-0324"
+release_date = "2025-03-24"
+last_updated = "2025-03-24"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.14
+output = 4.56
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure-cognitive-services/models/deepseek-v3.1.toml
+++ b/providers/azure-cognitive-services/models/deepseek-v3.1.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek-V3.1"
+release_date = "2025-08-21"
+last_updated = "2025-08-21"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.56
+output = 1.68
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/deepseek-r1-0528.toml
+++ b/providers/azure/models/deepseek-r1-0528.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek-R1-0528"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 1.35
+output = 5.4
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/deepseek-r1.toml
+++ b/providers/azure/models/deepseek-r1.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek-R1"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 1.35
+output = 5.4
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/deepseek-v3-0324.toml
+++ b/providers/azure/models/deepseek-v3-0324.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek-V3-0324"
+release_date = "2025-03-24"
+last_updated = "2025-03-24"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.14
+output = 4.56
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/deepseek-v3.1.toml
+++ b/providers/azure/models/deepseek-v3.1.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek-V3.1"
+release_date = "2025-08-21"
+last_updated = "2025-08-21"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.56
+output = 1.68
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds 4 DeepSeek models to both Azure and Azure Cognitive Services providers
- DeepSeek-R1 (reasoning model, Jan 2025)
- DeepSeek-R1-0528 (updated reasoning model, May 2025)
- DeepSeek-V3-0324 (chat model, Mar 2025)
- DeepSeek-V3.1 (hybrid thinking/chat model, Aug 2025)

## Sources
- [Azure AI Foundry Models](https://learn.microsoft.com/en-us/azure/ai-foundry/model-inference/concepts/models)
- [DeepSeek R1-0528 Release](https://api-docs.deepseek.com/news/news250528)
- [DeepSeek V3.1 Release](https://api-docs.deepseek.com/news/news250821)
- [Azure DeepSeek Pricing](https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/)

## Test plan
- [x] `bun validate` passes