### PR TITLE
feat: [deepseek]: update official DeepSeek model details

### DIFF
--- a/providers/deepseek/models/deepseek-chat.toml
+++ b/providers/deepseek/models/deepseek-chat.toml
@@ -1,13 +1,13 @@
 name = "DeepSeek Chat"
 family = "deepseek"
-release_date = "2024-12-26"
-last_updated = "2025-09-29"
+release_date = "2025-12-01"
+last_updated = "2026-02-28"
 attachment = true
 reasoning = false
 temperature = true
-knowledge = "2024-07"
+knowledge = "2025-09"
 tool_call = true
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.28

--- a/providers/deepseek/models/deepseek-reasoner.toml
+++ b/providers/deepseek/models/deepseek-reasoner.toml
@@ -1,13 +1,13 @@
 name = "DeepSeek Reasoner"
 family = "deepseek-thinking"
-release_date = "2025-01-20"
-last_updated = "2025-09-29"
+release_date = "2025-12-01"
+last_updated = "2026-02-28"
 attachment = true
 reasoning = true
 temperature = true
-knowledge = "2024-07"
+knowledge = "2025-09"
 tool_call = true
-open_weights = false
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -19,7 +19,7 @@ cache_read = 0.028
 
 [limit]
 context = 128_000
-output = 128_000
+output = 64_000
 
 [modalities]
 input = ["text"]

--- a/providers/deepseek/provider.toml
+++ b/providers/deepseek/provider.toml
@@ -1,5 +1,5 @@
 name = "DeepSeek"
 env = ["DEEPSEEK_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-doc = "https://platform.deepseek.com/api-docs/pricing"
+doc = "https://api-docs.deepseek.com/quick_start/pricing"
 api = "https://api.deepseek.com"


### PR DESCRIPTION
Updates the official deepseek provider and model details.

In more detail:
- Updated details on `deepseek-chat` & `deepseek-reasoner` for the official deepseek provider
  - Updated release dates to 1st of December 2025 as both models now use Deepseek V3.2
  - Bumped knowledge cutoffs accordingly. The exact date is not officially released but Sep 2025 seems to be the most commonly assumed one
  - Set `open_weights ` to true, DeepSeek V3.2 weights have been released under MIT license
  - Corrected `deepseek-reasoner` max output size to 64K instead of 128K
- Updated the deepseek provider doc url to latest one, the previous one was no longer valid. It was pointed to the pricing page so I've done the same

See the sources for these details on
- https://api-docs.deepseek.com/quick_start/pricing
- https://api-docs.deepseek.com/news/news251201