### PR TITLE
Fix Kimi pricing for fireworks-ai

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2-thinking.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2-thinking.toml
@@ -9,6 +9,7 @@ tool_call = true
 open_weights = true
 
 [cost]
+cache_read = 0.30
 input = 0.60
 output = 2.50
 

--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
@@ -10,9 +10,9 @@ tool_call = true
 open_weights = true
 
 [cost]
-cache_read = 0.60
-input = 1.20
-output = 1.20
+cache_read = 0.10
+input = 0.60
+output = 3.00
 
 [limit]
 context = 256_000


### PR DESCRIPTION
Pricing for Kimi K2.5 was incorrect, and Kimi K2 Thinking was missing the cache read cost.

You can confirm on their website:
* https://app.fireworks.ai/models/fireworks/kimi-k2p5
* https://app.fireworks.ai/models/fireworks/kimi-k2-thinking