### PR TITLE
feat: add GLM-4.7-Flash to the Cloudflare Workers AI provider

### DIFF
--- a/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
@@ -14,7 +14,7 @@ input = 0.06
 output = 0.40
 
 [limit]
-context = 200_000
+context = 131_072
 output = 131_072
 
 [modalities]

--- a/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
@@ -1,0 +1,22 @@
+name = "GLM-4.7-Flash"
+family = "glm-flash"
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.40
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add `GLM-4.7-Flash` to the Cloudflare Workers AI provider

Model specs from [Cloudflare doc](https://developers.cloudflare.com/workers-ai/models/glm-4.7-flash/):
- Context: 131,072 tokens
- Input:  $0.06/M
- Output: $0.40/M
- Reasoning: true (thinking model)
- Open weights: true (MIT license)
- Tool call: true