### PR TITLE
There is a Typo in the paid Devstral Name on openrouter (Indicate Free)

### DIFF
--- a/providers/openrouter/models/mistralai/devstral-2512.toml
+++ b/providers/openrouter/models/mistralai/devstral-2512.toml
@@ -1,4 +1,4 @@
-name = "Devstral 2 2512 (free)"
+name = "Devstral 2 2512"
 release_date = "2025-09-12"
 last_updated = "2025-09-12"
 attachment = false


### PR DESCRIPTION
I made a typo when I add last devstral mistralai model on openrouter. There are Free and paid version. I let the "Free3 word in the name of the paid model

This PR corrects this typo