### PR TITLE
fix: correct github-copilot model limits to match Copilot API

### DIFF
--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -14,9 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 144_000
-output = 32_000
-input = 128_000
+context = 200_000
+output = 64_000
+input = 136_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -14,9 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 160_000
+context = 200_000
 output = 32_000
-input = 128_000
+input = 168_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-opus-4.6.toml
+++ b/providers/github-copilot/models/claude-opus-4.6.toml
@@ -14,9 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 144_000
-output = 64_000
-input = 128_000
+context = 200_000
+output = 32_000
+input = 168_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -14,9 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 144_000
+context = 200_000
 output = 32_000
-input = 128_000
+input = 168_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-sonnet-4.6.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.6.toml
@@ -15,7 +15,7 @@ output = 0
 [limit]
 context = 200_000
 output = 32_000
-input = 128_000
+input = 168_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/gpt-5.2.toml
+++ b/providers/github-copilot/models/gpt-5.2.toml
@@ -14,9 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 264_000
-input = 128_000
-output = 64_000
+context = 400_000
+input = 272_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
## Summary

Corrects token limits for 6 models in the `github-copilot` provider to match the authoritative values from the Copilot API (`GET https://api.githubcopilot.com/models`).

This PR only fixes limits — no models are added or removed.

## Changes

| Model | Field | Before | After (Copilot API) | Delta |
|---|---|---:|---:|---:|
| **claude-haiku-4.5** | `context` | 144,000 | **200,000** | +56,000 |
| | `input` | 128,000 | **136,000** | +8,000 |
| | `output` | 32,000 | **64,000** | +32,000 |
| **claude-opus-4.5** | `context` | 160,000 | **200,000** | +40,000 |
| | `input` | 128,000 | **168,000** | +40,000 |
| **claude-opus-4.6** | `context` | 144,000 | **200,000** | +56,000 |
| | `input` | 128,000 | **168,000** | +40,000 |
| | `output` | 64,000 | **32,000** | -32,000 |
| **claude-sonnet-4.5** | `context` | 144,000 | **200,000** | +56,000 |
| | `input` | 128,000 | **168,000** | +40,000 |
| **claude-sonnet-4.6** | `input` | 128,000 | **168,000** | +40,000 |
| **gpt-5.2** | `context` | 264,000 | **400,000** | +136,000 |
| | `input` | 128,000 | **272,000** | +144,000 |
| | `output` | 64,000 | **128,000** | +64,000 |

## How the correct values were verified

```bash
curl -s "https://api.githubcopilot.com/models" \
  -H "Authorization: Bearer $(gh auth token)" \
  -H "Copilot-Integration-Id: vscode-chat"
```

Each model in the response includes:
```json
"limits": {
    "max_context_window_tokens": ...,   // → limit.context
    "max_prompt_tokens": ...,           // → limit.input
    "max_output_tokens": ...            // → limit.output
}
```

## Impact

The under-reported limits cause tools like OpenCode to trigger context compaction 40K–136K tokens earlier than necessary, significantly degrading the user experience especially for Claude and GPT-5.2 models.

Fixes #858
