### PR TITLE
feat: add gpt-5.2-codex model

### DIFF
--- a/providers/openai/models/gpt-5.2-codex.toml
+++ b/providers/openai/models/gpt-5.2-codex.toml
@@ -1,5 +1,5 @@
 name = "GPT-5.2 Codex"
-family = "gpt-5-codex"
+family = "gpt-codex"
 release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true

--- a/providers/openai/models/gpt-5.2-codex.toml
+++ b/providers/openai/models/gpt-5.2-codex.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.2 Codex"
+family = "gpt-5-codex"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Background
OpenAI’s official Codex CLI ships `gpt-5.2-codex` as a first-class model preset (see [`model_presets.rs`](https://github.com/openai/codex/blob/main/codex-rs/core/src/models_manager/model_presets.rs#L15-L41)) and uses it as the default ChatGPT/Codex model (see [`manager.rs`](https://github.com/openai/codex/blob/main/codex-rs/core/src/models_manager/manager.rs#L35-L36)). However, models.dev currently lacks this model entry.

## Change
- Add `providers/openai/models/gpt-5.2-codex.toml`
- Align specs with `gpt-5.2` (context window, pricing, knowledge date, etc.)

## Notes
- In the Codex CLI preset list, `gpt-5.2-codex` is marked `supported_in_api: false`, so this appears to be a Codex/ChatGPT channel model rather than a public API-key model. If the fields should differ, I’m happy to adjust.

## Verification
- `bun validate`
