### PR TITLE
cloudflare-ai-gateway: bump Opus 4.6 output limit to 128k

### DIFF
--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
@@ -23,7 +23,7 @@ cache_write = 12.50
 
 [limit]
 context = 1_000_000
-output = 64_000
+output = 128_000
 
 [modalities]
 input = ["text", "image", "pdf"]


### PR DESCRIPTION
The output limit is actually 128k, rather than 64k like the other models.