### PR TITLE
feat: add Xiaomi MiMo-V2-Flash model configuration

### DIFF
--- a/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
@@ -1,0 +1,25 @@
+name = "MiMo-V2-Flash"
+family = "mimo-v2-flash"
+release_date = "2025-12-17"
+last_updated = "2025-12-17"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-12-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.21
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
Add new Xiaomi MiMo-V2-Flash model to Zenmux provider with complete specification including capabilities, pricing, limits, and modalities.
* Configured reasoning and tool calling capabilities
* Set knowledge cutoff date to 2024-12-01
* Defined cost structure (input: $0.07, output: $0.21)
* Established context limits (256K input, 32K output)
* Text-only modality support