### PR TITLE
Add MiniMax models to cortecs

### DIFF
--- a/providers/cortecs/models/minimax-m2.toml
+++ b/providers/cortecs/models/minimax-m2.toml
@@ -1,0 +1,25 @@
+name = "MiniMax-M2"
+family = "minimax"
+release_date = "2025-10-27"
+last_updated = "2025-10-27"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-11"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.39
+output = 1.57
+
+[limit]
+context = 400_000
+output = 400_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/cortecs/models/minimax-m2p1.toml
+++ b/providers/cortecs/models/minimax-m2p1.toml
@@ -1,0 +1,24 @@
+name = "MiniMax-M2.1"
+family = "minimax"
+release_date = "2025-12-23"
+last_updated = "2025-12-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.34
+output = 1.34
+
+[limit]
+context = 196_000
+output = 196_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
Adding Minimax-2 and Minimax-2.1 models from cortecs.
Prices were taken in EUR and converted to USD at current exchange rate.