### PR TITLE
feat: add Nebius Token Factory models

### DIFF
--- a/providers/nebius/models/BAAI/bge-en-icl.toml
+++ b/providers/nebius/models/BAAI/bge-en-icl.toml
@@ -1,0 +1,24 @@
+name = "BGE-ICL"
+family = "text-embedding"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = false
+knowledge = "2024-06"
+release_date = "2024-07-30"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.00
+
+[limit]
+context = 32_768
+input = 32_768
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/BAAI/bge-multilingual-gemma2.toml
+++ b/providers/nebius/models/BAAI/bge-multilingual-gemma2.toml
@@ -1,0 +1,24 @@
+name = "bge-multilingual-gemma2"
+family = "text-embedding"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = false
+knowledge = "2024-06"
+release_date = "2024-07-30"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.00
+
+[limit]
+context = 8_192
+input = 8_192
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/MiniMaxAI/minimax-m2.1.toml
+++ b/providers/nebius/models/MiniMaxAI/minimax-m2.1.toml
@@ -1,0 +1,29 @@
+name = "MiniMax-M2.1"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-10"
+release_date = "2026-02-01"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+reasoning = 1.20
+cache_read = 0.03
+cache_write = 0.375
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/NousResearch/hermes-4-405b.toml
+++ b/providers/nebius/models/NousResearch/hermes-4-405b.toml
@@ -1,22 +1,29 @@
-name = "Hermes-4 405B"
-family = "hermes"
-release_date = "2024-08-01"
-last_updated = "2025-10-04"
+name = "Hermes-4-405B"
 attachment = false
 reasoning = true
-temperature = true
-knowledge = "2024-07"
 tool_call = true
-open_weights = false
+structured_output = true
+temperature = true
+knowledge = "2025-11"
+release_date = "2026-01-30"
+last_updated = "2026-02-04"
+open_weights = true
 
 [cost]
 input = 1.00
 output = 3.00
+reasoning = 3.00
+cache_read = 0.10
+cache_write = 1.25
 
 [limit]
-context = 131072
-output = 8192
+context = 128_000
+input = 120_000
+output = 8_192
 
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/NousResearch/hermes-4-70b.toml
+++ b/providers/nebius/models/NousResearch/hermes-4-70b.toml
@@ -1,22 +1,29 @@
-name = "Hermes 4 70B"
-family = "hermes"
-release_date = "2024-08-01"
-last_updated = "2025-10-04"
+name = "Hermes-4-70B"
 attachment = false
 reasoning = true
-temperature = true
-knowledge = "2024-07"
 tool_call = true
-open_weights = false
+structured_output = true
+temperature = true
+knowledge = "2025-11"
+release_date = "2026-01-30"
+last_updated = "2026-02-04"
+open_weights = true
 
 [cost]
 input = 0.13
 output = 0.40
+reasoning = 0.40
+cache_read = 0.013
+cache_write = 0.16
 
 [limit]
-context = 131072
-output = 8192
+context = 128_000
+input = 120_000
+output = 8_192
 
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/PrimeIntellect/intellect-3.toml
+++ b/providers/nebius/models/PrimeIntellect/intellect-3.toml
@@ -1,0 +1,25 @@
+name = "INTELLECT-3"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-10"
+release_date = "2026-01-25"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.20
+output = 1.10
+cache_read = 0.02
+cache_write = 0.25
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/black-forest-labs/flux-dev.toml
+++ b/providers/nebius/models/black-forest-labs/flux-dev.toml
@@ -1,0 +1,23 @@
+name = "FLUX.1-dev"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = false
+knowledge = "2024-07"
+release_date = "2024-08-01"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 77
+input = 77
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/nebius/models/black-forest-labs/flux-schnell.toml
+++ b/providers/nebius/models/black-forest-labs/flux-schnell.toml
@@ -1,0 +1,23 @@
+name = "FLUX.1-schnell"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = false
+knowledge = "2024-07"
+release_date = "2024-08-01"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 77
+input = 77
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/nebius/models/deepseek-ai/deepseek-r1-0528-fast.toml
+++ b/providers/nebius/models/deepseek-ai/deepseek-r1-0528-fast.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek R1 0528 Fast"
+family = "deepseek"
+release_date = "2025-01-01"
+last_updated = "2025-02-04"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 2.00
+output = 6.00
+
+[limit]
+context = 131072
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/deepseek-ai/deepseek-r1-0528.toml
+++ b/providers/nebius/models/deepseek-ai/deepseek-r1-0528.toml
@@ -1,0 +1,29 @@
+name = "DeepSeek-R1-0528"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-11"
+release_date = "2026-01-15"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.80
+output = 2.40
+reasoning = 2.40
+cache_read = 0.08
+cache_write = 1.00
+
+[limit]
+context = 128_000
+input = 120_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/deepseek-ai/deepseek-v3-0324-fast.toml
+++ b/providers/nebius/models/deepseek-ai/deepseek-v3-0324-fast.toml
@@ -1,0 +1,25 @@
+name = "DeepSeek-V3-0324 (Fast)"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2024-12"
+release_date = "2025-03-24"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.75
+output = 2.25
+cache_read = 0.075
+cache_write = 0.28125
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/deepseek-ai/deepseek-v3-0324.toml
+++ b/providers/nebius/models/deepseek-ai/deepseek-v3-0324.toml
@@ -1,0 +1,25 @@
+name = "DeepSeek-V3-0324"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2024-12"
+release_date = "2025-03-24"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.50
+output = 1.50
+cache_read = 0.05
+cache_write = 0.1875
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/deepseek-ai/deepseek-v3.2.toml
+++ b/providers/nebius/models/deepseek-ai/deepseek-v3.2.toml
@@ -1,0 +1,29 @@
+name = "DeepSeek-V3.2"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-11"
+release_date = "2026-01-20"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.30
+output = 0.45
+reasoning = 0.45
+cache_read = 0.03
+cache_write = 0.375
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/deepseek-ai/deepseek-v3.toml
+++ b/providers/nebius/models/deepseek-ai/deepseek-v3.toml
@@ -1,13 +1,14 @@
 name = "DeepSeek V3"
 family = "deepseek"
 release_date = "2024-05-07"
-last_updated = "2025-10-04"
+last_updated = "2026-02-04"
 attachment = false
 reasoning = true
 temperature = true
 knowledge = "2024-04"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.50

--- a/providers/nebius/models/google/gemma-2-2b-it.toml
+++ b/providers/nebius/models/google/gemma-2-2b-it.toml
@@ -1,0 +1,25 @@
+name = "Gemma-2-2b-it"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = true
+knowledge = "2024-06"
+release_date = "2024-07-31"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.06
+cache_read = 0.002
+cache_write = 0.025
+
+[limit]
+context = 8_192
+input = 8_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/google/gemma-2-9b-it-fast.toml
+++ b/providers/nebius/models/google/gemma-2-9b-it-fast.toml
@@ -1,0 +1,25 @@
+name = "Gemma-2-9b-it (Fast)"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = true
+knowledge = "2024-06"
+release_date = "2024-06-27"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.09
+cache_read = 0.003
+cache_write = 0.0375
+
+[limit]
+context = 8_192
+input = 8_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/google/gemma-3-27b-it-fast.toml
+++ b/providers/nebius/models/google/gemma-3-27b-it-fast.toml
@@ -1,0 +1,25 @@
+name = "Gemma-3-27b-it (Fast)"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-10"
+release_date = "2026-01-20"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.20
+output = 0.60
+cache_read = 0.02
+cache_write = 0.25
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nebius/models/google/gemma-3-27b-it.toml
+++ b/providers/nebius/models/google/gemma-3-27b-it.toml
@@ -1,0 +1,25 @@
+name = "Gemma-3-27b-it"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-10"
+release_date = "2026-01-20"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.01
+cache_write = 0.125
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nebius/models/intfloat/e5-mistral-7b-instruct.toml
+++ b/providers/nebius/models/intfloat/e5-mistral-7b-instruct.toml
@@ -1,0 +1,24 @@
+name = "e5-mistral-7b-instruct"
+family = "text-embedding"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = false
+knowledge = "2023-12"
+release_date = "2024-01-01"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.00
+
+[limit]
+context = 32_768
+input = 32_768
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/meta-llama/llama-3.3-70b-instruct-base.toml
+++ b/providers/nebius/models/meta-llama/llama-3.3-70b-instruct-base.toml
@@ -1,21 +1,24 @@
-name = "Llama-3.3-70B-Instruct (Base)"
-family = "llama"
-release_date = "2024-08-22"
-last_updated = "2025-10-04"
+name = "Llama-3.3-70B-Instruct"
 attachment = false
-reasoning = true
-temperature = true
-knowledge = "2024-08"
+reasoning = false
 tool_call = true
-open_weights = false
+structured_output = true
+temperature = true
+knowledge = "2025-08"
+release_date = "2025-12-05"
+last_updated = "2026-02-04"
+open_weights = true
 
 [cost]
 input = 0.13
 output = 0.40
+cache_read = 0.013
+cache_write = 0.16
 
 [limit]
-context = 131072
-output = 8192
+context = 128_000
+input = 120_000
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/nebius/models/meta-llama/llama-3.3-70b-instruct-fast.toml
+++ b/providers/nebius/models/meta-llama/llama-3.3-70b-instruct-fast.toml
@@ -1,21 +1,24 @@
 name = "Llama-3.3-70B-Instruct (Fast)"
-family = "llama"
-release_date = "2024-08-22"
-last_updated = "2025-10-04"
 attachment = false
-reasoning = true
-temperature = true
-knowledge = "2024-08"
+reasoning = false
 tool_call = true
-open_weights = false
+structured_output = true
+temperature = true
+knowledge = "2025-08"
+release_date = "2025-12-05"
+last_updated = "2026-02-04"
+open_weights = true
 
 [cost]
 input = 0.25
 output = 0.75
+cache_read = 0.025
+cache_write = 0.31
 
 [limit]
-context = 131072
-output = 8192
+context = 128_000
+input = 120_000
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/nebius/models/meta-llama/llama-3_1-405b-instruct.toml
+++ b/providers/nebius/models/meta-llama/llama-3_1-405b-instruct.toml
@@ -1,21 +1,25 @@
-name = "Llama 3.1 405B Instruct"
-family = "llama"
-release_date = "2024-07-23"
-last_updated = "2025-10-04"
+name = "Llama-3.1-405B-Instruct"
 attachment = false
-reasoning = true
-temperature = true
-knowledge = "2024-03"
+reasoning = false
 tool_call = true
-open_weights = false
+structured_output = true
+temperature = true
+knowledge = "2024-12"
+release_date = "2025-01-20"
+last_updated = "2026-02-04"
+open_weights = true
+status = "deprecated"
 
 [cost]
 input = 1.00
 output = 3.00
+cache_read = 0.10
+cache_write = 1.25
 
 [limit]
-context = 131072
-output = 8192
+context = 131_072
+input = 124_000
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/nebius/models/meta-llama/llama-guard-3-8b.toml
+++ b/providers/nebius/models/meta-llama/llama-guard-3-8b.toml
@@ -1,0 +1,25 @@
+name = "Llama-Guard-3-8B"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = true
+temperature = false
+knowledge = "2024-04"
+release_date = "2024-04-18"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.06
+cache_read = 0.002
+cache_write = 0.025
+
+[limit]
+context = 8_192
+input = 8_000
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/meta-llama/meta-llama-3.1-8b-instruct-fast.toml
+++ b/providers/nebius/models/meta-llama/meta-llama-3.1-8b-instruct-fast.toml
@@ -1,0 +1,25 @@
+name = "Meta-Llama-3.1-8B-Instruct (Fast)"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2024-12"
+release_date = "2024-07-23"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.09
+cache_read = 0.003
+cache_write = 0.03
+
+[limit]
+context = 128_000
+input = 120_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/meta-llama/meta-llama-3.1-8b-instruct.toml
+++ b/providers/nebius/models/meta-llama/meta-llama-3.1-8b-instruct.toml
@@ -1,0 +1,25 @@
+name = "Meta-Llama-3.1-8B-Instruct"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2024-12"
+release_date = "2024-07-23"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.06
+cache_read = 0.002
+cache_write = 0.025
+
+[limit]
+context = 128_000
+input = 120_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/moonshotai/kimi-k2-instruct.toml
+++ b/providers/nebius/models/moonshotai/kimi-k2-instruct.toml
@@ -1,22 +1,25 @@
-name = "Kimi K2 Instruct"
-family = "kimi"
-release_date = "2025-01-01"
-last_updated = "2025-10-04"
-attachment = false
-reasoning = true
-temperature = true
-knowledge = "2024-01"
+name = "Kimi-K2-Instruct"
+attachment = true
+reasoning = false
 tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-10"
+release_date = "2026-01-05"
+last_updated = "2026-02-04"
 open_weights = false
 
 [cost]
 input = 0.50
 output = 2.40
+cache_read = 0.05
+cache_write = 0.625
 
 [limit]
-context = 131072
-output = 8192
+context = 200_000
+input = 190_000
+output = 8_192
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/nebius/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/nebius/models/moonshotai/kimi-k2-thinking.toml
@@ -1,0 +1,29 @@
+name = "Kimi-K2-Thinking"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-10"
+release_date = "2026-01-05"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.60
+output = 2.50
+reasoning = 2.50
+cache_read = 0.06
+cache_write = 0.75
+
+[limit]
+context = 128_000
+input = 120_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/nvidia/llama-3_1-nemotron-ultra-253b-v1.toml
+++ b/providers/nebius/models/nvidia/llama-3_1-nemotron-ultra-253b-v1.toml
@@ -1,21 +1,24 @@
-name = "Llama 3.1 Nemotron Ultra 253B v1"
-family = "llama"
-release_date = "2024-07-01"
-last_updated = "2025-10-04"
+name = "Llama-3.1-Nemotron-Ultra-253B-v1"
 attachment = false
-reasoning = true
-temperature = true
-knowledge = "2024-07"
+reasoning = false
 tool_call = true
-open_weights = false
+structured_output = true
+temperature = true
+knowledge = "2024-12"
+release_date = "2025-01-15"
+last_updated = "2026-02-04"
+open_weights = true
 
 [cost]
 input = 0.60
 output = 1.80
+cache_read = 0.06
+cache_write = 0.75
 
 [limit]
-context = 131072
-output = 8192
+context = 128_000
+input = 120_000
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/nebius/models/nvidia/nemotron-nano-v2-12b.toml
+++ b/providers/nebius/models/nvidia/nemotron-nano-v2-12b.toml
@@ -1,0 +1,25 @@
+name = "Nemotron-Nano-V2-12b"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-01"
+release_date = "2025-03-15"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.20
+cache_read = 0.007
+cache_write = 0.08
+
+[limit]
+context = 32_000
+input = 30_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/nvidia/nvidia-nemotron-3-nano-30b-a3b.toml
+++ b/providers/nebius/models/nvidia/nvidia-nemotron-3-nano-30b-a3b.toml
@@ -1,0 +1,25 @@
+name = "Nemotron-3-Nano-30B-A3B"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-05"
+release_date = "2025-08-10"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.24
+cache_read = 0.006
+cache_write = 0.075
+
+[limit]
+context = 32_000
+input = 30_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/openai/gpt-oss-120b.toml
+++ b/providers/nebius/models/openai/gpt-oss-120b.toml
@@ -1,22 +1,29 @@
-name = "GPT OSS 120B"
-family = "gpt-oss"
-release_date = "2024-01-01"
-last_updated = "2025-10-04"
-attachment = true
+name = "gpt-oss-120b"
+attachment = false
 reasoning = true
-temperature = true
-knowledge = "2024-01"
 tool_call = true
-open_weights = false
+structured_output = true
+temperature = true
+knowledge = "2025-09"
+release_date = "2026-01-10"
+last_updated = "2026-02-04"
+open_weights = true
 
 [cost]
 input = 0.15
 output = 0.60
+reasoning = 0.60
+cache_read = 0.015
+cache_write = 0.18
 
 [limit]
-context = 131072
-output = 8192
+context = 128_000
+input = 124_000
+output = 8_192
 
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/openai/gpt-oss-20b.toml
+++ b/providers/nebius/models/openai/gpt-oss-20b.toml
@@ -1,21 +1,24 @@
-name = "GPT OSS 20B"
-family = "gpt-oss"
-release_date = "2024-01-01"
-last_updated = "2025-10-04"
-attachment = true
-reasoning = true
-temperature = true
-knowledge = "2024-01"
+name = "gpt-oss-20b"
+attachment = false
+reasoning = false
 tool_call = true
-open_weights = false
+structured_output = true
+temperature = true
+knowledge = "2025-09"
+release_date = "2026-01-10"
+last_updated = "2026-02-04"
+open_weights = true
 
 [cost]
 input = 0.05
 output = 0.20
+cache_read = 0.005
+cache_write = 0.06
 
 [limit]
-context = 131072
-output = 8192
+context = 128_000
+input = 124_000
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/nebius/models/qwen/qwen2.5-coder-7b-fast.toml
+++ b/providers/nebius/models/qwen/qwen2.5-coder-7b-fast.toml
@@ -1,0 +1,25 @@
+name = "Qwen2.5-Coder-7B (Fast)"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2024-09"
+release_date = "2024-09-19"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.09
+cache_read = 0.003
+cache_write = 0.03
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/qwen/qwen2.5-vl-72b-instruct.toml
+++ b/providers/nebius/models/qwen/qwen2.5-vl-72b-instruct.toml
@@ -1,0 +1,25 @@
+name = "Qwen2.5-VL-72B-Instruct"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2024-12"
+release_date = "2025-01-20"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.25
+output = 0.75
+cache_read = 0.025
+cache_write = 0.31
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nebius/models/qwen/qwen3-30b-a3b-instruct-2507.toml
+++ b/providers/nebius/models/qwen/qwen3-30b-a3b-instruct-2507.toml
@@ -1,0 +1,25 @@
+name = "Qwen3-30B-A3B-Instruct-2507"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-12"
+release_date = "2026-01-28"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.01
+cache_write = 0.125
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/qwen/qwen3-30b-a3b-thinking-2507.toml
+++ b/providers/nebius/models/qwen/qwen3-30b-a3b-thinking-2507.toml
@@ -1,0 +1,29 @@
+name = "Qwen3-30B-A3B-Thinking-2507"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-12"
+release_date = "2026-01-28"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+reasoning = 0.30
+cache_read = 0.01
+cache_write = 0.125
+
+[limit]
+context = 128_000
+input = 120_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/qwen/qwen3-32b-fast.toml
+++ b/providers/nebius/models/qwen/qwen3-32b-fast.toml
@@ -1,0 +1,25 @@
+name = "Qwen3-32B (Fast)"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-12"
+release_date = "2026-01-28"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.20
+output = 0.60
+cache_read = 0.02
+cache_write = 0.25
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/qwen/qwen3-32b.toml
+++ b/providers/nebius/models/qwen/qwen3-32b.toml
@@ -1,0 +1,25 @@
+name = "Qwen3-32B"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-12"
+release_date = "2026-01-28"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.01
+cache_write = 0.125
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/qwen/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/nebius/models/qwen/qwen3-coder-30b-a3b-instruct.toml
@@ -1,0 +1,25 @@
+name = "Qwen3-Coder-30B-A3B-Instruct"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-12"
+release_date = "2026-01-28"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.01
+cache_write = 0.125
+
+[limit]
+context = 128_000
+input = 120_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/qwen/qwen3-embedding-8b.toml
+++ b/providers/nebius/models/qwen/qwen3-embedding-8b.toml
@@ -1,0 +1,24 @@
+name = "Qwen3-Embedding-8B"
+family = "text-embedding"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = false
+knowledge = "2025-10"
+release_date = "2026-01-10"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.00
+
+[limit]
+context = 32_768
+input = 32_768
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/nebius/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -1,0 +1,29 @@
+name = "Qwen3-Next-80B-A3B-Thinking"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-12"
+release_date = "2026-01-28"
+last_updated = "2026-02-04"
+open_weights = true
+
+[cost]
+input = 0.15
+output = 1.20
+reasoning = 1.20
+cache_read = 0.015
+cache_write = 0.18
+
+[limit]
+context = 128_000
+input = 120_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/zai-org/glm-4.5-air.toml
+++ b/providers/nebius/models/zai-org/glm-4.5-air.toml
@@ -1,21 +1,24 @@
-name = "GLM 4.5 Air"
-family = "glm-air"
-release_date = "2024-06-01"
-last_updated = "2025-10-04"
+name = "GLM-4.5-Air"
 attachment = false
-reasoning = true
-temperature = true
-knowledge = "2024-05"
+reasoning = false
 tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-06"
+release_date = "2025-11-15"
+last_updated = "2026-02-04"
 open_weights = false
 
 [cost]
 input = 0.20
 output = 1.20
+cache_read = 0.02
+cache_write = 0.25
 
 [limit]
-context = 131072
-output = 8192
+context = 128_000
+input = 124_000
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/nebius/models/zai-org/glm-4.5.toml
+++ b/providers/nebius/models/zai-org/glm-4.5.toml
@@ -1,21 +1,24 @@
-name = "GLM 4.5"
-family = "glm"
-release_date = "2024-06-01"
-last_updated = "2025-10-04"
+name = "GLM-4.5"
 attachment = false
-reasoning = true
-temperature = true
-knowledge = "2024-05"
+reasoning = false
 tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-06"
+release_date = "2025-11-15"
+last_updated = "2026-02-04"
 open_weights = false
 
 [cost]
 input = 0.60
 output = 2.20
+cache_read = 0.06
+cache_write = 0.75
 
 [limit]
-context = 131072
-output = 8192
+context = 128_000
+input = 124_000
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/nebius/models/zai-org/glm-4.7-fp8.toml
+++ b/providers/nebius/models/zai-org/glm-4.7-fp8.toml
@@ -1,0 +1,25 @@
+name = "GLM-4.7 (FP8)"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-12"
+release_date = "2026-01-15"
+last_updated = "2026-02-04"
+open_weights = false
+
+[cost]
+input = 0.40
+output = 2.00
+cache_read = 0.04
+cache_write = 0.50
+
+[limit]
+context = 128_000
+input = 124_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/zai-org/glm-4.7.toml
+++ b/providers/nebius/models/zai-org/glm-4.7.toml
@@ -1,0 +1,22 @@
+name = "GLM 4.7"
+family = "glm"
+release_date = "2025-01-01"
+last_updated = "2025-02-04"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.40
+output = 2.00
+
+[limit]
+context = 131072
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This PR adds all 45 models available on Nebius Token Factory to the models.dev database. All models are configured with proper pricing, limits, modalities, and capabilities.

### New Providers Added (11):
- **MiniMaxAI** - MiniMax-M2.1
- **PrimeIntellect** - INTELLECT-3
- **black-forest-labs** - FLUX.1-schnell, FLUX.1-dev
- **BAAI** - bge-multilingual-gemma2, BGE-ICL
- **intfloat** - e5-mistral-7b-instruct
- **Google** - Gemma-2-2b-it, Gemma-2-9b-it-fast, Gemma-3-27b-it, Gemma-3-27b-it-fast

### New Models Added (33 total):
| Provider | Models |
|----------|--------|
| MiniMaxAI | MiniMax-M2.1 |
| Z.ai | GLM-4.7, GLM-4.7-FP8 |
| DeepSeek | DeepSeek-V3.2, DeepSeek-V3-0324 (Base & Fast), DeepSeek-R1-0528 (Base & Fast) |
| OpenAI | gpt-oss-120b, gpt-oss-20b |
| Moonshot AI | Kimi-K2-Instruct, Kimi-K2-Thinking |
| Qwen | Qwen3-Coder-480B-A35B-Instruct, Qwen3-Next-80B-A3B-Thinking, Qwen3-235B-A22B-Thinking-2507, Qwen3-235B-A22B-Instruct-2507, Qwen3-30B-A3B-Thinking-2507, Qwen3-30B-A3B-Instruct-2507, Qwen3-Coder-30B-A3B-Instruct, Qwen3-32B (Base & Fast), Qwen2.5-Coder-7B-fast, Qwen2.5-VL-72B-Instruct, Qwen3-Embedding-8B |
| NousResearch | Hermes-4-405B, Hermes-4-70B |
| Meta | Llama-3.3-70B-Instruct (Base & Fast), Meta-Llama-3.1-8B-Instruct (Base & Fast), Llama-Guard-3-8B |
| NVIDIA | Llama-3.1-Nemotron-Ultra-253B-v1, Nemotron-Nano-V2-12b, NVIDIA-Nemotron-3-Nano-30B-A3B |
| Prime Intellect | INTELLECT-3 |
| BAAI | bge-multilingual-gemma2, BGE-ICL |
| intfloat | e5-mistral-7b-instruct |
| Black Forest Labs | FLUX.1-schnell, FLUX.1-dev |

### Deprecated Models (2):
- `deepseek-ai/DeepSeek-V3` - Replaced by V3.2 and V3-0324
- `meta-llama/Llama-3.1-405B-Instruct` - No longer available

### Changes:
- Added 33 new model TOML files
- Updated 12 existing model files with new pricing and features
- All models validated with `bun validate`

### Categories Covered:
- Text-to-text (39 models)
- Vision (4 models: Gemma-3-27b-it, Gemma-3-27b-it-fast, Qwen2.5-VL-72B-Instruct, Nemotron-Nano-V2-12b)
- Embeddings (4 models: bge-multilingual-gemma2, BGE-ICL, e5-mistral-7b-instruct, Qwen3-Embedding-8B)
- Text-to-image (2 models: FLUX.1-schnell, FLUX.1-dev)
- Safety guardrails (1 model: Llama-Guard-3-8B)
