### PR TITLE
Bedrock: Add Opus 4.5

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -1,0 +1,23 @@
+name = "Claude Opus 4.5"
+release_date = "2025-11-24"
+last_updated = "2025-08-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 1.50
+cache_write = 18.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -1,4 +1,5 @@
 name = "Claude Opus 4.5"
+family = "claude-opus"
 release_date = "2025-11-24"
 last_updated = "2025-08-01"
 attachment = true
@@ -19,5 +20,5 @@ context = 200_000
 output = 64_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]


### PR DESCRIPTION
Opus 4.5 was removed in this PR because only global inference was available: https://github.com/sst/models.dev/pull/440

But now I believe us inference is available: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html

I also added `family = "claude-opus"` and `input = [..., 'pdf']` from what was originally here, basing my changes on the global model.