### PR TITLE
feat(deepinfra): add MiniMax M2.5 model config

### DIFF
--- a/providers/deepinfra/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/deepinfra/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,0 +1,25 @@
+name = "MiniMax M2.5"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+knowledge = "2025-10"
+
+[cost]
+input = 0.27
+output = 0.95
+cached_read = 0.03
+
+[limit]
+context = 196_608
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
Sources:
1. https://deepinfra.com/MiniMaxAI/MiniMax-M2.5/api
2. https://deepinfra.com/docs/advanced/max_tokens_limit
3. About output tokens:
    > "maximum length of the newly generated generated text.If explicitly set to None it will be the model's max context length minus input length or 16384, whichever is smaller (Default: empty, 1 ≤ max_new_tokens ≤ 1000000)" 
4. Rest are from google search