### PR TITLE
Added PDF to input modalities for gpt 5.2 codex

### DIFF
--- a/providers/openai/models/gpt-5.2-codex.toml
+++ b/providers/openai/models/gpt-5.2-codex.toml
@@ -21,5 +21,5 @@ input = 272_000
 output = 128_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]


### PR DESCRIPTION
## Issue
[Issue#9825](https://github.com/anomalyco/opencode/issues/9825)

## Steps
- `bun install`
- Went into `providers/openai/models/gpt-5.2-codex.toml`
- Added **"pdf"** to the **modalities input**
- `cd packages/web`
- `bun run dev`
- `cd dist && python3 -m http.server 3000`
- In a separate terminal in the opencode dir I ran 
`OPENCODE_MODELS_URL=http://localhost:3000 opencode models --refresh
  OPENCODE_MODELS_URL=http://localhost:3000 opencode`
- Opened up a project that contained a PDF and it was able to read it 

## Screenshot
<img width="1264" height="873" alt="Screenshot 2026-01-21 at 6 49 07 PM" src="https://github.com/user-attachments/assets/c5c8fd7e-437e-4fab-8bc1-cea0a5b8cf81" />
