### PR TITLE
Add 5 new Vercel AI Gateway models

### DIFF
--- a/providers/vercel/models/alibaba/qwen3-max-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-max-thinking.toml
@@ -1,0 +1,23 @@
+name = "Qwen 3 Max Thinking"
+family = "qwen"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.20
+output = 6.00
+cache_read = 0.24
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vercel/models/arcee-ai/trinity-large-preview.toml
+++ b/providers/vercel/models/arcee-ai/trinity-large-preview.toml
@@ -1,0 +1,22 @@
+name = "Trinity Large Preview"
+family = "trinity"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+knowledge = "2024-10"
+
+[cost]
+input = 0.25
+output = 1.00
+
+[limit]
+context = 131_000
+output = 131_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vercel/models/moonshotai/kimi-k2.5.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,23 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = true
+
+[cost]
+input = 0.60
+output = 3.00
+cache_read = 0.10
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/vercel/models/openai/gpt-4o-mini-search-preview.toml
+++ b/providers/vercel/models/openai/gpt-4o-mini-search-preview.toml
@@ -1,0 +1,23 @@
+name = "GPT 4o Mini Search Preview"
+family = "gpt-mini"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2023-09"
+tool_call = false
+structured_output = false
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vercel/models/zai/glm-4.7-flashx.toml
+++ b/providers/vercel/models/zai/glm-4.7-flashx.toml
@@ -1,0 +1,23 @@
+name = "GLM 4.7 FlashX"
+family = "glm-flash"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.40
+cache_read = 0.01
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Adds 5 new models from Vercel AI Gateway:
- **alibaba/qwen3-max-thinking**: Qwen 3 Max with reasoning capabilities (256K context, $1.20/$6.00)
- **arcee-ai/trinity-large-preview**: Trinity 400B MoE model (131K context, $0.25/$1.00)
- **moonshotai/kimi-k2.5**: Kimi K2.5 with vision and reasoning (256K context, $0.60/$3.00)
- **openai/gpt-4o-mini-search-preview**: GPT-4o Mini search variant (128K context, $0.15/$0.60)
- **zai/glm-4.7-flashx**: GLM 4.7 Flash lightweight model (200K context, $0.06/$0.40)

## Changes
- ✅ All models validated against schema
- ✅ Pricing converted from API (per-token → per-million-tokens)
- ✅ Capabilities mapped from API tags
- ✅ Verification shows 0 missing models

## Test plan
- [x] Run `bun validate` - passes
- [x] Run `bun scripts/verify-vercel-models.ts` - shows 0 missing models

🤖 Generated with [Claude Code](https://claude.com/claude-code)