### PR TITLE
Venice: Fixed modalities for grok-code-fast-1 and minimax-m21

### DIFF
--- a/providers/venice/models/grok-code-fast-1.toml
+++ b/providers/venice/models/grok-code-fast-1.toml
@@ -1,12 +1,12 @@
 name = "Grok Code Fast 1"
 family = "grok"
-attachment = true
+attachment = false
 reasoning = true
 tool_call = true
 structured_output = true
 temperature = true
 release_date = "2025-12-01"
-last_updated = "2025-12-30"
+last_updated = "2026-01-02"
 open_weights = false
 
 [cost]
@@ -19,5 +19,5 @@ context = 262_144
 output = 65_536
 
 [modalities]
-input = ["text", "image"]
+input = ["text"]
 output = ["text"]

--- a/providers/venice/models/minimax-m21.toml
+++ b/providers/venice/models/minimax-m21.toml
@@ -1,11 +1,12 @@
 name = "MiniMax M2.1"
-attachment = true
+family = "minimax"
+attachment = false
 reasoning = true
 tool_call = true
 structured_output = true
 temperature = true
 release_date = "2025-12-01"
-last_updated = "2025-12-30"
+last_updated = "2026-01-02"
 open_weights = false
 
 [cost]
@@ -18,5 +19,8 @@ context = 202_752
 output = 50_688
 
 [modalities]
-input = ["text", "image"]
+input = ["text"]
 output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
`grok-code-fast-1`:
- Set attachment to false
- Remove image input modality

`minimax-m21`:
- Set attachment to false
- Remove image input modality
- Add interleaved reasoning_content
- Add family