### PR TITLE
Add LlamaGate provider with 26 open-source models

### DIFF
--- a/providers/llamagate/models/codegemma-7b.toml
+++ b/providers/llamagate/models/codegemma-7b.toml
@@ -1,0 +1,21 @@
+name = "CodeGemma 7B"
+release_date = "2024-04-09"
+last_updated = "2024-04-09"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.12
+
+[limit]
+context = 8_192
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/codellama-7b.toml
+++ b/providers/llamagate/models/codellama-7b.toml
@@ -1,0 +1,21 @@
+name = "CodeLlama 7B"
+release_date = "2023-08-24"
+last_updated = "2023-08-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.12
+
+[limit]
+context = 16_384
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/deepseek-coder-6.7b.toml
+++ b/providers/llamagate/models/deepseek-coder-6.7b.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek Coder 6.7B"
+release_date = "2023-11-02"
+last_updated = "2023-11-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.12
+
+[limit]
+context = 16_384
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/deepseek-r1-7b-qwen.toml
+++ b/providers/llamagate/models/deepseek-r1-7b-qwen.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek R1 Distill Qwen 7B"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.15
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/deepseek-r1-8b.toml
+++ b/providers/llamagate/models/deepseek-r1-8b.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek R1 8B"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.20
+
+[limit]
+context = 65_536
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/dolphin3-8b.toml
+++ b/providers/llamagate/models/dolphin3-8b.toml
@@ -1,0 +1,21 @@
+name = "Dolphin 3 8B"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.15
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/embeddinggemma-300m.toml
+++ b/providers/llamagate/models/embeddinggemma-300m.toml
@@ -1,0 +1,19 @@
+name = "EmbeddingGemma 300M"
+release_date = "2024-06-27"
+last_updated = "2024-06-27"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.02
+
+[limit]
+context = 2_048
+
+[modalities]
+input = ["text"]
+output = ["embedding"]

--- a/providers/llamagate/models/embeddinggemma-300m.toml
+++ b/providers/llamagate/models/embeddinggemma-300m.toml
@@ -10,10 +10,12 @@ open_weights = true
 
 [cost]
 input = 0.02
+output = 0.00
 
 [limit]
 context = 2_048
+output = 768
 
 [modalities]
 input = ["text"]
-output = ["embedding"]
+output = ["text"]

--- a/providers/llamagate/models/functiongemma.toml
+++ b/providers/llamagate/models/functiongemma.toml
@@ -1,0 +1,21 @@
+name = "FunctionGemma"
+release_date = "2024-06-27"
+last_updated = "2024-06-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.04
+
+[limit]
+context = 8_192
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/gemma3-4b.toml
+++ b/providers/llamagate/models/gemma3-4b.toml
@@ -1,0 +1,21 @@
+name = "Gemma 3 4B"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.08
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/llamagate/models/gpt-oss-20b.toml
+++ b/providers/llamagate/models/gpt-oss-20b.toml
@@ -1,0 +1,21 @@
+name = "GPT-OSS 20B"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.25
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/granite4-3b.toml
+++ b/providers/llamagate/models/granite4-3b.toml
@@ -1,0 +1,21 @@
+name = "Granite 4 3B"
+release_date = "2024-10-21"
+last_updated = "2024-10-21"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.08
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/llama-3.1-8b.toml
+++ b/providers/llamagate/models/llama-3.1-8b.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.1 8B Instruct"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+knowledge = "2023-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.05
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/llama-3.2-3b.toml
+++ b/providers/llamagate/models/llama-3.2-3b.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.2 3B"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+knowledge = "2023-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.08
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/llava-7b.toml
+++ b/providers/llamagate/models/llava-7b.toml
@@ -1,0 +1,21 @@
+name = "LLaVA 1.5 7B"
+release_date = "2023-10-05"
+last_updated = "2023-10-05"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.20
+
+[limit]
+context = 4_096
+output = 2_048
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/llamagate/models/mistral-7b-v0.3.toml
+++ b/providers/llamagate/models/mistral-7b-v0.3.toml
@@ -1,0 +1,21 @@
+name = "Mistral 7B Instruct v0.3"
+release_date = "2024-05-22"
+last_updated = "2024-05-22"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.15
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/nomic-embed-text.toml
+++ b/providers/llamagate/models/nomic-embed-text.toml
@@ -10,10 +10,12 @@ open_weights = true
 
 [cost]
 input = 0.02
+output = 0.00
 
 [limit]
 context = 8_192
+output = 768
 
 [modalities]
 input = ["text"]
-output = ["embedding"]
+output = ["text"]

--- a/providers/llamagate/models/nomic-embed-text.toml
+++ b/providers/llamagate/models/nomic-embed-text.toml
@@ -1,0 +1,19 @@
+name = "Nomic Embed Text"
+release_date = "2024-02-02"
+last_updated = "2024-02-02"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.02
+
+[limit]
+context = 8_192
+
+[modalities]
+input = ["text"]
+output = ["embedding"]

--- a/providers/llamagate/models/olmo-3-7b.toml
+++ b/providers/llamagate/models/olmo-3-7b.toml
@@ -1,0 +1,21 @@
+name = "OLMo 3 7B"
+release_date = "2024-02-01"
+last_updated = "2024-02-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.20
+
+[limit]
+context = 8_192
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/olmocr-7b.toml
+++ b/providers/llamagate/models/olmocr-7b.toml
@@ -1,0 +1,21 @@
+name = "olmOCR 7B"
+release_date = "2024-02-25"
+last_updated = "2024-02-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.15
+
+[limit]
+context = 8_192
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/llamagate/models/openthinker-7b.toml
+++ b/providers/llamagate/models/openthinker-7b.toml
@@ -1,0 +1,21 @@
+name = "OpenThinker 7B"
+release_date = "2024-11-01"
+last_updated = "2024-11-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.15
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/qwen2.5-coder-7b.toml
+++ b/providers/llamagate/models/qwen2.5-coder-7b.toml
@@ -1,0 +1,21 @@
+name = "Qwen 2.5 Coder 7B"
+release_date = "2024-09-19"
+last_updated = "2024-09-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.12
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/qwen3-8b.toml
+++ b/providers/llamagate/models/qwen3-8b.toml
@@ -1,0 +1,21 @@
+name = "Qwen 3 8B"
+release_date = "2024-09-19"
+last_updated = "2024-09-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.14
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/qwen3-embedding-8b.toml
+++ b/providers/llamagate/models/qwen3-embedding-8b.toml
@@ -10,10 +10,12 @@ open_weights = true
 
 [cost]
 input = 0.02
+output = 0.00
 
 [limit]
 context = 40_960
+output = 4_096
 
 [modalities]
 input = ["text"]
-output = ["embedding"]
+output = ["text"]

--- a/providers/llamagate/models/qwen3-embedding-8b.toml
+++ b/providers/llamagate/models/qwen3-embedding-8b.toml
@@ -1,0 +1,19 @@
+name = "Qwen 3 Embedding 8B"
+release_date = "2025-01-01"
+last_updated = "2025-01-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.02
+
+[limit]
+context = 40_960
+
+[modalities]
+input = ["text"]
+output = ["embedding"]

--- a/providers/llamagate/models/qwen3-vl-8b.toml
+++ b/providers/llamagate/models/qwen3-vl-8b.toml
@@ -1,0 +1,21 @@
+name = "Qwen 3 VL 8B"
+release_date = "2024-09-18"
+last_updated = "2024-09-18"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.55
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/llamagate/models/rnj-1-8b.toml
+++ b/providers/llamagate/models/rnj-1-8b.toml
@@ -1,0 +1,21 @@
+name = "Rnj-1 8B"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.20
+
+[limit]
+context = 32_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/starcoder2-7b.toml
+++ b/providers/llamagate/models/starcoder2-7b.toml
@@ -1,0 +1,21 @@
+name = "StarCoder2 7B"
+release_date = "2024-02-28"
+last_updated = "2024-02-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.12
+
+[limit]
+context = 16_384
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llamagate/models/ui-tars-7b.toml
+++ b/providers/llamagate/models/ui-tars-7b.toml
@@ -1,0 +1,21 @@
+name = "UI-TARS 1.5 7B"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.15
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/llamagate/provider.toml
+++ b/providers/llamagate/provider.toml
@@ -1,0 +1,5 @@
+name = "LlamaGate"
+npm = "@ai-sdk/openai-compatible"
+env = ["LLAMAGATE_API_KEY"]
+doc = "https://llamagate.dev/docs"
+api = "https://api.llamagate.dev/v1"


### PR DESCRIPTION
Adds LlamaGate (https://llamagate.dev) as a new provider with:
- 3 embedding models (Nomic, EmbeddingGemma, Qwen3 Embedding)
- 8 general purpose models (Llama 3.1/3.2, Mistral, Qwen, etc.)
- 6 code models (DeepSeek Coder, CodeLlama, Qwen Coder, etc.)
- 3 reasoning models (DeepSeek R1, OpenThinker)
- 5 vision models (Qwen VL, LLaVA, olmOCR, UI-TARS, Gemma 3)
- 1 tool calling model (FunctionGemma)

Provider details:
- API: OpenAI-compatible (@ai-sdk/openai-compatible)
- Base URL: https://api.llamagate.dev/v1
- Auth: Bearer token via LLAMAGATE_API_KEY
- Pricing: $0.02-$0.55 per 1M tokens
- All models are open-weights (Apache 2.0, MIT, Llama, Gemma)