### PR TITLE
Fix qiniu-ai base URL typo

### DIFF
--- a/providers/qiniu-ai/provider.toml
+++ b/providers/qiniu-ai/provider.toml
@@ -1,5 +1,5 @@
 name = "Qiniu"
 env = ["Qiniu_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-api = "https://api.qnaigc.com.com/v1"
+api = "https://api.qnaigc.com/v1"
 doc= "https://developer.qiniu.com/aitokenapi"


### PR DESCRIPTION
Problem: Qiniu provider endpoint is set to https://api.qnaigc.com.com/v1, causing connection failures for OpenAI-compatible clients.

Fix: Update endpoint to https://api.qnaigc.com/v1 (official Qiniu AI inference base URL).

Validation: bun run validate (passed)