### PR TITLE
Add missing OpenRouter MistralAI models

### DIFF
--- a/providers/openrouter/models/mistralai/devstral-medium.toml
+++ b/providers/openrouter/models/mistralai/devstral-medium.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Devstral Medium"
+
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.4
+output = 2
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/devstral-small.toml
+++ b/providers/openrouter/models/mistralai/devstral-small.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Devstral Small 1.1"
+
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.3
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/ministral-14b-2512.toml
+++ b/providers/openrouter/models/mistralai/ministral-14b-2512.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Ministral 3 14B 2512"
+
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.2
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/ministral-3b-2512.toml
+++ b/providers/openrouter/models/mistralai/ministral-3b-2512.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Ministral 3 3B 2512"
+
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.1
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/ministral-8b-2512.toml
+++ b/providers/openrouter/models/mistralai/ministral-8b-2512.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Ministral 3 8B 2512"
+
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.15
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.1.toml
+++ b/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.1.toml
@@ -1,0 +1,21 @@
+name = "Mistral: Mistral 7B Instruct v0.1"
+
+release_date = "2023-09-28"
+last_updated = "2023-09-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.11
+output = 0.19
+
+[limit]
+context = 2_824
+output = 2_824
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.2.toml
+++ b/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.2.toml
@@ -1,0 +1,21 @@
+name = "Mistral: Mistral 7B Instruct v0.2"
+
+release_date = "2023-12-28"
+last_updated = "2023-12-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.2
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.3.toml
+++ b/providers/openrouter/models/mistralai/mistral-7b-instruct-v0.3.toml
@@ -1,0 +1,21 @@
+name = "Mistral: Mistral 7B Instruct v0.3"
+
+release_date = "2024-05-27"
+last_updated = "2024-05-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.2
+
+[limit]
+context = 32_768
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-7b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mistral-7b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Mistral: Mistral 7B Instruct"
+
+release_date = "2024-05-27"
+last_updated = "2024-05-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.2
+
+[limit]
+context = 32_768
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-large-2407.toml
+++ b/providers/openrouter/models/mistralai/mistral-large-2407.toml
@@ -1,0 +1,22 @@
+name = "Mistral Large 2407"
+
+release_date = "2024-11-19"
+last_updated = "2024-11-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2
+output = 6
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-large-2411.toml
+++ b/providers/openrouter/models/mistralai/mistral-large-2411.toml
@@ -1,0 +1,22 @@
+name = "Mistral Large 2411"
+
+release_date = "2024-11-19"
+last_updated = "2024-11-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2
+output = 6
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-large-2512.toml
+++ b/providers/openrouter/models/mistralai/mistral-large-2512.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Large 3 2512"
+
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.5
+output = 1.5
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-large.toml
+++ b/providers/openrouter/models/mistralai/mistral-large.toml
@@ -1,0 +1,22 @@
+name = "Mistral Large"
+
+release_date = "2024-02-26"
+last_updated = "2024-02-26"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2
+output = 6
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-nemo.toml
+++ b/providers/openrouter/models/mistralai/mistral-nemo.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Nemo"
+
+release_date = "2024-07-19"
+last_updated = "2024-07-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.04
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-saba.toml
+++ b/providers/openrouter/models/mistralai/mistral-saba.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Saba"
+
+release_date = "2025-02-17"
+last_updated = "2025-02-17"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.6
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-small-24b-instruct-2501.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-24b-instruct-2501.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Small 3"
+
+release_date = "2025-01-30"
+last_updated = "2025-01-30"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.08
+
+[limit]
+context = 32_768
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-small-3.1-24b-instruct:free.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-3.1-24b-instruct:free.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mistral Small 3.1 24B (free)"
+
+release_date = "2025-03-17"
+last_updated = "2025-03-17"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-small-creative.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-creative.toml
@@ -1,0 +1,21 @@
+name = "Mistral: Mistral Small Creative"
+
+release_date = "2025-12-16"
+last_updated = "2025-12-16"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.1
+output = 0.3
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mixtral-8x22b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mixtral-8x22b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mixtral 8x22B Instruct"
+
+release_date = "2024-04-17"
+last_updated = "2024-04-17"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 2
+output = 6
+
+[limit]
+context = 65_536
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/mixtral-8x7b-instruct.toml
+++ b/providers/openrouter/models/mistralai/mixtral-8x7b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Mixtral 8x7B Instruct"
+
+release_date = "2023-12-10"
+last_updated = "2023-12-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.54
+output = 0.54
+
+[limit]
+context = 32_768
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/pixtral-large-2411.toml
+++ b/providers/openrouter/models/mistralai/pixtral-large-2411.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Pixtral Large 2411"
+
+release_date = "2024-11-19"
+last_updated = "2024-11-19"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2
+output = 6
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openrouter/models/mistralai/voxtral-small-24b-2507.toml
+++ b/providers/openrouter/models/mistralai/voxtral-small-24b-2507.toml
@@ -1,0 +1,22 @@
+name = "Mistral: Voxtral Small 24B 2507"
+
+release_date = "2025-10-30"
+last_updated = "2025-10-30"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.3
+
+[limit]
+context = 32_000
+output = 32_000
+
+[modalities]
+input = ["text", "audio"]
+output = ["text"]


### PR DESCRIPTION
## Add missing mistralai models from OpenRouter

Adds TOML configurations for 22 models available on OpenRouter that were missing from the registry:

- `mistralai/mistral-small-creative`
- `mistralai/ministral-14b-2512`
- `mistralai/ministral-8b-2512`
- `mistralai/ministral-3b-2512`
- `mistralai/mistral-large-2512`
- `mistralai/voxtral-small-24b-2507`
- `mistralai/devstral-medium`
- `mistralai/devstral-small`
- `mistralai/mistral-small-3.1-24b-instruct:free`
- `mistralai/mistral-saba`
- `mistralai/mistral-small-24b-instruct-2501`
- `mistralai/mistral-large-2411`
- `mistralai/mistral-large-2407`
- `mistralai/pixtral-large-2411`
- `mistralai/mistral-nemo`
- `mistralai/mistral-7b-instruct`
- `mistralai/mistral-7b-instruct-v0.3`
- `mistralai/mixtral-8x22b-instruct`
- `mistralai/mistral-large`
- `mistralai/mistral-7b-instruct-v0.2`
- `mistralai/mixtral-8x7b-instruct`
- `mistralai/mistral-7b-instruct-v0.1`

Field mapping from OpenRouter API:
- `name` → name
- `pricing.prompt` × 1M → cost.input
- `pricing.completion` × 1M → cost.output
- `pricing.input_cache_read` × 1M → cost.cache_read
- `pricing.input_cache_write` × 1M → cost.cache_write
- `context_length` → limit.context
- `top_provider.max_completion_tokens` → limit.output
- `architecture.input_modalities` / `output_modalities` → modalities
- `supported_parameters` includes `tools` → tool_call
- `supported_parameters` includes `response_format`/`structured_outputs` → structured_output
- `supported_parameters` includes `reasoning` → reasoning
- `hugging_face_id` non-empty → open_weights

Source: https://openrouter.ai/api/v1/models