### PR TITLE
feat: add Qwen3.5 397B A17B TEE to Chutes provider listings

### DIFF
--- a/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
@@ -1,0 +1,26 @@
+name = "Qwen3.5 397B A17B TEE"
+family = "qwen"
+release_date = "2026-02-18"
+last_updated = "2026-02-18"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.15
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
This PR adds support for the Qwen3.5-397B-A17B-TEE model provided by Qwen to the Chutes provider ecosystem. This allows users to select and utilize the Qwen3.5 397B A17B architecture for their inference tasks via the Chutes interface.

Reference Chute: https://chutes.ai/app/chute/51a4284a-a5a0-5e44-a9cc-6af5a2abfbcf