### PR TITLE
feat(providers): add dinference provider

### DIFF
--- a/providers/dinference/logo.svg
+++ b/providers/dinference/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="lucide lucide-terminal h-5 w-5 text-primary"><path d="m4 17 6-6-6-6M12 19h8"/></svg>

--- a/providers/dinference/models/glm-4.7.toml
+++ b/providers/dinference/models/glm-4.7.toml
@@ -1,0 +1,25 @@
+name = "GLM-4.7"
+family = "glm"
+release_date = "2025-12"
+last_updated = "2025-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.45
+output = 1.65
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/dinference/models/glm-5.toml
+++ b/providers/dinference/models/glm-5.toml
@@ -1,0 +1,25 @@
+name = "GLM-5"
+family = "glm"
+release_date = "2026-02"
+last_updated = "2026-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.75
+output = 2.40
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/dinference/models/gpt-oss-120b.toml
+++ b/providers/dinference/models/gpt-oss-120b.toml
@@ -1,0 +1,20 @@
+name = "GPT OSS 120B"
+release_date = "2025-08"
+last_updated = "2025-08"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0675
+output = 0.27
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/dinference/provider.toml
+++ b/providers/dinference/provider.toml
@@ -1,0 +1,5 @@
+name = "DInference"
+env = ["DINFERENCE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://dinference.com"
+api = "https://api.dinference.com/v1"


### PR DESCRIPTION
Add DInference (https://dinference.com) as model provider.
We are compatible with OpenAi "chat_completions" API.

We provide following models:
glm-5
glm-4.7
gpt-oss-120b