### PR TITLE
fix: mark GLM-5 as open weights

### DIFF
--- a/providers/meganova/models/zai-org/GLM-5.toml
+++ b/providers/meganova/models/zai-org/GLM-5.toml
@@ -6,7 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.toml
+++ b/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/siliconflow/models/zai-org/GLM-5.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/vercel/models/zai/glm-5.toml
+++ b/providers/vercel/models/zai/glm-5.toml
@@ -6,7 +6,7 @@ tool_call = true
 temperature = true
 release_date = "2026-02-12"
 last_updated = "2026-02-19"
-open_weights = false
+open_weights = true
 
 [cost]
 input = 1

--- a/providers/zai-coding-plan/models/glm-5.toml
+++ b/providers/zai-coding-plan/models/glm-5.toml
@@ -6,7 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zai/models/glm-5.toml
+++ b/providers/zai/models/glm-5.toml
@@ -6,7 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zenmux/models/z-ai/glm-5.toml
+++ b/providers/zenmux/models/z-ai/glm-5.toml
@@ -6,7 +6,7 @@ reasoning = true
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zhipuai-coding-plan/models/glm-5.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5.toml
@@ -6,7 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zhipuai/models/glm-5.toml
+++ b/providers/zhipuai/models/glm-5.toml
@@ -6,7 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
GLM-5 is an open-source model, but several provider config files incorrectly had `open_weights` set to `false`. This PR corrects all GLM-5 configurations to properly reflect its open-source status.

## Changes

Updated `open_weights = false` to `open_weights = true` in the following provider config files:

- `providers/zhipuai/models/glm-5.toml`
- `providers/zhipuai-coding-plan/models/glm-5.toml`
- `providers/zai/models/glm-5.toml`
- `providers/zai-coding-plan/models/glm-5.toml`
- `providers/zenmux/models/z-ai/glm-5.toml`
- `providers/vercel/models/zai/glm-5.toml`
- `providers/siliconflow/models/zai-org/GLM-5.toml`
- `providers/siliconflow-cn/models/Pro/zai-org/GLM-5.toml`
- `providers/meganova/models/zai-org/GLM-5.toml`

## Verification

All other GLM-5 provider configs already had `open_weights = true`. This PR ensures consistency across all providers.