### PR TITLE
Add OpenAI gpt-image models

### DIFF
--- a/providers/openai/models/gpt-image-1-mini.toml
+++ b/providers/openai/models/gpt-image-1-mini.toml
@@ -1,0 +1,20 @@
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# Source: https://platform.openai.com/docs/models/gpt-image-1-mini
+# Release date source: https://platform.openai.com/docs/changelog (Oct 6, 2025 - OpenAI DevDay)
+
+name = "gpt-image-1-mini"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/openai/models/gpt-image-1.5.toml
+++ b/providers/openai/models/gpt-image-1.5.toml
@@ -1,0 +1,20 @@
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# Source: https://platform.openai.com/docs/models/gpt-image-1.5
+# Release date source: https://platform.openai.com/docs/changelog (Dec 16, 2025)
+
+name = "gpt-image-1.5"
+release_date = "2025-12-16"
+last_updated = "2025-12-16"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/openai/models/gpt-image-1.toml
+++ b/providers/openai/models/gpt-image-1.toml
@@ -1,0 +1,20 @@
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# Source: https://platform.openai.com/docs/models/gpt-image-1
+# Release date source: https://platform.openai.com/docs/changelog (Apr 23, 2025)
+
+name = "gpt-image-1"
+release_date = "2025-04-23"
+last_updated = "2025-04-23"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]


### PR DESCRIPTION
## Summary
- Add OpenAI gpt-image-1, gpt-image-1-mini, and gpt-image-1.5 model definitions
- Per-image pricing omitted to match existing repository patterns (dall-e-3, imagen-4)
- `family` field omitted as `gpt-image` is not yet in the schema enum

Split from #580.