### PR TITLE
use official ai-gateway-provider package for Cloudflare AI Gateway

### DIFF
--- a/providers/cloudflare-ai-gateway/provider.toml
+++ b/providers/cloudflare-ai-gateway/provider.toml
@@ -1,5 +1,4 @@
 name = "Cloudflare AI Gateway"
 env = ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID"]
-npm = "@ai-sdk/openai-compatible"
-api = "https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEWAY_ID}/compat/"
+npm = "ai-gateway-provider"
 doc = "https://developers.cloudflare.com/ai-gateway/"


### PR DESCRIPTION
Switches the Cloudflare AI Gateway provider from `@ai-sdk/openai-compatible` to the official `ai-gateway-provider` package.

The official package:
- handles `cf-aig-authorization` header correctly
- supports the Unified API model format (`{provider}/{model}`)
- supports fallback providers
- is maintained by Cloudflare

See: https://developers.cloudflare.com/ai-gateway/integrations/vercel-ai-sdk/