### PR TITLE
Fix the display name of GLM-4.7-Flash

### DIFF
--- a/providers/openrouter/models/z-ai/glm-4.7-flash.toml
+++ b/providers/openrouter/models/z-ai/glm-4.7-flash.toml
@@ -1,4 +1,4 @@
-name = "GLM-4.7"
+name = "GLM-4.7-Flash"
 family = "glm"
 release_date = "2026-01-19"
 last_updated = "2026-01-19"


### PR DESCRIPTION
Both GLM 4.7 and GLM 4.7 Flash had the same "GLM 4.7" name