### PR TITLE
feat(synthetic): update Kimi K2.5 model configuration

### DIFF
--- a/providers/synthetic/models/hf:moonshotai/Kimi-K2.5.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K2.5.toml
@@ -13,12 +13,12 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 1.20
-output = 1.20
+input = 0.55
+output = 2.19
 
 [limit]
 context = 262_144
-output = 32768
+output = 65_536
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
## Summary

Update Kimi K2.5 model configuration with corrected values:

### Changes
- **max_output**: 65_536 (increased from 32_768)
- **cost.input**: 0.55, **cost.output**: 2.19 (updated pricing)

### Files Changed
- `providers/synthetic/models/hf:moonshotai/Kimi-K2.5.toml`