### PR TITLE
fix(chutes): correct Kimi-K2.5-TEE model specifications

### DIFF
--- a/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
@@ -1,21 +1,26 @@
-name = "Kimi K2.5 TEE"
+name = "moonshotai/Kimi-K2.5-TEE"
+family = "kimi"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-tool_call = false
-structured_output = false
+tool_call = true
+structured_output = true
+knowledge = "2024-10"
 open_weights = true
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.60
 output = 3.00
 
 [limit]
-context = 32_768
-output = 8_192
+context = 262_144
+output = 65_535
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "video"]
 output = ["text"]


### PR DESCRIPTION
## Summary
- Fix model identifier from `"Kimi K2.5 TEE"` to `"moonshotai/Kimi-K2.5-TEE"`
- Add missing family field: `"kimi"`
- Correct reasoning capability from `false` to `true`
- Add interleaved reasoning_content field
- Correct tool_call capability from `false` to `true`
- Correct structured_output capability from `false` to `true`
- Add knowledge cutoff: `"2024-10"`
- Fix context window from `32,768` to `262,144`
- Fix output window from `8,192` to `65,535`
- Expand input modalities from `["text"]` to `["text", "image", "video"]`

## Context
This PR corrects the model specifications for `moonshotai/Kimi-K2.5-TEE` based on the [chutes API](https://chutes.ai/) source. The previous values were incorrect and need to be aligned with the actual API capabilities.

## Note
This PR supersedes #736 which contains errors in the model specifications. All corrections have been validated against the chutes API source.

## Files Changed
- `providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml`