### PR TITLE
Add Inception Mercury 2 and Mercury Edit models

### DIFF
--- a/providers/inception/models/mercury-2.toml
+++ b/providers/inception/models/mercury-2.toml
@@ -1,0 +1,24 @@
+name = "Inception: Mercury 2"
+family = "mercury"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-01-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 0.75
+cache_read = 0.025
+
+[limit]
+context = 128_000
+output = 50_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/inception/models/mercury-edit.toml
+++ b/providers/inception/models/mercury-edit.toml
@@ -1,0 +1,21 @@
+name = "Inception: Mercury Edit"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.25
+output = 0.75
+cache_read = 0.025
+
+[limit]
+context = 128000
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/inception/mercury-2.toml
+++ b/providers/kilo/models/inception/mercury-2.toml
@@ -1,0 +1,21 @@
+name = "Inception: Mercury 2"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 0.75
+cache_read = 0.025
+
+[limit]
+context = 128000
+output = 50000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kilo/models/inception/mercury-edit.toml
+++ b/providers/kilo/models/inception/mercury-edit.toml
@@ -1,0 +1,24 @@
+name = "Inception: Mercury Edit"
+family = "mercury"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-01-01"
+tool_call = false
+structured_output = false
+open_weights = false
+
+[cost]
+input = 0.25
+output = 0.75
+cache_read = 0.025
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add **Mercury 2** and **Mercury Edit** model definitions for the Inception provider
- Add **Mercury 2** and **Mercury Edit** model definitions for the Kilo provider (Inception namespace)

## Model Details
| Model | Context | Output | Input Cost | Output Cost | Features |
|-------|---------|--------|------------|-------------|----------|
| Mercury 2 | 128K | 50K | $0.25/M | $0.75/M | Reasoning, Tool Calls, Structured Output |
| Mercury Edit | 128K | 8K | $0.25/M | $0.75/M | Reasoning |

Both models were released on 2026-02-24.

## Files Added
- `providers/inception/models/mercury-2.toml`
- `providers/inception/models/mercury-edit.toml`
- `providers/kilo/models/inception/mercury-2.toml`
- `providers/kilo/models/inception/mercury-edit.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)