### PR TITLE
feat: add tool_call_format field for Kimi K2 Thinking models

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -31,6 +31,7 @@ export const Model = z
     attachment: z.boolean(),
     reasoning: z.boolean(),
     tool_call: z.boolean(),
+    tool_call_format: z.enum(["kimi"]).optional(),
     interleaved: z
       .union([
         z.literal(true),

--- a/providers/aihubmix/models/kimi-k2-thinking.toml
+++ b/providers/aihubmix/models/kimi-k2-thinking.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-11"
 tool_call = true
+tool_call_format = "kimi"
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -5,6 +5,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 interleaved = true
 open_weights = true
 

--- a/providers/azure/models/kimi-k2-thinking.toml
+++ b/providers/azure/models/kimi-k2-thinking.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-08"
 tool_call = true
+tool_call_format = "kimi"
 interleaved = true
 open_weights = true
 

--- a/providers/cortecs/models/kimi-k2-thinking.toml
+++ b/providers/cortecs/models/kimi-k2-thinking.toml
@@ -5,6 +5,7 @@ knowledge = "2025-12"
 attachment = true
 reasoning = true
 tool_call = true
+tool_call_format = "kimi"
 temperature = true
 open_weights = true
 

--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2-thinking.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 open_weights = true
 
 [cost]

--- a/providers/helicone/models/kimi-k2-thinking.toml
+++ b/providers/helicone/models/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2025-11"
 open_weights = false
 

--- a/providers/kimi-for-coding/models/kimi-k2-thinking.toml
+++ b/providers/kimi-for-coding/models/kimi-k2-thinking.toml
@@ -7,6 +7,7 @@ reasoning = true
 structured_output = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2025-07"
 open_weights = true
 

--- a/providers/moonshotai-cn/models/kimi-k2-thinking-turbo.toml
+++ b/providers/moonshotai-cn/models/kimi-k2-thinking-turbo.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2024-08"
 open_weights = true
 

--- a/providers/moonshotai-cn/models/kimi-k2-thinking.toml
+++ b/providers/moonshotai-cn/models/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2024-08"
 open_weights = true
 

--- a/providers/moonshotai/models/kimi-k2-thinking-turbo.toml
+++ b/providers/moonshotai/models/kimi-k2-thinking-turbo.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2024-08"
 open_weights = true
 

--- a/providers/moonshotai/models/kimi-k2-thinking.toml
+++ b/providers/moonshotai/models/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2024-08"
 open_weights = true
 

--- a/providers/nano-gpt/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2-thinking.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-08"
 tool_call = true
+tool_call_format = "kimi"
 structured_output = true
 open_weights = false
 

--- a/providers/novita-ai/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 structured_output = true
 open_weights = true
 

--- a/providers/nvidia/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k2-thinking.toml
@@ -7,6 +7,7 @@ reasoning = true
 structured_output = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2025-07"
 open_weights = true
 interleaved = true

--- a/providers/ollama-cloud/models/kimi-k2-thinking.toml
+++ b/providers/ollama-cloud/models/kimi-k2-thinking.toml
@@ -3,6 +3,7 @@ family = "kimi-thinking"
 attachment = false
 reasoning = true
 tool_call = true
+tool_call_format = "kimi"
 release_date = "2025-11-06"
 knowledge = "2024-08"
 last_updated = "2026-01-19"

--- a/providers/opencode/models/kimi-k2-thinking.toml
+++ b/providers/opencode/models/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2024-10"
 open_weights = true
 

--- a/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2024-08"
 open_weights = true
 

--- a/providers/poe/models/novita/kimi-k2-thinking.toml
+++ b/providers/poe/models/novita/kimi-k2-thinking.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = false
 open_weights = false
 tool_call = true
+tool_call_format = "kimi"
 
 [limit]
 context = 256_000

--- a/providers/venice/models/kimi-k2-thinking.toml
+++ b/providers/venice/models/kimi-k2-thinking.toml
@@ -3,6 +3,7 @@ family = "kimi-thinking"
 attachment = false
 reasoning = true
 tool_call = true
+tool_call_format = "kimi"
 structured_output = true
 temperature = true
 knowledge = "2024-04"

--- a/providers/vercel/models/moonshotai/kimi-k2-thinking-turbo.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2-thinking-turbo.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 open_weights = false
 knowledge = "2024-08"
 

--- a/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 open_weights = false
 knowledge = "2024-08"
 

--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2025-01-01"
 open_weights = false
 

--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+tool_call_format = "kimi"
 knowledge = "2025-01-01"
 open_weights = false
 


### PR DESCRIPTION
Kimi K2 Thinking models use special tokens for tool calls instead of standard OpenAI format. This field allows downstream consumers to properly parse these tool calls.

- Add tool_call_format enum to Model schema
- Add tool_call_format = "kimi" to all kimi-k2-thinking models
- Fix aihubmix model file extension (.toml)

It is needed to fully fix issue [#opencode/9878](https://github.com/anomalyco/opencode/issues/9878)

PR also: https://github.com/anomalyco/opencode/pull/10382