### PR TITLE
upstage: fix API base URL

### DIFF
--- a/providers/upstage/provider.toml
+++ b/providers/upstage/provider.toml
@@ -2,4 +2,4 @@ name = "Upstage"
 env = ["UPSTAGE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
 doc = "https://developers.upstage.ai/docs/apis/chat"
-api = "https://api.upstage.ai" 
+api = "https://api.upstage.ai/v1/solar" 


### PR DESCRIPTION
## Summary
- Fix Upstage API base URL from `https://api.upstage.ai` to `https://api.upstage.ai/v1/solar`

## Problem
The current API URL is incorrect. Upstage's OpenAI-compatible API requires the `/v1/solar` path for all Solar models (solar-mini, solar-pro2).

## Reference
- Official documentation: https://console.upstage.ai/docs/models/solar-pro-2
- LangChain integration: https://reference.langchain.com/python/integrations/langchain_upstage/

🤖 Generated with [Claude Code](https://claude.com/claude-code)