### PR TITLE
Update Vultr model list with 10 new models and updated pricing

### DIFF
--- a/providers/vultr/models/DeepSeek-R1-Distill-Llama-70B.toml
+++ b/providers/vultr/models/DeepSeek-R1-Distill-Llama-70B.toml
@@ -1,13 +1,13 @@
-name = "GPT OSS 120B"
-family = "gpt-oss"
+name = "DeepSeek R1 Distill Llama 70B"
+family = "deepseek-thinking"
 attachment = false
-reasoning = false
+reasoning = true
 tool_call = true
 temperature = true
 open_weights = true
 knowledge = "2024-10"
-release_date = "2025-06-23"
-last_updated = "2025-06-23"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
 
 [cost]
 input = 0.55
@@ -15,7 +15,7 @@ output = 2.75
 
 [limit]
 context = 130_000
-output = 8_192
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/vultr/models/DeepSeek-R1-Distill-Qwen-32B.toml
+++ b/providers/vultr/models/DeepSeek-R1-Distill-Qwen-32B.toml
@@ -1,21 +1,21 @@
-name = "Qwen2.5 Coder 32B Instruct"
+name = "DeepSeek R1 Distill Qwen 32B"
 family = "qwen"
 attachment = false
-reasoning = false
+reasoning = true
 tool_call = true
 temperature = true
 open_weights = true
 knowledge = "2024-10"
-release_date = "2024-11-06"
-last_updated = "2024-11-06"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.55
+output = 2.75
 
 [limit]
-context = 12_952
-output = 2_048
+context = 130_000
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/vultr/models/DeepSeek-V3.2.toml
+++ b/providers/vultr/models/DeepSeek-V3.2.toml
@@ -1,7 +1,7 @@
-name = "DeepSeek R1 Distill Llama 70B"
-family = "deepseek-thinking"
+name = "DeepSeek V3.2"
+family = "deepseek"
 attachment = false
-reasoning = true
+reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
@@ -10,12 +10,12 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.55
+output = 2.75
 
 [limit]
-context = 121_808
-output = 8_192
+context = 163_000
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/vultr/models/GLM-5-FP8.toml
+++ b/providers/vultr/models/GLM-5-FP8.toml
@@ -1,21 +1,21 @@
-name = "GPT OSS 120B"
-family = "gpt-oss"
+name = "GLM 5 FP8"
+family = "glm"
 attachment = false
 reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
 knowledge = "2024-10"
-release_date = "2025-06-23"
-last_updated = "2025-06-23"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
 
 [cost]
 input = 0.55
 output = 2.75
 
 [limit]
-context = 130_000
-output = 8_192
+context = 202_000
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/vultr/models/Kimi-K2.5.toml
+++ b/providers/vultr/models/Kimi-K2.5.toml
@@ -10,12 +10,12 @@ release_date = "2024-07-18"
 last_updated = "2024-07-18"
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.55
+output = 2.75
 
 [limit]
-context = 58_904
-output = 4_096
+context = 261_000
+output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/vultr/models/Llama-3_1-Nemotron-Ultra-253B-v1.toml
+++ b/providers/vultr/models/Llama-3_1-Nemotron-Ultra-253B-v1.toml
@@ -1,21 +1,21 @@
-name = "GPT OSS 120B"
-family = "gpt-oss"
+name = "Llama 3.1 Nemotron Ultra 253B v1"
+family = "llama"
 attachment = false
 reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
 knowledge = "2024-10"
-release_date = "2025-06-23"
-last_updated = "2025-06-23"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
 
 [cost]
 input = 0.55
 output = 2.75
 
 [limit]
-context = 130_000
-output = 8_192
+context = 32_000
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/vultr/models/MiniMax-M2.5.toml
+++ b/providers/vultr/models/MiniMax-M2.5.toml
@@ -1,21 +1,21 @@
-name = "GPT OSS 120B"
-family = "gpt-oss"
+name = "MiniMax M2.5"
+family = "minimax"
 attachment = false
 reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
 knowledge = "2024-10"
-release_date = "2025-06-23"
-last_updated = "2025-06-23"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
 
 [cost]
 input = 0.55
 output = 2.75
 
 [limit]
-context = 130_000
-output = 8_192
+context = 196_000
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/vultr/models/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4.toml
+++ b/providers/vultr/models/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4.toml
@@ -1,7 +1,7 @@
-name = "DeepSeek R1 Distill Qwen 32B"
-family = "qwen"
+name = "NVIDIA Nemotron 3 Super 120B A12B NVFP4"
+family = "nemotron"
 attachment = false
-reasoning = true
+reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
@@ -10,11 +10,11 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.55
+output = 2.75
 
 [limit]
-context = 121_808
+context = 260_000
 output = 8_192
 
 [modalities]

--- a/providers/vultr/models/Qwen2.5-Coder-32B-Instruct.toml
+++ b/providers/vultr/models/Qwen2.5-Coder-32B-Instruct.toml
@@ -1,21 +1,21 @@
-name = "GPT OSS 120B"
-family = "gpt-oss"
+name = "Qwen2.5 Coder 32B Instruct"
+family = "qwen"
 attachment = false
 reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
 knowledge = "2024-10"
-release_date = "2025-06-23"
-last_updated = "2025-06-23"
+release_date = "2024-11-06"
+last_updated = "2024-11-06"
 
 [cost]
 input = 0.55
 output = 2.75
 
 [limit]
-context = 130_000
-output = 8_192
+context = 15_000
+output = 256
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
- Updated pricing to $0.55/M input tokens, $2.75/M output tokens
- Updated context limits to safe floor values from official testing
- Added accurate output token limits from official model documentation
- Added 5 new models: MiniMax M2.5, DeepSeek V3.2, GLM-5 FP8, Llama 3.1 Nemotron Ultra 253B, NVIDIA Nemotron 3 Super 120B A12B NVFP4
- Updated existing models: DeepSeek R1 Distill variants, GPT OSS 120B, Kimi K2.5, Qwen2.5 Coder 32B

Model specifications:
- MiniMax M2.5: 196K context, 4,096 output
- Qwen2.5-Coder-32B: 15K context, 256 output
- DeepSeek R1 Distill Llama 70B: 130K context, 4,096 output
- DeepSeek R1 Distill Qwen 32B: 130K context, 4,096 output
- DeepSeek V3.2: 163K context, 4,096 output
- Kimi K2.5: 261K context, 32,768 output
- GPT OSS 120B: 130K context, 8,192 output
- GLM-5 FP8: 202K context, 131,072 output
- Llama 3.1 Nemotron Ultra 253B: 32K context, 4,096 output
- NVIDIA Nemotron 3 Super 120B A12B NVFP4: 260K context, 8,192 output

All models set to text-only (no vision support) as confirmed.