### PR TITLE
feat: Add lmstudio models (nemotron-3-nano, glm-4.7-flash, devstrall-small-2-2515)

### DIFF
--- a/providers/lmstudio/models/mistralai/devstral-small-2-2512.toml
+++ b/providers/lmstudio/models/mistralai/devstral-small-2-2512.toml
@@ -1,0 +1,20 @@
+name = "devstral-small-2-2512"
+family = "devstral"
+attachment = true
+reasoning = false
+tool_call = true
+release_date = "2025-12-09"
+last_updated = "2026-01-19"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text","image"]
+output = ["text"]

--- a/providers/lmstudio/models/nvidia/nemotron-3-nano.toml
+++ b/providers/lmstudio/models/nvidia/nemotron-3-nano.toml
@@ -1,0 +1,23 @@
+name = "nemotron-3-nano"
+family = "nemotron"
+
+release_date = "2024-12"
+last_updated = "2024-12"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-09"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/lmstudio/models/zai/glm-4.7-flash.toml
+++ b/providers/lmstudio/models/zai/glm-4.7-flash.toml
@@ -1,0 +1,24 @@
+name = "glm-4.7-flash"
+family = "glm-flash"
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## New Model Configurations:

- `providers/lmstudio/models/nvidia/nemotron-3-nano.toml` - NVIDIA Nemotron 3 Nano model
- `providers/lmstudio/models/zai/glm-4.7-flash.toml` - ZAI GLM 4.7 Flash model  
- `providers/lmstudio/models/mistralai/devstral-small-2-2512.toml` - Mistral Devstral Small model


## Details

All models are configured with zero cost (input = 0, output = 0) since they run locally via LMStudio. Configurations are based on existing provider definitions:

- nemotron-3-nano: Copied from nvidia provider
- glm-4.7-flash: Copied from zai provider
- devstral-small-2-2512: Adapted from ollama-cloud provider

## Notes

- Used LM Studio 0.4.1 (Build 1)
- Models were discovered by querying `http://localhost:1234/v1/models`
