### PR TITLE
Added Kimi K2.5 to FireworksAI.

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
@@ -1,0 +1,26 @@
+name = "Kimi K2.5"
+family = "kimi-thinking"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+knowledge = "2025-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+cache_read = 0.60
+input = 1.20
+output = 1.20
+
+[limit]
+context = 256_000
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
Adds Kimi K2.5 model to FireworksAI provider
Released January 27, 2027 per https://app.fireworks.ai/models/fireworks/kimi-k2p5
Specs: 256k context, multimodal (text/image/video), reasoning, tool calling
Pricing: $0.60/M cached input, $1.20/M input/output