### PR TITLE
feat(models): add Claude Sonnet 4.6 model configurations

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,30 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[cost.context_over_200k]
+input = 6.00
+output = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,30 @@
+name = "Claude Sonnet 4.6 (EU)"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[cost.context_over_200k]
+input = 6.00
+output = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,30 @@
+name = "Claude Sonnet 4.6 (Global)"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[cost.context_over_200k]
+input = 6.00
+output = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,30 @@
+name = "Claude Sonnet 4.6 (US)"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[cost.context_over_200k]
+input = 6.00
+output = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/anthropic/models/claude-sonnet-4-6.toml
+++ b/providers/anthropic/models/claude-sonnet-4-6.toml
@@ -1,0 +1,30 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[cost.context_over_200k]
+input = 6.00
+output = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
@@ -1,0 +1,30 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[cost.context_over_200k]
+input = 6.00
+output = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
- Add Claude Sonnet 4.6 to Anthropic provider with full capabilities
- Add regional variants (US, EU, Global) for Amazon Bedrock provider
- Add Google Vertex Anthropic provider configuration
- Define pricing, context limits (200k tokens), and modalities