### PR TITLE
add qwen3.5-397b-a17b and step-3-5-flash for nvidia

### DIFF
--- a/providers/nvidia/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/nvidia/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,0 +1,23 @@
+name = "Qwen3.5-397B-A17B"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-01"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 262_144
+output = 8_192
+
+[modalities]
+input = ["text", "image"] # video is natively supported by Qwen3.5 but not available on NVIDIA NIM
+output = ["text"]

--- a/providers/nvidia/models/stepfun-ai/step-3-5-flash.toml
+++ b/providers/nvidia/models/stepfun-ai/step-3-5-flash.toml
@@ -1,0 +1,20 @@
+name = "Step 3.5 Flash"
+release_date = "2026-02-02"
+last_updated = "2026-02-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 256_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Add two new model configurations for the NVIDIA NIM provider:

### 1. Qwen3.5-397B-A17B (`qwen/qwen3.5-397b-a17b`)
- MoE architecture (397B total params, 17B active)
- Supports reasoning (thinking mode), tool calling, vision (text + image input)
- Context: 262K, Output: 8K
- Note: video input is natively supported by Qwen3.5 but not available on NVIDIA NIM (documented in comment)

### 2. Step 3.5 Flash (`stepfun-ai/step-3-5-flash`)
- MoE architecture (196.81B total params, ~11B active) by StepFun
- Supports reasoning, tool calling, text-only input/output
- Context: 256K, Output: 16K
- Apache 2.0 open weights

## Validation

- `bun validate` passed ✅
- Dev server verified both models render correctly ✅