### PR TITLE
feat(openai): add GPT-5.4 and GPT-5.4 Pro model specs

### DIFF
--- a/providers/openai/models/gpt-5.4-pro.toml
+++ b/providers/openai/models/gpt-5.4-pro.toml
@@ -1,0 +1,28 @@
+name = "GPT-5.4 Pro"
+family = "gpt-pro"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = false
+open_weights = false
+
+[cost]
+input = 30.00
+output = 180.00
+
+[cost.context_over_200k]
+input = 60.00
+output = 270.00
+
+[limit]
+context = 1_050_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openai/models/gpt-5.4.toml
+++ b/providers/openai/models/gpt-5.4.toml
@@ -1,0 +1,30 @@
+name = "GPT-5.4"
+family = "gpt"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
+[cost.context_over_200k]
+input = 5.00
+output = 22.50
+cache_read = 0.50
+
+[limit]
+context = 1_050_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add OpenAI `gpt-5.4` and `gpt-5.4-pro` model entries to keep the OpenAI catalog current.
- Include long-context pricing in `cost.context_over_200k` for sessions that cross the 272k-token threshold.
- Keep field conventions aligned with existing OpenAI model files (capabilities, limits, modalities, and metadata).

## Changes
- Added `providers/openai/models/gpt-5.4.toml`.
- Added `providers/openai/models/gpt-5.4-pro.toml`.

## Validation
- `bun validate`
- `cd packages/web && bun run build`