### PR TITLE
feat: add glm-4.7 model with interleaved thinking

### DIFF
--- a/providers/zai-coding-plan/models/glm-4.7.toml
+++ b/providers/zai-coding-plan/models/glm-4.7.toml
@@ -1,0 +1,27 @@
+name = "GLM-4.7"
+family = "glm-4.7"
+release_date = "2025-12-22"
+last_updated = "2025-12-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.6
+output = 2.2
+cache_read = 0.11
+cache_write = 0
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zai/models/glm-4.7.toml
+++ b/providers/zai/models/glm-4.7.toml
@@ -1,0 +1,27 @@
+name = "GLM-4.7"
+family = "glm-4.7"
+release_date = "2025-12-22"
+last_updated = "2025-12-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.6
+output = 2.2
+cache_read = 0.11
+cache_write = 0
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zhipuai-coding-plan/models/glm-4.7.toml
+++ b/providers/zhipuai-coding-plan/models/glm-4.7.toml
@@ -1,0 +1,1 @@
+../../zai-coding-plan/models/glm-4.7.toml

--- a/providers/zhipuai/models/glm-4.7.toml
+++ b/providers/zhipuai/models/glm-4.7.toml
@@ -1,0 +1,1 @@
+../../zai/models/glm-4.7.toml


### PR DESCRIPTION
Add GLM-4.7 model configuration to zai, zai-coding-plan, zhipuai, and zhipuai-coding-plan providers. The model features interleaved reasoning capability with reasoning_content field.

* Created glm-4.7.toml in zai and zai-coding-plan providers
* Added symlinks in zhipuai and zhipuai-coding-plan providers
* Configured with same pricing and limits as glm-4.6
* Supports reasoning, tool_call, and temperature settings