### PR TITLE
correct model name for nemotron super 3 on baseten

### DIFF
--- a/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
+++ b/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
@@ -1,4 +1,4 @@
-name = "Nemotron 3 Super 120B"
+name = "Nemotron 3 Super"
 family = "nemotron"
 release_date = "2026-03-11"
 last_updated = "2026-03-11"

--- a/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
+++ b/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
@@ -1,4 +1,4 @@
-name = "Nemotron 120B A12B"
+name = "Nemotron 3 Super 120B"
 family = "nemotron"
 release_date = "2026-03-11"
 last_updated = "2026-03-11"

--- a/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
+++ b/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
@@ -1,4 +1,4 @@
-name = "Nemotron 3 Super"
+name = "Nemotron 120B A12B"
 family = "nemotron"
 release_date = "2026-03-11"
 last_updated = "2026-03-11"


### PR DESCRIPTION
rename file from providers/baseten/models/nvidia/Nemotron-3-Super.toml to providers/baseten/models/nvidia/Nemotron-120B-A12B.toml