### PR TITLE
Add OpenRouter stealth models: Hunter Alpha and Healer Alpha

### DIFF
--- a/providers/openrouter/models/openrouter/healer-alpha.toml
+++ b/providers/openrouter/models/openrouter/healer-alpha.toml
@@ -1,0 +1,23 @@
+name = "Healer Alpha"
+family = "healer-alpha"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2026-03-11"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262_144
+output = 64_000
+
+[modalities]
+input = ["text", "image", "audio", "pdf"]
+output = ["text"]

--- a/providers/openrouter/models/openrouter/healer-alpha.toml
+++ b/providers/openrouter/models/openrouter/healer-alpha.toml
@@ -1,5 +1,5 @@
 name = "Healer Alpha"
-family = "healer-alpha"
+family = "alpha"
 release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = true

--- a/providers/openrouter/models/openrouter/hunter-alpha.toml
+++ b/providers/openrouter/models/openrouter/hunter-alpha.toml
@@ -1,0 +1,23 @@
+name = "Hunter Alpha"
+family = "hunter-alpha"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2026-03-11"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 1_048_576
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/openrouter/models/openrouter/hunter-alpha.toml
+++ b/providers/openrouter/models/openrouter/hunter-alpha.toml
@@ -1,5 +1,5 @@
 name = "Hunter Alpha"
-family = "hunter-alpha"
+family = "alpha"
 release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = true


### PR DESCRIPTION
This PR adds the 2 new OpenRouter stealth models that dropped today to models.dev. 