### PR TITLE
feat(deepinfra): add GLM-4.7-Flash model

### DIFF
--- a/providers/deepinfra/models/zai-org/GLM-4.7-Flash.toml
+++ b/providers/deepinfra/models/zai-org/GLM-4.7-Flash.toml
@@ -1,0 +1,24 @@
+# https://deepinfra.com/zai-org/GLM-4.7-Flash
+name = "GLM-4.7-Flash"
+family = "glm-flash"
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+knowledge = "2025-04"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.40
+
+[limit]
+context = 202_752
+# https://deepinfra.com/docs/advanced/max_tokens_limit
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/deepinfra/models/zai-org/GLM-4.7-Flash.toml
+++ b/providers/deepinfra/models/zai-org/GLM-4.7-Flash.toml
@@ -10,6 +10,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[interleaved]
+field = "reasoning_content"
+
 [cost]
 input = 0.06
 output = 0.40


### PR DESCRIPTION
## Summary

Add zai-org/GLM-4.7-Flash model configuration to the DeepInfra provider. GLM-4.7-Flash is a 30B-A3B MoE model released by Z.AI (Zhipu AI) in January 2026, positioned as the "free-ish" variant of the GLM-4.7 family with strong performance across coding, reasoning, and generative tasks.

## Changes

- New file: providers/deepinfra/models/zai-org/GLM-4.7-Flash.toml
- Model ID: zai-org/GLM-4.7-Flash
- Family: glm-flash
- Pricing: $0.06 input / $0.40 output per 1M tokens
- Context window: 202,752 tokens
- Output limit: 16,384 tokens (DeepInfra enforced limit)
- Features: reasoning, tool calling, temperature control
- Open weights: true

## References
- DeepInfra model page: https://deepinfra.com/zai-org/GLM-4.7-Flash
- Z.AI documentation: https://docs.z.ai/guides/llm/glm-4.7#glm-4-7-flash
- Z.AI release notes: https://docs.z.ai/release-notes/new-released (2025-01-19 - corrected to 2026-01-19)
- Z.AI blog post: https://z.ai/blog/glm-4.7

Note: The release date uses 2026-01-19 as this is the logical correct date (Z.AI's website shows a typo with 2025, but GLM-4.7 was released in December 2025, making January 2026 the correct timeline for the Flash variant).