### PR TITLE
fix(amazon-bedrock): correct MiniMax M2.5 and GLM-5 context/output limits

### DIFF
--- a/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
@@ -1,6 +1,6 @@
 name = "MiniMax M2.5"
-family = "minimax-m2.5"
-release_date = "2026-02-12"
+family = "minimax"
+release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
@@ -14,8 +14,8 @@ input = 0.30
 output = 1.20
 
 [limit]
-context = 1_000_000
-output = 131_072
+context = 196_608
+output = 98_304
 
 [modalities]
 input = ["text"]

--- a/providers/amazon-bedrock/models/zai.glm-5.toml
+++ b/providers/amazon-bedrock/models/zai.glm-5.toml
@@ -1,6 +1,6 @@
 name = "GLM-5"
 family = "glm"
-release_date = "2026-02-11"
+release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
@@ -16,8 +16,8 @@ input = 1.00
 output = 3.20
 
 [limit]
-context = 200_000
-output = 131_072
+context = 202_752
+output = 101_376
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Fixes #1271 

## What does this PR do?

Corrects the context window, output limits, release dates, and family name for the Bedrock MiniMax M2.5 and GLM-5 entries in `providers/amazon-bedrock/models/` 

- MiniMax M2.5: context should be 196,608 (not 1M), output should be 98,304 (not 131,072)
- GLM-5: context should be 202,752 (not 200,000), output should be 101,376 (not 131,072)

## How did you verify?

Values come from the raw Bedrock list foundational models API metadata: `converse.maxTokensMaximum` for context limits and `consoleIDEMetadata.converse.maxTokensMaximum` for output limits. 

The models card for Minimax M2.5 incorrectly list it as having 1M token window and 8K output tokens.

This can also be validated by sending `maxTokens: 9999999` through the Converse API (the error response returns the exact enforced limit).

