### PR TITLE
feat: add GPT-5 series models to requesty provider

### DIFF
--- a/providers/requesty/models/openai/gpt-5-chat.toml
+++ b/providers/requesty/models/openai/gpt-5-chat.toml
@@ -1,0 +1,23 @@
+name = "GPT-5 Chat (latest)"
+family = "gpt-codex"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-09-30"
+tool_call = false
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.00
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5-codex.toml
+++ b/providers/requesty/models/openai/gpt-5-codex.toml
@@ -1,0 +1,24 @@
+name = "GPT-5 Codex"
+family = "gpt-codex"
+release_date = "2025-09-15"
+last_updated = "2025-09-15"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-10-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5-image.toml
+++ b/providers/requesty/models/openai/gpt-5-image.toml
@@ -1,0 +1,24 @@
+name = "GPT-5 Image"
+family = "gpt"
+release_date = "2025-10-14"
+last_updated = "2025-10-14"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-10-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5.00
+output = 10.00
+cache_read = 1.25
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text", "image"]

--- a/providers/requesty/models/openai/gpt-5-pro.toml
+++ b/providers/requesty/models/openai/gpt-5-pro.toml
@@ -1,0 +1,23 @@
+name = "GPT-5 Pro"
+family = "gpt-pro"
+release_date = "2025-10-06"
+last_updated = "2025-10-06"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-09-30"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 15.00
+output = 120.00
+
+[limit]
+context = 400_000
+output = 272_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.1-chat.toml
+++ b/providers/requesty/models/openai/gpt-5.1-chat.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.1 Chat"
+family = "gpt-codex"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-09-30"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex-max.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.1-Codex-Max"
+family = "gpt-codex"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-09-30"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.10
+output = 9.00
+cache_read = 0.11
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex-mini.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.1-Codex-Mini"
+family = "gpt-codex"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-09-30"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 2.00
+cache_read = 0.025
+
+[limit]
+context = 400_000
+output = 100_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.1-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.1-Codex"
+family = "gpt-codex"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-09-30"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.1.toml
+++ b/providers/requesty/models/openai/gpt-5.1.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.1"
+family = "gpt"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-09-30"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.2-chat.toml
+++ b/providers/requesty/models/openai/gpt-5.2-chat.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.2 Chat"
+family = "gpt-codex"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.2-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.2-codex.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.2-Codex"
+family = "gpt-codex"
+release_date = "2026-01-14"
+last_updated = "2026-01-14"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.2-pro.toml
+++ b/providers/requesty/models/openai/gpt-5.2-pro.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.2 Pro"
+family = "gpt-pro"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 21.00
+output = 168.00
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.2.toml
+++ b/providers/requesty/models/openai/gpt-5.2.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.2"
+family = "gpt"
+release_date = "2025-12-11"
+last_updated = "2025-12-11"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.3-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.3-codex.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.3-Codex"
+family = "gpt-codex"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.4-pro.toml
+++ b/providers/requesty/models/openai/gpt-5.4-pro.toml
@@ -1,0 +1,25 @@
+name = "GPT-5.4 Pro"
+family = "gpt-pro"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = false
+open_weights = false
+
+[cost]
+input = 30.00
+output = 180.00
+cache_read = 30.00
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/requesty/models/openai/gpt-5.4.toml
+++ b/providers/requesty/models/openai/gpt-5.4.toml
@@ -1,0 +1,30 @@
+name = "GPT-5.4"
+family = "gpt"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
+[cost.context_over_200k]
+input = 5.00
+output = 22.50
+cache_read = 0.50
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
Add missing OpenAI GPT-5 series models to requesty provider:
- GPT-5 Chat, Codex, Image, Pro
- GPT-5.1 Chat, Codex, Codex-Max, Codex-Mini
- GPT-5.2 Chat, Codex, Pro
- GPT-5.3 Codex
- GPT-5.4, GPT-5.4 Pro