### PR TITLE
Add Fireworks Kimi K2.5 Turbo router

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p5-turbo.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p5-turbo.toml
@@ -1,0 +1,26 @@
+name = "Kimi K2.5 Turbo"
+family = "kimi-thinking"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+knowledge = "2025-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+cache_read = 0
+input = 0
+output = 0
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
## Summary

Adds the Kimi K2.5 Turbo router model for Fireworks AI provider. This codifies the [Developer Pass](https://docs.fireworks.ai/developer-pass#developer-pass) offering for opencode users.

## Background

Fireworks AI offers a Developer Pass that provides access to models through a subscription/usage plan model rather than per-token pricing. This model entry enables opencode users to access Kimi K2.5 Turbo via the Fireworks router.

## Changes

- Model ID: `accounts/fireworks/routers/kimi-k2p5-turbo`
- Supports text and image input, text output
- Includes reasoning capabilities with interleaved reasoning content
- Pricing set to 0 (per-token costs absorbed by Developer Pass subscription - follows precedent from other flat-rate providers like alibaba-coding-plan-cn)

## Model Details

| Field | Value |
|-------|-------|
| Family | kimi-thinking |
| Context | 256K |
| Output | 256K |
| Reasoning | ✅ |
| Tool Calling | ✅ |
| Temperature | ✅ |
| Knowledge | 2025-01 |

## Pricing Note

This model uses Fireworks' Developer Pass pricing model rather than per-token billing. The `cost.input = 0` and `cost.output = 0` reflect that usage is covered by the subscription tier, similar to how other providers (aihubmix, alibaba-coding-plan-cn) handle their flat-rate plans in models.dev.