### PR TITLE
feat: chutes added minimax m2.1 and glm 4.7.

### DIFF
--- a/providers/chutes/models/MiniMaxAI/MiniMax-M2.1.toml
+++ b/providers/chutes/models/MiniMaxAI/MiniMax-M2.1.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2.1"
+family = "minimax"
+release_date = "2025-12-23"
+last_updated = "2025-12-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/chutes/models/zai-org/GLM-4.7.toml
+++ b/providers/chutes/models/zai-org/GLM-4.7.toml
@@ -1,0 +1,25 @@
+name = "GLM 4.7"
+family = "glm-4.7"
+release_date = "2025-12-22"
+last_updated = "2025-12-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.60
+output = 2.20
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
I asked MiniMax-M2.1 (OpenCode Zen) to write this.

I asked it to reference:
GLM4.7-https://chutes.ai/app/chute/08a7a60f-6956-5a9e-9983-5603c3ac5a38?tab=source MinimaxM2.1-https://chutes.ai/app/chute/1c2b2bd7-afdd-5248-9a73-938d55f03dcd

addresses https://github.com/sst/models.dev/issues/581