### PR TITLE
Add GLM-5 to Google Vertex AI

### DIFF
--- a/providers/google-vertex/models/zai-org/glm-5-maas.toml
+++ b/providers/google-vertex/models/zai-org/glm-5-maas.toml
@@ -1,0 +1,25 @@
+name = "GLM-5"
+family = "glm"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.00
+output = 3.20
+cache_read = 0.10
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds GLM-5 (glm-5-maas) to Google Vertex AI Model Garden
- Pricing from Vertex AI pricing page: $1.00/M input, $3.20/M output, $0.10/M cache hit
- Follows existing `glm-4.7-maas` pattern in `zai-org/` subdirectory

## Test plan
- [x] `bun validate` passes