### PR TITLE
fix(qwen): update Qwen3.5 release_date and last_updated to 2026-02-16

### DIFF
--- a/providers/alibaba-cn/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba-cn/models/qwen3.5-397b-a17b.toml
@@ -1,7 +1,7 @@
 name = "Qwen3.5 397B-A17B"
 family = "qwen"
-release_date = "2026-02"
-last_updated = "2026-02"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/alibaba-cn/models/qwen3.5-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.5-plus.toml
@@ -1,7 +1,7 @@
 name = "Qwen3.5 Plus"
 family = "qwen"
-release_date = "2026-02"
-last_updated = "2026-02"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/alibaba/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba/models/qwen3.5-397b-a17b.toml
@@ -1,7 +1,7 @@
 name = "Qwen3.5 397B-A17B"
 family = "qwen"
-release_date = "2026-02"
-last_updated = "2026-02"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/alibaba/models/qwen3.5-plus.toml
+++ b/providers/alibaba/models/qwen3.5-plus.toml
@@ -1,7 +1,7 @@
 name = "Qwen3.5 Plus"
 family = "qwen"
-release_date = "2026-02"
-last_updated = "2026-02"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
 attachment = false
 reasoning = true
 temperature = true


### PR DESCRIPTION
fix(qwen): Update Qwen3.5 Plus and 397B release and last_updated dates
Description: This PR updates the `release_date` and `last_updated` fields for the newly released Qwen3.5 Plus and Qwen3.5 397B models to the exact date: `2026-02-16`.