### PR TITLE
Add local server provider

### DIFF
--- a/providers/local/provider.toml
+++ b/providers/local/provider.toml
@@ -1,0 +1,2 @@
+name = "Local Server"
+npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
## Summary

- Adds a `local` provider entry for local OpenAI-compatible servers (llama.cpp, ollama, vLLM, LM Studio, etc.)
- No `api` URL or models included — local servers have user-defined endpoints and models are discovered dynamically

This is a companion to an [opencode PR](https://github.com/anomalyco/opencode/pull/new/autoload-models) that adds a custom loader for this provider, which auto-discovers models by querying the server's `/v1/models` endpoint at startup. The opencode PR is functional without this models.dev entry (users just need to define the provider in their config), but this entry provides a proper display name and makes the provider a first-class citizen.

Relates to anomalyco/opencode#6231