### PR TITLE
Add Naver CLOVA Studio models

### DIFF
--- a/providers/naver/models/HCX-003.toml
+++ b/providers/naver/models/HCX-003.toml
@@ -1,0 +1,21 @@
+name = "HCX-003"
+family = "naver"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = false
+open_weights = false
+
+[cost]
+input = 3.50
+output = 3.50
+
+[limit]
+context = 8192
+input = 7600
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/naver/models/HCX-005.toml
+++ b/providers/naver/models/HCX-005.toml
@@ -1,0 +1,21 @@
+name = "HCX-005"
+family = "naver"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = false
+temperature = false
+open_weights = false
+
+[cost]
+input = 0.90
+output = 3.50
+
+[limit]
+context = 128_000
+input = 128_000
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/naver/models/HCX-007.toml
+++ b/providers/naver/models/HCX-007.toml
@@ -1,0 +1,21 @@
+name = "HCX-007"
+family = "naver"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = false
+open_weights = false
+
+[cost]
+input = 0.90
+output = 3.50
+
+[limit]
+context = 128_000
+input = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/naver/models/HCX-DASH-001.toml
+++ b/providers/naver/models/HCX-DASH-001.toml
@@ -1,0 +1,21 @@
+name = "HCX-DASH-001"
+family = "naver"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+temperature = false
+open_weights = false
+
+[cost]
+input = 0.70
+output = 0.70
+
+[limit]
+context = 4096
+input = 3500
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/naver/models/HCX-DASH-002.toml
+++ b/providers/naver/models/HCX-DASH-002.toml
@@ -1,0 +1,21 @@
+name = "HCX-DASH-002"
+family = "naver"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = false
+temperature = false
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.70
+
+[limit]
+context = 128_000
+input = 128_000
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/naver/provider.toml
+++ b/providers/naver/provider.toml
@@ -1,0 +1,5 @@
+name = "Naver CLOVA Studio"
+env = ["CLOVA_STUDIO_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://clovastudio.stream.ntruss.com/v1/openai"
+doc = "https://api.ncloud-docs.com/docs/en/ai-naver-clovastudio-summary"


### PR DESCRIPTION
This PR adds the models from [Naver CLOVA Studio](https://api.ncloud-docs.com/docs/en/ai-naver-clovastudio-summary) to models.dev.