### PR TITLE
feat(models): add Kimi-K2.5 model support

### DIFF
--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.5.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.5.toml
@@ -1,0 +1,22 @@
+name = "Pro/moonshotai/Kimi-K2.5"
+family = "kimi"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.55
+output = 3.00
+
+[limit]
+context = 262_000
+output = 262_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/siliconflow/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2.5.toml
@@ -1,0 +1,22 @@
+name = "moonshotai/Kimi-K2.5"
+family = "kimi"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.55
+output = 3.00
+
+[limit]
+context = 262_000
+output = 262_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Add support for Moonshot AI's Kimi-K2.5 model with reasoning capabilities, structured output, and multi-modal support (text/image input, text output). Configured with a large context window of 262,000 tokens for both input and output. Added to both SiliconFlow and SiliconFlow CN providers.