### PR TITLE
Add Workers AI models: kimi-k2.5, nemotron-3-120b-a12b, glm-4.7-flash

### DIFF
--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.5.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,27 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+attachment = true
+reasoning = true
+structured_output = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.60
+output = 3.00
+cache_read = 0.10
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/nvidia/nemotron-3-120b-a12b.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/nvidia/nemotron-3-120b-a12b.toml
@@ -1,0 +1,24 @@
+name = "Nemotron 3 Super 120B"
+family = "nemotron"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.50
+output = 1.50
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/zai-org/glm-4.7-flash.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/zai-org/glm-4.7-flash.toml
@@ -1,0 +1,22 @@
+name = "GLM-4.7-Flash"
+family = "glm-flash"
+release_date = "2026-01-19"
+last_updated = "2026-01-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.40
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/moonshotai/kimi-k2.5.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,27 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+attachment = true
+reasoning = true
+structured_output = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.60
+output = 3.00
+cache_read = 0.10
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
@@ -1,0 +1,24 @@
+name = "Nemotron 3 Super 120B"
+family = "nemotron"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.50
+output = 1.50
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds 5 new model TOML files for Cloudflare Workers AI models across both `cloudflare-workers-ai` and `cloudflare-ai-gateway` providers:

- `@cf/moonshotai/kimi-k2.5` — Kimi K2.5 (reasoning, vision, 256K context)
- `@cf/nvidia/nemotron-3-120b-a12b` — Nemotron 3 Super 120B (reasoning, 256K context)
- `@cf/zai-org/glm-4.7-flash` — GLM-4.7-Flash (reasoning, 128K context)