### PR TITLE
Increase Github Copilot GPT 4.1 context limit from 64k to 128k

### DIFF
--- a/providers/github-copilot/models/gpt-4.1.toml
+++ b/providers/github-copilot/models/gpt-4.1.toml
@@ -14,7 +14,7 @@ input = 0
 output = 0
 
 [limit]
-context = 64_000
+context = 128_000
 output = 16_384
 
 [modalities]


### PR DESCRIPTION
Update Github Copilot GPT4.1 context window from 64k to 128k to fix #783