### PR TITLE
fix: update model limits for alibaba-coding-plan providers

### DIFF
--- a/providers/alibaba-coding-plan-cn/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-coding-plan-cn/models/MiniMax-M2.5.toml
@@ -1,13 +1,15 @@
-name = "Qwen3 Coder Plus"
-family = "qwen"
-release_date = "2025-07-23"
-last_updated = "2025-07-23"
+name = "MiniMax-M2.5"
+family = "minimax"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
-knowledge = "2025-04"
 tool_call = true
 open_weights = true
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0
@@ -16,8 +18,8 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 1_000_000
-output = 65_536
+context = 196_608
+output = 24_576
 
 [modalities]
 input = ["text"]

--- a/providers/alibaba-coding-plan-cn/models/qwen3-max-2026-01-23.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3-max-2026-01-23.toml
@@ -17,7 +17,7 @@ cache_write = 0
 
 [limit]
 context = 262_144
-output = 65_536
+output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/alibaba-coding-plan/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-coding-plan/models/MiniMax-M2.5.toml
@@ -18,8 +18,8 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 204_800
-output = 32_768
+context = 16_608
+output = 24_576
 
 [modalities]
 input = ["text"]

--- a/providers/alibaba-coding-plan/models/qwen3-max-2026-01-23.toml
+++ b/providers/alibaba-coding-plan/models/qwen3-max-2026-01-23.toml
@@ -17,7 +17,7 @@ cache_write = 0
 
 [limit]
 context = 262_144
-output = 65_536
+output = 32_768
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Add MiniMax-M2.5 model to alibaba-coding-plan-cn and fix token limits:

- Add MiniMax-M2.5 model to alibaba-coding-plan-cn
- Fix qwen3-max output limit (65536 -> 32768)
- Fix qwen3-coder-plus context limit (1048576 -> 1000000)
- Fix MiniMax-M2.5 limits (context: 196608, output: 24576)