### PR TITLE
Sync ZenMux models with latest website data

### DIFF
--- a/providers/zenmux/models/anthropic/claude-3.5-sonnet.toml
+++ b/providers/zenmux/models/anthropic/claude-3.5-sonnet.toml
@@ -1,6 +1,7 @@
 name = "Claude 3.5 Sonnet (Retiring Soon)"
 release_date = "2024-10-22"
 last_updated = "2024-10-22"
+status = "deprecated"
 attachment = true
 reasoning = false
 temperature = true

--- a/providers/zenmux/models/google/gemini-3-pro-image-preview.toml
+++ b/providers/zenmux/models/google/gemini-3-pro-image-preview.toml
@@ -1,0 +1,23 @@
+name = "Gemini 3 Pro Image Preview"
+release_date = "2025-03-20"
+last_updated = "2025-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01-01"
+open_weights = false
+
+[cost]
+input = 2.00
+output = 12.00
+cache_read = 0.20
+cache_write = 4.50
+
+[limit]
+context = 1048_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf", "audio", "video"]
+output = ["text"]

--- a/providers/zenmux/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/zenmux/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,20 @@
+name = "Gemini 3.1 Flash Lite Preview"
+release_date = "2025-03-20"
+last_updated = "2025-03-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1.50
+
+[limit]
+context = 1050000
+output = 65530
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/zenmux/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2.7 highspeed"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01-01"
+open_weights = false
+
+[cost]
+input = 0.611
+output = 2.4439
+
+[limit]
+context = 204_800
+output = 131_070
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/minimax/minimax-m2.7.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.7.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2.7"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01-01"
+open_weights = false
+
+[cost]
+input = 0.3055
+output = 1.2219
+
+[limit]
+context = 204_800
+output = 131_070
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/openai/gpt-5.3-chat.toml
+++ b/providers/zenmux/models/openai/gpt-5.3-chat.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.3 Chat"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+
+[limit]
+context = 128_000
+output = 16_380
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/openai/gpt-5.3-codex.toml
+++ b/providers/zenmux/models/openai/gpt-5.3-codex.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.3 Codex"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/openai/gpt-5.4-mini.toml
+++ b/providers/zenmux/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.4 Mini"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 0.75
+output = 4.50
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/openai/gpt-5.4-nano.toml
+++ b/providers/zenmux/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.4 Nano"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 0.20
+output = 1.25
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/openai/gpt-5.4-pro.toml
+++ b/providers/zenmux/models/openai/gpt-5.4-pro.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.4 Pro"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 45.00
+output = 225.00
+
+[limit]
+context = 1_050_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zenmux/models/openai/gpt-5.4.toml
+++ b/providers/zenmux/models/openai/gpt-5.4.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.4"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 3.75
+output = 18.75
+
+[limit]
+context = 1_050_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zenmux/models/qwen/qwen3.5-flash.toml
+++ b/providers/zenmux/models/qwen/qwen3.5-flash.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.5 Flash"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-01-01"
+open_weights = false
+
+[cost]
+input = 0.10
+output = 0.40
+
+[limit]
+context = 1_020_000
+output = 1_020_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zenmux/models/qwen/qwen3.5-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.5-plus.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.5 Plus"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01-01"
+open_weights = false
+
+[cost]
+input = 0.80
+output = 4.80
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zenmux/models/volcengine/doubao-seed-2.0-code.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-2.0-code.toml
@@ -1,0 +1,21 @@
+name = "Doubao Seed 2.0 Code"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-01-01"
+open_weights = false
+
+[cost]
+input = 0.90
+output = 4.48
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/x-ai/grok-4.2-fast-non-reasoning.toml
+++ b/providers/zenmux/models/x-ai/grok-4.2-fast-non-reasoning.toml
@@ -1,0 +1,21 @@
+name = "Grok 4.2 Fast Non Reasoning"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 9.00
+
+[limit]
+context = 2_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/zenmux/models/x-ai/grok-4.2-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4.2-fast.toml
@@ -1,0 +1,21 @@
+name = "Grok 4.2 Fast"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 3.00
+output = 9.00
+
+[limit]
+context = 2_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
@@ -1,0 +1,21 @@
+name = "MiMo V2 Omni"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2025-01-01"
+open_weights = false
+
+[cost]
+input = 0.40
+output = 2.00
+
+[limit]
+context = 265_000
+output = 265_000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
@@ -1,0 +1,21 @@
+name = "MiMo V2 Pro"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01-01"
+open_weights = false
+
+[cost]
+input = 1.50
+output = 4.50
+
+[limit]
+context = 1_000_000
+output = 256_000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/zenmux/models/z-ai/glm-5-turbo.toml
+++ b/providers/zenmux/models/z-ai/glm-5-turbo.toml
@@ -1,0 +1,21 @@
+name = "GLM 5 Turbo"
+release_date = "2026-03-20"
+last_updated = "2026-03-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01-01"
+open_weights = false
+
+[cost]
+input = 0.88
+output = 3.48
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This PR synchronizes the ZenMux provider models with the latest data from zenmux.ai.

## Changes Summary

### New Models Added (17)

| Provider | Model ID | Description |
|----------|----------|-------------|
| google | gemini-3-pro-image-preview | Gemini 3 Pro with image capabilities |
| google | gemini-3.1-flash-lite-preview | Cost-efficient Gemini 3.1 model |
| minimax | minimax-m2.7 | High-performance software engineering model |
| minimax | minimax-m2.7-highspeed | Faster variant of M2.7 |
| openai | gpt-5.3-chat | GPT-5.3 for chat use cases |
| openai | gpt-5.3-codex | GPT-5.3 optimized for coding |
| openai | gpt-5.4 | OpenAI's frontier model |
| openai | gpt-5.4-mini | Efficient variant of GPT-5.4 |
| openai | gpt-5.4-nano | Ultra-efficient GPT-5.4 |
| openai | gpt-5.4-pro | Advanced GPT-5.4 variant |
| qwen | qwen3.5-flash | Fast inference model |
| qwen | qwen3.5-plus | Enhanced Qwen 3.5 |
| volcengine | doubao-seed-2.0-code | Code-optimized Doubao model |
| x-ai | grok-4.2-fast | Fast Grok 4.2 variant |
| x-ai | grok-4.2-fast-non-reasoning | Non-reasoning Grok 4.2 |
| xiaomi | mimo-v2-omni | Multimodal interaction model |
| xiaomi | mimo-v2-pro | Professional MiMo variant |
| z-ai | glm-5-turbo | Fast GLM-5 inference |

### Deprecated Models (1)

| Model | Reason |
|-------|--------|
| anthropic/claude-3.5-sonnet | No longer listed on ZenMux website |

## Data Source
- Website: https://zenmux.ai/models
- Filter: sort=newest, supported_protocol=messages
- Parsed using: lightpanda browser

## Validation
- All TOML files validated against schema
- Pricing data extracted from website
- Context limits and capabilities accurately reflected

## Notes
- Total ZenMux models after this PR: 87
- Models not found on website have been marked as "deprecated" with status field
