### PR TITLE
Add GLM 5 to NanoGPT models list

### DIFF
--- a/providers/nano-gpt/models/zai-org/glm-5.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.toml
@@ -1,7 +1,7 @@
 name = "GLM 5"
 family = "glm"
-release_date = "2025-12-12"
-last_updated = "2025-12-12"
+release_date = "2025-02-11"
+last_updated = "2025-02-11"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/nano-gpt/models/zai-org/glm-5.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.toml
@@ -1,0 +1,26 @@
+name = "GLM 5"
+family = "glm"
+release_date = "2025-12-12"
+last_updated = "2025-12-12"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-06"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.80
+output = 2.56
+
+[limit]
+context = 200000
+output = 128000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nano-gpt/models/zai-org/glm-5:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5:thinking.toml
@@ -1,7 +1,7 @@
 name = "GLM 5 Thinking"
 family = "glm"
-release_date = "2025-12-12"
-last_updated = "2025-12-12"
+release_date = "2025-02-11"
+last_updated = "2025-02-11"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/nano-gpt/models/zai-org/glm-5:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5:thinking.toml
@@ -1,0 +1,26 @@
+name = "GLM 5 Thinking"
+family = "glm"
+release_date = "2025-12-12"
+last_updated = "2025-12-12"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-06"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.80
+output = 2.56
+
+[limit]
+context = 200000
+output = 128000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# Description
 Adds the GLM-5 and GLM-5:thinking models to the NanoGPT Provider

# Model Details
- Name: `GLM 5` & `GLM 5 Thinking`
- Provider: NanoGPT
- Release Date: 2026-02-11
- Context Window: 200,000 tokens
- Max Output: 128,000tokens
- Supports: Reasoning , tool calling, temperature, structured output

Metadata taken directly from the `https://nano-gpt.com/api/v1/models` API


Tested with both `bun validate` and `bun run dev`