### PR TITLE
Venice: Remove interleaved reasoning field for claude-sonnet-45

### DIFF
--- a/providers/venice/models/claude-sonnet-45.toml
+++ b/providers/venice/models/claude-sonnet-45.toml
@@ -23,6 +23,3 @@ output = 50_688
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[interleaved]
-field = "reasoning_content"


### PR DESCRIPTION
This field maybe breaking Claude models when used with Venice, though there is a bug in OpenCode that prevents it from happening when using the default OpenAI compatible library.