### PR TITLE
VULTR: Updated Vultr model pricing to reflect current serverless inference rates

### DIFF
--- a/providers/vultr/models/DeepSeek-R1-Distill-Llama-70B.toml
+++ b/providers/vultr/models/DeepSeek-R1-Distill-Llama-70B.toml
@@ -10,8 +10,8 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 
 [cost]
-input = 0.55
-output = 2.75
+input = 2.00
+output = 2.00
 
 [limit]
 context = 130_000

--- a/providers/vultr/models/DeepSeek-R1-Distill-Qwen-32B.toml
+++ b/providers/vultr/models/DeepSeek-R1-Distill-Qwen-32B.toml
@@ -10,8 +10,8 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 
 [cost]
-input = 0.55
-output = 2.75
+input = 0.30
+output = 0.30
 
 [limit]
 context = 130_000

--- a/providers/vultr/models/DeepSeek-V3.2.toml
+++ b/providers/vultr/models/DeepSeek-V3.2.toml
@@ -11,7 +11,7 @@ last_updated = "2025-01-20"
 
 [cost]
 input = 0.55
-output = 2.75
+output = 1.65
 
 [limit]
 context = 163_000

--- a/providers/vultr/models/GLM-5-FP8.toml
+++ b/providers/vultr/models/GLM-5-FP8.toml
@@ -10,8 +10,8 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 
 [cost]
-input = 0.55
-output = 2.75
+input = 0.85
+output = 3.10
 
 [limit]
 context = 202_000

--- a/providers/vultr/models/Llama-3_1-Nemotron-Ultra-253B-v1.toml
+++ b/providers/vultr/models/Llama-3_1-Nemotron-Ultra-253B-v1.toml
@@ -11,7 +11,7 @@ last_updated = "2025-01-20"
 
 [cost]
 input = 0.55
-output = 2.75
+output = 1.80
 
 [limit]
 context = 32_000

--- a/providers/vultr/models/MiniMax-M2.5.toml
+++ b/providers/vultr/models/MiniMax-M2.5.toml
@@ -10,8 +10,8 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 
 [cost]
-input = 0.55
-output = 2.75
+input = 0.30
+output = 1.20
 
 [limit]
 context = 196_000

--- a/providers/vultr/models/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4.toml
+++ b/providers/vultr/models/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4.toml
@@ -10,8 +10,8 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 
 [cost]
-input = 0.55
-output = 2.75
+input = 0.20
+output = 0.80
 
 [limit]
 context = 260_000

--- a/providers/vultr/models/Qwen2.5-Coder-32B-Instruct.toml
+++ b/providers/vultr/models/Qwen2.5-Coder-32B-Instruct.toml
@@ -10,8 +10,8 @@ release_date = "2024-11-06"
 last_updated = "2024-11-06"
 
 [cost]
-input = 0.55
-output = 2.75
+input = 0.20
+output = 0.60
 
 [limit]
 context = 15_000

--- a/providers/vultr/models/gpt-oss-120b.toml
+++ b/providers/vultr/models/gpt-oss-120b.toml
@@ -10,8 +10,8 @@ release_date = "2025-06-23"
 last_updated = "2025-06-23"
 
 [cost]
-input = 0.55
-output = 2.75
+input = 0.15
+output = 0.60
 
 [limit]
 context = 130_000


### PR DESCRIPTION
Updated Vultr model pricing to reflect current serverless inference rates, as they were just updated.

This commit updates the cost configuration for all Vultr models to align with their latest pricing tiers:

**Cost Reductions:**
- DeepSeek-R1-Distill-Qwen-32B: Input $0.55→$0.30, Output $2.75→$0.30 
- NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4: Input $0.55→$0.20, Output $2.75→$0.80 
- Qwen2.5-Coder-32B-Instruct: Input $0.55→$0.20, Output $2.75→$0.60
- gpt-oss-120b: Input $0.55→$0.15, Output $2.75→$0.60
- MiniMax-M2.5: Input $0.55→$0.30, Output $2.75→$1.20 

**Cost Adjustments:**
- DeepSeek-R1-Distill-Llama-70B: Input $0.55→$2.00, Output $2.75→$2.00
- DeepSeek-V3.2: Output $2.75→$1.65 
- Llama-3.1-Nemotron-Ultra-253B-v1: Output $2.75→$1.80 
- GLM-5-FP8: Input $0.55→$0.85, Output $2.75→$3.10 
