### PR TITLE
[Together AI] add prompt caching pricing for MiniMax m2.5

### DIFF
--- a/providers/togetherai/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/togetherai/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -10,6 +10,7 @@ open_weights = true
 
 [cost]
 input = 0.30
+cache_read = 0.06
 output = 1.20
 
 [limit]


### PR DESCRIPTION
We are rolling out prompt caching pricing for models starting with MiniMax M2.5. Will open PR's for other models as we roll them out.