### PR TITLE
Add ZAI coding plan GLM-5 model

### DIFF
--- a/providers/zhipuai-coding-plan/models/glm-5.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5.toml
@@ -6,7 +6,6 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "none"
 open_weights = false
 
 [interleaved]

--- a/providers/zhipuai-coding-plan/models/glm-5.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5.toml
@@ -1,0 +1,27 @@
+name = "GLM-5"
+family = "glm"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "none"
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Description
Add GLM-5 model support to ZAI Coding Plan provider.

## Model Details
- **Name**: GLM-5
- **Provider**: Z.AI (ZhipuAI Coding Plan)
- **Release Date**: 2026-02-11
- **Context Window**: 204,800 tokens
- **Max Output**: 131,072 tokens

## Capabilities
- ✅ Reasoning support
- ✅ Tool calling
- ✅ Temperature control
- ❌ Attachments (not supported)
- ❌ Open Weights

## Notes
This PR adds the GLM-5 model configuration. Pricing and some details may need verification from Z.AI official documentation.

## Related
- Complements #854