### PR TITLE
Add cross-region inference profiles for Claude 4.x family models in Amazon Bedrock

### DIFF
--- a/providers/amazon-bedrock/models/eu.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Haiku 4.5 (EU)"
+family = "claude-haiku"
+release_date = "2025-10-15"
+last_updated = "2025-10-15"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-02-28"
+open_weights = false
+
+[cost]
+input = 1.00
+output = 5.00
+cache_read = 0.10
+cache_write = 1.25
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.5 (EU)"
+family = "claude-opus"
+release_date = "2025-11-24"
+last_updated = "2025-08-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 1.50
+cache_write = 18.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-20250514-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-20250514-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4 (EU)"
+family = "claude-sonnet"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4.5 (EU)"
+family = "claude-sonnet"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-07-31"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Haiku 4.5 (Global)"
+family = "claude-haiku"
+release_date = "2025-10-15"
+last_updated = "2025-10-15"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-02-28"
+open_weights = false
+
+[cost]
+input = 1.00
+output = 5.00
+cache_read = 0.10
+cache_write = 1.25
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-20250514-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-20250514-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4 (Global)"
+family = "claude-sonnet"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4.5 (Global)"
+family = "claude-sonnet"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-07-31"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Haiku 4.5 (US)"
+family = "claude-haiku"
+release_date = "2025-10-15"
+last_updated = "2025-10-15"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-02-28"
+open_weights = false
+
+[cost]
+input = 1.00
+output = 5.00
+cache_read = 0.10
+cache_write = 1.25
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-1-20250805-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-1-20250805-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.1 (US)"
+family = "claude-opus"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 15.00
+output = 75.00
+cache_read = 1.50
+cache_write = 18.75
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-20250514-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-20250514-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4 (US)"
+family = "claude-opus"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 15.00
+output = 75.00
+cache_read = 1.50
+cache_write = 18.75
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.5 (US)"
+family = "claude-opus"
+release_date = "2025-11-24"
+last_updated = "2025-08-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 1.50
+cache_write = 18.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-20250514-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-20250514-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4 (US)"
+family = "claude-sonnet"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4.5 (US)"
+family = "claude-sonnet"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-07-31"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
Amazon Bedrock requires usage of cross-region inference for some models, especially the latest models including all Claude 4.x family. This change creates model files for all Claude 4.x models for cross-region inference profiles for Global, US and EU.

See https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html for more details. 
Related to https://github.com/anomalyco/models.dev/issues/37.