### PR TITLE
fix(amazon-bedrock): set Claude Sonnet 4.6 and Opus 4.6 context window to 1M

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
@@ -1,7 +1,7 @@
 name = "Claude Opus 4.6"
 family = "claude-opus"
 release_date = "2026-02-05"
-last_updated = "2026-02-05"
+last_updated = "2026-03-18"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
-input = 10.00
-output = 37.50
-cache_read = 1.00
-cache_write = 12.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-6.toml
@@ -1,7 +1,7 @@
 name = "Claude Sonnet 4.6"
 family = "claude-sonnet"
 release_date = "2026-02-17"
-last_updated = "2026-02-17"
+last_updated = "2026-03-18"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
-input = 6.00
-output = 22.50
-cache_read = 0.60
-cache_write = 7.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 64_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
@@ -1,7 +1,7 @@
 name = "Claude Opus 4.6 (EU)"
 family = "claude-opus"
 release_date = "2026-02-05"
-last_updated = "2026-02-05"
+last_updated = "2026-03-18"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
-input = 10.00
-output = 37.50
-cache_read = 1.00
-cache_write = 12.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
@@ -1,7 +1,7 @@
 name = "Claude Sonnet 4.6 (EU)"
 family = "claude-sonnet"
 release_date = "2026-02-17"
-last_updated = "2026-02-17"
+last_updated = "2026-03-18"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
-input = 6.00
-output = 22.50
-cache_read = 0.60
-cache_write = 7.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 64_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1.toml
@@ -1,7 +1,7 @@
 name = "Claude Opus 4.6 (Global)"
 family = "claude-opus"
 release_date = "2026-02-05"
-last_updated = "2026-02-05"
+last_updated = "2026-03-18"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
-input = 10.00
-output = 37.50
-cache_read = 1.00
-cache_write = 12.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-6.toml
@@ -1,7 +1,7 @@
 name = "Claude Sonnet 4.6 (Global)"
 family = "claude-sonnet"
 release_date = "2026-02-17"
-last_updated = "2026-02-17"
+last_updated = "2026-03-18"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
-input = 6.00
-output = 22.50
-cache_read = 0.60
-cache_write = 7.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 64_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1.toml
@@ -1,7 +1,7 @@
 name = "Claude Opus 4.6 (US)"
 family = "claude-opus"
 release_date = "2026-02-05"
-last_updated = "2026-02-05"
+last_updated = "2026-03-18"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
-input = 10.00
-output = 37.50
-cache_read = 1.00
-cache_write = 12.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-6.toml
@@ -1,7 +1,7 @@
 name = "Claude Sonnet 4.6 (US)"
 family = "claude-sonnet"
 release_date = "2026-02-17"
-last_updated = "2026-02-17"
+last_updated = "2026-03-18"
 attachment = true
 reasoning = true
 temperature = true
@@ -15,14 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
-input = 6.00
-output = 22.50
-cache_read = 0.60
-cache_write = 7.50
-
 [limit]
-context = 200_000
+context = 1_000_000
 output = 64_000
 
 [modalities]


### PR DESCRIPTION
Fixes #1220

## Changes

- `context = 200_000` → `context = 1_000_000` in all 8 Bedrock variants of Claude Sonnet 4.6 and Opus 4.6
- Removed `[cost.context_over_200k]` sections — AWS Bedrock pricing for these models is identical at all context lengths (confirmed on the [AWS pricing page](https://aws.amazon.com/bedrock/pricing/))

## Verification

Tested with `aws bedrock-runtime converse` against the live Bedrock API:

```
~950K tokens  →  OK (inputTokens=950015)
~1M tokens    →  ValidationException: prompt is too long: 1000032 tokens > 1000000 maximum
```

The limit is exactly 1,000,000 tokens, no beta headers needed. Both `us.anthropic.claude-sonnet-4-6` and `us.anthropic.claude-opus-4-6-v1` were tested directly.