### PR TITLE
feat(providers): update siliconflow-cn model catalog

### DIFF
--- a/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-R1.toml
@@ -1,0 +1,22 @@
+name = "Pro/deepseek-ai/DeepSeek-R1"
+family = "deepseek-thinking"
+release_date = "2025-05-28"
+last_updated = "2025-11-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.5
+output = 2.18
+
+[limit]
+context = 164_000
+output = 164_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-V3.1-Terminus.toml
+++ b/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-V3.1-Terminus.toml
@@ -1,0 +1,22 @@
+name = "Pro/deepseek-ai/DeepSeek-V3.1-Terminus"
+family = "deepseek"
+release_date = "2025-09-29"
+last_updated = "2025-11-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.27
+output = 1.0
+
+[limit]
+context = 164_000
+output = 164_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-V3.2.toml
+++ b/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-V3.2.toml
@@ -1,0 +1,22 @@
+name = "Pro/deepseek-ai/DeepSeek-V3.2"
+family = "deepseek"
+release_date = "2025-12-03"
+last_updated = "2025-12-03"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.27
+output = 0.42
+
+[limit]
+context = 164_000
+output = 164_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-V3.toml
+++ b/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-V3.toml
@@ -1,0 +1,22 @@
+name = "Pro/deepseek-ai/DeepSeek-V3"
+family = "deepseek"
+release_date = "2024-12-26"
+last_updated = "2025-11-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1.0
+
+[limit]
+context = 164_000
+output = 164_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,0 +1,22 @@
+name = "Pro/moonshotai/Kimi-K2-Instruct-0905"
+family = "kimi"
+release_date = "2025-09-08"
+last_updated = "2025-11-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.4
+output = 2.0
+
+[limit]
+context = 262_000
+output = 262_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Thinking.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Thinking.toml
@@ -1,0 +1,22 @@
+name = "Pro/moonshotai/Kimi-K2-Thinking"
+family = "kimi-thinking"
+release_date = "2025-11-07"
+last_updated = "2025-11-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.55
+output = 2.50
+
+[limit]
+context = 262_000
+output = 262_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/siliconflow-cn/models/Qwen/Qwen2.5-VL-7B-Instruct.toml
+++ b/providers/siliconflow-cn/models/Qwen/Qwen2.5-VL-7B-Instruct.toml
@@ -1,1 +1,0 @@
-../../../siliconflow/models/Qwen/Qwen2.5-VL-7B-Instruct.toml

--- a/providers/siliconflow-cn/models/Qwen/Qwen3-235B-A22B.toml
+++ b/providers/siliconflow-cn/models/Qwen/Qwen3-235B-A22B.toml
@@ -1,1 +1,0 @@
-../../../siliconflow/models/Qwen/Qwen3-235B-A22B.toml

--- a/providers/siliconflow-cn/models/moonshotai/Kimi-K2-Instruct.toml
+++ b/providers/siliconflow-cn/models/moonshotai/Kimi-K2-Instruct.toml
@@ -1,1 +1,0 @@
-../../../siliconflow/models/moonshotai/Kimi-K2-Instruct.toml

--- a/providers/siliconflow-cn/models/nex-agi/DeepSeek-V3.1-Nex-N1.toml
+++ b/providers/siliconflow-cn/models/nex-agi/DeepSeek-V3.1-Nex-N1.toml
@@ -1,1 +1,0 @@
-../../../siliconflow/models/nex-agi/DeepSeek-V3.1-Nex-N1.toml

--- a/providers/siliconflow-cn/models/openai/gpt-oss-120b.toml
+++ b/providers/siliconflow-cn/models/openai/gpt-oss-120b.toml
@@ -1,1 +1,0 @@
-../../../siliconflow/models/openai/gpt-oss-120b.toml

--- a/providers/siliconflow-cn/models/openai/gpt-oss-20b.toml
+++ b/providers/siliconflow-cn/models/openai/gpt-oss-20b.toml
@@ -1,1 +1,0 @@
-../../../siliconflow/models/openai/gpt-oss-20b.toml

--- a/providers/siliconflow-cn/models/zai-org/GLM-4.5.toml
+++ b/providers/siliconflow-cn/models/zai-org/GLM-4.5.toml
@@ -1,1 +1,0 @@
-../../../siliconflow/models/zai-org/GLM-4.5.toml


### PR DESCRIPTION
## Sync siliconflow-cn models with API
### Changes
Removed 7 models that are no longer available in API:

- moonshotai/Kimi-K2-Instruct
- Qwen/Qwen2.5-VL-7B-Instruct
- Qwen/Qwen3-235B-A22B
- nex-agi/DeepSeek-V3.1-Nex-N1
- openai/gpt-oss-120b
- openai/gpt-oss-20b
- zai-org/GLM-4.5

Added 6 Pro version models:

- Pro/deepseek-ai/DeepSeek-R1
- Pro/deepseek-ai/DeepSeek-V3
- Pro/deepseek-ai/DeepSeek-V3.1-Terminus
- Pro/deepseek-ai/DeepSeek-V3.2
- Pro/moonshotai/Kimi-K2-Instruct-0905
- Pro/moonshotai/Kimi-K2-Thinking

Cleanup:

Removed empty openai/ and nex-agi/ directories