### PR TITLE
Set default temperature parameters for Z.AI GLM-4.7

### DIFF
--- a/providers/cerebras/models/zai-glm-4.7.toml
+++ b/providers/cerebras/models/zai-glm-4.7.toml
@@ -7,6 +7,11 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[parameters]
+temperature = 0.9
+top_p = 0.95
+clear_thinking = false
+
 [cost]
 input = 0
 output = 0


### PR DESCRIPTION
- temperature: 0.9
- top_p: 0.95
- clear_thinking: false