### PR TITLE
feat(provider): add StepFun Step Plan provider

### DIFF
--- a/providers/stepfun-step-plan/models/step-3.5-flash.toml
+++ b/providers/stepfun-step-plan/models/step-3.5-flash.toml
@@ -1,0 +1,22 @@
+name = "Step 3.5 Flash"
+release_date = "2026-01-29"
+last_updated = "2026-03-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/stepfun-step-plan/provider.toml
+++ b/providers/stepfun-step-plan/provider.toml
@@ -1,0 +1,5 @@
+name = "StepFun Step Plan"
+env = ["STEPFUN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://platform.stepfun.com/docs/zh/step-plan/overview"
+api = "https://api.stepfun.com/step_plan/v1"


### PR DESCRIPTION
## Summary

Adds **StepFun Step Plan** (`stepfun-step-plan`) as a new provider in models.dev.

[StepFun Step Plan](https://platform.stepfun.com/docs/zh/step-plan/overview) is a subscription-based AI coding service by StepFun (阶跃星辰), using a distinct API endpoint from the standard StepFun provider.

### Changes

- `providers/stepfun-step-plan/provider.toml` — new provider definition
- `providers/stepfun-step-plan/models/step-3.5-flash.toml` — Step 3.5 Flash model (the current model available under this plan)

### Provider details

| Field | Value |
|---|---|
| Name | StepFun Step Plan |
| Base URL | `https://api.stepfun.com/step_plan/v1` |
| Auth env | `STEPFUN_API_KEY` |
| npm | `@ai-sdk/openai-compatible` |
| Docs | https://platform.stepfun.com/docs/zh/step-plan/overview |

### Model: `step-3.5-flash`

- 196B total params / 11B activated (sparse MoE architecture)
- Optimized for agent and coding tasks
- Supports reasoning, tool_call, temperature
- Context window: 256K tokens
- Cost: `0` (subscription-based plan at ¥49–699/month)

### Notes

- This is a separate provider from the existing `stepfun` provider because it uses a different base URL (`/step_plan/v1` vs `/v1`) and has subscription-based pricing (cost = 0)
- More models will be added to this plan by StepFun in future updates

Made with [Cursor](https://cursor.com)