### PR TITLE
feat: add DeepInfra Claude Opus 4 and Claude Sonnet 3.7 (latest) models

### DIFF
--- a/providers/deepinfra/models/anthropic/claude-3-7-sonnet-latest.toml
+++ b/providers/deepinfra/models/anthropic/claude-3-7-sonnet-latest.toml
@@ -1,5 +1,5 @@
 name = "Claude Sonnet 3.7 (Latest)"
-family = "claude-3-7-sonnet-latest"
+family = "claude-sonnet"
 release_date = "2025-03-13"
 last_updated = "2025-03-13"
 attachment = true

--- a/providers/deepinfra/models/anthropic/claude-3-7-sonnet-latest.toml
+++ b/providers/deepinfra/models/anthropic/claude-3-7-sonnet-latest.toml
@@ -1,0 +1,23 @@
+name = "Claude Sonnet 3.7 (Latest)"
+family = "claude-3-7-sonnet-latest"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-10-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.3
+output = 16.5
+cache_read = 0.33
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/deepinfra/models/anthropic/claude-4-opus.toml
+++ b/providers/deepinfra/models/anthropic/claude-4-opus.toml
@@ -1,0 +1,22 @@
+name = "Claude Opus 4"
+family = "claude-opus"
+release_date = "2025-06-12"
+last_updated = "2025-06-12"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-03-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 16.5
+output = 82.5
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Add two missing models for Deep Infra provider:
- Claude Opus 4 (https://deepinfra.com/anthropic/claude-4-opus/versions)
- Claude Sonnet 3.7 (latest) (https://deepinfra.com/anthropic/claude-3-7-sonnet-latest)

