### PR TITLE
Venice: Added new models Grok Code Fast 1 and Minimax M2.1

### DIFF
--- a/providers/venice/models/gemini-3-flash-preview.toml
+++ b/providers/venice/models/gemini-3-flash-preview.toml
@@ -7,7 +7,7 @@ structured_output = true
 temperature = true
 knowledge = "2025-01"
 release_date = "2025-12-19"
-last_updated = "2025-12-29"
+last_updated = "2025-12-30"
 open_weights = false
 
 [interleaved]
@@ -16,6 +16,7 @@ field = "reasoning_details"
 [cost]
 input = 0.7
 output = 3.75
+cache_read = 0.07
 
 [limit]
 context = 262_144

--- a/providers/venice/models/grok-code-fast-1.toml
+++ b/providers/venice/models/grok-code-fast-1.toml
@@ -1,0 +1,23 @@
+name = "Grok Code Fast 1"
+family = "grok"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2025-12-01"
+last_updated = "2025-12-30"
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1.87
+cache_read = 0.03
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/venice/models/kimi-k2-thinking.toml
+++ b/providers/venice/models/kimi-k2-thinking.toml
@@ -6,14 +6,14 @@ tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2024-04"
-release_date = "2025-11-12"
-last_updated = "2025-12-29"
+release_date = "2025-12-10"
+last_updated = "2025-12-30"
 open_weights = true
 
 [cost]
 input = 0.75
 output = 3.2
-cache_read = 0.1875
+cache_read = 0.375
 
 [limit]
 context = 262_144

--- a/providers/venice/models/minimax-m21.toml
+++ b/providers/venice/models/minimax-m21.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2.1"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2025-12-01"
+last_updated = "2025-12-30"
+open_weights = false
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.04
+
+[limit]
+context = 202_752
+output = 50_688
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Two new models added to Alpha:
 - minimax-m21
 - grok-code-fast-1
 

Updated `cache_read` from two other models: 
 - gemini-3-flash-preview 
 - kimi-k2-thinking
