### PR TITLE
feat: add google-vertex-openai provider for Vertex AI partner models

### DIFF
--- a/providers/google-vertex/models/deepseek-ai/deepseek-v3.1-maas.toml
+++ b/providers/google-vertex/models/deepseek-ai/deepseek-v3.1-maas.toml
@@ -1,25 +1,21 @@
-name = "GLM-4.7"
-family = "glm"
-release_date = "2026-01-06"
-last_updated = "2026-01-06"
+name = "DeepSeek V3.1"
+family = "deepseek"
+release_date = "2025-08-28"
+last_updated = "2025-08-28"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-04"
 open_weights = true
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0.60
-output = 2.20
+output = 1.70
 
 [limit]
-context = 200_000
-output = 128_000
+context = 163_840
+output = 32_768
 
 [modalities]
 input = ["text", "pdf"]

--- a/providers/google-vertex/models/deepseek-ai/deepseek-v3.1-maas.toml
+++ b/providers/google-vertex/models/deepseek-ai/deepseek-v3.1-maas.toml
@@ -23,3 +23,4 @@ output = ["text"]
 
 [provider]
 npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/meta/llama-3.3-70b-instruct-maas.toml
+++ b/providers/google-vertex/models/meta/llama-3.3-70b-instruct-maas.toml
@@ -24,3 +24,4 @@ output = ["text"]
 
 [provider]
 npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/meta/llama-3.3-70b-instruct-maas.toml
+++ b/providers/google-vertex/models/meta/llama-3.3-70b-instruct-maas.toml
@@ -1,0 +1,26 @@
+name = "Llama 3.3 70B Instruct"
+family = "llama"
+release_date = "2025-04-29"
+last_updated = "2025-04-29"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2023-12"
+open_weights = true
+
+[cost]
+input = 0.72
+output = 0.72
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/google-vertex/models/meta/llama-4-maverick-17b-128e-instruct-maas.toml
+++ b/providers/google-vertex/models/meta/llama-4-maverick-17b-128e-instruct-maas.toml
@@ -24,3 +24,4 @@ output = ["text"]
 
 [provider]
 npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/meta/llama-4-maverick-17b-128e-instruct-maas.toml
+++ b/providers/google-vertex/models/meta/llama-4-maverick-17b-128e-instruct-maas.toml
@@ -1,0 +1,26 @@
+name = "Llama 4 Maverick 17B 128E Instruct"
+family = "llama"
+release_date = "2025-04-29"
+last_updated = "2025-04-29"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2024-08"
+open_weights = true
+
+[cost]
+input = 0.35
+output = 1.15
+
+[limit]
+context = 524_288
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/google-vertex/models/qwen/qwen3-235b-a22b-instruct-2507-maas.toml
+++ b/providers/google-vertex/models/qwen/qwen3-235b-a22b-instruct-2507-maas.toml
@@ -1,0 +1,25 @@
+name = "Qwen3 235B A22B Instruct"
+family = "qwen"
+release_date = "2025-08-13"
+last_updated = "2025-08-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 0.88
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/google-vertex/models/qwen/qwen3-235b-a22b-instruct-2507-maas.toml
+++ b/providers/google-vertex/models/qwen/qwen3-235b-a22b-instruct-2507-maas.toml
@@ -23,3 +23,4 @@ output = ["text"]
 
 [provider]
 npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/zai-org/glm-4.7-maas.toml
+++ b/providers/google-vertex/models/zai-org/glm-4.7-maas.toml
@@ -27,3 +27,4 @@ output = ["text"]
 
 [provider]
 npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"


### PR DESCRIPTION
## Add Vertex AI Partner Models with `[provider]` Overrides

Adds partner/open models served via Google Vertex AI's OpenAI-compatible endpoint, consolidated under the existing `google-vertex` provider using per-model `[provider]` npm overrides (same pattern as Azure's Claude models).

### Models Added/Updated

| Model | ID | Context | Output | Cost In/Out | Modalities |
|-------|-----|---------|--------|-------------|------------|
| GLM-4.7 *(updated)* | `zai-org/glm-4.7-maas` | 200K | 128K | $0.60/$2.20 | text, pdf |
| DeepSeek V3.1 | `deepseek-ai/deepseek-v3.1-maas` | 163K | 32K | $0.60/$1.70 | text, pdf |
| Llama 4 Maverick | `meta/llama-4-maverick-17b-128e-instruct-maas` | 524K | 8K | $0.35/$1.15 | text, image |
| Llama 3.3 70B | `meta/llama-3.3-70b-instruct-maas` | 128K | 8K | $0.72/$0.72 | text |
| Qwen3 235B | `qwen/qwen3-235b-a22b-instruct-2507-maas` | 262K | 16K | $0.22/$0.88 | text |

### Approach

Per maintainer feedback ("Ideally we don't make 3 different providers for vertex"), all models live under `providers/google-vertex/models/` in vendor-namespaced subdirectories. Each uses:

```toml
[provider]
npm = "@ai-sdk/openai-compatible"
```

This follows the established pattern (e.g., Azure's `claude-haiku-4-5.toml` uses `[provider] npm = "@ai-sdk/anthropic"` to override the provider's default npm package).

### Verification

- All specs verified against official Google Cloud documentation:
  - [Vertex AI Pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing)
  - [GLM-4.7 Docs](https://cloud.google.com/vertex-ai/generative-ai/docs/maas/zaiorg/glm-47)
  - [DeepSeek V3.1 Docs](https://cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek/deepseek-v31)
  - [Llama 4 Maverick Docs](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/llama4-maverick)
  - [Llama 3.3 Docs](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/llama/llama3-3)
  - [Qwen3 Docs](https://cloud.google.com/vertex-ai/generative-ai/docs/maas/qwen/qwen3-235b)
- `bun validate` passes (exit code 0)

### GLM-4.7 Corrections from Original

Fixed specs that differed from official docs:
- `context`: 204,800 → 200,000
- `output`: 131,072 → 128,000
- `release_date`: 2025-12-22 → 2026-01-06
- Added `pdf` input modality
- Added `structured_output = true`

### Related

- Depends on [opencode PR #10303](https://github.com/anomalyco/opencode/pull/10303) for runtime support of `[provider]` overrides with `@ai-sdk/openai-compatible`