### PR TITLE
Add Kilo Gateway provider and import Kilo models

### DIFF
--- a/providers/kilo/logo.svg
+++ b/providers/kilo/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M5 3v18" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
+  <path d="M17.5 4.5 9.5 12l8 7.5" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/providers/kilo/models/allenai/molmo-2-8b.toml
+++ b/providers/kilo/models/allenai/molmo-2-8b.toml
@@ -1,0 +1,20 @@
+name = "AllenAI: Molmo2 8B"
+release_date = "2026-01-09"
+last_updated = "2026-01-31"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.2
+
+[limit]
+context = 36864
+output = 36864
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/kilo/models/amazon/nova-2-lite-v1.toml
+++ b/providers/kilo/models/amazon/nova-2-lite-v1.toml
@@ -1,0 +1,20 @@
+name = "Amazon: Nova 2 Lite"
+release_date = "2024-12-01"
+last_updated = "2025-12-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 2.5
+
+[limit]
+context = 1000000
+output = 65535
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/kilo/models/amazon/nova-pro-v1.toml
+++ b/providers/kilo/models/amazon/nova-pro-v1.toml
@@ -1,0 +1,20 @@
+name = "Amazon: Nova Pro 1.0"
+release_date = "2024-12-03"
+last_updated = "2024-12-03"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.8
+output = 3.2
+
+[limit]
+context = 300000
+output = 5120
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-3-haiku.toml
+++ b/providers/kilo/models/anthropic/claude-3-haiku.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude 3 Haiku"
+release_date = "2024-03-07"
+last_updated = "2024-03-07"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1.25
+cache_read = 0.03
+cache_write = 0.3
+
+[limit]
+context = 200000
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-3.5-haiku.toml
+++ b/providers/kilo/models/anthropic/claude-3.5-haiku.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude 3.5 Haiku"
+release_date = "2024-10-22"
+last_updated = "2024-10-22"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.8
+output = 4
+cache_read = 0.08
+cache_write = 1
+
+[limit]
+context = 200000
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-3.5-sonnet.toml
+++ b/providers/kilo/models/anthropic/claude-3.5-sonnet.toml
@@ -1,0 +1,20 @@
+name = "Anthropic: Claude 3.5 Sonnet"
+release_date = "2024-10-22"
+last_updated = "2024-10-22"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 6.0
+output = 30.0
+
+[limit]
+context = 200000
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-3.7-sonnet.toml
+++ b/providers/kilo/models/anthropic/claude-3.7-sonnet.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude 3.7 Sonnet"
+release_date = "2025-02-19"
+last_updated = "2025-02-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+context = 200000
+output = 64000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-3.7-sonnet:thinking.toml
+++ b/providers/kilo/models/anthropic/claude-3.7-sonnet:thinking.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude 3.7 Sonnet (thinking)"
+release_date = "2025-02-19"
+last_updated = "2025-02-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+context = 200000
+output = 64000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-haiku-4.5.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Haiku 4.5"
+release_date = "2025-10-15"
+last_updated = "2025-10-15"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25
+
+[limit]
+context = 200000
+output = 64000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-opus-4.1.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.1.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Opus 4.1"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 15.0
+output = 75.0
+cache_read = 1.5
+cache_write = 18.75
+
+[limit]
+context = 200000
+output = 32000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-opus-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.5.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Opus 4.5"
+release_date = "2025-11-24"
+last_updated = "2025-11-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 5.0
+output = 25.0
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200000
+output = 64000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-opus-4.6.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.6.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Opus 4.6"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 5.0
+output = 25.0
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 1000000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-opus-4.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Opus 4"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 15.0
+output = 75.0
+cache_read = 1.5
+cache_write = 18.75
+
+[limit]
+context = 200000
+output = 32000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.5.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Sonnet 4.5"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+context = 1000000
+output = 64000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/anthropic/claude-sonnet-4.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.toml
@@ -1,0 +1,22 @@
+name = "Anthropic: Claude Sonnet 4"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+context = 1000000
+output = 64000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/arcee-ai/trinity-large-preview:free.toml
+++ b/providers/kilo/models/arcee-ai/trinity-large-preview:free.toml
@@ -1,0 +1,20 @@
+name = "Arcee AI: Trinity Large Preview (free)"
+release_date = "2026-01-28"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131000
+output = 26200
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/arcee-ai/trinity-mini.toml
+++ b/providers/kilo/models/arcee-ai/trinity-mini.toml
@@ -1,0 +1,20 @@
+name = "Arcee AI: Trinity Mini"
+release_date = "2025-12"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.045
+output = 0.15
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/arcee-ai/trinity-mini:free.toml
+++ b/providers/kilo/models/arcee-ai/trinity-mini:free.toml
@@ -1,0 +1,20 @@
+name = "Arcee AI: Trinity Mini (free)"
+release_date = "2026-01-28"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/baidu/ernie-4.5-21b-a3b-thinking.toml
+++ b/providers/kilo/models/baidu/ernie-4.5-21b-a3b-thinking.toml
@@ -1,0 +1,20 @@
+name = "Baidu: ERNIE 4.5 21B A3B Thinking"
+release_date = "2025-09-19"
+last_updated = "2025-09-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.28
+
+[limit]
+context = 131072
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/baidu/ernie-4.5-21b-a3b.toml
+++ b/providers/kilo/models/baidu/ernie-4.5-21b-a3b.toml
@@ -1,0 +1,20 @@
+name = "Baidu: ERNIE 4.5 21B A3B"
+release_date = "2025-06-30"
+last_updated = "2025-06-30"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.28
+
+[limit]
+context = 120000
+output = 8000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/baidu/ernie-4.5-300b-a47b.toml
+++ b/providers/kilo/models/baidu/ernie-4.5-300b-a47b.toml
@@ -1,0 +1,20 @@
+name = "Baidu: ERNIE 4.5 300B A47B "
+release_date = "2025-06-30"
+last_updated = "2026-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.28
+output = 1.1
+
+[limit]
+context = 123000
+output = 12000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/baidu/ernie-4.5-vl-28b-a3b.toml
+++ b/providers/kilo/models/baidu/ernie-4.5-vl-28b-a3b.toml
@@ -1,0 +1,20 @@
+name = "Baidu: ERNIE 4.5 VL 28B A3B"
+release_date = "2025-06-30"
+last_updated = "2025-06-30"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.14
+output = 0.56
+
+[limit]
+context = 30000
+output = 8000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/baidu/ernie-4.5-vl-424b-a47b.toml
+++ b/providers/kilo/models/baidu/ernie-4.5-vl-424b-a47b.toml
@@ -1,0 +1,20 @@
+name = "Baidu: ERNIE 4.5 VL 424B A47B "
+release_date = "2025-06-30"
+last_updated = "2026-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.42
+output = 1.25
+
+[limit]
+context = 123000
+output = 16000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/bytedance-seed/seed-1.6.toml
+++ b/providers/kilo/models/bytedance-seed/seed-1.6.toml
@@ -1,0 +1,20 @@
+name = "ByteDance Seed: Seed 1.6"
+release_date = "2025-09"
+last_updated = "2025-09"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 2.0
+
+[limit]
+context = 262144
+output = 32768
+
+[modalities]
+input = ["image", "text", "video"]
+output = ["text"]

--- a/providers/kilo/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
+++ b/providers/kilo/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
@@ -1,0 +1,20 @@
+name = "Venice: Uncensored (free)"
+release_date = "2025-07-09"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 32768
+output = 6554
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/cohere/command-a.toml
+++ b/providers/kilo/models/cohere/command-a.toml
@@ -1,0 +1,20 @@
+name = "Cohere: Command A"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 2.5
+output = 10.0
+
+[limit]
+context = 256000
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/cohere/command-r-08-2024.toml
+++ b/providers/kilo/models/cohere/command-r-08-2024.toml
@@ -1,0 +1,20 @@
+name = "Cohere: Command R (08-2024)"
+release_date = "2024-08-30"
+last_updated = "2024-08-30"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+context = 128000
+output = 4000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/cohere/command-r-plus-08-2024.toml
+++ b/providers/kilo/models/cohere/command-r-plus-08-2024.toml
@@ -1,0 +1,20 @@
+name = "Cohere: Command R+ (08-2024)"
+release_date = "2024-08-30"
+last_updated = "2024-08-30"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 2.5
+output = 10.0
+
+[limit]
+context = 128000
+output = 4000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/cohere/command-r7b-12-2024.toml
+++ b/providers/kilo/models/cohere/command-r7b-12-2024.toml
@@ -1,0 +1,20 @@
+name = "Cohere: Command R7B (12-2024)"
+release_date = "2024-02-27"
+last_updated = "2024-02-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.0375
+output = 0.15
+
+[limit]
+context = 128000
+output = 4000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-chat-v3-0324.toml
+++ b/providers/kilo/models/deepseek/deepseek-chat-v3-0324.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek: DeepSeek V3 0324"
+release_date = "2025-03-24"
+last_updated = "2025-03-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.19
+output = 0.87
+cache_read = 0.095
+
+[limit]
+context = 163840
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-chat-v3.1.toml
+++ b/providers/kilo/models/deepseek/deepseek-chat-v3.1.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek: DeepSeek V3.1"
+release_date = "2025-08-21"
+last_updated = "2025-08-21"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.75
+
+[limit]
+context = 32768
+output = 7168
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-chat.toml
+++ b/providers/kilo/models/deepseek/deepseek-chat.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek: DeepSeek V3"
+release_date = "2024-12-01"
+last_updated = "2026-01-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.15
+
+[limit]
+context = 163840
+output = 163840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/kilo/models/deepseek/deepseek-r1-0528.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek: R1 0528"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.4
+output = 1.75
+cache_read = 0.2
+
+[limit]
+context = 163840
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-r1-0528:free.toml
+++ b/providers/kilo/models/deepseek/deepseek-r1-0528:free.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek: R1 0528 (free)"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 163840
+output = 163840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-r1-distill-llama-70b.toml
+++ b/providers/kilo/models/deepseek/deepseek-r1-distill-llama-70b.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek: R1 Distill Llama 70B"
+release_date = "2025-01-23"
+last_updated = "2025-01-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.11
+cache_read = 0.015
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/kilo/models/deepseek/deepseek-r1-distill-qwen-32b.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek: R1 Distill Qwen 32B"
+release_date = "2025-01-01"
+last_updated = "2025-11-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.29
+output = 0.29
+
+[limit]
+context = 32768
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-r1.toml
+++ b/providers/kilo/models/deepseek/deepseek-r1.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek: R1"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.7
+output = 2.5
+
+[limit]
+context = 64000
+output = 16000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-v3.1-terminus.toml
+++ b/providers/kilo/models/deepseek/deepseek-v3.1-terminus.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek: DeepSeek V3.1 Terminus"
+release_date = "2025-09-22"
+last_updated = "2025-09-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.21
+output = 0.79
+cache_read = 0.13
+
+[limit]
+context = 163840
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-v3.1-terminus:exacto.toml
+++ b/providers/kilo/models/deepseek/deepseek-v3.1-terminus:exacto.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek: DeepSeek V3.1 Terminus (exacto)"
+release_date = "2025-09-22"
+last_updated = "2025-09-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.21
+output = 0.79
+cache_read = 0.168
+
+[limit]
+context = 163840
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-v3.2-exp.toml
+++ b/providers/kilo/models/deepseek/deepseek-v3.2-exp.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek: DeepSeek V3.2 Exp"
+release_date = "2025-01-01"
+last_updated = "2025-09-29"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.27
+output = 0.41
+
+[limit]
+context = 163840
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-v3.2-speciale.toml
+++ b/providers/kilo/models/deepseek/deepseek-v3.2-speciale.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek: DeepSeek V3.2 Speciale"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.27
+output = 0.41
+cache_read = 0.135
+
+[limit]
+context = 163840
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/deepseek/deepseek-v3.2.toml
+++ b/providers/kilo/models/deepseek/deepseek-v3.2.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek: DeepSeek V3.2"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.25
+output = 0.38
+cache_read = 0.125
+
+[limit]
+context = 163840
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/essentialai/rnj-1-instruct.toml
+++ b/providers/kilo/models/essentialai/rnj-1-instruct.toml
@@ -1,0 +1,20 @@
+name = "EssentialAI: Rnj 1 Instruct"
+release_date = "2025-12-05"
+last_updated = "2025-12-05"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.15
+
+[limit]
+context = 32768
+output = 6554
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-2.0-flash-001.toml
+++ b/providers/kilo/models/google/gemini-2.0-flash-001.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.0 Flash"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.025
+cache_write = 0.083333
+
+[limit]
+context = 1048576
+output = 8192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-2.0-flash-lite-001.toml
+++ b/providers/kilo/models/google/gemini-2.0-flash-lite-001.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemini 2.0 Flash Lite"
+release_date = "2024-12-11"
+last_updated = "2025-06-16"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.075
+output = 0.3
+
+[limit]
+context = 1048576
+output = 8192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Flash Lite Preview 09-2025"
+release_date = "2025-09-25"
+last_updated = "2025-09-25"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01
+cache_write = 0.083333
+
+[limit]
+context = 1048576
+output = 65535
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash-lite.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Flash Lite"
+release_date = "2025-06-17"
+last_updated = "2025-06-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01
+cache_write = 0.083333
+
+[limit]
+context = 1048576
+output = 65535
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash-preview-09-2025.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Flash Preview 09-2025"
+release_date = "2025-09-25"
+last_updated = "2025-09-25"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03
+cache_write = 0.083333
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["image", "text", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-2.5-flash.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Flash"
+release_date = "2025-07-17"
+last_updated = "2025-07-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03
+cache_write = 0.083333
+
+[limit]
+context = 1048576
+output = 65535
+
+[modalities]
+input = ["image", "text", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro-preview-05-06.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Pro Preview 05-06"
+release_date = "2025-05-06"
+last_updated = "2025-05-06"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+cache_write = 0.375
+
+[limit]
+context = 1048576
+output = 65535
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-2.5-pro-preview.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro-preview.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Pro Preview 06-05"
+release_date = "2025-06-05"
+last_updated = "2026-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+cache_write = 0.375
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["image", "text", "audio"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-2.5-pro.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 2.5 Pro"
+release_date = "2025-03-20"
+last_updated = "2025-06-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+cache_write = 0.375
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-3-flash-preview.toml
+++ b/providers/kilo/models/google/gemini-3-flash-preview.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 3 Flash Preview"
+release_date = "2025-12-17"
+last_updated = "2025-12-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+cache_write = 0.083333
+
+[limit]
+context = 1048576
+output = 65535
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemini-3-pro-preview.toml
+++ b/providers/kilo/models/google/gemini-3-pro-preview.toml
@@ -1,0 +1,22 @@
+name = "Google: Gemini 3 Pro Preview"
+release_date = "2025-11-18"
+last_updated = "2025-11"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 0.375
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-2-27b-it.toml
+++ b/providers/kilo/models/google/gemma-2-27b-it.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemma 2 27B"
+release_date = "2024-06-24"
+last_updated = "2024-06-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.65
+output = 0.65
+
+[limit]
+context = 8192
+output = 2048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-2-9b-it.toml
+++ b/providers/kilo/models/google/gemma-2-9b-it.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemma 2 9B"
+release_date = "2024-06-28"
+last_updated = "2024-06-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.09
+
+[limit]
+context = 8192
+output = 1639
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-3-12b-it.toml
+++ b/providers/kilo/models/google/gemma-3-12b-it.toml
@@ -1,0 +1,21 @@
+name = "Google: Gemma 3 12B"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.1
+cache_read = 0.015
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-3-12b-it:free.toml
+++ b/providers/kilo/models/google/gemma-3-12b-it:free.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemma 3 12B (free)"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 32768
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-3-27b-it.toml
+++ b/providers/kilo/models/google/gemma-3-27b-it.toml
@@ -1,0 +1,21 @@
+name = "Google: Gemma 3 27B"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.15
+cache_read = 0.02
+
+[limit]
+context = 128000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-3-27b-it:free.toml
+++ b/providers/kilo/models/google/gemma-3-27b-it:free.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemma 3 27B (free)"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-3-4b-it.toml
+++ b/providers/kilo/models/google/gemma-3-4b-it.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemma 3 4B"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.01703
+output = 0.068154
+
+[limit]
+context = 96000
+output = 19200
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-3-4b-it:free.toml
+++ b/providers/kilo/models/google/gemma-3-4b-it:free.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemma 3 4B (free)"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 32768
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-3n-e2b-it:free.toml
+++ b/providers/kilo/models/google/gemma-3n-e2b-it:free.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemma 3n 2B (free)"
+release_date = "2025-07-09"
+last_updated = "2025-07-09"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8192
+output = 2048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-3n-e4b-it.toml
+++ b/providers/kilo/models/google/gemma-3n-e4b-it.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemma 3n 4B"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.04
+
+[limit]
+context = 32768
+output = 6554
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/google/gemma-3n-e4b-it:free.toml
+++ b/providers/kilo/models/google/gemma-3n-e4b-it:free.toml
@@ -1,0 +1,20 @@
+name = "Google: Gemma 3n 4B (free)"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8192
+output = 2048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/gryphe/mythomax-l2-13b.toml
+++ b/providers/kilo/models/gryphe/mythomax-l2-13b.toml
@@ -1,0 +1,20 @@
+name = "MythoMax 13B"
+release_date = "2024-04-25"
+last_updated = "2024-04-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.06
+
+[limit]
+context = 4096
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/inception/mercury-coder.toml
+++ b/providers/kilo/models/inception/mercury-coder.toml
@@ -1,0 +1,20 @@
+name = "Inception: Mercury Coder"
+release_date = "2025-02-26"
+last_updated = "2025-07-31"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1.0
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/inception/mercury.toml
+++ b/providers/kilo/models/inception/mercury.toml
@@ -1,0 +1,20 @@
+name = "Inception: Mercury"
+release_date = "2025-06-26"
+last_updated = "2025-07-31"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1.0
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/kilo/auto.toml
+++ b/providers/kilo/models/kilo/auto.toml
@@ -1,0 +1,20 @@
+name = "Kilo: Auto"
+release_date = "2024-06-01"
+last_updated = "2024-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.0
+output = 1.0
+
+[limit]
+context = 200000
+output = 64000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/kwaipilot/kat-coder-pro.toml
+++ b/providers/kilo/models/kwaipilot/kat-coder-pro.toml
@@ -1,0 +1,21 @@
+name = "Kwaipilot: KAT-Coder-Pro V1"
+release_date = "2025-09-30"
+last_updated = "2025-10-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.207
+output = 0.828
+cache_read = 0.0414
+
+[limit]
+context = 256000
+output = 128000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/liquid/lfm-2.5-1.2b-instruct:free.toml
+++ b/providers/kilo/models/liquid/lfm-2.5-1.2b-instruct:free.toml
@@ -1,0 +1,20 @@
+name = "LiquidAI: LFM2.5-1.2B-Instruct (free)"
+release_date = "2026-01-20"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 32768
+output = 6554
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/liquid/lfm-2.5-1.2b-thinking:free.toml
+++ b/providers/kilo/models/liquid/lfm-2.5-1.2b-thinking:free.toml
@@ -1,0 +1,20 @@
+name = "LiquidAI: LFM2.5-1.2B-Thinking (free)"
+release_date = "2026-01-20"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 32768
+output = 6554
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meituan/longcat-flash-chat.toml
+++ b/providers/kilo/models/meituan/longcat-flash-chat.toml
@@ -1,0 +1,21 @@
+name = "Meituan: LongCat Flash Chat"
+release_date = "2025-08-30"
+last_updated = "2025-08-30"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.8
+cache_read = 0.2
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3-70b-instruct.toml
+++ b/providers/kilo/models/meta-llama/llama-3-70b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3 70B Instruct"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.51
+output = 0.74
+
+[limit]
+context = 8192
+output = 8000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3-8b-instruct.toml
+++ b/providers/kilo/models/meta-llama/llama-3-8b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3 8B Instruct"
+release_date = "2024-04-25"
+last_updated = "2025-04-03"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.04
+
+[limit]
+context = 8192
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3.1-405b-instruct.toml
+++ b/providers/kilo/models/meta-llama/llama-3.1-405b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3.1 405B Instruct"
+release_date = "2024-07-16"
+last_updated = "2025-04-05"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 4.0
+output = 4.0
+
+[limit]
+context = 131000
+output = 26200
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3.1-70b-instruct.toml
+++ b/providers/kilo/models/meta-llama/llama-3.1-70b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3.1 70B Instruct"
+release_date = "2024-07-16"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.4
+output = 0.4
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3.1-8b-instruct.toml
+++ b/providers/kilo/models/meta-llama/llama-3.1-8b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3.1 8B Instruct"
+release_date = "2024-07-23"
+last_updated = "2025-12-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.05
+
+[limit]
+context = 16384
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3.2-11b-vision-instruct.toml
+++ b/providers/kilo/models/meta-llama/llama-3.2-11b-vision-instruct.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3.2 11B Vision Instruct"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.049
+output = 0.049
+
+[limit]
+context = 131072
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3.2-1b-instruct.toml
+++ b/providers/kilo/models/meta-llama/llama-3.2-1b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3.2 1B Instruct"
+release_date = "2024-09-18"
+last_updated = "2026-01-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.027
+output = 0.2
+
+[limit]
+context = 60000
+output = 12000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3.2-3b-instruct.toml
+++ b/providers/kilo/models/meta-llama/llama-3.2-3b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3.2 3B Instruct"
+release_date = "2024-09-18"
+last_updated = "2025-04-03"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.02
+
+[limit]
+context = 131072
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3.2-3b-instruct:free.toml
+++ b/providers/kilo/models/meta-llama/llama-3.2-3b-instruct:free.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3.2 3B Instruct (free)"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3.3-70b-instruct.toml
+++ b/providers/kilo/models/meta-llama/llama-3.3-70b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3.3 70B Instruct"
+release_date = "2024-08-01"
+last_updated = "2026-02-04"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.32
+
+[limit]
+context = 131072
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-3.3-70b-instruct:free.toml
+++ b/providers/kilo/models/meta-llama/llama-3.3-70b-instruct:free.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 3.3 70B Instruct (free)"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128000
+output = 128000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-4-maverick.toml
+++ b/providers/kilo/models/meta-llama/llama-4-maverick.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 4 Maverick"
+release_date = "2025-04-05"
+last_updated = "2025-12-24"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+context = 1048576
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-4-scout.toml
+++ b/providers/kilo/models/meta-llama/llama-4-scout.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama 4 Scout"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.3
+
+[limit]
+context = 327680
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-guard-3-8b.toml
+++ b/providers/kilo/models/meta-llama/llama-guard-3-8b.toml
@@ -1,0 +1,20 @@
+name = "Llama Guard 3 8B"
+release_date = "2024-04-18"
+last_updated = "2026-02-04"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.06
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/meta-llama/llama-guard-4-12b.toml
+++ b/providers/kilo/models/meta-llama/llama-guard-4-12b.toml
@@ -1,0 +1,20 @@
+name = "Meta: Llama Guard 4 12B"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.18
+output = 0.18
+
+[limit]
+context = 163840
+output = 32768
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/microsoft/phi-4.toml
+++ b/providers/kilo/models/microsoft/phi-4.toml
@@ -1,0 +1,20 @@
+name = "Microsoft: Phi 4"
+release_date = "2024-12-11"
+last_updated = "2024-12-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.14
+
+[limit]
+context = 16384
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/microsoft/wizardlm-2-8x22b.toml
+++ b/providers/kilo/models/microsoft/wizardlm-2-8x22b.toml
@@ -1,0 +1,20 @@
+name = "WizardLM-2 8x22B"
+release_date = "2024-04-24"
+last_updated = "2024-04-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.62
+output = 0.62
+
+[limit]
+context = 65535
+output = 8000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/minimax/minimax-01.toml
+++ b/providers/kilo/models/minimax/minimax-01.toml
@@ -1,0 +1,20 @@
+name = "MiniMax: MiniMax-01"
+release_date = "2025-01-15"
+last_updated = "2025-01-15"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.2
+output = 1.1
+
+[limit]
+context = 1000192
+output = 1000192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/minimax/minimax-m1.toml
+++ b/providers/kilo/models/minimax/minimax-m1.toml
@@ -1,0 +1,20 @@
+name = "MiniMax: MiniMax M1"
+release_date = "2025-06-17"
+last_updated = "2025-06-17"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.4
+output = 2.2
+
+[limit]
+context = 1000000
+output = 40000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/minimax/minimax-m2.1.toml
+++ b/providers/kilo/models/minimax/minimax-m2.1.toml
@@ -1,0 +1,21 @@
+name = "MiniMax: MiniMax M2.1"
+release_date = "2025-12-23"
+last_updated = "2025-12-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.27
+output = 0.95
+cache_read = 0.03
+
+[limit]
+context = 196608
+output = 39322
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/minimax/minimax-m2.5.toml
+++ b/providers/kilo/models/minimax/minimax-m2.5.toml
@@ -1,0 +1,21 @@
+name = "MiniMax: MiniMax M2.5"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.029
+
+[limit]
+context = 196608
+output = 39322
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/minimax/minimax-m2.5:free.toml
+++ b/providers/kilo/models/minimax/minimax-m2.5:free.toml
@@ -1,0 +1,21 @@
+name = "MiniMax: MiniMax M2.5 (free)"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/minimax/minimax-m2.toml
+++ b/providers/kilo/models/minimax/minimax-m2.toml
@@ -1,0 +1,21 @@
+name = "MiniMax: MiniMax M2"
+release_date = "2025-10-23"
+last_updated = "2025-10-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.255
+output = 1.0
+cache_read = 0.03
+
+[limit]
+context = 196608
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/codestral-2508.toml
+++ b/providers/kilo/models/mistralai/codestral-2508.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Codestral 2508"
+release_date = "2025-08-01"
+last_updated = "2025-08-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 0.9
+
+[limit]
+context = 256000
+output = 51200
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/devstral-2512.toml
+++ b/providers/kilo/models/mistralai/devstral-2512.toml
@@ -1,0 +1,21 @@
+name = "Mistral: Devstral 2 2512"
+release_date = "2025-09-12"
+last_updated = "2025-09-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.22
+cache_read = 0.025
+
+[limit]
+context = 262144
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/devstral-medium.toml
+++ b/providers/kilo/models/mistralai/devstral-medium.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Devstral Medium"
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.4
+output = 2
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/devstral-small.toml
+++ b/providers/kilo/models/mistralai/devstral-small.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Devstral Small 1.1"
+release_date = "2025-05-07"
+last_updated = "2025-07-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.3
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/ministral-14b-2512.toml
+++ b/providers/kilo/models/mistralai/ministral-14b-2512.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Ministral 3 14B 2512"
+release_date = "2025-12-16"
+last_updated = "2025-12-16"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.2
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-7b-instruct-v0.1.toml
+++ b/providers/kilo/models/mistralai/mistral-7b-instruct-v0.1.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mistral 7B Instruct v0.1"
+release_date = "2025-04-03"
+last_updated = "2025-04-03"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.11
+output = 0.19
+
+[limit]
+context = 2824
+output = 565
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-7b-instruct-v0.3.toml
+++ b/providers/kilo/models/mistralai/mistral-7b-instruct-v0.3.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mistral 7B Instruct v0.3"
+release_date = "2025-04-01"
+last_updated = "2025-04-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.2
+
+[limit]
+context = 32768
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-7b-instruct.toml
+++ b/providers/kilo/models/mistralai/mistral-7b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mistral 7B Instruct"
+release_date = "2024-05-27"
+last_updated = "2024-05-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.2
+
+[limit]
+context = 32768
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-large-2411.toml
+++ b/providers/kilo/models/mistralai/mistral-large-2411.toml
@@ -1,0 +1,20 @@
+name = "Mistral Large 2411"
+release_date = "2024-07-24"
+last_updated = "2024-11-04"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 2.0
+output = 6.0
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-large-2512.toml
+++ b/providers/kilo/models/mistralai/mistral-large-2512.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mistral Large 3 2512"
+release_date = "2024-11-01"
+last_updated = "2025-12-16"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.5
+output = 1.5
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-large.toml
+++ b/providers/kilo/models/mistralai/mistral-large.toml
@@ -1,0 +1,20 @@
+name = "Mistral Large"
+release_date = "2024-07-24"
+last_updated = "2025-12-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 2.0
+output = 6.0
+
+[limit]
+context = 128000
+output = 25600
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-medium-3.1.toml
+++ b/providers/kilo/models/mistralai/mistral-medium-3.1.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mistral Medium 3.1"
+release_date = "2025-08-12"
+last_updated = "2025-08-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.4
+output = 2
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-medium-3.toml
+++ b/providers/kilo/models/mistralai/mistral-medium-3.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mistral Medium 3"
+release_date = "2025-05-07"
+last_updated = "2025-05-07"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.4
+output = 2
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-nemo.toml
+++ b/providers/kilo/models/mistralai/mistral-nemo.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mistral Nemo"
+release_date = "2024-07-01"
+last_updated = "2024-07-30"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.04
+
+[limit]
+context = 131072
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-small-24b-instruct-2501.toml
+++ b/providers/kilo/models/mistralai/mistral-small-24b-instruct-2501.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mistral Small 3"
+release_date = "2025-12-29"
+last_updated = "2026-01-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.08
+
+[limit]
+context = 32768
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-small-3.1-24b-instruct.toml
+++ b/providers/kilo/models/mistralai/mistral-small-3.1-24b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Mistral: Mistral Small 3.1 24B"
+release_date = "2025-03-17"
+last_updated = "2025-03-17"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.11
+cache_read = 0.015
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-small-3.1-24b-instruct:free.toml
+++ b/providers/kilo/models/mistralai/mistral-small-3.1-24b-instruct:free.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mistral Small 3.1 24B (free)"
+release_date = "2025-03-17"
+last_updated = "2025-03-17"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128000
+output = 25600
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mistral-small-3.2-24b-instruct.toml
+++ b/providers/kilo/models/mistralai/mistral-small-3.2-24b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Mistral: Mistral Small 3.2 24B"
+release_date = "2025-06-20"
+last_updated = "2025-06-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.18
+cache_read = 0.03
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/mixtral-8x22b-instruct.toml
+++ b/providers/kilo/models/mistralai/mixtral-8x22b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Mixtral 8x22B Instruct"
+release_date = "2024-04-17"
+last_updated = "2024-04-17"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 2.0
+output = 6.0
+
+[limit]
+context = 65536
+output = 13108
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/mistralai/voxtral-small-24b-2507.toml
+++ b/providers/kilo/models/mistralai/voxtral-small-24b-2507.toml
@@ -1,0 +1,20 @@
+name = "Mistral: Voxtral Small 24B 2507"
+release_date = "2025-07-01"
+last_updated = "2025-07-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.3
+
+[limit]
+context = 32000
+output = 6400
+
+[modalities]
+input = ["text", "audio"]
+output = ["text"]

--- a/providers/kilo/models/moonshotai/kimi-k2-0905.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2-0905.toml
@@ -1,0 +1,21 @@
+name = "MoonshotAI: Kimi K2 0905"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.4
+output = 2
+cache_read = 0.15
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/moonshotai/kimi-k2-0905:exacto.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2-0905:exacto.toml
@@ -1,0 +1,20 @@
+name = "MoonshotAI: Kimi K2 0905 (exacto)"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 2.5
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2-thinking.toml
@@ -1,0 +1,21 @@
+name = "MoonshotAI: Kimi K2 Thinking"
+release_date = "2025-11-06"
+last_updated = "2025-11-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.4
+output = 1.75
+cache_read = 0.2
+
+[limit]
+context = 262144
+output = 65535
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/moonshotai/kimi-k2.5.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,20 @@
+name = "MoonshotAI: Kimi K2.5"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.23
+output = 3
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/moonshotai/kimi-k2.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2.toml
@@ -1,0 +1,20 @@
+name = "MoonshotAI: Kimi K2 0711"
+release_date = "2025-07-11"
+last_updated = "2025-07-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.5
+output = 2.4
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/morph/morph-v3-fast.toml
+++ b/providers/kilo/models/morph/morph-v3-fast.toml
@@ -1,0 +1,20 @@
+name = "Morph: Morph V3 Fast"
+release_date = "2024-08-15"
+last_updated = "2024-08-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.8
+output = 1.2
+
+[limit]
+context = 81920
+output = 38000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/morph/morph-v3-large.toml
+++ b/providers/kilo/models/morph/morph-v3-large.toml
@@ -1,0 +1,20 @@
+name = "Morph: Morph V3 Large"
+release_date = "2024-08-15"
+last_updated = "2024-08-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.9
+output = 1.9
+
+[limit]
+context = 262144
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nex-agi/deepseek-v3.1-nex-n1.toml
+++ b/providers/kilo/models/nex-agi/deepseek-v3.1-nex-n1.toml
@@ -1,0 +1,20 @@
+name = "Nex AGI: DeepSeek V3.1 Nex N1"
+release_date = "2025-01-01"
+last_updated = "2025-11-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.27
+output = 1.0
+
+[limit]
+context = 131072
+output = 163840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nousresearch/deephermes-3-mistral-24b-preview.toml
+++ b/providers/kilo/models/nousresearch/deephermes-3-mistral-24b-preview.toml
@@ -1,0 +1,21 @@
+name = "Nous: DeepHermes 3 Mistral 24B Preview"
+release_date = "2025-12-29"
+last_updated = "2026-01-10"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.1
+cache_read = 0.01
+
+[limit]
+context = 32768
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nousresearch/hermes-2-pro-llama-3-8b.toml
+++ b/providers/kilo/models/nousresearch/hermes-2-pro-llama-3-8b.toml
@@ -1,0 +1,20 @@
+name = "NousResearch: Hermes 2 Pro - Llama-3 8B"
+release_date = "2024-05-27"
+last_updated = "2024-06-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.14
+output = 0.14
+
+[limit]
+context = 8192
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nousresearch/hermes-3-llama-3.1-405b.toml
+++ b/providers/kilo/models/nousresearch/hermes-3-llama-3.1-405b.toml
@@ -1,0 +1,20 @@
+name = "Nous: Hermes 3 405B Instruct"
+release_date = "2024-08-16"
+last_updated = "2024-08-16"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 1.0
+output = 1.0
+
+[limit]
+context = 131072
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nousresearch/hermes-3-llama-3.1-405b:free.toml
+++ b/providers/kilo/models/nousresearch/hermes-3-llama-3.1-405b:free.toml
@@ -1,0 +1,20 @@
+name = "Nous: Hermes 3 405B Instruct (free)"
+release_date = "2024-08-16"
+last_updated = "2024-08-16"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nousresearch/hermes-4-405b.toml
+++ b/providers/kilo/models/nousresearch/hermes-4-405b.toml
@@ -1,0 +1,20 @@
+name = "Nous: Hermes 4 405B"
+release_date = "2025-08-25"
+last_updated = "2025-08-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 1.0
+output = 3.0
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nousresearch/hermes-4-70b.toml
+++ b/providers/kilo/models/nousresearch/hermes-4-70b.toml
@@ -1,0 +1,21 @@
+name = "Nous: Hermes 4 70B"
+release_date = "2025-08-25"
+last_updated = "2025-08-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.11
+output = 0.38
+cache_read = 0.055
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nvidia/llama-3.1-nemotron-70b-instruct.toml
+++ b/providers/kilo/models/nvidia/llama-3.1-nemotron-70b-instruct.toml
@@ -1,0 +1,20 @@
+name = "NVIDIA: Llama 3.1 Nemotron 70B Instruct"
+release_date = "2024-10-12"
+last_updated = "2024-10-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.2
+output = 1.2
+
+[limit]
+context = 131072
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nvidia/llama-3.1-nemotron-ultra-253b-v1.toml
+++ b/providers/kilo/models/nvidia/llama-3.1-nemotron-ultra-253b-v1.toml
@@ -1,0 +1,20 @@
+name = "NVIDIA: Llama 3.1 Nemotron Ultra 253B v1"
+release_date = "2024-07-01"
+last_updated = "2026-02-04"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.6
+output = 1.8
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
+++ b/providers/kilo/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
@@ -1,0 +1,20 @@
+name = "NVIDIA: Llama 3.3 Nemotron Super 49B V1.5"
+release_date = "2025-03-16"
+last_updated = "2025-03-16"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.1
+output = 0.4
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -1,0 +1,20 @@
+name = "NVIDIA: Nemotron 3 Nano 30B A3B"
+release_date = "2024-12"
+last_updated = "2026-02-04"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.2
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b:free.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b:free.toml
@@ -1,0 +1,20 @@
+name = "NVIDIA: Nemotron 3 Nano 30B A3B (free)"
+release_date = "2025-12-14"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 256000
+output = 51200
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nvidia/nemotron-nano-12b-v2-vl.toml
+++ b/providers/kilo/models/nvidia/nemotron-nano-12b-v2-vl.toml
@@ -1,0 +1,20 @@
+name = "NVIDIA: Nemotron Nano 12B 2 VL"
+release_date = "2025-10-28"
+last_updated = "2026-01-31"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.6
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["image", "text", "video"]
+output = ["text"]

--- a/providers/kilo/models/nvidia/nemotron-nano-12b-v2-vl:free.toml
+++ b/providers/kilo/models/nvidia/nemotron-nano-12b-v2-vl:free.toml
@@ -1,0 +1,20 @@
+name = "NVIDIA: Nemotron Nano 12B 2 VL (free)"
+release_date = "2025-10-28"
+last_updated = "2026-01-31"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128000
+output = 128000
+
+[modalities]
+input = ["image", "text", "video"]
+output = ["text"]

--- a/providers/kilo/models/nvidia/nemotron-nano-9b-v2.toml
+++ b/providers/kilo/models/nvidia/nemotron-nano-9b-v2.toml
@@ -1,0 +1,20 @@
+name = "NVIDIA: Nemotron Nano 9B V2"
+release_date = "2025-08-18"
+last_updated = "2025-08-18"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.16
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/nvidia/nemotron-nano-9b-v2:free.toml
+++ b/providers/kilo/models/nvidia/nemotron-nano-9b-v2:free.toml
@@ -1,0 +1,20 @@
+name = "NVIDIA: Nemotron Nano 9B V2 (free)"
+release_date = "2025-09-05"
+last_updated = "2025-08-18"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128000
+output = 25600
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/chatgpt-4o-latest.toml
+++ b/providers/kilo/models/openai/chatgpt-4o-latest.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: ChatGPT-4o"
+release_date = "2024-08-08"
+last_updated = "2024-08-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 5.0
+output = 15.0
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-3.5-turbo-0613.toml
+++ b/providers/kilo/models/openai/gpt-3.5-turbo-0613.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-3.5 Turbo (older v0613)"
+release_date = "2023-06-13"
+last_updated = "2023-06-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.0
+output = 2.0
+
+[limit]
+context = 4095
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-3.5-turbo-instruct.toml
+++ b/providers/kilo/models/openai/gpt-3.5-turbo-instruct.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-3.5 Turbo Instruct"
+release_date = "2023-03-01"
+last_updated = "2023-09-21"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 1.5
+output = 2.0
+
+[limit]
+context = 4095
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-3.5-turbo.toml
+++ b/providers/kilo/models/openai/gpt-3.5-turbo.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-3.5 Turbo"
+release_date = "2023-03-01"
+last_updated = "2023-11-06"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.5
+output = 1.5
+
+[limit]
+context = 16385
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4-turbo.toml
+++ b/providers/kilo/models/openai/gpt-4-turbo.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-4 Turbo"
+release_date = "2023-09-13"
+last_updated = "2024-04-09"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 10.0
+output = 30.0
+
+[limit]
+context = 128000
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4.1-mini.toml
+++ b/providers/kilo/models/openai/gpt-4.1-mini.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-4.1 Mini"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.1
+
+[limit]
+context = 1047576
+output = 32768
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4.1-nano.toml
+++ b/providers/kilo/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-4.1 Nano"
+release_date = "2025-04-14"
+last_updated = "2025-04-15"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.025
+
+[limit]
+context = 1047576
+output = 32768
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4.1.toml
+++ b/providers/kilo/models/openai/gpt-4.1.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-4.1"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.0
+output = 8.0
+cache_read = 0.5
+
+[limit]
+context = 1047576
+output = 32768
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4.toml
+++ b/providers/kilo/models/openai/gpt-4.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-4"
+release_date = "2023-03-14"
+last_updated = "2024-04-09"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 30.0
+output = 60.0
+
+[limit]
+context = 8191
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4o-2024-05-13.toml
+++ b/providers/kilo/models/openai/gpt-4o-2024-05-13.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-4o (2024-05-13)"
+release_date = "2024-05-13"
+last_updated = "2024-05-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 5.0
+output = 15.0
+
+[limit]
+context = 128000
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4o-2024-08-06.toml
+++ b/providers/kilo/models/openai/gpt-4o-2024-08-06.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-4o (2024-08-06)"
+release_date = "2024-08-06"
+last_updated = "2024-08-06"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10.0
+cache_read = 1.25
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4o-2024-11-20.toml
+++ b/providers/kilo/models/openai/gpt-4o-2024-11-20.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-4o (2024-11-20)"
+release_date = "2024-11-20"
+last_updated = "2024-11-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10.0
+cache_read = 1.25
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4o-mini-search-preview.toml
+++ b/providers/kilo/models/openai/gpt-4o-mini-search-preview.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-4o-mini Search Preview"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4o-mini.toml
+++ b/providers/kilo/models/openai/gpt-4o-mini.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-4o-mini"
+release_date = "2024-07-18"
+last_updated = "2024-07-18"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.075
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4o.toml
+++ b/providers/kilo/models/openai/gpt-4o.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-4o"
+release_date = "2024-05-13"
+last_updated = "2024-08-06"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10.0
+cache_read = 1.25
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-4o:extended.toml
+++ b/providers/kilo/models/openai/gpt-4o:extended.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-4o (extended)"
+release_date = "2024-05-13"
+last_updated = "2024-08-06"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 6.0
+output = 18.0
+
+[limit]
+context = 128000
+output = 64000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5-chat.toml
+++ b/providers/kilo/models/openai/gpt-5-chat.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5 Chat"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5-codex.toml
+++ b/providers/kilo/models/openai/gpt-5-codex.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5 Codex"
+release_date = "2025-09-15"
+last_updated = "2025-09-15"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5-mini.toml
+++ b/providers/kilo/models/openai/gpt-5-mini.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5 Mini"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5-nano.toml
+++ b/providers/kilo/models/openai/gpt-5-nano.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5 Nano"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.05
+output = 0.4
+cache_read = 0.005
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5-pro.toml
+++ b/providers/kilo/models/openai/gpt-5-pro.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-5 Pro"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 15.0
+output = 120.0
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.1-chat.toml
+++ b/providers/kilo/models/openai/gpt-5.1-chat.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5.1 Chat"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex-max.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5.1-Codex-Max"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex-mini.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5.1-Codex-Mini"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025
+
+[limit]
+context = 400000
+output = 100000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.1-codex.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5.1-Codex"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.1.toml
+++ b/providers/kilo/models/openai/gpt-5.1.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5.1"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.2-chat.toml
+++ b/providers/kilo/models/openai/gpt-5.2-chat.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5.2 Chat"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.0
+cache_read = 0.175
+
+[limit]
+context = 128000
+output = 16384
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.2-codex.toml
+++ b/providers/kilo/models/openai/gpt-5.2-codex.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5.2-Codex"
+release_date = "2026-01-14"
+last_updated = "2026-01-14"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.0
+cache_read = 0.175
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.2-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.2-pro.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: GPT-5.2 Pro"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 21.0
+output = 168.0
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.2.toml
+++ b/providers/kilo/models/openai/gpt-5.2.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5.2"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.0
+cache_read = 0.175
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-5.toml
+++ b/providers/kilo/models/openai/gpt-5.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: GPT-5"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.0
+cache_read = 0.125
+
+[limit]
+context = 400000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-oss-120b.toml
+++ b/providers/kilo/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: gpt-oss-120b"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.039
+output = 0.19
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-oss-120b:exacto.toml
+++ b/providers/kilo/models/openai/gpt-oss-120b:exacto.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: gpt-oss-120b (exacto)"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.039
+output = 0.19
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-oss-120b:free.toml
+++ b/providers/kilo/models/openai/gpt-oss-120b:free.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: gpt-oss-120b (free)"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-oss-20b.toml
+++ b/providers/kilo/models/openai/gpt-oss-20b.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: gpt-oss-20b"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.14
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-oss-20b:free.toml
+++ b/providers/kilo/models/openai/gpt-oss-20b:free.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: gpt-oss-20b (free)"
+release_date = "2025-08-05"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/kilo/models/openai/gpt-oss-safeguard-20b.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: gpt-oss-safeguard-20b"
+release_date = "2025-10-29"
+last_updated = "2025-10-29"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.075
+output = 0.3
+cache_read = 0.037
+
+[limit]
+context = 131072
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/o1-pro.toml
+++ b/providers/kilo/models/openai/o1-pro.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: o1-pro"
+release_date = "2025-03-19"
+last_updated = "2025-03-19"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 150.0
+output = 600.0
+
+[limit]
+context = 200000
+output = 100000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/o1.toml
+++ b/providers/kilo/models/openai/o1.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: o1"
+release_date = "2024-12-05"
+last_updated = "2025-01-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 15.0
+output = 60.0
+cache_read = 7.5
+
+[limit]
+context = 200000
+output = 100000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/o3-deep-research.toml
+++ b/providers/kilo/models/openai/o3-deep-research.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: o3 Deep Research"
+release_date = "2024-06-26"
+last_updated = "2025-06-27"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 10.0
+output = 40.0
+cache_read = 2.5
+
+[limit]
+context = 200000
+output = 100000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/o3-mini-high.toml
+++ b/providers/kilo/models/openai/o3-mini-high.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: o3 Mini High"
+release_date = "2025-01-31"
+last_updated = "2025-01-31"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.55
+
+[limit]
+context = 200000
+output = 100000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/o3-mini.toml
+++ b/providers/kilo/models/openai/o3-mini.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: o3 Mini"
+release_date = "2024-12-20"
+last_updated = "2026-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.55
+
+[limit]
+context = 200000
+output = 100000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/openai/o3-pro.toml
+++ b/providers/kilo/models/openai/o3-pro.toml
@@ -1,0 +1,20 @@
+name = "OpenAI: o3 Pro"
+release_date = "2025-04-16"
+last_updated = "2025-06-10"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 20.0
+output = 80.0
+
+[limit]
+context = 200000
+output = 100000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/openai/o3.toml
+++ b/providers/kilo/models/openai/o3.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: o3"
+release_date = "2025-04-16"
+last_updated = "2026-01"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.0
+output = 8.0
+cache_read = 0.5
+
+[limit]
+context = 200000
+output = 100000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/o4-mini-deep-research.toml
+++ b/providers/kilo/models/openai/o4-mini-deep-research.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: o4 Mini Deep Research"
+release_date = "2024-06-26"
+last_updated = "2025-06-27"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.0
+output = 8.0
+cache_read = 0.5
+
+[limit]
+context = 200000
+output = 100000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openai/o4-mini.toml
+++ b/providers/kilo/models/openai/o4-mini.toml
@@ -1,0 +1,21 @@
+name = "OpenAI: o4 Mini"
+release_date = "2025-04-16"
+last_updated = "2025-04-16"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.275
+
+[limit]
+context = 200000
+output = 100000
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/openrouter/aurora-alpha.toml
+++ b/providers/kilo/models/openrouter/aurora-alpha.toml
@@ -1,0 +1,20 @@
+name = "Aurora Alpha (free)"
+release_date = "2026-02-09"
+last_updated = "2026-02-09"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128000
+output = 50000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/perplexity/sonar-deep-research.toml
+++ b/providers/kilo/models/perplexity/sonar-deep-research.toml
@@ -1,0 +1,20 @@
+name = "Perplexity: Sonar Deep Research"
+release_date = "2025-01-27"
+last_updated = "2025-01-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 2.0
+output = 8.0
+
+[limit]
+context = 128000
+output = 25600
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/perplexity/sonar-pro.toml
+++ b/providers/kilo/models/perplexity/sonar-pro.toml
@@ -1,0 +1,20 @@
+name = "Perplexity: Sonar Pro"
+release_date = "2024-01-01"
+last_updated = "2025-09-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 3.0
+output = 15.0
+
+[limit]
+context = 200000
+output = 8000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/kilo/models/perplexity/sonar-reasoning-pro.toml
@@ -1,0 +1,20 @@
+name = "Perplexity: Sonar Reasoning Pro"
+release_date = "2024-01-01"
+last_updated = "2025-09-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 2.0
+output = 8.0
+
+[limit]
+context = 128000
+output = 25600
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/perplexity/sonar.toml
+++ b/providers/kilo/models/perplexity/sonar.toml
@@ -1,0 +1,20 @@
+name = "Perplexity: Sonar"
+release_date = "2024-01-01"
+last_updated = "2025-09-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 1.0
+output = 1.0
+
+[limit]
+context = 127072
+output = 25415
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/prime-intellect/intellect-3.toml
+++ b/providers/kilo/models/prime-intellect/intellect-3.toml
@@ -1,0 +1,20 @@
+name = "Prime Intellect: INTELLECT-3"
+release_date = "2025-11-26"
+last_updated = "2026-02-04"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.2
+output = 1.1
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen-2.5-72b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen-2.5-72b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen2.5 72B Instruct"
+release_date = "2024-09"
+last_updated = "2026-01-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.12
+output = 0.39
+
+[limit]
+context = 32768
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen-2.5-7b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen-2.5-7b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen2.5 7B Instruct"
+release_date = "2024-09"
+last_updated = "2025-04-16"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.1
+
+[limit]
+context = 32768
+output = 6554
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen-2.5-coder-32b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen-2.5-coder-32b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen2.5 Coder 32B Instruct"
+release_date = "2024-11-11"
+last_updated = "2024-11-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.11
+cache_read = 0.015
+
+[limit]
+context = 32768
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen-2.5-vl-7b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen-2.5-vl-7b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen2.5-VL 7B Instruct"
+release_date = "2024-08-28"
+last_updated = "2024-09"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.2
+
+[limit]
+context = 32768
+output = 6554
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen-max.toml
+++ b/providers/kilo/models/qwen/qwen-max.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen-Max "
+release_date = "2024-04-03"
+last_updated = "2025-01-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.6
+output = 6.4
+cache_read = 0.32
+
+[limit]
+context = 32768
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen-plus.toml
+++ b/providers/kilo/models/qwen/qwen-plus.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen-Plus"
+release_date = "2024-01-25"
+last_updated = "2025-09-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.4
+output = 1.2
+cache_read = 0.08
+
+[limit]
+context = 1000000
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen-turbo.toml
+++ b/providers/kilo/models/qwen/qwen-turbo.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen-Turbo"
+release_date = "2024-11-01"
+last_updated = "2025-07-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.05
+output = 0.2
+cache_read = 0.01
+
+[limit]
+context = 131072
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen-vl-max.toml
+++ b/providers/kilo/models/qwen/qwen-vl-max.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen VL Max"
+release_date = "2024-04-08"
+last_updated = "2025-08-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.8
+output = 3.2
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen-vl-plus.toml
+++ b/providers/kilo/models/qwen/qwen-vl-plus.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen VL Plus"
+release_date = "2024-01-25"
+last_updated = "2025-08-15"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.21
+output = 0.63
+cache_read = 0.042
+
+[limit]
+context = 131072
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen2.5-coder-7b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen2.5-coder-7b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen2.5 Coder 7B Instruct"
+release_date = "2024-09-17"
+last_updated = "2024-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.09
+
+[limit]
+context = 32768
+output = 6554
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen2.5-vl-32b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen2.5-vl-32b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen2.5 VL 32B Instruct"
+release_date = "2025-03-24"
+last_updated = "2026-01-10"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.22
+cache_read = 0.025
+
+[limit]
+context = 16384
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen2.5-vl-72b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen2.5-vl-72b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen2.5 VL 72B Instruct"
+release_date = "2025-02-01"
+last_updated = "2025-02-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.075
+
+[limit]
+context = 32768
+output = 32768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-14b.toml
+++ b/providers/kilo/models/qwen/qwen3-14b.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 14B"
+release_date = "2025-04"
+last_updated = "2026-01-10"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.22
+cache_read = 0.025
+
+[limit]
+context = 40960
+output = 40960
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-235b-a22b-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b-2507.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 235B A22B Instruct 2507"
+release_date = "2025-04"
+last_updated = "2026-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.071
+output = 0.1
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 235B A22B Thinking 2507"
+release_date = "2025-07-25"
+last_updated = "2025-07-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-235b-a22b.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 235B A22B"
+release_date = "2024-12-01"
+last_updated = "2026-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.15
+
+[limit]
+context = 40960
+output = 40960
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-30b-a3b-instruct-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-30b-a3b-instruct-2507.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 30B A3B Instruct 2507"
+release_date = "2025-07-29"
+last_updated = "2025-07-29"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.33
+cache_read = 0.04
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-30b-a3b-thinking-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-30b-a3b-thinking-2507.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 30B A3B Thinking 2507"
+release_date = "2025-07-29"
+last_updated = "2025-07-29"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.051
+output = 0.34
+
+[limit]
+context = 32768
+output = 6554
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-30b-a3b.toml
+++ b/providers/kilo/models/qwen/qwen3-30b-a3b.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 30B A3B"
+release_date = "2025-04"
+last_updated = "2026-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.22
+cache_read = 0.03
+
+[limit]
+context = 40960
+output = 40960
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-32b.toml
+++ b/providers/kilo/models/qwen/qwen3-32b.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 32B"
+release_date = "2024-12-01"
+last_updated = "2026-02-04"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.24
+cache_read = 0.04
+
+[limit]
+context = 40960
+output = 40960
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-4b.toml
+++ b/providers/kilo/models/qwen/qwen3-4b.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 4B"
+release_date = "2025-04-29"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0715
+output = 0.273
+
+[limit]
+context = 131072
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-4b:free.toml
+++ b/providers/kilo/models/qwen/qwen3-4b:free.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 4B (free)"
+release_date = "2025-04-30"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 40960
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-8b.toml
+++ b/providers/kilo/models/qwen/qwen3-8b.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 8B"
+release_date = "2025-04"
+last_updated = "2025-04"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.4
+cache_read = 0.05
+
+[limit]
+context = 32000
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen3-coder-30b-a3b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 Coder 30B A3B Instruct"
+release_date = "2025-07-31"
+last_updated = "2025-07-31"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.27
+
+[limit]
+context = 160000
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-coder-flash.toml
+++ b/providers/kilo/models/qwen/qwen3-coder-flash.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 Coder Flash"
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 1.5
+cache_read = 0.06
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-coder-next.toml
+++ b/providers/kilo/models/qwen/qwen3-coder-next.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 Coder Next"
+release_date = "2026-02-02"
+last_updated = "2026-02-08"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.3
+cache_read = 0.035
+
+[limit]
+context = 262144
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-coder-plus.toml
+++ b/providers/kilo/models/qwen/qwen3-coder-plus.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 Coder Plus"
+release_date = "2025-07-01"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.2
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-coder.toml
+++ b/providers/kilo/models/qwen/qwen3-coder.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 Coder 480B A35B"
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 1.0
+cache_read = 0.022
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-coder:exacto.toml
+++ b/providers/kilo/models/qwen/qwen3-coder:exacto.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 Coder 480B A35B (exacto)"
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 1.8
+cache_read = 0.022
+
+[limit]
+context = 262144
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-coder:free.toml
+++ b/providers/kilo/models/qwen/qwen3-coder:free.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 Coder 480B A35B (free)"
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262000
+output = 262000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-max-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-max-thinking.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 Max Thinking"
+release_date = "2026-01-23"
+last_updated = "2026-01-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.2
+output = 6.0
+
+[limit]
+context = 262144
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-max.toml
+++ b/providers/kilo/models/qwen/qwen3-max.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 Max"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.2
+output = 6.0
+cache_read = 0.24
+
+[limit]
+context = 262144
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen3-next-80b-a3b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 Next 80B A3B Instruct"
+release_date = "2025-09-11"
+last_updated = "2025-09-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.09
+output = 1.1
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-next-80b-a3b-instruct:free.toml
+++ b/providers/kilo/models/qwen/qwen3-next-80b-a3b-instruct:free.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 Next 80B A3B Instruct (free)"
+release_date = "2025-09-11"
+last_updated = "2025-09-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 Next 80B A3B Thinking"
+release_date = "2025-09-11"
+last_updated = "2025-09-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 1.2
+
+[limit]
+context = 128000
+output = 25600
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-vl-235b-a22b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-235b-a22b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen: Qwen3 VL 235B A22B Instruct"
+release_date = "2025-09-23"
+last_updated = "2026-01-10"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.88
+cache_read = 0.11
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-235b-a22b-thinking.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 VL 235B A22B Thinking"
+release_date = "2025-09-24"
+last_updated = "2025-09-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-vl-30b-a3b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-30b-a3b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 VL 30B A3B Instruct"
+release_date = "2025-10-05"
+last_updated = "2025-11-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.13
+output = 0.52
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-vl-30b-a3b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-30b-a3b-thinking.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 VL 30B A3B Thinking"
+release_date = "2025-10-11"
+last_updated = "2025-11-25"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-vl-32b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-32b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 VL 32B Instruct"
+release_date = "2025-10-21"
+last_updated = "2025-11-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.104
+output = 0.416
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-vl-8b-instruct.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-8b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 VL 8B Instruct"
+release_date = "2025-10-15"
+last_updated = "2025-11-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.5
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3-vl-8b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-8b-thinking.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3 VL 8B Thinking"
+release_date = "2025-10-15"
+last_updated = "2025-11-25"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.117
+output = 1.365
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3.5 397B A17B"
+release_date = "2026-02-15"
+last_updated = "2026-02-15"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.6
+output = 3.6
+
+[limit]
+context = 256000
+output = 64000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwen3.5-plus-02-15.toml
+++ b/providers/kilo/models/qwen/qwen3.5-plus-02-15.toml
@@ -1,0 +1,20 @@
+name = "Qwen: Qwen3.5 Plus 2026-02-15"
+release_date = "2026-02-15"
+last_updated = "2026-02-15"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.4
+output = 2.4
+
+[limit]
+context = 1000000
+output = 64000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/kilo/models/qwen/qwq-32b.toml
+++ b/providers/kilo/models/qwen/qwq-32b.toml
@@ -1,0 +1,20 @@
+name = "Qwen: QwQ 32B"
+release_date = "2024-11-28"
+last_updated = "2025-04-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.4
+
+[limit]
+context = 32768
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/stepfun/step-3.5-flash.toml
+++ b/providers/kilo/models/stepfun/step-3.5-flash.toml
@@ -1,0 +1,21 @@
+name = "StepFun: Step 3.5 Flash"
+release_date = "2026-01-29"
+last_updated = "2026-01-29"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.3
+cache_read = 0.02
+
+[limit]
+context = 256000
+output = 256000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/stepfun/step-3.5-flash:free.toml
+++ b/providers/kilo/models/stepfun/step-3.5-flash:free.toml
@@ -1,0 +1,20 @@
+name = "StepFun: Step 3.5 Flash (free)"
+release_date = "2026-01-29"
+last_updated = "2026-01-29"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 256000
+output = 256000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/tencent/hunyuan-a13b-instruct.toml
+++ b/providers/kilo/models/tencent/hunyuan-a13b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Tencent: Hunyuan A13B Instruct"
+release_date = "2025-06-30"
+last_updated = "2025-11-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.14
+output = 0.57
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/tngtech/deepseek-r1t-chimera.toml
+++ b/providers/kilo/models/tngtech/deepseek-r1t-chimera.toml
@@ -1,0 +1,21 @@
+name = "TNG: DeepSeek R1T Chimera"
+release_date = "2025-12-29"
+last_updated = "2026-01-10"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.15
+
+[limit]
+context = 163840
+output = 163840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/tngtech/deepseek-r1t2-chimera.toml
+++ b/providers/kilo/models/tngtech/deepseek-r1t2-chimera.toml
@@ -1,0 +1,21 @@
+name = "TNG: DeepSeek R1T2 Chimera"
+release_date = "2025-07-08"
+last_updated = "2025-07-08"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.25
+output = 0.85
+cache_read = 0.125
+
+[limit]
+context = 163840
+output = 163840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/tngtech/tng-r1t-chimera.toml
+++ b/providers/kilo/models/tngtech/tng-r1t-chimera.toml
@@ -1,0 +1,21 @@
+name = "TNG: R1T Chimera"
+release_date = "2025-11-26"
+last_updated = "2026-01-31"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.25
+output = 0.85
+cache_read = 0.125
+
+[limit]
+context = 163840
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/writer/palmyra-x5.toml
+++ b/providers/kilo/models/writer/palmyra-x5.toml
@@ -1,0 +1,20 @@
+name = "Writer: Palmyra X5"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.6
+output = 6.0
+
+[limit]
+context = 1040000
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/x-ai/grok-3-beta.toml
+++ b/providers/kilo/models/x-ai/grok-3-beta.toml
@@ -1,0 +1,21 @@
+name = "xAI: Grok 3 Beta"
+release_date = "2025-02-17"
+last_updated = "2025-02-17"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.75
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/x-ai/grok-3-mini-beta.toml
+++ b/providers/kilo/models/x-ai/grok-3-mini-beta.toml
@@ -1,0 +1,21 @@
+name = "xAI: Grok 3 Mini Beta"
+release_date = "2025-02-17"
+last_updated = "2025-02-17"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 0.5
+cache_read = 0.075
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/x-ai/grok-3-mini.toml
+++ b/providers/kilo/models/x-ai/grok-3-mini.toml
@@ -1,0 +1,21 @@
+name = "xAI: Grok 3 Mini"
+release_date = "2025-02-17"
+last_updated = "2025-02-17"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 0.5
+cache_read = 0.075
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/x-ai/grok-3.toml
+++ b/providers/kilo/models/x-ai/grok-3.toml
@@ -1,0 +1,21 @@
+name = "xAI: Grok 3"
+release_date = "2025-02-17"
+last_updated = "2025-02-17"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.75
+
+[limit]
+context = 131072
+output = 26215
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/x-ai/grok-4-fast.toml
+++ b/providers/kilo/models/x-ai/grok-4-fast.toml
@@ -1,0 +1,21 @@
+name = "xAI: Grok 4 Fast"
+release_date = "2025-08-19"
+last_updated = "2025-08-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.5
+cache_read = 0.05
+
+[limit]
+context = 2000000
+output = 30000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/x-ai/grok-4.1-fast.toml
+++ b/providers/kilo/models/x-ai/grok-4.1-fast.toml
@@ -1,0 +1,21 @@
+name = "xAI: Grok 4.1 Fast"
+release_date = "2025-11-19"
+last_updated = "2025-11-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.5
+cache_read = 0.05
+
+[limit]
+context = 2000000
+output = 30000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/x-ai/grok-4.toml
+++ b/providers/kilo/models/x-ai/grok-4.toml
@@ -1,0 +1,21 @@
+name = "xAI: Grok 4"
+release_date = "2025-07-09"
+last_updated = "2025-07-09"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.75
+
+[limit]
+context = 256000
+output = 51200
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/kilo/models/x-ai/grok-code-fast-1.toml
+++ b/providers/kilo/models/x-ai/grok-code-fast-1.toml
@@ -1,0 +1,21 @@
+name = "xAI: Grok Code Fast 1"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 1.5
+cache_read = 0.02
+
+[limit]
+context = 256000
+output = 10000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-flash.toml
@@ -1,0 +1,21 @@
+name = "Xiaomi: MiMo-V2-Flash"
+release_date = "2025-12-14"
+last_updated = "2025-12-14"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.09
+output = 0.29
+cache_read = 0.045
+
+[limit]
+context = 262144
+output = 52429
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-4.5-air.toml
+++ b/providers/kilo/models/z-ai/glm-4.5-air.toml
@@ -1,0 +1,21 @@
+name = "Z.ai: GLM 4.5 Air"
+release_date = "2025-07-28"
+last_updated = "2025-07-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.13
+output = 0.85
+cache_read = 0.025
+
+[limit]
+context = 131072
+output = 98304
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-4.5-air:free.toml
+++ b/providers/kilo/models/z-ai/glm-4.5-air:free.toml
@@ -1,0 +1,20 @@
+name = "Z.ai: GLM 4.5 Air (free)"
+release_date = "2025-07-28"
+last_updated = "2025-07-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 96000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-4.5.toml
+++ b/providers/kilo/models/z-ai/glm-4.5.toml
@@ -1,0 +1,21 @@
+name = "Z.ai: GLM 4.5"
+release_date = "2025-07-28"
+last_updated = "2025-07-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.35
+output = 1.55
+cache_read = 0.175
+
+[limit]
+context = 131072
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-4.5v.toml
+++ b/providers/kilo/models/z-ai/glm-4.5v.toml
@@ -1,0 +1,21 @@
+name = "Z.ai: GLM 4.5V"
+release_date = "2025-08-11"
+last_updated = "2025-08-11"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 1.8
+cache_read = 0.11
+
+[limit]
+context = 65536
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-4.6.toml
+++ b/providers/kilo/models/z-ai/glm-4.6.toml
@@ -1,0 +1,21 @@
+name = "Z.ai: GLM 4.6"
+release_date = "2025-09-30"
+last_updated = "2025-09-30"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.35
+output = 1.5
+cache_read = 0.175
+
+[limit]
+context = 202752
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-4.6:exacto.toml
+++ b/providers/kilo/models/z-ai/glm-4.6:exacto.toml
@@ -1,0 +1,21 @@
+name = "Z.ai: GLM 4.6 (exacto)"
+release_date = "2025-09-30"
+last_updated = "2025-09-30"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.44
+output = 1.76
+cache_read = 0.11
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-4.6v.toml
+++ b/providers/kilo/models/z-ai/glm-4.6v.toml
@@ -1,0 +1,20 @@
+name = "Z.ai: GLM 4.6V"
+release_date = "2025-09-30"
+last_updated = "2026-01-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 0.9
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["image", "text", "video"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-4.7-flash.toml
+++ b/providers/kilo/models/z-ai/glm-4.7-flash.toml
@@ -1,0 +1,21 @@
+name = "Z.ai: GLM 4.7 Flash"
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.4
+cache_read = 0.01
+
+[limit]
+context = 202752
+output = 40551
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-4.7.toml
+++ b/providers/kilo/models/z-ai/glm-4.7.toml
@@ -1,0 +1,21 @@
+name = "Z.ai: GLM 4.7"
+release_date = "2025-12-22"
+last_updated = "2025-12-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.4
+output = 1.5
+cache_read = 0.2
+
+[limit]
+context = 202752
+output = 65535
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-5.toml
+++ b/providers/kilo/models/z-ai/glm-5.toml
@@ -1,0 +1,20 @@
+name = "Z.ai: GLM 5"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 2.55
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/z-ai/glm-5:free.toml
+++ b/providers/kilo/models/z-ai/glm-5:free.toml
@@ -1,0 +1,21 @@
+name = "Z.ai: GLM 5 (free)"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 202800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/provider.toml
+++ b/providers/kilo/provider.toml
@@ -1,0 +1,4 @@
+name = "Kilo Gateway"
+env = ["KILO_API_KEY"]
+npm = "opencode-kilo-auth"
+doc = "https://kilo.ai"


### PR DESCRIPTION
## Summary
- Add a new `kilo` provider to `models.dev` with provider metadata and logo.
- Import Kilo model definitions from the Kilo source list and convert them to `models.dev` TOML schema.

## What was added
- `providers/kilo/provider.toml`
- `providers/kilo/logo.svg`
- `providers/kilo/models/**/*.toml` (263 model files)

## Data source and references
- Source model list: https://github.com/JungHoonGhae/opencode-kilo-auth
- Related upstream context: https://github.com/anomalyco/opencode/pull/13826

## Validation
- Ran: `bun validate`
- Result: passes