### PR TITLE
feat(huggingface): add GLM-5 for Hugging Face provider

### DIFF
--- a/providers/huggingface/models/zai-org/GLM-5.toml
+++ b/providers/huggingface/models/zai-org/GLM-5.toml
@@ -1,0 +1,25 @@
+name = "GLM-5"
+family = "glm"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_details"
+
+[cost]
+input = 1.00
+output = 3.20
+cache_read = 0.20
+
+[limit]
+context = 202_752
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Hello 👋 one of the maintainers of Hugging Face Inference Providers here. 

This PR adds metadata for GLM-5 (744B MoE, 40B active, MIT License) to Hugging Face provider.
Information taken from the official GLM-5 [blogpost](https://z.ai/blog/glm-5): 
- 202.8K context window, 131K max output tokens
- Pricing: $1.00 input, $3.20 output, $0.20 cached input
- Reasoning and tool calling enabled

cc @gary149 