### PR TITLE
fix: add unit tests and web build check to CI, add issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-model.yml
+++ b/.github/ISSUE_TEMPLATE/add-model.yml
@@ -1,0 +1,80 @@
+name: Add New Model
+description: Submit a new AI model to the database
+title: "feat: add [Provider] [Model Name]"
+labels: ["new-model"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing! Please fill in the details below.
+        Before submitting, check if the model already exists in the `providers/` directory.
+
+  - type: input
+    id: provider
+    attributes:
+      label: Provider
+      description: The provider name (e.g. OpenAI, Anthropic, Google)
+      placeholder: e.g. Mistral
+    validations:
+      required: true
+
+  - type: input
+    id: model-name
+    attributes:
+      label: Model Name
+      description: The display name of the model
+      placeholder: e.g. Mistral Large 2
+    validations:
+      required: true
+
+  - type: input
+    id: model-id
+    attributes:
+      label: Model ID
+      description: The AI SDK model identifier (used in code)
+      placeholder: e.g. mistral-large-2407
+    validations:
+      required: true
+
+  - type: input
+    id: docs-url
+    attributes:
+      label: Documentation URL
+      description: Link to the official model documentation or pricing page
+      placeholder: https://docs.provider.com/models/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: model-details
+    attributes:
+      label: Model Details
+      description: |
+        Provide the key model specs (copy from the official docs):
+        - Context window size
+        - Input/output pricing ($/1M tokens)
+        - Supported modalities (text, image, audio, video, pdf)
+        - Capabilities (tool calling, structured output, reasoning)
+        - Knowledge cutoff date
+        - Release date
+      placeholder: |
+        Context: 128K tokens
+        Input cost: $2.50/1M tokens
+        Output cost: $10.00/1M tokens
+        Modalities: text, image
+        Tool calling: yes
+        Structured output: yes
+        Knowledge cutoff: 2024-09
+        Release date: 2024-09-18
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Submission Checklist
+      options:
+        - label: I have checked that this model is not already in the `providers/` directory
+          required: true
+        - label: The data I provided comes from official documentation
+          required: true
+        - label: I have run `bun validate` and it passes
+          required: true

--- a/.github/ISSUE_TEMPLATE/update-model.yml
+++ b/.github/ISSUE_TEMPLATE/update-model.yml
@@ -1,0 +1,50 @@
+name: Update Model Data
+description: Report incorrect or outdated model information
+title: "fix: update [Provider] [Model Name] data"
+labels: ["data-correction"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to report incorrect pricing, context windows, capabilities,
+        or other model data that needs to be updated.
+
+  - type: input
+    id: provider-model
+    attributes:
+      label: Provider / Model
+      description: Provider name and model name
+      placeholder: e.g. OpenAI / GPT-4o
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-incorrect
+    attributes:
+      label: Current (Incorrect) Data
+      description: What does the current TOML file show that is wrong?
+      placeholder: |
+        context = 128_000  # wrong
+        cost.input = 5.00  # wrong
+    validations:
+      required: true
+
+  - type: textarea
+    id: correct-data
+    attributes:
+      label: Correct Data
+      description: What should the data be?
+      placeholder: |
+        context = 200_000  # correct per official docs
+        cost.input = 2.50  # updated pricing
+    validations:
+      required: true
+
+  - type: input
+    id: source
+    attributes:
+      label: Source URL
+      description: Link to the official documentation confirming the correct data
+      placeholder: https://platform.openai.com/docs/models/gpt-4o
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## What does this PR do?
+
+<!-- Briefly describe the change. Example: "Adds GPT-5 to the OpenAI provider" -->
+
+## Type of change
+
+- [ ] New model(s)
+- [ ] New provider
+- [ ] Data correction / update
+- [ ] Schema / validation improvement
+- [ ] Web UI feature or fix
+- [ ] CI / infrastructure
+
+## Checklist
+
+- [ ] `bun validate` passes locally
+- [ ] Data is sourced from official provider documentation (add URL below)
+- [ ] No secrets, API keys, or tokens in the diff
+- [ ] TOML syntax is valid (no extra fields, correct types)
+- [ ] Dates are in `YYYY-MM` or `YYYY-MM-DD` format
+- [ ] `last_updated` is set to today's date for modified models
+
+## Source URL(s)
+
+<!-- Link to the official documentation confirming the data you added/changed -->
+
+## Notes for reviewers
+
+<!-- Anything else the reviewer should know? -->

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Validate Models
+name: Validate
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   validate:
+    name: Validate Models & Schema
     runs-on: ubuntu-latest
 
     steps:
@@ -20,5 +21,21 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Run validation script
+      - name: Validate all provider/model TOML configurations
         run: bun validate
+
+      - name: Run unit tests
+        run: |
+          # Run tests if test directories exist; skip gracefully if not
+          TEST_DIRS=""
+          [ -d packages/core/test ] && TEST_DIRS="$TEST_DIRS packages/core/test/"
+          [ -d packages/web/test ] && TEST_DIRS="$TEST_DIRS packages/web/test/"
+          [ -d packages/function/test ] && TEST_DIRS="$TEST_DIRS packages/function/test/"
+          if [ -n "$TEST_DIRS" ]; then
+            bun test $TEST_DIRS
+          else
+            echo "No test directories found, skipping tests"
+          fi
+
+      - name: Build web interface
+        run: cd packages/web && bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,42 @@
+# Environment & secrets
 .env
+.env.*
+
+# SST build artifacts
 .sst
+
+# IDE / Editor
 .idea
+.vscode
+*.swp
+*.swo
+*~
+
+# Build output
 dist
+
+# OS files
 .DS_Store
+Thumbs.db
+
+# Dependencies
 node_modules
+
+# Data files
 data/tokenspeed-monitor.sqlite
 data/tokenspeed-monitor.sqlite-shm
 data/tokenspeed-monitor.sqlite-wal
+
+# Internal planning & reference documents (never commit)
+.plans/
+.internal/
+.reference/
+.notes/
+*.plan.md
+*.draft.md
+PLAN.md
+PLANNING.md
+TODO.md
+
+# Claude / AI assistant configs (project-specific, not upstream)
+.claude.md


### PR DESCRIPTION
## Summary

Strengthens the CI pipeline and adds contributor-facing GitHub templates.

**CI workflow (`validate.yml`):**
- Adds a unit test step: `bun test packages/core/test/` (and web/function test dirs if they exist — skips gracefully if not)
- Adds a web build verification step: `cd packages/web && bun run build`
- Previously only `bun validate` ran on PRs; this ensures code changes can't break the build undetected

**Issue templates (`.github/ISSUE_TEMPLATE/`):**
- `add-model.yml` — structured form for new model submissions with required fields (provider, model name/ID, docs URL, specs) and a validation checklist
- `update-model.yml` — form for reporting incorrect or outdated model data with fields for current vs correct values and a source URL

**PR template (`.github/PULL_REQUEST_TEMPLATE.md`):**
- Change type checkboxes (new model, data correction, schema fix, web feature, CI)
- Standard checklist: `bun validate`, source URL, no secrets, date format, `last_updated` set

## Checklist
- [x] `bun validate` passes
- [x] Web build passes
- [x] No breaking changes to existing workflow