### PR TITLE
add GPT OSS 120B and GPT OSS 20B model configuration files for VertexAI

### DIFF
--- a/providers/google-vertex/models/openai/gpt-oss-120b-maas.toml
+++ b/providers/google-vertex/models/openai/gpt-oss-120b-maas.toml
@@ -1,0 +1,20 @@
+name = "GPT OSS 120B"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.09
+output = 0.36
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/google-vertex/models/openai/gpt-oss-20b-maas.toml
+++ b/providers/google-vertex/models/openai/gpt-oss-20b-maas.toml
@@ -1,0 +1,20 @@
+name = "GPT OSS 20B"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.25
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
add new model for VertexAI
- openai/gpt-oss-120b-maas
- openai/gpt-oss-20b-maas