### PR TITLE
Feat: Add image generation models across providers

### DIFF
--- a/providers/azure-cognitive-services/models/FLUX-1.1-pro.toml
+++ b/providers/azure-cognitive-services/models/FLUX-1.1-pro.toml
@@ -1,0 +1,1 @@
+../../azure/models/FLUX-1.1-pro.toml

--- a/providers/azure-cognitive-services/models/FLUX.1-Kontext-pro.toml
+++ b/providers/azure-cognitive-services/models/FLUX.1-Kontext-pro.toml
@@ -1,0 +1,1 @@
+../../azure/models/FLUX.1-Kontext-pro.toml

--- a/providers/azure-cognitive-services/models/FLUX.2-pro.toml
+++ b/providers/azure-cognitive-services/models/FLUX.2-pro.toml
@@ -1,0 +1,1 @@
+../../azure/models/FLUX.2-pro.toml

--- a/providers/azure-cognitive-services/models/Stable-Diffusion-3.5-Large.toml
+++ b/providers/azure-cognitive-services/models/Stable-Diffusion-3.5-Large.toml
@@ -1,0 +1,1 @@
+../../azure/models/Stable-Diffusion-3.5-Large.toml

--- a/providers/azure-cognitive-services/models/Stable-Image-Core.toml
+++ b/providers/azure-cognitive-services/models/Stable-Image-Core.toml
@@ -1,0 +1,1 @@
+../../azure/models/Stable-Image-Core.toml

--- a/providers/azure-cognitive-services/models/Stable-Image-Ultra.toml
+++ b/providers/azure-cognitive-services/models/Stable-Image-Ultra.toml
@@ -1,0 +1,1 @@
+../../azure/models/Stable-Image-Ultra.toml

--- a/providers/azure-cognitive-services/models/gpt-5.1-codex-max.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.1-codex-max.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5.1-codex-max.toml

--- a/providers/azure-cognitive-services/models/gpt-5.2.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.2.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-5.2.toml

--- a/providers/azure-cognitive-services/models/gpt-image-1-mini.toml
+++ b/providers/azure-cognitive-services/models/gpt-image-1-mini.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-image-1-mini.toml

--- a/providers/azure-cognitive-services/models/gpt-image-1.5.toml
+++ b/providers/azure-cognitive-services/models/gpt-image-1.5.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-image-1.5.toml

--- a/providers/azure-cognitive-services/models/gpt-image-1.toml
+++ b/providers/azure-cognitive-services/models/gpt-image-1.toml
@@ -1,0 +1,1 @@
+../../azure/models/gpt-image-1.toml

--- a/providers/azure/models/FLUX-1.1-pro.toml
+++ b/providers/azure/models/FLUX-1.1-pro.toml
@@ -1,0 +1,19 @@
+name = "FLUX-1.1-pro"
+family = "Black Forest Labs"
+# Source: https://blackforestlabs.ai/blog/24-10-02-flux
+release_date = "2024-10-02"
+last_updated = "2024-10-02"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[modalities]
+input = ["text"]
+output = ["image"]
+
+[limit]
+context = 5000
+output = 0
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)

--- a/providers/azure/models/FLUX.1-Kontext-pro.toml
+++ b/providers/azure/models/FLUX.1-Kontext-pro.toml
@@ -1,0 +1,19 @@
+name = "FLUX.1-Kontext-pro"
+family = "Black Forest Labs"
+# Source: https://blackforestlabs.ai/blog/flux-1-kontext
+release_date = "2025-05-29"
+last_updated = "2025-05-29"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[limit]
+context = 5000
+output = 0
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)

--- a/providers/azure/models/FLUX.2-pro.toml
+++ b/providers/azure/models/FLUX.2-pro.toml
@@ -1,0 +1,19 @@
+name = "FLUX.2-pro"
+family = "Black Forest Labs"
+# Source: https://blackforestlabs.ai/blog/flux-2
+release_date = "2025-11-25"
+last_updated = "2025-11-25"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[limit]
+context = 32000
+output = 0
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)

--- a/providers/azure/models/Stable-Diffusion-3.5-Large.toml
+++ b/providers/azure/models/Stable-Diffusion-3.5-Large.toml
@@ -1,0 +1,19 @@
+name = "Stable Diffusion 3.5 Large"
+family = "Stability AI"
+# Source: https://stability.ai/news/introducing-stable-diffusion-3-5
+release_date = "2024-10-22"
+last_updated = "2024-10-22"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[limit]
+context = 1000
+output = 0
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)

--- a/providers/azure/models/Stable-Image-Core.toml
+++ b/providers/azure/models/Stable-Image-Core.toml
@@ -1,0 +1,19 @@
+name = "Stable Image Core"
+family = "Stability AI"
+# Source: https://stability.ai/news/stability-ais-top-3-text-to-image-models-now-available-in-amazon-bedrock
+release_date = "2024-09-04"
+last_updated = "2024-09-04"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[modalities]
+input = ["text"]
+output = ["image"]
+
+[limit]
+context = 1000
+output = 0
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)

--- a/providers/azure/models/Stable-Image-Ultra.toml
+++ b/providers/azure/models/Stable-Image-Ultra.toml
@@ -1,0 +1,19 @@
+name = "Stable Image Ultra"
+family = "Stability AI"
+# Source: https://stability.ai/news/stability-ais-top-3-text-to-image-models-now-available-in-amazon-bedrock
+release_date = "2024-09-04"
+last_updated = "2024-09-04"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[modalities]
+input = ["text"]
+output = ["image"]
+
+[limit]
+context = 1000
+output = 0
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)

--- a/providers/azure/models/gpt-image-1-mini.toml
+++ b/providers/azure/models/gpt-image-1-mini.toml
@@ -1,0 +1,18 @@
+name = "gpt-image-1-mini"
+family = "Azure OpenAI"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
+attachment = true
+reasoning = false
+tool_call = false
+open_weights = false
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[limit]
+context = 0
+output = 0
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)

--- a/providers/azure/models/gpt-image-1.5.toml
+++ b/providers/azure/models/gpt-image-1.5.toml
@@ -1,0 +1,19 @@
+name = "gpt-image-1.5"
+family = "Azure OpenAI"
+# Release date matches upstream OpenAI model; Azure publishes no independent date
+release_date = "2025-12-16"
+last_updated = "2025-12-16"
+attachment = true
+reasoning = false
+tool_call = false
+open_weights = false
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[limit]
+context = 0
+output = 0
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)

--- a/providers/azure/models/gpt-image-1.toml
+++ b/providers/azure/models/gpt-image-1.toml
@@ -1,0 +1,18 @@
+name = "gpt-image-1"
+family = "Azure OpenAI"
+release_date = "2025-04-15"
+last_updated = "2025-04-15"
+attachment = true
+reasoning = false
+tool_call = false
+open_weights = false
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[limit]
+context = 0
+output = 0
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)

--- a/providers/google-vertex/models/gemini-2.5-flash-image.toml
+++ b/providers/google-vertex/models/gemini-2.5-flash-image.toml
@@ -1,0 +1,1 @@
+../../google/models/gemini-2.5-flash-image.toml

--- a/providers/google-vertex/models/gemini-3-pro-image.toml
+++ b/providers/google-vertex/models/gemini-3-pro-image.toml
@@ -1,0 +1,1 @@
+../../google/models/gemini-3-pro-image.toml

--- a/providers/google-vertex/models/imagen-4.0-fast-generate-001.toml
+++ b/providers/google-vertex/models/imagen-4.0-fast-generate-001.toml
@@ -1,0 +1,1 @@
+../../google/models/imagen-4.0-fast-generate-001.toml

--- a/providers/google-vertex/models/imagen-4.0-generate-001.toml
+++ b/providers/google-vertex/models/imagen-4.0-generate-001.toml
@@ -1,0 +1,1 @@
+../../google/models/imagen-4.0-generate-001.toml

--- a/providers/google-vertex/models/imagen-4.0-ultra-generate-001.toml
+++ b/providers/google-vertex/models/imagen-4.0-ultra-generate-001.toml
@@ -1,0 +1,1 @@
+../../google/models/imagen-4.0-ultra-generate-001.toml

--- a/providers/google/models/gemini-3-pro-image.toml
+++ b/providers/google/models/gemini-3-pro-image.toml
@@ -1,0 +1,23 @@
+name = "Gemini 3 Pro Image"
+family = "gemini-pro-image"
+release_date = "2025-11-01"
+last_updated = "2025-11-01"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = false
+open_weights = false
+
+[cost]
+# Multi-modal pricing simplified to primary token rates (matches gemini-2.5-flash-image pattern)
+input = 2.00
+output = 120.00
+
+[limit]
+context = 65_536
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]

--- a/providers/google/models/imagen-4.0-fast-generate-001.toml
+++ b/providers/google/models/imagen-4.0-fast-generate-001.toml
@@ -1,0 +1,21 @@
+name = "Imagen 4 Fast"
+family = "imagen"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# [cost]
+
+[limit]
+context = 480
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/google/models/imagen-4.0-generate-001.toml
+++ b/providers/google/models/imagen-4.0-generate-001.toml
@@ -1,0 +1,21 @@
+name = "Imagen 4"
+family = "imagen"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# [cost]
+
+[limit]
+context = 480
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/google/models/imagen-4.0-ultra-generate-001.toml
+++ b/providers/google/models/imagen-4.0-ultra-generate-001.toml
@@ -1,0 +1,21 @@
+name = "Imagen 4 Ultra"
+family = "imagen"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# [cost]
+
+[limit]
+context = 480
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/openai/models/gpt-image-1-mini.toml
+++ b/providers/openai/models/gpt-image-1-mini.toml
@@ -1,0 +1,21 @@
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# Source: https://platform.openai.com/docs/models/gpt-image-1-mini
+# Release date source: https://platform.openai.com/docs/changelog (Oct 6, 2025 - OpenAI DevDay)
+
+name = "gpt-image-1-mini"
+family = "gpt-image"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/openai/models/gpt-image-1.5.toml
+++ b/providers/openai/models/gpt-image-1.5.toml
@@ -1,0 +1,21 @@
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# Source: https://platform.openai.com/docs/models/gpt-image-1.5
+# Release date source: https://platform.openai.com/docs/changelog (Dec 16, 2025)
+
+name = "gpt-image-1.5"
+family = "gpt-image"
+release_date = "2025-12-16"
+last_updated = "2025-12-16"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image", "text"]

--- a/providers/openai/models/gpt-image-1.toml
+++ b/providers/openai/models/gpt-image-1.toml
@@ -1,0 +1,21 @@
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# Source: https://platform.openai.com/docs/models/gpt-image-1
+# Release date source: https://platform.openai.com/docs/changelog (Apr 23, 2025)
+
+name = "gpt-image-1"
+family = "gpt-image"
+release_date = "2025-04-23"
+last_updated = "2025-04-23"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]


### PR DESCRIPTION
## Summary
- Add OpenAI gpt-image-1, gpt-image-1.5, gpt-image-1-mini models
- Add Google gemini-3-pro-image and imagen-4.0 variants (generate, fast, ultra)
- Add Google Vertex gemini-2.5-flash-image, gemini-3-pro-image, and imagen-4.0 variants
- Add Azure FLUX models (1.1-pro, Kontext-pro, 2-pro), Stable Diffusion/Image models, and gpt-image models
- Add Azure Cognitive Services models (symlinks to Azure models plus gpt-5 variants)

## Test plan
- [x] All model TOML files follow existing repository patterns
- [x] Symlinks for Azure Cognitive Services and Google Vertex point to correct source files