### PR TITLE
Reapply "feat: add github copilot gpt-5.3-codex model (#912)"

### DIFF
--- a/providers/github-copilot/models/gpt-5.3-codex.toml
+++ b/providers/github-copilot/models/gpt-5.3-codex.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.3-Codex"
+family = "gpt-codex"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
This reverts commit bac557c176c0c3c52735060da9bd8c6c56e46a9b.

---

This feature had been previously reverted (#920) because the model was not yet generally available.

It seems like the model is now available for all users.

@rversteegen mentions on issue #885 
> A Github employee commented [on Reddit 4 days ago](https://www.reddit.com/r/GithubCopilot/comments/1r5rxgc/comment/o5nftxb/) that the rollout to all users is complete.

The Github employee says on Reddit:
> All the users should have it now. Make sure you are on latest vscode version. If you still do not see it - let me know what GitHub plan are you on?

<img width="684" height="130" alt="image" src="https://github.com/user-attachments/assets/58fd26e8-dfab-4045-b65c-c2905a5189da" />

## Closes
- #885 
- #838
