### PR TITLE
Add structured output support for OpenRouter models

### DIFF
--- a/providers/openrouter/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-haiku-4.5.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-02-28"
 open_weights = false
 

--- a/providers/openrouter/models/anthropic/claude-opus-4.1.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.1.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-03-31"
 open_weights = false
 

--- a/providers/openrouter/models/anthropic/claude-opus-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.5.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-05-30"
 open_weights = false
 

--- a/providers/openrouter/models/anthropic/claude-opus-4.6.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.6.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-05-30"
 open_weights = false
 

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-07-31"
 open_weights = false
 

--- a/providers/openrouter/models/arcee-ai/trinity-large-preview:free.toml
+++ b/providers/openrouter/models/arcee-ai/trinity-large-preview:free.toml
@@ -8,6 +8,7 @@ temperature = true
 # may be inaccurate
 knowledge = "2025-06"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/arcee-ai/trinity-mini:free.toml
+++ b/providers/openrouter/models/arcee-ai/trinity-mini:free.toml
@@ -8,6 +8,7 @@ temperature = true
 # may be inaccurate
 knowledge = "2025-06"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
+++ b/providers/openrouter/models/cognitivecomputations/dolphin-mistral-24b-venice-edition:free.toml
@@ -8,6 +8,7 @@ temperature = true
 # may be inaccurate
 knowledge = "2025-06"
 tool_call = false
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/deepseek/deepseek-chat-v3-0324.toml
+++ b/providers/openrouter/models/deepseek/deepseek-chat-v3-0324.toml
@@ -8,6 +8,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-10"
 tool_call = false
+structured_output = true
 open_weights = true
 cost = { input = 0, output = 0 }
 limit = { context = 16384, output = 8192 }

--- a/providers/openrouter/models/deepseek/deepseek-chat-v3.1.toml
+++ b/providers/openrouter/models/deepseek/deepseek-chat-v3.1.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-07"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/deepseek/deepseek-r1-0528:free.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-0528:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-05"
 tool_call = false
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/deepseek/deepseek-r1-distill-llama-70b.toml
+++ b/providers/openrouter/models/deepseek/deepseek-r1-distill-llama-70b.toml
@@ -8,6 +8,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-10"
 tool_call = false
+structured_output = true
 open_weights = true
 cost = { input = 0, output = 0 }
 limit = { context = 8192, output = 8192 }

--- a/providers/openrouter/models/deepseek/deepseek-v3.1-terminus.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.1-terminus.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-07"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/deepseek/deepseek-v3.1-terminus:exacto.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.1-terminus:exacto.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-07"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/deepseek/deepseek-v3.2-speciale.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.2-speciale.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-07"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/deepseek/deepseek-v3.2.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v3.2.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-07"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/google/gemini-2.0-flash-001.toml
+++ b/providers/openrouter/models/google/gemini-2.0-flash-001.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-06"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-lite.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/google/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-preview-09-2025.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/google/gemini-2.5-flash.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/google/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/openrouter/models/google/gemini-2.5-pro-preview-05-06.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/google/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/openrouter/models/google/gemini-2.5-pro-preview-06-05.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/google/gemini-2.5-pro.toml
+++ b/providers/openrouter/models/google/gemini-2.5-pro.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/google/gemini-3-flash-preview.toml
+++ b/providers/openrouter/models/google/gemini-3-flash-preview.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [interleaved]

--- a/providers/openrouter/models/google/gemini-3-pro-preview.toml
+++ b/providers/openrouter/models/google/gemini-3-pro-preview.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [interleaved]

--- a/providers/openrouter/models/google/gemma-3-12b-it.toml
+++ b/providers/openrouter/models/google/gemma-3-12b-it.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-10"
 tool_call = false
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/google/gemma-3-27b-it.toml
+++ b/providers/openrouter/models/google/gemma-3-27b-it.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-10"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/kwaipilot/kat-coder-pro:free.toml
+++ b/providers/openrouter/models/kwaipilot/kat-coder-pro:free.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-11"
 open_weights = false
 

--- a/providers/openrouter/models/meta-llama/llama-3.1-405b-instruct:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.1-405b-instruct:free.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-08"
 tool_call = false
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct:free.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-12"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/meta-llama/llama-4-scout:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-4-scout:free.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-08"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/minimax/minimax-m2.1.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.1.toml
@@ -3,6 +3,7 @@ family = "minimax"
 attachment = false
 reasoning = true
 tool_call = true
+structured_output = true
 temperature = true
 release_date = "2025-12-23"
 last_updated = "2025-12-23"

--- a/providers/openrouter/models/minimax/minimax-m2.5.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.5.toml
@@ -3,6 +3,7 @@ family = "minimax"
 attachment = false
 reasoning = true
 tool_call = true
+structured_output = true
 temperature = true
 release_date = "2026-02-12"
 last_updated = "2026-02-12"

--- a/providers/openrouter/models/minimax/minimax-m2.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.toml
@@ -3,6 +3,7 @@ family = "minimax"
 attachment = false
 reasoning = true
 tool_call = true
+structured_output = true
 temperature = true
 release_date = "2025-10-23"
 last_updated = "2025-10-23"

--- a/providers/openrouter/models/mistralai/codestral-2508.toml
+++ b/providers/openrouter/models/mistralai/codestral-2508.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-05"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/mistralai/devstral-2512.toml
+++ b/providers/openrouter/models/mistralai/devstral-2512.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-12"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/mistralai/devstral-medium-2507.toml
+++ b/providers/openrouter/models/mistralai/devstral-medium-2507.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-05"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/mistralai/devstral-small-2507.toml
+++ b/providers/openrouter/models/mistralai/devstral-small-2507.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-05"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/mistralai/mistral-medium-3.1.toml
+++ b/providers/openrouter/models/mistralai/mistral-medium-3.1.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-05"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/mistralai/mistral-medium-3.toml
+++ b/providers/openrouter/models/mistralai/mistral-medium-3.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-05"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/mistralai/mistral-nemo:free.toml
+++ b/providers/openrouter/models/mistralai/mistral-nemo:free.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-07"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/mistralai/mistral-small-3.1-24b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-3.1-24b-instruct.toml
@@ -8,6 +8,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-10"
 tool_call = true
+structured_output = true
 open_weights = true
 cost = { input = 0, output = 0 }
 limit = { context = 128000, output = 8192 }

--- a/providers/openrouter/models/mistralai/mistral-small-3.2-24b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-3.2-24b-instruct.toml
@@ -8,6 +8,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-10"
 tool_call = true
+structured_output = true
 open_weights = true
 cost = { input = 0, output = 0 }
 limit = { context = 96000, output = 8192 }

--- a/providers/openrouter/models/mistralai/mistral-small-3.2-24b-instruct:free.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-3.2-24b-instruct:free.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-06"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/moonshotai/kimi-k2-0905.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-0905.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-10"
 open_weights = true
 

--- a/providers/openrouter/models/moonshotai/kimi-k2-0905:exacto.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-0905:exacto.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-10"
 open_weights = true
 

--- a/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-08"
 open_weights = true
 

--- a/providers/openrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.5.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-01"
 open_weights = true
 

--- a/providers/openrouter/models/nousresearch/hermes-4-70b.toml
+++ b/providers/openrouter/models/nousresearch/hermes-4-70b.toml
@@ -8,6 +8,7 @@ reasoning = true
 temperature = true
 knowledge = "2023-12"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/nvidia/nemotron-3-nano-30b-a3b:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-3-nano-30b-a3b:free.toml
@@ -8,6 +8,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-11"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/nvidia/nemotron-nano-9b-v2:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-nano-9b-v2:free.toml
@@ -8,6 +8,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-09"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-4.1-mini.toml
+++ b/providers/openrouter/models/openai/gpt-4.1-mini.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-04"
 open_weights = false
 

--- a/providers/openrouter/models/openai/gpt-4.1.toml
+++ b/providers/openrouter/models/openai/gpt-4.1.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-04"
 open_weights = false
 

--- a/providers/openrouter/models/openai/gpt-4o-mini.toml
+++ b/providers/openrouter/models/openai/gpt-4o-mini.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-10"
 open_weights = false
 

--- a/providers/openrouter/models/openai/gpt-5-chat.toml
+++ b/providers/openrouter/models/openai/gpt-5-chat.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-09-30"
 tool_call = false
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-5-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5-codex.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-5-image.toml
+++ b/providers/openrouter/models/openai/gpt-5-image.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-5-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5-mini.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-5-nano.toml
+++ b/providers/openrouter/models/openai/gpt-5-nano.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5-pro.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-5.2.toml
+++ b/providers/openrouter/models/openai/gpt-5.2.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-5.toml
+++ b/providers/openrouter/models/openai/gpt-5.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-oss-120b.toml
+++ b/providers/openrouter/models/openai/gpt-oss-120b.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-oss-120b:exacto.toml
+++ b/providers/openrouter/models/openai/gpt-oss-120b:exacto.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-oss-20b.toml
+++ b/providers/openrouter/models/openai/gpt-oss-20b.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/openai/o4-mini.toml
+++ b/providers/openrouter/models/openai/o4-mini.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-06"
 open_weights = false
 

--- a/providers/openrouter/models/openrouter/aurora-alpha.toml
+++ b/providers/openrouter/models/openrouter/aurora-alpha.toml
@@ -5,6 +5,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/prime-intellect/intellect-3.toml
+++ b/providers/openrouter/models/prime-intellect/intellect-3.toml
@@ -8,6 +8,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-10"
 tool_call = true
+structured_output = true
 open_weights = true
 cost = { input = 0.2, output = 1.1 }
 limit = { context = 131072, output = 8192 }

--- a/providers/openrouter/models/qwen/qwen-2.5-coder-32b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen-2.5-coder-32b-instruct.toml
@@ -8,6 +8,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-10"
 tool_call = false
+structured_output = true
 open_weights = true
 cost = { input = 0, output = 0 }
 limit = { context = 32768, output = 8192 }

--- a/providers/openrouter/models/qwen/qwen2.5-vl-32b-instruct:free.toml
+++ b/providers/openrouter/models/qwen/qwen2.5-vl-32b-instruct:free.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-03"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen2.5-vl-72b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen2.5-vl-72b-instruct.toml
@@ -8,6 +8,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-10"
 tool_call = false
+structured_output = true
 open_weights = true
 cost = { input = 0, output = 0 }
 limit = { context = 32768, output = 8192 }

--- a/providers/openrouter/models/qwen/qwen3-14b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-14b:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-235b-a22b-07-25.toml
+++ b/providers/openrouter/models/qwen/qwen3-235b-a22b-07-25.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/openrouter/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-235b-a22b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-235b-a22b:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-30b-a3b-instruct-2507.toml
+++ b/providers/openrouter/models/qwen/qwen3-30b-a3b-instruct-2507.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-30b-a3b-thinking-2507.toml
+++ b/providers/openrouter/models/qwen/qwen3-30b-a3b-thinking-2507.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-30b-a3b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-30b-a3b:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-32b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-32b:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-4b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-4b:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-8b:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-8b:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder-30b-a3b-instruct.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-coder.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-coder:exacto.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder:exacto.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct:free.toml
+++ b/providers/openrouter/models/qwen/qwen3-next-80b-a3b-instruct:free.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/openrouter/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/openrouter/models/qwen/qwen3.5-397b-a17b.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/qwen/qwen3.5-plus-02-15.toml
+++ b/providers/openrouter/models/qwen/qwen3.5-plus-02-15.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/qwen/qwq-32b:free.toml
+++ b/providers/openrouter/models/qwen/qwq-32b:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-03"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/tngtech/deepseek-r1t2-chimera:free.toml
+++ b/providers/openrouter/models/tngtech/deepseek-r1t2-chimera:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-07"
 tool_call = false
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/tngtech/tng-r1t-chimera:free.toml
+++ b/providers/openrouter/models/tngtech/tng-r1t-chimera:free.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-07"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/x-ai/grok-3-mini.toml
+++ b/providers/openrouter/models/x-ai/grok-3-mini.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-11"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/x-ai/grok-3.toml
+++ b/providers/openrouter/models/x-ai/grok-3.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-11"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/x-ai/grok-4-fast.toml
+++ b/providers/openrouter/models/x-ai/grok-4-fast.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-11"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/x-ai/grok-4.1-fast.toml
+++ b/providers/openrouter/models/x-ai/grok-4.1-fast.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-11"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/x-ai/grok-4.toml
+++ b/providers/openrouter/models/x-ai/grok-4.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-07"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/x-ai/grok-code-fast-1.toml
+++ b/providers/openrouter/models/x-ai/grok-code-fast-1.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-08"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-12"
 open_weights = true
 

--- a/providers/openrouter/models/z-ai/glm-4.5-air.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5-air.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-04"
 open_weights = true
 

--- a/providers/openrouter/models/z-ai/glm-4.5.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-04"
 open_weights = true
 

--- a/providers/openrouter/models/z-ai/glm-4.5v.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5v.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/openrouter/models/z-ai/glm-4.6.toml
+++ b/providers/openrouter/models/z-ai/glm-4.6.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-09"
 open_weights = true
 

--- a/providers/openrouter/models/z-ai/glm-4.6:exacto.toml
+++ b/providers/openrouter/models/z-ai/glm-4.6:exacto.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-09"
 open_weights = true
 

--- a/providers/openrouter/models/z-ai/glm-4.7.toml
+++ b/providers/openrouter/models/z-ai/glm-4.7.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-04"
 open_weights = true
 


### PR DESCRIPTION
## Summary

- Added `structured_output = true` to 106 OpenRouter model definitions based on OpenRouter's current supported parameters data
- Models span multiple providers including OpenAI, Anthropic, Google, Qwen, DeepSeek, xAI, Mistral, MiniMax, MoonshotAI, Z.ai, and others
- 10 models already had the field set correctly and were left unchanged

## Source

https://openrouter.ai/models?fmt=cards&order=newest&supported_parameters=structured_outputs