### PR TITLE
fix(sap-ai-core): use working provider fork for stable OpenCode integration

### DIFF
--- a/providers/sap-ai-core/provider.toml
+++ b/providers/sap-ai-core/provider.toml
@@ -1,4 +1,4 @@
 name = "SAP AI Core"
 env = ["AICORE_SERVICE_KEY"]
-npm = "@mymediset/sap-ai-provider"
+npm = "@jerome-benoit/sap-ai-provider"
 doc = "https://help.sap.com/docs/sap-ai-core"

--- a/providers/sap-ai-core/provider.toml
+++ b/providers/sap-ai-core/provider.toml
@@ -1,4 +1,4 @@
 name = "SAP AI Core"
 env = ["AICORE_SERVICE_KEY"]
-npm = "@jerome-benoit/sap-ai-provider"
+npm = "@jerome-benoit/sap-ai-provider-v2"
 doc = "https://help.sap.com/docs/sap-ai-core"


### PR DESCRIPTION
## Summary

This PR  switches the SAP AI Core provider package from `@mymediset/sap-ai-provider` to `@jerome-benoit/sap-ai-provider-v2` (fork).

Depends on PR https://github.com/anomalyco/opencode/pull/10275 for provider package transition handling. 

### Background

The fork at https://github.com/jerome-benoit/sap-ai-provider for Vercel v3 API and https://github.com/jerome-benoit/sap-ai-provider-v2 for Vercel v2 API includes critical streaming fixes and provider name support and has been used successfully via local configuration for several weeks. Upstream PR https://github.com/BITASIA/sap-ai-provider/pull/28 has been open for several weeks without response.

Without these fixes, SAP AI Core cannot be used in production with OpenCode due to regular SSE stream errors.

### Changes

- Updated `providers/sap-ai-core/provider.toml` to reference the fork package

### Workaround
Users can configure OpenCode to use the fork by adding to their JSONC config:

```jsonc
"provider": {
    "sap-ai-core": {
      "npm": "@jerome-benoit/sap-ai-provider-v2",
      "models": {
        // Claude models
        "anthropic--claude-4.5-opus": {},
        "anthropic--claude-4.5-sonnet": {},
        "anthropic--claude-4.5-haiku": {},
        "anthropic--claude-4-opus": {},
        "anthropic--claude-4-sonnet": {},
        "anthropic--claude-3.7-sonnet": {},
        "anthropic--claude-3.5-sonnet": {},
        "anthropic--claude-3-opus": {},
        "anthropic--claude-3-sonnet": {},
        "anthropic--claude-3-haiku": {},
        // OpenAI models
        "gpt-5": {},
        "gpt-5-mini": {},
        "gpt-5-nano": {},
        // Gemini models
        "gemini-2.5-pro": {},
        "gemini-2.5-flash": {},
      },
    },
  },
```

Then 

```shell
rm -rf /$HOME/.cache/opencode/node_modules/
rm /$HOME/.cache/opencode/package.json
rm /$HOME/.cache/opencode/bun.lock
```

And restart opencode