### PR TITLE
Add supported z.ai GLM models to cortecs

### DIFF
--- a/providers/cortecs/models/glm-4p5-air.toml
+++ b/providers/cortecs/models/glm-4p5-air.toml
@@ -1,0 +1,22 @@
+name = "GLM 4.5 Air"
+family = "glm-air"
+release_date = "2025-08-01"
+last_updated = "2025-08-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.22
+output = 1.34
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cortecs/models/glm-4p5.toml
+++ b/providers/cortecs/models/glm-4p5.toml
@@ -1,0 +1,25 @@
+name = "GLM 4.5"
+family = "glm"
+release_date = "2025-07-29"
+last_updated = "2025-07-29"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.67
+output = 2.46
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/cortecs/models/glm-4p7.toml
+++ b/providers/cortecs/models/glm-4p7.toml
@@ -1,0 +1,25 @@
+name = "GLM 4.7"
+family = "glm"
+release_date = "2025-12-22"
+last_updated = "2025-12-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.45
+output = 2.23
+
+[limit]
+context = 198_000
+output = 198_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
This PR adds the GLM 4.5-air, GLM 4.5 and GLM 4.7 models from cortecs to the database.
The prices were taken in EUR and converted to USD using the current exchange rate.