### PR TITLE
Add Venice models: Gemini 3 Pro Preview and Kimi K2 Thinking

### DIFF
--- a/providers/venice/models/gemini-3-pro-preview.toml
+++ b/providers/venice/models/gemini-3-pro-preview.toml
@@ -1,0 +1,21 @@
+name = "Gemini 3 Pro Preview"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+knowledge = "2024-04"
+release_date = "2025-11-18"
+last_updated = "2025-11-18"
+open_weights = false
+
+[cost]
+input = 2.50
+output = 15.00
+
+[limit]
+context = 202_752
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/venice/models/kimi-k2-thinking.toml
+++ b/providers/venice/models/kimi-k2-thinking.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2 Thinking"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+knowledge = "2024-04"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
+open_weights = true
+
+[cost]
+input = 0.75
+output = 3.20
+
+[limit]
+context = 262_144
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add new models now available in at Venice AI.

Information about the models available here

https://docs.venice.ai/api-reference/endpoint/models/list
https://docs.venice.ai/overview/models
