### PR TITLE
feat: add Snowflake provider

### DIFF
--- a/providers/snowflake/models/claude-3-5-sonnet.toml
+++ b/providers/snowflake/models/claude-3-5-sonnet.toml
@@ -1,0 +1,18 @@
+name = "Claude Sonnet 3.5 v2"
+family = "claude-sonnet"
+release_date = "2024-10-22"
+last_updated = "2024-10-22"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-04-30"
+open_weights = false
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/claude-3-7-sonnet.toml
+++ b/providers/snowflake/models/claude-3-7-sonnet.toml
@@ -1,0 +1,18 @@
+name = "Claude Sonnet 3.7"
+family = "claude-sonnet"
+release_date = "2025-02-19"
+last_updated = "2025-02-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-10-31"
+open_weights = false
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/claude-4-opus.toml
+++ b/providers/snowflake/models/claude-4-opus.toml
@@ -1,0 +1,18 @@
+name = "Claude Opus 4"
+family = "claude-opus"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-03-31"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/claude-4-sonnet.toml
+++ b/providers/snowflake/models/claude-4-sonnet.toml
@@ -1,0 +1,18 @@
+name = "Claude Sonnet 4"
+family = "claude-sonnet"
+release_date = "2025-05-22"
+last_updated = "2025-05-22"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/claude-haiku-4-5.toml
+++ b/providers/snowflake/models/claude-haiku-4-5.toml
@@ -1,0 +1,18 @@
+name = "Claude Haiku 4.5"
+family = "claude-haiku"
+release_date = "2025-10-15"
+last_updated = "2025-10-15"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-02-28"
+open_weights = false
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/claude-opus-4-5.toml
+++ b/providers/snowflake/models/claude-opus-4-5.toml
@@ -1,0 +1,18 @@
+name = "Claude Opus 4.5"
+family = "claude-opus"
+release_date = "2025-11-24"
+last_updated = "2025-11-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-03-31"
+open_weights = false
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/claude-opus-4-6.toml
+++ b/providers/snowflake/models/claude-opus-4-6.toml
@@ -1,0 +1,18 @@
+name = "Claude Opus 4.6"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-03-13"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-05"
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/claude-sonnet-4-5.toml
+++ b/providers/snowflake/models/claude-sonnet-4-5.toml
@@ -1,0 +1,18 @@
+name = "Claude Sonnet 4.5"
+family = "claude-sonnet"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-07-31"
+open_weights = false
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/claude-sonnet-4-6.toml
+++ b/providers/snowflake/models/claude-sonnet-4-6.toml
@@ -1,0 +1,18 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-03-13"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08"
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-4.1.toml
+++ b/providers/snowflake/models/openai-gpt-4.1.toml
@@ -1,0 +1,19 @@
+name = "GPT-4.1"
+family = "gpt"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_047_576
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5-chat.toml
+++ b/providers/snowflake/models/openai-gpt-5-chat.toml
@@ -1,0 +1,19 @@
+name = "GPT-5 Chat"
+family = "gpt-codex"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2024-09-30"
+tool_call = false
+structured_output = true
+open_weights = false
+
+[limit]
+context = 400_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5-mini.toml
+++ b/providers/snowflake/models/openai-gpt-5-mini.toml
@@ -1,0 +1,20 @@
+name = "GPT-5 Mini"
+family = "gpt-mini"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-05-30"
+tool_call = true
+structured_output = true
+open_weights = false
+status = "beta"
+
+[limit]
+context = 400_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5-nano.toml
+++ b/providers/snowflake/models/openai-gpt-5-nano.toml
@@ -1,0 +1,20 @@
+name = "GPT-5 Nano"
+family = "gpt-nano"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-05-30"
+tool_call = true
+structured_output = true
+open_weights = false
+status = "beta"
+
+[limit]
+context = 400_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5.1.toml
+++ b/providers/snowflake/models/openai-gpt-5.1.toml
@@ -1,0 +1,20 @@
+name = "GPT-5.1"
+family = "gpt"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-09-30"
+tool_call = true
+structured_output = true
+open_weights = false
+status = "beta"
+
+[limit]
+context = 400_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5.toml
+++ b/providers/snowflake/models/openai-gpt-5.toml
@@ -1,0 +1,20 @@
+name = "GPT-5"
+family = "gpt"
+release_date = "2025-08-07"
+last_updated = "2025-08-07"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2024-09-30"
+tool_call = true
+structured_output = true
+open_weights = false
+status = "beta"
+
+[limit]
+context = 400_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-oss-120b.toml
+++ b/providers/snowflake/models/openai-gpt-oss-120b.toml
@@ -1,0 +1,18 @@
+name = "GPT-OSS 120B"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+status = "beta"
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/provider.toml
+++ b/providers/snowflake/provider.toml
@@ -1,0 +1,5 @@
+name = "Snowflake"
+env = ["SNOWFLAKE_ACCOUNT_IDENTIFIER", "SNOWFLAKE_PAT"]
+npm = "@ai-sdk/openai"
+api = "https://${SNOWFLAKE_ACCOUNT_IDENTIFIER}.snowflakecomputing.com/api/v2/cortex/v1"
+doc = "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api"


### PR DESCRIPTION
This fixes #1238.

What I changed
- added a `Snowflake` provider pointing at the Cortex Chat Completions base URL
- added an initial Snowflake model set for the Claude and OpenAI models listed in the Cortex REST API docs
- marked Snowflake preview models as `beta` and kept the documented `16_384` max output limit

How to verify
- parsed the new `providers/snowflake/*.toml` files with `python3` and `tomllib` and checked the required sections
- I could not get `bun validate` to run cleanly in this Windows/WSL checkout
