### PR TITLE
Add GLM5 model to nvidia provider

### DIFF
--- a/providers/nvidia/models/z-ai/glm5.toml
+++ b/providers/nvidia/models/z-ai/glm5.toml
@@ -17,8 +17,8 @@ input = 0.0
 output = 0.0
 
 [limit]
-context = 202_752
-output = 131_000
+context = 202752
+output = 131000
 
 [modalities]
 input = ["text"]

--- a/providers/nvidia/models/z-ai/glm5.toml
+++ b/providers/nvidia/models/z-ai/glm5.toml
@@ -1,0 +1,25 @@
+name = "GLM5"
+family = "glm"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 202_752
+output = 131_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add GLM5 model to NVIDIA provider

## Details
- **Model**: GLM5 (z-ai/glm5)
- **Release Date**: 2026-02-12
- **Context Limit**: 202,752 tokens
- **Output Limit**: 131,000 tokens
- **Capabilities**: reasoning, temperature, tool_call, structured_output, open_weights
- **Cost**: Free (NVIDIA NIM)
