### PR TITLE
feat: add StepFun Step 3.5 Flash on OpenRouter

### DIFF
--- a/providers/openrouter/models/stepfun/step-3.5-flash.toml
+++ b/providers/openrouter/models/stepfun/step-3.5-flash.toml
@@ -1,0 +1,23 @@
+name = "Step 3.5 Flash"
+family = "step"
+release_date = "2026-01-29"
+last_updated = "2026-01-29"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.02
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/stepfun/step-3.5-flash:free.toml
+++ b/providers/openrouter/models/stepfun/step-3.5-flash:free.toml
@@ -1,0 +1,22 @@
+name = "Step 3.5 Flash (free)"
+family = "step"
+release_date = "2026-01-29"
+last_updated = "2026-01-29"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add StepFun Step 3.5 Flash model and its free variant to OpenRouter provider
- Values sourced from the OpenRouter `/api/v1/models` API and model page
- Supersedes #778 with corrected values based on review feedback
- Pricing: $0.10/$0.30 input/output, cache read $0.02 (free variant: $0.00)
- Context: 256,000 tokens, max output: 256,000 tokens
- Modality: text→text only

## Test plan
- [x] `bun validate` passes successfully
- [x] Models appear in generated output with correct IDs `stepfun/step-3.5-flash` and `stepfun/step-3.5-flash:free`
- [x] No duplicate PR for these models