### PR TITLE
feat: add GLM-4.7-FlashX model configuration

### DIFF
--- a/providers/zai-coding-plan/models/glm-4.7-flashx.toml
+++ b/providers/zai-coding-plan/models/glm-4.7-flashx.toml
@@ -1,0 +1,24 @@
+name = "GLM-4.7-FlashX"
+family = "glm-flash"
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.40
+cache_read = 0.01
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# Summary

Add GLM-4.7-FlashX model to the zai-coding-plan provider.

Added model
- glm-4.7-flashx

Details
- Release date / last updated: 2026-01-19
- Pricing per 1M tokens: $0.07 input, $0.40 output, $0.01 cache read
- Context window: 200,000
- Max output: 131,072
- Modalities: text in, text out
- Capabilities: reasoning, tool_call, temperature

Validation
- Ran: bun validate
- Result: passes