### PR TITLE
Add four Qwen3.5 models for NanoGPT

### DIFF
--- a/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b-thinking.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b-thinking.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 397B A17B Thinking"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 3.60
+
+[limit]
+context = 258000
+output = 8192
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 397B A17B"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 3.60
+
+[limit]
+context = 258000
+output = 8192
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nano-gpt/models/qwen/qwen3.5-plus-thinking.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-plus-thinking.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 Plus Thinking"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.40
+output = 2.40
+
+[limit]
+context = 983600
+output = 8192
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nano-gpt/models/qwen/qwen3.5-plus.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-plus.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 Plus"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.40
+output = 2.40
+
+[limit]
+context = 983600
+output = 8192
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add four new Qwen3.5 models for the `nano-gpt` provider.

## Added models
- `qwen/qwen3.5-397b-a17b`
- `qwen/qwen3.5-397b-a17b-thinking`
- `qwen/qwen3.5-plus`
- `qwen/qwen3.5-plus-thinking`

## Details
- Release date / last updated: `2026-02-16`
- Pricing per 1M tokens:
  - Qwen3.5 397B A17B (+ Thinking): `$0.60` input, `$3.60` output
  - Qwen3.5 Plus (+ Thinking): `$0.40` input, `$2.40` output
- Context windows:
  - 397B variants: `258000`
  - Plus variants: `983600`
- Modalities: input `text,image,video`; output `text`

## Validation
- Ran: `bun validate`
- Result: passes