### PR TITLE
fix(scaleway): set the correct family for Qwen 3.5 for Scaleway

### DIFF
--- a/providers/scaleway/models/qwen3.5-397b-a17b.toml
+++ b/providers/scaleway/models/qwen3.5-397b-a17b.toml
@@ -1,10 +1,11 @@
 name = "Qwen3.5 397B A17B"
-family = "devstral"
+family = "qwen"
 release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = false
 reasoning = true
 temperature = true
+knowledge = "2025-04"
 tool_call = true
 open_weights = true
 


### PR DESCRIPTION
cc @scwgoire 