### PR TITLE
Add Claude Opus 4.6 model for Github Copilot

### DIFF
--- a/providers/github-copilot/models/claude-opus-4.6.toml
+++ b/providers/github-copilot/models/claude-opus-4.6.toml
@@ -1,0 +1,22 @@
+name = "Claude Opus 4.6"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 16_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Add the config file of claude opus 4.6 for github copilot provider.