### PR TITLE
feat(amazon-bedrock): add MiniMax M2.5 and GLM-5 models

### DIFF
--- a/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2.5"
+family = "minimax-m2.5"
+release_date = "2026-02-12"
+last_updated = "2026-03-18"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/zai.glm-5.toml
+++ b/providers/amazon-bedrock/models/zai.glm-5.toml
@@ -1,0 +1,24 @@
+name = "GLM-5"
+family = "glm"
+release_date = "2026-02-11"
+last_updated = "2026-03-18"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.00
+output = 3.20
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds two newly available Amazon Bedrock models that were launched on March 18, 2026:

### MiniMax M2.5 (`minimax.minimax-m2.5`)
- **Context**: 1,000,000 tokens
- **Max Output**: 131,072 tokens
- **Pricing**: $0.30 input / $1.20 output per 1M tokens
- **Capabilities**: reasoning, tool_call, temperature
- **Open Weights**: Yes
- **Family**: minimax-m2.5

### GLM-5 (`zai.glm-5`)
- **Context**: 200,000 tokens
- **Max Output**: 131,072 tokens
- **Pricing**: $1.00 input / $3.20 output per 1M tokens
- **Capabilities**: reasoning, tool_call, temperature, interleaved (reasoning_content)
- **Open Weights**: Yes
- **Family**: glm

### Sources
- [AWS Bedrock Pricing](https://aws.amazon.com/bedrock/pricing/)
- [AWS What's New - March 18, 2026](https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-minimax-glm/)
- [MiniMax M2.5 specs](https://automatio.ai/models/minimax-m2-5)
- [Z.AI GLM-5 docs](https://docs.z.ai/guides/llm/glm-5)

### Validation
`bun validate` passes successfully.