### PR TITLE
Add AWS_BEARER_TOKEN_BEDROCK to Amazon Bedrock provider env

### DIFF
--- a/providers/amazon-bedrock/provider.toml
+++ b/providers/amazon-bedrock/provider.toml
@@ -1,4 +1,4 @@
 name = "Amazon Bedrock"
-env = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"]
+env = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION", "AWS_BEARER_TOKEN_BEDROCK"]
 npm = "@ai-sdk/amazon-bedrock"
 doc = "https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html"


### PR DESCRIPTION
## Summary

- Adds `AWS_BEARER_TOKEN_BEDROCK` to the Amazon Bedrock provider's `env` array

## Context

The `@ai-sdk/amazon-bedrock` package supports [Bearer token authentication](https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock#authentication) via the `AWS_BEARER_TOKEN_BEDROCK` environment variable as an alternative to IAM SigV4 auth. This uses [Amazon Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html) for simplified access without requiring full IAM credentials.

This env var is currently missing from the provider metadata, meaning downstream consumers (like opencode) don't know about this authentication option.