### PR TITLE
docs: fix schema status info

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ Models must conform to the following schema, as defined in `app/schemas.ts`.
 - `limit.output`: Number — Maximum output tokens
 - `modalities.input`: Array of strings — Supported input modalities (e.g., ["text", "image", "audio", "video", "pdf"])
 - `modalities.output`: Array of strings — Supported output modalities (e.g., ["text"])
-- `status` _(optional)_: Array of strings — Supported status:
+- `status` _(optional)_: String — Supported status:
+  - `alpha` - Indicate the model is in alpha testing
+  - `beta` - Indicate the model is in beta testing
   - `deprecated` - Indicate the model is no longer served by the provider's public API
 
 ### Examples


### PR DESCRIPTION
Noticed this was a little off - it being an enum (string) rather than an array, and it missing the other two statuses (`alpha`, `beta`).

https://github.com/sst/models.dev/blob/dd10de3aa8938e5d75e461418c444a552a7cd999/packages/core/src/schema.ts#L58