### PR TITLE
feat(github-copilot): add gpt-5.3-codex model

### DIFF
--- a/providers/github-copilot/models/gpt-5.3-codex.toml
+++ b/providers/github-copilot/models/gpt-5.3-codex.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.3-Codex"
+family = "gpt-codex"
+release_date = "2026-02-09"
+last_updated = "2026-02-09"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/github-copilot/models/gpt-5.3-codex.toml
+++ b/providers/github-copilot/models/gpt-5.3-codex.toml
@@ -1,7 +1,7 @@
 name = "GPT-5.3-Codex"
 family = "gpt-codex"
-release_date = "2026-02-09"
-last_updated = "2026-02-09"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
 attachment = false
 reasoning = true
 temperature = false


### PR DESCRIPTION
## Summary
- add `providers/github-copilot/models/gpt-5.3-codex.toml`
- mirror capabilities/limits/cost structure from existing `gpt-5.2-codex` Copilot entry
- align metadata with existing repo conventions:
  - `release_date` / `last_updated` set to `2026-02-05` (model release date)
  - Copilot GA/rollout date (`2026-02-09`) is channel availability, not model release metadata
- keep `knowledge = 2025-08-31` and `limit = 272k/128k`, consistent with existing OpenAI/Copilot GPT-5.2+ codex entries

## Validation
- ran `bun validate`

## Context
- supports downstream consumers (including OpenCode) that source GitHub Copilot model catalogs from `models.dev` https://github.com/anomalyco/opencode/issues/12954