### PR TITLE
feat(nano-gpt): add MiniMax M2.5 route alongside official variant

### DIFF
--- a/providers/nano-gpt/models/minimax/minimax-m2.5-official.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.5-official.toml
@@ -3,11 +3,14 @@ family = "minimax"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
 open_weights = false
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.30

--- a/providers/nano-gpt/models/minimax/minimax-m2.5.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.5.toml
@@ -3,11 +3,14 @@ family = "minimax"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
 open_weights = false
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.30


### PR DESCRIPTION
## Summary
- add `minimax/minimax-m2.5` under NanoGPT with 204.8K context and pricing set to `$0.30` input / `$1.20` output
- keep `minimax/minimax-m2.5-official` available and align it as the non-reasoning official/original route
- preserve both MiniMax M2.5 options so users can choose the default route or official/original route