### PR TITLE
Feat: add AI Enabler to providers list

### DIFF
--- a/providers/ai-enabler/models/glm-5-fp8.toml
+++ b/providers/ai-enabler/models/glm-5-fp8.toml
@@ -1,0 +1,24 @@
+name = "GLM-5 FP8"
+family = "glm"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.00
+output = 3.20
+
+[limit]
+context = 130_000
+output = 30_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ai-enabler/models/minimax-m2.5.toml
+++ b/providers/ai-enabler/models/minimax-m2.5.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2.5"
+family = "minimax"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 200_000
+output = 45_760
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ai-enabler/provider.toml
+++ b/providers/ai-enabler/provider.toml
@@ -1,0 +1,5 @@
+name = "AI Enabler by Cast AI"
+env = ["AI_ENABLER_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.cast.ai/v1/spec/#/AIEnablerAPI"
+doc = "https://docs.cast.ai/docs/ai-enabler-serverless-endpoints"


### PR DESCRIPTION
# Add Cast AI (AI Enabler) provider

## Summary

Adds [[Cast AI AI Enabler](https://cast.ai/ai-enabler/)](https://cast.ai/ai-enabler/) as a new OpenAI-compatible provider. AI Enabler is a unified LLM gateway that provides access to SaaS models (via serverless endpoints).

## Changes

- `providers/castai/provider.toml` — provider definition using `@ai-sdk/openai-compatible`
- `providers/castai/logo.svg` — Cast AI logo
- `providers/castai/models/` — model definitions for serverless endpoint models

## Notes

AI Enabler acts as both a provider and a gateway — users can access serverless models directly, or route requests through registered external providers (OpenAI, Anthropic, Google, etc.) and self-hosted models. The models included in this PR are the always-available serverless endpoints. Users with additional providers/models configured will need to add those manually via `opencode.json` until dynamic model discovery is supported.
