### PR TITLE
Add Ambient provider

### DIFF
--- a/providers/ambient/logo.svg
+++ b/providers/ambient/logo.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 1L2 23H6.8L8.8 18.5H15.2L17.2 23H22L12 1ZM9.8 15.5L12 9L14.2 15.5H9.8Z" fill="currentColor"/>
+</svg>

--- a/providers/ambient/models/ambient/large.toml
+++ b/providers/ambient/models/ambient/large.toml
@@ -1,0 +1,22 @@
+name = "Ambient Large"
+family = "glm"
+release_date = "2025-10"
+last_updated = "2025-10"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.35
+output = 1.71
+
+[limit]
+context = 202_752
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ambient/provider.toml
+++ b/providers/ambient/provider.toml
@@ -1,0 +1,5 @@
+name = "Ambient"
+env = ["AMBIENT_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://docs.ambient.xyz"
+api = "https://api.ambient.xyz/v1"


### PR DESCRIPTION
Adds [Ambient](https://ambient.xyz) as an OpenAI-compatible model provider. Ambient is a Solana-compatible network that replaces traditional Proof-of-Work with Proof of Logits (PoL) — verified LLM inference as useful work.

Currently serving GLM 4.6 as `ambient/large`:
- 202K context, 131K max output
- Reasoning, tool calling, structured output
- $0.35/M input, $1.71/M output

Docs: https://docs.ambient.xyz
API: `https://api.ambient.xyz/v1` (OpenAI-compatible)
