### PR TITLE
Update context limit in anthropic.claude-opus-4-6-v1.toml

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
@@ -22,7 +22,7 @@ cache_read = 1.00
 cache_write = 12.50
 
 [limit]
-context = 1_000_000
+context = 200_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
I don't want to spam pr but i was not sure why sonnet models are set to 200k and opus to 1m ? maybe we can different config for 1m versions, I think this will be especially required considering premium pricing for context window crossing 200k 