### PR TITLE
feat(scaleway): add devstral 2 123B to Scaleway catalog

### DIFF
--- a/providers/scaleway/models/devstral-2-123b-instruct-2512.toml
+++ b/providers/scaleway/models/devstral-2-123b-instruct-2512.toml
@@ -1,0 +1,21 @@
+name = "Devstral 2 123B Instruct (2512)"
+family = "devstral"
+release_date = "2026-01-07"
+last_updated = "2026-01-07"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.40
+output = 2.00
+
+[limit]
+context = 256_000
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
We recently added Devstral 2 123B to Scaleway catalog. Reflecting this new model here.