### PR TITLE
Venice: Update zai-org-glm-4.7

### DIFF
--- a/providers/venice/models/zai-org-glm-4.7.toml
+++ b/providers/venice/models/zai-org-glm-4.7.toml
@@ -1,25 +1,22 @@
-name = "GLM-4.7"
+name = "GLM 4.7"
 family = "glm-4.7"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
 attachment = false
-reasoning = true
-temperature = true
+reasoning = false
 tool_call = true
+structured_output = true
+temperature = true
 knowledge = "2025-04"
+release_date = "2024-04-01"
+last_updated = "2025-12-24"
 open_weights = true
 
-[interleaved]
-field = "reasoning_details"
-
 [cost]
-input = 0.6
-output = 2.2
-cache_read = 0.11
+input = 0.85
+output = 2.75
 
 [limit]
-context = 204800
-output = 131072
+context = 131_072
+output = 32_768
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Some fields of `zai-org-glm-4.7` needed to be updated to match the settings of the provider.