### PR TITLE
Add Gemini 3 Flash Preview to OpenRouter

### DIFF
--- a/providers/openrouter/models/google/gemini-3-flash-preview.toml
+++ b/providers/openrouter/models/google/gemini-3-flash-preview.toml
@@ -1,0 +1,26 @@
+name = "Gemini 3 Flash Preview"
+family = "gemini-flash"
+release_date = "2025-12-17"
+last_updated = "2025-12-17"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_details"
+
+[cost]
+input = 0.15
+output = 0.60
+cache_read = 0.0375
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "audio", "video", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add Google Gemini 3 Flash Preview model to OpenRouter provider
- Includes thinking/reasoning capabilities with interleaved reasoning details