### PR TITLE
Add GLM-4.7 for DeepInfra

### DIFF
--- a/providers/deepinfra/models/zai-org/GLM-4.5.toml
+++ b/providers/deepinfra/models/zai-org/GLM-4.5.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+# https://deepinfra.com/zai-org/GLM-4.5
+# It is now being redirected to GLM-4.6
+status = "deprecated"
+
 [cost]
 input = 0.60
 output = 2.20

--- a/providers/deepinfra/models/zai-org/glm-4.7.toml
+++ b/providers/deepinfra/models/zai-org/glm-4.7.toml
@@ -16,7 +16,8 @@ cache_read = 0.08
 cache_write = 0
 
 [limit]
-context = 202_752
+context = 202_752 
+# https://deepinfra.com/docs/advanced/max_tokens_limit
 output = 16_384
 
 [modalities]

--- a/providers/deepinfra/models/zai-org/glm-4.7.toml
+++ b/providers/deepinfra/models/zai-org/glm-4.7.toml
@@ -3,6 +3,7 @@ name = "GLM-4.7"
 family = "glm-4.7"
 release_date = "2025-12-22"
 last_updated = "2025-12-22"
+knowledge = "2025-04"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/deepinfra/models/zai-org/glm-4.7.toml
+++ b/providers/deepinfra/models/zai-org/glm-4.7.toml
@@ -13,7 +13,6 @@ open_weights = true
 input = 0.43
 output = 1.75
 cache_read = 0.08
-cache_write = 0
 
 [limit]
 context = 202_752 

--- a/providers/deepinfra/models/zai-org/glm-4.7.toml
+++ b/providers/deepinfra/models/zai-org/glm-4.7.toml
@@ -10,6 +10,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[interleaved]
+field = "reasoning_content"
+
 [cost]
 input = 0.43
 output = 1.75

--- a/providers/deepinfra/models/zai-org/glm-4.7.toml
+++ b/providers/deepinfra/models/zai-org/glm-4.7.toml
@@ -1,0 +1,24 @@
+# https://deepinfra.com/zai-org/GLM-4.7
+name = "GLM-4.7"
+family = "glm-4.7"
+release_date = "2025-12-22"
+last_updated = "2025-12-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.43
+output = 1.75
+cache_read = 0.08
+cache_write = 0
+
+[limit]
+context = 202_752
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This merge request makes two changes to the DeepInfra provider: it marks the GLM-4.5 model as deprecated and adds support for the newer GLM-4.7 model.