### PR TITLE
add moonshotai kimi K2.5 to amazon-bedrock provider

### DIFF
--- a/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
+++ b/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2.5"
+release_date = "2026-02-06"
+last_updated = "2026-02-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+interleaved = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 3
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
This PR aims to add support for kimi k2.5 model recently released on Amazon Bedrock. #835

References:
https://aws.amazon.com/bedrock/pricing/