### PR TITLE
Re-add zai-glm-4.6 temporarily until Jan 20, 2026

### DIFF
--- a/providers/cerebras/models/zai-glm-4.6.toml
+++ b/providers/cerebras/models/zai-glm-4.6.toml
@@ -1,0 +1,22 @@
+name = "Z.AI GLM-4.6"
+release_date = "2025-11-05"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 131_072
+output = 40_960
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Thanks for the incredibly fast merge! We appreciate the efficiency, though we need to temporarily re-add GLM 4.6. The model will be officially deprecated on January 20, 2026. Our apologies for any confusion - we should have been clearer about the timeline in the original PR.