### PR TITLE
Add Kimi K2.5 models to NanoGPT provider

### DIFF
--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5-thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5-thinking.toml
@@ -1,0 +1,25 @@
+name = "Kimi K2.5 Thinking"
+family = "kimi"
+release_date = "2026-01-26"
+last_updated = "2026-02-11"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.30
+output = 1.90
+
+[limit]
+context = 256000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5-thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5-thinking.toml
@@ -1,7 +1,7 @@
 name = "Kimi K2.5 Thinking"
 family = "kimi"
 release_date = "2026-01-26"
-last_updated = "2026-02-11"
+last_updated = "2026-01-26"
 attachment = true
 reasoning = true
 temperature = true

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5-thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5-thinking.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
@@ -3,11 +3,14 @@ family = "kimi"
 release_date = "2026-01-26"
 last_updated = "2026-01-26"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
 open_weights = true
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.30

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2026-01-26"
+last_updated = "2026-02-11"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = false
+
+[cost]
+input = 0.30
+output = 1.90
+
+[limit]
+context = 256000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
@@ -7,7 +7,7 @@ reasoning = false
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.30

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
@@ -1,7 +1,7 @@
 name = "Kimi K2.5"
 family = "kimi"
 release_date = "2026-01-26"
-last_updated = "2026-02-11"
+last_updated = "2026-01-26"
 attachment = true
 reasoning = false
 temperature = true


### PR DESCRIPTION
# Description
 Adds the Kimi K2.5 and Kimi K2.5:thinking models to the NanoGPT Provider

# Model Details
- Name: `Kimi K2.5` & `Kimi K2.5 Thinking`
- Provider: NanoGPT
- Release Date: 2026-01-26
- Context Window: 256,000 tokens
- Max Output: 65536 tokens
- Supports: Reasoning (thinking model only), tool calling, parallel tool calling (thinking model only) , temperature, attachment

Metadata taken directly from the `https://nano-gpt.com/api/v1/models` API


Tested with both `bun validate` and `bun run dev`