### PR TITLE
feat: add GLM-5-Turbo to Chutes provider listings

### DIFF
--- a/providers/chutes/models/zai-org/GLM-5-Turbo.toml
+++ b/providers/chutes/models/zai-org/GLM-5-Turbo.toml
@@ -1,0 +1,26 @@
+name = "GLM 5 Turbo"
+family = "glm"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.49
+output = 1.96
+cache_read = 0.245
+
+[limit]
+context = 202_752
+output = 65_535
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
This PR adds support for the **GLM-5-Turbo** model (by zai-org) to the Chutes provider ecosystem.

## Model Details
- **Model**: GLM-5-Turbo (`zai-org/GLM-5-Turbo`)
- **Family**: GLM
- **Context Length**: 202,752 tokens
- **Max Output**: 65,535 tokens
- **Input Modalities**: Text
- **Output Modalities**: Text

## Pricing (per million tokens)
| Type | USD |
|------|-----|
| Input | $0.49 |
| Output | $1.96 |
| Cache Read | $0.245 |

## Supported Features
- Reasoning (interleaved via `reasoning_content` field)
- Tool calling
- Structured output / JSON mode
- Temperature control

## Source
Data sourced from the [Chutes API](https://llm.chutes.ai/v1/models).