### PR TITLE
feat(provider): exclude image/video models

### DIFF
--- a/packages/core/script/generate-vercel.ts
+++ b/packages/core/script/generate-vercel.ts
@@ -493,6 +493,11 @@ async function main() {
   let unchanged = 0;
 
   for (const apiModel of apiModels) {
+    // Skip these since OpenCode does not support image / video generation yet
+    if (apiModel.type === ModelType.Image || apiModel.type === ModelType.Video) {
+      continue;
+    }
+
     const relativePath = `${apiModel.id}.toml`;
     const filePath = path.join(modelsDir, relativePath);
     const dirPath = path.dirname(filePath);


### PR DESCRIPTION
In Vercel model gen script, exclude image / video generation only models since OpenCode does not support those modes

Tested locally with dry runs