### PR TITLE
Added kimi k2.5 to Venice AI

### DIFF
--- a/providers/venice/models/kimi-k2.5.toml
+++ b/providers/venice/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi-k2"
+family = "kimi"
 attachment = true
 reasoning = true
 tool_call = true

--- a/providers/venice/models/kimi-k2.5.toml
+++ b/providers/venice/models/kimi-k2.5.toml
@@ -1,0 +1,23 @@
+name = "Kimi K2.5"
+family = "kimi-k2"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+knowledge = "2024-04"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+open_weights = true
+
+[cost]
+input = 0.75
+cache_input = 0.125
+output = 3.75
+
+[limit]
+context = 262_144
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/venice/models/kimi-k2.5.toml
+++ b/providers/venice/models/kimi-k2.5.toml
@@ -16,7 +16,7 @@ output = 3.75
 
 [limit]
 context = 262_144
-output = 8_192
+output = 65_536
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION


`{
  "created": 1769548800,
  "id": "kimi-k2-5",
  "model_spec": {
    "beta": true,
    "betaModel": true,
    "pricing": {
      "input": {
        "usd": 0.75,
        "diem": 0.75
      },
      "cache_input": {
        "usd": 0.125,
        "diem": 0.125
      },
      "output": {
        "usd": 3.75,
        "diem": 3.75
      }
    },
    "availableContextTokens": 262144,
    "capabilities": {
      "optimizedForCode": true,
      "quantization": "not-available",
      "supportsAudioInput": false,
      "supportsFunctionCalling": true,
      "supportsLogProbs": true,
      "supportsReasoning": true,
      "supportsResponseSchema": true,
      "supportsVideoInput": false,
      "supportsVision": true,
      "supportsWebSearch": true
    },
    "constraints": {
      "temperature": {
        "default": 0.7
      },
      "top_p": {
        "default": 0.9
      }
    },
    "description": "Kimi K2.5 is Moonshot AIs most advanced open reasoning model, featuring trillion-parameter Mixture-of-Experts architecture with 32B active parameters and 256K context windows.",
    "name": "Kimi K2.5",
    "modelSource": "",
    "offline": false,
    "privacy": "anonymized",
    "traits": []
  },
  "object": "model",
  "owned_by": "venice.ai",
  "type": "text"
}`