### PR TITLE
Venice: Update generate script & add new models (sonnet 4.5, gpt 5.2 codex)

### DIFF
--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import path from "node:path";
 import { readdir } from "node:fs/promises";
 import * as readline from "node:readline";
+import { ModelFamilyValues } from "../src/family.js";
 
 // Venice API endpoint
 const API_ENDPOINT = "https://api.venice.ai/api/v1/models?type=text";
@@ -83,31 +84,35 @@ const VeniceResponse = z
   })
   .passthrough();
 
-// Family inference patterns
-const familyPatterns: [RegExp, string][] = [
-  [/^llama-3\.3/i, "llama-3.3"],
-  [/^llama-3\.2/i, "llama-3.2"],
-  [/^qwen3/i, "qwen3"],
-  [/^deepseek/i, "deepseek"],
-  [/^mistral/i, "mistral"],
-  [/^devstral/i, "devstral"],
-  [/^gemini/i, "gemini"],
-  [/^grok/i, "grok"],
-  [/^claude/i, "claude"],
-  [/^hermes/i, "hermes"],
-  [/^google-gemma/i, "gemma"],
-  [/^kimi/i, "kimi"],
-  [/glm-4.6/i, "glm-4.6"],
-  [/^venice/i, "venice-uncensored"],
-  [/^openai-gpt/i, "openai-gpt"],
-];
+function matchesFamily(target: string, family: string): boolean {
+  const targetLower = target.toLowerCase();
+  const familyLower = family.toLowerCase();
+  let familyIdx = 0;
+
+  for (let i = 0; i < targetLower.length && familyIdx < familyLower.length; i++) {
+    if (targetLower[i] === familyLower[familyIdx]) {
+      familyIdx++;
+    }
+  }
+
+  return familyIdx === familyLower.length;
+}
 
 function inferFamily(modelId: string, modelName: string): string | undefined {
-  for (const [pattern, family] of familyPatterns) {
-    if (pattern.test(modelId) || pattern.test(modelName)) {
+  const sortedFamilies = [...ModelFamilyValues].sort((a, b) => b.length - a.length);
+
+  for (const family of sortedFamilies) {
+    if (matchesFamily(modelId, family)) {
       return family;
     }
   }
+
+  for (const family of sortedFamilies) {
+    if (matchesFamily(modelName, family)) {
+      return family;
+    }
+  }
+
   return undefined;
 }
 
@@ -282,15 +287,8 @@ function mergeModel(
     };
   }
 
-  // Preserve from existing OR infer
-  if (existing?.family) {
-    merged.family = existing.family;
-  } else {
-    const inferred = inferFamily(apiModel.id, spec.name);
-    if (inferred) {
-      merged.family = inferred;
-    }
-  }
+  const inferred = inferFamily(apiModel.id, spec.name);
+  merged.family = inferred ?? existing?.family;
 
   // Preserve manual fields from existing
   if (existing?.knowledge) {

--- a/providers/venice/models/claude-sonnet-45.toml
+++ b/providers/venice/models/claude-sonnet-45.toml
@@ -1,0 +1,25 @@
+name = "Claude Sonnet 4.5"
+family = "claude-sonnet"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-09"
+release_date = "2025-01-15"
+last_updated = "2026-01-15"
+open_weights = false
+
+[cost]
+input = 3.75
+output = 18.75
+cache_read = 0.375
+cache_write = 4.69
+
+[limit]
+context = 202_752
+output = 50_688
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/venice/models/hermes-3-llama-3.1-405b.toml
+++ b/providers/venice/models/hermes-3-llama-3.1-405b.toml
@@ -1,12 +1,12 @@
 name = "Hermes 3 Llama 3.1 405b"
-family = "llama"
+family = "hermes"
 attachment = false
 reasoning = false
 tool_call = false
 temperature = true
 knowledge = "2024-04"
 release_date = "2025-09-25"
-last_updated = "2025-12-29"
+last_updated = "2026-01-15"
 open_weights = true
 
 [cost]

--- a/providers/venice/models/openai-gpt-52-codex.toml
+++ b/providers/venice/models/openai-gpt-52-codex.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.2 Codex"
+family = "gpt-codex"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-08"
+release_date = "2025-01-15"
+last_updated = "2026-01-15"
+open_weights = false
+
+[cost]
+input = 2.19
+output = 17.5
+cache_read = 0.219
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/venice/models/zai-org-glm-4.6v.toml
+++ b/providers/venice/models/zai-org-glm-4.6v.toml
@@ -1,12 +1,12 @@
 name = "GLM 4.6V"
-family = "glm"
+family = "glmv"
 attachment = true
 reasoning = false
 tool_call = true
 structured_output = true
 temperature = true
 release_date = "2025-12-11"
-last_updated = "2025-12-29"
+last_updated = "2026-01-15"
 open_weights = true
 
 [cost]
@@ -20,3 +20,6 @@ output = 32_768
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[interleaved]
+field = "reasoning_details"


### PR DESCRIPTION
Generation script updated:
- Updated `generate-venice.ts` to infer model family to match `ModelFamilyValues`

Model updates:
- Changed family from 'llama' to 'hermes' in **hermes-3-llama-3.1-405b**
- Changed family from 'glm' to 'glmv' in **zai-org-glm-4.6v**
- Added interleaved `reasoning_details` field in **zai-org-glm-4.6v**

Add new model configurations:
- Add **claude-sonnet-45** model configuration
- Add **openai-gpt-52-codex** model configuration