### PR TITLE
feat(provider): Vercel model file generation and update script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "validate": "bun ./packages/core/script/validate.ts",
     "helicone:generate": "bun ./packages/core/script/generate-helicone.ts",
-    "venice:generate": "bun ./packages/core/script/generate-venice.ts"
+    "venice:generate": "bun ./packages/core/script/generate-venice.ts",
+    "vercel:generate": "bun ./packages/core/script/generate-vercel.ts"
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.20250801.0",

--- a/packages/core/script/generate-vercel.ts
+++ b/packages/core/script/generate-vercel.ts
@@ -1,0 +1,467 @@
+#!/usr/bin/env bun
+
+import { z } from "zod";
+import path from "node:path";
+import { mkdir } from "node:fs/promises";
+import { ModelFamilyValues } from "../src/family.js";
+
+const API_ENDPOINT = "https://ai-gateway.vercel.sh/v1/models";
+
+const PricingTier = z.object({
+  cost: z.string(),
+  min: z.number(),
+  max: z.number().optional(),
+});
+
+const Pricing = z.object({
+  input: z.string().optional(),
+  output: z.string().optional(),
+  cache_read: z.string().optional(),
+  cache_write: z.string().optional(),
+  input_tiers: z.array(PricingTier).optional(),
+  output_tiers: z.array(PricingTier).optional(),
+}).passthrough();
+
+const VercelModel = z.object({
+  id: z.string(),
+  name: z.string(),
+  created: z.number(),
+  released: z.number().optional(),
+  context_window: z.number(),
+  max_tokens: z.number(),
+  tags: z.array(z.string()).optional().default([]),
+  pricing: Pricing.optional(),
+}).passthrough();
+
+const VercelResponse = z.object({
+  data: z.array(VercelModel),
+}).passthrough();
+
+function formatNumber(n: number): string {
+  if (n >= 1000) {
+    return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, "_");
+  }
+  return n.toString();
+}
+
+function timestampToDate(timestamp: number): string {
+  const date = new Date(timestamp * 1000);
+  return date.toISOString().slice(0, 10);
+}
+
+function getTodayDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function matchesFamily(target: string, family: string): boolean {
+  const targetLower = target.toLowerCase();
+  const familyLower = family.toLowerCase();
+  let familyIdx = 0;
+
+  for (let i = 0; i < targetLower.length && familyIdx < familyLower.length; i++) {
+    if (targetLower[i] === familyLower[familyIdx]) {
+      familyIdx++;
+    }
+  }
+
+  return familyIdx === familyLower.length;
+}
+
+function inferFamily(modelId: string, modelName: string): string | undefined {
+  const sortedFamilies = [...ModelFamilyValues].sort((a, b) => b.length - a.length);
+
+  for (const family of sortedFamilies) {
+    if (matchesFamily(modelId, family)) {
+      return family;
+    }
+  }
+
+  for (const family of sortedFamilies) {
+    if (matchesFamily(modelName, family)) {
+      return family;
+    }
+  }
+
+  return undefined;
+}
+
+function buildInputModalities(tags: string[]): string[] {
+  const mods: string[] = ["text"];
+  const tagSet = new Set(tags);
+
+  if (tagSet.has("vision")) mods.push("image");
+  if (tagSet.has("file-input")) mods.push("pdf");
+
+  return mods;
+}
+
+interface ExistingModel {
+  name?: string;
+  family?: string;
+  attachment?: boolean;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  structured_output?: boolean;
+  temperature?: boolean;
+  knowledge?: string;
+  release_date?: string;
+  last_updated?: string;
+  open_weights?: boolean;
+  interleaved?: boolean | { field: string };
+  status?: string;
+  cost?: {
+    input?: number;
+    output?: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
+  limit?: {
+    context?: number;
+    output?: number;
+  };
+  modalities?: {
+    input?: string[];
+    output?: string[];
+  };
+}
+
+interface MergedModel {
+  name: string;
+  family?: string;
+  attachment: boolean;
+  reasoning: boolean;
+  tool_call: boolean;
+  structured_output?: boolean;
+  temperature: boolean;
+  knowledge?: string;
+  release_date: string;
+  last_updated: string;
+  open_weights: boolean;
+  interleaved?: boolean | { field: string };
+  status?: string;
+  cost?: {
+    input: number;
+    output: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
+  limit: {
+    context: number;
+    output: number;
+  };
+  modalities: {
+    input: string[];
+    output: string[];
+  };
+}
+
+async function loadExistingModel(filePath: string): Promise<ExistingModel | null> {
+  try {
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) {
+      return null;
+    }
+    const toml = await import(filePath, { with: { type: "toml" } }).then(
+      (mod) => mod.default,
+    );
+    return toml as ExistingModel;
+  } catch (e) {
+    console.warn(`Warning: Failed to parse existing file ${filePath}:`, e);
+    return null;
+  }
+}
+
+function mergeModel(
+  apiModel: z.infer<typeof VercelModel>,
+  existing: ExistingModel | null,
+): MergedModel {
+  const tagSet = new Set(apiModel.tags);
+  const inputModalities = buildInputModalities(apiModel.tags);
+
+  const attachment = tagSet.has("vision") || tagSet.has("file-input");
+  const releaseDate = apiModel.released
+    ? timestampToDate(apiModel.released)
+    : timestampToDate(apiModel.created);
+
+  const merged: MergedModel = {
+    name: apiModel.name,
+    attachment,
+    reasoning: tagSet.has("reasoning"),
+    tool_call: tagSet.has("tool-use"),
+    temperature: true,
+    release_date: releaseDate,
+    last_updated: getTodayDate(),
+    open_weights: false,
+    limit: {
+      context: apiModel.context_window,
+      output: apiModel.max_tokens,
+    },
+    modalities: {
+      input: inputModalities,
+      output: ["text"],
+    },
+  };
+
+  if (tagSet.has("structured-output")) {
+    merged.structured_output = true;
+  }
+
+  if (apiModel.pricing?.input && apiModel.pricing?.output) {
+    merged.cost = {
+      input: parseFloat(apiModel.pricing.input) * 1_000_000,
+      output: parseFloat(apiModel.pricing.output) * 1_000_000,
+      ...(apiModel.pricing.cache_read && {
+        cache_read: parseFloat(apiModel.pricing.cache_read) * 1_000_000,
+      }),
+      ...(apiModel.pricing.cache_write && {
+        cache_write: parseFloat(apiModel.pricing.cache_write) * 1_000_000,
+      }),
+    };
+  }
+
+  const inferred = inferFamily(apiModel.id, apiModel.name);
+  merged.family = inferred ?? existing?.family;
+
+  if (existing?.knowledge) {
+    merged.knowledge = existing.knowledge;
+  }
+  if (existing?.interleaved !== undefined) {
+    merged.interleaved = existing.interleaved;
+  }
+  if (existing?.status !== undefined) {
+    merged.status = existing.status;
+  }
+
+  return merged;
+}
+
+function formatToml(model: MergedModel): string {
+  const lines: string[] = [];
+
+  lines.push(`name = "${model.name.replace(/"/g, '\\"')}"`);
+  if (model.family) {
+    lines.push(`family = "${model.family}"`);
+  }
+  lines.push(`attachment = ${model.attachment}`);
+  lines.push(`reasoning = ${model.reasoning}`);
+  lines.push(`tool_call = ${model.tool_call}`);
+  if (model.structured_output !== undefined) {
+    lines.push(`structured_output = ${model.structured_output}`);
+  }
+  lines.push(`temperature = ${model.temperature}`);
+  if (model.knowledge) {
+    lines.push(`knowledge = "${model.knowledge}"`);
+  }
+  lines.push(`release_date = "${model.release_date}"`);
+  lines.push(`last_updated = "${model.last_updated}"`);
+  lines.push(`open_weights = ${model.open_weights}`);
+  if (model.status) {
+    lines.push(`status = "${model.status}"`);
+  }
+
+  if (model.interleaved !== undefined) {
+    lines.push("");
+    if (model.interleaved === true) {
+      lines.push(`interleaved = true`);
+    } else if (typeof model.interleaved === "object") {
+      lines.push(`[interleaved]`);
+      lines.push(`field = "${model.interleaved.field}"`);
+    }
+  }
+
+  if (model.cost) {
+    lines.push("");
+    lines.push(`[cost]`);
+    lines.push(`input = ${model.cost.input}`);
+    lines.push(`output = ${model.cost.output}`);
+    if (model.cost.cache_read !== undefined) {
+      lines.push(`cache_read = ${model.cost.cache_read}`);
+    }
+    if (model.cost.cache_write !== undefined) {
+      lines.push(`cache_write = ${model.cost.cache_write}`);
+    }
+  }
+
+  lines.push("");
+  lines.push(`[limit]`);
+  lines.push(`context = ${formatNumber(model.limit.context)}`);
+  lines.push(`output = ${formatNumber(model.limit.output)}`);
+
+  lines.push("");
+  lines.push(`[modalities]`);
+  lines.push(`input = [${model.modalities.input.map((m) => `"${m}"`).join(", ")}]`);
+  lines.push(`output = [${model.modalities.output.map((m) => `"${m}"`).join(", ")}]`);
+
+  return lines.join("\n") + "\n";
+}
+
+interface Changes {
+  field: string;
+  oldValue: string;
+  newValue: string;
+}
+
+function detectChanges(
+  existing: ExistingModel | null,
+  merged: MergedModel,
+): Changes[] {
+  if (!existing) return [];
+
+  const changes: Changes[] = [];
+
+  const formatValue = (val: unknown): string => {
+    if (typeof val === "number") return formatNumber(val);
+    if (Array.isArray(val)) return `[${val.join(", ")}]`;
+    if (val === undefined) return "(none)";
+    return String(val);
+  };
+
+  const compare = (field: string, oldVal: unknown, newVal: unknown) => {
+    const oldStr = JSON.stringify(oldVal);
+    const newStr = JSON.stringify(newVal);
+    if (oldStr !== newStr) {
+      changes.push({
+        field,
+        oldValue: formatValue(oldVal),
+        newValue: formatValue(newVal),
+      });
+    }
+  };
+
+  compare("name", existing.name, merged.name);
+  compare("family", existing.family, merged.family);
+  compare("attachment", existing.attachment, merged.attachment);
+  compare("reasoning", existing.reasoning, merged.reasoning);
+  compare("tool_call", existing.tool_call, merged.tool_call);
+  compare("structured_output", existing.structured_output, merged.structured_output);
+  compare("open_weights", existing.open_weights, merged.open_weights);
+  compare("release_date", existing.release_date, merged.release_date);
+  compare("cost.input", existing.cost?.input, merged.cost?.input);
+  compare("cost.output", existing.cost?.output, merged.cost?.output);
+  compare("cost.cache_read", existing.cost?.cache_read, merged.cost?.cache_read);
+  compare("cost.cache_write", existing.cost?.cache_write, merged.cost?.cache_write);
+  compare("limit.context", existing.limit?.context, merged.limit.context);
+  compare("limit.output", existing.limit?.output, merged.limit.output);
+  compare("modalities.input", existing.modalities?.input, merged.modalities.input);
+
+  return changes;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+
+  const modelsDir = path.join(
+    import.meta.dirname,
+    "..",
+    "..",
+    "..",
+    "providers",
+    "vercel",
+    "models",
+  );
+
+  console.log(`${dryRun ? "[DRY RUN] " : ""}Fetching Vercel models from API...`);
+
+  const res = await fetch(API_ENDPOINT);
+  if (!res.ok) {
+    console.error(`Failed to fetch API: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+
+  const json = await res.json();
+  const parsed = VercelResponse.safeParse(json);
+  if (!parsed.success) {
+    console.error("Invalid API response:", parsed.error.errors);
+    process.exit(1);
+  }
+
+  const apiModels = parsed.data.data;
+
+  const existingFiles = new Set<string>();
+  try {
+    for await (const file of new Bun.Glob("**/*.toml").scan({
+      cwd: modelsDir,
+      absolute: false,
+    })) {
+      existingFiles.add(file);
+    }
+  } catch {
+  }
+
+  console.log(`Found ${apiModels.length} models in API, ${existingFiles.size} existing files\n`);
+
+  const apiModelIds = new Set<string>();
+
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+
+  for (const apiModel of apiModels) {
+    const relativePath = `${apiModel.id}.toml`;
+    const filePath = path.join(modelsDir, relativePath);
+    const dirPath = path.dirname(filePath);
+
+    apiModelIds.add(relativePath);
+
+    const existing = await loadExistingModel(filePath);
+    const merged = mergeModel(apiModel, existing);
+    const tomlContent = formatToml(merged);
+
+    if (existing === null) {
+      created++;
+      if (dryRun) {
+        console.log(`[DRY RUN] Would create: ${relativePath}`);
+        console.log(`  name = "${merged.name}"`);
+        if (merged.family) {
+          console.log(`  family = "${merged.family}" (inferred)`);
+        }
+        console.log("");
+      } else {
+        await mkdir(dirPath, { recursive: true });
+        await Bun.write(filePath, tomlContent);
+        console.log(`Created: ${relativePath}`);
+      }
+    } else {
+      const changes = detectChanges(existing, merged);
+
+      if (changes.length > 0) {
+        updated++;
+        if (dryRun) {
+          console.log(`[DRY RUN] Would update: ${relativePath}`);
+        } else {
+          await mkdir(dirPath, { recursive: true });
+          await Bun.write(filePath, tomlContent);
+          console.log(`Updated: ${relativePath}`);
+        }
+        for (const change of changes) {
+          console.log(`  ${change.field}: ${change.oldValue} → ${change.newValue}`);
+        }
+        console.log("");
+      } else {
+        unchanged++;
+      }
+    }
+  }
+
+  const orphaned: string[] = [];
+  for (const file of existingFiles) {
+    if (!apiModelIds.has(file)) {
+      orphaned.push(file);
+      console.log(`Warning: Orphaned file (not in API): ${file}`);
+    }
+  }
+
+  console.log("");
+  if (dryRun) {
+    console.log(
+      `Summary: ${created} would be created, ${updated} would be updated, ${unchanged} unchanged, ${orphaned.length} orphaned`,
+    );
+  } else {
+    console.log(
+      `Summary: ${created} created, ${updated} updated, ${unchanged} unchanged, ${orphaned.length} orphaned`,
+    );
+  }
+}
+
+await main();

--- a/packages/core/script/generate-vercel.ts
+++ b/packages/core/script/generate-vercel.ts
@@ -1,11 +1,26 @@
 #!/usr/bin/env bun
 
+/**
+ * Generates Vercel model TOML files from the AI Gateway API.
+ *
+ * Flags:
+ * --dry-run: Preview changes without writing files
+ * --new-only: Only create new models, skip updating existing ones
+ */
+
 import { z } from "zod";
 import path from "node:path";
 import { mkdir } from "node:fs/promises";
 import { ModelFamilyValues } from "../src/family.js";
 
 const API_ENDPOINT = "https://ai-gateway.vercel.sh/v1/models";
+
+enum ModelType {
+  Language = "language",
+  Image = "image",
+  Video = "video",
+  Embedding = "embedding",
+}
 
 const PricingTier = z.object({
   cost: z.string(),
@@ -29,6 +44,7 @@ const VercelModel = z.object({
   released: z.number().optional(),
   context_window: z.number(),
   max_tokens: z.number(),
+  type: z.nativeEnum(ModelType),
   tags: z.array(z.string()).optional().default([]),
   pricing: Pricing.optional(),
 }).passthrough();
@@ -53,6 +69,10 @@ function getTodayDate(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+function isSubstring(target: string, family: string): boolean {
+  return target.toLowerCase().includes(family.toLowerCase());
+}
+
 function matchesFamily(target: string, family: string): boolean {
   const targetLower = target.toLowerCase();
   const familyLower = family.toLowerCase();
@@ -70,6 +90,20 @@ function matchesFamily(target: string, family: string): boolean {
 function inferFamily(modelId: string, modelName: string): string | undefined {
   const sortedFamilies = [...ModelFamilyValues].sort((a, b) => b.length - a.length);
 
+  // First pass: try exact substring matches
+  for (const family of sortedFamilies) {
+    if (isSubstring(modelId, family)) {
+      return family;
+    }
+  }
+
+  for (const family of sortedFamilies) {
+    if (isSubstring(modelName, family)) {
+      return family;
+    }
+  }
+
+  // Second pass: fall back to subsequence matching
   for (const family of sortedFamilies) {
     if (matchesFamily(modelId, family)) {
       return family;
@@ -178,32 +212,57 @@ function mergeModel(
   const tagSet = new Set(apiModel.tags);
   const inputModalities = buildInputModalities(apiModel.tags);
 
-  const attachment = tagSet.has("vision") || tagSet.has("file-input");
+  // Preserve existing values when available  
+  const name = existing?.name ?? apiModel.name;
+  const attachment = existing?.attachment ?? (tagSet.has("vision") || tagSet.has("file-input"));
+  const reasoning = existing?.reasoning ?? tagSet.has("reasoning");
+  const toolCall = existing?.tool_call ?? tagSet.has("tool-use");
+  const openWeights = existing?.open_weights ?? false;
+
+  // Use API, fallback to existing, then today
   const releaseDate = apiModel.released
     ? timestampToDate(apiModel.released)
-    : timestampToDate(apiModel.created);
+    : (existing?.release_date ?? getTodayDate());
+
+  // Preserve existing if API returns 0 (indicates missing/invalid data)
+  const contextLimit = apiModel.context_window > 0
+    ? apiModel.context_window
+    : (existing?.limit?.context ?? 0);
+  const outputLimit = apiModel.max_tokens > 0
+    ? apiModel.max_tokens
+    : (existing?.limit?.output ?? 0);
+
+  // Deduce output modalities from model type
+  const outputModalities: string[] = ["text"];
+  if (apiModel.type === ModelType.Image) {
+    outputModalities.push("image");
+  } else if (apiModel.type === ModelType.Video) {
+    outputModalities.push("video");
+  }
 
   const merged: MergedModel = {
-    name: apiModel.name,
+    name,
     attachment,
-    reasoning: tagSet.has("reasoning"),
-    tool_call: tagSet.has("tool-use"),
+    reasoning,
+    tool_call: toolCall,
     temperature: true,
     release_date: releaseDate,
     last_updated: getTodayDate(),
-    open_weights: false,
+    open_weights: openWeights,
     limit: {
-      context: apiModel.context_window,
-      output: apiModel.max_tokens,
+      context: contextLimit,
+      output: outputLimit,
     },
     modalities: {
       input: inputModalities,
-      output: ["text"],
+      output: outputModalities,
     },
   };
 
   if (tagSet.has("structured-output")) {
     merged.structured_output = true;
+  } else if (existing?.structured_output !== undefined) {
+    merged.structured_output = existing.structured_output;
   }
 
   if (apiModel.pricing?.input && apiModel.pricing?.output) {
@@ -219,8 +278,7 @@ function mergeModel(
     };
   }
 
-  const inferred = inferFamily(apiModel.id, apiModel.name);
-  merged.family = inferred ?? existing?.family;
+  merged.family = existing?.family ?? inferFamily(apiModel.id, apiModel.name);
 
   if (existing?.knowledge) {
     merged.knowledge = existing.knowledge;
@@ -301,6 +359,11 @@ interface Changes {
   newValue: string;
 }
 
+enum SkipZeroFields {
+  LimitContext = "limit.context",
+  LimitOutput = "limit.output",
+}
+
 function detectChanges(
   existing: ExistingModel | null,
   merged: MergedModel,
@@ -308,6 +371,14 @@ function detectChanges(
   if (!existing) return [];
 
   const changes: Changes[] = [];
+  const EPSILON = 0.0001;
+
+  const shouldSkipZero = (field: string, oldVal: unknown, newVal: unknown): boolean => {
+    if (!Object.values(SkipZeroFields).includes(field as SkipZeroFields)) {
+      return false;
+    }
+    return (typeof oldVal === "number" && oldVal === 0) || (typeof newVal === "number" && newVal === 0);
+  };
 
   const formatValue = (val: unknown): string => {
     if (typeof val === "number") return formatNumber(val);
@@ -316,10 +387,21 @@ function detectChanges(
     return String(val);
   };
 
+  const isMaterialPriceDiff = (oldPrice: unknown, newPrice: unknown): boolean => {
+    // 0 → undefined is not material (cost removed)
+    // undefined → 0 is material (cost added)
+    if (oldPrice === 0 && newPrice === undefined) return false;
+
+    if (typeof oldPrice === "number" && typeof newPrice === "number") {
+      return Math.abs(oldPrice - newPrice) > EPSILON;
+    }
+    return JSON.stringify(oldPrice) !== JSON.stringify(newPrice);
+  };
+
   const compare = (field: string, oldVal: unknown, newVal: unknown) => {
-    const oldStr = JSON.stringify(oldVal);
-    const newStr = JSON.stringify(newVal);
-    if (oldStr !== newStr) {
+    if (shouldSkipZero(field, oldVal, newVal)) return;
+
+    if (isMaterialPriceDiff(oldVal, newVal)) {
       changes.push({
         field,
         oldValue: formatValue(oldVal),
@@ -350,6 +432,7 @@ function detectChanges(
 async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes("--dry-run");
+  const newOnly = args.includes("--new-only");
 
   const modelsDir = path.join(
     import.meta.dirname,
@@ -361,7 +444,7 @@ async function main() {
     "models",
   );
 
-  console.log(`${dryRun ? "[DRY RUN] " : ""}Fetching Vercel models from API...`);
+  console.log(`${dryRun ? "[DRY RUN] " : ""}${newOnly ? "[NEW ONLY] " : ""}Fetching Vercel models from API...`);
 
   const res = await fetch(API_ENDPOINT);
   if (!res.ok) {
@@ -423,6 +506,11 @@ async function main() {
         console.log(`Created: ${relativePath}`);
       }
     } else {
+      if (newOnly) {
+        unchanged++;
+        continue;
+      }
+
       const changes = detectChanges(existing, merged);
 
       if (changes.length > 0) {

--- a/packages/core/script/generate-vercel.ts
+++ b/packages/core/script/generate-vercel.ts
@@ -17,9 +17,14 @@ const API_ENDPOINT = "https://ai-gateway.vercel.sh/v1/models";
 
 enum ModelType {
   Language = "language",
+  Embedding = "embedding",
   Image = "image",
   Video = "video",
-  Embedding = "embedding",
+}
+
+enum SkipZeroFields {
+  LimitContext = "limit.context",
+  LimitOutput = "limit.output",
 }
 
 const PricingTier = z.object({
@@ -31,10 +36,12 @@ const PricingTier = z.object({
 const Pricing = z.object({
   input: z.string().optional(),
   output: z.string().optional(),
-  cache_read: z.string().optional(),
-  cache_write: z.string().optional(),
+  input_cache_read: z.string().optional(),
+  input_cache_write: z.string().optional(),
   input_tiers: z.array(PricingTier).optional(),
   output_tiers: z.array(PricingTier).optional(),
+  input_cache_read_tiers: z.array(PricingTier).optional(),
+  input_cache_write_tiers: z.array(PricingTier).optional(),
 }).passthrough();
 
 const VercelModel = z.object({
@@ -53,11 +60,70 @@ const VercelResponse = z.object({
   data: z.array(VercelModel),
 }).passthrough();
 
-function formatNumber(n: number): string {
-  if (n >= 1000) {
-    return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, "_");
-  }
-  return n.toString();
+interface ExistingModel {
+  name?: string;
+  family?: string;
+  attachment?: boolean;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  structured_output?: boolean;
+  temperature?: boolean;
+  knowledge?: string;
+  release_date?: string;
+  last_updated?: string;
+  open_weights?: boolean;
+  interleaved?: boolean | { field: string };
+  status?: string;
+  cost?: {
+    input?: number;
+    output?: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
+  limit?: {
+    context?: number;
+    output?: number;
+  };
+  modalities?: {
+    input?: string[];
+    output?: string[];
+  };
+}
+
+interface MergedModel {
+  name: string;
+  family?: string;
+  attachment: boolean;
+  reasoning: boolean;
+  tool_call: boolean;
+  structured_output?: boolean;
+  temperature: boolean;
+  knowledge?: string;
+  release_date: string;
+  last_updated: string;
+  open_weights: boolean;
+  interleaved?: boolean | { field: string };
+  status?: string;
+  cost?: {
+    input: number;
+    output: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
+  limit: {
+    context: number;
+    output: number;
+  };
+  modalities: {
+    input: string[];
+    output: string[];
+  };
+}
+
+interface Changes {
+  field: string;
+  oldValue: string;
+  newValue: string;
 }
 
 function timestampToDate(timestamp: number): string {
@@ -67,6 +133,14 @@ function timestampToDate(timestamp: number): string {
 
 function getTodayDate(): string {
   return new Date().toISOString().slice(0, 10);
+}
+
+// Number utilities
+function formatNumber(n: number): string {
+  if (n >= 1000) {
+    return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, "_");
+  }
+  return n.toString();
 }
 
 function isSubstring(target: string, family: string): boolean {
@@ -129,64 +203,17 @@ function buildInputModalities(tags: string[]): string[] {
   return mods;
 }
 
-interface ExistingModel {
-  name?: string;
-  family?: string;
-  attachment?: boolean;
-  reasoning?: boolean;
-  tool_call?: boolean;
-  structured_output?: boolean;
-  temperature?: boolean;
-  knowledge?: string;
-  release_date?: string;
-  last_updated?: string;
-  open_weights?: boolean;
-  interleaved?: boolean | { field: string };
-  status?: string;
-  cost?: {
-    input?: number;
-    output?: number;
-    cache_read?: number;
-    cache_write?: number;
-  };
-  limit?: {
-    context?: number;
-    output?: number;
-  };
-  modalities?: {
-    input?: string[];
-    output?: string[];
-  };
-}
+function buildOutputModalities(modelType: ModelType, tags: string[]): string[] {
+  const mods: string[] = ["text"];
+  const tagSet = new Set(tags);
 
-interface MergedModel {
-  name: string;
-  family?: string;
-  attachment: boolean;
-  reasoning: boolean;
-  tool_call: boolean;
-  structured_output?: boolean;
-  temperature: boolean;
-  knowledge?: string;
-  release_date: string;
-  last_updated: string;
-  open_weights: boolean;
-  interleaved?: boolean | { field: string };
-  status?: string;
-  cost?: {
-    input: number;
-    output: number;
-    cache_read?: number;
-    cache_write?: number;
-  };
-  limit: {
-    context: number;
-    output: number;
-  };
-  modalities: {
-    input: string[];
-    output: string[];
-  };
+  if (modelType === ModelType.Image || tagSet.has("image-generation")) {
+    mods.push("image");
+  } else if (modelType === ModelType.Video) {
+    mods.push("video");
+  }
+
+  return mods;
 }
 
 async function loadExistingModel(filePath: string): Promise<ExistingModel | null> {
@@ -211,20 +238,26 @@ function mergeModel(
 ): MergedModel {
   const tagSet = new Set(apiModel.tags);
   const inputModalities = buildInputModalities(apiModel.tags);
+  const outputModalities = buildOutputModalities(apiModel.type, apiModel.tags);
 
-  // Preserve existing values when available  
+  // Preserve existing values when available (previously manually specified)
   const name = existing?.name ?? apiModel.name;
   const attachment = existing?.attachment ?? (tagSet.has("vision") || tagSet.has("file-input"));
   const reasoning = existing?.reasoning ?? tagSet.has("reasoning");
   const toolCall = existing?.tool_call ?? tagSet.has("tool-use");
   const openWeights = existing?.open_weights ?? false;
+  const family = existing?.family ?? inferFamily(apiModel.id, apiModel.name);
+  const structuredOutput = existing?.structured_output;
+  const knowledge = existing?.knowledge;
+  const interleaved = existing?.interleaved;
+  const status = existing?.status;
 
-  // Use API, fallback to existing, then today
+  // Release date: use API, fallback to existing, then today
   const releaseDate = apiModel.released
     ? timestampToDate(apiModel.released)
     : (existing?.release_date ?? getTodayDate());
 
-  // Preserve existing if API returns 0 (indicates missing/invalid data)
+  // Preserve existing limits if API returns 0 (indicates missing/invalid data)
   const contextLimit = apiModel.context_window > 0
     ? apiModel.context_window
     : (existing?.limit?.context ?? 0);
@@ -232,16 +265,9 @@ function mergeModel(
     ? apiModel.max_tokens
     : (existing?.limit?.output ?? 0);
 
-  // Deduce output modalities from model type
-  const outputModalities: string[] = ["text"];
-  if (apiModel.type === ModelType.Image) {
-    outputModalities.push("image");
-  } else if (apiModel.type === ModelType.Video) {
-    outputModalities.push("video");
-  }
-
   const merged: MergedModel = {
     name,
+    family,
     attachment,
     reasoning,
     tool_call: toolCall,
@@ -249,6 +275,10 @@ function mergeModel(
     release_date: releaseDate,
     last_updated: getTodayDate(),
     open_weights: openWeights,
+    ...(structuredOutput !== undefined && { structured_output: structuredOutput }),
+    ...(knowledge && { knowledge }),
+    ...(interleaved !== undefined && { interleaved }),
+    ...(status && { status }),
     limit: {
       context: contextLimit,
       output: outputLimit,
@@ -259,35 +289,24 @@ function mergeModel(
     },
   };
 
-  if (tagSet.has("structured-output")) {
-    merged.structured_output = true;
-  } else if (existing?.structured_output !== undefined) {
-    merged.structured_output = existing.structured_output;
-  }
+  if (apiModel.pricing) {
+    const inputPrice = apiModel.pricing.input_tiers?.[0]?.cost ?? apiModel.pricing.input;
+    const outputPrice = apiModel.pricing.output_tiers?.[0]?.cost ?? apiModel.pricing.output;
+    const cacheReadPrice = apiModel.pricing.input_cache_read_tiers?.[0]?.cost ?? apiModel.pricing.input_cache_read;
+    const cacheWritePrice = apiModel.pricing.input_cache_write_tiers?.[0]?.cost ?? apiModel.pricing.input_cache_write;
 
-  if (apiModel.pricing?.input && apiModel.pricing?.output) {
-    merged.cost = {
-      input: parseFloat(apiModel.pricing.input) * 1_000_000,
-      output: parseFloat(apiModel.pricing.output) * 1_000_000,
-      ...(apiModel.pricing.cache_read && {
-        cache_read: parseFloat(apiModel.pricing.cache_read) * 1_000_000,
-      }),
-      ...(apiModel.pricing.cache_write && {
-        cache_write: parseFloat(apiModel.pricing.cache_write) * 1_000_000,
-      }),
-    };
-  }
-
-  merged.family = existing?.family ?? inferFamily(apiModel.id, apiModel.name);
-
-  if (existing?.knowledge) {
-    merged.knowledge = existing.knowledge;
-  }
-  if (existing?.interleaved !== undefined) {
-    merged.interleaved = existing.interleaved;
-  }
-  if (existing?.status !== undefined) {
-    merged.status = existing.status;
+    if (inputPrice && outputPrice) {
+      merged.cost = {
+        input: parseFloat(inputPrice) * 1_000_000,
+        output: parseFloat(outputPrice) * 1_000_000,
+        ...(cacheReadPrice && {
+          cache_read: parseFloat(cacheReadPrice) * 1_000_000,
+        }),
+        ...(cacheWritePrice && {
+          cache_write: parseFloat(cacheWritePrice) * 1_000_000,
+        }),
+      };
+    }
   }
 
   return merged;
@@ -353,17 +372,6 @@ function formatToml(model: MergedModel): string {
   return lines.join("\n") + "\n";
 }
 
-interface Changes {
-  field: string;
-  oldValue: string;
-  newValue: string;
-}
-
-enum SkipZeroFields {
-  LimitContext = "limit.context",
-  LimitOutput = "limit.output",
-}
-
 function detectChanges(
   existing: ExistingModel | null,
   merged: MergedModel,
@@ -371,7 +379,7 @@ function detectChanges(
   if (!existing) return [];
 
   const changes: Changes[] = [];
-  const EPSILON = 0.0001;
+  const EPSILON = 0.001; // price diff to ignore (per million tokens)
 
   const shouldSkipZero = (field: string, oldVal: unknown, newVal: unknown): boolean => {
     if (!Object.values(SkipZeroFields).includes(field as SkipZeroFields)) {
@@ -389,19 +397,23 @@ function detectChanges(
 
   const isMaterialPriceDiff = (oldPrice: unknown, newPrice: unknown): boolean => {
     // 0 → undefined is not material (cost removed)
-    // undefined → 0 is material (cost added)
     if (oldPrice === 0 && newPrice === undefined) return false;
 
-    if (typeof oldPrice === "number" && typeof newPrice === "number") {
-      return Math.abs(oldPrice - newPrice) > EPSILON;
+    if (oldPrice !== undefined && newPrice !== undefined) {
+      return Math.abs((oldPrice as number) - (newPrice as number)) > EPSILON;
     }
-    return JSON.stringify(oldPrice) !== JSON.stringify(newPrice);
+
+    return oldPrice !== newPrice;
   };
 
   const compare = (field: string, oldVal: unknown, newVal: unknown) => {
     if (shouldSkipZero(field, oldVal, newVal)) return;
 
-    if (isMaterialPriceDiff(oldVal, newVal)) {
+    const isDiff = field.startsWith("cost.")
+      ? isMaterialPriceDiff(oldVal, newVal)
+      : JSON.stringify(oldVal) !== JSON.stringify(newVal);
+
+    if (isDiff) {
       changes.push({
         field,
         oldValue: formatValue(oldVal),

--- a/providers/vercel/README.md
+++ b/providers/vercel/README.md
@@ -1,0 +1,22 @@
+Vercel AI Gateway Models
+
+Generate model TOMLs from Vercel AI Gateway API.
+
+Prerequisites
+- Install Bun: https://bun.sh
+
+Commands
+- Generate files: `bun run vercel:generate`
+- Dry run: `bun run vercel:generate --dry-run`
+- New only: `bun run vercel:generate --new-only`
+- Validate: `bun validate`
+
+Details
+- Source endpoint: `https://ai-gateway.vercel.sh/v1/models`
+- Output path: `providers/vercel/models/<model-id>.toml` (nested folders for IDs with `/`)
+
+Notes
+- The generator merges with existing files rather than replacing them
+- Orphaned files (not in API) are warned about but not deleted
+- Use `--dry-run` to preview changes before writing
+- Use `--new-only` to skip updating existing model files


### PR DESCRIPTION
## Context & Changes
Added new script for model .toml file generation for Vercel AI Gateway.

The command `vercel:generate` is capable of 
- **creating** new .toml files
- **updating** existing .toml files

It takes two optional flags `--dry-run`, `--new-only`. See added `README.md` for more details.
```
bun vercel:generate (--dry-run) (--new-only)
```

## Future Work
(will be in a separate PR) add a Github action to automatically run this command 
