### PR TITLE
Add Clarifai Model Provider

### DIFF
--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -197,6 +197,9 @@ export const ModelFamilyValues = [
   // Mimo
   "mimo",
 
+  // Clarifai
+  "mm-poly",
+
   // Longcat
   "longcat",
 

--- a/providers/clarifai/models/arcee_ai/AFM/models/trinity-mini.toml
+++ b/providers/clarifai/models/arcee_ai/AFM/models/trinity-mini.toml
@@ -1,0 +1,22 @@
+name = "Trinity Mini"
+family = "trinity-mini"
+release_date = "2025-12"
+last_updated = "2026-02-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-10"
+open_weights = true
+
+[cost]
+input = 0.045
+output = 0.15
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/clarifai/models/clarifai/main/models/mm-poly-8b.toml
+++ b/providers/clarifai/models/clarifai/main/models/mm-poly-8b.toml
@@ -1,0 +1,21 @@
+name = "MM Poly 8B"
+family = "mm-poly"
+release_date = "2025-06"
+last_updated = "2026-02-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.658
+output = 1.11
+
+[limit]
+context = 32_768
+output = 4_096
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/clarifai/models/deepseek-ai/deepseek-ocr/models/DeepSeek-OCR.toml
+++ b/providers/clarifai/models/deepseek-ai/deepseek-ocr/models/DeepSeek-OCR.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek OCR"
+family = "deepseek"
+release_date = "2025-10-20"
+last_updated = "2026-02-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.20
+output = 0.70
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/clarifai/models/minimaxai/chat-completion/models/MiniMax-M2_5-high-throughput.toml
+++ b/providers/clarifai/models/minimaxai/chat-completion/models/MiniMax-M2_5-high-throughput.toml
@@ -1,0 +1,21 @@
+name = "MiniMax-M2.5 High Throughput"
+family = "minimax"
+release_date = "2026-02-12"
+last_updated = "2026-02-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/clarifai/models/mistralai/completion/models/Ministral-3-14B-Reasoning-2512.toml
+++ b/providers/clarifai/models/mistralai/completion/models/Ministral-3-14B-Reasoning-2512.toml
@@ -1,0 +1,22 @@
+name = "Ministral 3 14B Reasoning 2512"
+family = "ministral"
+release_date = "2025-12-01"
+last_updated = "2025-12-12"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-12"
+open_weights = true
+
+[cost]
+input = 2.50
+output = 1.70
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/clarifai/models/mistralai/completion/models/Ministral-3-3B-Reasoning-2512.toml
+++ b/providers/clarifai/models/mistralai/completion/models/Ministral-3-3B-Reasoning-2512.toml
@@ -1,0 +1,21 @@
+name = "Ministral 3 3B Reasoning 2512"
+family = "ministral"
+release_date = "2025-12"
+last_updated = "2026-02-25"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.039
+output = 0.54825
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/clarifai/models/openai/chat-completion/models/gpt-oss-120b-high-throughput.toml
+++ b/providers/clarifai/models/openai/chat-completion/models/gpt-oss-120b-high-throughput.toml
@@ -1,0 +1,21 @@
+name = "GPT OSS 120B High Throughput"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2026-02-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.09
+output = 0.36
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/clarifai/models/openai/chat-completion/models/gpt-oss-20b.toml
+++ b/providers/clarifai/models/openai/chat-completion/models/gpt-oss-20b.toml
@@ -1,0 +1,21 @@
+name = "GPT OSS 20B"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2025-12-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.045
+output = 0.18
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/clarifai/models/qwen/qwenCoder/models/Qwen3-Coder-30B-A3B-Instruct.toml
+++ b/providers/clarifai/models/qwen/qwenCoder/models/Qwen3-Coder-30B-A3B-Instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 Coder 30B A3B Instruct"
+family = "qwen"
+release_date = "2025-07-31"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.11458
+output = 0.74812
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/clarifai/models/qwen/qwenLM/models/Qwen3-30B-A3B-Instruct-2507.toml
+++ b/providers/clarifai/models/qwen/qwenLM/models/Qwen3-30B-A3B-Instruct-2507.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 30B A3B Instruct 2507"
+family = "qwen"
+release_date = "2025-07-30"
+last_updated = "2026-02-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 0.50
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/clarifai/models/qwen/qwenLM/models/Qwen3-30B-A3B-Thinking-2507.toml
+++ b/providers/clarifai/models/qwen/qwenLM/models/Qwen3-30B-A3B-Thinking-2507.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 30B A3B Thinking 2507"
+family = "qwen"
+release_date = "2025-07-31"
+last_updated = "2026-02-25"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.36
+output = 1.30
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/clarifai/provider.toml
+++ b/providers/clarifai/provider.toml
@@ -1,0 +1,5 @@
+name = "Clarifai"
+env = ["CLARIFAI_PAT"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.clarifai.com/v2/ext/openai/v1"
+doc = "https://docs.clarifai.com/compute/inference/"


### PR DESCRIPTION
﻿Add Clarifai as a new provider with 11 models:

- GPT OSS 20B, GPT OSS 120B High Throughput
- Ministral 3 14B/3B Reasoning 2512
- Qwen3 Coder 30B, Qwen3 30B Instruct/Thinking 2507
- MiniMax-M2.5 High Throughput
- Trinity Mini, DeepSeek OCR, MM Poly 8B

Also adds mm-poly family to family.ts for the Clarifai multimodal model.
