### PR TITLE
Venice: Updated GLM 4.7 model configuration

### DIFF
--- a/providers/venice/models/zai-org-glm-4.7.toml
+++ b/providers/venice/models/zai-org-glm-4.7.toml
@@ -1,23 +1,26 @@
 name = "GLM 4.7"
 family = "glm-4.7"
 attachment = false
-reasoning = false
+reasoning = true
 tool_call = true
 structured_output = true
 temperature = true
 knowledge = "2025-04"
 release_date = "2025-12-24"
-last_updated = "2025-12-29"
+last_updated = "2026-01-07"
 open_weights = true
 
 [cost]
-input = 0.85
-output = 2.75
+input = 0.55
+output = 2.65
 
 [limit]
-context = 131_072
-output = 32_768
+context = 202_752
+output = 50_688
 
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[interleaved]
+field = "reasoning_details"


### PR DESCRIPTION
 - Enabled reasoning capability
 - Reduced input cost from 0.85 to 0.55
 - Reduced output cost from 2.75 to 2.65
 - Increased context limit from 131_072 to 202_752
 - Increased output limit from 32_768 to 50_688
 - Added interleaved reasoning_details field