### PR TITLE
Added hf:deepseek-ai/DeepSeek-V3.2 to synthetic

### DIFF
--- a/providers/synthetic/models/hf:deepseek-ai/DeepSeek-V3.2.toml
+++ b/providers/synthetic/models/hf:deepseek-ai/DeepSeek-V3.2.toml
@@ -1,0 +1,24 @@
+name = "DeepSeek V3.2"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+structured_output = true
+
+[cost]
+input = 0.27
+output = 0.40
+cache_read  = 0.27
+cache_write = 0.0
+
+[limit]
+context = 162_816
+input   = 162_816
+output = 8_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Information pulled from synthetic's `/models` API

```json
        {
            "always_on": true,
            "context_length": 162816,
            "hugging_face_id": "deepseek-ai/DeepSeek-V3.2",
            "id": "hf:deepseek-ai/DeepSeek-V3.2",
            "input_modalities": [
                "text"
            ],
            "name": "deepseek-ai/DeepSeek-V3.2",
            "output_modalities": [
                "text"
            ],
            "pricing": {
                "completion": "$0.0000004",
                "image": "0",
                "input_cache_reads": "$0.00000027",
                "input_cache_writes": "0",
                "prompt": "$0.00000027",
                "request": "0"
            },
            "provider": "deepinfra"
        }
```

as well as DeepSeek [news](https://api-docs.deepseek.com/news/news251201).