### PR TITLE
fix(google-vertex-anthropic): Fix incorrect NPM package used for Anthropic models used through Vertex

### DIFF
--- a/providers/google-vertex-anthropic/provider.toml
+++ b/providers/google-vertex-anthropic/provider.toml
@@ -1,4 +1,4 @@
 name = "Vertex (Anthropic)"
 env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]
-npm = "@ai-sdk/google-vertex"
+npm = "@ai-sdk/google-vertex/anthropic"
 doc = "https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude"


### PR DESCRIPTION
## Summary
Fix the npm package path for the google-vertex-anthropic provider to use the correct subpath import.

## Changes
- Changed npm from `@ai-sdk/google-vertex` to `@ai-sdk/google-vertex/anthropic` in `providers/google-vertex-anthropic/provider.toml`

## Context
The `google-vertex-anthropic` provider requires the `/anthropic` subpath import from `@ai-sdk/google-vertex` for Claude models on Vertex AI to work correctly ([Official docs reference](https://ai-sdk.dev/providers/ai-sdk-providers/google-vertex#google-vertex-anthropic-provider-usage)).

Without this fix, thinking/reasoning capabilities don't work because:
1. The SDK key is incorrectly resolved to "google" instead of "anthropic"
2. Anthropic-specific message transforms (caching, thinking options) are not applied
3. The providerOptions get wrapped with the wrong key

This fixes https://github.com/anomalyco/opencode/issues/9894