### PR TITLE
fix: gpt 5-2-pro does not support structured output

### DIFF
--- a/providers/openai/models/gpt-5.2-pro.toml
+++ b/providers/openai/models/gpt-5.2-pro.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true
-structured_output = true
+structured_output = false
 open_weights = false
 
 [cost]


### PR DESCRIPTION
GPT-5-2 does not support structured output as per the official OpenAI Docs: https://developers.openai.com/api/docs/models/gpt-5.2