### PR TITLE
fix(kilo): use @ai-sdk/openai-compatible instead of opencode-kilo-auth

### DIFF
--- a/providers/kilo/provider.toml
+++ b/providers/kilo/provider.toml
@@ -1,4 +1,5 @@
 name = "Kilo Gateway"
 env = ["KILO_API_KEY"]
-npm = "opencode-kilo-auth"
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.kilo.ai/api/gateway"
 doc = "https://kilo.ai"


### PR DESCRIPTION
Fixes the Kilo provider npm field from `opencode-kilo-auth` to `@ai-sdk/openai-compatible` and adds the `api` endpoint.

**The bug:** The current `npm = "opencode-kilo-auth"` causes `ProviderInitError: fn3 is not a function` in OpenCode because that package is not bundled and does not export a standard `create*` function ([ref](https://github.com/anomalyco/opencode/pull/13765#issuecomment-2933968508)).

**The fix:** `@ai-sdk/openai-compatible` is already bundled in OpenCode and works with the Kilo gateway. Added `api` field pointing to Kilo endpoint, matching other OpenAI-compatible providers (deepseek, together, fireworks-ai, nvidia).

Companion to anomalyco/opencode#13765 (CUSTOM_LOADERS wiring for Kilo).