### PR TITLE
Adds optional `huggingface_id` field to model configurations for linking open-weight models

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ knowledge = "2024-04"       # Knowledge-cutoff date
 release_date = "2025-02-19" # First public release date
 last_updated = "2025-02-19" # Most recent update date
 open_weights = true         # or false  - model’s trained weights are publicly available
+huggingface_id = "org/model-name" # Optional - HuggingFace model ID (only for open_weights=true)
 
 [cost]
 input = 3.00                # Cost per million input tokens (USD)

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -60,6 +60,12 @@ export const Model = z
       output: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
     }),
     open_weights: z.boolean(),
+    huggingface_id: z
+      .string()
+      .regex(/^[a-zA-Z0-9_\-\.]+\/[a-zA-Z0-9_\-\.]+$/, {
+        message: "Must be in format 'organization/model-name'",
+      })
+      .optional(),
     cost: Cost.extend({
       context_over_200k: Cost.optional(),
     }).optional(),
@@ -84,6 +90,17 @@ export const Model = z
     {
       message: "Cannot set cost.reasoning when reasoning is false",
       path: ["cost", "reasoning"],
+    },
+  )
+  .refine(
+    (data) => {
+      return !(
+        data.huggingface_id !== undefined && data.open_weights === false
+      );
+    },
+    {
+      message: "Cannot set huggingface_id when open_weights is false",
+      path: ["huggingface_id"],
     },
   );
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -62,7 +62,7 @@ export const Model = z
     open_weights: z.boolean(),
     huggingface_id: z
       .string()
-      .regex(/^[a-zA-Z0-9_\-\.]+\/[a-zA-Z0-9_\-\.]+$/, {
+      .regex(/^[a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-\.]+$/, {
         message: "Must be in format 'organization/model-name'",
       })
       .optional(),
@@ -94,9 +94,11 @@ export const Model = z
   )
   .refine(
     (data) => {
-      return !(
-        data.huggingface_id !== undefined && data.open_weights === false
-      );
+      // huggingface_id can only be set when open_weights is true
+      if (data.huggingface_id !== undefined) {
+        return data.open_weights === true;
+      }
+      return true;
     },
     {
       message: "Cannot set huggingface_id when open_weights is false",

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -332,6 +332,9 @@ export const Rendered = renderToString(
             Weights <span class="sort-indicator"></span>
           </th>
           <th class="sortable" data-type="text">
+            HuggingFace ID <span class="sort-indicator"></span>
+          </th>
+          <th class="sortable" data-type="text">
             Knowledge <span class="sort-indicator"></span>
           </th>
           <th class="sortable" data-type="text">
@@ -446,6 +449,19 @@ export const Rendered = renderToString(
                   </td>
                   <td>{model.temperature ? "Yes" : "No"}</td>
                   <td>{model.open_weights ? "Open" : "Closed"}</td>
+                  <td>
+                    {model.huggingface_id ? (
+                      <a
+                        href={`https://huggingface.co/${model.huggingface_id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {model.huggingface_id}
+                      </a>
+                    ) : (
+                      "-"
+                    )}
+                  </td>
                   <td>
                     {model.knowledge ? model.knowledge.substring(0, 7) : "-"}
                   </td>

--- a/providers/chutes/models/MiniMaxAI/MiniMax-M2.5-TEE.toml
+++ b/providers/chutes/models/MiniMaxAI/MiniMax-M2.5-TEE.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
+huggingface_id = "MiniMaxAI/MiniMax-M2.5"
 
 [cost]
 input = 0.15


### PR DESCRIPTION
Fixes: https://github.com/anomalyco/models.dev/issues/941
Adds optional `huggingface_id` field to model configurations for linking open-weight models to their HuggingFace repositories (e.g., `MiniMaxAI/MiniMax-M2.5`).

## Changes

- **Schema**: Added `huggingface_id` string field with format validation (`org/model-name`) and constraint requiring `open_weights=true`
- **Web UI**: New sortable column with clickable links to `https://huggingface.co/{id}`
- **Documentation**: Updated README model configuration example

## Example

```toml
name = "MiniMax M2.5 TEE"
open_weights = true
huggingface_id = "MiniMaxAI/MiniMax-M2.5"  # Optional, links to HuggingFace repo
```

The field appears in the web interface as a link when present, displays "-" otherwise.