### PR TITLE
Add OpenRouter Sherlock models

### DIFF
--- a/providers/openrouter/models/openrouter/sherlock-dash-alpha.toml
+++ b/providers/openrouter/models/openrouter/sherlock-dash-alpha.toml
@@ -1,0 +1,22 @@
+name = "Sherlock Dash Alpha"
+family = "sherlock"
+release_date = "2025-11-15"
+last_updated = "2025-12-14"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-11"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 1_840_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/openrouter/sherlock-think-alpha.toml
+++ b/providers/openrouter/models/openrouter/sherlock-think-alpha.toml
@@ -1,0 +1,22 @@
+name = "Sherlock Think Alpha"
+family = "sherlock"
+release_date = "2025-11-15"
+last_updated = "2025-12-14"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-11"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 1_840_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Adds Sherlock Think Alpha and Dash Alpha models from OpenRouter.

- Sherlock Think Alpha: Frontier reasoning model with 1.8M context, multimodal, excels at tool calling
- Sherlock Dash Alpha: Frontier non-reasoning model with 1.8M context, multimodal, excels at tool calling
- Both are free during alpha phase