### PR TITLE
feat(nano-gpt): add MiniMax M2.5 Official model

### DIFF
--- a/providers/nano-gpt/models/minimax/minimax-m2.5-official.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.5-official.toml
@@ -1,0 +1,25 @@
+name = "MiniMax M2.5"
+family = "minimax"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add `minimax/minimax-m2.5-official` to NanoGPT model catalog.
- Configure limits, pricing, and capabilities for the official NanoGPT model ID.
- Keep schema and formatting aligned with existing NanoGPT model entries.