### PR TITLE
upstage: add solar-pro3 model

### DIFF
--- a/providers/upstage/models/solar-pro3.toml
+++ b/providers/upstage/models/solar-pro3.toml
@@ -1,0 +1,22 @@
+name = "solar-pro3"
+family = "solar-pro"
+release_date = "2026-01"
+last_updated = "2026-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 0.25
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add Upstage Solar Pro 3 model

## Model Specifications
| Field | Value |
|-------|-------|
| Model ID | `solar-pro3` |
| Family | solar-pro |
| Context Window | 131,072 tokens (128K) |
| Output Limit | 8,192 tokens |
| Reasoning | Yes |
| Tool Call | Yes |

## Note
- Pricing is estimated based on Solar Pro 2 ($0.25/1M tokens for both input/output)
- Official pricing documentation is not yet publicly available
- Please update pricing when official information is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)