### PR TITLE
feat(provider): add MiniMax M2.5 for DeepInfra

### DIFF
--- a/providers/deepinfra/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/deepinfra/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,0 +1,25 @@
+name = "MiniMax M2.5"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+knowledge = "2026-01"
+
+[cost]
+input = 0.27
+output = 0.95
+cache_read = 0.03
+
+[limit]
+context = 196_608
+output = 196_608
+ 
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
This PR adds the MiniMax M2.5 model for the DeepInfra provider.