### PR TITLE
Add Kimi K2.5 model for Baseten

### DIFF
--- a/providers/baseten/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.5.toml
@@ -1,0 +1,25 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2026-01-30"
+last_updated = "2026-02-12"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-12"
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 262144
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[cost]
+input = 0.60
+output = 3.00


### PR DESCRIPTION
## Summary
- Add Kimi K2.5 model configuration for Baseten provider
- Model supports reasoning, tool calling, and attachments
- 262K context window with 8K output limit
- Pricing: $0.60 input / $3.00 output per 1M tokens

## Changes
- New model file: `providers/baseten/models/moonshotai/Kimi-K2.5.toml`
- Configured with proper family, capabilities, and cost structure
- Validated against schema requirements