### PR TITLE
Append (latest) to Mistral models that refer to the latest version.

### DIFF
--- a/providers/mistral/models/codestral-latest.toml
+++ b/providers/mistral/models/codestral-latest.toml
@@ -1,4 +1,4 @@
-name = "Codestral"
+name = "Codestral (latest)"
 family = "codestral"
 release_date = "2024-05-29"
 last_updated = "2025-01-04"

--- a/providers/mistral/models/devstral-medium-latest.toml
+++ b/providers/mistral/models/devstral-medium-latest.toml
@@ -1,4 +1,4 @@
-name = "Devstral 2"
+name = "Devstral 2 (latest)"
 family = "devstral"
 release_date = "2025-12-02"
 last_updated = "2025-12-02"

--- a/providers/mistral/models/magistral-medium-latest.toml
+++ b/providers/mistral/models/magistral-medium-latest.toml
@@ -1,4 +1,4 @@
-name = "Magistral Medium"
+name = "Magistral Medium (latest)"
 family = "magistral-medium"
 release_date = "2025-03-17"
 last_updated = "2025-03-20"

--- a/providers/mistral/models/ministral-3b-latest.toml
+++ b/providers/mistral/models/ministral-3b-latest.toml
@@ -1,4 +1,4 @@
-name = "Ministral 3B"
+name = "Ministral 3B (latest)"
 family = "ministral"
 release_date = "2024-10-01"
 last_updated = "2024-10-04"

--- a/providers/mistral/models/ministral-8b-latest.toml
+++ b/providers/mistral/models/ministral-8b-latest.toml
@@ -1,4 +1,4 @@
-name = "Ministral 8B"
+name = "Ministral 8B (latest)"
 family = "ministral"
 release_date = "2024-10-01"
 last_updated = "2024-10-04"

--- a/providers/mistral/models/mistral-large-latest.toml
+++ b/providers/mistral/models/mistral-large-latest.toml
@@ -1,4 +1,4 @@
-name = "Mistral Large"
+name = "Mistral Large (latest)"
 family = "mistral-large"
 release_date = "2024-11-01"
 last_updated = "2025-12-02"

--- a/providers/mistral/models/mistral-medium-latest.toml
+++ b/providers/mistral/models/mistral-medium-latest.toml
@@ -1,4 +1,4 @@
-name = "Mistral Medium"
+name = "Mistral Medium (latest)"
 family = "mistral-medium"
 release_date = "2025-05-07"
 last_updated = "2025-05-10"

--- a/providers/mistral/models/mistral-small-latest.toml
+++ b/providers/mistral/models/mistral-small-latest.toml
@@ -1,4 +1,4 @@
-name = "Mistral Small"
+name = "Mistral Small (latest)"
 family = "mistral-small"
 release_date = "2024-09-01"
 last_updated = "2024-09-04"

--- a/providers/mistral/models/pixtral-large-latest.toml
+++ b/providers/mistral/models/pixtral-large-latest.toml
@@ -1,4 +1,4 @@
-name = "Pixtral Large"
+name = "Pixtral Large (latest)"
 family = "pixtral"
 release_date = "2024-11-01"
 last_updated = "2024-11-04"


### PR DESCRIPTION
Append `(latest)` to the Mistral models that refer to the latest version. This is to make it easier to know which is which in Opencode. It currently lists two Devstral 2 models and it is not obvious which refers to the latest version.