### PR TITLE
Fix GPT-5.2 models to match GPT-5.1 structure

### DIFF
--- a/providers/openai/models/gpt-5.2-chat-latest.toml
+++ b/providers/openai/models/gpt-5.2-chat-latest.toml
@@ -1,5 +1,5 @@
 name = "GPT-5.2 Chat"
-family = "gpt-5"
+family = "gpt-5-chat"
 release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
@@ -7,6 +7,7 @@ reasoning = true
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]
@@ -15,9 +16,9 @@ output = 14.00
 cache_read = 0.175
 
 [limit]
-context = 400_000
-output = 128_000
+context = 128_000
+output = 16_384
 
 [modalities]
 input = ["text", "image"]
-output = ["text", "image"]
+output = ["text"]

--- a/providers/openai/models/gpt-5.2-pro.toml
+++ b/providers/openai/models/gpt-5.2-pro.toml
@@ -1,5 +1,5 @@
 name = "GPT-5.2 Pro"
-family = "gpt-5"
+family = "gpt-5-pro"
 release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
@@ -7,6 +7,7 @@ reasoning = true
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]
@@ -19,4 +20,4 @@ output = 128_000
 
 [modalities]
 input = ["text", "image"]
-output = ["text", "image"]
+output = ["text"]

--- a/providers/openai/models/gpt-5.2.toml
+++ b/providers/openai/models/gpt-5.2.toml
@@ -20,4 +20,4 @@ output = 128_000
 
 [modalities]
 input = ["text", "image"]
-output = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Fix GPT-5.2 model configs to match the existing GPT-5.1 pattern

## Changes
- `gpt-5.2.toml`: Fix output modality to `["text"]`
- `gpt-5.2-pro.toml`: Fix family to `gpt-5-pro`, add `structured_output = true`, fix output modality
- `gpt-5.2-chat-latest.toml`: Fix family to `gpt-5-chat`, add `structured_output = true`, fix context/output limits (128K/16K), fix output modality