### PR TITLE
feat: adjust pricing of devstral-2512 hosted by mistral

### DIFF
--- a/providers/mistral/models/devstral-2512.toml
+++ b/providers/mistral/models/devstral-2512.toml
@@ -10,8 +10,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.00
-output = 0.00
+input = 0.40
+output = 2.00
 
 [limit]
 context = 262_144


### PR DESCRIPTION
Updated pricing of devstral-2512 hosted by mistral.

Based on mistrals official website:
https://docs.mistral.ai/models/devstral-2-25-12