### PR TITLE
feat: add MiniMax-M2.1 model configuration

### DIFF
--- a/providers/minimax-cn/models/MiniMax-M2.1.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.1.toml
@@ -1,0 +1,1 @@
+../../minimax/models/MiniMax-M2.1.toml

--- a/providers/minimax/models/MiniMax-M2.1.toml
+++ b/providers/minimax/models/MiniMax-M2.1.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M2.1"
+family = "minimax"
+release_date = "2025-12-23"
+last_updated = "2025-12-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+cached_input = 0.03
+cached_write = 0.375
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add new MiniMax-M2.1 reasoning model to both global and Chinese providers
* Supports reasoning capabilities, temperature settings, and tool calls
* Includes open weights support with context limit of 196,608 tokens
* Pricing: $0.30/input and $1.20/output per million tokens