### PR TITLE
Add MiniMax-M2.5-highspeed models for official MiniMax providers

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M2.5-highspeed.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M2.5-highspeed.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M2.5-highspeed"
+family = "minimax"
+release_date = "2026-02-13"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/minimax-cn/models/MiniMax-M2.5-highspeed.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.5-highspeed.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M2.5-highspeed"
+family = "minimax"
+release_date = "2026-02-13"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 2.40
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/minimax-coding-plan/models/MiniMax-M2.5-highspeed.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M2.5-highspeed.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M2.5-highspeed"
+family = "minimax"
+release_date = "2026-02-13"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/minimax/models/MiniMax-M2.5-highspeed.toml
+++ b/providers/minimax/models/MiniMax-M2.5-highspeed.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M2.5-highspeed"
+family = "minimax"
+release_date = "2026-02-13"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 2.40
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This adds MiniMax-M2.5-highspeed model configs for official MiniMax providers in both global and CN variants, including coding-plan counterparts.

Files added:
- providers/minimax/models/MiniMax-M2.5-highspeed.toml
- providers/minimax-coding-plan/models/MiniMax-M2.5-highspeed.toml
- providers/minimax-cn/models/MiniMax-M2.5-highspeed.toml
- providers/minimax-cn-coding-plan/models/MiniMax-M2.5-highspeed.toml

Validation:
- bun validate (pass)

Source:
- https://platform.minimax.io/docs/api-reference/text-anthropic-api