### PR TITLE
feat(gitlab): add Claude Sonnet 4.6 model

### DIFF
--- a/providers/gitlab/models/duo-chat-sonnet-4-6.toml
+++ b/providers/gitlab/models/duo-chat-sonnet-4-6.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (Claude Sonnet 4.6)"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds `duo-chat-sonnet-4-6` (Claude Sonnet 4.6) to the GitLab Duo provider.

This model was recently deployed on GitLab's AI Gateway ([ai-assist!4607](https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/merge_requests/4607)) and added to the `@gitlab/gitlab-ai-provider` npm package.

## Model details

| Property | Value |
|----------|-------|
| API ID | `claude-sonnet-4-6` |
| Family | `claude-sonnet` |
| Context window | 200K tokens |
| Max output | 64K tokens |
| Knowledge cutoff | Aug 2025 |
| Modalities | text, image, pdf → text |