### PR TITLE
chore(openai): gpt-5.2-codex input limit

### DIFF
--- a/providers/openai/models/gpt-5.2-codex.toml
+++ b/providers/openai/models/gpt-5.2-codex.toml
@@ -17,6 +17,7 @@ cache_read = 0.175
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
Follow up on #642 now that this has landed.

@rekram1-node want me to remove the 5.2 model stitching from `packages/opencode/src/plugin/codex.ts` in https://github.com/anomalyco/opencode/pull/8465?