### PR TITLE
Update model sizes for github-copilot

### DIFF
--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -14,8 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
-output = 16_000
+context = 200_000
+input = 128_000
+output = 32_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -14,8 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
-output = 16_000
+context = 200_000
+input = 128_000
+output = 32_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-opus-4.6.toml
+++ b/providers/github-copilot/models/claude-opus-4.6.toml
@@ -14,7 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 200_000
+input = 128_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-opus-41.toml
+++ b/providers/github-copilot/models/claude-opus-41.toml
@@ -15,6 +15,7 @@ output = 0
 
 [limit]
 context = 80_000
+input = 80_000
 output = 16_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -14,8 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
-output = 16_000
+context = 200_000
+input = 128_000
+output = 32_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-sonnet-4.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.toml
@@ -14,7 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 216_000
+input = 128_000
 output = 16_000
 
 [modalities]

--- a/providers/github-copilot/models/gemini-2.5-pro.toml
+++ b/providers/github-copilot/models/gemini-2.5-pro.toml
@@ -15,6 +15,7 @@ output = 0
 
 [limit]
 context = 128_000
+input = 109_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/gemini-3-flash-preview.toml
+++ b/providers/github-copilot/models/gemini-3-flash-preview.toml
@@ -16,6 +16,7 @@ output = 0
 
 [limit]
 context = 128_000
+input = 109_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/gemini-3-pro-preview.toml
+++ b/providers/github-copilot/models/gemini-3-pro-preview.toml
@@ -16,6 +16,7 @@ output = 0
 
 [limit]
 context = 128_000
+input = 109_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/gpt-4.1.toml
+++ b/providers/github-copilot/models/gpt-4.1.toml
@@ -15,7 +15,8 @@ output = 0
 
 [limit]
 context = 128_000
-output = 16_384
+input = 111_000
+output = 16_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/gpt-4o.toml
+++ b/providers/github-copilot/models/gpt-4o.toml
@@ -14,8 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 64_000
-output = 16_384
+context = 128_000
+input = 64_000
+output = 4_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/gpt-5-mini.toml
+++ b/providers/github-copilot/models/gpt-5-mini.toml
@@ -14,7 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 264_000
+input = 128_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/gpt-5.1-codex-max.toml
+++ b/providers/github-copilot/models/gpt-5.1-codex-max.toml
@@ -14,7 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 400_000
+input = 128_000
 output = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/gpt-5.1-codex-mini.toml
+++ b/providers/github-copilot/models/gpt-5.1-codex-mini.toml
@@ -14,8 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
-output = 100_000
+context = 400_000
+input = 128_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/gpt-5.1-codex.toml
+++ b/providers/github-copilot/models/gpt-5.1-codex.toml
@@ -14,7 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 400_000
+input = 128_000
 output = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/gpt-5.1.toml
+++ b/providers/github-copilot/models/gpt-5.1.toml
@@ -14,8 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
-output = 128_000
+context = 264_000
+input = 128_000
+output = 64_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/gpt-5.2-codex.toml
+++ b/providers/github-copilot/models/gpt-5.2-codex.toml
@@ -14,7 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 272_000
+context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/gpt-5.2.toml
+++ b/providers/github-copilot/models/gpt-5.2.toml
@@ -14,7 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 264_000
+input = 128_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/gpt-5.toml
+++ b/providers/github-copilot/models/gpt-5.toml
@@ -14,7 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 400_000
+input = 128_000
 output = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/grok-code-fast-1.toml
+++ b/providers/github-copilot/models/grok-code-fast-1.toml
@@ -15,6 +15,7 @@ output = 0
 
 [limit]
 context = 128_000
+input = 109_000
 output = 64_000
 
 [modalities]


### PR DESCRIPTION
A bunch of model sizes are wrong. I fixed them  
The sizes are also approximate (some are kinda weird and don't end with zeros, e.g. 127805 input size for gpt 5.2). I didn't fix that

<img width="834" height="593" alt="Screenshot 2026-02-05 at 20 53 03" src="https://github.com/user-attachments/assets/d17da261-6ceb-4eaa-9ba4-32a67851002e" />
