### PR TITLE
Venice: Add cache_read to GLM 4.7

### DIFF
--- a/providers/venice/models/zai-org-glm-4.7.toml
+++ b/providers/venice/models/zai-org-glm-4.7.toml
@@ -7,12 +7,16 @@ structured_output = true
 temperature = true
 knowledge = "2025-04"
 release_date = "2025-12-24"
-last_updated = "2026-01-07"
+last_updated = "2026-01-26"
 open_weights = true
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.55
 output = 2.65
+cache_read = 0.11
 
 [limit]
 context = 202_752
@@ -21,6 +25,3 @@ output = 50_688
 [modalities]
 input = ["text"]
 output = ["text"]
-
-[interleaved]
-field = "reasoning_content"


### PR DESCRIPTION
Added `cache_read` cost to `zai-org-glm-4.7`