### PR TITLE
feat(openai): add gpt-5.4 model

### DIFF
--- a/providers/openai/models/gpt-5.4.toml
+++ b/providers/openai/models/gpt-5.4.toml
@@ -1,0 +1,29 @@
+name = "GPT-5.4"
+family = "gpt"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
+[cost.context_over_200k]
+input = 5.00
+output = 22.50
+cache_read = 0.50
+
+[limit]
+context = 1_050_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
https://openai.com/index/introducing-gpt-5-4/

This pull request adds a new model configuration file for `GPT-5.4` to the OpenAI provider. The configuration specifies the model's capabilities, supported modalities, cost structure, and context/output limits.

Model configuration additions:

* Added a new model definition for `GPT-5.4` in `providers/openai/models/gpt-5.4.toml` with metadata such as release date, knowledge cutoff, and feature flags (attachment, reasoning, tool_call, structured_output).
* Defined cost parameters for standard and context-over-200k usage, including input, output, and cache read costs.
* Set model limits for context size (1,050,000 tokens) and output size (128,000 tokens).
* Specified supported input modalities (`text`, `image`) and output modality (`text`).