### PR TITLE
feat: add thegrid.ai provider and associated models

### DIFF
--- a/providers/the-grid-ai/logo.svg
+++ b/providers/the-grid-ai/logo.svg
@@ -1,0 +1,14 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 3L7.76471 6.40541V8.35135H4V3Z" fill="currentColor"/>
+<path d="M4 21L7.76471 17.5946V15.6486H4V21Z" fill="currentColor"/>
+<path d="M20 3L16.2353 6.40541V8.35135H20V3Z" fill="currentColor"/>
+<path d="M20 21L16.2353 17.5946V15.6486H20V21Z" fill="currentColor"/>
+<path d="M9.17642 3L11.0588 6.40542V8.35135H9.17642V3Z" fill="currentColor"/>
+<path d="M9.17642 21L11.0588 17.5946V15.6486H9.17642V21Z" fill="currentColor"/>
+<path d="M14.8236 3L12.9412 6.40542V8.35135H14.8236V3Z" fill="currentColor"/>
+<path d="M14.8236 21L12.9412 17.5946V15.6486H14.8236V21Z" fill="currentColor"/>
+<path d="M4 8.59458L7.7647 10.5405V13.4594L4 15.4054V8.59458Z" fill="currentColor"/>
+<path d="M9.17642 8.59457L11.0588 10.5405V13.4594L9.17642 15.4054V8.59457Z" fill="currentColor"/>
+<path d="M14.8236 8.59457L12.9412 10.5405V13.4594L14.8236 15.4054V8.59457Z" fill="currentColor"/>
+<path d="M20 8.59458L16.2353 10.5405V13.4594L20 15.4054V8.59458Z" fill="currentColor"/>
+</svg>

--- a/providers/the-grid-ai/models/text-max.toml
+++ b/providers/the-grid-ai/models/text-max.toml
@@ -1,5 +1,4 @@
 name = "Text Max"
-family = "text"
 release_date = "2026-03-24"
 last_updated = "2026-03-24"
 attachment = false
@@ -8,6 +7,7 @@ temperature = true
 tool_call = true
 structured_output = true
 status = "beta"
+open_weights = false
 
 [limit]
 context = 1_000_000

--- a/providers/the-grid-ai/models/text-max.toml
+++ b/providers/the-grid-ai/models/text-max.toml
@@ -1,0 +1,18 @@
+name = "Text Max"
+family = "text"
+release_date = "2026-03-24"
+last_updated = "2026-03-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+status = "beta"
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/the-grid-ai/models/text-prime.toml
+++ b/providers/the-grid-ai/models/text-prime.toml
@@ -1,0 +1,18 @@
+name = "Text Prime"
+family = "text"
+release_date = "2026-02-26"
+last_updated = "2026-02-26"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+status = "beta"
+
+[limit]
+context = 128_000
+output = 30_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/the-grid-ai/models/text-prime.toml
+++ b/providers/the-grid-ai/models/text-prime.toml
@@ -1,5 +1,4 @@
 name = "Text Prime"
-family = "text"
 release_date = "2026-02-26"
 last_updated = "2026-02-26"
 attachment = false
@@ -8,6 +7,7 @@ temperature = true
 tool_call = true
 structured_output = true
 status = "beta"
+open_weights = false
 
 [limit]
 context = 128_000

--- a/providers/the-grid-ai/models/text-standard.toml
+++ b/providers/the-grid-ai/models/text-standard.toml
@@ -1,5 +1,4 @@
 name = "Text Standard"
-family = "text"
 release_date = "2026-02-26"
 last_updated = "2026-02-26"
 attachment = false
@@ -8,6 +7,7 @@ temperature = true
 tool_call = true
 structured_output = true
 status = "beta"
+open_weights = false
 
 [limit]
 context = 128_000

--- a/providers/the-grid-ai/models/text-standard.toml
+++ b/providers/the-grid-ai/models/text-standard.toml
@@ -1,0 +1,18 @@
+name = "Text Standard"
+family = "text"
+release_date = "2026-02-26"
+last_updated = "2026-02-26"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+status = "beta"
+
+[limit]
+context = 128_000
+output = 16_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/the-grid-ai/provider.toml
+++ b/providers/the-grid-ai/provider.toml
@@ -1,0 +1,5 @@
+name = "The Grid AI"
+env = ["THEGRIDAI_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.thegrid.ai/v1"
+doc = "https://thegrid.ai/docs"


### PR DESCRIPTION
Add [The Grid](https://thegrid.ai) as a model provider.

We are compatible with OpenAI "chat_completions" API and offer our own "models" which are actually groupings of models. Users specify a quality grade, and we route to the provider offering the best price within that grade. 

The specifications for each grade can be seen in [our documentation](https://thegrid.ai/docs/introduction/instruments-and-specifications/instrument-specifications-latest). 