### PR TITLE
Add Azure Kimi-K2.5 model

### DIFF
--- a/providers/azure-cognitive-services/models/kimi-k2.5.toml
+++ b/providers/azure-cognitive-services/models/kimi-k2.5.toml
@@ -1,0 +1,1 @@
+../../azure/models/kimi-k2.5.toml

--- a/providers/azure/models/kimi-k2.5.toml
+++ b/providers/azure/models/kimi-k2.5.toml
@@ -1,0 +1,24 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2026-02-06"
+last_updated = "2026-02-06"
+attachment = false
+reasoning = true
+structured_output = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+interleaved = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 3.00
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add Kimi-K2.5 model configuration for Azure and Azure Cognitive Services (symlink)
- Pricing: $0.60/M input, $3.00/M output (no prompt caching on Azure for this model)
- 262K context window, 262K max output
- Supports reasoning, structured output, interleaved thinking, tool calling, temperature
- Input modalities: text, image
- Released on Azure 2026-02-06 per [Microsoft blog](https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/kimi-k2-5-now-in-microsoft-foundry/4492321)

## Test plan
- [x] `bun validate` passes