### PR TITLE
fix(sap-ai-core): align model specs with official sources

### DIFF
--- a/providers/sap-ai-core/models/anthropic--claude-4-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4-opus.toml
@@ -6,7 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-01-31"
+knowledge = "2025-03-31"
 open_weights = false
 
 [cost]

--- a/providers/sap-ai-core/models/anthropic--claude-4-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4-sonnet.toml
@@ -6,7 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-01-31"
+knowledge = "2025-03-31"
 open_weights = false
 
 [cost]

--- a/providers/sap-ai-core/models/anthropic--claude-4.5-haiku.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.5-haiku.toml
@@ -1,7 +1,7 @@
 name = "anthropic--claude-4.5-haiku"
 family = "claude-haiku"
-release_date = "2025-10-01"
-last_updated = "2025-10-01"
+release_date = "2025-10-15"
+last_updated = "2025-10-15"
 attachment = true
 reasoning = true
 temperature = true

--- a/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
@@ -6,7 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-04-30"
+knowledge = "2025-05"
 open_weights = false
 
 [cost]

--- a/providers/sap-ai-core/models/anthropic--claude-4.5-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.5-sonnet.toml
@@ -6,7 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-knowledge = "2025-01-31"
+knowledge = "2025-07-31"
 open_weights = false
 
 [cost]

--- a/providers/sap-ai-core/models/anthropic--claude-4.6-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-opus.toml
@@ -1,7 +1,7 @@
 name = "anthropic--claude-4.6-opus"
 family = "claude-opus"
 release_date = "2026-02-05"
-last_updated = "2026-02-05"
+last_updated = "2026-03-13"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
-input = 10.00
-output = 37.50
-cache_read = 1.00
-cache_write = 12.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
@@ -1,7 +1,7 @@
 name = "anthropic--claude-4.6-sonnet"
 family = "claude-sonnet"
 release_date = "2026-02-17"
-last_updated = "2026-02-17"
+last_updated = "2026-03-13"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
-input = 6.00
-output = 22.50
-cache_read = 0.60
-cache_write = 7.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 64_000
 
 [modalities]

--- a/providers/sap-ai-core/models/gpt-5-nano.toml
+++ b/providers/sap-ai-core/models/gpt-5-nano.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 0.05
 output = 0.40
-cache_read = 0.01
+cache_read = 0.005
 
 [limit]
 context = 400_000

--- a/providers/sap-ai-core/models/gpt-5.toml
+++ b/providers/sap-ai-core/models/gpt-5.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 1.25
 output = 10.00
-cache_read = 0.13
+cache_read = 0.125
 
 [limit]
 context = 400_000


### PR DESCRIPTION
Fix SAP AI Core model specifications to align with official provider documentation.

**Anthropic models — 1M context GA ([blog](https://claude.com/blog/1m-context-ga), March 13 2026):**
- `claude-4.6-opus` / `claude-4.6-sonnet`: context 200K → 1M, remove `cost.context_over_200k` (no long-context premium), update `last_updated`

**Anthropic models — knowledge cutoff corrections (cross-validated against [Anthropic docs](https://docs.anthropic.com/en/about-claude/models/overview)):**
- `claude-4-opus` / `claude-4-sonnet`: knowledge `2025-01-31` → `2025-03-31` (training data cutoff: March 2025)
- `claude-4.5-sonnet`: knowledge `2025-01-31` → `2025-07-31` (training data cutoff: July 2025)
- `claude-4.5-opus`: knowledge `2025-04-30` → `2025-05` (official: May 2025)
- `claude-4.5-haiku`: release_date/last_updated `2025-10-01` → `2025-10-15` ([announcement](https://www.anthropic.com/news/claude-haiku-4-5))

**OpenAI models — cache pricing corrections (cross-validated against [OpenAI pricing](https://platform.openai.com/docs/pricing)):**
- `gpt-5-nano`: cache_read `0.01` → `0.005`
- `gpt-5`: cache_read `0.13` → `0.125`