### PR TITLE
feat: add GLM-4.7-Flash to OpenCode provider

### DIFF
--- a/providers/opencode/models/glm-4.7-flash.toml
+++ b/providers/opencode/models/glm-4.7-flash.toml
@@ -1,0 +1,24 @@
+name = "GLM-4.7-Flash"
+family = "glm-flash"
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds `glm-4.7-flash` to the OpenCode (Zen) provider
- Same model definition as `zhipuai/glm-4.7-flash` — free, reasoning-capable, 200K context flash model from Zhipu AI
- This enables VoltCode users to use GLM-4.7-Flash as a small/auxiliary model via the Voltropy endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)