### PR TITLE
Add sonnet 4.6 and opus 4.6 to abacus model list

### DIFF
--- a/providers/abacus/models/claude-opus-4-6.toml
+++ b/providers/abacus/models/claude-opus-4-6.toml
@@ -1,0 +1,22 @@
+name = "Claude Opus 4.6"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/abacus/models/claude-sonnet-4-6.toml
+++ b/providers/abacus/models/claude-sonnet-4-6.toml
@@ -1,0 +1,22 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
Added the following models to the Abacus provider:

- claude-opus-4-6
- claude-sonnet-4-6