### PR TITLE
feat(amazon-bedrock): add Writer Palmyra X4 and X5 models

### DIFF
--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -365,6 +365,9 @@ export const ModelFamilyValues = [
 
   // AllenAI
   "allenai",
+
+  // Writer
+  "palmyra",
 ] as const;
 
 export const ModelFamily = z.enum(ModelFamilyValues);

--- a/providers/amazon-bedrock/models/writer.palmyra-x4-v1:0.toml
+++ b/providers/amazon-bedrock/models/writer.palmyra-x4-v1:0.toml
@@ -1,0 +1,21 @@
+name = "Palmyra X4"
+family = "palmyra"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10
+
+[limit]
+context = 122_880
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/writer.palmyra-x5-v1:0.toml
+++ b/providers/amazon-bedrock/models/writer.palmyra-x5-v1:0.toml
@@ -1,0 +1,21 @@
+name = "Palmyra X5"
+family = "palmyra"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.6
+output = 6
+
+[limit]
+context = 1_040_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add two new Writer AI models to the Amazon Bedrock provider:

- writer.palmyra-x4-v1:0 (Palmyra X4): 128K context, 8K output, reasoning and tool calling, $2.50/$10 per M tokens (input/output)
- writer.palmyra-x5-v1:0 (Palmyra X5): 1M context, 8K output, reasoning and tool calling, $0.60/$6 per M tokens (input/output)

Both models support text-only input/output modalities and are closed-weight.

Also adds the 'palmyra' family to the ModelFamilyValues enum in packages/core/src/family.ts to support validation.