### PR TITLE
Fix Hugging Face interleaved `reasoning field: reasoning_details` -> `reasoning_content`

### DIFF
--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M2.1.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M2.1.toml
@@ -10,7 +10,7 @@ knowledge = "2025-10"
 open_weights = true
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [cost]
 input = 0.30

--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -9,7 +9,7 @@ tool_call = true
 open_weights = true
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [cost]
 input = 0.30

--- a/providers/huggingface/models/Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-397B-A17B.toml
@@ -10,7 +10,7 @@ knowledge = "2025-04"
 open_weights = true
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [cost]
 input = 0.60

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Thinking.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Thinking.toml
@@ -10,7 +10,7 @@ knowledge = "2024-08"
 open_weights = true
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [cost]
 input = 0.6

--- a/providers/huggingface/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2.5.toml
@@ -10,7 +10,7 @@ knowledge = "2025-01"
 open_weights = true
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [cost]
 input = 0.60

--- a/providers/huggingface/models/zai-org/GLM-4.7-Flash.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.7-Flash.toml
@@ -10,7 +10,7 @@ knowledge = "2025-04"
 open_weights = true
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/huggingface/models/zai-org/GLM-4.7.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.7.toml
@@ -10,7 +10,7 @@ knowledge = "2025-04"
 open_weights = true
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [cost]
 input = 0.6

--- a/providers/huggingface/models/zai-org/GLM-5.toml
+++ b/providers/huggingface/models/zai-org/GLM-5.toml
@@ -9,7 +9,7 @@ tool_call = true
 open_weights = true
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [cost]
 input = 1.00


### PR DESCRIPTION
This PR updates Hugging Face model metadata to use `interleaved.field = "reasoning_content"` for entries currently set to `reasoning_details`.

OpenCode use `interleaved.field` to map assistant reasoning into OpenAI compatible `messages[]` fields. For Hugging Face Inference Providers, some models with` interleaved.field = "reasoning_details"` cause strict validation failures like:
```
  Extra inputs are not permitted: messages[n].reasoning_details
```
 
This breaks requests for models such as Kimi K2.5 on Hugging Face.