### PR TITLE
add Firework's MiniMax-M2.1

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2.toml
@@ -12,10 +12,11 @@ open_weights = true
 [cost]
 input = 0.30
 output = 1.20
+cache_read = 0.15
 
 [limit]
-context = 128_000
-output = 128_000
+context = 192_000
+output = 192_000
 
 [modalities]
 input = ["text"]

--- a/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p1.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p1.toml
@@ -1,0 +1,25 @@
+name = "MiniMax-M2.1"
+family = "minimax"
+release_date = "2025-12-23"
+last_updated = "2025-12-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.15
+
+[limit]
+context = 200_000
+output = 200_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
For Fireworks provider:
- Adding [MiniMax-M2.1](https://app.fireworks.ai/models/fireworks/minimax-m2p1), got context size from support

- Update  context size of [MiniMax-M2](https://app.fireworks.ai/models/fireworks/minimax-m2)

I have confirmed with support that in Fireworks the context size is also the max output tokens.