### PR TITLE
models: alibaba-cn: add MiniMax-M2.5

### DIFF
--- a/providers/alibaba-cn/models/MiniMax/MiniMax-M2.5.toml
+++ b/providers/alibaba-cn/models/MiniMax/MiniMax-M2.5.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2.5"
+family = "minimax"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.301
+output = 1.205
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Adds `MiniMax-M2.5` to the `alibaba-cn` provider.

**Model specs (from Alibaba Bailian docs):**
- Context: 204,800 tokens
- Max output: 131,072 tokens
- Input: ¥2.1/M tokens -> $0.301/M
- Output: ¥8.4/M tokens -> $1.205/M
- Reasoning: true (thinking model)
- Open weights: true (MIT license)
- Tool call: true

Note: Added under the `MiniMax/` directory folder as `providers/alibaba-cn/models/MiniMax/MiniMax-M2.5.toml` to preserve the required upper-casing format for the model `id` string (`MiniMax/MiniMax-M2.5`).