### PR TITLE
feat: add OfoxAI provider

### DIFF
--- a/providers/ofoxai/models/claude-sonnet-4-20250514.toml
+++ b/providers/ofoxai/models/claude-sonnet-4-20250514.toml
@@ -1,0 +1,15 @@
+name = "Claude Sonnet 4"
+family = "claude"
+release_date = "2025-05-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/ofoxai/models/deepseek-chat.toml
+++ b/providers/ofoxai/models/deepseek-chat.toml
@@ -1,0 +1,15 @@
+name = "DeepSeek V3"
+family = "deepseek"
+release_date = "2025-03-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+
+[limit]
+context = 64_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ofoxai/models/deepseek-reasoner.toml
+++ b/providers/ofoxai/models/deepseek-reasoner.toml
@@ -1,0 +1,15 @@
+name = "DeepSeek R1"
+family = "deepseek"
+release_date = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = false
+tool_call = false
+
+[limit]
+context = 64_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ofoxai/models/gemini-2.5-flash.toml
+++ b/providers/ofoxai/models/gemini-2.5-flash.toml
@@ -1,0 +1,15 @@
+name = "Gemini 2.5 Flash"
+family = "gemini"
+release_date = "2025-03-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/ofoxai/models/gpt-4o-mini.toml
+++ b/providers/ofoxai/models/gpt-4o-mini.toml
@@ -1,0 +1,15 @@
+name = "GPT-4o Mini"
+family = "gpt"
+release_date = "2024-07-18"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/ofoxai/provider.toml
+++ b/providers/ofoxai/provider.toml
@@ -1,0 +1,5 @@
+name = "OfoxAI"
+npm = "@ai-sdk/openai-compatible"
+env = ["OFOXAI_API_KEY"]
+api = "https://api.ofox.ai/v1"
+doc = "https://docs.ofox.ai/zh/api"


### PR DESCRIPTION
## Summary

Add [OfoxAI](https://ofox.ai) as a new provider.

**OfoxAI** is a unified API gateway for 100+ LLM models (Claude, GPT, Gemini, DeepSeek, etc.) with a single API key. OpenAI-compatible format.

- **Website**: https://ofox.ai
- **API Docs**: https://docs.ofox.ai/zh/api
- **Base URL**: `https://api.ofox.ai/v1`
- **SDK**: `@ai-sdk/openai-compatible`
- **Env var**: `OFOXAI_API_KEY`

## Files

- `providers/ofoxai/provider.toml` — Provider configuration
- `providers/ofoxai/models/*.toml` — Default models (GPT-4o Mini, Claude Sonnet 4, Gemini 2.5 Flash, DeepSeek V3, DeepSeek R1)