### PR TITLE
Add all missing cohere models offered by the cohere api

### DIFF
--- a/providers/cohere/models/c4ai-aya-expanse-32b.toml
+++ b/providers/cohere/models/c4ai-aya-expanse-32b.toml
@@ -1,0 +1,16 @@
+name = "Aya Expanse 32B"
+release_date = "2024-10-24"
+last_updated = "2024-10-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cohere/models/c4ai-aya-expanse-8b.toml
+++ b/providers/cohere/models/c4ai-aya-expanse-8b.toml
@@ -1,0 +1,16 @@
+name = "Aya Expanse 8B"
+release_date = "2024-10-24"
+last_updated = "2024-10-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 8_000
+output = 4_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cohere/models/c4ai-aya-vision-32b.toml
+++ b/providers/cohere/models/c4ai-aya-vision-32b.toml
@@ -1,0 +1,16 @@
+name = "Aya Vision 32B"
+release_date = "2025-03-04"
+last_updated = "2025-05-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 16_000
+output = 4_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/cohere/models/c4ai-aya-vision-8b.toml
+++ b/providers/cohere/models/c4ai-aya-vision-8b.toml
@@ -1,0 +1,16 @@
+name = "Aya Vision 8B"
+release_date = "2025-03-04"
+last_updated = "2025-05-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 16_000
+output = 4_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/cohere/models/command-r7b-arabic-02-2025.toml
+++ b/providers/cohere/models/command-r7b-arabic-02-2025.toml
@@ -1,0 +1,22 @@
+name = "Command R7B Arabic"
+family = "command-r"
+release_date = "2025-02-27"
+last_updated = "2025-02-27"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-06-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0375
+output = 0.15
+
+[limit]
+context = 128_000
+output = 4_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This commit adds all the models offered by the official cohere api that are not yet available in the models.dev repo, excluding the rerank and embed models.