### PR TITLE
Fix: Fix incorrect OpenAI, Gemini prices

### DIFF
--- a/providers/google-vertex/models/gemini-2.0-flash.toml
+++ b/providers/google-vertex/models/gemini-2.0-flash.toml
@@ -10,8 +10,8 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.10
-output = 0.40
+input = 0.15
+output = 0.60
 cache_read = 0.025
 
 [limit]

--- a/providers/openai/models/gpt-5-mini.toml
+++ b/providers/openai/models/gpt-5-mini.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 0.25
 output = 2.00
-cache_read = 0.03
+cache_read = 0.025
 
 [limit]
 context = 400_000

--- a/providers/openai/models/gpt-5-nano.toml
+++ b/providers/openai/models/gpt-5-nano.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 0.05
 output = 0.40
-cache_read = 0.01
+cache_read = 0.005
 
 [limit]
 context = 400_000

--- a/providers/openai/models/gpt-5.toml
+++ b/providers/openai/models/gpt-5.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 1.25
 output = 10.00
-cache_read = 0.13
+cache_read = 0.125
 
 [limit]
 context = 400_000


### PR DESCRIPTION
This PR increases the precision of OpenAI's `gpt-5`, `gpt-5-nano`, and `gpt-5-mini` models' `cache_read` prices to reflect the pricing displayed on their pricing page: https://platform.openai.com/docs/pricing. It also updates the price of google-vertex's `gemini-2.0-flash` to reflect the pricing displayed on their pricing page: https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models-2.0.

**Models Updated**:
`openai/gpt-5`
`openai/gpt-5-nano`
`openai/gpt-5-mini`
`google-vertex/gemini-2.0-flash`

**Prices updated**:
`openai/gpt-5`: cache_read $0.13/MTokens -> $0.125/MTokens
`openai/gpt-5-nano`: cache_read $0.01/MTokens -> $0.005/MTokens
`openai/gpt-5-mini`: cache_read $0.03/MTokens -> $0.025/MTokens
`google-vertex/gemini-2.0-flash`:
* input: $0.10/MTokens -> $0.15/MTokens
* output: $0.40/MTokens -> $0.60/MTokens


