### PR TITLE
feat: add MiniMax M2.5 to Chutes provider listings

### DIFF
--- a/providers/chutes/models/MiniMaxAI/MiniMax-M2.5-TEE.toml
+++ b/providers/chutes/models/MiniMaxAI/MiniMax-M2.5-TEE.toml
@@ -1,0 +1,25 @@
+name = "MiniMax M2.5 TEE"
+family = "minimax"
+release_date = "2026-02-15"
+last_updated = "2026-02-15"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+context = 196_608
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
This PR adds support for the MiniMax M2.5 model provided by MiniMax to the Chutes provider ecosystem. This allows users to select and utilize the GLM-5 architecture for their inference tasks via the Chutes interface.

Reference Chute: https://chutes.ai/app/chute/ce6a92e4-5c2f-5681-9742-c80a4447bbdf

Model Listing: https://llm.chutes.ai/v1/models