### PR TITLE
Add Google Imagen 4.0 models and Vertex symlinks

### DIFF
--- a/providers/google-vertex/models/imagen-4.0-fast-generate-001.toml
+++ b/providers/google-vertex/models/imagen-4.0-fast-generate-001.toml
@@ -1,0 +1,1 @@
+../../google/models/imagen-4.0-fast-generate-001.toml

--- a/providers/google-vertex/models/imagen-4.0-generate-001.toml
+++ b/providers/google-vertex/models/imagen-4.0-generate-001.toml
@@ -1,0 +1,1 @@
+../../google/models/imagen-4.0-generate-001.toml

--- a/providers/google-vertex/models/imagen-4.0-ultra-generate-001.toml
+++ b/providers/google-vertex/models/imagen-4.0-ultra-generate-001.toml
@@ -1,0 +1,1 @@
+../../google/models/imagen-4.0-ultra-generate-001.toml

--- a/providers/google/models/imagen-4.0-fast-generate-001.toml
+++ b/providers/google/models/imagen-4.0-fast-generate-001.toml
@@ -1,0 +1,21 @@
+name = "Imagen 4 Fast"
+family = "imagen"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# [cost]
+
+[limit]
+context = 480
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/google/models/imagen-4.0-fast-generate-001.toml
+++ b/providers/google/models/imagen-4.0-fast-generate-001.toml
@@ -1,11 +1,10 @@
 name = "Imagen 4 Fast"
 family = "imagen"
-release_date = "2025-06-01"
-last_updated = "2025-06-01"
+release_date = "2025-08-14"
+last_updated = "2025-08-14"
 attachment = false
 reasoning = false
 temperature = false
-knowledge = "2025-06"
 tool_call = false
 open_weights = false
 

--- a/providers/google/models/imagen-4.0-generate-001.toml
+++ b/providers/google/models/imagen-4.0-generate-001.toml
@@ -1,0 +1,21 @@
+name = "Imagen 4"
+family = "imagen"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# [cost]
+
+[limit]
+context = 480
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/google/models/imagen-4.0-generate-001.toml
+++ b/providers/google/models/imagen-4.0-generate-001.toml
@@ -1,11 +1,10 @@
 name = "Imagen 4"
 family = "imagen"
-release_date = "2025-06-01"
-last_updated = "2025-06-01"
+release_date = "2025-08-14"
+last_updated = "2025-08-14"
 attachment = false
 reasoning = false
 temperature = false
-knowledge = "2025-06"
 tool_call = false
 open_weights = false
 

--- a/providers/google/models/imagen-4.0-ultra-generate-001.toml
+++ b/providers/google/models/imagen-4.0-ultra-generate-001.toml
@@ -1,11 +1,10 @@
 name = "Imagen 4 Ultra"
 family = "imagen"
-release_date = "2025-06-01"
-last_updated = "2025-06-01"
+release_date = "2025-08-14"
+last_updated = "2025-08-14"
 attachment = false
 reasoning = false
 temperature = false
-knowledge = "2025-06"
 tool_call = false
 open_weights = false
 

--- a/providers/google/models/imagen-4.0-ultra-generate-001.toml
+++ b/providers/google/models/imagen-4.0-ultra-generate-001.toml
@@ -1,0 +1,21 @@
+name = "Imagen 4 Ultra"
+family = "imagen"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = false
+reasoning = false
+temperature = false
+knowledge = "2025-06"
+tool_call = false
+open_weights = false
+
+# Real pricing is per-image — omitted to match patterns in repository (see dall-e-3, imagen-4)
+# [cost]
+
+[limit]
+context = 480
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]


### PR DESCRIPTION
## Summary
- Add Imagen 4, Imagen 4 Fast, and Imagen 4 Ultra to the Google provider
- Add corresponding Google Vertex symlinks
- Follows existing imagen model patterns (Vercel, Poe providers already have these)

## Test plan
- [x] `bun validate` passes
- [x] Symlinks point to correct source files