### PR TITLE
feat: add gpt-5.3-codex to github-copilot provider

### DIFF
--- a/providers/github-copilot/models/gpt-5.3-codex.toml
+++ b/providers/github-copilot/models/gpt-5.3-codex.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.3-Codex"
+family = "gpt-codex"
+release_date = "2026-02-09"
+last_updated = "2026-02-09"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Adds `gpt-5.3-codex` model definition to the `github-copilot` provider.
- GPT-5.3-Codex was made generally available for GitHub Copilot on February 9, 2026: https://github.blog/changelog/2026-02-09-gpt-5-3-codex-is-now-generally-available-for-github-copilot/
- Model definition follows the same structure as the existing `gpt-5.2-codex.toml`, with updated release date and name.
- The OpenAI provider entry (`providers/openai/models/gpt-5.3-codex.toml`) already exists; this adds the corresponding GitHub Copilot entry with zero cost (subscription-based) and matching Copilot context limits (272K context / 128K output).