### PR TITLE
Unify GLM model names to GLM-x.y pattern

### DIFF
--- a/providers/zai-coding-plan/models/glm-4.5v.toml
+++ b/providers/zai-coding-plan/models/glm-4.5v.toml
@@ -1,4 +1,4 @@
-name = "GLM 4.5V"
+name = "GLM-4.5V"
 release_date = "2025-08-11"
 last_updated = "2025-08-11"
 attachment = true

--- a/providers/zai/models/glm-4.5v.toml
+++ b/providers/zai/models/glm-4.5v.toml
@@ -1,4 +1,4 @@
-name = "GLM 4.5V"
+name = "GLM-4.5V"
 release_date = "2025-08-11"
 last_updated = "2025-08-11"
 attachment = true


### PR DESCRIPTION
- Update GLM 4.5V to GLM-4.5V in zai and zai-coding-plan providers
- Ensures consistent naming convention across GLM serial models