### PR TITLE
fix: Increase output limit to match context for kimi K2.5 on Together

### DIFF
--- a/providers/togetherai/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/togetherai/models/moonshotai/Kimi-K2.5.toml
@@ -16,7 +16,7 @@ output = 2.80
 
 [limit]
 context = 262_144
-output = 32_768
+output = 262_144
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
Update providers/togetherai/models/moonshotai/Kimi-K2.5.toml to set [limit].output from 32_768 to 262_144. This aligns the output token limit with the context size (262_144) to avoid premature truncation and allow full-length responses.