### PR TITLE
Add multi-select provider filter to table

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -418,6 +418,137 @@ tbody {
   }
 }
 
+/* Column Filters */
+
+.filter-icon {
+  position: absolute;
+  right: 0.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease;
+
+  &:hover,
+  &.active {
+    color: var(--color-brand);
+  }
+
+  &.active {
+    opacity: 1;
+  }
+
+  svg {
+    display: block;
+  }
+}
+
+th.filterable:hover .filter-icon {
+  opacity: 1;
+}
+
+.filter-dropdown {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  z-index: 100;
+  min-width: 12rem;
+  max-width: 20rem;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  box-shadow:
+    0 4px 8px rgba(0, 0, 0, 0.12),
+    0 8px 16px rgba(0, 0, 0, 0.08);
+  padding: 0.375rem;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: normal;
+  white-space: normal;
+}
+
+.filter-search {
+  width: 100%;
+  font-size: 0.75rem;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.25rem;
+  background: none;
+  color: var(--color-text);
+  margin-bottom: 0.25rem;
+  height: auto;
+
+  &:focus {
+    border-color: var(--color-text-tertiary);
+    outline: none;
+  }
+}
+
+.filter-actions {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 0.25rem;
+
+  button {
+    flex: 1;
+    font-size: 0.6875rem;
+    padding: 0.25rem 0.375rem;
+    border: none;
+    border-radius: 0.25rem;
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    line-height: 1;
+    height: auto;
+
+    &:hover {
+      color: var(--color-text);
+    }
+  }
+}
+
+.filter-list {
+  max-height: 14rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.filter-option {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.3125rem 0.375rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--color-text);
+  line-height: 1.2;
+
+  &:hover {
+    background-color: var(--color-surface);
+  }
+
+  input[type="checkbox"] {
+    flex: 0 0 auto;
+    margin: 0;
+    accent-color: var(--color-brand);
+  }
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 dialog::backdrop {
   backdrop-filter: blur(8px);
   background-color: rgba(0, 0, 0, 0.03);

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -26,7 +26,9 @@ function updateQueryParams(updates: Record<string, string | null>) {
 }
 
 function getColumnNameForURL(headerEl: Element): string {
-  const text = headerEl.textContent?.trim().toLowerCase() || "";
+  const clone = headerEl.cloneNode(true) as Element;
+  clone.querySelectorAll(".filter-icon, .filter-dropdown").forEach((el) => el.remove());
+  const text = clone.textContent?.trim().toLowerCase() || "";
   return text.replace(/↑|↓/g, "").trim().split(/\s+/).slice(0, 2).join("-");
 }
 
@@ -147,21 +149,8 @@ document.querySelectorAll("th.sortable").forEach((header) => {
 // Handle Search
 ///////////////////
 function filterTable(value: string) {
-  const lowerCaseValues = value.toLowerCase().split(",").filter(str => str.trim() !== "");
-  const rows = document.querySelectorAll(
-    "table tbody tr"
-  ) as NodeListOf<HTMLTableRowElement>;
-
-  rows.forEach((row) => {
-    const cellTexts = Array.from(row.cells).map((cell) =>
-      cell.textContent!.toLowerCase()
-    );
-    const isVisible = lowerCaseValues.length === 0 ||
-     lowerCaseValues.some((lowerCaseValue) => cellTexts.some((text) => text.includes(lowerCaseValue)));
-    row.style.display = isVisible ? "" : "none";
-  });
-
   updateQueryParams({ search: value || null });
+  applyFilters();
 }
 
 search.addEventListener("input", () => {
@@ -212,18 +201,236 @@ search.addEventListener("keydown", (e) => {
 };
 
 ///////////////////////////////////
+// Handle Column Filters
+///////////////////////////////////
+const filterSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon></svg>`;
+
+const activeFilters: Map<number, Set<string>> = new Map();
+let openDropdown: HTMLElement | null = null;
+
+function getColumnIndex(th: Element): number {
+  return Array.from(th.parentElement!.children).indexOf(th);
+}
+
+function getUniqueValues(colIndex: number): string[] {
+  const rows = document.querySelectorAll("table tbody tr") as NodeListOf<HTMLTableRowElement>;
+  const values = new Set<string>();
+  rows.forEach((row) => {
+    const text = row.cells[colIndex]?.textContent?.trim() || "";
+    if (text) values.add(text);
+  });
+  return Array.from(values).sort((a, b) => a.localeCompare(b));
+}
+
+function applyFilters() {
+  const rows = document.querySelectorAll("table tbody tr") as NodeListOf<HTMLTableRowElement>;
+  rows.forEach((row) => {
+    let visible = true;
+
+    // check column filters
+    for (const [colIndex, allowed] of activeFilters) {
+      if (allowed.size === 0) continue;
+      const text = row.cells[colIndex]?.textContent?.trim() || "";
+      if (!allowed.has(text)) {
+        visible = false;
+        break;
+      }
+    }
+
+    // also respect search
+    if (visible && search.value) {
+      const lowerCaseValues = search.value.toLowerCase().split(",").filter(str => str.trim() !== "");
+      if (lowerCaseValues.length > 0) {
+        const cellTexts = Array.from(row.cells).map((cell) => cell.textContent!.toLowerCase());
+        visible = lowerCaseValues.some((v) => cellTexts.some((text) => text.includes(v)));
+      }
+    }
+
+    row.style.display = visible ? "" : "none";
+  });
+
+  // update URL
+  const filterParams: Record<string, string | null> = {};
+  document.querySelectorAll("th.filterable").forEach((th) => {
+    const col = getColumnIndex(th);
+    const name = getColumnNameForURL(th);
+    const selected = activeFilters.get(col);
+    filterParams[`filter-${name}`] = selected && selected.size > 0
+      ? Array.from(selected).join(",")
+      : null;
+  });
+  updateQueryParams(filterParams);
+
+  // update filter icon active state
+  document.querySelectorAll("th.filterable").forEach((th) => {
+    const col = getColumnIndex(th);
+    const icon = th.querySelector(".filter-icon");
+    const selected = activeFilters.get(col);
+    if (icon) {
+      icon.classList.toggle("active", !!selected && selected.size > 0);
+    }
+  });
+}
+
+function closeDropdown() {
+  if (openDropdown) {
+    openDropdown.remove();
+    openDropdown = null;
+  }
+}
+
+function openFilterDropdown(th: Element, colIndex: number) {
+  closeDropdown();
+
+  const values = getUniqueValues(colIndex);
+  const selected = activeFilters.get(colIndex) || new Set<string>();
+
+  const dropdown = document.createElement("div");
+  dropdown.className = "filter-dropdown";
+
+  // search within filter
+  const filterSearch = document.createElement("input");
+  filterSearch.type = "text";
+  filterSearch.placeholder = "Search...";
+  filterSearch.className = "filter-search";
+  dropdown.appendChild(filterSearch);
+
+  // actions row
+  const actions = document.createElement("div");
+  actions.className = "filter-actions";
+  const selectAll = document.createElement("button");
+  selectAll.textContent = "All";
+  selectAll.addEventListener("click", (e) => {
+    e.stopPropagation();
+    dropdown.querySelectorAll<HTMLInputElement>(".filter-option input[type=checkbox]").forEach((cb) => {
+      cb.checked = true;
+    });
+    const newSet = new Set(values);
+    activeFilters.set(colIndex, newSet);
+    applyFilters();
+  });
+  const clearAll = document.createElement("button");
+  clearAll.textContent = "Clear";
+  clearAll.addEventListener("click", (e) => {
+    e.stopPropagation();
+    dropdown.querySelectorAll<HTMLInputElement>(".filter-option input[type=checkbox]").forEach((cb) => {
+      cb.checked = false;
+    });
+    activeFilters.delete(colIndex);
+    applyFilters();
+  });
+  actions.appendChild(selectAll);
+  actions.appendChild(clearAll);
+  dropdown.appendChild(actions);
+
+  // options list
+  const list = document.createElement("div");
+  list.className = "filter-list";
+  values.forEach((value) => {
+    const option = document.createElement("label");
+    option.className = "filter-option";
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.checked = selected.has(value);
+    cb.addEventListener("change", (e) => {
+      e.stopPropagation();
+      const current = activeFilters.get(colIndex) || new Set<string>();
+      if (cb.checked) {
+        current.add(value);
+      } else {
+        current.delete(value);
+      }
+      if (current.size === 0) {
+        activeFilters.delete(colIndex);
+      } else {
+        activeFilters.set(colIndex, current);
+      }
+      applyFilters();
+    });
+    const span = document.createElement("span");
+    span.textContent = value;
+    option.appendChild(cb);
+    option.appendChild(span);
+    list.appendChild(option);
+  });
+  dropdown.appendChild(list);
+
+  // filter search functionality
+  filterSearch.addEventListener("input", () => {
+    const query = filterSearch.value.toLowerCase();
+    list.querySelectorAll<HTMLLabelElement>(".filter-option").forEach((opt) => {
+      const text = opt.textContent?.toLowerCase() || "";
+      opt.style.display = text.includes(query) ? "" : "none";
+    });
+  });
+  filterSearch.addEventListener("click", (e) => e.stopPropagation());
+
+  th.appendChild(dropdown);
+  openDropdown = dropdown;
+
+  // prevent clicks inside dropdown from sorting
+  dropdown.addEventListener("click", (e) => e.stopPropagation());
+
+  // focus search
+  filterSearch.focus();
+}
+
+// inject filter icons into filterable headers
+document.querySelectorAll("th.filterable").forEach((th) => {
+  const icon = document.createElement("span");
+  icon.className = "filter-icon";
+  icon.innerHTML = filterSvg;
+  icon.addEventListener("click", (e) => {
+    e.stopPropagation();
+    const colIndex = getColumnIndex(th);
+    if (openDropdown && openDropdown.parentElement === th) {
+      closeDropdown();
+    } else {
+      openFilterDropdown(th, colIndex);
+    }
+  });
+  th.appendChild(icon);
+});
+
+// close dropdown when clicking outside or pressing Escape
+document.addEventListener("click", (e) => {
+  if (openDropdown && !openDropdown.contains(e.target as Node)) {
+    closeDropdown();
+  }
+});
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && openDropdown) {
+    e.stopPropagation();
+    closeDropdown();
+  }
+});
+
+///////////////////////////////////
 // Initialize State from URL
 ///////////////////////////////////
 function initializeFromURL() {
   const params = getQueryParams();
 
+  // restore search
   (() => {
     const searchQuery = params.get("search");
     if (!searchQuery) return;
     search.value = searchQuery;
-    filterTable(searchQuery);
   })();
 
+  // restore column filters
+  document.querySelectorAll("th.filterable").forEach((th) => {
+    const col = getColumnIndex(th);
+    const name = getColumnNameForURL(th);
+    const filterValue = params.get(`filter-${name}`);
+    if (filterValue) {
+      activeFilters.set(col, new Set(filterValue.split(",")));
+    }
+  });
+
+  applyFilters();
+
+  // restore sort
   (() => {
     const columnName = params.get("sort");
     if (!columnName) return;

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -216,7 +216,7 @@ export const Rendered = renderToString(
     <table>
       <thead>
         <tr>
-          <th class="sortable" data-type="text">
+          <th class="sortable filterable" data-type="text">
             Provider <span class="sort-indicator"></span>
           </th>
           <th class="sortable" data-type="text">


### PR DESCRIPTION
With hundreds of models across 40+ providers, it's hard to compare models from specific providers. This adds a filter dropdown to the Provider column header so you can narrow the table to just the providers you care about.

- Multi-select checkboxes with search within the dropdown
- Filter state persists in URL params for sharing
- Escape / click outside to dismiss