### PR TITLE
add MiniMaxAI/MiniMax-M2.5 to CloudFerro Sherlock

### DIFF
--- a/providers/cloudferro-sherlock/models/ MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/cloudferro-sherlock/models/ MiniMaxAI/MiniMax-M2.5.toml
@@ -1,0 +1,22 @@
+name = "MiniMax-M2.5"
+family = "minimax"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2026-01"
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 196_000
+output = 196_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adding new model: MiniMaxAI/MiniMax-M2.5. 

Provider: CloudFerro Sherlock