### PR TITLE
NVIDIA: Add MiniMax M2.5 model and remove MiniMax M2

### DIFF
--- a/providers/nvidia/models/minimaxai/minimax-m2.5.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m2.5.toml
@@ -2,10 +2,10 @@ name = "MiniMax-M2.5"
 family = "minimax"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
-knowledge = "2025-08"
 attachment = false
 reasoning = true
 temperature = true
+knowledge = "2025-08"
 tool_call = true
 open_weights = true
 

--- a/providers/nvidia/models/minimaxai/minimax-m2.5.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m2.5.toml
@@ -1,11 +1,11 @@
-name = "MiniMax-M2"
+name = "MiniMax-M2.5"
 family = "minimax"
-release_date = "2025-10-27"
-last_updated = "2025-10-31"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+knowledge = "2025-08"
 attachment = false
 reasoning = true
 temperature = true
-knowledge = "2024-07"
 tool_call = true
 open_weights = true
 
@@ -14,8 +14,8 @@ input = 0.0
 output = 0.0
 
 [limit]
-context = 128_000
-output = 16_384
+context = 204_800
+output = 131_072
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Add support for the NVIDIA MiniMax M2.5 model and remove the deprecated MiniMax M2 model.