### PR TITLE
fix: Update models tool call to false

### DIFF
--- a/providers/openrouter/models/allenai/molmo-2-8b:free.toml
+++ b/providers/openrouter/models/allenai/molmo-2-8b:free.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 # may be inaccurate
 knowledge = "2025-06"
-tool_call = true
+tool_call = false
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
+++ b/providers/openrouter/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
@@ -7,7 +7,7 @@ reasoning = false
 temperature = true
 # may be inaccurate
 knowledge = "2025-06"
-tool_call = true
+tool_call = false
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/liquid/lfm-2.5-1.2b-instruct:free.toml
+++ b/providers/openrouter/models/liquid/lfm-2.5-1.2b-instruct:free.toml
@@ -7,7 +7,7 @@ reasoning = false
 temperature = true
 # may be inaccurate
 knowledge = "2025-06"
-tool_call = true
+tool_call = false
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/liquid/lfm-2.5-1.2b-thinking:free.toml
+++ b/providers/openrouter/models/liquid/lfm-2.5-1.2b-thinking:free.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 # may be inaccurate
 knowledge = "2025-06"
-tool_call = true
+tool_call = false
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/meta-llama/llama-3.1-405b-instruct:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.1-405b-instruct:free.toml
@@ -6,7 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 knowledge = "2024-08"
-tool_call = true
+tool_call = false
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/meta-llama/llama-3.2-3b-instruct:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.2-3b-instruct:free.toml
@@ -6,7 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 knowledge = "2023-12"
-tool_call = true
+tool_call = false
 open_weights = true
 cost = { input = 0, output = 0 }
 limit = { context = 131072, output = 131072 }

--- a/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-405b:free.toml
+++ b/providers/openrouter/models/nousresearch/hermes-3-llama-3.1-405b:free.toml
@@ -6,7 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 knowledge = "2023-12"
-tool_call = true
+tool_call = false
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/tngtech/tng-r1t-chimera:free.toml
+++ b/providers/openrouter/models/tngtech/tng-r1t-chimera:free.toml
@@ -6,7 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 knowledge = "2025-07"
-tool_call = false
+tool_call = true
 open_weights = true
 
 [cost]


### PR DESCRIPTION
Updated the following Openrouter provider models tool call to false after manual testing:

- allenai/molmo-2-8b:free
- cognitivecomputations/dolphin-mistral-24b-venice-edition:free
- liquid/lfm-2.5-1.2b-instruct:free
- liquid/lfm-2.5-1.2b-thinking:free
- meta-llama/llama-3.1-405b-instruct:free
- meta-llama/llama-3.2-3b-instruct:free
- nousresearch/hermes-3-llama-3.1-405b:free
- tngtech/tng-r1t-chimera:free