### PR TITLE
Venice: Update Autogenerate Script

### DIFF
--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -46,6 +46,7 @@ const Pricing = z
   .object({
     input: z.object({ usd: z.number(), diem: z.number().optional() }).passthrough(),
     output: z.object({ usd: z.number(), diem: z.number().optional() }).passthrough(),
+    cache_input: z.object({ usd: z.number(), diem: z.number().optional() }).passthrough().optional(),
   })
   .passthrough();
 
@@ -203,6 +204,7 @@ interface MergedModel {
   cost?: {
     input: number;
     output: number;
+    cache_read?: number;
   };
   limit: {
     context: number;
@@ -273,6 +275,7 @@ function mergeModel(
     merged.cost = {
       input: spec.pricing.input.usd,
       output: spec.pricing.output.usd,
+      ...(spec.pricing.cache_input && { cache_read: spec.pricing.cache_input.usd }),
     };
   }
 
@@ -342,6 +345,9 @@ function formatToml(model: MergedModel): string {
     lines.push(`[cost]`);
     lines.push(`input = ${model.cost.input}`);
     lines.push(`output = ${model.cost.output}`);
+    if (model.cost.cache_read !== undefined) {
+      lines.push(`cache_read = ${model.cost.cache_read}`);
+    }
   }
 
   // Limit section
@@ -402,6 +408,7 @@ function detectChanges(
   compare("release_date", existing.release_date, merged.release_date);
   compare("cost.input", existing.cost?.input, merged.cost?.input);
   compare("cost.output", existing.cost?.output, merged.cost?.output);
+  compare("cost.cache_read", existing.cost?.cache_read, merged.cost?.cache_read);
   compare("limit.context", existing.limit?.context, merged.limit.context);
   compare("limit.output", existing.limit?.output, merged.limit.output);
   compare("modalities.input", existing.modalities?.input, merged.modalities.input);

--- a/providers/venice/models/claude-opus-45.toml
+++ b/providers/venice/models/claude-opus-45.toml
@@ -6,13 +6,14 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-03"
-release_date = "2025-12-18"
-last_updated = "2025-12-18"
+release_date = "2024-12-05"
+last_updated = "2025-12-23"
 open_weights = false
 
 [cost]
 input = 6
 output = 30
+cache_read = 0.6
 
 [limit]
 context = 202_752

--- a/providers/venice/models/deepseek-v3.2.toml
+++ b/providers/venice/models/deepseek-v3.2.toml
@@ -6,12 +6,13 @@ tool_call = false
 temperature = true
 knowledge = "2025-10"
 release_date = "2025-12-07"
-last_updated = "2025-12-18"
+last_updated = "2025-12-23"
 open_weights = true
 
 [cost]
 input = 0.4
 output = 1
+cache_read = 0.2
 
 [limit]
 context = 163_840

--- a/providers/venice/models/gemini-3-flash-preview.toml
+++ b/providers/venice/models/gemini-3-flash-preview.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-01"
-release_date = "2025-12-18"
-last_updated = "2025-12-18"
+release_date = "2025-12-13"
+last_updated = "2025-12-23"
 open_weights = false
 
 [interleaved]

--- a/providers/venice/models/gemini-3-pro-preview.toml
+++ b/providers/venice/models/gemini-3-pro-preview.toml
@@ -7,12 +7,13 @@ structured_output = true
 temperature = true
 knowledge = "2024-04"
 release_date = "2024-06-07"
-last_updated = "2025-12-18"
+last_updated = "2025-12-23"
 open_weights = false
 
 [cost]
 input = 2.5
 output = 15
+cache_read = 0.625
 
 [limit]
 context = 202_752

--- a/providers/venice/models/grok-41-fast.toml
+++ b/providers/venice/models/grok-41-fast.toml
@@ -7,12 +7,13 @@ structured_output = true
 temperature = true
 knowledge = "2025-07"
 release_date = "2025-04-29"
-last_updated = "2025-12-18"
+last_updated = "2025-12-23"
 open_weights = false
 
 [cost]
 input = 0.5
 output = 1.25
+cache_read = 0.125
 
 [limit]
 context = 262_144

--- a/providers/venice/models/openai-gpt-52.toml
+++ b/providers/venice/models/openai-gpt-52.toml
@@ -6,13 +6,14 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-08-31"
-release_date = "2025-12-18"
-last_updated = "2025-12-18"
+release_date = "2024-12-11"
+last_updated = "2025-12-23"
 open_weights = false
 
 [cost]
 input = 2.19
 output = 17.5
+cache_read = 0.219
 
 [limit]
 context = 262_144


### PR DESCRIPTION
Venice added the cache feature for models that support it:
- Updated the autogenerate script to include the `cache_read` field (write doesn't incurs in extra fees)
- Updated models to include the new field (`claude-opus-45`, `deepseek-v3.2`, `gemini-3-pro-preview`, `grok-41-fast` and `openai-gpt-52`)