### PR TITLE
Add raptor-mini model to github-copilot provider

### DIFF
--- a/providers/github-copilot/models/raptor-mini.toml
+++ b/providers/github-copilot/models/raptor-mini.toml
@@ -1,0 +1,22 @@
+name = "Raptor mini"
+family = "raptor"
+release_date = "2025-11-10"
+last_updated = "2025-11-10"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-06"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Raptor mini is a finetuned gpt-mini variant
Not much info is [in the announcement](https://github.blog/changelog/2025-11-10-raptor-mini-is-rolling-out-in-public-preview-for-github-copilot/) but it's free so worth having around as a small_model in opencode

I mostly took the values from gpt-mini definition and tweaked the sizes and release date