### PR TITLE
Add Meta Llama models to Azure and Azure Cognitive Services

### DIFF
--- a/providers/azure-cognitive-services/models/llama-3.2-11b-vision-instruct.toml
+++ b/providers/azure-cognitive-services/models/llama-3.2-11b-vision-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/llama-3.2-11b-vision-instruct.toml

--- a/providers/azure-cognitive-services/models/llama-3.2-90b-vision-instruct.toml
+++ b/providers/azure-cognitive-services/models/llama-3.2-90b-vision-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/llama-3.2-90b-vision-instruct.toml

--- a/providers/azure-cognitive-services/models/llama-3.3-70b-instruct.toml
+++ b/providers/azure-cognitive-services/models/llama-3.3-70b-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/llama-3.3-70b-instruct.toml

--- a/providers/azure-cognitive-services/models/llama-4-maverick-17b-128e-instruct-fp8.toml
+++ b/providers/azure-cognitive-services/models/llama-4-maverick-17b-128e-instruct-fp8.toml
@@ -1,0 +1,1 @@
+../../azure/models/llama-4-maverick-17b-128e-instruct-fp8.toml

--- a/providers/azure-cognitive-services/models/llama-4-scout-17b-16e-instruct.toml
+++ b/providers/azure-cognitive-services/models/llama-4-scout-17b-16e-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/llama-4-scout-17b-16e-instruct.toml

--- a/providers/azure-cognitive-services/models/meta-llama-3-70b-instruct.toml
+++ b/providers/azure-cognitive-services/models/meta-llama-3-70b-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/meta-llama-3-70b-instruct.toml

--- a/providers/azure-cognitive-services/models/meta-llama-3-8b-instruct.toml
+++ b/providers/azure-cognitive-services/models/meta-llama-3-8b-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/meta-llama-3-8b-instruct.toml

--- a/providers/azure-cognitive-services/models/meta-llama-3.1-405b-instruct.toml
+++ b/providers/azure-cognitive-services/models/meta-llama-3.1-405b-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/meta-llama-3.1-405b-instruct.toml

--- a/providers/azure-cognitive-services/models/meta-llama-3.1-70b-instruct.toml
+++ b/providers/azure-cognitive-services/models/meta-llama-3.1-70b-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/meta-llama-3.1-70b-instruct.toml

--- a/providers/azure-cognitive-services/models/meta-llama-3.1-8b-instruct.toml
+++ b/providers/azure-cognitive-services/models/meta-llama-3.1-8b-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/meta-llama-3.1-8b-instruct.toml

--- a/providers/azure/models/llama-3.2-11b-vision-instruct.toml
+++ b/providers/azure/models/llama-3.2-11b-vision-instruct.toml
@@ -1,0 +1,21 @@
+name = "Llama-3.2-11B-Vision-Instruct"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.37
+output = 0.37
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/llama-3.2-90b-vision-instruct.toml
+++ b/providers/azure/models/llama-3.2-90b-vision-instruct.toml
@@ -1,0 +1,21 @@
+name = "Llama-3.2-90B-Vision-Instruct"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 2.04
+output = 2.04
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/llama-3.3-70b-instruct.toml
+++ b/providers/azure/models/llama-3.3-70b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Llama-3.3-70B-Instruct"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.71
+output = 0.71
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/llama-4-maverick-17b-128e-instruct-fp8.toml
+++ b/providers/azure/models/llama-4-maverick-17b-128e-instruct-fp8.toml
@@ -1,0 +1,21 @@
+name = "Llama 4 Maverick 17B 128E Instruct FP8"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-08"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.25
+output = 1.00
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/llama-4-scout-17b-16e-instruct.toml
+++ b/providers/azure/models/llama-4-scout-17b-16e-instruct.toml
@@ -1,0 +1,21 @@
+name = "Llama 4 Scout 17B 16E Instruct"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-08"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.20
+output = 0.78
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/meta-llama-3-70b-instruct.toml
+++ b/providers/azure/models/meta-llama-3-70b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Meta-Llama-3-70B-Instruct"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 2.68
+output = 3.54
+
+[limit]
+context = 8_192
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/meta-llama-3-8b-instruct.toml
+++ b/providers/azure/models/meta-llama-3-8b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Meta-Llama-3-8B-Instruct"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.30
+output = 0.61
+
+[limit]
+context = 8_192
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/meta-llama-3.1-405b-instruct.toml
+++ b/providers/azure/models/meta-llama-3.1-405b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Meta-Llama-3.1-405B-Instruct"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 5.33
+output = 16.00
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/meta-llama-3.1-70b-instruct.toml
+++ b/providers/azure/models/meta-llama-3.1-70b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Meta-Llama-3.1-70B-Instruct"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 2.68
+output = 3.54
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/meta-llama-3.1-8b-instruct.toml
+++ b/providers/azure/models/meta-llama-3.1-8b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Meta-Llama-3.1-8B-Instruct"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 0.61
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Adds 10 Meta Llama models to Azure provider with Azure-specific pricing
- Creates symlinks for Azure Cognitive Services

## Models Added

- Llama 4 Maverick 17B 128E Instruct FP8
- Llama 4 Scout 17B 16E Instruct
- Llama 3.3 70B Instruct
- Llama 3.2 90B Vision Instruct
- Llama 3.2 11B Vision Instruct
- Meta Llama 3.1 405B Instruct
- Meta Llama 3.1 70B Instruct
- Meta Llama 3.1 8B Instruct
- Meta Llama 3 70B Instruct
- Meta Llama 3 8B Instruct

## Test plan

- [x] `bun validate` passes