### PR TITLE
Update synthetic.new models: promote MiniMax-M2.5, add GLM-4.7-Flash

### DIFF
--- a/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.5.toml
@@ -8,7 +8,6 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
-status = "beta"
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.5.toml
@@ -1,0 +1,29 @@
+name = "MiniMax-M2.5"
+family = "minimax"
+release_date = "2026-02-07"
+last_updated = "2026-02-07"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+status = "beta"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.60
+output = 3.00
+cache_read = 0.60
+
+[limit]
+context = 191_488
+output = 65_536
+
+[modalities]
+# https://api.synthetic.new/openai/v1/models reports image support
+# even though model itself does not natively support images (rerouted?)
+input = ["text", "image"]
+output = ["text"]

--- a/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M2.5.toml
@@ -23,7 +23,5 @@ context = 191_488
 output = 65_536
 
 [modalities]
-# https://api.synthetic.new/openai/v1/models reports image support
-# even though model itself does not natively support images (rerouted?)
-input = ["text", "image"]
+input = ["text"]
 output = ["text"]

--- a/providers/synthetic/models/hf:Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/synthetic/models/hf:Qwen/Qwen3.5-397B-A17B.toml
@@ -1,0 +1,29 @@
+name = "Qwen3.5-397B-A17B"
+family = "qwen"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+status = "beta"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.60
+output = 3.00
+cache_read = 0.60
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+# https://api.synthetic.new/openai/v1/models reports image support
+# even though model itself does not natively support images (rerouted?)
+input = ["text", "image"]
+output = ["text"]

--- a/providers/synthetic/models/hf:Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/synthetic/models/hf:Qwen/Qwen3.5-397B-A17B.toml
@@ -23,7 +23,5 @@ context = 262_144
 output = 65_536
 
 [modalities]
-# https://api.synthetic.new/openai/v1/models reports image support
-# even though model itself does not natively support images (rerouted?)
 input = ["text", "image"]
 output = ["text"]

--- a/providers/synthetic/models/hf:zai-org/GLM-4.7-Flash.toml
+++ b/providers/synthetic/models/hf:zai-org/GLM-4.7-Flash.toml
@@ -1,27 +1,26 @@
-name = "Qwen3.5-397B-A17B"
-family = "qwen"
-release_date = "2026-02-11"
-last_updated = "2026-02-11"
+name = "GLM-4.7-Flash"
+family = "glm"
+release_date = "2026-01-18"
+last_updated = "2026-01-18"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
-status = "beta"
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.60
-output = 3.00
-cache_read = 0.60
+input = 0.06
+output = 0.40
+cache_read = 0.06
 
 [limit]
-context = 262_144
+context = 196_608
 output = 65_536
 
 [modalities]
-input = ["text", "image"]
+input = ["text"]
 output = ["text"]


### PR DESCRIPTION
## Summary

Updates synthetic.new model configurations based on API changes:
- `hf:MiniMaxAI/MiniMax-M2.5` - promoted from beta to stable
- `hf:zai-org/GLM-4.7-Flash` - newly added
- `hf:Qwen/Qwen3.5-397B-A17B` - removed (retired)
    - Was in earlier version of this PR

## Changes

All specs sourced from https://api.synthetic.new/openai/v1/models:

### GLM-4.7-Flash (new)
- Context: 196,608 / Output: 65,536
- Pricing: $0.06/M input, $0.40/M output, $0.06/M cache read
- Capabilities: reasoning, tool_call, structured_output, interleaved reasoning

### MiniMax-M2.5
- Removed beta status (now stable)

## Checklist
- [x] Configuration validated with `bun validate`
- [x] Specs match API response from synthetic.new