### PR TITLE
Add OpenAI GPT-5.4 mini and nano

### DIFF
--- a/providers/openai/models/gpt-5.4-mini.toml
+++ b/providers/openai/models/gpt-5.4-mini.toml
@@ -1,0 +1,25 @@
+name = "GPT-5.4 mini"
+family = "gpt-mini"
+release_date = "2026-03-17"
+last_updated = "2026-03-17"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.75
+output = 4.50
+cache_read = 0.075
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openai/models/gpt-5.4-nano.toml
+++ b/providers/openai/models/gpt-5.4-nano.toml
@@ -1,0 +1,25 @@
+name = "GPT-5.4 nano"
+family = "gpt-nano"
+release_date = "2026-03-17"
+last_updated = "2026-03-17"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 1.25
+cache_read = 0.02
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Adds two new OpenAI model entries:
- `gpt-5.4-mini`
- `gpt-5.4-nano`