### PR TITLE
add-kimi-k2.5 from OpenRouter

### DIFF
--- a/providers/openrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.5.toml
@@ -22,7 +22,7 @@ context = 262_144
 output = 262_144
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video"]
 output = ["text"]
 
 [provider]

--- a/providers/openrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.5.toml
@@ -23,3 +23,6 @@ output = 262_144
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[provider]
+npm = "@openrouter/ai-sdk-provider"

--- a/providers/openrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.5.toml
@@ -6,7 +6,6 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2024-10"
 open_weights = true
 
 [interleaved]

--- a/providers/openrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.5.toml
@@ -15,6 +15,7 @@ field = "reasoning_details"
 [cost]
 input = 0.60
 output = 3.00
+cache_read = 0.10
 
 [limit]
 context = 262_144

--- a/providers/openrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,25 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = true
+
+[interleaved]
+field = "reasoning_details"
+
+[cost]
+input = 0.60
+output = 3.00
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.5.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+knowledge = "2025-01"
 open_weights = true
 
 [interleaved]


### PR DESCRIPTION
Summary
- Add Kimi K2.5 model definition for OpenRouter provider

## Details
Kimi K2.5 is Moonshot AI's native multimodal model built on Kimi K2 with continued 
pretraining over ~15T mixed visual and text tokens. It delivers strong performance 
in general reasoning, visual coding, and agentic tool-calling.

**Model ID:** `openrouter/moonshotai/kimi-k2.5`
**Source:** https://openrouter.ai/moonshotai/kimi-k2.5

## Changes
- Added `providers/openrouter/models/moonshotai/kimi-k2.5.toml`
