### PR TITLE
Add Kimi K2.5 to Vercel provider

### DIFF
--- a/providers/vercel/models/moonshotai/kimi-k2.5.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,25 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2026-01-26"
+last_updated = "2026-01-26"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[interleaved]
+field = "reasoning_details"
+
+[cost]
+input = 0.60
+output = 1.20
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds Kimi K2.5 model to Vercel AI Gateway provider
- Released January 26, 2026 per [Vercel changelog](https://vercel.com/changelog/kimi-k2-5-on-ai-gateway)
- Specs: 262K context, multimodal (text/image/video), reasoning, tool calling
- Pricing: $0.60/M input, $1.20/M output