### PR TITLE
add gemini 3.1 pro preview custom tools for openrouter

### DIFF
--- a/providers/openrouter/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/openrouter/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,0 +1,32 @@
+name = "Gemini 3.1 Pro Preview Custom Tools"
+family = "gemini-pro"
+release_date = "2026-02-19"
+last_updated = "2026-02-19"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_details"
+
+[cost]
+input = 2.00
+output = 12.00
+reasoning = 12.00
+
+[cost.context_over_200k]
+input = 4.00
+output = 18.00
+cache_read = 0.40
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "audio", "video", "pdf"]
+output = ["text"]


### PR DESCRIPTION
 Summary
- Add `google/gemini-3.1-pro-preview-customtools` under OpenRouter at `providers/openrouter/models/google/gemini-3.1-pro-preview-customtools.toml`.
- Include full model metadata and capabilities (reasoning, tool calling, structured output, multimodal input, 1,048,576 context window).
- Configure OpenRouter-specific reasoning interleaving (`reasoning_details`) and pricing tiers, including `cost.context_over_200k`.
