### PR TITLE
Add Qwen3.5 models for alibaba & alibaba-cn provider

### DIFF
--- a/providers/alibaba-cn/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba-cn/models/qwen3.5-397b-a17b.toml
@@ -1,0 +1,23 @@
+name = "Qwen3.5 397B-A17B"
+family = "qwen"
+release_date = "2026-02"
+last_updated = "2026-02"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.430
+output = 2.58
+reasoning = 2.58
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/alibaba-cn/models/qwen3.5-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.5-plus.toml
@@ -1,0 +1,23 @@
+name = "Qwen3.5 Plus"
+family = "qwen"
+release_date = "2026-02"
+last_updated = "2026-02"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.573
+output = 3.44
+reasoning = 3.44
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/alibaba/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba/models/qwen3.5-397b-a17b.toml
@@ -1,0 +1,23 @@
+name = "Qwen3.5 397B-A17B"
+family = "qwen"
+release_date = "2026-02"
+last_updated = "2026-02"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 3.6
+reasoning = 3.6
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/alibaba/models/qwen3.5-plus.toml
+++ b/providers/alibaba/models/qwen3.5-plus.toml
@@ -1,0 +1,24 @@
+name = "Qwen3.5 Plus"
+family = "qwen"
+release_date = "2026-02"
+last_updated = "2026-02"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.4
+output = 2.4
+reasoning = 2.4
+
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add Qwen3.5 models for alibaba & alibaba-cn provider

## Added Models
- qwen3.5-plus 
- qwen3.5-397b-a17b

## References
- [Alibaba Cloud Model Studio Doc](https://www.alibabacloud.com/help/en/model-studio/models)
- [International Pricing (Singapore)](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.5-plus)
- [China Pricing](https://bailian.console.alibabacloud.com/cn-beijing?tab=model#/model-market/detail/qwen3.5-plus)