### PR TITLE
Add Microsoft Phi and MAI models to Azure providers

### DIFF
--- a/providers/azure-cognitive-services/models/mai-ds-r1.toml
+++ b/providers/azure-cognitive-services/models/mai-ds-r1.toml
@@ -1,0 +1,1 @@
+../../azure/models/mai-ds-r1.toml

--- a/providers/azure-cognitive-services/models/phi-3-medium-128k-instruct.toml
+++ b/providers/azure-cognitive-services/models/phi-3-medium-128k-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-3-medium-128k-instruct.toml

--- a/providers/azure-cognitive-services/models/phi-3-medium-4k-instruct.toml
+++ b/providers/azure-cognitive-services/models/phi-3-medium-4k-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-3-medium-4k-instruct.toml

--- a/providers/azure-cognitive-services/models/phi-3-mini-128k-instruct.toml
+++ b/providers/azure-cognitive-services/models/phi-3-mini-128k-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-3-mini-128k-instruct.toml

--- a/providers/azure-cognitive-services/models/phi-3-mini-4k-instruct.toml
+++ b/providers/azure-cognitive-services/models/phi-3-mini-4k-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-3-mini-4k-instruct.toml

--- a/providers/azure-cognitive-services/models/phi-3-small-128k-instruct.toml
+++ b/providers/azure-cognitive-services/models/phi-3-small-128k-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-3-small-128k-instruct.toml

--- a/providers/azure-cognitive-services/models/phi-3-small-8k-instruct.toml
+++ b/providers/azure-cognitive-services/models/phi-3-small-8k-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-3-small-8k-instruct.toml

--- a/providers/azure-cognitive-services/models/phi-3.5-mini-instruct.toml
+++ b/providers/azure-cognitive-services/models/phi-3.5-mini-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-3.5-mini-instruct.toml

--- a/providers/azure-cognitive-services/models/phi-3.5-moe-instruct.toml
+++ b/providers/azure-cognitive-services/models/phi-3.5-moe-instruct.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-3.5-moe-instruct.toml

--- a/providers/azure-cognitive-services/models/phi-4-mini-reasoning.toml
+++ b/providers/azure-cognitive-services/models/phi-4-mini-reasoning.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-4-mini-reasoning.toml

--- a/providers/azure-cognitive-services/models/phi-4-mini.toml
+++ b/providers/azure-cognitive-services/models/phi-4-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-4-mini.toml

--- a/providers/azure-cognitive-services/models/phi-4-multimodal.toml
+++ b/providers/azure-cognitive-services/models/phi-4-multimodal.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-4-multimodal.toml

--- a/providers/azure-cognitive-services/models/phi-4-reasoning-plus.toml
+++ b/providers/azure-cognitive-services/models/phi-4-reasoning-plus.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-4-reasoning-plus.toml

--- a/providers/azure-cognitive-services/models/phi-4-reasoning.toml
+++ b/providers/azure-cognitive-services/models/phi-4-reasoning.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-4-reasoning.toml

--- a/providers/azure-cognitive-services/models/phi-4.toml
+++ b/providers/azure-cognitive-services/models/phi-4.toml
@@ -1,0 +1,1 @@
+../../azure/models/phi-4.toml

--- a/providers/azure/models/mai-ds-r1.toml
+++ b/providers/azure/models/mai-ds-r1.toml
@@ -1,0 +1,21 @@
+name = "MAI-DS-R1"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-06"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.35
+output = 5.40
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-3-medium-128k-instruct.toml
+++ b/providers/azure/models/phi-3-medium-128k-instruct.toml
@@ -1,0 +1,21 @@
+name = "Phi-3-medium-instruct (128k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.17
+output = 0.68
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-3-medium-4k-instruct.toml
+++ b/providers/azure/models/phi-3-medium-4k-instruct.toml
@@ -1,0 +1,21 @@
+name = "Phi-3-medium-instruct (4k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.17
+output = 0.68
+
+[limit]
+context = 4_096
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-3-mini-128k-instruct.toml
+++ b/providers/azure/models/phi-3-mini-128k-instruct.toml
@@ -1,0 +1,21 @@
+name = "Phi-3-mini-instruct (128k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.13
+output = 0.52
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-3-mini-4k-instruct.toml
+++ b/providers/azure/models/phi-3-mini-4k-instruct.toml
@@ -1,0 +1,21 @@
+name = "Phi-3-mini-instruct (4k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.13
+output = 0.52
+
+[limit]
+context = 4_096
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-3-small-128k-instruct.toml
+++ b/providers/azure/models/phi-3-small-128k-instruct.toml
@@ -1,0 +1,21 @@
+name = "Phi-3-small-instruct (128k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-3-small-8k-instruct.toml
+++ b/providers/azure/models/phi-3-small-8k-instruct.toml
@@ -1,0 +1,21 @@
+name = "Phi-3-small-instruct (8k)"
+release_date = "2024-04-23"
+last_updated = "2024-04-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 8_192
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-3.5-mini-instruct.toml
+++ b/providers/azure/models/phi-3.5-mini-instruct.toml
@@ -1,0 +1,21 @@
+name = "Phi-3.5-mini-instruct"
+release_date = "2024-08-20"
+last_updated = "2024-08-20"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.13
+output = 0.52
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-3.5-moe-instruct.toml
+++ b/providers/azure/models/phi-3.5-moe-instruct.toml
@@ -1,0 +1,21 @@
+name = "Phi-3.5-MoE-instruct"
+release_date = "2024-08-20"
+last_updated = "2024-08-20"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.16
+output = 0.64
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-4-mini-reasoning.toml
+++ b/providers/azure/models/phi-4-mini-reasoning.toml
@@ -1,0 +1,21 @@
+name = "Phi-4-mini-reasoning"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.075
+output = 0.30
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-4-mini.toml
+++ b/providers/azure/models/phi-4-mini.toml
@@ -1,0 +1,21 @@
+name = "Phi-4-mini"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.075
+output = 0.30
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-4-multimodal.toml
+++ b/providers/azure/models/phi-4-multimodal.toml
@@ -1,0 +1,22 @@
+name = "Phi-4-multimodal"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.32
+input_audio = 4.00
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text", "image", "audio"]
+output = ["text"]

--- a/providers/azure/models/phi-4-reasoning-plus.toml
+++ b/providers/azure/models/phi-4-reasoning-plus.toml
@@ -1,0 +1,21 @@
+name = "Phi-4-reasoning-plus"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.125
+output = 0.50
+
+[limit]
+context = 32_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-4-reasoning.toml
+++ b/providers/azure/models/phi-4-reasoning.toml
@@ -1,0 +1,21 @@
+name = "Phi-4-reasoning"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.125
+output = 0.50
+
+[limit]
+context = 32_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/phi-4.toml
+++ b/providers/azure/models/phi-4.toml
@@ -1,0 +1,21 @@
+name = "Phi-4"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.125
+output = 0.50
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add 15 Microsoft models to Azure and Azure Cognitive Services providers
- Models include Phi-4, Phi-3.5, Phi-3 series and MAI-DS-R1
- ACS models are symlinks to Azure equivalents
- Pricing sourced from Azure AI Foundry

## Models Added

### Phi-4 Series (6 models)
| Model | Context | Tool Call | Reasoning |
|-------|---------|-----------|-----------|
| Phi-4 | 128K | No | No |
| Phi-4-mini | 128K | Yes | No |
| Phi-4-multimodal | 128K | No | No |
| Phi-4-reasoning | 32K | No | Yes |
| Phi-4-mini-reasoning | 128K | Yes | Yes |
| Phi-4-reasoning-plus | 32K | No | Yes |

### Phi-3.5 Series (2 models)
- Phi-3.5-mini-instruct (128K)
- Phi-3.5-MoE-instruct (128K)

### Phi-3 Series (6 models)
- Phi-3-mini (4k/128k variants)
- Phi-3-small (8k/128k variants)
- Phi-3-medium (4k/128k variants)

### MAI Series (1 model)
- MAI-DS-R1 (128K context, tool_call=true, reasoning=true)

## Research Notes
- Tool calling only officially supported for: Phi-4-mini, Phi-4-mini-reasoning, MAI-DS-R1
- Phi-4-multimodal tool calling NOT supported on Azure (per docs, despite UI)
- Phi-3.x models do not have official function calling support
- Phi-4-reasoning/Phi-4-reasoning-plus (14B) do not support function calling

## Test Plan
- [x] `bun validate` passes