### PR TITLE
feat: add AWS Kiro provider

### DIFF
--- a/providers/kiro/models/auto.toml
+++ b/providers/kiro/models/auto.toml
@@ -1,0 +1,5 @@
+name = "Auto"
+
+[cost]
+input = 0
+output = 0

--- a/providers/kiro/models/claude-sonnet-4-5.toml
+++ b/providers/kiro/models/claude-sonnet-4-5.toml
@@ -1,0 +1,18 @@
+name = "Claude Sonnet 4.5"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/kiro/models/claude-sonnet-4.toml
+++ b/providers/kiro/models/claude-sonnet-4.toml
@@ -1,0 +1,18 @@
+name = "Claude Sonnet 4.0"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/kiro/models/deepseek-3.2.toml
+++ b/providers/kiro/models/deepseek-3.2.toml
@@ -1,0 +1,18 @@
+name = "DeepSeek 3.2"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kiro/models/minimax-m2.1.toml
+++ b/providers/kiro/models/minimax-m2.1.toml
@@ -1,0 +1,18 @@
+name = "MiniMax 2.1"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kiro/models/minimax-m2.5.toml
+++ b/providers/kiro/models/minimax-m2.5.toml
@@ -1,0 +1,18 @@
+name = "MiniMax 2.5"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kiro/models/qwen3-coder-next.toml
+++ b/providers/kiro/models/qwen3-coder-next.toml
@@ -1,0 +1,18 @@
+name = "Qwen3 Coder Next"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 256_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kiro/provider.toml
+++ b/providers/kiro/provider.toml
@@ -1,0 +1,3 @@
+name = "AWS Kiro"
+env = []
+doc = "https://kiro.dev"


### PR DESCRIPTION
## Summary

Adds [AWS Kiro](https://kiro.dev) (CodeWhisperer) as a provider with advertised free-tier models.

Source: [kiro.dev/docs/models](https://kiro.dev/docs/models/)

### Models Added

| Model ID | Display Name | Credits | Context | Cost |
|----------|--------------|---------|---------|------|
| auto | Auto | 1.0x | — | $0 |
| claude-sonnet-4 | Claude Sonnet 4.0 | 1.3x | 200K | $0 |
| claude-sonnet-4-5 | Claude Sonnet 4.5 | 1.3x | 200K | $0 |
| deepseek-3.2 | DeepSeek 3.2 | 0.25x | 128K | $0 |
| minimax-m2.1 | MiniMax 2.1 | 0.15x | 200K | $0 |
| minimax-m2.5 | MiniMax 2.5 | 0.25x | 200K | $0 |
| qwen3-coder-next | Qwen3 Coder Next | 0.05x | 256K | $0 |

### Notes

- All models use AWS Builder ID (Google/GitHub OAuth) for authentication
- Credit multipliers are relative to Auto (1.0x baseline) within Kiro's token system
- Model capabilities (attachment, reasoning, tool_call, open_weights) verified via models.dev/api.json cross-provider lookup
- Kiro is available in us-east-1 and eu-central-1 regions

---
*This PR was generated by an autonomous agent (Kilo/MiMo-V-Omni).*