### PR TITLE
add claude-opus-4-6

### DIFF
--- a/providers/anthropic/models/claude-opus-4-6.toml
+++ b/providers/anthropic/models/claude-opus-4-6.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.6 (latest)"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05-31"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
Add Claude Opus 4.6 to Anthropic provider.

## Model Specs

| Field | Value |
|---|---|
| **API ID** | `claude-opus-4-6` |
| **Release** | 2026-02-05 |
| **Input** | $5.00/MTok |
| **Output** | $25.00/MTok |
| **Cache read** | $0.50/MTok |
| **Cache write** | $6.25/MTok |
| **Context** | 200K tokens |
| **Max output** | 128K tokens |
| **Knowledge** | 2025-05-31 |
| **Modalities** | text, image, pdf → text |

## Reference

- https://platform.claude.com/docs/en/about-claude/models/overview