### PR TITLE
feat(github-copilot): add Claude Sonnet 4.6 model

### DIFF
--- a/providers/github-copilot/models/claude-sonnet-4.6.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.6.toml
@@ -1,0 +1,22 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds Claude Sonnet 4.6 model configuration for the GitHub Copilot provider
- Follows existing GitHub Copilot conventions: zero cost (included in subscription), 128K context window
- Model capabilities based on the Anthropic reference: reasoning, tool calling, attachments, image input, 64K output limit