### PR TITLE
feat(sap-ai-core): add Claude 4.5 Opus and align pricing

### DIFF
--- a/providers/sap-ai-core/models/anthropic--claude-3-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-3-sonnet.toml
@@ -13,7 +13,7 @@ open_weights = false
 input = 3.00
 output = 15.00
 cache_read = 0.30
-cache_write = 0.30
+cache_write = 3.75
 
 [limit]
 context = 200_000

--- a/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
@@ -1,0 +1,24 @@
+name = "anthropic--claude-4.5-opus"
+family = "claude-opus"
+release_date = "2025-11-24"
+last_updated = "2025-11-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04-30"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/sap-ai-core/models/gemini-2.5-flash.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-flash.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 0.30
 output = 2.50
-cache_read = 0.075
+cache_read = 0.030
 input_audio = 1.00
 
 [limit]

--- a/providers/sap-ai-core/models/gemini-2.5-pro.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-pro.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 1.25
 output = 10.00
-cache_read = 0.31
+cache_read = 0.125
 
 [limit]
 context = 1_048_576

--- a/providers/sap-ai-core/models/gpt-5-mini.toml
+++ b/providers/sap-ai-core/models/gpt-5-mini.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 0.25
 output = 2.00
-cache_read = 0.03
+cache_read = 0.025
 
 [limit]
 context = 400_000


### PR DESCRIPTION
## Summary

- Add Claude 4.5 Opus model to SAP AI Core provider
- Align cache pricing with official vendor pricing pages

## Changes

### New Model
- **Claude 4.5 Opus**: Added with correct pricing from Anthropic ($5/$25 per MTok, cache: $0.50/$6.25)

### Pricing Adjustments
- **Claude 3 Sonnet**: cache_write $0.30 → $3.75
- **Gemini 2.5 Pro**: cache_read $0.31 → $0.125
- **Gemini 2.5 Flash**: cache_read $0.075 → $0.030
- **GPT-5 Mini**: cache_read $0.03 → $0.025

## Verification
- ✅ All pricing verified against official vendor pages (Anthropic, Google Vertex AI, OpenAI)
- ✅ `bun validate` passes