### PR TITLE
add model-schema.json endpoint for model autocomplete

### DIFF
--- a/packages/function/src/worker.ts
+++ b/packages/function/src/worker.ts
@@ -35,6 +35,44 @@ export default {
       );
     }
 
+    if (url.pathname === "/model-schema.json") {
+      const apiUrl = new URL(url);
+      apiUrl.pathname = "/_api.json";
+      const apiResponse = await env.ASSETS.fetch(
+        new Request(apiUrl.toString(), request),
+      );
+      const providers = (await apiResponse.json()) as Record<
+        string,
+        { models: Record<string, unknown> }
+      >;
+
+      const modelIds: string[] = [];
+      for (const [providerId, provider] of Object.entries(providers)) {
+        for (const modelId of Object.keys(provider.models)) {
+          modelIds.push(`${providerId}/${modelId}`);
+        }
+      }
+
+      const schema = {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        $id: "https://models.dev/model-schema.json",
+        $defs: {
+          Model: {
+            type: "string",
+            enum: modelIds.sort(),
+            description: "AI model identifier in provider/model format",
+          },
+        },
+      };
+
+      return new Response(JSON.stringify(schema, null, 2), {
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=3600",
+        },
+      });
+    }
+
     if (url.pathname === "/api.json") {
       url.pathname = "/_api.json";
     } else if (


### PR DESCRIPTION
Adds a `/model-schema.json` endpoint that generates a JSON Schema with all model IDs as an enum. This allows tools like opencode to reference it for model name autocomplete.

Example usage in opencode's config.json schema:
```json
{
  "model": {
    "$ref": "https://models.dev/model-schema.json#/$defs/Model"
  }
}
```

This gives editors autocomplete for all available models in `provider/model` format.