### PR TITLE
fix: update Claude Opus latest tag to 4.6

### DIFF
--- a/providers/anthropic/models/claude-opus-4-5.toml
+++ b/providers/anthropic/models/claude-opus-4-5.toml
@@ -1,4 +1,4 @@
-name = "Claude Opus 4.5 (latest)"
+name = "Claude Opus 4.5"
 family = "claude-opus"
 release_date = "2025-11-24"
 last_updated = "2025-11-24"

--- a/providers/anthropic/models/claude-opus-4-6.toml
+++ b/providers/anthropic/models/claude-opus-4-6.toml
@@ -1,4 +1,4 @@
-name = "Claude Opus 4.6"
+name = "Claude Opus 4.6 (latest)"
 family = "claude-opus"
 release_date = "2026-02-05"
 last_updated = "2026-02-05"


### PR DESCRIPTION
Claude Opus 4.6 is the current latest Opus model, but the `(latest)` tag is still on 4.5.

Moves the tag to the correct model.