### PR TITLE
feat: Add SAP AI Core provider

### DIFF
--- a/providers/sap-ai-core/models/claude-3-5-sonnet.toml
+++ b/providers/sap-ai-core/models/claude-3-5-sonnet.toml
@@ -1,0 +1,20 @@
+name = "Claude 3.5 Sonnet"
+release_date = "2024-06-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/sap-ai-core/models/claude-3-5-sonnet.toml
+++ b/providers/sap-ai-core/models/claude-3-5-sonnet.toml
@@ -1,4 +1,4 @@
-name = "Claude 3.5 Sonnet"
+name = "Claude Sonnet 3.5"
 release_date = "2024-06-20"
 attachment = true
 reasoning = false

--- a/providers/sap-ai-core/models/claude-3-5-sonnet.toml
+++ b/providers/sap-ai-core/models/claude-3-5-sonnet.toml
@@ -1,9 +1,11 @@
 name = "Claude Sonnet 3.5"
 release_date = "2024-06-20"
+last_updated = "2024-06-20"
 attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+open_weights = false
 
 [cost]
 input = 3.00

--- a/providers/sap-ai-core/models/gemini-1.5-pro.toml
+++ b/providers/sap-ai-core/models/gemini-1.5-pro.toml
@@ -1,0 +1,18 @@
+name = "Gemini 1.5 Pro"
+release_date = "2024-05-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+
+[cost]
+input = 1.25
+output = 5.00
+
+[limit]
+context = 2_000_000
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/sap-ai-core/models/gemini-1.5-pro.toml
+++ b/providers/sap-ai-core/models/gemini-1.5-pro.toml
@@ -1,5 +1,5 @@
 name = "Gemini 1.5 Pro"
-release_date = "2024-05-14"
+release_date = "2024-02-15"
 attachment = true
 reasoning = false
 temperature = true

--- a/providers/sap-ai-core/models/gemini-1.5-pro.toml
+++ b/providers/sap-ai-core/models/gemini-1.5-pro.toml
@@ -1,9 +1,11 @@
 name = "Gemini 1.5 Pro"
 release_date = "2024-02-15"
+last_updated = "2024-02-15"
 attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+open_weights = false
 
 [cost]
 input = 1.25

--- a/providers/sap-ai-core/models/gpt-4o.toml
+++ b/providers/sap-ai-core/models/gpt-4o.toml
@@ -1,0 +1,18 @@
+name = "GPT-4o"
+release_date = "2024-05-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+
+[cost]
+input = 2.50
+output = 10.00
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/sap-ai-core/models/gpt-4o.toml
+++ b/providers/sap-ai-core/models/gpt-4o.toml
@@ -1,9 +1,11 @@
 name = "GPT-4o"
 release_date = "2024-05-13"
+last_updated = "2024-05-13"
 attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+open_weights = false
 
 [cost]
 input = 2.50

--- a/providers/sap-ai-core/provider.toml
+++ b/providers/sap-ai-core/provider.toml
@@ -1,0 +1,4 @@
+name = "SAP AI Core"
+env = ["SAP_AI_SERVICE_KEY"]
+npm = "@mymediset/sap-ai-provider"
+doc = "https://help.sap.com/docs/sap-ai-core"


### PR DESCRIPTION
## Summary

Adds SAP AI Core provider to models.dev with initial model support.

## Provider Details

- **Name**: SAP AI Core
- **NPM Package**: `@mymediset/sap-ai-provider`
- **Authentication**: SAP_AI_SERVICE_KEY environment variable (SAP BTP service key JSON)
- **Documentation**: https://help.sap.com/docs/sap-ai-core

## Models Added

Initial support for 3 commonly used models:

1. **GPT-4o** - OpenAI multimodal flagship model
2. **Claude 3.5 Sonnet** - Anthropic balanced model with prompt caching
3. **Gemini 1.5 Pro** - Google long-context multimodal model

## Context

SAP AI Core provides access to 40+ models from OpenAI, Anthropic, Google, Amazon, Meta, Mistral, and AI21 through a unified platform. This provider enables enterprise users to access these models through their SAP BTP subscriptions.

## Testing

Provider has been tested in opencode PR: https://github.com/sst/opencode/pull/5023

## Related

- OpenCode PR: https://github.com/sst/opencode/pull/5023
- NPM Package: https://www.npmjs.com/package/@mymediset/sap-ai-provider
