### PR TITLE
feat(amazon-bedrock): add DeepSeek V3.2

### DIFF
--- a/providers/amazon-bedrock/models/deepseek.v3.2-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3.2-v1:0.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek-V3.2"
+family = "deepseek"
+release_date = "2026-02-15"
+last_updated = "2026-02-15"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.62
+output = 1.85
+
+[limit]
+context = 163_840
+output = 81_920
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add DeepSeek V3.2 model to Amazon Bedrock provider.

## Details
- **Model ID:** `deepseek.v3.2-v1:0`
- **Pricing (US regions):** $0.62/1M input, $1.85/1M output
- **Context:** 163,840 tokens
- **Output limit:** 81,920 tokens

## Reference
- [AWS Announcement](https://aws.amazon.com/about-aws/whats-new/2026/02/amazon-bedrock-adds-support-six-open-weights-models/)
- [AWS Bedrock Pricing](https://aws.amazon.com/bedrock/pricing/)