### PR TITLE
add friendli minimax m2.5 model config

### DIFF
--- a/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,0 +1,25 @@
+name = "MiniMax M2.5"
+family = "minimax"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 196_608
+output = 196_608
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add `providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml` for Friendli's MiniMax M2.5 offering
- align limits, capabilities, and pricing to the live Friendli models API response from `https://api.friendli.ai/serverless/v1/models`
- include `structured_output = true` and set `limit.context/output = 196_608` based on endpoint data

## Validation
- `bun validate`