### PR TITLE
Venice: Update provider package

### DIFF
--- a/providers/venice/models/claude-sonnet-45.toml
+++ b/providers/venice/models/claude-sonnet-45.toml
@@ -23,3 +23,6 @@ output = 50_688
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/venice/models/gemini-3-flash-preview.toml
+++ b/providers/venice/models/gemini-3-flash-preview.toml
@@ -10,9 +10,6 @@ release_date = "2025-12-19"
 last_updated = "2025-12-30"
 open_weights = false
 
-[interleaved]
-field = "reasoning_details"
-
 [cost]
 input = 0.7
 output = 3.75
@@ -25,3 +22,6 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/venice/models/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/venice/models/qwen3-235b-a22b-thinking-2507.toml
@@ -21,3 +21,6 @@ output = 32_768
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/venice/models/zai-org-glm-4.7.toml
+++ b/providers/venice/models/zai-org-glm-4.7.toml
@@ -23,4 +23,4 @@ input = ["text"]
 output = ["text"]
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"

--- a/providers/venice/provider.toml
+++ b/providers/venice/provider.toml
@@ -2,4 +2,4 @@ name = "Venice AI"
 env = ["VENICE_API_KEY"]
 npm = "venice-ai-sdk-provider"
 doc = "https://docs.venice.ai"
-api = "https://api.venice.ai/api/v1"
+# api = "https://api.venice.ai/api/v1"

--- a/providers/venice/provider.toml
+++ b/providers/venice/provider.toml
@@ -1,5 +1,5 @@
 name = "Venice AI"
 env = ["VENICE_API_KEY"]
-npm = "@ai-sdk/openai-compatible"
+npm = "venice-ai-sdk-provider"
 doc = "https://docs.venice.ai"
 api = "https://api.venice.ai/api/v1"


### PR DESCRIPTION
Replace `@ai-sdk/openai-compatible` with `venice-ai-sdk-provider`.

This new provider package is tailored towards Venice, it fixes/improve features over the default package, like better handling of `cache_control` for Claude models. It will also allow to provide better compatibility with Venice as new features come out both withing OpenCode and Venice.

As it is, it already gives better cache read/write with claude models (which were caching only the system prompt at the provider level, and tools), now caching part of the conversation (there is room for improvement).
Also, it adds `topK` param, which is disabled in `openai-compatible`.