### PR TITLE
feat: add Qwen3.5 models on OpenRouter

### DIFF
--- a/providers/openrouter/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/openrouter/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 397B A17B"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 3.60
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen3.5-plus-02-15.toml
+++ b/providers/openrouter/models/qwen/qwen3.5-plus-02-15.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 Plus 2026-02-15"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.40
+output = 2.40
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add OpenRouter model entries for `qwen/qwen3.5-plus-02-15` and `qwen/qwen3.5-397b-a17b`.
- Configure pricing, limits, capabilities, and modalities based on current OpenRouter model metadata.
- Keep naming and field conventions aligned with recent OpenRouter model additions.

## Validation
- `bun validate`
- Verified `context` and `output` values against `https://openrouter.ai/api/v1/models`.