### PR TITLE
Venice: Update gemini-3-1-pro-preview config

### DIFF
--- a/providers/venice/models/gemini-3-1-pro-preview.toml
+++ b/providers/venice/models/gemini-3-1-pro-preview.toml
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-02-19"
-last_updated = "2026-02-19"
+last_updated = "2026-02-24"
 open_weights = false
 
 [cost]
@@ -22,7 +22,7 @@ cache_read = 0.5
 
 [limit]
 context = 1_000_000
-output = 250_000
+output = 65_000
 
 [modalities]
 input = ["text", "image", "audio", "video"]


### PR DESCRIPTION
- Reduce output token limit from 250K to 65K