### PR TITLE
Venice: Add MiniMax M2.5 model configuration

### DIFF
--- a/providers/venice/models/minimax-m25.toml
+++ b/providers/venice/models/minimax-m25.toml
@@ -1,0 +1,25 @@
+name = "MiniMax M2.5"
+family = "minimax"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-02-12"
+last_updated = "2026-02-13"
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.04
+
+[limit]
+context = 198_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
- Modalities: text input/output
- Context window: 198K tokens
- Max output: 32K tokens
- Pricing: $0.40/M input, $1.60/M output, $0.04/M cache read