### PR TITLE
Update Claude 4.6 context/pricing

### DIFF
--- a/providers/anthropic/models/claude-opus-4-6.toml
+++ b/providers/anthropic/models/claude-opus-4-6.toml
@@ -1,7 +1,7 @@
 name = "Claude Opus 4.6"
 family = "claude-opus"
 release_date = "2026-02-05"
-last_updated = "2026-02-05"
+last_updated = "2026-03-13"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
-input = 10.00
-output = 37.50
-cache_read = 1.00
-cache_write = 12.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/anthropic/models/claude-opus-4-6.toml
+++ b/providers/anthropic/models/claude-opus-4-6.toml
@@ -16,7 +16,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [limit]
-context = 1_000_000
+context = 200_000
 output = 128_000
 
 [modalities]

--- a/providers/anthropic/models/claude-sonnet-4-6.toml
+++ b/providers/anthropic/models/claude-sonnet-4-6.toml
@@ -1,7 +1,7 @@
 name = "Claude Sonnet 4.6"
 family = "claude-sonnet"
 release_date = "2026-02-17"
-last_updated = "2026-02-17"
+last_updated = "2026-03-13"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
-input = 6.00
-output = 22.50
-cache_read = 0.60
-cache_write = 7.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 64_000
 
 [modalities]

--- a/providers/anthropic/models/claude-sonnet-4-6.toml
+++ b/providers/anthropic/models/claude-sonnet-4-6.toml
@@ -16,7 +16,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [limit]
-context = 1_000_000
+context = 200_000
 output = 64_000
 
 [modalities]


### PR DESCRIPTION
- Update context window from 200K to 1M for Claude Opus 4.6 and Sonnet 4.6
- Remove `[cost.context_over_200k]` pricing tier — standard pricing now applies across the full 1M window
- Update `last_updated` to 2026-03-13

## Reference
https://claude.com/blog/1m-context-ga