### PR TITLE
[fix] Rename model to 'Qwen3 Coder Next FP8'

### DIFF
--- a/providers/togetherai/models/Qwen/Qwen3-Coder-Next-FP8.toml
+++ b/providers/togetherai/models/Qwen/Qwen3-Coder-Next-FP8.toml
@@ -1,4 +1,4 @@
-name = "Qwen3 Coder Next"
+name = "Qwen3 Coder Next FP8"
 family = "qwen"
 release_date = "2026-02-03"
 last_updated = "2026-02-03"


### PR DESCRIPTION
previously used incorrect model name which was causing and error `Unable to access non-serverless model Qwen/Qwen3-Coder-Next. Please visit https://api.together.ai/models/Qwen/Qwen3-Coder-Next to create and start a new dedicated endpoint for the model.`

<img width="1713" height="915" alt="image" src="https://github.com/user-attachments/assets/568b42ba-e813-41e0-8441-48f49fbd4435" />
