### PR TITLE
add mistral models to azure and azure cognitive services

### DIFF
--- a/providers/azure-cognitive-services/models/codestral-2501.toml
+++ b/providers/azure-cognitive-services/models/codestral-2501.toml
@@ -1,0 +1,1 @@
+../../azure/models/codestral-2501.toml

--- a/providers/azure-cognitive-services/models/ministral-3b.toml
+++ b/providers/azure-cognitive-services/models/ministral-3b.toml
@@ -1,0 +1,1 @@
+../../azure/models/ministral-3b.toml

--- a/providers/azure-cognitive-services/models/mistral-large-2411.toml
+++ b/providers/azure-cognitive-services/models/mistral-large-2411.toml
@@ -1,0 +1,1 @@
+../../azure/models/mistral-large-2411.toml

--- a/providers/azure-cognitive-services/models/mistral-medium-2505.toml
+++ b/providers/azure-cognitive-services/models/mistral-medium-2505.toml
@@ -1,0 +1,1 @@
+../../azure/models/mistral-medium-2505.toml

--- a/providers/azure-cognitive-services/models/mistral-nemo.toml
+++ b/providers/azure-cognitive-services/models/mistral-nemo.toml
@@ -1,0 +1,1 @@
+../../azure/models/mistral-nemo.toml

--- a/providers/azure-cognitive-services/models/mistral-small-2503.toml
+++ b/providers/azure-cognitive-services/models/mistral-small-2503.toml
@@ -1,0 +1,1 @@
+../../azure/models/mistral-small-2503.toml

--- a/providers/azure/models/codestral-2501.toml
+++ b/providers/azure/models/codestral-2501.toml
@@ -1,0 +1,21 @@
+name = "Codestral 25.01"
+release_date = "2025-01-01"
+last_updated = "2025-01-01"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.30
+output = 0.90
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/ministral-3b.toml
+++ b/providers/azure/models/ministral-3b.toml
@@ -1,0 +1,21 @@
+name = "Ministral 3B"
+release_date = "2024-10-22"
+last_updated = "2024-10-22"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.04
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/mistral-large-2411.toml
+++ b/providers/azure/models/mistral-large-2411.toml
@@ -1,0 +1,21 @@
+name = "Mistral Large 24.11"
+release_date = "2024-11-01"
+last_updated = "2024-11-01"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-09"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 6.00
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/mistral-medium-2505.toml
+++ b/providers/azure/models/mistral-medium-2505.toml
@@ -1,0 +1,21 @@
+name = "Mistral Medium 3"
+release_date = "2025-05-07"
+last_updated = "2025-05-07"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-05"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.40
+output = 2.00
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/mistral-nemo.toml
+++ b/providers/azure/models/mistral-nemo.toml
@@ -1,0 +1,21 @@
+name = "Mistral Nemo"
+release_date = "2024-07-18"
+last_updated = "2024-07-18"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.15
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/mistral-small-2503.toml
+++ b/providers/azure/models/mistral-small-2503.toml
@@ -1,0 +1,21 @@
+name = "Mistral Small 3.1"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-09"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.10
+output = 0.30
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add 6 Mistral models to Azure and Azure Cognitive Services providers
- Models: Mistral Nemo, Mistral Small 3.1, Mistral Medium 3, Mistral Large 24.11, Ministral 3B, Codestral 25.01
- Azure Cognitive Services files are symlinks to Azure equivalents
- Pricing from Azure AI Foundry Marketplace

## Models Added
| Model | Context | Input $/M | Output $/M |
|-------|---------|-----------|------------|
| Mistral Nemo | 128K | $0.15 | $0.15 |
| Mistral Small 3.1 | 128K | $0.10 | $0.30 |
| Mistral Medium 3 | 128K | $0.40 | $2.00 |
| Mistral Large 24.11 | 128K | $2.00 | $6.00 |
| Ministral 3B | 128K | $0.04 | $0.04 |
| Codestral 25.01 | 256K | $0.30 | $0.90 |

## Test plan
- [x] `bun validate` passes