### PR TITLE
feat: add GLM-4.6V model to ZAI providers

### DIFF
--- a/providers/zai-coding-plan/models/glm-4.6v.toml
+++ b/providers/zai-coding-plan/models/glm-4.6v.toml
@@ -1,0 +1,21 @@
+name = "GLM-4.6V"
+release_date = "2025-12-08"
+last_updated = "2025-12-08"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128000
+output = 32768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/zai/models/glm-4.6v.toml
+++ b/providers/zai/models/glm-4.6v.toml
@@ -1,0 +1,21 @@
+name = "GLM-4.6V"
+release_date = "2025-12-08"
+last_updated = "2025-12-08"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.3
+output = 0.9
+
+[limit]
+context = 128000
+output = 32768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/zhipuai-coding-plan/models/glm-4.6v.toml
+++ b/providers/zhipuai-coding-plan/models/glm-4.6v.toml
@@ -1,0 +1,1 @@
+../../zai-coding-plan/models/glm-4.6v.toml

--- a/providers/zhipuai/models/glm-4.6v.toml
+++ b/providers/zhipuai/models/glm-4.6v.toml
@@ -1,0 +1,1 @@
+../../zai/models/glm-4.6v.toml


### PR DESCRIPTION
- Add GLM-4.6V model to ZAI provider with official pricing (/usr/bin/zsh.3//usr/bin/zsh.9 per 1M tokens)
- Add GLM-4.6V model to ZAI Coding Plan provider with free pricing (0/0)
- Create symlinks for zhipuai and zhipuai-coding-plan providers
- Based on official Z.AI documentation (Dec 8, 2025)
- Features: 128K context, native tool calling, multimodal support
- Modalities: text, image, video input → text output
- Open source model with MIT license
- Add proper formatting with trailing newlines