### PR TITLE
feat(gitlab): add Claude Opus 4.6 model (duo-chat-opus-4-6)

### DIFF
--- a/providers/gitlab/models/duo-chat-opus-4-6.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-6.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (Claude Opus 4.6)"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add the newly released Claude Opus 4.6 model for GitLab Duo Agentic Chat.

## Changes
- Added `providers/gitlab/models/duo-chat-opus-4-6.toml`

## Model Details
| Property | Value |
|----------|-------|
| Name | Agentic Chat (Claude Opus 4.6) |
| Family | claude-opus |
| Context | 200,000 tokens |
| Output | 64,000 tokens |
| Capabilities | attachment, reasoning, temperature, tool_call |

## Related
- AI Gateway MR: https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/merge_requests/4492
- Provider MR: https://gitlab.com/gitlab-org/editor-extensions/gitlab-ai-provider/-/merge_requests/4