### PR TITLE
feat(sap-ai-core): Add GPT-4.1, Gemini 2.5 Flash Lite, Perplexity Sonar, and Claude 4.6 models

### DIFF
--- a/providers/sap-ai-core/models/anthropic--claude-4.6-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-opus.toml
@@ -1,0 +1,30 @@
+name = "anthropic--claude-4.6-opus"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[cost.context_over_200k]
+input = 10.00
+output = 37.50
+cache_read = 1.00
+cache_write = 12.50
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
@@ -1,0 +1,30 @@
+name = "anthropic--claude-4.6-sonnet"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[cost.context_over_200k]
+input = 6.00
+output = 22.50
+cache_read = 0.60
+cache_write = 7.50
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/sap-ai-core/models/gemini-2.5-flash-lite.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-flash-lite.toml
@@ -1,0 +1,24 @@
+name = "gemini-2.5-flash-lite"
+family = "gemini-flash-lite"
+release_date = "2025-06-17"
+last_updated = "2025-06-17"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.10
+output = 0.40
+cache_read = 0.025
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "audio", "video", "pdf"]
+output = ["text"]

--- a/providers/sap-ai-core/models/gpt-4.1-mini.toml
+++ b/providers/sap-ai-core/models/gpt-4.1-mini.toml
@@ -1,0 +1,24 @@
+name = "gpt-4.1-mini"
+family = "gpt-mini"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.40
+output = 1.60
+cache_read = 0.10
+
+[limit]
+context = 1_047_576
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/sap-ai-core/models/gpt-4.1.toml
+++ b/providers/sap-ai-core/models/gpt-4.1.toml
@@ -1,0 +1,24 @@
+name = "gpt-4.1"
+family = "gpt"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 8.00
+cache_read = 0.50
+
+[limit]
+context = 1_047_576
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/sap-ai-core/models/sonar-pro.toml
+++ b/providers/sap-ai-core/models/sonar-pro.toml
@@ -1,0 +1,22 @@
+name = "sonar-pro"
+family = "sonar-pro"
+release_date = "2024-01-01"
+last_updated = "2025-09-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+knowledge = "2025-09-01"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/sap-ai-core/models/sonar.toml
+++ b/providers/sap-ai-core/models/sonar.toml
@@ -1,0 +1,22 @@
+name = "sonar"
+family = "sonar"
+release_date = "2024-01-01"
+last_updated = "2025-09-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+knowledge = "2025-09-01"
+open_weights = false
+
+[cost]
+input = 1.00
+output = 1.00
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Add 7 new model definitions for the SAP AI Core provider:

| Model | Context | Max Output | Provider |
|-------|---------|------------|----------|
| `gpt-4.1` | 1,047,576 | 32,768 | OpenAI |
| `gpt-4.1-mini` | 1,047,576 | 32,768 | OpenAI |
| `gemini-2.5-flash-lite` | 1,048,576 | 65,536 | Google |
| `sonar` | 128,000 | 4,096 | Perplexity |
| `sonar-pro` | 200,000 | 8,192 | Perplexity |
| `anthropic--claude-4.6-opus` | 200,000 | 128,000 | Anthropic |
| `anthropic--claude-4.6-sonnet` | 200,000 | 64,000 | Anthropic |

## Details

All specifications have been verified against official provider documentation:
- OpenAI: https://platform.openai.com/docs/models
- Google: https://ai.google.dev/gemini-api/docs/models
- Perplexity: https://docs.perplexity.ai/guides/model-cards
- Anthropic: https://docs.anthropic.com/en/docs/about-claude/models

These models are available through SAP AI Core's generative AI hub, which provides access to various LLM providers via a unified API.