### PR TITLE
feat: add Claude Opus 4.6 (fast mode) to GitHub Copilot provider

### DIFF
--- a/providers/github-copilot/models/claude-opus-4.6-fast.toml
+++ b/providers/github-copilot/models/claude-opus-4.6-fast.toml
@@ -1,0 +1,22 @@
+name = "Claude Opus 4.6 (fast mode) (preview)"
+family = "claude-opus"
+release_date = "2026-02-07"
+last_updated = "2026-02-07"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-copilot/models/claude-opus-4.6-fast.toml
+++ b/providers/github-copilot/models/claude-opus-4.6-fast.toml
@@ -1,4 +1,4 @@
-name = "Claude Opus 4.6 (fast mode) (preview)"
+name = "Claude Opus 4.6 (fast mode)"
 family = "claude-opus"
 release_date = "2026-02-07"
 last_updated = "2026-02-07"
@@ -14,7 +14,7 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 200_000
 output = 64_000
 
 [modalities]


### PR DESCRIPTION
## Summary

Adds the Claude Opus 4.6 (fast mode) (preview) model to the `github-copilot` provider.

This was announced on Feb 7, 2026 and is currently rolling out as a research preview for Copilot Pro+ and Enterprise users.

- **Announcement:** https://github.blog/changelog/2026-02-07-claude-opus-4-6-fast-is-now-in-public-preview-for-github-copilot/
- **Supported models docs:** https://docs.github.com/copilot/reference/ai-models/supported-models
- **Related issue:** #833

## Notes & Caveats

I want to be transparent about a few uncertainties:

- **Model ID:** I've used `claude-opus-4.6-fast` as the filename/ID, following the pattern of `grok-code-fast-1` already in this provider. However, I don't have access to the exact internal model ID that the Copilot API uses — this model is only visible to Pro+/Enterprise users in the model picker. If the maintainers know the correct ID, feel free to rename the file.
- **Capabilities:** I've mirrored the values from the existing `claude-opus-4.6.toml` since GitHub describes the fast mode as delivering "the same intelligence as Opus 4.6" but with up to 2.5x faster output token speeds.
- **Status:** This is a public preview model. I noticed other preview models in this provider (like `gemini-3-flash-preview.toml`) don't use the `status` field, so I've followed that pattern. Happy to add `status = "beta"` if preferred.
- **Premium multiplier:** 9x during the promotional period (through Feb 16, 2026). Not sure if this is tracked in the TOML schema.

Please let me know if anything needs adjusting — happy to update! 🙏