### PR TITLE
feat(nano-gpt): add text and image models

### DIFF
--- a/providers/nano-gpt/models/chroma.toml
+++ b/providers/nano-gpt/models/chroma.toml
@@ -1,0 +1,17 @@
+name = "Chroma"
+release_date = "2025-08-12"
+last_updated = "2025-08-12"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = true
+structured_output = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/nano-gpt/models/hidream.toml
+++ b/providers/nano-gpt/models/hidream.toml
@@ -1,0 +1,17 @@
+name = "Hidream"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = true
+structured_output = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/nano-gpt/models/qwen-image.toml
+++ b/providers/nano-gpt/models/qwen-image.toml
@@ -1,0 +1,17 @@
+name = "Qwen Image"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = true
+structured_output = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 397B A17B"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.60
+output = 3.60
+
+[limit]
+context = 258_048
+input = 258_048
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nano-gpt/models/z-image-turbo.toml
+++ b/providers/nano-gpt/models/z-image-turbo.toml
@@ -1,0 +1,17 @@
+name = "Z Image Turbo"
+release_date = "2025-11-27"
+last_updated = "2025-11-27"
+attachment = true
+reasoning = false
+tool_call = false
+temperature = true
+structured_output = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/nano-gpt/models/zai-org/glm-5.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.toml
@@ -1,0 +1,22 @@
+name = "GLM 5"
+family = "glm"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 2.55
+
+[limit]
+context = 200_000
+input = 200_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add the approved NanoGPT subscription text model entries for GLM 5 and Qwen3.5 397B A17B
- add the approved NanoGPT image model entries for Hidream, Chroma, Z Image Turbo, and Qwen Image
- keep the update scoped to NanoGPT model catalog additions and validate it with `bun run validate`