### PR TITLE
Add GLM-5 model to ZAI Coding Plan provider

### DIFF
--- a/providers/zai-coding-plan/models/glm-5.toml
+++ b/providers/zai-coding-plan/models/glm-5.toml
@@ -1,0 +1,26 @@
+name = "GLM-5"
+family = "glm"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Description

Add GLM-5 model to the `zai-coding-plan` provider. The model was added to `zhipuai-coding-plan` in #855, but was missing from the international Z.AI provider as noted in [this comment](https://github.com/anomalyco/models.dev/pull/855#issuecomment-3885929943).

   ## Model Details
   - **Name**: GLM-5
   - **Provider**: Z.AI Coding Plan
   - **Release Date**: 2026-02-11
   - **Context Window**: 204,800 tokens
   - **Max Output**: 131,072 tokens

   ## Capabilities
   - ✅ Reasoning support
   - ✅ Tool calling
   - ✅ Temperature control
   - ❌ Attachments
   - ❌ Open weights

   ## Related
   - Follows up on #855
   - Reference: https://github.com/anomalyco/models.dev/pull/855#issuecomment-3885929943"
   - Comment: https://github.com/anomalyco/opencode/issues/13169#issuecomment-3886068704
