### PR TITLE
Venice: Add GPT-5.3 Codex model config

### DIFF
--- a/providers/venice/models/openai-gpt-53-codex.toml
+++ b/providers/venice/models/openai-gpt-53-codex.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.3 Codex"
+family = "gpt-codex"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-02-24"
+last_updated = "2026-02-25"
+open_weights = false
+
+[cost]
+input = 2.19
+output = 17.5
+cache_read = 0.219
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
- Add OpenAI GPT-5.3 Codex model to Venice provider
- Configure capabilities: reasoning, tool_call, structured_output, image attachment
- Set pricing: $2.19 input, $17.50 output, $0.219 cache read
-  400K context