### PR TITLE
Remove interleaved section from MiniMax-M2.1.toml

### DIFF
--- a/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.1.toml
+++ b/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.1.toml
@@ -8,9 +8,6 @@ temperature = true
 tool_call = true
 open_weights = true
 
-[interleaved]
-field = "reasoning_content" 
-
 [cost]
 input = 0.55
 output = 2.19


### PR DESCRIPTION
Remove interleaved section from MiniMax-M2.1.toml for Synthetic provider.

No interleaved section in definition for the identical model in OpenCode Zen. See providers/opencode/models/minimax-m2.1-free.toml