### PR TITLE
vercel: add new models from Vercel AI Gateway

### DIFF
--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -140,6 +140,7 @@ export const ModelFamilyValues = [
   "dall-e",
   "flux",
   "imagen",
+  "recraft",
   "stable-diffusion",
   "ideogram",
   "dreamshaper",

--- a/providers/vercel/models/bytedance/seed-1.8.toml
+++ b/providers/vercel/models/bytedance/seed-1.8.toml
@@ -1,0 +1,23 @@
+name = "Seed 1.8"
+family = "seed"
+release_date = "2025-10"
+last_updated = "2025-10"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+knowledge = "2024-10"
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.05
+
+[limit]
+context = 256000
+output = 64000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/vercel/models/openai/gpt-5.2-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.2-codex.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.2-Codex"
+family = "gpt"
+release_date = "2025-12"
+last_updated = "2025-12"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+knowledge = "2024-10"
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/vercel/models/openai/gpt-5.2-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.2-codex.toml
@@ -1,5 +1,5 @@
 name = "GPT-5.2-Codex"
-family = "gpt"
+family = "gpt-codex"
 release_date = "2025-12"
 last_updated = "2025-12"
 attachment = true

--- a/providers/vercel/models/recraft/recraft-v2.toml
+++ b/providers/vercel/models/recraft/recraft-v2.toml
@@ -1,0 +1,17 @@
+name = "Recraft V2"
+family = "recraft"
+release_date = "2024-03"
+last_updated = "2024-03"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 512
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/vercel/models/recraft/recraft-v3.toml
+++ b/providers/vercel/models/recraft/recraft-v3.toml
@@ -1,0 +1,17 @@
+name = "Recraft V3"
+family = "recraft"
+release_date = "2024-10"
+last_updated = "2024-10"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 512
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]


### PR DESCRIPTION
## Summary
- Add bytedance/seed-1.8 (multimodal with reasoning, 256K context)
- Add openai/gpt-5.2-codex (agentic coding, 400K context)
- Add recraft/recraft-v2 and recraft-v3 (image generation)
- Add `recraft` to model family schema

## Test plan
- [x] `bun validate` passes

🤖 Generated with [Claude Code](https://claude.ai/code)