### PR TITLE
Venice: Enable reasoning for GLM-4.7-Flash model

### DIFF
--- a/providers/venice/models/zai-org-glm-4.7-flash.toml
+++ b/providers/venice/models/zai-org-glm-4.7-flash.toml
@@ -1,12 +1,12 @@
 name = "GLM 4.7 Flash"
 family = "glm-flash"
 attachment = false
-reasoning = false
+reasoning = true
 tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-01-29"
-last_updated = "2026-01-30"
+last_updated = "2026-02-10"
 open_weights = true
 
 [cost]


### PR DESCRIPTION
Model got updated to enable reasoning.