### PR TITLE
Xiaomi: Add MiMo-V2-Pro and MiMo-V2-Omni

### DIFF
--- a/providers/xiaomi/models/mimo-v2-omni.toml
+++ b/providers/xiaomi/models/mimo-v2-omni.toml
@@ -1,0 +1,26 @@
+name = "MiMo-V2-Omni"
+family = "mimo"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-12"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.40
+output = 2.00
+cache_read = 0.08
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "audio", "video", "pdf"]
+output = ["text"]

--- a/providers/xiaomi/models/mimo-v2-pro.toml
+++ b/providers/xiaomi/models/mimo-v2-pro.toml
@@ -1,0 +1,26 @@
+name = "MiMo-V2-Pro"
+family = "mimo"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-12"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.00
+output = 3.00
+cache_read = 0.20
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add Xiaomi MiMo-V2-Pro and MiMo-V2-Omni models

- [MiMo-V2-Pro](https://platform.xiaomimimo.com/#/docs/news/v2-pro-release)
- [MiMo-V2-Omni](https://platform.xiaomimimo.com/#/docs/news/v2-omni-release)