### PR TITLE
Add MiniMax-M2.5 across minimax and coding-plan providers

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M2.5.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M2.5.toml
@@ -1,7 +1,7 @@
-name = "MiniMax-M2.1"
+name = "MiniMax-M2.5"
 family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
 attachment = false
 reasoning = true
 temperature = true
@@ -9,10 +9,10 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.30
-output = 1.20
-cached_input = 0.03
-cached_write = 0.375
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
 
 [limit]
 context = 204_800

--- a/providers/minimax-cn/models/MiniMax-M2.5.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.5.toml
@@ -1,7 +1,7 @@
-name = "MiniMax-M2.1"
+name = "MiniMax-M2.5"
 family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
 attachment = false
 reasoning = true
 temperature = true
@@ -11,8 +11,8 @@ open_weights = true
 [cost]
 input = 0.30
 output = 1.20
-cached_input = 0.03
-cached_write = 0.375
+cache_read = 0.03
+cache_write = 0.375
 
 [limit]
 context = 204_800

--- a/providers/minimax-cn/models/MiniMax-M2.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.toml
@@ -1,1 +1,22 @@
-../../minimax/models/MiniMax-M2.toml
+name = "MiniMax-M2"
+family = "minimax"
+release_date = "2025-10-27"
+last_updated = "2025-10-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+# knowledge = "2025-04" # Not listed on model page.
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 196_608
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/minimax-coding-plan/models/MiniMax-M2.5.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M2.5.toml
@@ -1,7 +1,7 @@
-name = "MiniMax-M2.1"
+name = "MiniMax-M2.5"
 family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
 attachment = false
 reasoning = true
 temperature = true
@@ -9,10 +9,10 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.30
-output = 1.20
-cached_input = 0.03
-cached_write = 0.375
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
 
 [limit]
 context = 204_800

--- a/providers/minimax/models/MiniMax-M2.5.toml
+++ b/providers/minimax/models/MiniMax-M2.5.toml
@@ -1,7 +1,7 @@
-name = "MiniMax-M2.1"
+name = "MiniMax-M2.5"
 family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
 attachment = false
 reasoning = true
 temperature = true
@@ -11,8 +11,8 @@ open_weights = true
 [cost]
 input = 0.30
 output = 1.20
-cached_input = 0.03
-cached_write = 0.375
+cache_read = 0.03
+cache_write = 0.375
 
 [limit]
 context = 204_800


### PR DESCRIPTION
## Summary
- add MiniMax-M2.5 model config to providers/minimax/models
- add MiniMax-M2.5 model config to providers/minimax-coding-plan/models
- add MiniMax-M2.5 model config to providers/minimax-cn-coding-plan/models
- replace providers/minimax-cn/models symlinks with standalone files and add MiniMax-M2.5 there

## Validation
- ran bun validate successfully

## Sources
- https://platform.minimax.io/docs/guides/pricing
- https://platform.minimaxi.com/docs/guides/pricing
- https://platform.minimaxi.com/docs/overview/model-overview
- https://platform.minimaxi.com/docs/coding-plan/quickstart
- https://platform.minimaxi.com/docs/release-notes/models
