### PR TITLE
Add three NVIDIA NIM models: Qwen3.5-397B, MiniMax-M2.5, and Step-3.5-Flash

### DIFF
--- a/providers/nvidia/models/minimaxai/minimax-m2.5.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m2.5.toml
@@ -1,0 +1,21 @@
+name = "MiniMax-M2.5"
+family = "minimax"
+release_date = "2026-02-12"
+last_updated = "2026-02-26"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nvidia/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/nvidia/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.5-397B-A17B"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nvidia/models/stepfun-ai/step-3.5-flash.toml
+++ b/providers/nvidia/models/stepfun-ai/step-3.5-flash.toml
@@ -1,0 +1,21 @@
+name = "Step-3.5-Flash"
+family = "step"
+release_date = "2026-02-01"
+last_updated = "2026-02-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 256_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add three new model configurations for NVIDIA NIM provider, verified against official NVIDIA NIM documentation.

## Changes

### 1. Qwen3.5-397B-A17B (`providers/nvidia/models/qwen/qwen3.5-397b-a17b.toml`)
- **Type**: 397B MoE multimodal model (text, image, video)
- **Context**: 262,144 tokens (native), extensible to 1M with YaRN
- **Output**: 81,920 tokens
- **Release Date**: 2026-02-16
- **Source**: https://build.nvidia.com/qwen/qwen3.5-397b-a17b

### 2. MiniMax-M2.5 (`providers/nvidia/models/minimaxai/minimax-m2.5.toml`)
- **Type**: 230B parameter coding and reasoning model
- **Context**: 204,800 tokens
- **Performance**: SOTA on SWE-Bench Verified (80.2%)
- **Release Date**: 2026-02-12
- **Source**: https://build.nvidia.com/minimaxai/minimax-m2.5

### 3. Step-3.5-Flash (`providers/nvidia/models/stepfun-ai/step-3.5-flash.toml`)
- **Type**: 196B MoE reasoning model (~11B active parameters)
- **Context**: 256,000 tokens
- **Throughput**: 100-300 tok/s
- **Release Date**: 2026-02
- **Source**: https://build.nvidia.com/stepfun-ai/step-3.5-flash

## Verification
- [x] All configurations validated with `bun validate`
- [x] Specifications verified against NVIDIA NIM official documentation
- [x] Model cards referenced from official sources

## Notes
- Model specifications (context length, modalities, release dates) sourced from official NVIDIA NIM documentation
- Knowledge cutoff dates are estimates based on release dates where not explicitly stated by vendors