### PR TITLE
feat: add Xiaomi MiMo-V2-Flash on OpenRouter

### DIFF
--- a/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
@@ -1,0 +1,23 @@
+name = "MiMo-V2-Flash"
+family = "mimo"
+release_date = "2025-12-14"
+last_updated = "2025-12-14"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-12"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.01
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add Xiaomi MiMo-V2-Flash model to OpenRouter provider
- Values sourced from the primary provider (Xiaomi) on OpenRouter and confirmed via the `/api/v1/models` API
- Pricing: $0.10/$0.30 input/output, cache read $0.01
- Context: 262,144 tokens, max output: 65,536 tokens
- Knowledge cutoff: December 2024

## Test plan
- [x] `bun validate` passes successfully
- [x] Model appears in generated output with correct ID `xiaomi/mimo-v2-flash`
- [x] No existing PR for this model