### PR TITLE
feat(providers): add Latitude.sh as new provider

### DIFF
--- a/providers/latitude/logo.svg
+++ b/providers/latitude/logo.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 805 1000" xmlns="http://www.w3.org/2000/svg">
+<path d="M804.567 749.136L720.38 1000H235.628L319.816 749.136H804.567ZM537.058 0H236.554L0 704.889H300.495L537.058 0Z" fill="currentColor"/>
+</svg>

--- a/providers/latitude/models/deepseek-r1-distill-14b.toml
+++ b/providers/latitude/models/deepseek-r1-distill-14b.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek R1 Distill 14B"
+family = "deepseek-thinking"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 1.44
+output = 1.44
+
+[limit]
+context = 64_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/latitude/models/gemma-2-27b.toml
+++ b/providers/latitude/models/gemma-2-27b.toml
@@ -1,0 +1,22 @@
+name = "Gemma 2 27B"
+family = "gemma"
+release_date = "2024-06-27"
+last_updated = "2024-06-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.45
+output = 0.45
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/latitude/models/llama-3.1-8b.toml
+++ b/providers/latitude/models/llama-3.1-8b.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.1 8B"
+family = "llama"
+release_date = "2024-07-24"
+last_updated = "2024-07-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.16
+output = 0.16
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/latitude/models/qwen-2.5-7b.toml
+++ b/providers/latitude/models/qwen-2.5-7b.toml
@@ -1,0 +1,22 @@
+name = "Qwen 2.5 7B"
+family = "qwen"
+release_date = "2024-09-19"
+last_updated = "2024-09-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.27
+output = 0.27
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/latitude/models/qwen-2.5-vl-7b.toml
+++ b/providers/latitude/models/qwen-2.5-vl-7b.toml
@@ -1,0 +1,22 @@
+name = "Qwen 2.5 VL 7B"
+family = "qwen"
+release_date = "2024-10-31"
+last_updated = "2024-10-31"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.36
+output = 0.36
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/latitude/models/qwen2.5-coder-32b.toml
+++ b/providers/latitude/models/qwen2.5-coder-32b.toml
@@ -1,0 +1,22 @@
+name = "Qwen 2.5 Coder 32B"
+family = "qwen"
+release_date = "2024-11-12"
+last_updated = "2024-11-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.72
+output = 0.72
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/latitude/models/qwen3-32b.toml
+++ b/providers/latitude/models/qwen3-32b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 32B"
+family = "qwen"
+release_date = "2025-04-29"
+last_updated = "2025-04-29"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.45
+output = 0.90
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/latitude/provider.toml
+++ b/providers/latitude/provider.toml
@@ -1,0 +1,5 @@
+name = "Latitude"
+env = ["LATITUDE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.lsh.ai/v1"
+doc = "https://api.lsh.ai/docs"


### PR DESCRIPTION
## Summary
- Add Latitude.sh (lsh.ai) as a new inference provider with OpenAI-compatible API endpoints
- Latitude offers bare metal GPU infrastructure (NVIDIA RTX 6000 PRO Blackwell) with vLLM
- 7 models included across Qwen, Llama, Gemma, and DeepSeek families

## Models Added
| Model | Family | Input | Output | Context | Features |
|-------|--------|-------|--------|---------|----------|
| Qwen 2.5 7B | qwen | $0.27 | $0.27 | 131K | tool_call |
| Llama 3.1 8B | llama | $0.16 | $0.16 | 128K | tool_call |
| Qwen3 32B | qwen | $0.45 | $0.90 | 131K | tool_call |
| Gemma 2 27B | gemma | $0.45 | $0.45 | 8K | tool_call |
| DeepSeek R1 Distill 14B | deepseek-thinking | $1.44 | $1.44 | 64K | reasoning |
| Qwen 2.5 Coder 32B | qwen | $0.72 | $0.72 | 131K | tool_call |
| Qwen 2.5 VL 7B | qwen | $0.36 | $0.36 | 32K | vision |

## Test plan
- [x] Ran `bun ./packages/core/script/validate.ts` - all validations pass
- [x] Verified API endpoint returns proper OpenAI-compatible error format
- [x] Logo SVG follows `fill="currentColor"` pattern