### PR TITLE
feat(gitlab): add OpenAI GPT-5 model definitions

### DIFF
--- a/providers/gitlab/models/duo-chat-gpt-5-1.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-1.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (GPT-5.1)"
+family = "gpt"
+release_date = "2026-01-22"
+last_updated = "2026-01-22"
+knowledge = "2024-09-30"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/gitlab/models/duo-chat-gpt-5-2-codex.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-2-codex.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (GPT-5.2 Codex)"
+family = "gpt-codex"
+release_date = "2026-01-22"
+last_updated = "2026-01-22"
+knowledge = "2025-08-31"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/gitlab/models/duo-chat-gpt-5-codex.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-codex.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (GPT-5 Codex)"
+family = "gpt-codex"
+release_date = "2026-01-22"
+last_updated = "2026-01-22"
+knowledge = "2024-09-30"
+attachment = false
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/gitlab/models/duo-chat-gpt-5-mini.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-mini.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (GPT-5 Mini)"
+family = "gpt-mini"
+release_date = "2026-01-22"
+last_updated = "2026-01-22"
+knowledge = "2024-05-30"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add GitLab Duo model definitions for OpenAI GPT-5 family

## Models Added
| Model ID | Name | Family | Maps to OpenAI |
|----------|------|--------|----------------|
| `duo-chat-gpt-5-1` | Agentic Chat (GPT-5.1) | `gpt` | `gpt-5.1-2025-11-13` |
| `duo-chat-gpt-5-mini` | Agentic Chat (GPT-5 Mini) | `gpt-mini` | `gpt-5-mini-2025-08-07` |
| `duo-chat-gpt-5-codex` | Agentic Chat (GPT-5 Codex) | `gpt-codex` | `gpt-5-codex` |
| `duo-chat-gpt-5-2-codex` | Agentic Chat (GPT-5.2 Codex) | `gpt-codex` | `gpt-5.2-codex` |

## Validation
- [x] `bun run validate` passes