### PR TITLE
add Cohere models to Azure providers

### DIFF
--- a/providers/azure-cognitive-services/models/cohere-command-a.toml
+++ b/providers/azure-cognitive-services/models/cohere-command-a.toml
@@ -1,0 +1,1 @@
+../../azure/models/cohere-command-a.toml

--- a/providers/azure-cognitive-services/models/cohere-command-r-08-2024.toml
+++ b/providers/azure-cognitive-services/models/cohere-command-r-08-2024.toml
@@ -1,0 +1,1 @@
+../../azure/models/cohere-command-r-08-2024.toml

--- a/providers/azure-cognitive-services/models/cohere-command-r-plus-08-2024.toml
+++ b/providers/azure-cognitive-services/models/cohere-command-r-plus-08-2024.toml
@@ -1,0 +1,1 @@
+../../azure/models/cohere-command-r-plus-08-2024.toml

--- a/providers/azure-cognitive-services/models/cohere-embed-v-4-0.toml
+++ b/providers/azure-cognitive-services/models/cohere-embed-v-4-0.toml
@@ -1,0 +1,1 @@
+../../azure/models/cohere-embed-v-4-0.toml

--- a/providers/azure-cognitive-services/models/cohere-embed-v3-english.toml
+++ b/providers/azure-cognitive-services/models/cohere-embed-v3-english.toml
@@ -1,0 +1,1 @@
+../../azure/models/cohere-embed-v3-english.toml

--- a/providers/azure-cognitive-services/models/cohere-embed-v3-multilingual.toml
+++ b/providers/azure-cognitive-services/models/cohere-embed-v3-multilingual.toml
@@ -1,0 +1,1 @@
+../../azure/models/cohere-embed-v3-multilingual.toml

--- a/providers/azure/models/cohere-command-a.toml
+++ b/providers/azure/models/cohere-command-a.toml
@@ -1,0 +1,21 @@
+name = "Command A"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-06-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 2.50
+output = 10.00
+
+[limit]
+context = 256_000
+output = 8_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/cohere-command-r-08-2024.toml
+++ b/providers/azure/models/cohere-command-r-08-2024.toml
@@ -1,0 +1,21 @@
+name = "Command R"
+release_date = "2024-08-30"
+last_updated = "2024-08-30"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-06-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 128_000
+output = 4_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/cohere-command-r-plus-08-2024.toml
+++ b/providers/azure/models/cohere-command-r-plus-08-2024.toml
@@ -1,0 +1,21 @@
+name = "Command R+"
+release_date = "2024-08-30"
+last_updated = "2024-08-30"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-06-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 2.50
+output = 10.00
+
+[limit]
+context = 128_000
+output = 4_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/cohere-embed-v-4-0.toml
+++ b/providers/azure/models/cohere-embed-v-4-0.toml
@@ -1,0 +1,20 @@
+name = "Embed v4"
+release_date = "2025-04-15"
+last_updated = "2025-04-15"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.12
+output = 0.00
+
+[limit]
+context = 128_000
+output = 1_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/cohere-embed-v3-english.toml
+++ b/providers/azure/models/cohere-embed-v3-english.toml
@@ -1,0 +1,20 @@
+name = "Embed v3 English"
+release_date = "2023-11-07"
+last_updated = "2023-11-07"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.00
+
+[limit]
+context = 512
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/cohere-embed-v3-multilingual.toml
+++ b/providers/azure/models/cohere-embed-v3-multilingual.toml
@@ -1,0 +1,20 @@
+name = "Embed v3 Multilingual"
+release_date = "2023-11-07"
+last_updated = "2023-11-07"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.00
+
+[limit]
+context = 512
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add 6 Cohere models to Azure and Azure Cognitive Services providers
- Command models: Command A, Command R (08-2024), Command R+ (08-2024)
- Embed models: Embed v3 English, Embed v3 Multilingual, Embed v4 (multimodal)

## Test plan
- [x] `bun validate` passes