### PR TITLE
feat(provider): add Pro/zai-org/GLM-4.7 for SiliconFlow-CN

### DIFF
--- a/providers/siliconflow-cn/models/Pro/zai-org/GLM-4.7.toml
+++ b/providers/siliconflow-cn/models/Pro/zai-org/GLM-4.7.toml
@@ -1,0 +1,22 @@
+name = "Pro/zai-org/GLM-4.7"
+family = "glm"
+release_date = "2025-12-22"
+last_updated = "2025-12-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = false
+
+[cost]
+input = 0.60
+output = 2.20
+
+[limit]
+context = 205_000
+output = 205_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Siliconflow-cn only offers the `Pro/zai-org/GLM-4.7`, not the standard `zai-org/GLM-4.7`.