### PR TITLE
Add GLM 4.7 Family and MiniMax M2.1 to Amazon Bedrock

### DIFF
--- a/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2.1"
+family = "minimax"
+release_date = "2025-12-23"
+last_updated = "2025-12-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
@@ -1,0 +1,22 @@
+name = "GLM-4.7-Flash"
+family = "glm-flash"
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.40
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/zai.glm-4.7.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7.toml
@@ -1,0 +1,25 @@
+name = "GLM-4.7"
+family = "glm"
+release_date = "2025-12-22"
+last_updated = "2025-12-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.60
+output = 2.20
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
This PR adds three new models to the Amazon Bedrock provider:
- **GLM-4.7** (`zai.glm-4.7`)
- **GLM-4.7-Flash** (`zai.glm-4.7-flash`)
- **MiniMax M2.1** (`minimax.minimax-m2.1`)

## Models Added
| Model ID | Name | Input Cost | Output Cost | Context | Output |
|---|---|---|---|---|---|
| `zai.glm-4.7` | GLM-4.7 | $0.60 | $2.20 | 204,800 | 131,072 |
| `zai.glm-4.7-flash` | GLM-4.7-Flash | $0.07 | $0.40 | 200,000 | 131,072 |
| `minimax.minimax-m2.1` | MiniMax M2.1 | $0.30 | $1.20 | 204,800 | 131,072 |

## Sources
- **AWS Bedrock Pricing**: https://aws.amazon.com/bedrock/pricing/
- **AWS Bedrock Model IDs**: Confirmed via AWS console and supported models documentation https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html

## Related
- Implements additional models for [GH issue #835](https://github.com/anomalyco/models.dev/issues/835)