### PR TITLE
Add Mistral Small 4 for OpenRouter

### DIFF
--- a/providers/openrouter/models/mistralai/mistral-small-2603.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-2603.toml
@@ -1,0 +1,23 @@
+id = "mistralai/mistral-small-2603"
+name = "Mistral Small 4"
+family = "mistral-small"
+release_date = "2026-03-16"
+last_updated = "2026-03-16"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-06"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
This PR adds OpenRouter's Mistral Small 4 to the list.
Link : https://openrouter.ai/mistralai/mistral-small-2603
I tested it according to the instructions in the readme and it works fine in OpenCode
```
id = "mistralai/mistral-small-2603"
name = "Mistral Small 4"
family = "mistral-small"
release_date = "2026-03-16"
last_updated = "2026-03-16"
attachment = true
reasoning = true
temperature = true
knowledge = "2025-06"
tool_call = true
open_weights = true

[cost]
input = 0.15
output = 0.60

[limit]
context = 262_144
output = 262_144

[modalities]
input = ["text", "image"]
output = ["text"]
```
