### PR TITLE
Fix documentation URL for Zhipu AI provider

### DIFF
--- a/providers/zhipuai/provider.toml
+++ b/providers/zhipuai/provider.toml
@@ -1,5 +1,5 @@
 name = "Zhipu AI"
 env = ["ZHIPU_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-doc = "https://docs.z.ai/guides/overview/pricing"
+doc = "https://open.bigmodel.cn/pricing"
 api = "https://open.bigmodel.cn/api/paas/v4"


### PR DESCRIPTION
looks like copy&past issue from "z.ai" provider. this are different companies