### PR TITLE
feat(provider): add openai gpt-5.4 and gpt-5.4-pro

### DIFF
--- a/providers/openai/models/gpt-5.4-pro.toml
+++ b/providers/openai/models/gpt-5.4-pro.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.4 Pro"
+family = "gpt-pro"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 30.00
+output = 180.00
+
+[limit]
+context = 1_050_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openai/models/gpt-5.4.toml
+++ b/providers/openai/models/gpt-5.4.toml
@@ -1,0 +1,25 @@
+name = "GPT-5.4"
+family = "gpt"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 15.00
+cache_read = 0.25
+
+[limit]
+context = 1_050_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
This PR adds the newly released `gpt-5.4` and `gpt-5.4-pro` models to the `openai` provider catalog.

The immediate user impact is that clients consuming the OpenAI provider data from models.dev, including opencode flows that rely on the provider-scoped model list, could not resolve these March 5, 2026 OpenAI models from the `openai` provider even though the repo already carried matching `gpt-5.4` metadata under the `opencode` provider.

The root cause was provider coverage lag rather than a generator or schema problem: the repo was missing provider-scoped OpenAI model definition files for the new 5.4 release line.

This change fixes that by adding:
- `providers/openai/models/gpt-5.4.toml`
- `providers/openai/models/gpt-5.4-pro.toml`

The `gpt-5.4` entry matches the existing in-repo `opencode` metadata, and the `gpt-5.4-pro` entry follows the existing OpenAI `pro` model conventions while using the current OpenAI release metadata, pricing, limits, and capability flags.

Validation:
- `bun run validate`
