### PR TITLE
Add OpenAI and Anthropic compatible endpoints

### DIFF
--- a/providers/synthetic/provider.toml
+++ b/providers/synthetic/provider.toml
@@ -2,4 +2,4 @@ name = "Synthetic"
 env = ["SYNTHETIC_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
 doc = "https://synthetic.new/pricing"
-api = "https://api.synthetic.new/v1"
+api = "https://api.synthetic.new/openai/v1"


### PR DESCRIPTION
## Summary
Synthetic now provides native OpenAI-compatible and Anthropic-compatible API endpoints:

- **OpenAI**: `https://api.synthetic.new/openai/v1`
  - `/models` - List available models
  - `/chat/completions` - Chat completions
  - `/completions` - Text completions
  - `/embeddings` - Vector embeddings

- **Anthropic**: `https://api.synthetic.new/anthropic/v1`
  - `/messages` - Send and receive messages
  - `/messages/count_tokens` - Count tokens

## Backward Compatibility
The legacy `/v1` endpoint still works via redirect, but the new intended endpoints are `/openai/v1` and `/anthropic/v1`.