### PR TITLE
feat: add Z-AI GLM-5 to Chutes provider listings

### DIFF
--- a/providers/chutes/models/zai-org/GLM-5-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-5-TEE.toml
@@ -1,4 +1,4 @@
-name = "GLM 5TEE"
+name = "GLM 5 TEE"
 family = "glm"
 release_date = "2026-02-14"
 last_updated = "2026-02-14"

--- a/providers/chutes/models/zai-org/GLM-5-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-5-TEE.toml
@@ -1,0 +1,25 @@
+name = "GLM 5TEE"
+family = "glm"
+release_date = "2026-02-14"
+last_updated = "2026-02-14"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.750
+output = 2.50
+
+[limit]
+context = 202_752
+output = 65_535
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
This PR adds support for the GLM-5 model provided by Z-AI to the Chutes provider ecosystem. This allows users to select and utilize the GLM-5 architecture for their inference tasks via the Chutes interface.

Reference Chute: https://chutes.ai/app/chute/e51e818e-fa63-570d-9f68-49d7d1b4d12f