### PR TITLE
fix(opencode): add input token limit for Claude Opus 4.6

### DIFF
--- a/providers/opencode/models/claude-opus-4-6.toml
+++ b/providers/opencode/models/claude-opus-4-6.toml
@@ -23,6 +23,7 @@ cache_write = 12.50
 
 [limit]
 context = 1_000_000
+input = 200_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
## Summary

Adds `input = 200_000` to the `opencode` provider's Claude Opus 4.6 model definition.

## Context

Related to https://github.com/anomalyco/opencode/pull/12342#issuecomment-3857181334

Claude Opus 4.6 has a 1M context window, but without the `context-1m-2025-08-07` beta header the Anthropic API enforces a 200k **input token** limit. The `opencode` provider uses OAuth, which doesn't support this beta header, so the effective input limit is 200k.

This is different from models with a 200k context window (like Haiku 4.5), where 200k is the total budget for input + output combined. For Opus 4.6, the 200k only gates input tokens — output and thinking tokens live in the larger 1M context window space.

Without this field, opencode's compaction logic (`compaction.ts:37`) falls back to `context - output` (1M - 128k = ~872k) as the compaction threshold, which is far too high. The API rejects requests at 200k input tokens long before compaction triggers.

The `model.limit.input` field is already supported in opencode's compaction check — it just wasn't populated for this model.