### PR TITLE
Venice: Update/fix 'release_date' for many models

### DIFF
--- a/providers/venice/models/claude-opus-45.toml
+++ b/providers/venice/models/claude-opus-45.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-03"
-release_date = "2024-12-05"
-last_updated = "2025-12-23"
+release_date = "2025-12-06"
+last_updated = "2025-12-29"
 open_weights = false
 
 [cost]

--- a/providers/venice/models/deepseek-v3.2.toml
+++ b/providers/venice/models/deepseek-v3.2.toml
@@ -5,8 +5,8 @@ reasoning = true
 tool_call = false
 temperature = true
 knowledge = "2025-10"
-release_date = "2025-12-07"
-last_updated = "2025-12-23"
+release_date = "2025-12-04"
+last_updated = "2025-12-29"
 open_weights = true
 
 [cost]

--- a/providers/venice/models/gemini-3-flash-preview.toml
+++ b/providers/venice/models/gemini-3-flash-preview.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-01"
-release_date = "2025-12-13"
-last_updated = "2025-12-23"
+release_date = "2025-12-19"
+last_updated = "2025-12-29"
 open_weights = false
 
 [interleaved]

--- a/providers/venice/models/gemini-3-pro-preview.toml
+++ b/providers/venice/models/gemini-3-pro-preview.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2024-04"
-release_date = "2024-06-07"
-last_updated = "2025-12-23"
+release_date = "2025-12-02"
+last_updated = "2025-12-29"
 open_weights = false
 
 [cost]

--- a/providers/venice/models/google-gemma-3-27b-it.toml
+++ b/providers/venice/models/google-gemma-3-27b-it.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-07"
-release_date = "2024-04-01"
-last_updated = "2025-12-18"
+release_date = "2025-11-04"
+last_updated = "2025-12-29"
 open_weights = true
 
 [cost]

--- a/providers/venice/models/grok-41-fast.toml
+++ b/providers/venice/models/grok-41-fast.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-07"
-release_date = "2025-04-29"
-last_updated = "2025-12-23"
+release_date = "2025-12-01"
+last_updated = "2025-12-29"
 open_weights = false
 
 [cost]

--- a/providers/venice/models/hermes-3-llama-3.1-405b.toml
+++ b/providers/venice/models/hermes-3-llama-3.1-405b.toml
@@ -5,8 +5,8 @@ reasoning = false
 tool_call = false
 temperature = true
 knowledge = "2024-04"
-release_date = "2024-04-01"
-last_updated = "2025-12-18"
+release_date = "2025-09-25"
+last_updated = "2025-12-29"
 open_weights = true
 
 [cost]

--- a/providers/venice/models/kimi-k2-thinking.toml
+++ b/providers/venice/models/kimi-k2-thinking.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2024-04"
-release_date = "2024-06-07"
-last_updated = "2025-12-24"
+release_date = "2025-11-12"
+last_updated = "2025-12-29"
 open_weights = true
 
 [cost]

--- a/providers/venice/models/llama-3.3-70b.toml
+++ b/providers/venice/models/llama-3.3-70b.toml
@@ -5,8 +5,8 @@ reasoning = false
 tool_call = true
 temperature = true
 knowledge = "2023-12"
-release_date = "2024-12-09"
-last_updated = "2025-12-18"
+release_date = "2025-04-06"
+last_updated = "2025-12-29"
 open_weights = true
 
 [cost]

--- a/providers/venice/models/openai-gpt-52.toml
+++ b/providers/venice/models/openai-gpt-52.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-08-31"
-release_date = "2024-12-11"
-last_updated = "2025-12-23"
+release_date = "2025-12-13"
+last_updated = "2025-12-29"
 open_weights = false
 
 [cost]

--- a/providers/venice/models/openai-gpt-oss-120b.toml
+++ b/providers/venice/models/openai-gpt-oss-120b.toml
@@ -5,8 +5,8 @@ reasoning = false
 tool_call = true
 temperature = true
 knowledge = "2025-07"
-release_date = "2024-04-01"
-last_updated = "2025-12-18"
+release_date = "2025-11-06"
+last_updated = "2025-12-29"
 open_weights = true
 
 [cost]

--- a/providers/venice/models/zai-org-glm-4.6.toml
+++ b/providers/venice/models/zai-org-glm-4.6.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2024-04"
-release_date = "2024-04-01"
-last_updated = "2025-12-18"
+release_date = "2025-10-18"
+last_updated = "2025-12-29"
 open_weights = true
 
 [cost]

--- a/providers/venice/models/zai-org-glm-4.6v.toml
+++ b/providers/venice/models/zai-org-glm-4.6v.toml
@@ -5,8 +5,8 @@ reasoning = false
 tool_call = true
 structured_output = true
 temperature = true
-release_date = "2024-12-10"
-last_updated = "2025-12-18"
+release_date = "2025-12-11"
+last_updated = "2025-12-29"
 open_weights = true
 
 [cost]

--- a/providers/venice/models/zai-org-glm-4.7.toml
+++ b/providers/venice/models/zai-org-glm-4.7.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-04"
-release_date = "2024-04-01"
-last_updated = "2025-12-24"
+release_date = "2025-12-24"
+last_updated = "2025-12-29"
 open_weights = true
 
 [cost]


### PR DESCRIPTION
Venice was reporting a wrong `release_date` for many of their models. This has now been fixed.