### PR TITLE
feat: add free openrouter models

### DIFF
--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -352,6 +352,15 @@ export const ModelFamilyValues = [
 
   // Pangu (Ascend Tribe)
   "pangu",
+
+  // LiquidAI
+  "liquid",
+
+  // Sourceful
+  "sourceful",
+
+  // AllenAI
+  "allenai"
 ] as const;
 
 export const ModelFamily = z.enum(ModelFamilyValues);

--- a/providers/openrouter/models/allenai/molmo-2-8b:free.toml
+++ b/providers/openrouter/models/allenai/molmo-2-8b:free.toml
@@ -1,0 +1,23 @@
+name = "Molmo2 8B (free)"
+family = "allenai"
+release_date = "2026-01-09"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = true
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 36_864
+output = 36_864
+
+[modalities]
+input = ["text","image","video"]
+output = ["text"]

--- a/providers/openrouter/models/black-forest-labs/flux.2-flex.toml
+++ b/providers/openrouter/models/black-forest-labs/flux.2-flex.toml
@@ -1,0 +1,23 @@
+name = "FLUX.2 Flex"
+family = "flux"
+release_date = "2025-11-25"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 67_344
+output = 67_344
+
+[modalities]
+input = ["image","text"]
+output = ["image", "text"]

--- a/providers/openrouter/models/black-forest-labs/flux.2-klein-4b.toml
+++ b/providers/openrouter/models/black-forest-labs/flux.2-klein-4b.toml
@@ -1,0 +1,23 @@
+name = "FLUX.2 Klein 4B"
+family = "flux"
+release_date = "2026-01-14"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 40_960
+output = 40_960
+
+[modalities]
+input = ["image","text"]
+output = ["image", "text"]

--- a/providers/openrouter/models/black-forest-labs/flux.2-max.toml
+++ b/providers/openrouter/models/black-forest-labs/flux.2-max.toml
@@ -1,0 +1,23 @@
+name = "FLUX.2 Max"
+family = "flux"
+release_date = "2025-12-16"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 46_864
+output = 46_864
+
+[modalities]
+input = ["image","text"]
+output = ["image", "text"]

--- a/providers/openrouter/models/black-forest-labs/flux.2-pro.toml
+++ b/providers/openrouter/models/black-forest-labs/flux.2-pro.toml
@@ -1,0 +1,23 @@
+name = "FLUX.2 Pro"
+family = "flux"
+release_date = "2025-11-25"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 46_864
+output = 46_864
+
+[modalities]
+input = ["image","text"]
+output = ["image", "text"]

--- a/providers/openrouter/models/bytedance-seed/seedream-4.5.toml
+++ b/providers/openrouter/models/bytedance-seed/seedream-4.5.toml
@@ -1,0 +1,23 @@
+name = "Seedream 4.5"
+family = "seed"
+release_date = "2025-12-23"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 4_096
+output = 4_096
+
+[modalities]
+input = ["image","text"]
+output = ["image","text"]

--- a/providers/openrouter/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
+++ b/providers/openrouter/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
@@ -1,0 +1,23 @@
+name = "Uncensored (free)"
+family = "mistral"
+release_date = "2025-07-09"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-r1-0528:free.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-0528:free.toml
@@ -6,7 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 knowledge = "2025-05"
-tool_call = true
+tool_call = false
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/liquid/lfm-2.5-1.2b-instruct:free.toml
+++ b/providers/openrouter/models/liquid/lfm-2.5-1.2b-instruct:free.toml
@@ -1,0 +1,23 @@
+name = "LFM2.5-1.2B-Instruct (free)"
+family = "liquid"
+release_date = "2026-01-20"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/liquid/lfm-2.5-1.2b-thinking:free.toml
+++ b/providers/openrouter/models/liquid/lfm-2.5-1.2b-thinking:free.toml
@@ -1,0 +1,23 @@
+name = "LFM2.5-1.2B-Thinking (free)"
+family = "liquid"
+release_date = "2026-01-20"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = true
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/meta-llama/llama-3.1-405b-instruct:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.1-405b-instruct:free.toml
@@ -1,11 +1,11 @@
-name = "Llama 3.3 70B Instruct (free)"
+name = "Llama 3.1 405B Instruct (free)"
 family = "llama"
-release_date = "2024-12-06"
-last_updated = "2024-12-06"
-attachment = false
+release_date = "2024-07-23"
+last_updated = "2025-04-05"
+attachment = true
 reasoning = false
 temperature = true
-knowledge = "2024-12"
+knowledge = "2024-08"
 tool_call = true
 open_weights = true
 

--- a/providers/openrouter/models/meta-llama/llama-3.2-3b-instruct:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.2-3b-instruct:free.toml
@@ -1,0 +1,16 @@
+name = "Llama 3.2 3B Instruct (free)"
+family = "llama"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+cost = { input = 0, output = 0 }
+limit = { context = 131072, output = 131072 }
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-405b:free.toml
+++ b/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-405b:free.toml
@@ -1,0 +1,22 @@
+name = "Hermes 3 405B Instruct (free)"
+family = "hermes"
+release_date = "2024-08-16"
+last_updated = "2024-08-16"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2023-12"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/nvidia/nemotron-3-nano-30b-a3b:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-3-nano-30b-a3b:free.toml
@@ -1,0 +1,23 @@
+name = "Nemotron 3 Nano 30B A3B (free)"
+family = "nemotron"
+
+release_date = "2025-12-14"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-11"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/nvidia/nemotron-nano-12b-v2-vl:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-nano-12b-v2-vl:free.toml
@@ -1,0 +1,23 @@
+name = "Nemotron Nano 12B 2 VL (free)"
+family = "nemotron"
+
+release_date = "2025-10-28"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-11"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text","image"]
+output = ["text"]

--- a/providers/openrouter/models/nvidia/nemotron-nano-9b-v2:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-nano-9b-v2:free.toml
@@ -1,0 +1,23 @@
+name = "Nemotron Nano 9B V2 (free)"
+family = "nemotron"
+
+release_date = "2025-09-05"
+last_updated = "2025-08-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-09"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-oss-120b:free.toml
+++ b/providers/openrouter/models/openai/gpt-oss-120b:free.toml
@@ -1,0 +1,21 @@
+name = "gpt-oss-120b (free)"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-oss-20b:free.toml
+++ b/providers/openrouter/models/openai/gpt-oss-20b:free.toml
@@ -1,0 +1,21 @@
+name = "gpt-oss-20b (free)"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen-2.5-vl-7b-instruct:free.toml
+++ b/providers/openrouter/models/qwen/qwen-2.5-vl-7b-instruct:free.toml
@@ -1,0 +1,22 @@
+name = "Qwen2.5-VL 7B Instruct (free)"
+family = "qwen"
+release_date = "2024-08-28"
+last_updated = "2024-08-28"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-02"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen3-4b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-4b:free.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 4B (free)"
+family = "qwen"
+release_date = "2025-04-30"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 40_960
+output = 40_960
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct:free.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 Next 80B A3B Instruct (free)"
+family = "qwen"
+release_date = "2025-09-11"
+last_updated = "2025-09-11"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/sourceful/riverflow-v2-fast-preview.toml
+++ b/providers/openrouter/models/sourceful/riverflow-v2-fast-preview.toml
@@ -1,0 +1,23 @@
+name = "Riverflow V2 Fast Preview"
+family = "sourceful"
+release_date = "2025-12-08"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text","image"]
+output = ["image"]

--- a/providers/openrouter/models/sourceful/riverflow-v2-max-preview.toml
+++ b/providers/openrouter/models/sourceful/riverflow-v2-max-preview.toml
@@ -1,0 +1,23 @@
+name = "Riverflow V2 Max Preview"
+family = "sourceful"
+release_date = "2025-12-08"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text","image"]
+output = ["image"]

--- a/providers/openrouter/models/sourceful/riverflow-v2-standard-preview.toml
+++ b/providers/openrouter/models/sourceful/riverflow-v2-standard-preview.toml
@@ -1,0 +1,23 @@
+name = "Riverflow V2 Standard Preview"
+family = "sourceful"
+release_date = "2025-12-08"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = false
+temperature = true
+# may be inaccurate
+knowledge = "2025-06"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text","image"]
+output = ["image"]

--- a/providers/openrouter/models/tngtech/tng-r1t-chimera:free.toml
+++ b/providers/openrouter/models/tngtech/tng-r1t-chimera:free.toml
@@ -1,0 +1,22 @@
+name = "R1T Chimera (free)"
+family = "tngtech"
+release_date = "2025-11-26"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-07"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Updated Deepseek R1 0528 Tool Call to false

Updated Meta Llama 3.3 70B Instruct Context and Output Limits

Added Model Families: liquid, allenai and sourceful

Added Free Models to Openrouter Provider:
  
AllenAI Models:

- Molmo2 8B (free)

Liquid Models:

- LFM2.5-1.2B-Instruct (free)
- LFM2.5-1.2B-Thinking (free)

Sourceful Models:

- Riverflow V2 Fast Preview
- Riverflow V2 Standard Preview
- Riverflow V2 Max Preview

Black Forest Labs Models:

- FLUX.2 Flex
- FLUX.2 Klein 4B
- FLUX.2 Max
- FLUX.2 Pro

Meta Llama Models:

- Llama 3.1 405B Instruct (free)
- Llama 3.2 3B Instruct (free)

Seed Models:

- Seedream 4.5

CognitiveComputation Models:

- Uncensored (free)

Tngtech Models:

- R1T Chimera (free)

Nouresearch Models:

- Hermes 3 405B Instruct (free)

OpenAI Models:

- gpt-oss-120b (free)
- gpt-oss-20b (free)

Nvidia Models:

- Nemotron 3 Nano 30B A3B (free)
- Nemotron Nano 12B 2 VL (free)
- Nemotron Nano 9B V2 (free)

Qwen Models:

- Qwen2.5-VL 7B Instruct (free)
- Qwen3 4B (free)
- Qwen3 Next 80B A3B Instruct (free)