### PR TITLE
feat: add GitHub Copilot GPT-5.3 Codex

### DIFF
--- a/providers/github-copilot/models/gpt-5.3-codex.toml
+++ b/providers/github-copilot/models/gpt-5.3-codex.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.3-Codex"
+family = "gpt-codex"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add GitHub Copilot gpt-5.3-codex model config
- include capabilities, limits, and modalities aligned with 5.3 Codex
- set Copilot pricing to zero