### PR TITLE
Add Fuel1 provider with active models

### DIFF
--- a/providers/fuel1/logo.svg
+++ b/providers/fuel1/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
+</svg>

--- a/providers/fuel1/models/BAAI/bge-multilingual-gemma2-eu.toml
+++ b/providers/fuel1/models/BAAI/bge-multilingual-gemma2-eu.toml
@@ -1,0 +1,21 @@
+name = "BGE Multilingual Gemma2 (EU)"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.00
+
+[limit]
+context = 8192
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fuel1/models/BAAI/bge-multilingual-gemma2.toml
+++ b/providers/fuel1/models/BAAI/bge-multilingual-gemma2.toml
@@ -1,0 +1,21 @@
+name = "BGE Multilingual Gemma2"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.00
+
+[limit]
+context = 8192
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fuel1/models/MiniMaxAI/MiniMax-M2-5.toml
+++ b/providers/fuel1/models/MiniMaxAI/MiniMax-M2-5.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2.5"
+release_date = "2025-02"
+last_updated = "2025-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-02"
+open_weights = false
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 204800
+output = 204800
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fuel1/models/Qwen/Qwen3-5-397B-A17B.toml
+++ b/providers/fuel1/models/Qwen/Qwen3-5-397B-A17B.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5-397B-A17B"
+release_date = "2025-02"
+last_updated = "2025-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-02"
+open_weights = true
+
+[cost]
+input = 0.60
+output = 3.60
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/fuel1/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
+++ b/providers/fuel1/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen3-VL-30B-A3B-Instruct"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.45
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/fuel1/models/meta-llama/Llama-3-3-70B-Instruct.toml
+++ b/providers/fuel1/models/meta-llama/Llama-3-3-70B-Instruct.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.3 70B Instruct"
+release_date = "2024-12"
+last_updated = "2025-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2024-12"
+open_weights = true
+
+[cost]
+input = 0.72
+output = 0.72
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fuel1/models/meta-llama/Llama-3.3-70B-Instruct.toml
+++ b/providers/fuel1/models/meta-llama/Llama-3.3-70B-Instruct.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.3 70B Instruct"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-12"
+open_weights = true
+
+[cost]
+input = 0.72
+output = 0.72
+
+[limit]
+context = 131072
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fuel1/models/moonshotai/Kimi-K2-5.toml
+++ b/providers/fuel1/models/moonshotai/Kimi-K2-5.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2.5"
+release_date = "2025-02"
+last_updated = "2025-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-02"
+open_weights = false
+
+[cost]
+input = 0.50
+output = 2.80
+
+[limit]
+context = 256000
+output = 256000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/fuel1/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/fuel1/models/moonshotai/Kimi-K2.5.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2.5"
+release_date = "2026-02"
+last_updated = "2026-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-06"
+open_weights = false
+
+[cost]
+input = 0.50
+output = 2.80
+
+[limit]
+context = 256000
+output = 256000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/fuel1/models/openai/gpt-oss-120b-eu.toml
+++ b/providers/fuel1/models/openai/gpt-oss-120b-eu.toml
@@ -1,0 +1,21 @@
+name = "GPT OSS 120B (EU)"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 128000
+output = 128000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fuel1/models/openai/gpt-oss-120b.toml
+++ b/providers/fuel1/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,21 @@
+name = "GPT OSS 120B"
+release_date = "2025-01"
+last_updated = "2025-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 128000
+output = 128000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fuel1/provider.toml
+++ b/providers/fuel1/provider.toml
@@ -1,0 +1,5 @@
+name = "Fuel1"
+env = ["FUEL1_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.fuel1.ai/v1"
+doc = "https://docs.fuel1.ai"


### PR DESCRIPTION
## Summary

This PR adds the Fuel1 inference platform as a new provider to the Models.dev database.

### Added Provider: Fuel1
- Provider ID: `fuel1`
- API Endpoint: `https://api.fuel1.ai/v1` (OpenAI-compatible)
- Documentation: https://docs.fuel1.ai

### Models Added (10 total)

**Embeddings:**
- BGE Multilingual Gemma2 (BAAI) - 9B multilingual embedding model
- BGE Multilingual Gemma2 (EU) - EU-hosted variant

**Chat Models:**
- GPT OSS 120B (OpenAI) - 120B parameter model with function calling
- GPT OSS 120B (EU) - EU-hosted variant
- Kimi K2.5 (Moonshot AI) - 1T MoE multimodal with vision & video
- Llama 3.3 70B Instruct (Meta) - Meta's instruction-tuned model
- MiniMax M2.5 (MiniMax) - 230B MoE coding model
- Qwen3.5-397B-A17B (Qwen) - 403B MoE multimodal model
- Qwen3-VL-30B-A3B-Instruct (Qwen) - Vision-language model

### Configuration Details
- All models include pricing (per 1M tokens USD)
- Context window limits specified
- Modality support (text/image/video)
- Feature flags (tool_call, reasoning, structured_output, etc.)
- Open weights status indicated

### Validation
✅ All configurations validated with `bun validate`
✅ Follows Models.dev TOML schema
✅ Consistent with existing provider patterns