### PR TITLE
feat(gitlab): update context limit to 1M for Claude Sonnet and Opus 4.6

### DIFF
--- a/providers/gitlab/models/duo-chat-opus-4-6.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-6.toml
@@ -16,7 +16,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 200_000
+context = 1_000_000
 output = 64_000
 
 [modalities]

--- a/providers/gitlab/models/duo-chat-sonnet-4-6.toml
+++ b/providers/gitlab/models/duo-chat-sonnet-4-6.toml
@@ -16,7 +16,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 200_000
+context = 1_000_000
 output = 64_000
 
 [modalities]


### PR DESCRIPTION
Claude Sonnet 4.6 and Claude Opus 4.6 support a 1M token context window when using the `context-1m-2025-08-07` Anthropic beta header.

This is confirmed in the [GitLab AI Gateway source](https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/blob/main/ai_gateway/model_selection/models.yml) where `duo-chat-opus-4-6` already has `max_context_tokens: 1_000_000` and the gateway forwards the `anthropic-beta` header downstream.

Updates `limit.context` from `200_000` to `1_000_000` for both models.

A companion PR to send `context-1m-2025-08-07` beta header to enable 1M context window in opencode is at https://github.com/anomalyco/opencode/pull/16153