### PR TITLE
feat(vultr): add 6 new inference models and update pricing to flat rate

### DIFF
--- a/providers/vultr/models/deepseek-r1-distill-llama-70b.toml
+++ b/providers/vultr/models/deepseek-r1-distill-llama-70b.toml
@@ -10,8 +10,8 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.55
+output = 2.75
 
 [limit]
 context = 121_808

--- a/providers/vultr/models/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/vultr/models/deepseek-r1-distill-qwen-32b.toml
@@ -10,8 +10,8 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.55
+output = 2.75
 
 [limit]
 context = 121_808

--- a/providers/vultr/models/deepseek-v3.2.toml
+++ b/providers/vultr/models/deepseek-v3.2.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = true
+knowledge = "2025-09"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+
+[cost]
+input = 0.55
+output = 2.75
+
+[limit]
+context = 164_000
+output = 66_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vultr/models/glm-5-fp8.toml
+++ b/providers/vultr/models/glm-5-fp8.toml
@@ -1,0 +1,22 @@
+name = "GLM-5 FP8"
+family = "glm"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+knowledge = "2025-06"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+
+[cost]
+input = 0.55
+output = 2.75
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vultr/models/gpt-oss-120b.toml
+++ b/providers/vultr/models/gpt-oss-120b.toml
@@ -10,8 +10,8 @@ release_date = "2025-06-23"
 last_updated = "2025-06-23"
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.55
+output = 2.75
 
 [limit]
 context = 121_808

--- a/providers/vultr/models/kimi-k2-instruct.toml
+++ b/providers/vultr/models/kimi-k2-instruct.toml
@@ -10,8 +10,8 @@ release_date = "2024-07-18"
 last_updated = "2024-07-18"
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.55
+output = 2.75
 
 [limit]
 context = 58_904

--- a/providers/vultr/models/kimi-k2.5.toml
+++ b/providers/vultr/models/kimi-k2.5.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2.5"
+family = "kimi"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+knowledge = "2025-10"
+release_date = "2026-01-20"
+last_updated = "2026-01-20"
+
+[cost]
+input = 0.55
+output = 2.75
+
+[limit]
+context = 256_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vultr/models/llama-3.1-nemotron-ultra-253b-v1.toml
+++ b/providers/vultr/models/llama-3.1-nemotron-ultra-253b-v1.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.1 Nemotron Ultra 253B"
+family = "nemotron"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = true
+knowledge = "2024-12"
+release_date = "2025-04-15"
+last_updated = "2025-04-15"
+
+[cost]
+input = 0.55
+output = 2.75
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vultr/models/minimax-m2.5.toml
+++ b/providers/vultr/models/minimax-m2.5.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2.5"
+family = "minimax"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+knowledge = "2025-08"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+
+[cost]
+input = 0.55
+output = 2.75
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vultr/models/nvidia-nemotron-3-super-120b-a12b-nvfp4.toml
+++ b/providers/vultr/models/nvidia-nemotron-3-super-120b-a12b-nvfp4.toml
@@ -1,0 +1,22 @@
+name = "NVIDIA Nemotron 3 Super 120B"
+family = "nemotron"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+knowledge = "2025-06"
+release_date = "2026-03-01"
+last_updated = "2026-03-01"
+
+[cost]
+input = 0.55
+output = 2.75
+
+[limit]
+context = 1_000_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vultr/models/qwen2.5-coder-32b-instruct.toml
+++ b/providers/vultr/models/qwen2.5-coder-32b-instruct.toml
@@ -10,8 +10,8 @@ release_date = "2024-11-06"
 last_updated = "2024-11-06"
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.55
+output = 2.75
 
 [limit]
 context = 12_952


### PR DESCRIPTION
## Summary
- Add 6 new Vultr Serverless Inference models: MiniMax M2.5, Kimi K2.5, GLM-5-FP8, DeepSeek V3.2, Llama 3.1 Nemotron Ultra 253B, NVIDIA Nemotron 3 Super 120B
- Update all Vultr model pricing to flat rate: $0.55 input / $2.75 output (previously $0.20/$0.20)
- Verified model capabilities via Vultr Inference API

## Changes
- Added new model TOML files in `providers/vultr/models/`
- Updated pricing in existing model files

## Notes
- Vultr uses flat pricing for all inference models
- All models verified via API testing to support temperature, tool_call, and reasoning (where applicable)
- Model limits sourced from Vultr documentation and API