### PR TITLE
fix: increase output token limit for GitLab Claude models to 64k

### DIFF
--- a/providers/gitlab/models/duo-chat-haiku-4-5.toml
+++ b/providers/gitlab/models/duo-chat-haiku-4-5.toml
@@ -2,10 +2,11 @@ name = "Agentic Chat (Claude Haiku 4.5)"
 family = "claude-haiku"
 release_date = "2026-01-08"
 last_updated = "2026-01-08"
-attachment = false
-reasoning = false
+attachment = true
+reasoning = true
 temperature = true
 tool_call = true
+knowledge = "2025-02-28"
 open_weights = false
 
 [cost]
@@ -19,5 +20,5 @@ context = 200_000
 output = 64_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/gitlab/models/duo-chat-haiku-4-5.toml
+++ b/providers/gitlab/models/duo-chat-haiku-4-5.toml
@@ -16,7 +16,7 @@ cache_write = 0
 
 [limit]
 context = 200_000
-output = 4_096
+output = 64_000
 
 [modalities]
 input = ["text"]

--- a/providers/gitlab/models/duo-chat-opus-4-5.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-5.toml
@@ -2,10 +2,11 @@ name = "Agentic Chat (Claude Opus 4.5)"
 family = "claude-opus"
 release_date = "2026-01-08"
 last_updated = "2026-01-08"
-attachment = false
-reasoning = false
+attachment = true
+reasoning = true
 temperature = true
 tool_call = true
+knowledge = "2025-03-31"
 open_weights = false
 
 [cost]
@@ -19,5 +20,5 @@ context = 200_000
 output = 64_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/gitlab/models/duo-chat-opus-4-5.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-5.toml
@@ -16,7 +16,7 @@ cache_write = 0
 
 [limit]
 context = 200_000
-output = 4_096
+output = 64_000
 
 [modalities]
 input = ["text"]

--- a/providers/gitlab/models/duo-chat-sonnet-4-5.toml
+++ b/providers/gitlab/models/duo-chat-sonnet-4-5.toml
@@ -2,10 +2,11 @@ name = "Agentic Chat (Claude Sonnet 4.5)"
 family = "claude-sonnet"
 release_date = "2026-01-08"
 last_updated = "2026-01-08"
-attachment = false
-reasoning = false
+attachment = true
+reasoning = true
 temperature = true
 tool_call = true
+knowledge = "2025-07-31"
 open_weights = false
 
 [cost]
@@ -19,5 +20,5 @@ context = 200_000
 output = 64_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/gitlab/models/duo-chat-sonnet-4-5.toml
+++ b/providers/gitlab/models/duo-chat-sonnet-4-5.toml
@@ -16,7 +16,7 @@ cache_write = 0
 
 [limit]
 context = 200_000
-output = 4_096
+output = 64_000
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
The output limit was set to 4,096 tokens which caused tool calls with large content (like file generation) to be truncated mid-JSON.

Updated to match standard Anthropic model limits:
- duo-chat-opus-4-5: 4,096 → 64,000
- duo-chat-sonnet-4-5: 4,096 → 64,000
- duo-chat-haiku-4-5: 4,096 → 64,000

Also adjusting other parameters to match the models definitions.