### PR TITLE
chore: Add gpt-5.2-codex to GitHub Copilot provider

### DIFF
--- a/providers/github-copilot/models/gpt-5.2-codex.toml
+++ b/providers/github-copilot/models/gpt-5.2-codex.toml
@@ -14,7 +14,7 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/gpt-5.2-codex.toml
+++ b/providers/github-copilot/models/gpt-5.2-codex.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.2-Codex"
+family = "gpt-codex"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
This PR adds the gpt-5.2-codex model to the GitHub Copilot provider.

Changes:
- Added new model configuration file: providers/github-copilot/models/gpt-5.2-codex.toml
- Model features: reasoning enabled, tool calling, 272k context tokens & 128K output tokens  
- Knowledge cutoff: 2025-08-31
- Release date: 2025-12-11

The configuration follows the existing Codex model patterns and has been validated with bun validate.