### PR TITLE
fix(chutes): update pricing and limits from live API

### DIFF
--- a/providers/chutes/models/MiniMaxAI/MiniMax-M2.5-TEE.toml
+++ b/providers/chutes/models/MiniMaxAI/MiniMax-M2.5-TEE.toml
@@ -10,8 +10,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.15
-output = 0.6
+input = 0.30
+output = 1.10
+cache_read = 0.15
 
 [limit]
 context = 196_608

--- a/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
@@ -10,9 +10,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.30
-output = 1.20
-cache_read = 0.15
+input = 0.39
+output = 2.34
+cache_read = 0.195
 
 [limit]
 context = 262_144

--- a/providers/chutes/models/deepseek-ai/DeepSeek-V3.2-TEE.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V3.2-TEE.toml
@@ -10,12 +10,12 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.25
-output = 0.38
-cache_read = 0.125
+input = 0.28
+output = 0.42
+cache_read = 0.14
 
 [limit]
-context = 163_840
+context = 131_072
 output = 65_536
 
 [modalities]

--- a/providers/chutes/models/zai-org/GLM-4.6-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-4.6-TEE.toml
@@ -10,8 +10,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.35
-output = 1.50
+input = 0.40
+output = 1.70
+cache_read = 0.20
 
 [limit]
 context = 202_752

--- a/providers/chutes/models/zai-org/GLM-4.6V.toml
+++ b/providers/chutes/models/zai-org/GLM-4.6V.toml
@@ -12,6 +12,7 @@ open_weights = true
 [cost]
 input = 0.30
 output = 0.90
+cache_read = 0.15
 
 [limit]
 context = 131_072

--- a/providers/chutes/models/zai-org/GLM-5-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-5-TEE.toml
@@ -10,8 +10,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.750
-output = 2.50
+input = 0.95
+output = 3.15
+cache_read = 0.475
 
 [limit]
 context = 202_752


### PR DESCRIPTION
## Summary

Synced 6 Chutes model definitions against the live Chutes API at `https://llm.chutes.ai/v1/models` (queried 2026-03-16).

Chutes has updated their pricing since these models were last added. The current TOML files contain stale values that no longer match the live API.

## Changes

| Model | Field | Old | New (live API) |
|-------|-------|-----|----------------|
| deepseek-ai/DeepSeek-V3.2-TEE | cost.input | 0.25 | **0.28** |
| | cost.output | 0.38 | **0.42** |
| | cost.cache_read | 0.125 | **0.14** |
| | limit.context | 163,840 | **131,072** |
| zai-org/GLM-5-TEE | cost.input | 0.75 | **0.95** |
| | cost.output | 2.50 | **3.15** |
| | cost.cache_read | *(missing)* | **0.475** |
| zai-org/GLM-4.6-TEE | cost.input | 0.35 | **0.40** |
| | cost.output | 1.50 | **1.70** |
| | cost.cache_read | *(missing)* | **0.20** |
| zai-org/GLM-4.6V | cost.cache_read | *(missing)* | **0.15** |
| MiniMaxAI/MiniMax-M2.5-TEE | cost.input | 0.15 | **0.30** |
| | cost.output | 0.60 | **1.10** |
| | cost.cache_read | *(missing)* | **0.15** |
| Qwen/Qwen3.5-397B-A17B-TEE | cost.input | 0.30 | **0.39** |
| | cost.output | 1.20 | **2.34** |
| | cost.cache_read | 0.15 | **0.195** |

## Verification

All values cross-referenced against `GET https://llm.chutes.ai/v1/models` using `pricing.prompt`, `pricing.completion`, `pricing.input_cache_read`, `context_length`, and `max_output_length` fields from the live API response (2026-03-16).

## Note

The DeepSeek-V3.2-TEE context limit change (163,840 → 131,072) is particularly important — clients using the old value may attempt to send more tokens than the model accepts.