### PR TITLE
Add NanoGPT MiniMax M2.7 model metadata

### DIFF
--- a/providers/nano-gpt/models/minimax/minimax-m2.7.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.7.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2.7"
+family = "minimax"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 204_800
+input = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add the NanoGPT MiniMax M2.7 model definition under the MiniMax provider folder
- include NanoGPT pricing, token limits, and text-only modality metadata for the model
- validate the new model entry with the repository validation script before opening the PR
