### PR TITLE
Update Vercel models

### DIFF
--- a/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
@@ -6,7 +6,7 @@ tool_call = true
 temperature = true
 release_date = "2026-03-18"
 last_updated = "2026-03-18"
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.6

--- a/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,0 +1,23 @@
+name = "MiniMax M2.7 High Speed"
+family = "minimax"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+open_weights = false
+
+[cost]
+input = 0.6
+output = 2.4
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 204_800
+output = 131_100
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/vercel/models/minimax/minimax-m2.7.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7.toml
@@ -6,7 +6,7 @@ tool_call = true
 temperature = true
 release_date = "2026-03-18"
 last_updated = "2026-03-18"
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.3

--- a/providers/vercel/models/minimax/minimax-m2.7.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7.toml
@@ -1,0 +1,23 @@
+name = "Minimax M2.7"
+family = "minimax"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+open_weights = false
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 204_800
+output = 131_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Automated weekly sync of Vercel model definitions from the [AI Gateway API](https://ai-gateway.vercel.sh/v1/models).

See commit for details on models added, updated, or removed.

## Test plan
- `bun validate` passes

---
🤖 Auto-generated by [`update-vercel-models`](.github/workflows/update-vercel-models.yml)