### PR TITLE
Google VertexAI - Add gemini-3-flash-preview model

### DIFF
--- a/providers/google-vertex/models/gemini-3-flash-preview.toml
+++ b/providers/google-vertex/models/gemini-3-flash-preview.toml
@@ -1,0 +1,29 @@
+name = "Gemini 3 Flash Preview"
+family = "gemini-flash"
+release_date = "2025-12-17"
+last_updated = "2025-12-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-01"
+open_weights = false
+
+[cost]
+input = 0.50
+output = 3.00
+cache_read = 0.05
+
+[cost.context_over_200k]
+input = 0.50
+output = 3.00
+cache_read = 0.05
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text", "image", "video", "audio", "pdf"]
+output = ["text"]


### PR DESCRIPTION
This MR aims to add the newly Gemini 3 Flash Preview model for the Google VertexAI provider