### PR TITLE
Venice: Remove interactive API key prompt & use new maxCompletionTokens field

### DIFF
--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -50,6 +50,7 @@ const ModelSpec = z
   .object({
     pricing: Pricing.optional(),
     availableContextTokens: z.number(),
+    maxCompletionTokens: z.number().optional(),
     capabilities: Capabilities,
     constraints: z.any().optional(),
     name: z.string(),
@@ -238,11 +239,7 @@ function mergeModel(
   const caps = spec.capabilities;
 
   const contextTokens = spec.availableContextTokens;
-  const proposedOutputTokens = Math.floor(contextTokens / 4);
-  const outputTokens =
-    existing?.limit?.output !== undefined && existing.limit.output < proposedOutputTokens
-      ? existing.limit.output
-      : proposedOutputTokens
+  const outputTokens = spec.maxCompletionTokens ?? Math.floor(contextTokens / 4);
 
   const openWeights = spec.modelSource
     ? spec.modelSource.toLowerCase().includes("huggingface")

--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -3,29 +3,10 @@
 import { z } from "zod";
 import path from "node:path";
 import { readdir } from "node:fs/promises";
-import * as readline from "node:readline";
 import { ModelFamilyValues } from "../src/family.js";
 
 // Venice API endpoint
 const API_ENDPOINT = "https://api.venice.ai/api/v1/models?type=text";
-
-async function promptForApiKey(): Promise<string | null> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  return new Promise((resolve) => {
-    rl.question(
-      "Enter Venice API key to include alpha models (or press Enter to skip): ",
-      (answer) => {
-        rl.close();
-        const trimmed = answer.trim();
-        resolve(trimmed.length > 0 ? trimmed : null);
-      },
-    );
-  });
-}
 
 // Zod schemas for API response validation
 const Capabilities = z
@@ -487,7 +468,7 @@ async function main() {
     "models",
   );
 
-  // Check for API key from CLI argument, environment, or prompt
+  // Check for API key from CLI argument or environment variable
   let apiKey: string | null = null;
 
   // Check CLI args for --api-key=xxx or --api-key xxx
@@ -504,11 +485,6 @@ async function main() {
   // Fall back to environment variable
   if (!apiKey) {
     apiKey = process.env.VENICE_API_KEY ?? null;
-  }
-
-  // Prompt if still no key
-  if (!apiKey) {
-    apiKey = await promptForApiKey();
   }
 
   const includeAlpha = apiKey !== null;

--- a/providers/venice/README.md
+++ b/providers/venice/README.md
@@ -22,7 +22,7 @@ Details
 - Output path: `providers/venice/models/<model-id>.toml`
 - Merge behavior: Updates API-sourced fields, preserves manual fields
 - Dates: `release_date`/`last_updated` use `YYYY-MM-DD`; `knowledge` uses `YYYY-MM`
-- Output limit: Calculated as `context / 4`
+- Output limit: Sourced from `maxCompletionTokens` in the API response (falls back to `context / 4` if absent)
 
 Preserved Fields (manual input)
 - `family`: Inferred from model ID if not already set

--- a/providers/venice/README.md
+++ b/providers/venice/README.md
@@ -16,7 +16,6 @@ The script can include alpha models when provided with a Venice API key with alp
 Key can be provided via:
 1. CLI argument: `--api-key=YOUR_KEY` or `--api-key YOUR_KEY`
 2. Environment variable: `VENICE_API_KEY`
-3. Interactive prompt (press Enter to skip for public models only)
 
 Details
 - Source endpoint: `https://api.venice.ai/api/v1/models?type=text`


### PR DESCRIPTION
This allows for better automation and also you dont usually need the API key so it is better to not ask for it every time.
- Remove readline import and promptForApiKey function
- Remove prompt fallback, rely on CLI arg or env var only

Venice finally added the max output tokens to their endpoint. The script now uses this field instead of guessing.

- Update README to reflect the changes