### PR TITLE
fix: reorganize STACKIT models with organization prefixes

### DIFF
--- a/providers/stackit/models/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8.toml
+++ b/providers/stackit/models/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8.toml
@@ -1,19 +1,20 @@
-name = "Gemma 3 27B"
-release_date = "2025-05-17"
-last_updated = "2025-05-17"
+name = "Qwen3-VL 235B"
+family = "qwen"
+release_date = "2024-11-01"
+last_updated = "2024-11-01"
 attachment = true
 reasoning = false
 temperature = true
-tool_call = false
+tool_call = true
 structured_output = false
 open_weights = true
 
 [cost]
-input = 0.53
-output = 0.77
+input = 1.64
+output = 1.91
 
 [limit]
-context = 37_000
+context = 218_000
 output = 8_192
 
 [modalities]

--- a/providers/stackit/models/Qwen/Qwen3-VL-Embedding-8B.toml
+++ b/providers/stackit/models/Qwen/Qwen3-VL-Embedding-8B.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-VL Embedding 8B"
+family = "qwen"
 release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true

--- a/providers/stackit/models/cortecs/Llama-3.3-70B-Instruct-FP8-Dynamic.toml
+++ b/providers/stackit/models/cortecs/Llama-3.3-70B-Instruct-FP8-Dynamic.toml
@@ -1,4 +1,5 @@
 name = "Llama 3.3 70B"
+family = "llama"
 release_date = "2024-12-05"
 last_updated = "2024-12-05"
 attachment = false
@@ -9,8 +10,8 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.53
-output = 0.77
+input = 0.49
+output = 0.71
 
 [limit]
 context = 128_000

--- a/providers/stackit/models/google/gemma-3-27b-it.toml
+++ b/providers/stackit/models/google/gemma-3-27b-it.toml
@@ -1,19 +1,20 @@
-name = "Qwen3-VL 235B"
-release_date = "2024-11-01"
-last_updated = "2024-11-01"
+name = "Gemma 3 27B"
+family = "gemma"
+release_date = "2025-05-17"
+last_updated = "2025-05-17"
 attachment = true
 reasoning = false
 temperature = true
-tool_call = true
+tool_call = false
 structured_output = false
 open_weights = true
 
 [cost]
-input = 1.77
-output = 2.07
+input = 0.49
+output = 0.71
 
 [limit]
-context = 218_000
+context = 37_000
 output = 8_192
 
 [modalities]

--- a/providers/stackit/models/intfloat/e5-mistral-7b-instruct.toml
+++ b/providers/stackit/models/intfloat/e5-mistral-7b-instruct.toml
@@ -1,4 +1,5 @@
 name = "E5 Mistral 7B"
+family = "mistral"
 release_date = "2023-12-11"
 last_updated = "2023-12-11"
 attachment = false

--- a/providers/stackit/models/neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8.toml
+++ b/providers/stackit/models/neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8.toml
@@ -1,4 +1,5 @@
 name = "Llama 3.1 8B"
+family = "llama"
 release_date = "2024-07-23"
 last_updated = "2024-07-23"
 attachment = false
@@ -9,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.18
-output = 0.30
+input = 0.16
+output = 0.27
 
 [limit]
 context = 128_000

--- a/providers/stackit/models/neuralmagic/Mistral-Nemo-Instruct-2407-FP8.toml
+++ b/providers/stackit/models/neuralmagic/Mistral-Nemo-Instruct-2407-FP8.toml
@@ -1,16 +1,17 @@
-name = "GPT-OSS 120B"
-release_date = "2025-08-05"
-last_updated = "2025-08-05"
+name = "Mistral Nemo"
+family = "mistral"
+release_date = "2024-07-01"
+last_updated = "2024-07-01"
 attachment = false
-reasoning = true
+reasoning = false
 temperature = true
 tool_call = true
 structured_output = false
 open_weights = true
 
 [cost]
-input = 0.53
-output = 0.77
+input = 0.49
+output = 0.71
 
 [limit]
 context = 128_000

--- a/providers/stackit/models/openai/gpt-oss-120b.toml
+++ b/providers/stackit/models/openai/gpt-oss-120b.toml
@@ -1,19 +1,20 @@
-name = "Mistral Nemo"
-release_date = "2024-07-01"
-last_updated = "2024-07-01"
+name = "GPT-OSS 120B"
+family = "gpt"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
 open_weights = true
 
 [cost]
-input = 0.53
-output = 0.77
+input = 0.49
+output = 0.71
 
 [limit]
-context = 128_000
+context = 131_000
 output = 8_192
 
 [modalities]


### PR DESCRIPTION
## Summary

This PR fixes the STACKIT provider model configurations with proper organization prefixes and updated pricing.

### Changes Made

**Model ID Updates:**
- Moved models to organization subfolders for proper model ID generation
- Model IDs now match STACKIT's actual format (e.g., `Qwen/Qwen3-VL-235B-A22B-Instruct-FP8`)


**Context & Feature Fixes:**
- GPT-OSS 120B: Context limit corrected to 131K tokens
- Added architectural family classifications (llama, mistral, gpt, gemma, qwen)
- Verified tool_call settings for all models
- Prices updated for selected models (in USD)

### Validation

All configurations pass `bun validate` successfully.