### PR TITLE
feat(amazon-bedrock): add NVIDIA Nemotron 3 Super 120B

### DIFF
--- a/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
@@ -1,0 +1,21 @@
+name = "NVIDIA Nemotron 3 Super 120B A12B"
+family = "nemotron"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.65
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## What does this PR do?

Fixes #1269

Adds the NVIDIA Nemotron 3 Super 120B entries in models.dev for Amazon Bedrock:

- `providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml`

## How did you verify?

TOML format follows the existing entries for other NVIDIA Models.

<img width="877" height="396" alt="Screenshot 2026-03-25 at 15 49 11" src="https://github.com/user-attachments/assets/7fc10455-7da9-40b5-92d2-079c79c9d008" />

