### PR TITLE
Add Brainiall provider with 33 AI models

### DIFF
--- a/providers/brainiall/logo.svg
+++ b/providers/brainiall/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z" stroke="currentColor" stroke-width="1.5"/>
+  <path d="M12 6v4l3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M8.5 14.5c0-1.93 1.57-3.5 3.5-3.5s3.5 1.57 3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="9" cy="17" r="1" fill="currentColor"/>
+  <circle cx="12" cy="18" r="1" fill="currentColor"/>
+  <circle cx="15" cy="17" r="1" fill="currentColor"/>
+</svg>

--- a/providers/brainiall/models/claude-3-haiku.toml
+++ b/providers/brainiall/models/claude-3-haiku.toml
@@ -1,0 +1,19 @@
+name = "Claude 3 Haiku"
+family = "claude-haiku"
+release_date = "2024-03-07"
+last_updated = "2024-03-07"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1.25
+
+[limit]
+context = 200_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/claude-3.5-haiku.toml
+++ b/providers/brainiall/models/claude-3.5-haiku.toml
@@ -1,0 +1,23 @@
+name = "Claude 3.5 Haiku"
+family = "claude-haiku"
+release_date = "2024-10-22"
+last_updated = "2024-10-22"
+attachment = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.80
+output = 4.00
+cache_read = 0.08
+cache_write = 1.00
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/claude-haiku-4-5.toml
+++ b/providers/brainiall/models/claude-haiku-4-5.toml
@@ -1,0 +1,23 @@
+name = "Claude Haiku 4.5"
+family = "claude-haiku"
+release_date = "2025-10-01"
+last_updated = "2025-10-01"
+attachment = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.00
+output = 5.00
+cache_read = 0.10
+cache_write = 1.25
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/claude-opus-4-5.toml
+++ b/providers/brainiall/models/claude-opus-4-5.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.5"
+family = "claude-opus"
+release_date = "2025-11-01"
+last_updated = "2025-11-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 15.00
+output = 75.00
+cache_read = 1.50
+cache_write = 18.75
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/claude-opus-4-6.toml
+++ b/providers/brainiall/models/claude-opus-4-6.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.6"
+family = "claude-opus"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/claude-sonnet-4-5.toml
+++ b/providers/brainiall/models/claude-sonnet-4-5.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4.5"
+family = "claude-sonnet"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/claude-sonnet-4-6.toml
+++ b/providers/brainiall/models/claude-sonnet-4-6.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/command-r-plus.toml
+++ b/providers/brainiall/models/command-r-plus.toml
@@ -1,0 +1,19 @@
+name = "Command R+"
+family = "command-r"
+release_date = "2024-08-01"
+last_updated = "2024-08-01"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/deepseek-r1.toml
+++ b/providers/brainiall/models/deepseek-r1.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek R1"
+family = "deepseek"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.70
+output = 2.50
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/deepseek-v3.toml
+++ b/providers/brainiall/models/deepseek-v3.toml
@@ -1,0 +1,19 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.32
+output = 0.89
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/devstral-2.toml
+++ b/providers/brainiall/models/devstral-2.toml
@@ -1,0 +1,19 @@
+name = "Devstral 2"
+family = "mistral"
+release_date = "2025-05-01"
+last_updated = "2025-05-01"
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/gemma-3-27b.toml
+++ b/providers/brainiall/models/gemma-3-27b.toml
@@ -1,0 +1,18 @@
+name = "Gemma 3 27B"
+family = "gemma"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.11
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/glm-4.7.toml
+++ b/providers/brainiall/models/glm-4.7.toml
@@ -1,0 +1,19 @@
+name = "GLM 4.7"
+family = "glm"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.50
+output = 2.00
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/gpt-oss-120b.toml
+++ b/providers/brainiall/models/gpt-oss-120b.toml
@@ -1,0 +1,19 @@
+name = "GPT OSS 120B"
+family = "gpt-oss"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.19
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/kimi-k2.5.toml
+++ b/providers/brainiall/models/kimi-k2.5.toml
@@ -1,0 +1,20 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2025-07-01"
+last_updated = "2025-07-01"
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.60
+output = 2.40
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/llama-3.1-8b.toml
+++ b/providers/brainiall/models/llama-3.1-8b.toml
@@ -1,0 +1,19 @@
+name = "Llama 3.1 8B Instruct"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.05
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/llama-3.2-1b.toml
+++ b/providers/brainiall/models/llama-3.2-1b.toml
@@ -1,0 +1,18 @@
+name = "Llama 3.2 1B Instruct"
+family = "llama"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.20
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/llama-3.2-3b.toml
+++ b/providers/brainiall/models/llama-3.2-3b.toml
@@ -1,0 +1,19 @@
+name = "Llama 3.2 3B Instruct"
+family = "llama"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.34
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/llama-3.3-70b.toml
+++ b/providers/brainiall/models/llama-3.3-70b.toml
@@ -1,0 +1,19 @@
+name = "Llama 3.3 70B Instruct"
+family = "llama"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.32
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/llama-4-maverick.toml
+++ b/providers/brainiall/models/llama-4-maverick.toml
@@ -1,0 +1,19 @@
+name = "Llama 4 Maverick"
+family = "llama"
+release_date = "2025-04-01"
+last_updated = "2025-04-01"
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 1_048_576
+output = 1_048_576
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/llama-4-scout.toml
+++ b/providers/brainiall/models/llama-4-scout.toml
@@ -1,0 +1,19 @@
+name = "Llama 4 Scout"
+family = "llama"
+release_date = "2025-04-01"
+last_updated = "2025-04-01"
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.30
+
+[limit]
+context = 512_000
+output = 512_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/minimax-m2.toml
+++ b/providers/brainiall/models/minimax-m2.toml
@@ -1,0 +1,19 @@
+name = "MiniMax M2"
+family = "minimax"
+release_date = "2025-01-15"
+last_updated = "2025-01-15"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 1.10
+
+[limit]
+context = 1_000_000
+output = 1_000_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/mistral-large-3.toml
+++ b/providers/brainiall/models/mistral-large-3.toml
@@ -1,0 +1,20 @@
+name = "Mistral Large 3 (675B)"
+family = "mistral"
+release_date = "2024-11-01"
+last_updated = "2024-11-01"
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 6.00
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/mistral-small.toml
+++ b/providers/brainiall/models/mistral-small.toml
@@ -1,0 +1,19 @@
+name = "Mistral Small 3.1 24B"
+family = "mistral"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.10
+output = 0.30
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/nemotron-30b.toml
+++ b/providers/brainiall/models/nemotron-30b.toml
@@ -1,0 +1,19 @@
+name = "Nemotron 3 Nano 30B"
+family = "nemotron"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.10
+output = 0.10
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/nemotron-70b.toml
+++ b/providers/brainiall/models/nemotron-70b.toml
@@ -1,0 +1,19 @@
+name = "Nemotron 70B Instruct"
+family = "nemotron"
+release_date = "2024-10-01"
+last_updated = "2024-10-01"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.30
+output = 0.30
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/nova-lite.toml
+++ b/providers/brainiall/models/nova-lite.toml
@@ -1,0 +1,19 @@
+name = "Nova Lite"
+family = "nova"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.06
+output = 0.24
+
+[limit]
+context = 300_000
+output = 5_120
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/nova-micro.toml
+++ b/providers/brainiall/models/nova-micro.toml
@@ -1,0 +1,19 @@
+name = "Nova Micro"
+family = "nova"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.035
+output = 0.14
+
+[limit]
+context = 128_000
+output = 5_120
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/nova-premier.toml
+++ b/providers/brainiall/models/nova-premier.toml
@@ -1,0 +1,20 @@
+name = "Nova Premier"
+family = "nova"
+release_date = "2025-02-01"
+last_updated = "2025-02-01"
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.50
+output = 12.50
+
+[limit]
+context = 1_000_000
+output = 5_120
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/nova-pro.toml
+++ b/providers/brainiall/models/nova-pro.toml
@@ -1,0 +1,19 @@
+name = "Nova Pro"
+family = "nova"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.80
+output = 3.20
+
+[limit]
+context = 300_000
+output = 5_120
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/brainiall/models/palmyra-x5.toml
+++ b/providers/brainiall/models/palmyra-x5.toml
@@ -1,0 +1,20 @@
+name = "Palmyra X5"
+family = "palmyra"
+release_date = "2025-05-01"
+last_updated = "2025-05-01"
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 6.00
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/qwen3-32b.toml
+++ b/providers/brainiall/models/qwen3-32b.toml
@@ -1,0 +1,20 @@
+name = "Qwen3 32B"
+family = "qwen"
+release_date = "2025-04-01"
+last_updated = "2025-04-01"
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.35
+output = 0.35
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/models/qwen3-80b.toml
+++ b/providers/brainiall/models/qwen3-80b.toml
@@ -1,0 +1,20 @@
+name = "Qwen3 235B-A22B (MoE)"
+family = "qwen"
+release_date = "2025-04-01"
+last_updated = "2025-04-01"
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.45
+output = 1.82
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/brainiall/provider.toml
+++ b/providers/brainiall/provider.toml
@@ -1,0 +1,5 @@
+name = "Brainiall"
+env = ["BRAINIALL_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://apim-ai-apis.azure-api.net/v1"
+doc = "https://app.brainiall.com"

--- a/providers/brainiall/provider.toml
+++ b/providers/brainiall/provider.toml
@@ -1,5 +1,5 @@
 name = "Brainiall"
 env = ["BRAINIALL_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-api = "https://apim-ai-apis.azure-api.net/v1"
+api = "https://api.brainiall.com/v1"
 doc = "https://app.brainiall.com"


### PR DESCRIPTION
## Summary

Adds **Brainiall** as a new AI model provider with 33 models across 13 families.

### Provider

- **API**: `https://apim-ai-apis.azure-api.net/v1` (OpenAI-compatible)
- **Auth**: Bearer token (`BRAINIALL_API_KEY`)
- **SDK**: `@ai-sdk/openai-compatible`
- **Docs**: https://app.brainiall.com

### Models (33)

| Family | Models | Price Range ($/MTok in/out) |
|--------|--------|---------------------------|
| Claude (Anthropic) | Opus 4.6, Sonnet 4.6, Haiku 4.5, Opus 4.5, Sonnet 4.5, 3.5 Haiku, 3 Haiku | $0.25–$75.00 |
| DeepSeek | R1, V3.2 | $0.32–$2.50 |
| Llama (Meta) | 4 Maverick, 4 Scout, 3.3 70B, 3.1 8B, 3.2 3B, 3.2 1B | $0.02–$0.60 |
| Nova (Amazon) | Premier, Pro, Lite, Micro | $0.035–$12.50 |
| Mistral | Large 3 675B, Devstral 2, Small 3.1 24B | $0.10–$6.00 |
| Qwen | 3 235B MoE, 3 32B | $0.35–$1.82 |
| Other | MiniMax M2, Kimi K2.5, Nemotron 70B/30B, GPT OSS 120B, Gemma 27B, Command R+, Palmyra X5, GLM 4.7 | $0.03–$15.00 |

### Features

- Prompt caching with cost breakdown for Claude models
- Context windows up to 1M tokens
- Reasoning support (Claude Opus/Sonnet, DeepSeek R1, Nova Premier, Qwen3, Kimi)
- Image input for Claude, Nova, Llama 4, Mistral Large

### Notes

This is a clean resubmission replacing #1009, which unintentionally modified files from other providers. This PR only adds files under `providers/brainiall/`.