### PR TITLE
Venice: Add Qwen 3.5 35B A3B model

### DIFF
--- a/providers/venice/models/qwen3-5-35b-a3b.toml
+++ b/providers/venice/models/qwen3-5-35b-a3b.toml
@@ -1,0 +1,23 @@
+name = "Qwen 3.5 35B A3B"
+family = "qwen"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-02-25"
+last_updated = "2026-02-28"
+open_weights = true
+
+[cost]
+input = 0.3125
+output = 1.25
+cache_read = 0.15625
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
- Add new model configuration for Qwen 3.5 35B A3B
- Includes cost, limits, and capabilities (reasoning, tool_call, structured_output)