### PR TITLE
Add Cortecs AI models

### DIFF
--- a/providers/cortecs/models/glm-4.7-flash.toml
+++ b/providers/cortecs/models/glm-4.7-flash.toml
@@ -1,0 +1,25 @@
+name = "GLM-4.7-Flash"
+family = "glm"
+release_date = "2025-08-08"
+last_updated = "2025-08-08"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.09
+output = 0.53
+
+[limit]
+context = 203_000
+output = 203_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cortecs/models/kimi-k2.5.toml
+++ b/providers/cortecs/models/kimi-k2.5.toml
@@ -1,0 +1,25 @@
+name = "Kimi K2.5"
+family = "kimi-thinking"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+knowledge = "2025-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.55
+output = 2.76
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
This PR adds the following models for cortecs ai:
- glm 4.7 flash
- kimi k2.5

All prices were taken in eur and converted to usd at
current exchange rate.