### PR TITLE
feat(provider): add MiniMax M2.1 for DeepInfra

### DIFF
--- a/providers/deepinfra/models/MiniMaxAI/MiniMax-M2.1.toml
+++ b/providers/deepinfra/models/MiniMaxAI/MiniMax-M2.1.toml
@@ -1,0 +1,25 @@
+name = "MiniMax M2.1"
+release_date = "2025-12-23"
+last_updated = "2025-12-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+knowledge = "2025-06"
+
+[cost]
+input = 0.28
+output = 1.20
+cached_read = 0.14
+
+[limit]
+context = 196_608
+output = 196_608
+ 
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
This PR adds the **MiniMax M2.1** model for the **DeepInfra** provider.

Data has been verified against DeepInfra's official pricing page and the MiniMax M2.1 technical release notes from December 2025.