### PR TITLE
Add GLM-5-Turbo model support

### DIFF
--- a/providers/zai-coding-plan/models/glm-5-turbo.toml
+++ b/providers/zai-coding-plan/models/glm-5-turbo.toml
@@ -1,0 +1,27 @@
+name = "GLM-5-Turbo"
+family = "glm"
+release_date = "2026-03-16"
+last_updated = "2026-03-16"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200000
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zai/models/glm-5-turbo.toml
+++ b/providers/zai/models/glm-5-turbo.toml
@@ -1,0 +1,27 @@
+name = "GLM-5-Turbo"
+family = "glm"
+release_date = "2026-03-16"
+last_updated = "2026-03-16"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.20
+output = 4.00
+cache_read = 0.24
+cache_write = 0
+
+[limit]
+context = 200000
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add support for GLM-5-Turbo model to both Z.AI providers.

## Changes
- Added `providers/zai/models/glm-5-turbo.toml` (API plan with pricing)
- Added `providers/zai-coding-plan/models/glm-5-turbo.toml` (coding plan, $0 cost)

## Model Details
- **Context:** 200K tokens
- **Max Output:** 128K tokens
- **Capabilities:** reasoning, tool_call, structured_output, temperature, interleaved
- **Pricing (API plan):** $1.20 input / $4.00 output / $0.24 cache read

## Reference
https://docs.z.ai/guides/llm/glm-5-turbo