### PR TITLE
providers: fix ollama api url

### DIFF
--- a/providers/ollama-cloud/provider.toml
+++ b/providers/ollama-cloud/provider.toml
@@ -1,5 +1,5 @@
 name = "Ollama Cloud"
 env = ["OLLAMA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-api = "https://ollama.com"
+api = "https://ollama.com/v1"
 doc = "https://docs.ollama.com/cloud"


### PR DESCRIPTION
Missing the `/v1`