### PR TITLE
cloudflare-ai-gateway: add claude opus 4.6

### DIFF
--- a/providers/cloudflare-ai-gateway/data/model_names.json
+++ b/providers/cloudflare-ai-gateway/data/model_names.json
@@ -9,6 +9,7 @@
   "anthropic/claude-opus-4": "Claude Opus 4",
   "anthropic/claude-opus-4-1": "Claude Opus 4.1",
   "anthropic/claude-opus-4-5": "Claude Opus 4.5",
+  "anthropic/claude-opus-4-6": "Claude Opus 4.6",
   "anthropic/claude-sonnet-4": "Claude Sonnet 4",
   "anthropic/claude-sonnet-4-5": "Claude Sonnet 4.5",
   "openai/gpt-3.5-turbo": "GPT 3.5 Turbo",

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
@@ -1,0 +1,30 @@
+name = "Claude Opus 4.6 (latest)"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 1.00
+cache_write = 12.50
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/cloudflare-ai-gateway/scripts/utils.sh
+++ b/providers/cloudflare-ai-gateway/scripts/utils.sh
@@ -42,6 +42,7 @@ WELL_KNOWN_MODELS=(
   # Anthropic - canonical names only, no dated versions or duplicates
   # API uses BOTH dots and hyphens: claude-3.5-sonnet AND claude-3-5-sonnet
   "anthropic/claude-sonnet-4-5$"
+  "anthropic/claude-opus-4-6$"
   "anthropic/claude-opus-4-5$"
   "anthropic/claude-haiku-4-5$"
   "anthropic/claude-opus-4-1$"
@@ -68,6 +69,7 @@ get_mapped_name() {
   case "${normalized_name}" in
     # Anthropic mappings - map to source file names with date suffixes
     "claude-sonnet-4-5") echo "claude-sonnet-4-5" ;;
+    "claude-opus-4-6") echo "claude-opus-4-6" ;;
     "claude-opus-4-5") echo "claude-opus-4-5" ;;
     "claude-haiku-4-5") echo "claude-haiku-4-5" ;;
     "claude-opus-4-1") echo "claude-opus-4-1" ;;


### PR DESCRIPTION
## Summary
- Add Claude Opus 4.6 to Cloudflare AI Gateway
- 1M context window with tiered pricing for >200k context