### PR TITLE
feat(gitlab): add GPT-5.2 model definition (duo-chat-gpt-5-2)

### DIFF
--- a/providers/gitlab/models/duo-chat-gpt-5-2.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-2.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (GPT-5.2)"
+family = "gpt"
+release_date = "2026-01-23"
+last_updated = "2026-01-23"
+knowledge = "2025-08-31"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds GPT-5.2 model definition for GitLab Duo provider.

- Model ID: `duo-chat-gpt-5-2`
- Maps to OpenAI `gpt-5.2-2025-12-11`
- 400K context window, 128K max output
- Knowledge cutoff: Aug 31, 2025
- Supports: reasoning, tool calling, structured outputs, image input

## Related

- gitlab-ai-provider v3.3.1 added support for this model