### PR TITLE
fix(amazon-bedrock): correct Claude Opus 4.6 context window from 1M to 200K

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
@@ -22,7 +22,7 @@ cache_read = 1.00
 cache_write = 12.50
 
 [limit]
-context = 1_000_000
+context = 200_000
 output = 128_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
@@ -22,7 +22,7 @@ cache_read = 1.00
 cache_write = 12.50
 
 [limit]
-context = 1_000_000
+context = 200_000
 output = 128_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1.toml
@@ -22,7 +22,7 @@ cache_read = 1.00
 cache_write = 12.50
 
 [limit]
-context = 1_000_000
+context = 200_000
 output = 128_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1.toml
@@ -22,7 +22,7 @@ cache_read = 1.00
 cache_write = 12.50
 
 [limit]
-context = 1_000_000
+context = 200_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION

Fixes #1013 

## What does this PR do?

The Amazon Bedrock model entries for Claude Opus 4.6 in models.dev specify context = 1_000_000 when the actual default context window is 200K tokens. The 1M context window is a beta feature that requires an explicit anthropic_beta: ["context-1m-2025-08-07"] header, it is not the default behavior when using the Claude Opus 4.6 model ids with Amazon Bedrock.

This PR changes `context = 1_000_000` to `context = 200_000` on  each affected model configuration:

- `providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml`
- `providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1.toml`
- `providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1.toml`
- `providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml`

## How did you verify?

Before the fix, a conversation in opencode using Opus 4-6 through Amazon Bedrock crashed after going over 200K tokens:

<img width="880" height="545" alt="Screenshot 2026-02-23 at 20 23 34" src="https://github.com/user-attachments/assets/65a240c9-8d40-40cf-bdc9-3e08f3b4e04d" />

After applying the fix, opencode correctly identifies the changes in models.dev and the session compacts before reaching the maximum context window supported by the model.

<img width="883" height="545" alt="Screenshot 2026-02-23 at 20 24 08" src="https://github.com/user-attachments/assets/a1ad27af-8410-42cb-94ae-61cb50c29922" />


