### PR TITLE
feat: add glm-4.7-flash model

### DIFF
--- a/providers/zai-coding-plan/models/glm-4.7-flash.toml
+++ b/providers/zai-coding-plan/models/glm-4.7-flash.toml
@@ -1,0 +1,24 @@
+name = "GLM-4.7-Flash"
+family = "glm-flash"
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add GLM-4.7-Flash model to zai-coding-plan provider.

- Context: 200K tokens
- Max output: 131K tokens
- Pricing: $0.07/1M input, $0.40/1M output, $0.01/1M cache read
- Released: 2026-01-19