### PR TITLE
provider: update ollama cloud, and use openai compat

### DIFF
--- a/providers/ollama-cloud/provider.toml
+++ b/providers/ollama-cloud/provider.toml
@@ -1,4 +1,5 @@
 name = "Ollama Cloud"
 env = ["OLLAMA_API_KEY"]
-npm = "ai-sdk-ollama"
+npm = "@ai-sdk/openai-compatible"
+api = "https://ollama.com"
 doc = "https://docs.ollama.com/cloud"


### PR DESCRIPTION
Ollama has improved compatibility with openai chat completions - it's best to use that with Ollama. The ai sdk does not have an official Ollama integrations.

Also updated the cloud to point to `ollama.com` directly