### PR TITLE
Url parameter to filter /api.json per provider and to flatten the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,33 @@ You can access this data through an API.
 curl https://models.dev/api.json
 ```
 
+### Query Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `provider` | Filter to a specific provider's models only | All providers |
+| `flatten` | Return models as a flat array with `id` field included | `false` |
+
+### Examples
+
+Get all providers and models:
+
+```bash
+curl https://models.dev/api.json
+```
+
+Get models for a specific provider:
+
+```bash
+curl "https://models.dev/api.json?provider=anthropic"
+```
+
+Get models for a specific provider as a flat array:
+
+```bash
+curl "https://models.dev/api.json?provider=anthropic&flatten=true"
+```
+
 Use the **Model ID** field to do a lookup on any model; it's the identifier used by [AI SDK](https://ai-sdk.dev/).
 
 ### Logos

--- a/packages/function/src/worker.ts
+++ b/packages/function/src/worker.ts
@@ -76,6 +76,7 @@ export default {
     if (url.pathname === "/api.json") {
       url.pathname = "/_api.json";
       const providerParam = url.searchParams.get("provider");
+      const flattenParam = url.searchParams.get("flatten");
 
       if (providerParam) {
         const apiResponse = await env.ASSETS.fetch(
@@ -87,15 +88,26 @@ export default {
         >;
 
         if (providers[providerParam]) {
-          return new Response(
-            JSON.stringify(providers[providerParam].models),
-            {
+          const models = providers[providerParam].models;
+
+          if (flattenParam === "true") {
+            const flattened = Object.entries(models).map(
+              ([id, model]) => ({ id, ...model as object }),
+            );
+            return new Response(JSON.stringify(flattened), {
               headers: {
                 "Content-Type": "application/json",
                 "Cache-Control": "public, max-age=3600",
               },
+            });
+          }
+
+          return new Response(JSON.stringify(models), {
+            headers: {
+              "Content-Type": "application/json",
+              "Cache-Control": "public, max-age=3600",
             },
-          );
+          });
         }
 
         return new Response(

--- a/packages/function/src/worker.ts
+++ b/packages/function/src/worker.ts
@@ -75,6 +75,37 @@ export default {
 
     if (url.pathname === "/api.json") {
       url.pathname = "/_api.json";
+      const providerParam = url.searchParams.get("provider");
+
+      if (providerParam) {
+        const apiResponse = await env.ASSETS.fetch(
+          new Request(url.toString(), request),
+        );
+        const providers = (await apiResponse.json()) as Record<
+          string,
+          { models: Record<string, unknown> }
+        >;
+
+        if (providers[providerParam]) {
+          return new Response(
+            JSON.stringify(providers[providerParam].models),
+            {
+              headers: {
+                "Content-Type": "application/json",
+                "Cache-Control": "public, max-age=3600",
+              },
+            },
+          );
+        }
+
+        return new Response(
+          JSON.stringify({ error: `Provider '${providerParam}' not found` }),
+          {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
     } else if (
       url.pathname === "/" ||
       url.pathname === "/index.html" ||


### PR DESCRIPTION
Added two url parameters to the /api.json endpoint 

- provider : to filter the output on a single provider 
- flatten : to flatten the output an make it easier to ingest for data ETL tools like airbyte 