### PR TITLE
Add Nemotron 3 Super model to OpenRouter and NVIDIA providers

### DIFF
--- a/providers/nvidia/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/nvidia/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,22 @@
+name = "Nemotron 3 Super"
+family = "nemotron"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+knowledge = "2024-04"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+open_weights = true
+
+[cost]
+input = 0.20
+output = 0.80
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/nvidia/nemotron-3-super-120b-a12b-free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-3-super-120b-a12b-free.toml
@@ -1,0 +1,22 @@
+name = "Nemotron 3 Super (free)"
+family = "nemotron"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+knowledge = "2024-04"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/openrouter/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,22 @@
+name = "Nemotron 3 Super"
+family = "nemotron"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+knowledge = "2024-04"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.50
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This pull request adds configuration files for the "Nemotron 3 Super" model to both the NVIDIA and OpenRouter providers, including both free and paid variants. These files define the model's properties, capabilities, cost, and usage limits.

**New model configurations:**

*Nemotron 3 Super model additions:*
- Added `nemotron-3-super-120b-a12b.toml` for the NVIDIA provider, specifying model details, features, costs, and limits.
- Added `nemotron-3-super-120b-a12b.toml` for the OpenRouter provider, with slightly different cost values.
- Added `nemotron-3-super-120b-a12b-free.toml` for the OpenRouter provider, representing a free version of the model (zero input/output cost).