### PR TITLE
fix: alibaba-coding-plan MiniMax-M2.5 context window

### DIFF
--- a/providers/alibaba-coding-plan/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-coding-plan/models/MiniMax-M2.5.toml
@@ -18,7 +18,8 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 16_608
+context = 196_608
+input = 196_601
 output = 24_576
 
 [modalities]


### PR DESCRIPTION
Fix model "minimax-m2.5" context window and add input limit for provider "alibaba-coding-plan" according to ["Alibaba Cloud Model Studio Docs"](https://www.alibabacloud.com/help/en/model-studio/models#391dd8e25fp3g).