### PR TITLE
fix tool_call settings for azure deepseek-r1-0528 and mai-ds-r1

### DIFF
--- a/providers/azure/models/deepseek-r1-0528.toml
+++ b/providers/azure/models/deepseek-r1-0528.toml
@@ -5,7 +5,7 @@ attachment = false
 reasoning = true
 temperature = true
 knowledge = "2024-07"
-tool_call = false
+tool_call = true
 open_weights = true
 
 [cost]

--- a/providers/azure/models/mai-ds-r1.toml
+++ b/providers/azure/models/mai-ds-r1.toml
@@ -5,7 +5,7 @@ attachment = false
 reasoning = true
 temperature = true
 knowledge = "2024-06"
-tool_call = true
+tool_call = false
 open_weights = false
 
 [cost]


### PR DESCRIPTION
## Summary
- Enable tool_call for deepseek-r1-0528 (supports function calling)
- Disable tool_call for mai-ds-r1 (does not support function calling)

## Test plan
- [x] Run `bun validate` - passes