### PR TITLE
Add new Azure models: GPT-5.2 Chat, DeepSeek-V3.2, Kimi K2 Thinking

### DIFF
--- a/providers/azure-cognitive-services/models/deepseek-v3.2-speciale.toml
+++ b/providers/azure-cognitive-services/models/deepseek-v3.2-speciale.toml
@@ -1,0 +1,1 @@
+../../azure/models/deepseek-v3.2-speciale.toml

--- a/providers/azure-cognitive-services/models/deepseek-v3.2.toml
+++ b/providers/azure-cognitive-services/models/deepseek-v3.2.toml
@@ -1,0 +1,1 @@
+../../azure/models/deepseek-v3.2.toml

--- a/providers/azure-cognitive-services/models/gpt-5.2-chat.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.2-chat.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5.2-chat.toml

--- a/providers/azure-cognitive-services/models/kimi-k2-thinking.toml
+++ b/providers/azure-cognitive-services/models/kimi-k2-thinking.toml
@@ -1,0 +1,1 @@
+../../azure/models/kimi-k2-thinking.toml

--- a/providers/azure/models/deepseek-v3.2-speciale.toml
+++ b/providers/azure/models/deepseek-v3.2-speciale.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek-V3.2-Speciale"
+family = "deepseek-v3"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.28
+output = 0.42
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/deepseek-v3.2.toml
+++ b/providers/azure/models/deepseek-v3.2.toml
@@ -1,0 +1,23 @@
+name = "DeepSeek-V3.2"
+family = "deepseek-v3"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.28
+output = 0.42
+cache_read = 0.028
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/gpt-5.2-chat.toml
+++ b/providers/azure/models/gpt-5.2-chat.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.2 Chat"
+family = "gpt-5-chat"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/kimi-k2-thinking.toml
+++ b/providers/azure/models/kimi-k2-thinking.toml
@@ -1,0 +1,24 @@
+name = "Kimi K2 Thinking"
+family = "kimi-k2"
+release_date = "2025-11-06"
+last_updated = "2025-12-02"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-08"
+tool_call = true
+interleaved = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 2.50
+cache_read = 0.15
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add GPT-5.2 Chat model (128K context, 16K output, multimodal)
- Add DeepSeek-V3.2 model (128K context/output, reasoning with tool calling)
- Add DeepSeek-V3.2-Speciale model (128K context/output, reasoning without tool calling)
- Add Kimi K2 Thinking model (262K context/output, agentic reasoning with interleaved thinking)

All models symlinked to Azure Cognitive Services.

## Test plan
- [x] Ran `bun validate` - passed