### PR TITLE
Venice: Add cost.cache_read to kimi-k2-thinking

### DIFF
--- a/providers/venice/models/kimi-k2-thinking.toml
+++ b/providers/venice/models/kimi-k2-thinking.toml
@@ -7,12 +7,13 @@ structured_output = true
 temperature = true
 knowledge = "2024-04"
 release_date = "2024-06-07"
-last_updated = "2025-12-18"
+last_updated = "2025-12-24"
 open_weights = true
 
 [cost]
 input = 0.75
 output = 3.2
+cache_read = 0.1875
 
 [limit]
 context = 262_144


### PR DESCRIPTION
`kimi-k2-thinking` was updated with cache_read cost