### PR TITLE
Add OpenAI GPT-5.2 model family

### DIFF
--- a/providers/openai/models/gpt-5.2-chat-latest.toml
+++ b/providers/openai/models/gpt-5.2-chat-latest.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.2 Chat"
+family = "gpt-5"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]

--- a/providers/openai/models/gpt-5.2-pro.toml
+++ b/providers/openai/models/gpt-5.2-pro.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.2 Pro"
+family = "gpt-5"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 21.00
+output = 168.00
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]

--- a/providers/openai/models/gpt-5.2.toml
+++ b/providers/openai/models/gpt-5.2.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.2"
+family = "gpt-5"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]


### PR DESCRIPTION
## Summary
- Add OpenAI GPT-5.2 models released on December 11, 2025
- Includes `gpt-5.2`, `gpt-5.2-pro`, and `gpt-5.2-chat-latest` variants
- Specs sourced from official OpenAI documentation and announcement