### PR TITLE
feat: add fireworks minimax m2.5 model and fix m2.1 cache pricing

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p5.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p5.toml
@@ -1,7 +1,7 @@
-name = "MiniMax-M2.1"
+name = "MiniMax-M2.5"
 family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
 attachment = false
 reasoning = true
 temperature = true
@@ -14,8 +14,8 @@ output = 1.20
 cache_read = 0.03
 
 [limit]
-context = 200_000
-output = 200_000
+context = 196_608
+output = 196_608
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
## Summary
- Add new MiniMax M2.5 model to Fireworks AI provider with correct pricing
- Fix MiniMax M2.1 cache read pricing from $0.15 to $0.03/1M tokens

## Changes
- Created `providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p5.toml`
- Updated `providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p1.toml`

## Pricing Details
Per Fireworks pricing page, the MiniMax M2 family has:
- Input: $0.30/1M tokens
- Cache read: $0.03/1M tokens
- Output: $1.20/1M tokens