### PR TITLE
fix: set costs to 0 for zai-coding-plan provider

### DIFF
--- a/providers/zai-coding-plan/models/glm-4.7.toml
+++ b/providers/zai-coding-plan/models/glm-4.7.toml
@@ -13,9 +13,9 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 0.6
-output = 2.2
-cache_read = 0.11
+input = 0
+output = 0
+cache_read = 0
 cache_write = 0
 
 [limit]


### PR DESCRIPTION
Updated cost configuration for GLM-4.7 model to reflect subscription-based billing rather than token-based pricing. Since zai-coding-plan uses a subscription model, all per-token costs should be zero.
- Changed input cost from 0.6 to 0
- Changed output cost from 2.2 to 0
- Changed cache_read cost from 0.11 to 0