### PR TITLE
Add Intellect 3 model from Prime Intellect

### DIFF
--- a/providers/openrouter/models/prime-intellect/intellect-3.toml
+++ b/providers/openrouter/models/prime-intellect/intellect-3.toml
@@ -1,0 +1,17 @@
+id = "prime-intellect/intellect-3"
+name = "Intellect 3"
+family = "glm"
+release_date = "2025-01-15"
+last_updated = "2025-01-15"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = true
+cost = { input = 0.2, output = 1.1 }
+limit = { context = 131072, output = 8192 }
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This PR adds the Intellect 3 model from Prime Intellect to the OpenRouter models list.

Model details:
- ID: prime-intellect/intellect-3
- Context: 131,072 tokens
- Reasoning: true
- Tool calls: true