### PR TITLE
Fix Claude Opus 4.5 cache pricing (3x too high)

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -12,8 +12,8 @@ open_weights = false
 [cost]
 input = 5.00
 output = 25.00
-cache_read = 1.50
-cache_write = 18.75
+cache_read = 0.50
+cache_write = 6.25
 
 [limit]
 context = 200_000

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -12,8 +12,8 @@ open_weights = false
 [cost]
 input = 5.00
 output = 25.00
-cache_read = 1.50
-cache_write = 18.75
+cache_read = 0.50
+cache_write = 6.25
 
 [limit]
 context = 200_000

--- a/providers/azure/models/claude-opus-4-5.toml
+++ b/providers/azure/models/claude-opus-4-5.toml
@@ -12,8 +12,8 @@ open_weights = false
 [cost]
 input = 5.00
 output = 25.00
-cache_read = 1.50
-cache_write = 18.75
+cache_read = 0.50
+cache_write = 6.25
 
 [limit]
 context = 200_000

--- a/providers/helicone/models/claude-4.5-opus.toml
+++ b/providers/helicone/models/claude-4.5-opus.toml
@@ -12,7 +12,7 @@ open_weights = false
 [cost]
 input = 5
 output = 25
-cache_read = 0.5000000000000001
+cache_read = 0.50
 cache_write = 6.25
 
 [limit]


### PR DESCRIPTION
## Summary
- Fixed Opus 4.5 cache pricing which was 3x too high after Anthropic's price reduction
- Updated Amazon Bedrock (regional and global), Azure, and Helicone
- Also fixed floating point precision issue in Helicone

**Changes:**
- `cache_read`: 1.50 → 0.50
- `cache_write`: 18.75 → 6.25