### PR TITLE
feat(openrouter): add openai/gpt-5.1-codex-max model

### DIFF
--- a/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.1-Codex-Max"
+family = "gpt-codex"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-09-30"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.10
+output = 9.00
+cache_read = 0.11
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add GPT-5.1-Codex-Max model to OpenRouter provider

## Context
This model is available in OpenRouter's API but was missing from models.dev.

Related to: https://github.com/anomalyco/opencode/pull/8371#discussion_r2690958134

## Model Details
Based on `gpt-5.1-codex.toml` with pricing adjusted per OpenRouter's API:
- Input: $1.10/M tokens
- Output: $9.00/M tokens  
- Cache read: $0.11/M tokens

🤖 Generated with [Claude Code](https://claude.ai/code)