### PR TITLE
Update Grok 4.2 model names

### DIFF
--- a/providers/xai/models/grok-4.20-0309-non-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-non-reasoning.toml
@@ -1,6 +1,5 @@
-name = "Grok 4.20 Beta (Non-Reasoning)"
+name = "Grok 4.20 (Non-Reasoning)"
 family = "grok"
-status = "beta"
 release_date = "2026-03-09"
 last_updated = "2026-03-09"
 attachment = true

--- a/providers/xai/models/grok-4.20-0309-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-reasoning.toml
@@ -1,6 +1,5 @@
-name = "Grok 4.20 Beta (Reasoning)"
+name = "Grok 4.20 (Reasoning)"
 family = "grok"
-status = "beta"
 release_date = "2026-03-09"
 last_updated = "2026-03-09"
 attachment = true

--- a/providers/xai/models/grok-4.20-multi-agent-0309.toml
+++ b/providers/xai/models/grok-4.20-multi-agent-0309.toml
@@ -1,6 +1,5 @@
-name = "Grok 4.20 Multi-Agent Beta"
+name = "Grok 4.20 Multi-Agent"
 family = "grok"
-status = "beta"
 release_date = "2026-03-09"
 last_updated = "2026-03-09"
 attachment = true


### PR DESCRIPTION
I might be doing something silly..

In case anyone knows the proper way to set this up (resilient to name changes, works with aliases), pls send a follow-up PR.

xAI console says:

model name
grok-4.20-multi-agent-0309

aliases
grok-4.20-multi-agent
grok-4.20-multi-agent-latest

etc..
