### PR TITLE
Add missing OpenRouter OpenAI models

### DIFF
--- a/providers/openrouter/models/openai/gpt-3.5-turbo-0613.toml
+++ b/providers/openrouter/models/openai/gpt-3.5-turbo-0613.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-3.5 Turbo (older v0613)"
+
+release_date = "2024-01-25"
+last_updated = "2024-01-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1
+output = 2
+
+[limit]
+context = 4_095
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-3.5-turbo-16k.toml
+++ b/providers/openrouter/models/openai/gpt-3.5-turbo-16k.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-3.5 Turbo 16k"
+
+release_date = "2023-08-28"
+last_updated = "2023-08-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3
+output = 4
+
+[limit]
+context = 16_385
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-3.5-turbo-instruct.toml
+++ b/providers/openrouter/models/openai/gpt-3.5-turbo-instruct.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-3.5 Turbo Instruct"
+
+release_date = "2023-09-28"
+last_updated = "2023-09-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.5
+output = 2
+
+[limit]
+context = 4_095
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-3.5-turbo.toml
+++ b/providers/openrouter/models/openai/gpt-3.5-turbo.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-3.5 Turbo"
+
+release_date = "2023-05-28"
+last_updated = "2023-05-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.5
+output = 1.5
+
+[limit]
+context = 16_385
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4-0314.toml
+++ b/providers/openrouter/models/openai/gpt-4-0314.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4 (older v0314)"
+
+release_date = "2023-05-28"
+last_updated = "2023-05-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 30
+output = 60
+
+[limit]
+context = 8_191
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4-1106-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4-1106-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4 Turbo (older v1106)"
+
+release_date = "2023-11-06"
+last_updated = "2023-11-06"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 10
+output = 30
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4-turbo-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4-turbo-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4 Turbo Preview"
+
+release_date = "2024-01-25"
+last_updated = "2024-01-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 10
+output = 30
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4-turbo.toml
+++ b/providers/openrouter/models/openai/gpt-4-turbo.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4 Turbo"
+
+release_date = "2024-04-09"
+last_updated = "2024-04-09"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 10
+output = 30
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4.1-nano.toml
+++ b/providers/openrouter/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: GPT-4.1 Nano"
+
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.025
+
+[limit]
+context = 1_047_576
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4.toml
+++ b/providers/openrouter/models/openai/gpt-4.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4"
+
+release_date = "2023-05-28"
+last_updated = "2023-05-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 30
+output = 60
+
+[limit]
+context = 8_191
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-2024-05-13.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-05-13.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o (2024-05-13)"
+
+release_date = "2024-05-13"
+last_updated = "2024-05-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5
+output = 15
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-2024-08-06.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-08-06.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: GPT-4o (2024-08-06)"
+
+release_date = "2024-08-06"
+last_updated = "2024-08-06"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-2024-11-20.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-11-20.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: GPT-4o (2024-11-20)"
+
+release_date = "2024-11-20"
+last_updated = "2024-11-20"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-audio-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4o-audio-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o Audio"
+
+release_date = "2025-08-15"
+last_updated = "2025-08-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-mini-2024-07-18.toml
+++ b/providers/openrouter/models/openai/gpt-4o-mini-2024-07-18.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: GPT-4o-mini (2024-07-18)"
+
+release_date = "2024-07-18"
+last_updated = "2024-07-18"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.075
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-mini-search-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4o-mini-search-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o-mini Search Preview"
+
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-search-preview.toml
+++ b/providers/openrouter/models/openai/gpt-4o-search-preview.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o Search Preview"
+
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o.toml
+++ b/providers/openrouter/models/openai/gpt-4o.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: GPT-4o"
+
+release_date = "2024-05-13"
+last_updated = "2024-05-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o:extended.toml
+++ b/providers/openrouter/models/openai/gpt-4o:extended.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT-4o (extended)"
+
+release_date = "2024-05-13"
+last_updated = "2024-05-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 6
+output = 18
+
+[limit]
+context = 128_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5-image-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5-image-mini.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: GPT-5 Image Mini"
+
+release_date = "2025-10-16"
+last_updated = "2025-10-16"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 2
+cache_read = 0.25
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.3-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.3-codex.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: GPT-5.3-Codex"
+
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-audio-mini.toml
+++ b/providers/openrouter/models/openai/gpt-audio-mini.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT Audio Mini"
+
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/gpt-audio.toml
+++ b/providers/openrouter/models/openai/gpt-audio.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: GPT Audio"
+
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 10
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/o1-pro.toml
+++ b/providers/openrouter/models/openai/o1-pro.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o1-pro"
+
+release_date = "2025-03-19"
+last_updated = "2025-03-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = false
+
+[cost]
+input = 150
+output = 600
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/o1.toml
+++ b/providers/openrouter/models/openai/o1.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: o1"
+
+release_date = "2024-12-17"
+last_updated = "2024-12-17"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 15
+output = 60
+cache_read = 7.5
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/o3-deep-research.toml
+++ b/providers/openrouter/models/openai/o3-deep-research.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: o3 Deep Research"
+
+release_date = "2025-10-10"
+last_updated = "2025-10-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 10
+output = 40
+cache_read = 2.5
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/o3-mini-high.toml
+++ b/providers/openrouter/models/openai/o3-mini-high.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: o3 Mini High"
+
+release_date = "2025-02-12"
+last_updated = "2025-02-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.55
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/o3-mini.toml
+++ b/providers/openrouter/models/openai/o3-mini.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: o3 Mini"
+
+release_date = "2025-01-31"
+last_updated = "2025-01-31"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.55
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/o3-pro.toml
+++ b/providers/openrouter/models/openai/o3-pro.toml
@@ -1,0 +1,22 @@
+name = "OpenAI: o3 Pro"
+
+release_date = "2025-06-11"
+last_updated = "2025-06-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 20
+output = 80
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/o3.toml
+++ b/providers/openrouter/models/openai/o3.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: o3"
+
+release_date = "2025-04-16"
+last_updated = "2025-04-16"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2
+output = 8
+cache_read = 0.5
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/o4-mini-deep-research.toml
+++ b/providers/openrouter/models/openai/o4-mini-deep-research.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: o4 Mini Deep Research"
+
+release_date = "2025-10-10"
+last_updated = "2025-10-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2
+output = 8
+cache_read = 0.5
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/openai/o4-mini-high.toml
+++ b/providers/openrouter/models/openai/o4-mini-high.toml
@@ -1,0 +1,23 @@
+name = "OpenAI: o4 Mini High"
+
+release_date = "2025-04-16"
+last_updated = "2025-04-16"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.275
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Add missing openai models from OpenRouter

Adds TOML configurations for 32 models available on OpenRouter that were missing from the registry:

- `openai/gpt-5.3-codex`
- `openai/gpt-audio`
- `openai/gpt-audio-mini`
- `openai/gpt-5-image-mini`
- `openai/o3-deep-research`
- `openai/o4-mini-deep-research`
- `openai/gpt-4o-audio-preview`
- `openai/o3-pro`
- `openai/o4-mini-high`
- `openai/o3`
- `openai/gpt-4.1-nano`
- `openai/o1-pro`
- `openai/gpt-4o-mini-search-preview`
- `openai/gpt-4o-search-preview`
- `openai/o3-mini-high`
- `openai/o3-mini`
- `openai/o1`
- `openai/gpt-4o-2024-11-20`
- `openai/gpt-4o-2024-08-06`
- `openai/gpt-4o-mini-2024-07-18`
- `openai/gpt-4o-2024-05-13`
- `openai/gpt-4o`
- `openai/gpt-4o:extended`
- `openai/gpt-4-turbo`
- `openai/gpt-3.5-turbo-0613`
- `openai/gpt-4-turbo-preview`
- `openai/gpt-4-1106-preview`
- `openai/gpt-3.5-turbo-instruct`
- `openai/gpt-3.5-turbo-16k`
- `openai/gpt-4-0314`
- `openai/gpt-4`
- `openai/gpt-3.5-turbo`

Field mapping from OpenRouter API:
- `name` → name
- `pricing.prompt` × 1M → cost.input
- `pricing.completion` × 1M → cost.output
- `pricing.input_cache_read` × 1M → cost.cache_read
- `pricing.input_cache_write` × 1M → cost.cache_write
- `context_length` → limit.context
- `top_provider.max_completion_tokens` → limit.output
- `architecture.modalities` → modalities
- `supported_parameters` includes `tools` → tool_call
- `supported_parameters` includes `response_format` → structured_output

Source: https://openrouter.ai/api/v1/models