### PR TITLE
Feat: update Groq provider with latest pricing, limits, and capabilities

### DIFF
--- a/providers/groq/models/llama-3.1-8b-instant.toml
+++ b/providers/groq/models/llama-3.1-8b-instant.toml
@@ -15,7 +15,7 @@ output = 0.08
 
 [limit]
 context = 131_072
-output = 8_192
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/groq/models/meta-llama/llama-4-maverick-17b-128e-instruct.toml
+++ b/providers/groq/models/meta-llama/llama-4-maverick-17b-128e-instruct.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-08"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/groq/models/meta-llama/llama-4-scout-17b-16e-instruct.toml
+++ b/providers/groq/models/meta-llama/llama-4-scout-17b-16e-instruct.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-08"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/groq/models/meta-llama/llama-guard-4-12b.toml
+++ b/providers/groq/models/meta-llama/llama-guard-4-12b.toml
@@ -14,7 +14,7 @@ output = 0.20
 
 [limit]
 context = 131_072
-output = 128
+output = 1_024
 
 [modalities]
 input = ["text", "image"]

--- a/providers/groq/models/moonshotai/kimi-k2-instruct-0905.toml
+++ b/providers/groq/models/moonshotai/kimi-k2-instruct-0905.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-10"
 open_weights = true
 

--- a/providers/groq/models/openai/gpt-oss-120b.toml
+++ b/providers/groq/models/openai/gpt-oss-120b.toml
@@ -10,11 +10,11 @@ open_weights = true
 
 [cost]
 input = 0.15
-output = 0.75
+output = 0.60
 
 [limit]
 context = 131_072
-output = 32_768
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/groq/models/openai/gpt-oss-120b.toml
+++ b/providers/groq/models/openai/gpt-oss-120b.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/groq/models/openai/gpt-oss-20b.toml
+++ b/providers/groq/models/openai/gpt-oss-20b.toml
@@ -9,12 +9,12 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.10
-output = 0.50
+input = 0.075
+output = 0.30
 
 [limit]
 context = 131_072
-output = 32_768
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/groq/models/openai/gpt-oss-20b.toml
+++ b/providers/groq/models/openai/gpt-oss-20b.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/groq/models/qwen-qwq-32b.toml
+++ b/providers/groq/models/qwen-qwq-32b.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-09"
 tool_call = true
 open_weights = true
+status = "deprecated"
 
 [cost]
 input = 0.29


### PR DESCRIPTION
Reference: [groq models doc ](https://console.groq.com/docs/models)

## Summary

Updates the Groq provider models with the latest pricing, token limits, and capabilities to match Groq's current API offerings.

## Changes
### Pricing & Limits Updates
- **llama-3.1-8b-instant**: Increased max output tokens from 8,192 to 131,072
- **openai/gpt-oss-20b**: Updated pricing ($0.10→$0.075 input, $0.50→$0.30 output) and max output (32,768→65,536)
- **openai/gpt-oss-120b**: Updated output pricing ($0.75→$0.60) and max output (32,768→65,536)  
- **meta-llama/llama-guard-4-12b**: Increased max output tokens from 128 to 1,024

### Structured Output Support
Added `structured_output = true` capability to models that support JSON Schema mode:
- openai/gpt-oss-20b
- openai/gpt-oss-120b
- moonshotai/kimi-k2-instruct-0905
- meta-llama/llama-4-maverick-17b-128e-instruct
- meta-llama/llama-4-scout-17b-16e-instruct

### Deprecation Updates
- Marked `qwen-qwq-32b` as deprecated to reflect current Groq API status
