### PR TITLE
core: make provider/model generation deterministic

### DIFF
--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -1,0 +1,26 @@
+import path from "path";
+import { expect, test } from "bun:test";
+
+import { generate } from "./generate.js";
+
+function compareStrings(a: string, b: string) {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+}
+
+test("generate returns providers and models in sorted key order", async () => {
+  const providersDir = path.join(import.meta.dir, "..", "..", "..", "providers");
+  const providers = await generate(providersDir);
+  const providerIds = Object.keys(providers);
+  expect(providerIds).toEqual([...providerIds].sort(compareStrings));
+
+  for (const providerId of providerIds) {
+    const modelIds = Object.keys(providers[providerId].models);
+    expect(modelIds).toEqual([...modelIds].sort(compareStrings));
+  }
+});

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -2,13 +2,39 @@ import path from "path";
 
 import { Provider, Model } from "./schema.js";
 
+function compareStrings(a: string, b: string) {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+}
+
 export async function generate(directory: string) {
   const result = {} as Record<string, Provider>;
+
+  const providers: Array<{ id: string; providerPath: string }> = [];
   for await (const providerPath of new Bun.Glob("*/provider.toml").scan({
     cwd: directory,
     absolute: true,
   })) {
-    const providerID = path.basename(path.dirname(providerPath));
+    providers.push({
+      id: path.basename(path.dirname(providerPath)),
+      providerPath,
+    });
+  }
+
+  providers.sort((a, b) => {
+    const byId = compareStrings(a.id, b.id);
+    if (byId !== 0) {
+      return byId;
+    }
+    return compareStrings(a.providerPath, b.providerPath);
+  });
+
+  for (const { id: providerID, providerPath } of providers) {
     const toml = await import(providerPath, {
       with: {
         type: "toml",
@@ -23,12 +49,27 @@ export async function generate(directory: string) {
     }
 
     const modelsPath = path.join(directory, providerID, "models");
+    const models: Array<{ id: string; modelPath: string }> = [];
     for await (const modelPath of new Bun.Glob("**/*.toml").scan({
       cwd: modelsPath,
       absolute: true,
       followSymlinks: true,
     })) {
-      const modelID = path.relative(modelsPath, modelPath).slice(0, -5);
+      models.push({
+        id: path.relative(modelsPath, modelPath).slice(0, -5),
+        modelPath,
+      });
+    }
+
+    models.sort((a, b) => {
+      const byId = compareStrings(a.id, b.id);
+      if (byId !== 0) {
+        return byId;
+      }
+      return compareStrings(a.modelPath, b.modelPath);
+    });
+
+    for (const { id: modelID, modelPath } of models) {
       const toml = await import(modelPath, {
         with: {
           type: "toml",


### PR DESCRIPTION
The issue was non-deterministic output ordering in `generate()`:
- provider files and model files were read via `Bun.Glob(...).scan()` and consumed directly
- traversal order from glob scanning is not guaranteed stable
- object insertion order then leaked into generated JSON/TS snapshots, producing different byte output between builds

Fix approach:
- collect provider and model paths first, then sort explicitly before processing
- sort by stable string keys (`id`), with path as a deterministic tie-breaker
- use locale-independent string comparison (`a < b` / `a > b`) instead of `localeCompare` to avoid locale/ICU-dependent ordering

Testing:
- added `packages/core/src/generate.test.ts`
- test asserts returned provider keys are sorted
- test asserts each provider's model keys are sorted
- verified with: `bun test packages/core/src/generate.test.ts`

This makes generation deterministic and prevents ordering-only drift in downstream artifacts.