### PR TITLE
Add Azure Claude Opus 4.6 model

### DIFF
--- a/providers/azure-cognitive-services/models/claude-opus-4-6.toml
+++ b/providers/azure-cognitive-services/models/claude-opus-4-6.toml
@@ -1,0 +1,1 @@
+../../azure/models/claude-opus-4-6.toml

--- a/providers/azure/models/claude-opus-4-6.toml
+++ b/providers/azure/models/claude-opus-4-6.toml
@@ -1,0 +1,33 @@
+name = "Claude Opus 4.6"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 1.00
+cache_write = 12.50
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"


### PR DESCRIPTION
## Summary
- Add Claude Opus 4.6 model configuration for Azure (Microsoft Foundry)
- Add azure-cognitive-services symlink
- Pricing, limits, and capabilities verified against Azure AI model catalog and Anthropic documentation
- Includes `cost.context_over_200k` section for 1M context beta pricing tier

## Details
- Same-day availability on Azure (2026-02-05)
- Standard Anthropic pricing: $5.00/$25.00 input/output per 1M tokens
- Prompt caching supported: $0.50 cache read, $6.25 cache write
- Over 200K context pricing: $10.00/$37.50 input/output
- 200K context window, 128K max output
- Input modalities: text, image, PDF