### PR TITLE
feat: Add GLM-5.1 model to zai-coding-plan provider

### DIFF
--- a/providers/zai-coding-plan/models/glm-5.1.toml
+++ b/providers/zai-coding-plan/models/glm-5.1.toml
@@ -1,0 +1,26 @@
+name = "GLM-5.1"
+family = "glm"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This PR adds the GLM 5.1 model to the Zai Coding Plan provider. 

I could not find a complete model card for this new model, but this tweet strongly suggests that it uses the same settings as GLM-5 and upon testing this does appear to work properly. 

<img width="783" height="251" alt="glm-5 1" src="https://github.com/user-attachments/assets/ab43637e-6824-4204-aa59-f75a35823dd4" />

### Shown working with an identical config set locally in my `opencode.json`:

<img width="532" height="473" alt="Screenshot 2026-03-27 at 9 04 03 AM" src="https://github.com/user-attachments/assets/16f3829f-dca0-4fee-9840-87a8d8b6afbe" />
9bf815ff" />