### PR TITLE
Adds Kimi K2 Thinking model config to Amazon Bedrock provider

### DIFF
--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -5,6 +5,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+interleaved = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -1,0 +1,20 @@
+name = "Kimi K2 Thinking"
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 2.5
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds Kimi K2 Thinking to Amazon Bedrock.

<img width="823" height="863" alt="image" src="https://github.com/user-attachments/assets/221eb516-1b46-44fa-ad73-0a639b7fc728" />

closes: #518
