### PR TITLE
feat(github-copilot): add Claude Sonnet 4.6 model

### DIFF
--- a/providers/github-copilot/models/claude-sonnet-4.6.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.6.toml
@@ -5,8 +5,8 @@ last_updated = "2026-02-17"
 attachment = true
 reasoning = true
 temperature = true
-tool_call = true
 knowledge = "2025-08"
+tool_call = true
 open_weights = false
 
 [cost]

--- a/providers/github-copilot/models/claude-sonnet-4.6.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.6.toml
@@ -1,0 +1,22 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds Claude Sonnet 4.6 model configuration for the GitHub Copilot provider
- 200K context window, 64K output limit, zero cost (included in Copilot subscription)
- Model capabilities: reasoning, tool calling, attachments, image input