### PR TITLE
Add Claude Opus 4.6 model

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.6"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1:0.toml
@@ -15,6 +15,12 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 1.00
+cache_write = 12.50
+
 [limit]
 context = 200_000
 output = 128_000

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1:0.toml
@@ -15,6 +15,12 @@ output = 25.00
 cache_read = 1.50
 cache_write = 18.75
 
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 3.00
+cache_write = 37.50
+
 [limit]
 context = 200_000
 output = 128_000

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.6 (EU)"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 1.50
+cache_write = 18.75
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.6 (Global)"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1:0.toml
@@ -15,6 +15,12 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 1.00
+cache_write = 12.50
+
 [limit]
 context = 200_000
 output = 128_000

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1:0.toml
@@ -15,6 +15,12 @@ output = 25.00
 cache_read = 1.50
 cache_write = 18.75
 
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 3.00
+cache_write = 37.50
+
 [limit]
 context = 200_000
 output = 128_000

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1:0.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.6 (US)"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 1.50
+cache_write = 18.75
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/anthropic/models/claude-opus-4-6-20260205.toml
+++ b/providers/anthropic/models/claude-opus-4-6-20260205.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.6"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/anthropic/models/claude-opus-4-6-20260205.toml
+++ b/providers/anthropic/models/claude-opus-4-6-20260205.toml
@@ -15,6 +15,12 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 1.00
+cache_write = 12.50
+
 [limit]
 context = 200_000
 output = 128_000

--- a/providers/anthropic/models/claude-opus-4-6.toml
+++ b/providers/anthropic/models/claude-opus-4-6.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.6 (latest)"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/anthropic/models/claude-opus-4-6.toml
+++ b/providers/anthropic/models/claude-opus-4-6.toml
@@ -15,6 +15,12 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 1.00
+cache_write = 12.50
+
 [limit]
 context = 200_000
 output = 128_000

--- a/providers/google-vertex-anthropic/models/claude-opus-4-6@20260205.toml
+++ b/providers/google-vertex-anthropic/models/claude-opus-4-6@20260205.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.6"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/google-vertex-anthropic/models/claude-opus-4-6@20260205.toml
+++ b/providers/google-vertex-anthropic/models/claude-opus-4-6@20260205.toml
@@ -15,6 +15,12 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 1.00
+cache_write = 12.50
+
 [limit]
 context = 200_000
 output = 128_000


### PR DESCRIPTION
## Summary

- Adds Claude Opus 4.6 across all three Anthropic-serving providers: Anthropic (native API), Amazon Bedrock (4 region variants), and Google Vertex AI
- 7 new TOML config files total: 2 Anthropic (dated + latest alias), 4 Bedrock (default/US/EU/global), 1 Vertex AI

## Model Details

| Feature | Value |
|---------|-------|
| Pricing | $5/MTok input, $25/MTok output |
| Context window | 200K tokens |
| Max output | 128K tokens |
| Knowledge cutoff | May 2025 |
| Extended thinking | Yes |
| Modalities | text, image, pdf input; text output |

Validation (`bun validate`) and web build both pass.