### PR TITLE
Add GPT-5.3 Chat to Azure

### DIFF
--- a/providers/azure/models/gpt-5.3-chat.toml
+++ b/providers/azure/models/gpt-5.3-chat.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.3 Chat"
+family = "gpt-codex"
+release_date = "2026-03-03"
+last_updated = "2026-03-03"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds the GPT-5.3 Chat (Instant) model configuration for Azure OpenAI
- 128K context window, 16,384 max output tokens
- $1.75 input / $14.00 output / $0.175 cached input per 1M tokens