### PR TITLE
Fix GLM-5 context window size on Google Vertex

### DIFF
--- a/providers/google-vertex/models/zai-org/glm-5-maas.toml
+++ b/providers/google-vertex/models/zai-org/glm-5-maas.toml
@@ -17,7 +17,7 @@ output = 3.20
 cache_read = 0.10
 
 [limit]
-context = 204800
+context = 202752
 output = 131072
 
 [modalities]


### PR DESCRIPTION
## Summary
- Corrects the GLM-5 context window from 204800 to 202752 tokens on Google Vertex