### PR TITLE
Add GLM-5.1 model to Z.AI provider

### DIFF
--- a/providers/zai/models/glm-5.1.toml
+++ b/providers/zai/models/glm-5.1.toml
@@ -1,0 +1,26 @@
+name = "GLM-5"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.00
+output = 0.00
+cache_read = 0.00
+cache_write = 0
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Simply add the `glm-5.1` model to the Z.AI provider.

## Note
This model is currently only available on the Z.AI Coding Plan and is not accessible via the public API yet. Pricing is set to $0 as it is not yet available through the standard API.

Model is supposed to public via api and open weights on april 6/7.