### PR TITLE
feat: Add StepFun provider support

### DIFF
--- a/providers/stepfun/models/step-1-32k.toml
+++ b/providers/stepfun/models/step-1-32k.toml
@@ -1,0 +1,23 @@
+name = "Step 1 (32K)"
+release_date = "2025-01-01"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-06"
+open_weights = false
+
+[cost]
+input = 2.05
+output = 9.59
+cache_read = 0.41
+
+[limit]
+context = 32_768
+input = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/stepfun/models/step-2-16k.toml
+++ b/providers/stepfun/models/step-2-16k.toml
@@ -1,0 +1,23 @@
+name = "Step 2 (16K)"
+release_date = "2025-01-01"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-06"
+open_weights = false
+
+[cost]
+input = 5.21
+output = 16.44
+cache_read = 1.04
+
+[limit]
+context = 16_384
+input = 16_384
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/stepfun/models/step-3.5-flash.toml
+++ b/providers/stepfun/models/step-3.5-flash.toml
@@ -1,0 +1,23 @@
+name = "Step 3.5 Flash"
+release_date = "2026-01-29"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.096
+output = 0.288
+cache_read = 0.019
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/stepfun/provider.toml
+++ b/providers/stepfun/provider.toml
@@ -1,5 +1,5 @@
 name = "StepFun"
 env = ["STEPFUN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-doc = "https://platform.stepfun.com/docs"
+doc = "https://platform.stepfun.com/docs/zh/overview/concept"
 api = "https://api.stepfun.com/v1"

--- a/providers/stepfun/provider.toml
+++ b/providers/stepfun/provider.toml
@@ -1,0 +1,5 @@
+name = "StepFun"
+env = ["STEPFUN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://platform.stepfun.com/docs"
+api = "https://api.stepfun.com/v1"


### PR DESCRIPTION
## Summary

Add StepFun(阶跃星辰) as a new provider with OpenAI-compatible API support.

## Changes

- Add StepFun provider definition with `@ai-sdk/openai-compatible`
- Add support for 3 main models:
  - **step-3.5-flash**: 256K context, reasoning model, fast inference
  - **step-2-16k**: 1T parameters, 16K context, strong reasoning
  - **step-1-32k**: 100B parameters, 32K context, balanced performance

## Technical Details

- **Provider ID**: `stepfun`
- **API Endpoint**: `https://api.stepfun.com/v1`
- **Environment Variable**: `STEPFUN_API_KEY`
- **NPM Package**: `@ai-sdk/openai-compatible`

## Pricing (USD per 1M tokens)

Based on official StepFun documentation (converted from CNY):

| Model | Input | Output | Cache Read |
|-------|-------|--------|------------|
| step-3.5-flash | $0.096 | $0.288 | $0.019 |
| step-2-16k | $5.21 | $16.44 | $1.04 |
| step-1-32k | $2.05 | $9.59 | $0.41 |

## Related Issues

Fixes anomalyco/opencode#11760
Fixes anomalyco/opencode#11960

## References

- StepFun Platform: https://platform.stepfun.com
- Pricing Documentation: https://platform.stepfun.com/docs/zh/pricing/details
- API Documentation: https://platform.stepfun.com/docs/zh/overview/concept
- Migration Guide: https://platform.stepfun.com/docs/guide/openai

## Testing

After PR is merged, users can test with:

```bash
# Add API Key
opencode auth login stepfun

# Select model
opencode models
```