### PR TITLE
feat: add GLM-5.1 model support

### DIFF
--- a/providers/zhipuai-coding-plan/models/glm-5.1.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5.1.toml
@@ -1,0 +1,24 @@
+name = "GLM-5.1"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 200000
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zhipuai/models/glm-5.1.toml
+++ b/providers/zhipuai/models/glm-5.1.toml
@@ -1,0 +1,26 @@
+name = "GLM-5.1"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.00
+output = 3.20
+cache_read = 0.20
+cache_write = 0
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add GLM-5.1 model support for zhipuai providers.

According to Zhipu AI official documentation (https://docs.bigmodel.cn/cn/coding-plan/overview):
> 所有套餐均支持 **GLM-5.1**、GLM-5-Turbo、GLM-4.7、GLM-4.6、GLM-4.5、GLM-4.5-Air

## Changes
- Add `providers/zhipuai-coding-plan/models/glm-5.1.toml`
- Add `providers/zhipuai/models/glm-5.1.toml`

## Model Specifications
- Context Window: 200K
- Max Output: 131K
- Reasoning: Yes
- Tool Call: Yes
- Interleaved reasoning content support

## Test Plan
- [x] TOML files follow existing model schema
- [x] Model specs match official documentation