### PR TITLE
Venice: Update model pricing for 7 models

### DIFF
--- a/providers/venice/models/claude-opus-4-6.toml
+++ b/providers/venice/models/claude-opus-4-6.toml
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-02-05"
-last_updated = "2026-02-18"
+last_updated = "2026-03-16"
 open_weights = false
 
 [cost]
@@ -14,12 +14,6 @@ input = 6
 output = 30
 cache_read = 0.6
 cache_write = 7.5
-
-[cost.context_over_200k]
-input = 11
-output = 41.25
-cache_read = 1.1
-cache_write = 13.75
 
 [limit]
 context = 1_000_000

--- a/providers/venice/models/claude-sonnet-4-6.toml
+++ b/providers/venice/models/claude-sonnet-4-6.toml
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-02-17"
-last_updated = "2026-02-28"
+last_updated = "2026-03-16"
 open_weights = false
 
 [cost]
@@ -14,12 +14,6 @@ input = 3.6
 output = 18
 cache_read = 0.36
 cache_write = 4.5
-
-[cost.context_over_200k]
-input = 7.2
-output = 27
-cache_read = 0.72
-cache_write = 9
 
 [limit]
 context = 1_000_000

--- a/providers/venice/models/grok-4-20-beta.toml
+++ b/providers/venice/models/grok-4-20-beta.toml
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-03-12"
-last_updated = "2026-03-13"
+last_updated = "2026-03-16"
 open_weights = false
 
 [cost]
@@ -17,7 +17,7 @@ cache_read = 0.25
 [cost.context_over_200k]
 input = 5
 output = 15
-cache_read = 0.5
+cache_read = 0.25
 
 [limit]
 context = 2_000_000

--- a/providers/venice/models/grok-4-20-multi-agent-beta.toml
+++ b/providers/venice/models/grok-4-20-multi-agent-beta.toml
@@ -6,7 +6,7 @@ tool_call = false
 structured_output = true
 temperature = true
 release_date = "2026-03-12"
-last_updated = "2026-03-13"
+last_updated = "2026-03-16"
 open_weights = false
 
 [cost]
@@ -17,7 +17,7 @@ cache_read = 0.25
 [cost.context_over_200k]
 input = 5
 output = 15
-cache_read = 0.5
+cache_read = 0.25
 
 [limit]
 context = 2_000_000

--- a/providers/venice/models/kimi-k2-5.toml
+++ b/providers/venice/models/kimi-k2-5.toml
@@ -7,16 +7,16 @@ structured_output = true
 temperature = true
 knowledge = "2024-04"
 release_date = "2026-01-27"
-last_updated = "2026-03-12"
+last_updated = "2026-03-16"
 open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.75
-output = 3.75
-cache_read = 0.125
+input = 0.56
+output = 3.5
+cache_read = 0.11
 
 [limit]
 context = 256_000

--- a/providers/venice/models/minimax-m21.toml
+++ b/providers/venice/models/minimax-m21.toml
@@ -6,15 +6,15 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2025-12-01"
-last_updated = "2026-03-12"
+last_updated = "2026-03-16"
 open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.4
-output = 1.6
+input = 0.35
+output = 1.5
 cache_read = 0.04
 
 [limit]

--- a/providers/venice/models/minimax-m25.toml
+++ b/providers/venice/models/minimax-m25.toml
@@ -5,15 +5,15 @@ reasoning = true
 tool_call = true
 temperature = true
 release_date = "2026-02-12"
-last_updated = "2026-03-12"
+last_updated = "2026-03-16"
 open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.4
-output = 1.6
+input = 0.34
+output = 1.19
 cache_read = 0.04
 
 [limit]


### PR DESCRIPTION
- Remove context_over_200k pricing from Claude models
- Update Grok cache_read pricing from 0.5 to 0.25
- Update Kimi, MiniMax input/output pricing