### PR TITLE
fireworks: Raise Kimi K2.5 max output

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
@@ -16,7 +16,7 @@ output = 3.00
 
 [limit]
 context = 256_000
-output = 32_768
+output = 256_000
 
 [modalities]
 input = ["text", "image", "video"]


### PR DESCRIPTION
Raise max output tokens to be equal to the context limit.
Fireworks models output limit is equal to their context limit, according to customer support.