### PR TITLE
Venice: Add MiniMax M2.7 and update DeepSeek V3.2 pricing

### DIFF
--- a/providers/venice/models/deepseek-v3.2.toml
+++ b/providers/venice/models/deepseek-v3.2.toml
@@ -6,13 +6,13 @@ tool_call = false
 temperature = true
 knowledge = "2025-10"
 release_date = "2025-12-04"
-last_updated = "2026-03-12"
+last_updated = "2026-03-18"
 open_weights = true
 
 [cost]
-input = 0.4
-output = 1
-cache_read = 0.2
+input = 0.33
+output = 0.48
+cache_read = 0.16
 
 [limit]
 context = 160_000

--- a/providers/venice/models/minimax-m27.toml
+++ b/providers/venice/models/minimax-m27.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2.7"
+family = "minimax"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+open_weights = false
+
+[cost]
+input = 0.375
+output = 1.5
+cache_read = 0.075
+
+[limit]
+context = 198_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/venice/models/minimax-m27.toml
+++ b/providers/venice/models/minimax-m27.toml
@@ -6,7 +6,7 @@ tool_call = true
 temperature = true
 release_date = "2026-03-18"
 last_updated = "2026-03-18"
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.375


### PR DESCRIPTION
 - Add MiniMax M2.7 model with reasoning and tool_call support
 - Update DeepSeek V3.2 pricing (input: $0.33, output: $0.48, cache: $0.16)