### PR TITLE
feat(chutes): update Kimi K2.5 TEE model capabilities

### DIFF
--- a/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2024-10"
 open_weights = true
+structured_output = true
 
 [interleaved]
 field = "reasoning_content"
@@ -18,7 +19,7 @@ output = 3.00
 
 [limit]
 context = 262_144
-output = 65_536
+output = 65_535
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
@@ -1,21 +1,25 @@
 name = "Kimi K2.5 TEE"
+family = "kimi"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-tool_call = false
-structured_output = false
+tool_call = true
+knowledge = "2024-10"
 open_weights = true
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.60
 output = 3.00
 
 [limit]
-context = 32_768
-output = 8_192
+context = 262_144
+output = 65_536
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "video"]
 output = ["text"]


### PR DESCRIPTION
Enable reasoning, tool calling, and multimodal input support for the Kimi K2.5 TEE model. Increase context limit from 32k to 262k tokens and output limit from 8k to 65k tokens. Add support for image and video inputs alongside text. Configure interleaved reasoning content field.