### PR TITLE
fix(vivgrid): set npm for gemini-3 models for vivgrid provider

### DIFF
--- a/providers/vivgrid/models/gemini-3-flash-preview.toml
+++ b/providers/vivgrid/models/gemini-3-flash-preview.toml
@@ -27,3 +27,6 @@ output = 65536
 [modalities]
 input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/vivgrid/models/gemini-3-pro-preview.toml
+++ b/providers/vivgrid/models/gemini-3-pro-preview.toml
@@ -27,3 +27,6 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
This PR updates the Gemini invocation logic in Vivgrid to use an OpenAI API–compatible client SDK when calling gemini-3-pro-preview and gemini-3-flash-preview.

Using an OpenAI-compatible SDK simplifies integration, improves consistency across providers, and reduces maintenance by reusing existing client abstractions.