### PR TITLE
fix(github-copilot): update context limits to match official Copilot docs

### DIFF
--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -14,7 +14,7 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 168_000
 output = 32_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -14,7 +14,7 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 168_000
 output = 32_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-opus-41.toml
+++ b/providers/github-copilot/models/claude-opus-41.toml
@@ -14,7 +14,7 @@ input = 0
 output = 0
 
 [limit]
-context = 80_000
+context = 68_000
 output = 16_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -14,7 +14,7 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 168_000
 output = 32_000
 
 [modalities]

--- a/providers/github-copilot/models/gemini-2.5-pro.toml
+++ b/providers/github-copilot/models/gemini-2.5-pro.toml
@@ -14,7 +14,7 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 109_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/gemini-3-flash-preview.toml
+++ b/providers/github-copilot/models/gemini-3-flash-preview.toml
@@ -15,7 +15,7 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 109_000
 output = 64_000
 
 [modalities]

--- a/providers/github-copilot/models/gemini-3-pro-preview.toml
+++ b/providers/github-copilot/models/gemini-3-pro-preview.toml
@@ -15,7 +15,7 @@ input = 0
 output = 0
 
 [limit]
-context = 128_000
+context = 109_000
 output = 64_000
 
 [modalities]


### PR DESCRIPTION
## Summary

Updates context window sizes for 7 GitHub Copilot models to match the values shown in GitHub's official supported models documentation.

**Source:** [Supported AI models in GitHub Copilot](https://docs.github.com/en/copilot/reference/ai-models/supported-models)

## Changes

| Model | Before | After |
|-------|--------|-------|
| claude-haiku-4.5 | 128,000 | 168,000 |
| claude-opus-41 | 80,000 | 68,000 |
| claude-opus-4.5 | 128,000 | 168,000 |
| claude-sonnet-4.5 | 128,000 | 168,000 |
| gemini-2.5-pro | 128,000 | 109,000 |
| gemini-3-flash-preview | 128,000 | 109,000 |
| gemini-3-pro-preview | 128,000 | 109,000 |

## Notes

- These are the **input context limits** as reported by GitHub Copilot, which may differ from the raw provider limits — e.g., Claude Haiku 4.5 has 200K natively but Copilot exposes 168K.
- Values verified against the official GitHub Copilot documentation as of Feb 12, 2026.