### PR TITLE
add claude sonnet 4.6 on openrouter

### DIFF
--- a/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
@@ -1,0 +1,30 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[cost.context_over_200k]
+input = 6.00
+output = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
**Summary**

Add anthropic/claude-sonnet-4.6 to the OpenRouter provider with metadata and pricing sourced from OpenRouter’s published model data.

**Changes**

- Added new model file: providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
- Included OpenRouter-backed model metadata:
  - name, family, release_date, last_updated
  - capability flags (attachment, reasoning, temperature, tool_call, structured_output)
  - open_weights = false
- Added standard pricing:
  - input: 3.00
  - output: 15.00
  - cache read: 0.30
  - cache write: 3.75
- Added long-context pricing ([cost.context_over_200k]) from OpenRouter line items:
  - input: 6.00
  - output: 22.50
  - cache read: 0.60
  - cache write: 7.50
- Set limits/modalities from OpenRouter:
  - context = 1_000_000
  - output = 128_000
  - input modalities: text, image
  - output modalities: text
  
**Notes**
- knowledge was intentionally not set because OpenRouter does not expose a knowledge-cutoff field for this model in the public model payload/page data.

**Validation**

- Ran bun validate successfully.
