### PR TITLE
Update schema add interleaved

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ name = "Model Display Name"
 attachment = true           # or false - supports file attachments
 reasoning = false           # or true - supports reasoning / chain-of-thought
 tool_call = true            # or false - supports tool calling
+interleaved = true          # or { name = "reasoning_content" | "reasoning_details" }
 structured_output = true    # or false - supports a dedicated structured output feature
 temperature = true          # or false - supports temperature control
 knowledge = "2024-04"       # Knowledge-cutoff date
@@ -151,6 +152,7 @@ Models must conform to the following schema, as defined in `app/schemas.ts`.
 - `attachment`: Boolean — Supports file attachments
 - `reasoning`: Boolean — Supports reasoning / chain-of-thought
 - `tool_call`: Boolean - Supports tool calling
+- `interleaved` _(optional)_: `true` for general support or an object with `name` set to either `reasoning_content` or `reasoning_details` to specify which stream is interleaved
 - `structured_output` _(optional)_: Boolean — Supports structured output feature
 - `temperature` _(optional)_: Boolean — Supports temperature control
 - `knowledge` _(optional)_: String — Knowledge-cutoff date in `YYYY-MM` or `YYYY-MM-DD` format

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -28,6 +28,16 @@ export const Model = z
     attachment: z.boolean(),
     reasoning: z.boolean(),
     tool_call: z.boolean(),
+    interleaved: z
+      .union([
+        z.literal(true),
+        z
+          .object({
+            name: z.enum(["reasoning_content", "reasoning_details"]),
+          })
+          .strict(),
+      ])
+      .optional(),
     structured_output: z.boolean().optional(),
     temperature: z.boolean().optional(),
     knowledge: z

--- a/providers/opencode/models/claude-sonnet-4-5.toml
+++ b/providers/opencode/models/claude-sonnet-4-5.toml
@@ -5,6 +5,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+interleaved = true
 knowledge = "2025-07-31"
 open_weights = false
 

--- a/providers/opencode/models/kimi-k2-thinking.toml
+++ b/providers/opencode/models/kimi-k2-thinking.toml
@@ -5,9 +5,11 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-interleaved = { name = "reasoning_details" }
 knowledge = "2024-10"
 open_weights = true
+
+[interleaved]
+name = "reasoning_details"
 
 [cost]
 input = 0.4

--- a/providers/opencode/models/kimi-k2-thinking.toml
+++ b/providers/opencode/models/kimi-k2-thinking.toml
@@ -5,6 +5,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+interleaved = { name = "reasoning_details" }
 knowledge = "2024-10"
 open_weights = true
 


### PR DESCRIPTION
Add an `interleaved` field to the schema to allow models to advertise simple enablement or specific reasoning streams for interleaving.

---
<a href="https://cursor.com/background-agent?bcId=bc-a227a7a3-ae99-490e-865f-343d15760fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a227a7a3-ae99-490e-865f-343d15760fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

