### PR TITLE
add xAI Grok models to Azure providers

### DIFF
--- a/providers/azure-cognitive-services/models/grok-3-mini.toml
+++ b/providers/azure-cognitive-services/models/grok-3-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/grok-3-mini.toml

--- a/providers/azure-cognitive-services/models/grok-3.toml
+++ b/providers/azure-cognitive-services/models/grok-3.toml
@@ -1,0 +1,1 @@
+../../azure/models/grok-3.toml

--- a/providers/azure-cognitive-services/models/grok-4-fast-non-reasoning.toml
+++ b/providers/azure-cognitive-services/models/grok-4-fast-non-reasoning.toml
@@ -1,0 +1,1 @@
+../../azure/models/grok-4-fast-non-reasoning.toml

--- a/providers/azure-cognitive-services/models/grok-4-fast-reasoning.toml
+++ b/providers/azure-cognitive-services/models/grok-4-fast-reasoning.toml
@@ -1,0 +1,1 @@
+../../azure/models/grok-4-fast-reasoning.toml

--- a/providers/azure-cognitive-services/models/grok-4.toml
+++ b/providers/azure-cognitive-services/models/grok-4.toml
@@ -1,0 +1,1 @@
+../../azure/models/grok-4.toml

--- a/providers/azure-cognitive-services/models/grok-code-fast-1.toml
+++ b/providers/azure-cognitive-services/models/grok-code-fast-1.toml
@@ -1,0 +1,1 @@
+../../azure/models/grok-code-fast-1.toml

--- a/providers/azure/models/grok-3-mini.toml
+++ b/providers/azure/models/grok-3-mini.toml
@@ -1,0 +1,23 @@
+name = "Grok 3 Mini"
+release_date = "2025-02-17"
+last_updated = "2025-02-17"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-11"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.30
+output = 0.50
+reasoning = 0.50
+cache_read = 0.075
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/grok-3.toml
+++ b/providers/azure/models/grok-3.toml
@@ -1,0 +1,22 @@
+name = "Grok 3"
+release_date = "2025-02-17"
+last_updated = "2025-02-17"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-11"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.75
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/grok-4-fast-non-reasoning.toml
+++ b/providers/azure/models/grok-4-fast-non-reasoning.toml
@@ -1,0 +1,22 @@
+name = "Grok 4 Fast (Non-Reasoning)"
+release_date = "2025-09-19"
+last_updated = "2025-09-19"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-07"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.50
+cache_read = 0.05
+
+[limit]
+context = 2_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/grok-4-fast-reasoning.toml
+++ b/providers/azure/models/grok-4-fast-reasoning.toml
@@ -1,0 +1,22 @@
+name = "Grok 4 Fast (Reasoning)"
+release_date = "2025-09-19"
+last_updated = "2025-09-19"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-07"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.50
+cache_read = 0.05
+
+[limit]
+context = 2_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/grok-4.toml
+++ b/providers/azure/models/grok-4.toml
@@ -1,0 +1,23 @@
+name = "Grok 4"
+release_date = "2025-07-09"
+last_updated = "2025-07-09"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-07"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+reasoning = 15.00
+cache_read = 0.75
+
+[limit]
+context = 256_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/grok-code-fast-1.toml
+++ b/providers/azure/models/grok-code-fast-1.toml
@@ -1,0 +1,22 @@
+name = "Grok Code Fast 1"
+release_date = "2025-08-28"
+last_updated = "2025-08-28"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 1.50
+cache_read = 0.02
+
+[limit]
+context = 256_000
+output = 10_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds 6 xAI Grok models to Azure and Azure Cognitive Services providers
- Models: grok-3, grok-3-mini, grok-4, grok-4-fast-reasoning, grok-4-fast-non-reasoning, grok-code-fast-1
- Azure Cognitive Services files are symlinks to Azure equivalents

## Test plan
- [x] `bun validate` passes