### PR TITLE
Fix Azure DeepSeek V3.2 pricing

### DIFF
--- a/providers/azure/models/deepseek-v3.2-speciale.toml
+++ b/providers/azure/models/deepseek-v3.2-speciale.toml
@@ -10,8 +10,8 @@ tool_call = false
 open_weights = true
 
 [cost]
-input = 0.28
-output = 0.42
+input = 0.58
+output = 1.68
 
 [limit]
 context = 128_000

--- a/providers/azure/models/deepseek-v3.2.toml
+++ b/providers/azure/models/deepseek-v3.2.toml
@@ -10,9 +10,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.28
-output = 0.42
-cache_read = 0.028
+input = 0.58
+output = 1.68
 
 [limit]
 context = 128_000


### PR DESCRIPTION
## Summary
- Fixed Azure DeepSeek V3.2 and V3.2-Speciale pricing to match Azure AI Foundry rates
- Input: $0.28 → $0.58 per 1M tokens  
- Output: $0.42 → $1.68 per 1M tokens
- Removed `cache_read` - Azure doesn't offer prompt caching for third-party models like DeepSeek

## Sources
- [Azure AI Foundry pricing](https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/)
- [Microsoft Foundry blog](https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-deepseek-v3-2-and-deepseek-v3-2-speciale-in-microsoft-foundry/4477549)

Fixes #624