### PR TITLE
fix(zenmux:minimax): remove duplicated prefix & feat(zenmux:openai): add GPT-5.2-Pro model

### DIFF
--- a/providers/zenmux/models/minimax/minimax-m2.5-lightning.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.5-lightning.toml
@@ -1,4 +1,4 @@
-name = "MiniMax: MiniMax M2.5 highspeed"
+name = "MiniMax M2.5 highspeed"
 release_date = "2026-02-13"
 last_updated = "2026-02-13"
 attachment = false

--- a/providers/zenmux/models/openai/gpt-5.2-pro.toml
+++ b/providers/zenmux/models/openai/gpt-5.2-pro.toml
@@ -6,7 +6,6 @@ reasoning = true
 temperature = false
 tool_call = true
 knowledge = "2025-08-31"
-structured_output = false
 open_weights = false
 
 [cost]

--- a/providers/zenmux/models/openai/gpt-5.2-pro.toml
+++ b/providers/zenmux/models/openai/gpt-5.2-pro.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.2-Pro"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2025-08-31"
+structured_output = false
+open_weights = false
+
+[cost]
+input = 21.00
+output = 168.00
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Changes

### 1. Fix MiniMax M2.5 Lightning model name (zenmux provider) to maintain consistency

- Removed the duplicated provider prefix `MiniMax:` from the model display name
- `"MiniMax: MiniMax M2.5 highspeed"` → `"MiniMax M2.5 highspeed"`

<img width="674" height="113" alt="image" src="https://github.com/user-attachments/assets/f5a84e76-043d-4289-a958-7421a73a4c8e" />

### 2. Add GPT-5.2-Pro model (zenmux provider)

- Added OpenAI GPT-5.2-Pro model definition
- Key specs:
  - 400K context / 128K output
  - Supports: attachments, reasoning, tool calls
  - Input modalities: text, image, pdf
  - Cost: $21.00 input / $168.00 output per 1M tokens
  - Knowledge cutoff: 2025-08-31
