### PR TITLE
feat: add gpt-5.3-codex to github-copilot provider

### DIFF
--- a/providers/github-copilot/models/gpt-5.3-codex.toml
+++ b/providers/github-copilot/models/gpt-5.3-codex.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.3-Codex"
+family = "gpt-codex"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
summary
gpt-5.3-codex is available in github copilot (confirmed GA, visible in vs code and copilot cli) but missing from the github-copilot provider in models.dev. this means opencode users can't select it even after enabling it in the copilot dashboard.

root cause
the model was added to the `openai` and `opencode` providers but the corresponding toml was never added under `providers/github-copilot/models/`.

changes
- added `providers/github-copilot/models/gpt-5.3-codex.toml` modeled after `gpt-5.2-codex.toml`
- context window bumped to 400k (matches the openai provider entry)
- cost set to 0/0 (consistent with all other copilot models — subscription-based)

testing
- verified the model exists in `models.dev/api.json` under `openai` but not `github-copilot`
- toml structure matches the existing pattern for neighboring models (`gpt-5.2-codex.toml`)