### PR TITLE
feat(provider): add gpt-5.4 for GitHub Copilot

### DIFF
--- a/providers/github-copilot/models/gpt-5.4.toml
+++ b/providers/github-copilot/models/gpt-5.4.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.4"
+family = "gpt"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add GPT-5.4 to GitHub Copilot
- align its limits with the existing GPT-5.3-Codex config
- keep the `gpt` family to match the existing non-Codex GPT models

## References
- [GitHub Changelog: GPT-5.4 is generally available in GitHub Copilot](https://github.blog/changelog/2026-03-05-gpt-5-4-is-generally-available-in-github-copilot/)
- [GitHub Docs: Supported AI models in GitHub Copilot](https://docs.github.com/en/copilot/reference/ai-models/supported-models?utm_source=model-release-announcement&utm_medium=changelog&utm_campaign=newmodels#supported-ai-models-in-copilot)

## Validation
- run `bun validate`