### PR TITLE
Add new model configurations for various AI models

### DIFF
--- a/providers/openrouter/models/ai21/jamba-large-1.7.toml
+++ b/providers/openrouter/models/ai21/jamba-large-1.7.toml
@@ -1,0 +1,22 @@
+name = "AI21: Jamba Large 1.7"
+release_date = "2025-08-08"
+last_updated = "2025-08-08"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 4096
+
+[cost]
+input = 2.0
+output = 8.0

--- a/providers/openrouter/models/ai21/jamba-mini-1.7.toml
+++ b/providers/openrouter/models/ai21/jamba-mini-1.7.toml
@@ -1,0 +1,22 @@
+name = "AI21: Jamba Mini 1.7"
+release_date = "2025-08-08"
+last_updated = "2025-08-08"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 4096
+
+[cost]
+input = 0.19999999999999998
+output = 0.39999999999999997

--- a/providers/openrouter/models/aion-labs/aion-1.0-mini.toml
+++ b/providers/openrouter/models/aion-labs/aion-1.0-mini.toml
@@ -1,0 +1,22 @@
+name = "AionLabs: Aion-1.0-Mini"
+release_date = "2025-02-04"
+last_updated = "2025-02-04"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 32768
+
+[cost]
+input = 0.7
+output = 1.4

--- a/providers/openrouter/models/aion-labs/aion-1.0.toml
+++ b/providers/openrouter/models/aion-labs/aion-1.0.toml
@@ -1,0 +1,22 @@
+name = "AionLabs: Aion-1.0"
+release_date = "2025-02-04"
+last_updated = "2025-02-04"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 32768
+
+[cost]
+input = 4.0
+output = 8.0

--- a/providers/openrouter/models/aion-labs/aion-rp-llama-3.1-8b.toml
+++ b/providers/openrouter/models/aion-labs/aion-rp-llama-3.1-8b.toml
@@ -1,0 +1,22 @@
+name = "AionLabs: Aion-RP 1.0 (8B)"
+release_date = "2025-02-04"
+last_updated = "2025-02-04"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.19999999999999998
+output = 0.19999999999999998

--- a/providers/openrouter/models/alfredpros/codellama-7b-instruct-solidity.toml
+++ b/providers/openrouter/models/alfredpros/codellama-7b-instruct-solidity.toml
@@ -1,0 +1,22 @@
+name = "AlfredPros: CodeLLaMa 7B Instruct Solidity"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 4096
+input = 4096
+output = 4096
+
+[cost]
+input = 0.7999999999999999
+output = 1.2

--- a/providers/openrouter/models/alibaba/tongyi-deepresearch-30b-a3b.toml
+++ b/providers/openrouter/models/alibaba/tongyi-deepresearch-30b-a3b.toml
@@ -1,0 +1,22 @@
+name = "Tongyi DeepResearch 30B A3B"
+release_date = "2025-09-18"
+last_updated = "2025-09-18"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.09
+output = 0.39999999999999997

--- a/providers/openrouter/models/alibaba/tongyi-deepresearch-30b-a3b:free.toml
+++ b/providers/openrouter/models/alibaba/tongyi-deepresearch-30b-a3b:free.toml
@@ -1,0 +1,22 @@
+name = "Tongyi DeepResearch 30B A3B (free)"
+release_date = "2025-09-18"
+last_updated = "2025-09-18"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/allenai/olmo-2-0325-32b-instruct.toml
+++ b/providers/openrouter/models/allenai/olmo-2-0325-32b-instruct.toml
@@ -1,0 +1,22 @@
+name = "AllenAI: Olmo 2 32B Instruct"
+release_date = "2025-03-14"
+last_updated = "2025-03-14"
+open_weights = true
+tool_call = false
+structured_output = false
+temperature = false
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 0.049999999999999996
+output = 0.19999999999999998

--- a/providers/openrouter/models/allenai/olmo-3-32b-think:free.toml
+++ b/providers/openrouter/models/allenai/olmo-3-32b-think:free.toml
@@ -1,0 +1,22 @@
+name = "AllenAI: Olmo 3 32B Think (free)"
+release_date = "2025-11-21"
+last_updated = "2025-11-21"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 65536
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/allenai/olmo-3-7b-instruct.toml
+++ b/providers/openrouter/models/allenai/olmo-3-7b-instruct.toml
@@ -1,0 +1,22 @@
+name = "AllenAI: Olmo 3 7B Instruct"
+release_date = "2025-11-21"
+last_updated = "2025-11-21"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 65536
+
+[cost]
+input = 0.09999999999999999
+output = 0.19999999999999998

--- a/providers/openrouter/models/allenai/olmo-3-7b-think.toml
+++ b/providers/openrouter/models/allenai/olmo-3-7b-think.toml
@@ -1,0 +1,22 @@
+name = "AllenAI: Olmo 3 7B Think"
+release_date = "2025-11-21"
+last_updated = "2025-11-21"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 65536
+
+[cost]
+input = 0.12
+output = 0.19999999999999998

--- a/providers/openrouter/models/alpindale/goliath-120b.toml
+++ b/providers/openrouter/models/alpindale/goliath-120b.toml
@@ -1,0 +1,22 @@
+name = "Goliath 120B"
+release_date = "2023-11-09"
+last_updated = "2023-11-09"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 6144
+input = 6144
+output = 1024
+
+[cost]
+input = 6.0
+output = 8.0

--- a/providers/openrouter/models/amazon/nova-2-lite-v1.toml
+++ b/providers/openrouter/models/amazon/nova-2-lite-v1.toml
@@ -1,0 +1,22 @@
+name = "Amazon: Nova 2 Lite"
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "video", "file",]
+output = [ "text",]
+
+[limit]
+context = 1000000
+input = 1000000
+output = 65535
+
+[cost]
+input = 0.3
+output = 2.5

--- a/providers/openrouter/models/amazon/nova-2-lite-v1:free.toml
+++ b/providers/openrouter/models/amazon/nova-2-lite-v1:free.toml
@@ -1,0 +1,22 @@
+name = "Amazon: Nova 2 Lite (free)"
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "video", "file",]
+output = [ "text",]
+
+[limit]
+context = 1000000
+input = 1000000
+output = 65535
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/amazon/nova-lite-v1.toml
+++ b/providers/openrouter/models/amazon/nova-lite-v1.toml
@@ -1,0 +1,22 @@
+name = "Amazon: Nova Lite 1.0"
+release_date = "2024-12-05"
+last_updated = "2024-12-05"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 300000
+input = 300000
+output = 5120
+
+[cost]
+input = 0.06
+output = 0.24

--- a/providers/openrouter/models/amazon/nova-micro-v1.toml
+++ b/providers/openrouter/models/amazon/nova-micro-v1.toml
@@ -1,0 +1,22 @@
+name = "Amazon: Nova Micro 1.0"
+release_date = "2024-12-05"
+last_updated = "2024-12-05"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 5120
+
+[cost]
+input = 0.035
+output = 0.14

--- a/providers/openrouter/models/amazon/nova-premier-v1.toml
+++ b/providers/openrouter/models/amazon/nova-premier-v1.toml
@@ -1,0 +1,22 @@
+name = "Amazon: Nova Premier 1.0"
+release_date = "2025-10-31"
+last_updated = "2025-10-31"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 1000000
+input = 1000000
+output = 32000
+
+[cost]
+input = 2.5
+output = 12.5

--- a/providers/openrouter/models/amazon/nova-pro-v1.toml
+++ b/providers/openrouter/models/amazon/nova-pro-v1.toml
@@ -1,0 +1,22 @@
+name = "Amazon: Nova Pro 1.0"
+release_date = "2024-12-05"
+last_updated = "2024-12-05"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 300000
+input = 300000
+output = 5120
+
+[cost]
+input = 0.7999999999999999
+output = 3.1999999999999997

--- a/providers/openrouter/models/anthracite-org/magnum-v4-72b.toml
+++ b/providers/openrouter/models/anthracite-org/magnum-v4-72b.toml
@@ -1,0 +1,22 @@
+name = "Magnum v4 72B"
+release_date = "2024-10-21"
+last_updated = "2024-10-21"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 16384
+input = 16384
+output = 2048
+
+[cost]
+input = 3.0
+output = 5.0

--- a/providers/openrouter/models/anthropic/claude-3-haiku.toml
+++ b/providers/openrouter/models/anthropic/claude-3-haiku.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude 3 Haiku"
+release_date = "2024-03-12"
+last_updated = "2024-03-12"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 4096
+
+[cost]
+input = 0.25
+output = 1.25

--- a/providers/openrouter/models/anthropic/claude-3-opus.toml
+++ b/providers/openrouter/models/anthropic/claude-3-opus.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude 3 Opus"
+release_date = "2024-03-04"
+last_updated = "2024-03-04"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 4096
+
+[cost]
+input = 15.0
+output = 75.0

--- a/providers/openrouter/models/anthropic/claude-3.5-haiku-20241022.toml
+++ b/providers/openrouter/models/anthropic/claude-3.5-haiku-20241022.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude 3.5 Haiku (2024-10-22)"
+release_date = "2024-11-03"
+last_updated = "2024-11-03"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 8192
+
+[cost]
+input = 0.7999999999999999
+output = 4.0

--- a/providers/openrouter/models/anthropic/claude-3.5-sonnet.toml
+++ b/providers/openrouter/models/anthropic/claude-3.5-sonnet.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude 3.5 Sonnet"
+release_date = "2024-10-21"
+last_updated = "2024-10-21"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 8192
+
+[cost]
+input = 6.0
+output = 30.0

--- a/providers/openrouter/models/anthropic/claude-3.7-sonnet:thinking.toml
+++ b/providers/openrouter/models/anthropic/claude-3.7-sonnet:thinking.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude 3.7 Sonnet (thinking)"
+release_date = "2025-02-24"
+last_updated = "2025-02-24"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 64000
+
+[cost]
+input = 3.0
+output = 15.0

--- a/providers/openrouter/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-haiku-4.5.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Haiku 4.5"
+release_date = "2025-10-15"
+last_updated = "2025-10-15"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 64000
+
+[cost]
+input = 1.0
+output = 5.0

--- a/providers/openrouter/models/anthropic/claude-opus-4.1.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.1.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Opus 4.1"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 32000
+
+[cost]
+input = 15.0
+output = 75.0

--- a/providers/openrouter/models/anthropic/claude-opus-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.5.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Opus 4.5"
+release_date = "2025-11-24"
+last_updated = "2025-11-24"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "file", "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 32000
+
+[cost]
+input = 5.0
+output = 25.0

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Sonnet 4.5"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 1000000
+input = 1000000
+output = 64000
+
+[cost]
+input = 3.0
+output = 15.0

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Sonnet 4"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 1000000
+input = 1000000
+output = 64000
+
+[cost]
+input = 3.0
+output = 15.0

--- a/providers/openrouter/models/arcee-ai/coder-large.toml
+++ b/providers/openrouter/models/arcee-ai/coder-large.toml
@@ -1,0 +1,22 @@
+name = "Arcee AI: Coder Large"
+release_date = "2025-05-05"
+last_updated = "2025-05-05"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.5
+output = 0.7999999999999999

--- a/providers/openrouter/models/arcee-ai/maestro-reasoning.toml
+++ b/providers/openrouter/models/arcee-ai/maestro-reasoning.toml
@@ -1,0 +1,22 @@
+name = "Arcee AI: Maestro Reasoning"
+release_date = "2025-05-05"
+last_updated = "2025-05-05"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 32000
+
+[cost]
+input = 0.8999999999999999
+output = 3.3000000000000003

--- a/providers/openrouter/models/arcee-ai/spotlight.toml
+++ b/providers/openrouter/models/arcee-ai/spotlight.toml
@@ -1,0 +1,22 @@
+name = "Arcee AI: Spotlight"
+release_date = "2025-05-05"
+last_updated = "2025-05-05"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 65537
+
+[cost]
+input = 0.18
+output = 0.18

--- a/providers/openrouter/models/arcee-ai/trinity-mini.toml
+++ b/providers/openrouter/models/arcee-ai/trinity-mini.toml
@@ -1,0 +1,22 @@
+name = "Arcee AI: Trinity Mini"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.045
+output = 0.15

--- a/providers/openrouter/models/arcee-ai/trinity-mini:free.toml
+++ b/providers/openrouter/models/arcee-ai/trinity-mini:free.toml
@@ -1,0 +1,22 @@
+name = "Arcee AI: Trinity Mini (free)"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/arcee-ai/virtuoso-large.toml
+++ b/providers/openrouter/models/arcee-ai/virtuoso-large.toml
@@ -1,0 +1,22 @@
+name = "Arcee AI: Virtuoso Large"
+release_date = "2025-05-05"
+last_updated = "2025-05-05"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 64000
+
+[cost]
+input = 0.75
+output = 1.2

--- a/providers/openrouter/models/arliai/qwq-32b-arliai-rpr-v1.toml
+++ b/providers/openrouter/models/arliai/qwq-32b-arliai-rpr-v1.toml
@@ -1,0 +1,22 @@
+name = "ArliAI: QwQ 32B RpR v1"
+release_date = "2025-04-13"
+last_updated = "2025-04-13"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.03
+output = 0.11

--- a/providers/openrouter/models/baidu/ernie-4.5-21b-a3b-thinking.toml
+++ b/providers/openrouter/models/baidu/ernie-4.5-21b-a3b-thinking.toml
@@ -1,0 +1,22 @@
+name = "Baidu: ERNIE 4.5 21B A3B Thinking"
+release_date = "2025-10-09"
+last_updated = "2025-10-09"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 65536
+
+[cost]
+input = 0.056
+output = 0.224

--- a/providers/openrouter/models/baidu/ernie-4.5-21b-a3b.toml
+++ b/providers/openrouter/models/baidu/ernie-4.5-21b-a3b.toml
@@ -1,0 +1,22 @@
+name = "Baidu: ERNIE 4.5 21B A3B"
+release_date = "2025-08-12"
+last_updated = "2025-08-12"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 120000
+input = 120000
+output = 8000
+
+[cost]
+input = 0.056
+output = 0.224

--- a/providers/openrouter/models/baidu/ernie-4.5-300b-a47b.toml
+++ b/providers/openrouter/models/baidu/ernie-4.5-300b-a47b.toml
@@ -1,0 +1,22 @@
+name = "Baidu: ERNIE 4.5 300B A47B "
+release_date = "2025-06-30"
+last_updated = "2025-06-30"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 123000
+input = 123000
+output = 12000
+
+[cost]
+input = 0.224
+output = 0.88

--- a/providers/openrouter/models/baidu/ernie-4.5-vl-28b-a3b.toml
+++ b/providers/openrouter/models/baidu/ernie-4.5-vl-28b-a3b.toml
@@ -1,0 +1,22 @@
+name = "Baidu: ERNIE 4.5 VL 28B A3B"
+release_date = "2025-08-12"
+last_updated = "2025-08-12"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 30000
+input = 30000
+output = 8000
+
+[cost]
+input = 0.112
+output = 0.448

--- a/providers/openrouter/models/baidu/ernie-4.5-vl-424b-a47b.toml
+++ b/providers/openrouter/models/baidu/ernie-4.5-vl-424b-a47b.toml
@@ -1,0 +1,22 @@
+name = "Baidu: ERNIE 4.5 VL 424B A47B "
+release_date = "2025-06-30"
+last_updated = "2025-06-30"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 123000
+input = 123000
+output = 16000
+
+[cost]
+input = 0.33599999999999997
+output = 1.0

--- a/providers/openrouter/models/bytedance/ui-tars-1.5-7b.toml
+++ b/providers/openrouter/models/bytedance/ui-tars-1.5-7b.toml
@@ -1,0 +1,22 @@
+name = "ByteDance: UI-TARS 7B "
+release_date = "2025-07-22"
+last_updated = "2025-07-22"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 2048
+
+[cost]
+input = 0.09999999999999999
+output = 0.19999999999999998

--- a/providers/openrouter/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
+++ b/providers/openrouter/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
@@ -1,0 +1,22 @@
+name = "Venice: Uncensored (free)"
+release_date = "2025-07-09"
+last_updated = "2025-07-09"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/cohere/command-a.toml
+++ b/providers/openrouter/models/cohere/command-a.toml
@@ -1,0 +1,22 @@
+name = "Cohere: Command A"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 8192
+
+[cost]
+input = 2.5
+output = 10.0

--- a/providers/openrouter/models/cohere/command-r-08-2024.toml
+++ b/providers/openrouter/models/cohere/command-r-08-2024.toml
@@ -1,0 +1,22 @@
+name = "Cohere: Command R (08-2024)"
+release_date = "2024-08-29"
+last_updated = "2024-08-29"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4000
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/openrouter/models/cohere/command-r-plus-08-2024.toml
+++ b/providers/openrouter/models/cohere/command-r-plus-08-2024.toml
@@ -1,0 +1,22 @@
+name = "Cohere: Command R+ (08-2024)"
+release_date = "2024-08-29"
+last_updated = "2024-08-29"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4000
+
+[cost]
+input = 2.5
+output = 10.0

--- a/providers/openrouter/models/cohere/command-r7b-12-2024.toml
+++ b/providers/openrouter/models/cohere/command-r7b-12-2024.toml
@@ -1,0 +1,22 @@
+name = "Cohere: Command R7B (12-2024)"
+release_date = "2024-12-14"
+last_updated = "2024-12-14"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4000
+
+[cost]
+input = 0.0375
+output = 0.15

--- a/providers/openrouter/models/deepcogito/cogito-v2-preview-llama-109b-moe.toml
+++ b/providers/openrouter/models/deepcogito/cogito-v2-preview-llama-109b-moe.toml
@@ -1,0 +1,22 @@
+name = "Cogito V2 Preview Llama 109B"
+release_date = "2025-09-02"
+last_updated = "2025-09-02"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 32767
+input = 32767
+output = 4096
+
+[cost]
+input = 0.18
+output = 0.59

--- a/providers/openrouter/models/deepcogito/cogito-v2-preview-llama-405b.toml
+++ b/providers/openrouter/models/deepcogito/cogito-v2-preview-llama-405b.toml
@@ -1,0 +1,22 @@
+name = "Deep Cogito: Cogito V2 Preview Llama 405B"
+release_date = "2025-10-17"
+last_updated = "2025-10-17"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 3.5
+output = 3.5

--- a/providers/openrouter/models/deepcogito/cogito-v2-preview-llama-70b.toml
+++ b/providers/openrouter/models/deepcogito/cogito-v2-preview-llama-70b.toml
@@ -1,0 +1,22 @@
+name = "Deep Cogito: Cogito V2 Preview Llama 70B"
+release_date = "2025-09-02"
+last_updated = "2025-09-02"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.88
+output = 0.88

--- a/providers/openrouter/models/deepcogito/cogito-v2.1-671b.toml
+++ b/providers/openrouter/models/deepcogito/cogito-v2.1-671b.toml
@@ -1,0 +1,22 @@
+name = "Deep Cogito: Cogito v2.1 671B"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 1.25
+output = 1.25

--- a/providers/openrouter/models/deepseek/deepseek-chat-v3.1.toml
+++ b/providers/openrouter/models/deepseek/deepseek-chat-v3.1.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: DeepSeek V3.1"
+release_date = "2025-08-21"
+last_updated = "2025-08-21"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 7168
+
+[cost]
+input = 0.15
+output = 0.75

--- a/providers/openrouter/models/deepseek/deepseek-chat.toml
+++ b/providers/openrouter/models/deepseek/deepseek-chat.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: DeepSeek V3"
+release_date = "2024-12-26"
+last_updated = "2024-12-26"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 163840
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/openrouter/models/deepseek/deepseek-prover-v2.toml
+++ b/providers/openrouter/models/deepseek/deepseek-prover-v2.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: DeepSeek Prover V2"
+release_date = "2025-04-30"
+last_updated = "2025-04-30"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 4096
+
+[cost]
+input = 0.5
+output = 2.1799999999999997

--- a/providers/openrouter/models/deepseek/deepseek-r1-0528-qwen3-8b.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-0528-qwen3-8b.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: DeepSeek R1 0528 Qwen3 8B"
+release_date = "2025-05-29"
+last_updated = "2025-05-29"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.02
+output = 0.09999999999999999

--- a/providers/openrouter/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-0528.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: R1 0528"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 163840
+
+[cost]
+input = 0.39999999999999997
+output = 1.75

--- a/providers/openrouter/models/deepseek/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-distill-qwen-32b.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: R1 Distill Qwen 32B"
+release_date = "2025-01-29"
+last_updated = "2025-01-29"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 64000
+input = 64000
+output = 32000
+
+[cost]
+input = 0.24
+output = 0.24

--- a/providers/openrouter/models/deepseek/deepseek-r1.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: R1"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 4096
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/openrouter/models/deepseek/deepseek-v3.1-terminus.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.1-terminus.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: DeepSeek V3.1 Terminus"
+release_date = "2025-09-22"
+last_updated = "2025-09-22"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 4096
+
+[cost]
+input = 0.21
+output = 0.7899999999999999

--- a/providers/openrouter/models/deepseek/deepseek-v3.1-terminus:exacto.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.1-terminus:exacto.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: DeepSeek V3.1 Terminus (exacto)"
+release_date = "2025-09-22"
+last_updated = "2025-09-22"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 4096
+
+[cost]
+input = 0.21
+output = 0.7899999999999999

--- a/providers/openrouter/models/deepseek/deepseek-v3.2-exp.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.2-exp.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: DeepSeek V3.2 Exp"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 4096
+
+[cost]
+input = 0.21
+output = 0.32

--- a/providers/openrouter/models/deepseek/deepseek-v3.2-speciale.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.2-speciale.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: DeepSeek V3.2 Speciale"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 65536
+
+[cost]
+input = 0.27
+output = 0.41

--- a/providers/openrouter/models/deepseek/deepseek-v3.2.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.2.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek: DeepSeek V3.2"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 65536
+
+[cost]
+input = 0.26
+output = 0.39

--- a/providers/openrouter/models/eleutherai/llemma_7b.toml
+++ b/providers/openrouter/models/eleutherai/llemma_7b.toml
@@ -1,0 +1,22 @@
+name = "EleutherAI: Llemma 7b"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 4096
+input = 4096
+output = 4096
+
+[cost]
+input = 0.7999999999999999
+output = 1.2

--- a/providers/openrouter/models/essentialai/rnj-1-instruct.toml
+++ b/providers/openrouter/models/essentialai/rnj-1-instruct.toml
@@ -1,0 +1,22 @@
+name = "EssentialAI: Rnj 1 Instruct"
+release_date = "2025-12-07"
+last_updated = "2025-12-07"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.15
+output = 0.15

--- a/providers/openrouter/models/google/gemini-2.0-flash-lite-001.toml
+++ b/providers/openrouter/models/google/gemini-2.0-flash-lite-001.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.0 Flash Lite"
+release_date = "2025-02-25"
+last_updated = "2025-02-25"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file", "audio", "video",]
+output = [ "text",]
+
+[limit]
+context = 1048576
+input = 1048576
+output = 8192
+
+[cost]
+input = 0.075
+output = 0.3

--- a/providers/openrouter/models/google/gemini-2.5-flash-image-preview.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-image-preview.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Flash Image Preview (Nano Banana)"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "image", "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.3
+output = 2.5

--- a/providers/openrouter/models/google/gemini-2.5-flash-image.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-image.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Flash Image (Nano Banana)"
+release_date = "2025-10-07"
+last_updated = "2025-10-07"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "image", "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.3
+output = 2.5

--- a/providers/openrouter/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Flash Lite Preview 09-2025"
+release_date = "2025-09-25"
+last_updated = "2025-09-25"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file", "audio", "video",]
+output = [ "text",]
+
+[limit]
+context = 1048576
+input = 1048576
+output = 65536
+
+[cost]
+input = 0.09999999999999999
+output = 0.39999999999999997

--- a/providers/openrouter/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-lite.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Flash Lite"
+release_date = "2025-07-22"
+last_updated = "2025-07-22"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file", "audio", "video",]
+output = [ "text",]
+
+[limit]
+context = 1048576
+input = 1048576
+output = 65535
+
+[cost]
+input = 0.09999999999999999
+output = 0.39999999999999997

--- a/providers/openrouter/models/google/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-preview-09-2025.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Flash Preview 09-2025"
+release_date = "2025-09-25"
+last_updated = "2025-09-25"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "file", "text", "audio", "video",]
+output = [ "text",]
+
+[limit]
+context = 1048576
+input = 1048576
+output = 65536
+
+[cost]
+input = 0.3
+output = 2.5

--- a/providers/openrouter/models/google/gemini-2.5-pro-preview.toml
+++ b/providers/openrouter/models/google/gemini-2.5-pro-preview.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Pro Preview 06-05"
+release_date = "2025-06-05"
+last_updated = "2025-06-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "file", "image", "text", "audio",]
+output = [ "text",]
+
+[limit]
+context = 1048576
+input = 1048576
+output = 65536
+
+[cost]
+input = 1.25
+output = 10.0

--- a/providers/openrouter/models/google/gemini-3-pro-image-preview.toml
+++ b/providers/openrouter/models/google/gemini-3-pro-image-preview.toml
@@ -1,0 +1,22 @@
+name = "Google: Nano Banana Pro (Gemini 3 Pro Image Preview)"
+release_date = "2025-11-20"
+last_updated = "2025-11-20"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "image", "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 32768
+
+[cost]
+input = 2.0
+output = 12.0

--- a/providers/openrouter/models/google/gemini-3-pro-preview.toml
+++ b/providers/openrouter/models/google/gemini-3-pro-preview.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 3 Pro Preview"
+release_date = "2025-11-18"
+last_updated = "2025-11-18"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file", "audio", "video",]
+output = [ "text",]
+
+[limit]
+context = 1048576
+input = 1048576
+output = 65536
+
+[cost]
+input = 2.0
+output = 12.0

--- a/providers/openrouter/models/google/gemma-2-27b-it.toml
+++ b/providers/openrouter/models/google/gemma-2-27b-it.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemma 2 27B"
+release_date = "2024-07-12"
+last_updated = "2024-07-12"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 4096
+
+[cost]
+input = 0.65
+output = 0.65

--- a/providers/openrouter/models/google/gemma-2-9b-it.toml
+++ b/providers/openrouter/models/google/gemma-2-9b-it.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemma 2 9B"
+release_date = "2024-06-27"
+last_updated = "2024-06-27"
+open_weights = true
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 4096
+
+[cost]
+input = 0.03
+output = 0.09

--- a/providers/openrouter/models/google/gemma-3-12b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-3-12b-it:free.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemma 3 12B (free)"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 8192
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/google/gemma-3-27b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-3-27b-it:free.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemma 3 27B (free)"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 8192
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/google/gemma-3-4b-it.toml
+++ b/providers/openrouter/models/google/gemma-3-4b-it.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemma 3 4B"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 96000
+input = 96000
+output = 4096
+
+[cost]
+input = 0.01703012
+output = 0.0681536

--- a/providers/openrouter/models/google/gemma-3-4b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-3-4b-it:free.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemma 3 4B (free)"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 8192
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/google/gemma-3n-e2b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-3n-e2b-it:free.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemma 3n 2B (free)"
+release_date = "2025-07-09"
+last_updated = "2025-07-09"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 2048
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/gryphe/mythomax-l2-13b.toml
+++ b/providers/openrouter/models/gryphe/mythomax-l2-13b.toml
@@ -1,0 +1,22 @@
+name = "MythoMax 13B"
+release_date = "2023-07-01"
+last_updated = "2023-07-01"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 4096
+input = 4096
+output = 4096
+
+[cost]
+input = 0.06
+output = 0.06

--- a/providers/openrouter/models/ibm-granite/granite-4.0-h-micro.toml
+++ b/providers/openrouter/models/ibm-granite/granite-4.0-h-micro.toml
@@ -1,0 +1,22 @@
+name = "IBM: Granite 4.0 Micro"
+release_date = "2025-10-19"
+last_updated = "2025-10-19"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131000
+input = 131000
+output = 4096
+
+[cost]
+input = 0.017
+output = 0.11

--- a/providers/openrouter/models/inception/mercury-coder.toml
+++ b/providers/openrouter/models/inception/mercury-coder.toml
@@ -1,0 +1,22 @@
+name = "Inception: Mercury Coder"
+release_date = "2025-04-30"
+last_updated = "2025-04-30"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 0.25
+output = 1.0

--- a/providers/openrouter/models/inception/mercury.toml
+++ b/providers/openrouter/models/inception/mercury.toml
@@ -1,0 +1,22 @@
+name = "Inception: Mercury"
+release_date = "2025-06-26"
+last_updated = "2025-06-26"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 0.25
+output = 1.0

--- a/providers/openrouter/models/inflection/inflection-3-pi.toml
+++ b/providers/openrouter/models/inflection/inflection-3-pi.toml
@@ -1,0 +1,22 @@
+name = "Inflection: Inflection 3 Pi"
+release_date = "2024-10-10"
+last_updated = "2024-10-10"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8000
+input = 8000
+output = 1024
+
+[cost]
+input = 2.5
+output = 10.0

--- a/providers/openrouter/models/inflection/inflection-3-productivity.toml
+++ b/providers/openrouter/models/inflection/inflection-3-productivity.toml
@@ -1,0 +1,22 @@
+name = "Inflection: Inflection 3 Productivity"
+release_date = "2024-10-10"
+last_updated = "2024-10-10"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8000
+input = 8000
+output = 1024
+
+[cost]
+input = 2.5
+output = 10.0

--- a/providers/openrouter/models/kwaipilot/kat-coder-pro:free.toml
+++ b/providers/openrouter/models/kwaipilot/kat-coder-pro:free.toml
@@ -1,0 +1,22 @@
+name = "Kwaipilot: KAT-Coder-Pro V1 (free)"
+release_date = "2025-11-09"
+last_updated = "2025-11-09"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 32768
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/liquid/lfm-2.2-6b.toml
+++ b/providers/openrouter/models/liquid/lfm-2.2-6b.toml
@@ -1,0 +1,22 @@
+name = "LiquidAI/LFM2-2.6B"
+release_date = "2025-10-20"
+last_updated = "2025-10-20"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.049999999999999996
+output = 0.09999999999999999

--- a/providers/openrouter/models/liquid/lfm2-8b-a1b.toml
+++ b/providers/openrouter/models/liquid/lfm2-8b-a1b.toml
@@ -1,0 +1,22 @@
+name = "LiquidAI/LFM2-8B-A1B"
+release_date = "2025-10-20"
+last_updated = "2025-10-20"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.049999999999999996
+output = 0.09999999999999999

--- a/providers/openrouter/models/mancer/weaver.toml
+++ b/providers/openrouter/models/mancer/weaver.toml
@@ -1,0 +1,22 @@
+name = "Mancer: Weaver (alpha)"
+release_date = "2023-08-01"
+last_updated = "2023-08-01"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8000
+input = 8000
+output = 2000
+
+[cost]
+input = 1.125
+output = 1.125

--- a/providers/openrouter/models/meituan/longcat-flash-chat.toml
+++ b/providers/openrouter/models/meituan/longcat-flash-chat.toml
@@ -1,0 +1,22 @@
+name = "Meituan: LongCat Flash Chat"
+release_date = "2025-09-09"
+last_updated = "2025-09-09"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.15
+output = 0.75

--- a/providers/openrouter/models/meituan/longcat-flash-chat:free.toml
+++ b/providers/openrouter/models/meituan/longcat-flash-chat:free.toml
@@ -1,0 +1,22 @@
+name = "Meituan: LongCat Flash Chat (free)"
+release_date = "2025-09-09"
+last_updated = "2025-09-09"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/meta-llama/llama-3-70b-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3-70b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3 70B Instruct"
+release_date = "2024-04-17"
+last_updated = "2024-04-17"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 16384
+
+[cost]
+input = 0.3
+output = 0.39999999999999997

--- a/providers/openrouter/models/meta-llama/llama-3-8b-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3-8b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3 8B Instruct"
+release_date = "2024-04-17"
+last_updated = "2024-04-17"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 16384
+
+[cost]
+input = 0.03
+output = 0.06

--- a/providers/openrouter/models/meta-llama/llama-3.1-405b-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.1-405b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3.1 405B Instruct"
+release_date = "2024-07-22"
+last_updated = "2024-07-22"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 130815
+input = 130815
+output = 4096
+
+[cost]
+input = 3.5
+output = 3.5

--- a/providers/openrouter/models/meta-llama/llama-3.1-405b.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.1-405b.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3.1 405B (base)"
+release_date = "2024-08-01"
+last_updated = "2024-08-01"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 4.0
+output = 4.0

--- a/providers/openrouter/models/meta-llama/llama-3.1-70b-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.1-70b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3.1 70B Instruct"
+release_date = "2024-07-22"
+last_updated = "2024-07-22"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.39999999999999997
+output = 0.39999999999999997

--- a/providers/openrouter/models/meta-llama/llama-3.1-8b-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.1-8b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3.1 8B Instruct"
+release_date = "2024-07-22"
+last_updated = "2024-07-22"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[cost]
+input = 0.02
+output = 0.03

--- a/providers/openrouter/models/meta-llama/llama-3.2-1b-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.2-1b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3.2 1B Instruct"
+release_date = "2024-09-24"
+last_updated = "2024-09-24"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 60000
+input = 60000
+output = 4096
+
+[cost]
+input = 0.027
+output = 0.19999999999999998

--- a/providers/openrouter/models/meta-llama/llama-3.2-3b-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.2-3b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3.2 3B Instruct"
+release_date = "2024-09-24"
+last_updated = "2024-09-24"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[cost]
+input = 0.02
+output = 0.02

--- a/providers/openrouter/models/meta-llama/llama-3.2-3b-instruct:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.2-3b-instruct:free.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3.2 3B Instruct (free)"
+release_date = "2024-09-24"
+last_updated = "2024-09-24"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/meta-llama/llama-3.2-90b-vision-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.2-90b-vision-instruct.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3.2 90B Vision Instruct"
+release_date = "2024-09-24"
+last_updated = "2024-09-24"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 16384
+
+[cost]
+input = 0.35
+output = 0.39999999999999997

--- a/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 3.3 70B Instruct"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 120000
+
+[cost]
+input = 0.108
+output = 0.32

--- a/providers/openrouter/models/meta-llama/llama-4-maverick.toml
+++ b/providers/openrouter/models/meta-llama/llama-4-maverick.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 4 Maverick"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 1048576
+input = 1048576
+output = 16384
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/openrouter/models/meta-llama/llama-4-scout.toml
+++ b/providers/openrouter/models/meta-llama/llama-4-scout.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama 4 Scout"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 327680
+input = 327680
+output = 16384
+
+[cost]
+input = 0.08
+output = 0.3

--- a/providers/openrouter/models/meta-llama/llama-guard-2-8b.toml
+++ b/providers/openrouter/models/meta-llama/llama-guard-2-8b.toml
@@ -1,0 +1,22 @@
+name = "Meta: LlamaGuard 2 8B"
+release_date = "2024-05-12"
+last_updated = "2024-05-12"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 4096
+
+[cost]
+input = 0.19999999999999998
+output = 0.19999999999999998

--- a/providers/openrouter/models/meta-llama/llama-guard-3-8b.toml
+++ b/providers/openrouter/models/meta-llama/llama-guard-3-8b.toml
@@ -1,0 +1,22 @@
+name = "Llama Guard 3 8B"
+release_date = "2025-02-12"
+last_updated = "2025-02-12"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.02
+output = 0.06

--- a/providers/openrouter/models/meta-llama/llama-guard-4-12b.toml
+++ b/providers/openrouter/models/meta-llama/llama-guard-4-12b.toml
@@ -1,0 +1,22 @@
+name = "Meta: Llama Guard 4 12B"
+release_date = "2025-04-29"
+last_updated = "2025-04-29"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 4096
+
+[cost]
+input = 0.18
+output = 0.18

--- a/providers/openrouter/models/microsoft/mai-ds-r1.toml
+++ b/providers/openrouter/models/microsoft/mai-ds-r1.toml
@@ -1,0 +1,22 @@
+name = "Microsoft: MAI DS R1"
+release_date = "2025-04-20"
+last_updated = "2025-04-20"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 163840
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/openrouter/models/microsoft/phi-3-medium-128k-instruct.toml
+++ b/providers/openrouter/models/microsoft/phi-3-medium-128k-instruct.toml
@@ -1,0 +1,22 @@
+name = "Microsoft: Phi-3 Medium 128K Instruct"
+release_date = "2024-05-23"
+last_updated = "2024-05-23"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 1.0
+output = 1.0

--- a/providers/openrouter/models/microsoft/phi-3-mini-128k-instruct.toml
+++ b/providers/openrouter/models/microsoft/phi-3-mini-128k-instruct.toml
@@ -1,0 +1,22 @@
+name = "Microsoft: Phi-3 Mini 128K Instruct"
+release_date = "2024-05-25"
+last_updated = "2024-05-25"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 0.09999999999999999
+output = 0.09999999999999999

--- a/providers/openrouter/models/microsoft/phi-3.5-mini-128k-instruct.toml
+++ b/providers/openrouter/models/microsoft/phi-3.5-mini-128k-instruct.toml
@@ -1,0 +1,22 @@
+name = "Microsoft: Phi-3.5 Mini 128K Instruct"
+release_date = "2024-08-20"
+last_updated = "2024-08-20"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 0.09999999999999999
+output = 0.09999999999999999

--- a/providers/openrouter/models/microsoft/phi-4-multimodal-instruct.toml
+++ b/providers/openrouter/models/microsoft/phi-4-multimodal-instruct.toml
@@ -1,0 +1,22 @@
+name = "Microsoft: Phi 4 Multimodal Instruct"
+release_date = "2025-03-07"
+last_updated = "2025-03-07"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.049999999999999996
+output = 0.09999999999999999

--- a/providers/openrouter/models/microsoft/phi-4-reasoning-plus.toml
+++ b/providers/openrouter/models/microsoft/phi-4-reasoning-plus.toml
@@ -1,0 +1,22 @@
+name = "Microsoft: Phi 4 Reasoning Plus"
+release_date = "2025-05-01"
+last_updated = "2025-05-01"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.07
+output = 0.35

--- a/providers/openrouter/models/microsoft/phi-4.toml
+++ b/providers/openrouter/models/microsoft/phi-4.toml
@@ -1,0 +1,22 @@
+name = "Microsoft: Phi 4"
+release_date = "2025-01-10"
+last_updated = "2025-01-10"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 16384
+input = 16384
+output = 4096
+
+[cost]
+input = 0.06
+output = 0.14

--- a/providers/openrouter/models/microsoft/wizardlm-2-8x22b.toml
+++ b/providers/openrouter/models/microsoft/wizardlm-2-8x22b.toml
@@ -1,0 +1,22 @@
+name = "WizardLM-2 8x22B"
+release_date = "2024-04-15"
+last_updated = "2024-04-15"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 16384
+
+[cost]
+input = 0.48
+output = 0.48

--- a/providers/openrouter/models/minimax/minimax-01.toml
+++ b/providers/openrouter/models/minimax/minimax-01.toml
@@ -1,0 +1,22 @@
+name = "MiniMax: MiniMax-01"
+release_date = "2025-01-14"
+last_updated = "2025-01-14"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 1000192
+input = 1000192
+output = 1000192
+
+[cost]
+input = 0.19999999999999998
+output = 1.1

--- a/providers/openrouter/models/minimax/minimax-m1.toml
+++ b/providers/openrouter/models/minimax/minimax-m1.toml
@@ -1,0 +1,22 @@
+name = "MiniMax: MiniMax M1"
+release_date = "2025-06-17"
+last_updated = "2025-06-17"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 1000000
+input = 1000000
+output = 40000
+
+[cost]
+input = 0.39999999999999997
+output = 2.2

--- a/providers/openrouter/models/minimax/minimax-m2.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.toml
@@ -1,0 +1,22 @@
+name = "MiniMax: MiniMax M2"
+release_date = "2025-10-23"
+last_updated = "2025-10-23"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 4096
+
+[cost]
+input = 0.254
+output = 1.02

--- a/providers/openrouter/models/mistralai/codestral-2508.toml
+++ b/providers/openrouter/models/mistralai/codestral-2508.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Codestral 2508"
+release_date = "2025-08-01"
+last_updated = "2025-08-01"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 4096
+
+[cost]
+input = 0.3
+output = 0.8999999999999999

--- a/providers/openrouter/models/mistralai/devstral-2512.toml
+++ b/providers/openrouter/models/mistralai/devstral-2512.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Devstral 2 2512"
+release_date = "2025-12-09"
+last_updated = "2025-12-09"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 65536
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/openrouter/models/mistralai/devstral-2512:free.toml
+++ b/providers/openrouter/models/mistralai/devstral-2512:free.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Devstral 2 2512 (free)"
+release_date = "2025-12-09"
+last_updated = "2025-12-09"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/mistralai/devstral-medium.toml
+++ b/providers/openrouter/models/mistralai/devstral-medium.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Devstral Medium"
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.39999999999999997
+output = 2.0

--- a/providers/openrouter/models/mistralai/devstral-small.toml
+++ b/providers/openrouter/models/mistralai/devstral-small.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Devstral Small 1.1"
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 0.07
+output = 0.28

--- a/providers/openrouter/models/mistralai/ministral-14b-2512.toml
+++ b/providers/openrouter/models/mistralai/ministral-14b-2512.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Ministral 3 14B 2512"
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 4096
+
+[cost]
+input = 0.19999999999999998
+output = 0.19999999999999998

--- a/providers/openrouter/models/mistralai/ministral-3b-2512.toml
+++ b/providers/openrouter/models/mistralai/ministral-3b-2512.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Ministral 3 3B 2512"
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.09999999999999999
+output = 0.09999999999999999

--- a/providers/openrouter/models/mistralai/ministral-3b.toml
+++ b/providers/openrouter/models/mistralai/ministral-3b.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Ministral 3B"
+release_date = "2024-10-16"
+last_updated = "2024-10-16"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.04
+output = 0.04

--- a/providers/openrouter/models/mistralai/ministral-8b-2512.toml
+++ b/providers/openrouter/models/mistralai/ministral-8b-2512.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Ministral 3 8B 2512"
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 4096
+
+[cost]
+input = 0.15
+output = 0.15

--- a/providers/openrouter/models/mistralai/ministral-8b.toml
+++ b/providers/openrouter/models/mistralai/ministral-8b.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Ministral 8B"
+release_date = "2024-10-16"
+last_updated = "2024-10-16"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.09999999999999999
+output = 0.09999999999999999

--- a/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.1.toml
+++ b/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.1.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral 7B Instruct v0.1"
+release_date = "2023-09-27"
+last_updated = "2023-09-27"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 2824
+input = 2824
+output = 4096
+
+[cost]
+input = 0.11
+output = 0.19

--- a/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.2.toml
+++ b/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.2.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral 7B Instruct v0.2"
+release_date = "2023-12-27"
+last_updated = "2023-12-27"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.19999999999999998
+output = 0.19999999999999998

--- a/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.3.toml
+++ b/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.3.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral 7B Instruct v0.3"
+release_date = "2024-05-26"
+last_updated = "2024-05-26"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.19999999999999998
+output = 0.19999999999999998

--- a/providers/openrouter/models/mistralai/mistral-7b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mistral-7b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral 7B Instruct"
+release_date = "2024-05-26"
+last_updated = "2024-05-26"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 16384
+
+[cost]
+input = 0.028
+output = 0.054

--- a/providers/openrouter/models/mistralai/mistral-large-2407.toml
+++ b/providers/openrouter/models/mistralai/mistral-large-2407.toml
@@ -1,0 +1,22 @@
+name = "Mistral Large 2407"
+release_date = "2024-11-18"
+last_updated = "2024-11-18"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 2.0
+output = 6.0

--- a/providers/openrouter/models/mistralai/mistral-large-2411.toml
+++ b/providers/openrouter/models/mistralai/mistral-large-2411.toml
@@ -1,0 +1,22 @@
+name = "Mistral Large 2411"
+release_date = "2024-11-18"
+last_updated = "2024-11-18"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 2.0
+output = 6.0

--- a/providers/openrouter/models/mistralai/mistral-large-2512.toml
+++ b/providers/openrouter/models/mistralai/mistral-large-2512.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Large 3 2512"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 4096
+
+[cost]
+input = 0.5
+output = 1.5

--- a/providers/openrouter/models/mistralai/mistral-large.toml
+++ b/providers/openrouter/models/mistralai/mistral-large.toml
@@ -1,0 +1,22 @@
+name = "Mistral Large"
+release_date = "2024-02-25"
+last_updated = "2024-02-25"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 2.0
+output = 6.0

--- a/providers/openrouter/models/mistralai/mistral-medium-3.1.toml
+++ b/providers/openrouter/models/mistralai/mistral-medium-3.1.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Medium 3.1"
+release_date = "2025-08-13"
+last_updated = "2025-08-13"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.39999999999999997
+output = 2.0

--- a/providers/openrouter/models/mistralai/mistral-medium-3.toml
+++ b/providers/openrouter/models/mistralai/mistral-medium-3.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Medium 3"
+release_date = "2025-05-07"
+last_updated = "2025-05-07"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.39999999999999997
+output = 2.0

--- a/providers/openrouter/models/mistralai/mistral-nemo.toml
+++ b/providers/openrouter/models/mistralai/mistral-nemo.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Nemo"
+release_date = "2024-07-18"
+last_updated = "2024-07-18"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[cost]
+input = 0.02
+output = 0.04

--- a/providers/openrouter/models/mistralai/mistral-saba.toml
+++ b/providers/openrouter/models/mistralai/mistral-saba.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Saba"
+release_date = "2025-02-17"
+last_updated = "2025-02-17"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.19999999999999998
+output = 0.6

--- a/providers/openrouter/models/mistralai/mistral-small-24b-instruct-2501.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-24b-instruct-2501.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Small 3"
+release_date = "2025-01-30"
+last_updated = "2025-01-30"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.03
+output = 0.11

--- a/providers/openrouter/models/mistralai/mistral-small-3.1-24b-instruct:free.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-3.1-24b-instruct:free.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Small 3.1 24B (free)"
+release_date = "2025-03-17"
+last_updated = "2025-03-17"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/mistralai/mistral-tiny.toml
+++ b/providers/openrouter/models/mistralai/mistral-tiny.toml
@@ -1,0 +1,22 @@
+name = "Mistral Tiny"
+release_date = "2024-01-09"
+last_updated = "2024-01-09"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.25
+output = 0.25

--- a/providers/openrouter/models/mistralai/mixtral-8x22b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mixtral-8x22b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mixtral 8x22B Instruct"
+release_date = "2024-04-16"
+last_updated = "2024-04-16"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 4096
+
+[cost]
+input = 2.0
+output = 6.0

--- a/providers/openrouter/models/mistralai/mixtral-8x7b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mixtral-8x7b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mixtral 8x7B Instruct"
+release_date = "2023-12-09"
+last_updated = "2023-12-09"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 16384
+
+[cost]
+input = 0.54
+output = 0.54

--- a/providers/openrouter/models/mistralai/pixtral-12b.toml
+++ b/providers/openrouter/models/mistralai/pixtral-12b.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Pixtral 12B"
+release_date = "2024-09-09"
+last_updated = "2024-09-09"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.09999999999999999
+output = 0.09999999999999999

--- a/providers/openrouter/models/mistralai/pixtral-large-2411.toml
+++ b/providers/openrouter/models/mistralai/pixtral-large-2411.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Pixtral Large 2411"
+release_date = "2024-11-18"
+last_updated = "2024-11-18"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 2.0
+output = 6.0

--- a/providers/openrouter/models/mistralai/voxtral-small-24b-2507.toml
+++ b/providers/openrouter/models/mistralai/voxtral-small-24b-2507.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Voxtral Small 24B 2507"
+release_date = "2025-10-30"
+last_updated = "2025-10-30"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text", "audio",]
+output = [ "text",]
+
+[limit]
+context = 32000
+input = 32000
+output = 4096
+
+[cost]
+input = 0.09999999999999999
+output = 0.3

--- a/providers/openrouter/models/moonshotai/kimi-dev-72b.toml
+++ b/providers/openrouter/models/moonshotai/kimi-dev-72b.toml
@@ -1,0 +1,22 @@
+name = "MoonshotAI: Kimi Dev 72B"
+release_date = "2025-06-16"
+last_updated = "2025-06-16"
+open_weights = true
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.29
+output = 1.15

--- a/providers/openrouter/models/moonshotai/kimi-k2-0905.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-0905.toml
@@ -1,0 +1,22 @@
+name = "MoonshotAI: Kimi K2 0905"
+release_date = "2025-09-04"
+last_updated = "2025-09-04"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 262144
+
+[cost]
+input = 0.39
+output = 1.9

--- a/providers/openrouter/models/moonshotai/kimi-k2-0905:exacto.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-0905:exacto.toml
@@ -1,0 +1,22 @@
+name = "MoonshotAI: Kimi K2 0905 (exacto)"
+release_date = "2025-09-04"
+last_updated = "2025-09-04"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 4096
+
+[cost]
+input = 0.6
+output = 2.5

--- a/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
@@ -1,0 +1,22 @@
+name = "MoonshotAI: Kimi K2 Thinking"
+release_date = "2025-11-06"
+last_updated = "2025-11-06"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 16384
+
+[cost]
+input = 0.44999999999999996
+output = 2.35

--- a/providers/openrouter/models/moonshotai/kimi-k2:free.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2:free.toml
@@ -1,0 +1,22 @@
+name = "MoonshotAI: Kimi K2 0711 (free)"
+release_date = "2025-07-11"
+last_updated = "2025-07-11"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/moonshotai/kimi-linear-48b-a3b-instruct.toml
+++ b/providers/openrouter/models/moonshotai/kimi-linear-48b-a3b-instruct.toml
@@ -1,0 +1,22 @@
+name = "MoonshotAI: Kimi Linear 48B A3B Instruct"
+release_date = "2025-11-07"
+last_updated = "2025-11-07"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 1048576
+input = 1048576
+output = 1048576
+
+[cost]
+input = 0.7
+output = 0.8999999999999999

--- a/providers/openrouter/models/morph/morph-v3-fast.toml
+++ b/providers/openrouter/models/morph/morph-v3-fast.toml
@@ -1,0 +1,22 @@
+name = "Morph: Morph V3 Fast"
+release_date = "2025-07-07"
+last_updated = "2025-07-07"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 81920
+input = 81920
+output = 38000
+
+[cost]
+input = 0.7999999999999999
+output = 1.2

--- a/providers/openrouter/models/morph/morph-v3-large.toml
+++ b/providers/openrouter/models/morph/morph-v3-large.toml
@@ -1,0 +1,22 @@
+name = "Morph: Morph V3 Large"
+release_date = "2025-07-07"
+last_updated = "2025-07-07"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 131072
+
+[cost]
+input = 0.8999999999999999
+output = 1.9

--- a/providers/openrouter/models/neversleep/llama-3.1-lumimaid-8b.toml
+++ b/providers/openrouter/models/neversleep/llama-3.1-lumimaid-8b.toml
@@ -1,0 +1,22 @@
+name = "NeverSleep: Lumimaid v0.2 8B"
+release_date = "2024-09-14"
+last_updated = "2024-09-14"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.09
+output = 0.6

--- a/providers/openrouter/models/neversleep/noromaid-20b.toml
+++ b/providers/openrouter/models/neversleep/noromaid-20b.toml
@@ -1,0 +1,22 @@
+name = "Noromaid 20B"
+release_date = "2023-11-25"
+last_updated = "2023-11-25"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 4096
+input = 4096
+output = 4096
+
+[cost]
+input = 1.0
+output = 1.75

--- a/providers/openrouter/models/nex-agi/deepseek-v3.1-nex-n1:free.toml
+++ b/providers/openrouter/models/nex-agi/deepseek-v3.1-nex-n1:free.toml
@@ -1,0 +1,22 @@
+name = "Nex AGI: DeepSeek V3.1 Nex N1 (free)"
+release_date = "2025-12-08"
+last_updated = "2025-12-08"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 163840
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/nousresearch/deephermes-3-mistral-24b-preview.toml
+++ b/providers/openrouter/models/nousresearch/deephermes-3-mistral-24b-preview.toml
@@ -1,0 +1,22 @@
+name = "Nous: DeepHermes 3 Mistral 24B Preview"
+release_date = "2025-05-09"
+last_updated = "2025-05-09"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.049999999999999996
+output = 0.19999999999999998

--- a/providers/openrouter/models/nousresearch/hermes-2-pro-llama-3-8b.toml
+++ b/providers/openrouter/models/nousresearch/hermes-2-pro-llama-3-8b.toml
@@ -1,0 +1,22 @@
+name = "NousResearch: Hermes 2 Pro - Llama-3 8B"
+release_date = "2024-05-26"
+last_updated = "2024-05-26"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 2048
+
+[cost]
+input = 0.024999999999999998
+output = 0.08

--- a/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-405b.toml
+++ b/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-405b.toml
@@ -1,0 +1,22 @@
+name = "Nous: Hermes 3 405B Instruct"
+release_date = "2024-08-15"
+last_updated = "2024-08-15"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[cost]
+input = 1.0
+output = 1.0

--- a/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-405b:free.toml
+++ b/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-405b:free.toml
@@ -1,0 +1,22 @@
+name = "Nous: Hermes 3 405B Instruct (free)"
+release_date = "2024-08-15"
+last_updated = "2024-08-15"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-70b.toml
+++ b/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-70b.toml
@@ -1,0 +1,22 @@
+name = "Nous: Hermes 3 70B Instruct"
+release_date = "2024-08-17"
+last_updated = "2024-08-17"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 4096
+
+[cost]
+input = 0.3
+output = 0.3

--- a/providers/openrouter/models/nousresearch/hermes-4-405b.toml
+++ b/providers/openrouter/models/nousresearch/hermes-4-405b.toml
@@ -1,0 +1,22 @@
+name = "Nous: Hermes 4 405B"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/openrouter/models/nousresearch/hermes-4-70b.toml
+++ b/providers/openrouter/models/nousresearch/hermes-4-70b.toml
@@ -1,0 +1,22 @@
+name = "Nous: Hermes 4 70B"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.11
+output = 0.38

--- a/providers/openrouter/models/nvidia/llama-3.1-nemotron-70b-instruct.toml
+++ b/providers/openrouter/models/nvidia/llama-3.1-nemotron-70b-instruct.toml
@@ -1,0 +1,22 @@
+name = "NVIDIA: Llama 3.1 Nemotron 70B Instruct"
+release_date = "2024-10-14"
+last_updated = "2024-10-14"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[cost]
+input = 1.2
+output = 1.2

--- a/providers/openrouter/models/nvidia/llama-3.1-nemotron-ultra-253b-v1.toml
+++ b/providers/openrouter/models/nvidia/llama-3.1-nemotron-ultra-253b-v1.toml
@@ -1,0 +1,22 @@
+name = "NVIDIA: Llama 3.1 Nemotron Ultra 253B v1"
+release_date = "2025-04-08"
+last_updated = "2025-04-08"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.6
+output = 1.7999999999999998

--- a/providers/openrouter/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
+++ b/providers/openrouter/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
@@ -1,0 +1,22 @@
+name = "NVIDIA: Llama 3.3 Nemotron Super 49B V1.5"
+release_date = "2025-10-10"
+last_updated = "2025-10-10"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.09999999999999999
+output = 0.39999999999999997

--- a/providers/openrouter/models/nvidia/nemotron-nano-12b-v2-vl.toml
+++ b/providers/openrouter/models/nvidia/nemotron-nano-12b-v2-vl.toml
@@ -1,0 +1,22 @@
+name = "NVIDIA: Nemotron Nano 12B 2 VL"
+release_date = "2025-10-28"
+last_updated = "2025-10-28"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "video",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.19999999999999998
+output = 0.6

--- a/providers/openrouter/models/nvidia/nemotron-nano-12b-v2-vl:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-nano-12b-v2-vl:free.toml
@@ -1,0 +1,22 @@
+name = "NVIDIA: Nemotron Nano 12B 2 VL (free)"
+release_date = "2025-10-28"
+last_updated = "2025-10-28"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "video",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 128000
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/nvidia/nemotron-nano-9b-v2.toml
+++ b/providers/openrouter/models/nvidia/nemotron-nano-9b-v2.toml
@@ -1,0 +1,22 @@
+name = "NVIDIA: Nemotron Nano 9B V2"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.04
+output = 0.16

--- a/providers/openrouter/models/nvidia/nemotron-nano-9b-v2:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-nano-9b-v2:free.toml
@@ -1,0 +1,22 @@
+name = "NVIDIA: Nemotron Nano 9B V2 (free)"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/openai/chatgpt-4o-latest.toml
+++ b/providers/openrouter/models/openai/chatgpt-4o-latest.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: ChatGPT-4o"
+release_date = "2024-08-13"
+last_updated = "2024-08-13"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 5.0
+output = 15.0

--- a/providers/openrouter/models/openai/codex-mini.toml
+++ b/providers/openrouter/models/openai/codex-mini.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: Codex Mini"
+release_date = "2025-05-16"
+last_updated = "2025-05-16"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 1.5
+output = 6.0

--- a/providers/openrouter/models/openai/gpt-3.5-turbo-0613.toml
+++ b/providers/openrouter/models/openai/gpt-3.5-turbo-0613.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-3.5 Turbo (older v0613)"
+release_date = "2024-01-24"
+last_updated = "2024-01-24"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 4095
+input = 4095
+output = 4096
+
+[cost]
+input = 1.0
+output = 2.0

--- a/providers/openrouter/models/openai/gpt-3.5-turbo-16k.toml
+++ b/providers/openrouter/models/openai/gpt-3.5-turbo-16k.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-3.5 Turbo 16k"
+release_date = "2023-08-27"
+last_updated = "2023-08-27"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 16385
+input = 16385
+output = 4096
+
+[cost]
+input = 3.0
+output = 4.0

--- a/providers/openrouter/models/openai/gpt-3.5-turbo-instruct.toml
+++ b/providers/openrouter/models/openai/gpt-3.5-turbo-instruct.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-3.5 Turbo Instruct"
+release_date = "2023-09-27"
+last_updated = "2023-09-27"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 4095
+input = 4095
+output = 4096
+
+[cost]
+input = 1.5
+output = 2.0

--- a/providers/openrouter/models/openai/gpt-3.5-turbo.toml
+++ b/providers/openrouter/models/openai/gpt-3.5-turbo.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-3.5 Turbo"
+release_date = "2023-05-27"
+last_updated = "2023-05-27"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 16385
+input = 16385
+output = 4096
+
+[cost]
+input = 0.5
+output = 1.5

--- a/providers/openrouter/models/openai/gpt-4-0314.toml
+++ b/providers/openrouter/models/openai/gpt-4-0314.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4 (older v0314)"
+release_date = "2023-05-27"
+last_updated = "2023-05-27"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8191
+input = 8191
+output = 4096
+
+[cost]
+input = 30.0
+output = 60.0

--- a/providers/openrouter/models/openai/gpt-4-1106-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4-1106-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4 Turbo (older v1106)"
+release_date = "2023-11-05"
+last_updated = "2023-11-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 10.0
+output = 30.0

--- a/providers/openrouter/models/openai/gpt-4-turbo-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4-turbo-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4 Turbo Preview"
+release_date = "2024-01-24"
+last_updated = "2024-01-24"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 10.0
+output = 30.0

--- a/providers/openrouter/models/openai/gpt-4-turbo.toml
+++ b/providers/openrouter/models/openai/gpt-4-turbo.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4 Turbo"
+release_date = "2024-04-08"
+last_updated = "2024-04-08"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 10.0
+output = 30.0

--- a/providers/openrouter/models/openai/gpt-4.1-nano.toml
+++ b/providers/openrouter/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4.1 Nano"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "image", "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 1047576
+input = 1047576
+output = 32768
+
+[cost]
+input = 0.09999999999999999
+output = 0.39999999999999997

--- a/providers/openrouter/models/openai/gpt-4.toml
+++ b/providers/openrouter/models/openai/gpt-4.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4"
+release_date = "2023-05-27"
+last_updated = "2023-05-27"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8191
+input = 8191
+output = 4096
+
+[cost]
+input = 30.0
+output = 60.0

--- a/providers/openrouter/models/openai/gpt-4o-2024-05-13.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-05-13.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o (2024-05-13)"
+release_date = "2024-05-12"
+last_updated = "2024-05-12"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 5.0
+output = 15.0

--- a/providers/openrouter/models/openai/gpt-4o-2024-08-06.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-08-06.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o (2024-08-06)"
+release_date = "2024-08-05"
+last_updated = "2024-08-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 2.5
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-4o-2024-11-20.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-11-20.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o (2024-11-20)"
+release_date = "2024-11-20"
+last_updated = "2024-11-20"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 2.5
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-4o-audio-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4o-audio-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o Audio"
+release_date = "2025-08-15"
+last_updated = "2025-08-15"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "audio", "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 2.5
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-4o-mini-2024-07-18.toml
+++ b/providers/openrouter/models/openai/gpt-4o-mini-2024-07-18.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o-mini (2024-07-18)"
+release_date = "2024-07-17"
+last_updated = "2024-07-17"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/openrouter/models/openai/gpt-4o-mini-search-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4o-mini-search-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o-mini Search Preview"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = false
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/openrouter/models/openai/gpt-4o-search-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4o-search-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o Search Preview"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = false
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 2.5
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-4o.toml
+++ b/providers/openrouter/models/openai/gpt-4o.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o"
+release_date = "2024-05-12"
+last_updated = "2024-05-12"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 2.5
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-4o:extended.toml
+++ b/providers/openrouter/models/openai/gpt-4o:extended.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o (extended)"
+release_date = "2024-05-12"
+last_updated = "2024-05-12"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 64000
+
+[cost]
+input = 6.0
+output = 18.0

--- a/providers/openrouter/models/openai/gpt-5-chat.toml
+++ b/providers/openrouter/models/openai/gpt-5-chat.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5 Chat"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = false
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "file", "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 1.25
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-5-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5-codex.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5 Codex"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 1.25
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-5-image-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5-image-mini.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5 Image Mini"
+release_date = "2025-10-16"
+last_updated = "2025-10-16"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "file", "image", "text",]
+output = [ "image", "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 2.5
+output = 2.0

--- a/providers/openrouter/models/openai/gpt-5-image.toml
+++ b/providers/openrouter/models/openai/gpt-5-image.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5 Image"
+release_date = "2025-10-14"
+last_updated = "2025-10-14"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "file",]
+output = [ "image", "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 10.0
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-5-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5-mini.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5 Mini"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 0.25
+output = 2.0

--- a/providers/openrouter/models/openai/gpt-5-nano.toml
+++ b/providers/openrouter/models/openai/gpt-5-nano.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5 Nano"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 0.049999999999999996
+output = 0.39999999999999997

--- a/providers/openrouter/models/openai/gpt-5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5-pro.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5 Pro"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 15.0
+output = 120.0

--- a/providers/openrouter/models/openai/gpt-5.1-chat.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-chat.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5.1 Chat"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "file", "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 16384
+
+[cost]
+input = 1.25
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5.1-Codex-Max"
+release_date = "2025-12-04"
+last_updated = "2025-12-04"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 1.25
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex-mini.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5.1-Codex-Mini"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 100000
+
+[cost]
+input = 0.25
+output = 2.0

--- a/providers/openrouter/models/openai/gpt-5.1-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5.1-Codex"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 1.25
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-5.1.toml
+++ b/providers/openrouter/models/openai/gpt-5.1.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5.1"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 1.25
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-5.toml
+++ b/providers/openrouter/models/openai/gpt-5.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-5"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 400000
+input = 400000
+output = 128000
+
+[cost]
+input = 1.25
+output = 10.0

--- a/providers/openrouter/models/openai/gpt-oss-120b.toml
+++ b/providers/openrouter/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: gpt-oss-120b"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.039
+output = 0.19

--- a/providers/openrouter/models/openai/gpt-oss-120b:exacto.toml
+++ b/providers/openrouter/models/openai/gpt-oss-120b:exacto.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: gpt-oss-120b (exacto)"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.039
+output = 0.19

--- a/providers/openrouter/models/openai/gpt-oss-120b:free.toml
+++ b/providers/openrouter/models/openai/gpt-oss-120b:free.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: gpt-oss-120b (free)"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/openai/gpt-oss-20b.toml
+++ b/providers/openrouter/models/openai/gpt-oss-20b.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: gpt-oss-20b"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.03
+output = 0.14

--- a/providers/openrouter/models/openai/gpt-oss-20b:free.toml
+++ b/providers/openrouter/models/openai/gpt-oss-20b:free.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: gpt-oss-20b (free)"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 128000
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/openrouter/models/openai/gpt-oss-safeguard-20b.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: gpt-oss-safeguard-20b"
+release_date = "2025-10-29"
+last_updated = "2025-10-29"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 65536
+
+[cost]
+input = 0.075
+output = 0.3

--- a/providers/openrouter/models/openai/o1-pro.toml
+++ b/providers/openrouter/models/openai/o1-pro.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o1-pro"
+release_date = "2025-03-19"
+last_updated = "2025-03-19"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 150.0
+output = 600.0

--- a/providers/openrouter/models/openai/o1.toml
+++ b/providers/openrouter/models/openai/o1.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o1"
+release_date = "2024-12-17"
+last_updated = "2024-12-17"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 15.0
+output = 60.0

--- a/providers/openrouter/models/openai/o3-deep-research.toml
+++ b/providers/openrouter/models/openai/o3-deep-research.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o3 Deep Research"
+release_date = "2025-10-10"
+last_updated = "2025-10-10"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "image", "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 10.0
+output = 40.0

--- a/providers/openrouter/models/openai/o3-mini-high.toml
+++ b/providers/openrouter/models/openai/o3-mini-high.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o3 Mini High"
+release_date = "2025-02-12"
+last_updated = "2025-02-12"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 1.1
+output = 4.4

--- a/providers/openrouter/models/openai/o3-mini.toml
+++ b/providers/openrouter/models/openai/o3-mini.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o3 Mini"
+release_date = "2025-01-31"
+last_updated = "2025-01-31"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 1.1
+output = 4.4

--- a/providers/openrouter/models/openai/o3-pro.toml
+++ b/providers/openrouter/models/openai/o3-pro.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o3 Pro"
+release_date = "2025-06-10"
+last_updated = "2025-06-10"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "file", "image",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 20.0
+output = 80.0

--- a/providers/openrouter/models/openai/o3.toml
+++ b/providers/openrouter/models/openai/o3.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o3"
+release_date = "2025-04-16"
+last_updated = "2025-04-16"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 2.0
+output = 8.0

--- a/providers/openrouter/models/openai/o4-mini-deep-research.toml
+++ b/providers/openrouter/models/openai/o4-mini-deep-research.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o4 Mini Deep Research"
+release_date = "2025-10-10"
+last_updated = "2025-10-10"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "file", "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 2.0
+output = 8.0

--- a/providers/openrouter/models/openai/o4-mini-high.toml
+++ b/providers/openrouter/models/openai/o4-mini-high.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o4 Mini High"
+release_date = "2025-04-16"
+last_updated = "2025-04-16"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = false
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "file",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 100000
+
+[cost]
+input = 1.1
+output = 4.4

--- a/providers/openrouter/models/opengvlab/internvl3-78b.toml
+++ b/providers/openrouter/models/opengvlab/internvl3-78b.toml
@@ -1,0 +1,22 @@
+name = "OpenGVLab: InternVL3 78B"
+release_date = "2025-09-15"
+last_updated = "2025-09-15"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.09999999999999999
+output = 0.39

--- a/providers/openrouter/models/openrouter/auto.toml
+++ b/providers/openrouter/models/openrouter/auto.toml
@@ -1,0 +1,22 @@
+name = "Auto Router"
+release_date = "2023-11-07"
+last_updated = "2023-11-07"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = false
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 2000000
+input = 2000000
+output = 4096
+
+[cost]
+input = -1000000.0
+output = -1000000.0

--- a/providers/openrouter/models/openrouter/bodybuilder.toml
+++ b/providers/openrouter/models/openrouter/bodybuilder.toml
@@ -1,0 +1,22 @@
+name = "Body Builder"
+release_date = "2025-12-04"
+last_updated = "2025-12-04"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = false
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = -1000000.0
+output = -1000000.0

--- a/providers/openrouter/models/perplexity/sonar-deep-research.toml
+++ b/providers/openrouter/models/perplexity/sonar-deep-research.toml
@@ -1,0 +1,23 @@
+name = "Perplexity: Sonar Deep Research"
+release_date = "2025-03-06"
+last_updated = "2025-03-06"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 2.0
+output = 8.0
+reasoning = 3.0

--- a/providers/openrouter/models/perplexity/sonar-pro-search.toml
+++ b/providers/openrouter/models/perplexity/sonar-pro-search.toml
@@ -1,0 +1,22 @@
+name = "Perplexity: Sonar Pro Search"
+release_date = "2025-10-30"
+last_updated = "2025-10-30"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 8000
+
+[cost]
+input = 3.0
+output = 15.0

--- a/providers/openrouter/models/perplexity/sonar-pro.toml
+++ b/providers/openrouter/models/perplexity/sonar-pro.toml
@@ -1,0 +1,22 @@
+name = "Perplexity: Sonar Pro"
+release_date = "2025-03-06"
+last_updated = "2025-03-06"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 200000
+input = 200000
+output = 8000
+
+[cost]
+input = 3.0
+output = 15.0

--- a/providers/openrouter/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/openrouter/models/perplexity/sonar-reasoning-pro.toml
@@ -1,0 +1,22 @@
+name = "Perplexity: Sonar Reasoning Pro"
+release_date = "2025-03-06"
+last_updated = "2025-03-06"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 2.0
+output = 8.0

--- a/providers/openrouter/models/perplexity/sonar-reasoning.toml
+++ b/providers/openrouter/models/perplexity/sonar-reasoning.toml
@@ -1,0 +1,22 @@
+name = "Perplexity: Sonar Reasoning"
+release_date = "2025-01-29"
+last_updated = "2025-01-29"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 127000
+input = 127000
+output = 4096
+
+[cost]
+input = 1.0
+output = 5.0

--- a/providers/openrouter/models/perplexity/sonar.toml
+++ b/providers/openrouter/models/perplexity/sonar.toml
@@ -1,0 +1,22 @@
+name = "Perplexity: Sonar"
+release_date = "2025-01-27"
+last_updated = "2025-01-27"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 127072
+input = 127072
+output = 4096
+
+[cost]
+input = 1.0
+output = 1.0

--- a/providers/openrouter/models/prime-intellect/intellect-3.toml
+++ b/providers/openrouter/models/prime-intellect/intellect-3.toml
@@ -1,0 +1,22 @@
+name = "Prime Intellect: INTELLECT-3"
+release_date = "2025-11-26"
+last_updated = "2025-11-26"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.19999999999999998
+output = 1.1

--- a/providers/openrouter/models/qwen/qwen-2.5-72b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen-2.5-72b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen2.5 72B Instruct"
+release_date = "2024-09-18"
+last_updated = "2024-09-18"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.07
+output = 0.26

--- a/providers/openrouter/models/qwen/qwen-2.5-7b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen-2.5-7b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen2.5 7B Instruct"
+release_date = "2024-10-15"
+last_updated = "2024-10-15"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.04
+output = 0.09999999999999999

--- a/providers/openrouter/models/qwen/qwen-2.5-vl-7b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen-2.5-vl-7b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen2.5-VL 7B Instruct"
+release_date = "2024-08-27"
+last_updated = "2024-08-27"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.19999999999999998
+output = 0.19999999999999998

--- a/providers/openrouter/models/qwen/qwen-max.toml
+++ b/providers/openrouter/models/qwen/qwen-max.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen-Max "
+release_date = "2025-02-01"
+last_updated = "2025-02-01"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 8192
+
+[cost]
+input = 1.5999999999999999
+output = 6.3999999999999995

--- a/providers/openrouter/models/qwen/qwen-plus-2025-07-28.toml
+++ b/providers/openrouter/models/qwen/qwen-plus-2025-07-28.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen Plus 0728"
+release_date = "2025-09-08"
+last_updated = "2025-09-08"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 1000000
+input = 1000000
+output = 32768
+
+[cost]
+input = 0.39999999999999997
+output = 1.2

--- a/providers/openrouter/models/qwen/qwen-plus-2025-07-28:thinking.toml
+++ b/providers/openrouter/models/qwen/qwen-plus-2025-07-28:thinking.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen Plus 0728 (thinking)"
+release_date = "2025-09-08"
+last_updated = "2025-09-08"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 1000000
+input = 1000000
+output = 32768
+
+[cost]
+input = 0.39999999999999997
+output = 4.0

--- a/providers/openrouter/models/qwen/qwen-plus.toml
+++ b/providers/openrouter/models/qwen/qwen-plus.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen-Plus"
+release_date = "2025-02-01"
+last_updated = "2025-02-01"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 8192
+
+[cost]
+input = 0.39999999999999997
+output = 1.2

--- a/providers/openrouter/models/qwen/qwen-turbo.toml
+++ b/providers/openrouter/models/qwen/qwen-turbo.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen-Turbo"
+release_date = "2025-02-01"
+last_updated = "2025-02-01"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 1000000
+input = 1000000
+output = 8192
+
+[cost]
+input = 0.049999999999999996
+output = 0.19999999999999998

--- a/providers/openrouter/models/qwen/qwen-vl-max.toml
+++ b/providers/openrouter/models/qwen/qwen-vl-max.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen VL Max"
+release_date = "2025-02-01"
+last_updated = "2025-02-01"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 8192
+
+[cost]
+input = 0.7999999999999999
+output = 3.1999999999999997

--- a/providers/openrouter/models/qwen/qwen-vl-plus.toml
+++ b/providers/openrouter/models/qwen/qwen-vl-plus.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen VL Plus"
+release_date = "2025-02-04"
+last_updated = "2025-02-04"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 7500
+input = 7500
+output = 1500
+
+[cost]
+input = 0.21
+output = 0.63

--- a/providers/openrouter/models/qwen/qwen2.5-coder-7b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen2.5-coder-7b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen2.5 Coder 7B Instruct"
+release_date = "2025-04-15"
+last_updated = "2025-04-15"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.03
+output = 0.09

--- a/providers/openrouter/models/qwen/qwen2.5-vl-32b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen2.5-vl-32b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen2.5 VL 32B Instruct"
+release_date = "2025-03-24"
+last_updated = "2025-03-24"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 16384
+input = 16384
+output = 16384
+
+[cost]
+input = 0.049999999999999996
+output = 0.22

--- a/providers/openrouter/models/qwen/qwen3-14b.toml
+++ b/providers/openrouter/models/qwen/qwen3-14b.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 14B"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 40960
+input = 40960
+output = 40960
+
+[cost]
+input = 0.049999999999999996
+output = 0.22

--- a/providers/openrouter/models/qwen/qwen3-235b-a22b-2507.toml
+++ b/providers/openrouter/models/qwen/qwen3-235b-a22b-2507.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 235B A22B Instruct 2507"
+release_date = "2025-07-21"
+last_updated = "2025-07-21"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 4096
+
+[cost]
+input = 0.071
+output = 0.463

--- a/providers/openrouter/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/openrouter/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 235B A22B Thinking 2507"
+release_date = "2025-07-25"
+last_updated = "2025-07-25"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 262144
+
+[cost]
+input = 0.11
+output = 0.6

--- a/providers/openrouter/models/qwen/qwen3-235b-a22b.toml
+++ b/providers/openrouter/models/qwen/qwen3-235b-a22b.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 235B A22B"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 40960
+input = 40960
+output = 40960
+
+[cost]
+input = 0.18
+output = 0.54

--- a/providers/openrouter/models/qwen/qwen3-30b-a3b-instruct-2507.toml
+++ b/providers/openrouter/models/qwen/qwen3-30b-a3b-instruct-2507.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 30B A3B Instruct 2507"
+release_date = "2025-07-29"
+last_updated = "2025-07-29"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 262144
+
+[cost]
+input = 0.08
+output = 0.33

--- a/providers/openrouter/models/qwen/qwen3-30b-a3b-thinking-2507.toml
+++ b/providers/openrouter/models/qwen/qwen3-30b-a3b-thinking-2507.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 30B A3B Thinking 2507"
+release_date = "2025-08-28"
+last_updated = "2025-08-28"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.051
+output = 0.33999999999999997

--- a/providers/openrouter/models/qwen/qwen3-30b-a3b.toml
+++ b/providers/openrouter/models/qwen/qwen3-30b-a3b.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 30B A3B"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+open_weights = true
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 40960
+input = 40960
+output = 40960
+
+[cost]
+input = 0.06
+output = 0.22

--- a/providers/openrouter/models/qwen/qwen3-32b.toml
+++ b/providers/openrouter/models/qwen/qwen3-32b.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 32B"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 40960
+input = 40960
+output = 40960
+
+[cost]
+input = 0.08
+output = 0.24

--- a/providers/openrouter/models/qwen/qwen3-4b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-4b:free.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 4B (free)"
+release_date = "2025-04-30"
+last_updated = "2025-04-30"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 40960
+input = 40960
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/qwen/qwen3-8b.toml
+++ b/providers/openrouter/models/qwen/qwen3-8b.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 8B"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 20000
+
+[cost]
+input = 0.028
+output = 0.1104

--- a/providers/openrouter/models/qwen/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder-30b-a3b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 Coder 30B A3B Instruct"
+release_date = "2025-07-31"
+last_updated = "2025-07-31"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 262144
+
+[cost]
+input = 0.06
+output = 0.25

--- a/providers/openrouter/models/qwen/qwen3-coder-flash.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder-flash.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 Coder Flash"
+release_date = "2025-09-17"
+last_updated = "2025-09-17"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 65536
+
+[cost]
+input = 0.3
+output = 1.5

--- a/providers/openrouter/models/qwen/qwen3-coder-plus.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder-plus.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 Coder Plus"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 65536
+
+[cost]
+input = 1.0
+output = 5.0

--- a/providers/openrouter/models/qwen/qwen3-coder.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 Coder 480B A35B"
+release_date = "2025-07-22"
+last_updated = "2025-07-22"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 262144
+
+[cost]
+input = 0.22
+output = 0.95

--- a/providers/openrouter/models/qwen/qwen3-coder:exacto.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder:exacto.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 Coder 480B A35B (exacto)"
+release_date = "2025-07-22"
+last_updated = "2025-07-22"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 262144
+
+[cost]
+input = 0.38
+output = 1.53

--- a/providers/openrouter/models/qwen/qwen3-coder:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder:free.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 Coder 480B A35B (free)"
+release_date = "2025-07-22"
+last_updated = "2025-07-22"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262000
+input = 262000
+output = 262000
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/qwen/qwen3-max.toml
+++ b/providers/openrouter/models/qwen/qwen3-max.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 Max"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 32768
+
+[cost]
+input = 1.2
+output = 6.0

--- a/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 Next 80B A3B Instruct"
+release_date = "2025-09-11"
+last_updated = "2025-09-11"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 262144
+
+[cost]
+input = 0.09999999999999999
+output = 0.7999999999999999

--- a/providers/openrouter/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/openrouter/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 Next 80B A3B Thinking"
+release_date = "2025-09-11"
+last_updated = "2025-09-11"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 32768
+
+[cost]
+input = 0.12
+output = 1.2

--- a/providers/openrouter/models/qwen/qwen3-vl-235b-a22b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen3-vl-235b-a22b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 VL 235B A22B Instruct"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 4096
+
+[cost]
+input = 0.19999999999999998
+output = 1.2

--- a/providers/openrouter/models/qwen/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/openrouter/models/qwen/qwen3-vl-235b-a22b-thinking.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 VL 235B A22B Thinking"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 262144
+input = 262144
+output = 262144
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/openrouter/models/qwen/qwen3-vl-30b-a3b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen3-vl-30b-a3b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 VL 30B A3B Instruct"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.14
+output = 1.0

--- a/providers/openrouter/models/qwen/qwen3-vl-30b-a3b-thinking.toml
+++ b/providers/openrouter/models/qwen/qwen3-vl-30b-a3b-thinking.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 VL 30B A3B Thinking"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 32768
+
+[cost]
+input = 0.16
+output = 0.7999999999999999

--- a/providers/openrouter/models/qwen/qwen3-vl-8b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen3-vl-8b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 VL 8B Instruct"
+release_date = "2025-10-14"
+last_updated = "2025-10-14"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 32768
+
+[cost]
+input = 0.064
+output = 0.39999999999999997

--- a/providers/openrouter/models/qwen/qwen3-vl-8b-thinking.toml
+++ b/providers/openrouter/models/qwen/qwen3-vl-8b-thinking.toml
@@ -1,0 +1,22 @@
+name = "Qwen: Qwen3 VL 8B Thinking"
+release_date = "2025-10-14"
+last_updated = "2025-10-14"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 32768
+
+[cost]
+input = 0.18
+output = 2.0999999999999996

--- a/providers/openrouter/models/qwen/qwq-32b.toml
+++ b/providers/openrouter/models/qwen/qwq-32b.toml
@@ -1,0 +1,22 @@
+name = "Qwen: QwQ 32B"
+release_date = "2025-03-05"
+last_updated = "2025-03-05"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.15
+output = 0.39999999999999997

--- a/providers/openrouter/models/raifle/sorcererlm-8x22b.toml
+++ b/providers/openrouter/models/raifle/sorcererlm-8x22b.toml
@@ -1,0 +1,22 @@
+name = "SorcererLM 8x22B"
+release_date = "2024-11-08"
+last_updated = "2024-11-08"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 16000
+input = 16000
+output = 4096
+
+[cost]
+input = 4.5
+output = 4.5

--- a/providers/openrouter/models/relace/relace-apply-3.toml
+++ b/providers/openrouter/models/relace/relace-apply-3.toml
@@ -1,0 +1,22 @@
+name = "Relace: Relace Apply 3"
+release_date = "2025-09-26"
+last_updated = "2025-09-26"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = false
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 128000
+
+[cost]
+input = 0.85
+output = 1.25

--- a/providers/openrouter/models/relace/relace-search.toml
+++ b/providers/openrouter/models/relace/relace-search.toml
@@ -1,0 +1,22 @@
+name = "Relace: Relace Search"
+release_date = "2025-12-08"
+last_updated = "2025-12-08"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 128000
+
+[cost]
+input = 1.0
+output = 3.0

--- a/providers/openrouter/models/sao10k/l3-euryale-70b.toml
+++ b/providers/openrouter/models/sao10k/l3-euryale-70b.toml
@@ -1,0 +1,22 @@
+name = "Sao10k: Llama 3 Euryale 70B v2.1"
+release_date = "2024-06-17"
+last_updated = "2024-06-17"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 8192
+
+[cost]
+input = 1.48
+output = 1.48

--- a/providers/openrouter/models/sao10k/l3-lunaris-8b.toml
+++ b/providers/openrouter/models/sao10k/l3-lunaris-8b.toml
@@ -1,0 +1,22 @@
+name = "Sao10K: Llama 3 8B Lunaris"
+release_date = "2024-08-12"
+last_updated = "2024-08-12"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 8192
+input = 8192
+output = 4096
+
+[cost]
+input = 0.04
+output = 0.049999999999999996

--- a/providers/openrouter/models/sao10k/l3.1-70b-hanami-x1.toml
+++ b/providers/openrouter/models/sao10k/l3.1-70b-hanami-x1.toml
@@ -1,0 +1,22 @@
+name = "Sao10K: Llama 3.1 70B Hanami x1"
+release_date = "2025-01-07"
+last_updated = "2025-01-07"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 16000
+input = 16000
+output = 4096
+
+[cost]
+input = 3.0
+output = 3.0

--- a/providers/openrouter/models/sao10k/l3.1-euryale-70b.toml
+++ b/providers/openrouter/models/sao10k/l3.1-euryale-70b.toml
@@ -1,0 +1,22 @@
+name = "Sao10K: Llama 3.1 Euryale 70B v2.2"
+release_date = "2024-08-27"
+last_updated = "2024-08-27"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.65
+output = 0.75

--- a/providers/openrouter/models/sao10k/l3.3-euryale-70b.toml
+++ b/providers/openrouter/models/sao10k/l3.3-euryale-70b.toml
@@ -1,0 +1,22 @@
+name = "Sao10K: Llama 3.3 Euryale 70B"
+release_date = "2024-12-18"
+last_updated = "2024-12-18"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[cost]
+input = 0.65
+output = 0.75

--- a/providers/openrouter/models/stepfun-ai/step3.toml
+++ b/providers/openrouter/models/stepfun-ai/step3.toml
@@ -1,0 +1,22 @@
+name = "StepFun: Step3"
+release_date = "2025-08-28"
+last_updated = "2025-08-28"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 65536
+
+[cost]
+input = 0.5700000000000001
+output = 1.42

--- a/providers/openrouter/models/switchpoint/router.toml
+++ b/providers/openrouter/models/switchpoint/router.toml
@@ -1,0 +1,22 @@
+name = "Switchpoint Router"
+release_date = "2025-07-11"
+last_updated = "2025-07-11"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 4096
+
+[cost]
+input = 0.85
+output = 3.4

--- a/providers/openrouter/models/tencent/hunyuan-a13b-instruct.toml
+++ b/providers/openrouter/models/tencent/hunyuan-a13b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Tencent: Hunyuan A13B Instruct"
+release_date = "2025-07-08"
+last_updated = "2025-07-08"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.14
+output = 0.5700000000000001

--- a/providers/openrouter/models/thedrummer/anubis-70b-v1.1.toml
+++ b/providers/openrouter/models/thedrummer/anubis-70b-v1.1.toml
@@ -1,0 +1,22 @@
+name = "TheDrummer: Anubis 70B V1.1"
+release_date = "2025-06-29"
+last_updated = "2025-06-29"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.75
+output = 1.0

--- a/providers/openrouter/models/thedrummer/cydonia-24b-v4.1.toml
+++ b/providers/openrouter/models/thedrummer/cydonia-24b-v4.1.toml
@@ -1,0 +1,22 @@
+name = "TheDrummer: Cydonia 24B V4.1"
+release_date = "2025-09-26"
+last_updated = "2025-09-26"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.3
+output = 0.5

--- a/providers/openrouter/models/thedrummer/rocinante-12b.toml
+++ b/providers/openrouter/models/thedrummer/rocinante-12b.toml
@@ -1,0 +1,22 @@
+name = "TheDrummer: Rocinante 12B"
+release_date = "2024-09-29"
+last_updated = "2024-09-29"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.16999999999999998
+output = 0.43

--- a/providers/openrouter/models/thedrummer/skyfall-36b-v2.toml
+++ b/providers/openrouter/models/thedrummer/skyfall-36b-v2.toml
@@ -1,0 +1,22 @@
+name = "TheDrummer: Skyfall 36B V2"
+release_date = "2025-03-10"
+last_updated = "2025-03-10"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 32768
+
+[cost]
+input = 0.55
+output = 0.7999999999999999

--- a/providers/openrouter/models/thedrummer/unslopnemo-12b.toml
+++ b/providers/openrouter/models/thedrummer/unslopnemo-12b.toml
@@ -1,0 +1,22 @@
+name = "TheDrummer: UnslopNemo 12B"
+release_date = "2024-11-08"
+last_updated = "2024-11-08"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 32768
+input = 32768
+output = 4096
+
+[cost]
+input = 0.39999999999999997
+output = 0.39999999999999997

--- a/providers/openrouter/models/thudm/glm-4.1v-9b-thinking.toml
+++ b/providers/openrouter/models/thudm/glm-4.1v-9b-thinking.toml
@@ -1,0 +1,22 @@
+name = "THUDM: GLM 4.1V 9B Thinking"
+release_date = "2025-07-11"
+last_updated = "2025-07-11"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text",]
+output = [ "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 8000
+
+[cost]
+input = 0.028
+output = 0.1104

--- a/providers/openrouter/models/tngtech/deepseek-r1t-chimera.toml
+++ b/providers/openrouter/models/tngtech/deepseek-r1t-chimera.toml
@@ -1,0 +1,22 @@
+name = "TNG: DeepSeek R1T Chimera"
+release_date = "2025-04-27"
+last_updated = "2025-04-27"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 163840
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/openrouter/models/tngtech/deepseek-r1t-chimera:free.toml
+++ b/providers/openrouter/models/tngtech/deepseek-r1t-chimera:free.toml
@@ -1,0 +1,22 @@
+name = "TNG: DeepSeek R1T Chimera (free)"
+release_date = "2025-04-27"
+last_updated = "2025-04-27"
+open_weights = false
+tool_call = false
+structured_output = false
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 4096
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/tngtech/deepseek-r1t2-chimera.toml
+++ b/providers/openrouter/models/tngtech/deepseek-r1t2-chimera.toml
@@ -1,0 +1,22 @@
+name = "TNG: DeepSeek R1T2 Chimera"
+release_date = "2025-07-08"
+last_updated = "2025-07-08"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 163840
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/openrouter/models/tngtech/tng-r1t-chimera.toml
+++ b/providers/openrouter/models/tngtech/tng-r1t-chimera.toml
@@ -1,0 +1,22 @@
+name = "TNG: R1T Chimera"
+release_date = "2025-11-26"
+last_updated = "2025-11-26"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 163840
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/openrouter/models/tngtech/tng-r1t-chimera:free.toml
+++ b/providers/openrouter/models/tngtech/tng-r1t-chimera:free.toml
@@ -1,0 +1,22 @@
+name = "TNG: R1T Chimera (free)"
+release_date = "2025-11-26"
+last_updated = "2025-11-26"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 163840
+input = 163840
+output = 163840
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/undi95/remm-slerp-l2-13b.toml
+++ b/providers/openrouter/models/undi95/remm-slerp-l2-13b.toml
@@ -1,0 +1,22 @@
+name = "ReMM SLERP 13B"
+release_date = "2023-07-21"
+last_updated = "2023-07-21"
+open_weights = false
+tool_call = false
+structured_output = true
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 6144
+input = 6144
+output = 4096
+
+[cost]
+input = 0.44999999999999996
+output = 0.65

--- a/providers/openrouter/models/x-ai/grok-4-fast.toml
+++ b/providers/openrouter/models/x-ai/grok-4-fast.toml
@@ -1,0 +1,22 @@
+name = "xAI: Grok 4 Fast"
+release_date = "2025-09-18"
+last_updated = "2025-09-18"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 2000000
+input = 2000000
+output = 30000
+
+[cost]
+input = 0.19999999999999998
+output = 0.5

--- a/providers/openrouter/models/x-ai/grok-4.1-fast.toml
+++ b/providers/openrouter/models/x-ai/grok-4.1-fast.toml
@@ -1,0 +1,22 @@
+name = "xAI: Grok 4.1 Fast"
+release_date = "2025-11-19"
+last_updated = "2025-11-19"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 2000000
+input = 2000000
+output = 30000
+
+[cost]
+input = 0.19999999999999998
+output = 0.5

--- a/providers/openrouter/models/x-ai/grok-code-fast-1.toml
+++ b/providers/openrouter/models/x-ai/grok-code-fast-1.toml
@@ -1,0 +1,22 @@
+name = "xAI: Grok Code Fast 1"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 256000
+input = 256000
+output = 10000
+
+[cost]
+input = 0.19999999999999998
+output = 1.5

--- a/providers/openrouter/models/z-ai/glm-4-32b.toml
+++ b/providers/openrouter/models/z-ai/glm-4-32b.toml
@@ -1,0 +1,22 @@
+name = "Z.AI: GLM 4 32B "
+release_date = "2025-07-24"
+last_updated = "2025-07-24"
+open_weights = false
+tool_call = true
+structured_output = false
+temperature = true
+reasoning = false
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 128000
+input = 128000
+output = 4096
+
+[cost]
+input = 0.09999999999999999
+output = 0.09999999999999999

--- a/providers/openrouter/models/z-ai/glm-4.5-air.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5-air.toml
@@ -1,0 +1,22 @@
+name = "Z.AI: GLM 4.5 Air"
+release_date = "2025-07-25"
+last_updated = "2025-07-25"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 98304
+
+[cost]
+input = 0.10400000000000001
+output = 0.6799999999999999

--- a/providers/openrouter/models/z-ai/glm-4.5-air:free.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5-air:free.toml
@@ -1,0 +1,22 @@
+name = "Z.AI: GLM 4.5 Air (free)"
+release_date = "2025-07-25"
+last_updated = "2025-07-25"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/z-ai/glm-4.5.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5.toml
@@ -1,0 +1,22 @@
+name = "Z.AI: GLM 4.5"
+release_date = "2025-07-25"
+last_updated = "2025-07-25"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 131072
+
+[cost]
+input = 0.35
+output = 1.55

--- a/providers/openrouter/models/z-ai/glm-4.5v.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5v.toml
@@ -1,0 +1,22 @@
+name = "Z.AI: GLM 4.5V"
+release_date = "2025-08-11"
+last_updated = "2025-08-11"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "text", "image",]
+output = [ "text",]
+
+[limit]
+context = 65536
+input = 65536
+output = 16384
+
+[cost]
+input = 0.48
+output = 1.44

--- a/providers/openrouter/models/z-ai/glm-4.6.toml
+++ b/providers/openrouter/models/z-ai/glm-4.6.toml
@@ -1,0 +1,22 @@
+name = "Z.AI: GLM 4.6"
+release_date = "2025-09-30"
+last_updated = "2025-09-30"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 202752
+input = 202752
+output = 202752
+
+[cost]
+input = 0.39999999999999997
+output = 1.75

--- a/providers/openrouter/models/z-ai/glm-4.6:exacto.toml
+++ b/providers/openrouter/models/z-ai/glm-4.6:exacto.toml
@@ -1,0 +1,22 @@
+name = "Z.AI: GLM 4.6 (exacto)"
+release_date = "2025-09-30"
+last_updated = "2025-09-30"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = false
+
+[modalities]
+input = [ "text",]
+output = [ "text",]
+
+[limit]
+context = 202752
+input = 202752
+output = 4096
+
+[cost]
+input = 0.43
+output = 1.75

--- a/providers/openrouter/models/z-ai/glm-4.6v.toml
+++ b/providers/openrouter/models/z-ai/glm-4.6v.toml
@@ -1,0 +1,22 @@
+name = "Z.AI: GLM 4.6V"
+release_date = "2025-12-08"
+last_updated = "2025-12-08"
+open_weights = false
+tool_call = true
+structured_output = true
+temperature = true
+reasoning = true
+attachment = true
+
+[modalities]
+input = [ "image", "text", "video",]
+output = [ "text",]
+
+[limit]
+context = 131072
+input = 131072
+output = 24000
+
+[cost]
+input = 0.3
+output = 0.8999999999999999


### PR DESCRIPTION
- Introduced Qwen models: Qwen3 VL 8B Thinking and QwQ 32B with respective parameters.
- Added SorcererLM 8x22B and Relace models: Relace Apply 3 and Relace Search with defined limits and costs.
- Included Sao10K models: Llama 3 Euryale 70B v2.1, Llama 3 8B Lunaris, and others with specific modalities and costs.
- Implemented StepFun: Step3 and Switchpoint Router models with detailed configurations.
- Added Tencent: Hunyuan A13B Instruct and TheDrummer models: Anubis 70B V1.1, Cydonia 24B V4.1, and others.
- Introduced TNG: DeepSeek R1T Chimera and its free version, along with additional TNG models.
- Added Z.AI models: GLM 4 series with various configurations and costs.