### PR TITLE
fix(azure): add gpt-5.3-codex model

### DIFF
--- a/providers/azure-cognitive-services/models/gpt-5.3-codex.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.3-codex.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.3 Codex"
+family = "gpt-codex"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/azure/models/gpt-5.3-codex.toml
+++ b/providers/azure/models/gpt-5.3-codex.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.3 Codex"
+family = "gpt-codex"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add gpt-5.3-codex model metadata for Azure OpenAI
- add gpt-5.3-codex model metadata for Azure Cognitive Services
- align dates/pricing with the Azure announcement (2026-02-24)

## Testing
- not run (metadata only)


Closes #1054 

Related anomalyco/opencode#15063