### PR TITLE
Smart search, SVG dedup, and infinite scroll

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -45,6 +45,7 @@ body {
   line-height: 1.6;
   color: var(--color-text);
   background-color: var(--color-background);
+  scrollbar-color: var(--color-border) transparent;
 }
 
 body:has(dialog[open]) {
@@ -140,14 +141,14 @@ header {
   .search-container {
     position: relative;
     flex: 1 1 auto;
-    min-width: 12.5rem;
+    min-width: 16rem;
   }
 
   input {
     width: 100%;
     font-size: 0.8125rem;
     line-height: 1.1;
-    padding: 0.5rem 2.5rem 0.5rem 0.625rem;
+    padding: 0.5rem 3.5rem 0.5rem 0.625rem;
     border-radius: 0.25rem;
     border: 1px solid var(--color-border);
     height: 2rem;
@@ -211,6 +212,10 @@ table {
   font-size: 0.875rem;
   width: 100%;
   margin-top: var(--header-height);
+}
+
+table.not-ready {
+  opacity: 0;
 }
 
 thead,
@@ -523,6 +528,26 @@ dialog {
       font-size: 0.8125rem;
       font-family: var(--font-mono);
     }
+
+    .help-table {
+      width: auto;
+      margin-bottom: 0.625rem;
+      margin-top: 0 !important;
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+
+      td {
+        padding: 0.25rem 0.75rem 0.25rem 0;
+        border: none;
+        white-space: normal;
+        color: var(--color-text-secondary);
+      }
+
+      td:first-child {
+        white-space: nowrap;
+        color: var(--color-text);
+      }
+    }
   }
 
   .footer {
@@ -546,4 +571,242 @@ dialog {
     }
   }
 
+}
+
+/* Filter toggle button inside search container */
+.filter-toggle {
+  position: absolute !important;
+  right: 2rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: none !important;
+  background: none !important;
+  color: var(--color-text-tertiary) !important;
+  padding: 0.25rem !important;
+  height: auto !important;
+  border-radius: 0.25rem;
+  transition: color 0.15s ease;
+}
+
+.filter-toggle:hover {
+  color: var(--color-text) !important;
+}
+
+.filter-toggle[aria-expanded="true"] {
+  color: var(--color-brand) !important;
+}
+
+.filter-toggle svg {
+  width: 14px;
+  height: 14px;
+}
+
+.filter-badge {
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  min-width: 10px;
+  height: 12px;
+  border-radius: 8px;
+  background-color: var(--color-brand);
+  color: var(--color-text-invert);
+  font-size: 0.5rem;
+  font-weight: 600;
+  line-height: 13px;
+  text-align: center;
+}
+
+.filter-badge[hidden] {
+  display: none;
+}
+
+/* Filter bar */
+.filter-bar {
+  position: fixed;
+  top: var(--header-height);
+  left: 0;
+  right: 0;
+  z-index: 9;
+  background-color: var(--color-background);
+  border-bottom: 1px solid var(--color-border);
+  overflow-x: auto;
+  overscroll-behavior: contain;
+}
+
+.filter-bar[hidden] {
+  display: none;
+}
+
+.filter-bar-inner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  min-width: max-content;
+}
+
+/* Filter groups */
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex: 0 0 auto;
+}
+
+.filter-group-label {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.filter-chips {
+  display: flex;
+  gap: 0.25rem;
+}
+
+/* Individual filter chips */
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background: none;
+  color: var(--color-text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1;
+  padding: 0.3125rem 0.5rem;
+  border-radius: 1rem;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+  user-select: none;
+}
+
+.filter-chip:hover {
+  border-color: var(--color-text-tertiary);
+  color: var(--color-text-secondary);
+}
+
+.filter-chip.active {
+  border-color: var(--color-brand);
+  background-color: var(--color-brand);
+  color: var(--color-text-invert);
+}
+
+.filter-chip.smart-matched {
+  border-color: var(--color-brand);
+  color: var(--color-brand);
+  animation: smart-pulse 0.6s ease-out;
+}
+
+.filter-chip.smart-matched.active {
+  background-color: var(--color-brand);
+  color: var(--color-text-invert);
+}
+
+@keyframes smart-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(253, 149, 39, 0.4);
+  }
+
+  100% {
+    box-shadow: 0 0 0 6px rgba(253, 149, 39, 0);
+  }
+}
+
+/* Filter actions (count + clear) */
+.filter-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+
+.filter-count {
+  font-size: 0.6875rem;
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+}
+
+.filter-count[hidden] {
+  display: none;
+}
+
+.filter-clear {
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: var(--color-brand);
+  font-size: 0.6875rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  white-space: nowrap;
+}
+
+.filter-clear[hidden] {
+  display: none;
+}
+
+.filter-clear:hover {
+  background-color: var(--color-surface);
+}
+
+/* Adjust table margin when filter bar is visible */
+body.filters-visible table {
+  margin-top: calc(var(--header-height) + var(--filter-bar-height, 44px));
+}
+
+body.filters-visible table thead th {
+  top: calc(var(--header-height) + var(--filter-bar-height, 44px));
+}
+
+/* Mobile: stack filter groups vertically */
+@media (max-width: 45rem) {
+  .filter-bar-inner {
+    flex-wrap: wrap;
+  }
+
+  .filter-group {
+    flex: 1 0 auto;
+  }
+
+  .filter-actions {
+    flex: 1 0 100%;
+    justify-content: space-between;
+  }
+}
+
+/* Ghost rows (Ctrl+F support for off-screen rows) */
+.ghost-container {
+  pointer-events: none;
+}
+
+.ghost-entry {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+/* Scroll sentinel for infinite scroll */
+.scroll-sentinel {
+  height: 1px;
+  width: 100%;
+}
+
+/* Provider logo via <use> ref */
+.provider-logo {
+  flex: 0 0 auto;
 }

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -2,6 +2,15 @@ const modal = document.getElementById("modal") as HTMLDialogElement;
 const modalClose = document.getElementById("close")!;
 const help = document.getElementById("help")!;
 const search = document.getElementById("search")! as HTMLInputElement;
+const filterToggle = document.getElementById("filter-toggle")!;
+const filterBar = document.getElementById("filter-bar")!;
+const filterCountEl = document.getElementById("filter-count")!;
+const filterBadge = document.getElementById("filter-badge")!;
+const clearFiltersBtn = document.getElementById("clear-filters")!;
+const scrollSentinel = document.getElementById("scroll-sentinel")!;
+const scrollSentinelTop = document.getElementById("scroll-sentinel-top")!;
+const ghostContainer = document.getElementById("ghost-container")!;
+const tbody = document.querySelector("table tbody")!;
 
 /////////////////////////
 // URL State Management
@@ -26,14 +35,13 @@ function updateQueryParams(updates: Record<string, string | null>) {
 }
 
 function getColumnNameForURL(headerEl: Element): string {
-  const text = headerEl.textContent?.trim().toLowerCase() || "";
-  return text.replace(/↑|↓/g, "").trim().split(/\s+/).slice(0, 2).join("-");
+  return (headerEl as HTMLElement).dataset.column || "";
 }
 
 function getColumnIndexByUrlName(name: string): number {
   const headers = document.querySelectorAll("th.sortable");
   return Array.from(headers).findIndex(
-    (header) => getColumnNameForURL(header) === name
+    (header) => (header as HTMLElement).dataset.column === name
   );
 }
 
@@ -62,33 +70,37 @@ modal.addEventListener("click", (e) => {
   if (e.target === modal) closeDialog();
 });
 
+/////////////////////////////////////////
+// Infinite Scroll & Pagination State
+/////////////////////////////////////////
+const BATCH_SIZE = 100;
+const MAX_FULL_ROWS = 500;
+let allRows: HTMLTableRowElement[] = [];
+let filteredRows: HTMLTableRowElement[] = [];
+let fullRowStart = 0; // index in filteredRows where full rows begin
+let fullRowEnd = 0;   // index in filteredRows where full rows end (exclusive)
+
 ////////////////////
 // Handle Sorting
 ////////////////////
 let currentSort = { column: -1, direction: "asc" };
+let sortSource: "search" | "header" | "none" = "none";
 
-function sortTable(column: number, direction: "asc" | "desc") {
+function sortFilteredRows(column: number, direction: "asc" | "desc") {
   const header = document.querySelectorAll("th.sortable")[column];
   const columnType = header.getAttribute("data-type");
   if (!columnType) return;
 
-  // update state
   currentSort = { column, direction };
   updateQueryParams({
     sort: getColumnNameForURL(header),
     order: direction,
   });
 
-  // sort rows
-  const tbody = document.querySelector("table tbody")!;
-  const rows = Array.from(
-    tbody.querySelectorAll("tr")
-  ) as HTMLTableRowElement[];
-  rows.sort((a, b) => {
+  filteredRows.sort((a, b) => {
     const aValue = getCellValue(a.cells[column], columnType);
     const bValue = getCellValue(b.cells[column], columnType);
 
-    // Handle undefined values - always sort to bottom
     if (aValue === undefined && bValue === undefined) return 0;
     if (aValue === undefined) return 1;
     if (bValue === undefined) return -1;
@@ -96,27 +108,24 @@ function sortTable(column: number, direction: "asc" | "desc") {
     let comparison = 0;
     if (columnType === "number" || columnType === "modalities") {
       comparison = (aValue as number) - (bValue as number);
-    } else if (columnType === "boolean") {
-      comparison = (aValue as string).localeCompare(bValue as string);
     } else {
       comparison = (aValue as string).localeCompare(bValue as string);
     }
 
     return direction === "asc" ? comparison : -comparison;
   });
-  rows.forEach((row) => tbody.appendChild(row));
 
-  // update sort indicators
+  // Update sort indicators
   const headers = document.querySelectorAll("th.sortable");
-  headers.forEach((header, i) => {
-    const indicator = header.querySelector(".sort-indicator")!;
-
-    if (i === column) {
-      indicator.textContent = direction === "asc" ? "↑" : "↓";
-    } else {
-      indicator.textContent = "";
-    }
+  headers.forEach((h, i) => {
+    const indicator = h.querySelector(".sort-indicator")!;
+    indicator.textContent = i === column ? (direction === "asc" ? "↑" : "↓") : "";
   });
+
+  // Re-render from scratch with new sort order
+  fullRowStart = 0;
+  fullRowEnd = 0;
+  renderView(true);
 }
 
 function getCellValue(
@@ -139,33 +148,874 @@ document.querySelectorAll("th.sortable").forEach((header) => {
       currentSort.column === column && currentSort.direction === "asc"
         ? "desc"
         : "asc";
-    sortTable(column, direction);
+    sortSource = "header";
+    sortFilteredRows(column, direction);
   });
 });
 
-///////////////////
-// Handle Search
-///////////////////
-function filterTable(value: string) {
-  const lowerCaseValues = value.toLowerCase().split(",").filter(str => str.trim() !== "");
-  const rows = document.querySelectorAll(
-    "table tbody tr"
-  ) as NodeListOf<HTMLTableRowElement>;
-
-  rows.forEach((row) => {
-    const cellTexts = Array.from(row.cells).map((cell) =>
-      cell.textContent!.toLowerCase()
-    );
-    const isVisible = lowerCaseValues.length === 0 ||
-     lowerCaseValues.some((lowerCaseValue) => cellTexts.some((text) => text.includes(lowerCaseValue)));
-    row.style.display = isVisible ? "" : "none";
-  });
-
-  updateQueryParams({ search: value || null });
+///////////////////////////
+// Filter State & Types
+///////////////////////////
+interface FilterState {
+  text: string;
+  reasoning: boolean | null;
+  tool_call: boolean | null;
+  open_weights: boolean | null;
+  structured_output: boolean | null;
+  inputModalities: Set<string>;
+  outputModalities: Set<string>;
+  inputCostMax: number | null;
+  inputCostMin: number | null;
+  outputCostMax: number | null;
+  outputCostMin: number | null;
+  contextLimitMin: number | null;
+  contextLimitMax: number | null;
+  outputLimitMin: number | null;
+  outputLimitMax: number | null;
+  provider: string;
+  family: string;
+  hideDeprecated: boolean;
+  hideBeta: boolean;
 }
 
+function createDefaultFilterState(): FilterState {
+  return {
+    text: "",
+    reasoning: null,
+    tool_call: null,
+    open_weights: null,
+    structured_output: null,
+    inputModalities: new Set(),
+    outputModalities: new Set(),
+    inputCostMax: null,
+    inputCostMin: null,
+    outputCostMax: null,
+    outputCostMin: null,
+    contextLimitMin: null,
+    contextLimitMax: null,
+    outputLimitMin: null,
+    outputLimitMax: null,
+    provider: "",
+    family: "",
+    hideDeprecated: false,
+    hideBeta: false,
+  };
+}
+
+///////////////////////////
+// Smart Search Keywords
+///////////////////////////
+interface SmartKeyword {
+  phrase: string;
+  apply: (state: FilterState) => void;
+  chipFilter?: string;
+  sortAction?: { column: string; direction: "asc" | "desc" };
+}
+
+const SMART_KEYWORDS: SmartKeyword[] = [
+  { phrase: "function calling", apply: (s) => { s.tool_call = true; }, chipFilter: "tool_call" },
+  { phrase: "structured output", apply: (s) => { s.structured_output = true; }, chipFilter: "structured_output" },
+  { phrase: "open source", apply: (s) => { s.open_weights = true; }, chipFilter: "open_weights" },
+  { phrase: "open-source", apply: (s) => { s.open_weights = true; }, chipFilter: "open_weights" },
+  { phrase: "open weights", apply: (s) => { s.open_weights = true; }, chipFilter: "open_weights" },
+  { phrase: "open-weights", apply: (s) => { s.open_weights = true; }, chipFilter: "open_weights" },
+  { phrase: "json mode", apply: (s) => { s.structured_output = true; }, chipFilter: "structured_output" },
+  { phrase: "tool call", apply: (s) => { s.tool_call = true; }, chipFilter: "tool_call" },
+  { phrase: "tool calling", apply: (s) => { s.tool_call = true; }, chipFilter: "tool_call" },
+  { phrase: "image input", apply: (s) => { s.inputModalities.add("image"); }, chipFilter: "input-image" },
+  { phrase: "audio input", apply: (s) => { s.inputModalities.add("audio"); }, chipFilter: "input-audio" },
+  { phrase: "video input", apply: (s) => { s.inputModalities.add("video"); }, chipFilter: "input-video" },
+  { phrase: "image output", apply: (s) => { s.outputModalities.add("image"); }, chipFilter: "output-image" },
+  { phrase: "image generation", apply: (s) => { s.outputModalities.add("image"); }, chipFilter: "output-image" },
+  { phrase: "audio output", apply: (s) => { s.outputModalities.add("audio"); }, chipFilter: "output-audio" },
+  { phrase: "video output", apply: (s) => { s.outputModalities.add("video"); }, chipFilter: "output-video" },
+  { phrase: "long context", apply: (s) => { s.contextLimitMin = 100000; } },
+  { phrase: "large context", apply: (s) => { s.contextLimitMin = 100000; } },
+  { phrase: "hide deprecated", apply: (s) => { s.hideDeprecated = true; }, chipFilter: "hide-deprecated" },
+  { phrase: "hide beta", apply: (s) => { s.hideBeta = true; }, chipFilter: "hide-beta" },
+  { phrase: "reasoning", apply: (s) => { s.reasoning = true; }, chipFilter: "reasoning" },
+  { phrase: "thinking", apply: (s) => { s.reasoning = true; }, chipFilter: "reasoning" },
+  { phrase: "thinks", apply: (s) => { s.reasoning = true; }, chipFilter: "reasoning" },
+  { phrase: "reason", apply: (s) => { s.reasoning = true; }, chipFilter: "reasoning" },
+  { phrase: "tools", apply: (s) => { s.tool_call = true; }, chipFilter: "tool_call" },
+  { phrase: "tool", apply: (s) => { s.tool_call = true; }, chipFilter: "tool_call" },
+  { phrase: "structured", apply: (s) => { s.structured_output = true; }, chipFilter: "structured_output" },
+  { phrase: "json", apply: (s) => { s.structured_output = true; }, chipFilter: "structured_output" },
+  { phrase: "oss", apply: (s) => { s.open_weights = true; }, chipFilter: "open_weights" },
+  { phrase: "vision", apply: (s) => { s.inputModalities.add("image"); }, chipFilter: "input-image" },
+  { phrase: "multimodal", apply: (s) => { s.inputModalities.add("image"); }, chipFilter: "input-image" },
+  { phrase: "image", apply: (s) => { s.inputModalities.add("image"); }, chipFilter: "input-image" },
+  { phrase: "audio", apply: (s) => { s.inputModalities.add("audio"); }, chipFilter: "input-audio" },
+  { phrase: "voice", apply: (s) => { s.inputModalities.add("audio"); }, chipFilter: "input-audio" },
+  { phrase: "video", apply: (s) => { s.inputModalities.add("video"); }, chipFilter: "input-video" },
+  { phrase: "pdf", apply: (s) => { s.inputModalities.add("pdf"); }, chipFilter: "input-pdf" },
+  { phrase: "tts", apply: (s) => { s.outputModalities.add("audio"); }, chipFilter: "output-audio" },
+  { phrase: "speech", apply: (s) => { s.outputModalities.add("audio"); }, chipFilter: "output-audio" },
+  { phrase: "free", apply: (s) => { s.inputCostMax = 0; s.outputCostMax = 0; } },
+];
+
+const SORTED_KEYWORDS = [...SMART_KEYWORDS].sort((a, b) => b.phrase.length - a.phrase.length);
+const NOISE_WORDS = new Set(["models", "model", "with", "and", "that", "the", "for", "can", "has", "have", "are", "is", "a", "an", "on", "of", "to", "or"]);
+
+///////////////////////////
+// Smart Search Parser
+///////////////////////////
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const MODALITIES = new Set(["text", "image", "audio", "video", "pdf"]);
+
+const SORT_ALIASES: Record<string, string> = {
+  "input": "input-cost",
+  "output": "output-cost",
+  "cache-r": "cache-read-cost",
+  "cache-w": "cache-write-cost",
+  "audio-in": "audio-input-cost",
+  "audio-out": "audio-output-cost",
+  "context": "context-limit",
+  "update": "last-updated",
+  "release": "release-date",
+  "reasoning": "reasoning-cost",
+};
+
+function parseNumericFilter(value: string): { op: "<" | ">"; num: number } | null {
+  const m = value.match(/^([<>])(\d+(?:\.\d+)?)(k|m)?$/i);
+  if (!m) return null;
+  let num = parseFloat(m[2]);
+  if (m[3]?.toLowerCase() === "k") num *= 1000;
+  if (m[3]?.toLowerCase() === "m") num *= 1000000;
+  return { op: m[1] as "<" | ">", num };
+}
+
+interface ParseResult {
+  state: FilterState;
+  matchedChips: Set<string>;
+  sortActions: Array<{ column: string; direction: "asc" | "desc" }>;
+}
+
+function parseSmartSearch(query: string): ParseResult {
+  const state = createDefaultFilterState();
+  let remaining = query.toLowerCase().trim();
+  const matchedChips = new Set<string>();
+  const sortActions: Array<{ column: string; direction: "asc" | "desc" }> = [];
+
+  if (!remaining) {
+    return { state, matchedChips, sortActions };
+  }
+
+  // 1. Extract keyword filters (prefix:value)
+  const keywordRegex = /(?:^|\s)(in|out|ctx|outlimit|provider|p|family|f|status|sort):(\S+)/gi;
+  let kwMatch;
+  while ((kwMatch = keywordRegex.exec(remaining)) !== null) {
+    const prefix = kwMatch[1].toLowerCase();
+    const value = kwMatch[2].toLowerCase();
+
+    switch (prefix) {
+      case "in": {
+        if (MODALITIES.has(value)) {
+          state.inputModalities.add(value);
+          matchedChips.add(`input-${value}`);
+        } else {
+          const parsed = parseNumericFilter(value);
+          if (parsed) {
+            if (parsed.op === "<") state.inputCostMax = parsed.num;
+            else state.inputCostMin = parsed.num;
+          }
+        }
+        break;
+      }
+      case "out": {
+        if (MODALITIES.has(value)) {
+          state.outputModalities.add(value);
+          matchedChips.add(`output-${value}`);
+        } else {
+          const parsed = parseNumericFilter(value);
+          if (parsed) {
+            if (parsed.op === "<") state.outputCostMax = parsed.num;
+            else state.outputCostMin = parsed.num;
+          }
+        }
+        break;
+      }
+      case "ctx": {
+        const parsed = parseNumericFilter(value);
+        if (parsed) {
+          if (parsed.op === ">") state.contextLimitMin = parsed.num;
+          else state.contextLimitMax = parsed.num;
+        }
+        break;
+      }
+      case "outlimit": {
+        const parsed = parseNumericFilter(value);
+        if (parsed) {
+          if (parsed.op === ">") state.outputLimitMin = parsed.num;
+          else state.outputLimitMax = parsed.num;
+        }
+        break;
+      }
+      case "provider": case "p":
+        state.provider = value;
+        break;
+      case "family": case "f":
+        state.family = value;
+        break;
+      case "status":
+        if (value === "deprecated") state.hideDeprecated = true;
+        else if (value === "beta") state.hideBeta = true;
+        break;
+      case "sort": {
+        let dir: "asc" | "desc" = "asc";
+        let col = value;
+        if (col.startsWith("-")) { dir = "desc"; col = col.slice(1); }
+        sortActions.push({ column: SORT_ALIASES[col] || col, direction: dir });
+        break;
+      }
+    }
+  }
+  // Remove matched keyword filters from remaining
+  remaining = remaining.replace(keywordRegex, " ").trim();
+
+  // 2. Natural-language keyword matching
+  for (const kw of SORTED_KEYWORDS) {
+    const regex = new RegExp(`\\b${escapeRegex(kw.phrase)}\\b`, "i");
+    if (regex.test(remaining)) {
+      kw.apply(state);
+      if (kw.chipFilter) matchedChips.add(kw.chipFilter);
+      if (kw.sortAction) sortActions.push(kw.sortAction);
+      remaining = remaining.replace(regex, " ").trim();
+    }
+  }
+
+  // 3. Remaining words become AND text terms
+  const words = remaining.split(/\s+/).filter(Boolean);
+  const unmatchedWords: string[] = [];
+  for (const word of words) {
+    if (NOISE_WORDS.has(word)) continue;
+    unmatchedWords.push(word);
+  }
+
+  state.text = unmatchedWords.join(" ");
+  return { state, matchedChips, sortActions };
+}
+
+///////////////////////////
+// Filter Engine
+///////////////////////////
+function applyFiltersToArray(state: FilterState): HTMLTableRowElement[] {
+  return allRows.filter((row) => {
+    const d = row.dataset;
+
+    if (state.reasoning !== null && (d.reasoning === "1") !== state.reasoning) return false;
+    if (state.tool_call !== null && (d.toolCall === "1") !== state.tool_call) return false;
+    if (state.open_weights !== null && (d.openWeights === "1") !== state.open_weights) return false;
+    if (state.structured_output !== null) {
+      if (d.structuredOutput !== "" && (d.structuredOutput === "1") !== state.structured_output) return false;
+    }
+
+    if (state.inputModalities.size > 0) {
+      const rowMods = d.inputModalities?.split(",") ?? [];
+      for (const mod of state.inputModalities) {
+        if (!rowMods.includes(mod)) return false;
+      }
+    }
+
+    if (state.outputModalities.size > 0) {
+      const rowMods = d.outputModalities?.split(",") ?? [];
+      for (const mod of state.outputModalities) {
+        if (!rowMods.includes(mod)) return false;
+      }
+    }
+
+    if (state.inputCostMax !== null) {
+      const cost = d.inputCost ? parseFloat(d.inputCost) : null;
+      if (cost === null || cost > state.inputCostMax) return false;
+    }
+    if (state.inputCostMin !== null) {
+      const cost = d.inputCost ? parseFloat(d.inputCost) : null;
+      if (cost === null || cost < state.inputCostMin) return false;
+    }
+    if (state.outputCostMax !== null) {
+      const cost = d.outputCost ? parseFloat(d.outputCost) : null;
+      if (cost === null || cost > state.outputCostMax) return false;
+    }
+    if (state.outputCostMin !== null) {
+      const cost = d.outputCost ? parseFloat(d.outputCost) : null;
+      if (cost === null || cost < state.outputCostMin) return false;
+    }
+    if (state.contextLimitMin !== null) {
+      const limit = d.contextLimit ? parseFloat(d.contextLimit) : 0;
+      if (limit < state.contextLimitMin) return false;
+    }
+    if (state.contextLimitMax !== null) {
+      const limit = d.contextLimit ? parseFloat(d.contextLimit) : 0;
+      if (limit > state.contextLimitMax) return false;
+    }
+    if (state.outputLimitMin !== null) {
+      const limit = d.outputLimit ? parseFloat(d.outputLimit) : 0;
+      if (limit < state.outputLimitMin) return false;
+    }
+    if (state.outputLimitMax !== null) {
+      const limit = d.outputLimit ? parseFloat(d.outputLimit) : 0;
+      if (limit > state.outputLimitMax) return false;
+    }
+
+    if (state.provider) {
+      if (!(d.provider?.includes(state.provider) || d.providerId?.includes(state.provider))) return false;
+    }
+
+    if (state.family) {
+      if (!d.family?.includes(state.family)) return false;
+    }
+
+    if (state.hideDeprecated && d.status === "deprecated") return false;
+    if (state.hideBeta && d.status === "beta") return false;
+
+    // AND logic: every word must match in at least one cell
+    if (state.text) {
+      const terms = state.text.split(/\s+/).filter(Boolean);
+      if (terms.length > 0) {
+        const cellTexts = Array.from(row.cells).map(c => c.textContent!.toLowerCase());
+        if (!terms.every(term => cellTexts.some(text => text.includes(term)))) return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+///////////////////////////
+// Chip State Management
+///////////////////////////
+let chipState = createDefaultFilterState();
+let lastParseResult: ParseResult = { state: createDefaultFilterState(), matchedChips: new Set(), sortActions: [] };
+
+const CHIP_TOGGLE_MAP: Record<string, (state: FilterState) => boolean> = {
+  "reasoning": (s) => { s.reasoning = s.reasoning === null ? true : null; return s.reasoning !== null; },
+  "tool_call": (s) => { s.tool_call = s.tool_call === null ? true : null; return s.tool_call !== null; },
+  "open_weights": (s) => { s.open_weights = s.open_weights === null ? true : null; return s.open_weights !== null; },
+  "structured_output": (s) => { s.structured_output = s.structured_output === null ? true : null; return s.structured_output !== null; },
+  "input-text": (s) => { return toggleSet(s.inputModalities, "text"); },
+  "input-image": (s) => { return toggleSet(s.inputModalities, "image"); },
+  "input-audio": (s) => { return toggleSet(s.inputModalities, "audio"); },
+  "input-video": (s) => { return toggleSet(s.inputModalities, "video"); },
+  "input-pdf": (s) => { return toggleSet(s.inputModalities, "pdf"); },
+  "output-text": (s) => { return toggleSet(s.outputModalities, "text"); },
+  "output-image": (s) => { return toggleSet(s.outputModalities, "image"); },
+  "output-audio": (s) => { return toggleSet(s.outputModalities, "audio"); },
+  "output-video": (s) => { return toggleSet(s.outputModalities, "video"); },
+  "hide-deprecated": (s) => { s.hideDeprecated = !s.hideDeprecated; return s.hideDeprecated; },
+  "hide-beta": (s) => { s.hideBeta = !s.hideBeta; return s.hideBeta; },
+};
+
+function toggleSet(set: Set<string>, value: string): boolean {
+  if (set.has(value)) { set.delete(value); return false; }
+  set.add(value);
+  return true;
+}
+
+///////////////////////////
+// Merge States
+///////////////////////////
+function computeFinalState(): FilterState {
+  const final = createDefaultFilterState();
+  const smart = lastParseResult.state;
+
+  final.text = smart.text;
+  final.reasoning = smart.reasoning;
+  final.tool_call = smart.tool_call;
+  final.open_weights = smart.open_weights;
+  final.structured_output = smart.structured_output;
+  for (const m of smart.inputModalities) final.inputModalities.add(m);
+  for (const m of smart.outputModalities) final.outputModalities.add(m);
+  final.inputCostMax = smart.inputCostMax;
+  final.inputCostMin = smart.inputCostMin;
+  final.outputCostMax = smart.outputCostMax;
+  final.outputCostMin = smart.outputCostMin;
+  final.contextLimitMin = smart.contextLimitMin;
+  final.contextLimitMax = smart.contextLimitMax;
+  final.outputLimitMin = smart.outputLimitMin;
+  final.outputLimitMax = smart.outputLimitMax;
+  final.provider = smart.provider;
+  final.family = smart.family;
+  final.hideDeprecated = smart.hideDeprecated;
+  final.hideBeta = smart.hideBeta;
+
+  if (chipState.reasoning !== null) final.reasoning = chipState.reasoning;
+  if (chipState.tool_call !== null) final.tool_call = chipState.tool_call;
+  if (chipState.open_weights !== null) final.open_weights = chipState.open_weights;
+  if (chipState.structured_output !== null) final.structured_output = chipState.structured_output;
+  for (const m of chipState.inputModalities) final.inputModalities.add(m);
+  for (const m of chipState.outputModalities) final.outputModalities.add(m);
+  if (chipState.hideDeprecated) final.hideDeprecated = true;
+  if (chipState.hideBeta) final.hideBeta = true;
+
+  return final;
+}
+
+///////////////////////////
+// UI Sync
+///////////////////////////
+function syncChipUI(finalState: FilterState) {
+  const chips = document.querySelectorAll(".filter-chip") as NodeListOf<HTMLButtonElement>;
+  chips.forEach((chip) => {
+    const filter = chip.dataset.filter!;
+    let isActive = false;
+    const isSmartMatched = lastParseResult.matchedChips.has(filter);
+
+    switch (filter) {
+      case "reasoning": isActive = finalState.reasoning === true; break;
+      case "tool_call": isActive = finalState.tool_call === true; break;
+      case "open_weights": isActive = finalState.open_weights === true; break;
+      case "structured_output": isActive = finalState.structured_output === true; break;
+      case "input-text": isActive = finalState.inputModalities.has("text"); break;
+      case "input-image": isActive = finalState.inputModalities.has("image"); break;
+      case "input-audio": isActive = finalState.inputModalities.has("audio"); break;
+      case "input-video": isActive = finalState.inputModalities.has("video"); break;
+      case "input-pdf": isActive = finalState.inputModalities.has("pdf"); break;
+      case "output-text": isActive = finalState.outputModalities.has("text"); break;
+      case "output-image": isActive = finalState.outputModalities.has("image"); break;
+      case "output-audio": isActive = finalState.outputModalities.has("audio"); break;
+      case "output-video": isActive = finalState.outputModalities.has("video"); break;
+      case "hide-deprecated": isActive = finalState.hideDeprecated; break;
+      case "hide-beta": isActive = finalState.hideBeta; break;
+    }
+
+    chip.classList.toggle("active", isActive);
+    chip.classList.toggle("smart-matched", isSmartMatched && isActive);
+  });
+}
+
+function countActiveFilters(state: FilterState): number {
+  let count = 0;
+  if (state.reasoning !== null) count++;
+  if (state.tool_call !== null) count++;
+  if (state.open_weights !== null) count++;
+  if (state.structured_output !== null) count++;
+  count += state.inputModalities.size;
+  count += state.outputModalities.size;
+  if (state.inputCostMax !== null) count++;
+  if (state.inputCostMin !== null) count++;
+  if (state.outputCostMax !== null) count++;
+  if (state.outputCostMin !== null) count++;
+  if (state.contextLimitMin !== null) count++;
+  if (state.contextLimitMax !== null) count++;
+  if (state.outputLimitMin !== null) count++;
+  if (state.outputLimitMax !== null) count++;
+  if (state.provider) count++;
+  if (state.family) count++;
+  if (state.hideDeprecated) count++;
+  if (state.hideBeta) count++;
+  return count;
+}
+
+function updateFilterUI(state: FilterState) {
+  const activeCount = countActiveFilters(state);
+  const hasFilters = activeCount > 0 || state.text;
+
+  if (hasFilters) {
+    filterCountEl.textContent = `${filteredRows.length.toLocaleString()} of ${allRows.length.toLocaleString()} models`;
+    filterCountEl.hidden = false;
+    clearFiltersBtn.hidden = false;
+  } else {
+    filterCountEl.hidden = true;
+    clearFiltersBtn.hidden = true;
+  }
+
+  if (activeCount > 0) {
+    filterBadge.textContent = String(activeCount);
+    filterBadge.hidden = false;
+  } else {
+    filterBadge.hidden = true;
+  }
+}
+
+///////////////////////////
+// URL Persistence
+///////////////////////////
+function filterStateToURLParams(state: FilterState): Record<string, string | null> {
+  return {
+    search: search.value || null,
+    reasoning: state.reasoning === true ? "1" : null,
+    tool_call: state.tool_call === true ? "1" : null,
+    open_weights: state.open_weights === true ? "1" : null,
+    structured_output: state.structured_output === true ? "1" : null,
+    input: state.inputModalities.size > 0 ? Array.from(state.inputModalities).join(",") : null,
+    output: state.outputModalities.size > 0 ? Array.from(state.outputModalities).join(",") : null,
+    max_input_cost: state.inputCostMax !== null ? String(state.inputCostMax) : null,
+    min_input_cost: state.inputCostMin !== null ? String(state.inputCostMin) : null,
+    max_output_cost: state.outputCostMax !== null ? String(state.outputCostMax) : null,
+    min_output_cost: state.outputCostMin !== null ? String(state.outputCostMin) : null,
+    min_context: state.contextLimitMin !== null ? String(state.contextLimitMin) : null,
+    max_context: state.contextLimitMax !== null ? String(state.contextLimitMax) : null,
+    min_output_limit: state.outputLimitMin !== null ? String(state.outputLimitMin) : null,
+    max_output_limit: state.outputLimitMax !== null ? String(state.outputLimitMax) : null,
+    provider: state.provider || null,
+    family: state.family || null,
+    hide_deprecated: state.hideDeprecated ? "1" : null,
+    hide_beta: state.hideBeta ? "1" : null,
+  };
+}
+
+function urlParamsToChipState(params: URLSearchParams): FilterState {
+  const state = createDefaultFilterState();
+  if (params.get("reasoning") === "1") state.reasoning = true;
+  if (params.get("tool_call") === "1") state.tool_call = true;
+  if (params.get("open_weights") === "1") state.open_weights = true;
+  if (params.get("structured_output") === "1") state.structured_output = true;
+  const inputMods = params.get("input");
+  if (inputMods) inputMods.split(",").forEach(m => state.inputModalities.add(m));
+  const outputMods = params.get("output");
+  if (outputMods) outputMods.split(",").forEach(m => state.outputModalities.add(m));
+  const maxIn = params.get("max_input_cost");
+  if (maxIn) state.inputCostMax = parseFloat(maxIn);
+  const minIn = params.get("min_input_cost");
+  if (minIn) state.inputCostMin = parseFloat(minIn);
+  const maxOut = params.get("max_output_cost");
+  if (maxOut) state.outputCostMax = parseFloat(maxOut);
+  const minOut = params.get("min_output_cost");
+  if (minOut) state.outputCostMin = parseFloat(minOut);
+  const minCtx = params.get("min_context");
+  if (minCtx) state.contextLimitMin = parseFloat(minCtx);
+  const maxCtx = params.get("max_context");
+  if (maxCtx) state.contextLimitMax = parseFloat(maxCtx);
+  const minOl = params.get("min_output_limit");
+  if (minOl) state.outputLimitMin = parseFloat(minOl);
+  const maxOl = params.get("max_output_limit");
+  if (maxOl) state.outputLimitMax = parseFloat(maxOl);
+  state.provider = params.get("provider") ?? "";
+  state.family = params.get("family") ?? "";
+  state.hideDeprecated = params.get("hide_deprecated") === "1";
+  state.hideBeta = params.get("hide_beta") === "1";
+  return state;
+}
+
+/////////////////////////////////////
+// Render Engine (Infinite Scroll)
+// Sliding window: at most MAX_FULL_ROWS full rows in DOM.
+// Everything outside [fullRowStart, fullRowEnd) is a ghost row.
+/////////////////////////////////////
+
+// Feature-detect hidden="until-found" support
+const supportsHiddenUntilFound = (() => {
+  const el = document.createElement("div");
+  el.setAttribute("hidden", "until-found");
+  return el.hidden !== true; // if supported, .hidden returns false
+})();
+
+function navigateToGhost(targetIdx: number) {
+  if (targetIdx >= fullRowStart && targetIdx < fullRowEnd) return;
+
+  const halfWindow = Math.floor(MAX_FULL_ROWS / 2);
+  fullRowStart = Math.max(0, targetIdx - halfWindow);
+  fullRowEnd = Math.min(fullRowStart + MAX_FULL_ROWS, filteredRows.length);
+  if (fullRowEnd - fullRowStart < MAX_FULL_ROWS) {
+    fullRowStart = Math.max(0, fullRowEnd - MAX_FULL_ROWS);
+  }
+
+  renderView();
+
+  const fullRow = filteredRows[targetIdx];
+  if (fullRow.parentElement) {
+    fullRow.scrollIntoView({ block: "center" });
+  }
+}
+
+function createGhostEntry(i: number): HTMLDivElement {
+  const row = filteredRows[i];
+  const ghost = document.createElement("div");
+  ghost.className = "ghost-entry";
+  ghost.dataset.ghostIndex = String(i);
+  const d = row.dataset;
+  ghost.textContent = `${d.provider} ${d.model} ${d.family || ""} ${d.providerId} ${d.modelId}`;
+
+  if (supportsHiddenUntilFound) {
+    ghost.setAttribute("hidden", "until-found");
+    ghost.addEventListener("beforematch", () => {
+      // Re-hide immediately so it doesn't flash visible
+      ghost.setAttribute("hidden", "until-found");
+      navigateToGhost(parseInt(ghost.dataset.ghostIndex!));
+    });
+  }
+
+  return ghost;
+}
+
+// Fallback: detect Ctrl+F landing on a ghost via selectionchange
+if (!supportsHiddenUntilFound) {
+  document.addEventListener("selectionchange", () => {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return;
+    const node = sel.getRangeAt(0).startContainer;
+    const ghost = (node.nodeType === Node.TEXT_NODE
+      ? node.parentElement
+      : node as Element
+    )?.closest(".ghost-entry") as HTMLElement | null;
+    if (ghost && ghost.dataset.ghostIndex) {
+      navigateToGhost(parseInt(ghost.dataset.ghostIndex));
+    }
+  });
+}
+
+// Deferred ghost building — populate ghost container in idle time
+const rIC = typeof requestIdleCallback === "function"
+  ? requestIdleCallback
+  : (cb: () => void) => setTimeout(cb, 1) as unknown as number;
+const cIC = typeof cancelIdleCallback === "function"
+  ? cancelIdleCallback
+  : (id: number) => clearTimeout(id);
+
+let ghostBuildId = 0;
+const GHOST_BATCH = 500;
+
+function scheduleGhostBuild() {
+  // Cancel any in-progress ghost build
+  if (ghostBuildId) cIC(ghostBuildId);
+  ghostContainer.textContent = "";
+
+  // Collect indices that need ghost entries
+  const indices: number[] = [];
+  for (let i = 0; i < filteredRows.length; i++) {
+    if (i >= fullRowStart && i < fullRowEnd) continue;
+    indices.push(i);
+  }
+
+  let offset = 0;
+  function buildBatch() {
+    const fragment = document.createDocumentFragment();
+    const end = Math.min(offset + GHOST_BATCH, indices.length);
+    for (let j = offset; j < end; j++) {
+      fragment.appendChild(createGhostEntry(indices[j]));
+    }
+    ghostContainer.appendChild(fragment);
+    offset = end;
+    if (offset < indices.length) {
+      ghostBuildId = rIC(buildBatch);
+    } else {
+      ghostBuildId = 0;
+    }
+  }
+
+  if (indices.length > 0) {
+    ghostBuildId = rIC(buildBatch);
+  }
+}
+
+// Full rebuild of tbody from current window state, ghosts deferred
+function renderView(reset = false) {
+  if (reset) {
+    fullRowEnd = Math.min(fullRowStart + BATCH_SIZE, filteredRows.length);
+  }
+
+  // Clamp window to MAX_FULL_ROWS
+  if (fullRowEnd - fullRowStart > MAX_FULL_ROWS) {
+    fullRowStart = fullRowEnd - MAX_FULL_ROWS;
+  }
+
+  // Clear tbody — only full rows live here
+  while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
+  for (let i = fullRowStart; i < fullRowEnd; i++) {
+    tbody.appendChild(filteredRows[i]);
+  }
+
+  // Build ghosts in idle time
+  scheduleGhostBuild();
+}
+
+// Extend window downward (infinite scroll)
+function extendWindow() {
+  if (fullRowEnd >= filteredRows.length) return;
+
+  const newEnd = Math.min(fullRowEnd + BATCH_SIZE, filteredRows.length);
+
+  // Append new full rows to tbody
+  for (let i = fullRowEnd; i < newEnd; i++) {
+    tbody.appendChild(filteredRows[i]);
+  }
+
+  fullRowEnd = newEnd;
+
+  // Trim front if window exceeds MAX_FULL_ROWS
+  if (fullRowEnd - fullRowStart > MAX_FULL_ROWS) {
+    const newStart = fullRowEnd - MAX_FULL_ROWS;
+    for (let i = fullRowStart; i < newStart; i++) {
+      tbody.removeChild(tbody.firstChild!);
+    }
+    fullRowStart = newStart;
+  }
+
+  // Rebuild ghosts in idle time
+  scheduleGhostBuild();
+}
+
+
+// Extend window upward (scroll up recovery)
+function extendWindowUp() {
+  if (fullRowStart <= 0) return;
+
+  const newStart = Math.max(0, fullRowStart - BATCH_SIZE);
+
+  // Prepend rows to the top of tbody
+  const firstChild = tbody.firstChild;
+  for (let i = newStart; i < fullRowStart; i++) {
+    tbody.insertBefore(filteredRows[i], firstChild);
+  }
+
+  fullRowStart = newStart;
+
+  // Trim back if window exceeds MAX_FULL_ROWS
+  if (fullRowEnd - fullRowStart > MAX_FULL_ROWS) {
+    const newEnd = fullRowStart + MAX_FULL_ROWS;
+    for (let i = fullRowEnd - 1; i >= newEnd; i--) {
+      tbody.removeChild(tbody.lastChild!);
+    }
+    fullRowEnd = newEnd;
+  }
+
+  // Rebuild ghosts in idle time
+  scheduleGhostBuild();
+}
+
+// IntersectionObserver for infinite scroll (bottom)
+const scrollObserver = new IntersectionObserver((entries) => {
+  if (entries[0].isIntersecting && fullRowEnd < filteredRows.length) {
+    extendWindow();
+  }
+}, { rootMargin: "400px" });
+
+scrollObserver.observe(scrollSentinel);
+
+// IntersectionObserver for scroll-up recovery (top)
+const scrollObserverTop = new IntersectionObserver((entries) => {
+  if (entries[0].isIntersecting && fullRowStart > 0) {
+    extendWindowUp();
+  }
+}, { rootMargin: "400px" });
+
+scrollObserverTop.observe(scrollSentinelTop);
+
+///////////////////////////
+// Main Apply Function
+///////////////////////////
+function applyAll() {
+  const final = computeFinalState();
+  filteredRows = applyFiltersToArray(final);
+
+  // Apply sort actions from smart search
+  if (lastParseResult.sortActions.length > 0) {
+    for (const action of lastParseResult.sortActions) {
+      const colIdx = getColumnIndexByUrlName(action.column);
+      if (colIdx !== -1) {
+        currentSort = { column: colIdx, direction: action.direction };
+        sortSource = "search";
+        const headers = document.querySelectorAll("th.sortable");
+        headers.forEach((h, i) => {
+          const indicator = h.querySelector(".sort-indicator")!;
+          indicator.textContent = i === colIdx ? (action.direction === "asc" ? "↑" : "↓") : "";
+        });
+      }
+    }
+  } else if (sortSource === "search") {
+    // Search sort keyword was removed — reset sort
+    currentSort = { column: -1, direction: "asc" };
+    sortSource = "none";
+    document.querySelectorAll("th.sortable .sort-indicator").forEach((el) => {
+      el.textContent = "";
+    });
+    updateQueryParams({ sort: null, order: null });
+  }
+
+  // Re-apply current sort if active
+  if (currentSort.column !== -1) {
+    const header = document.querySelectorAll("th.sortable")[currentSort.column];
+    const columnType = header?.getAttribute("data-type");
+    if (columnType) {
+      filteredRows.sort((a, b) => {
+        const aVal = getCellValue(a.cells[currentSort.column], columnType);
+        const bVal = getCellValue(b.cells[currentSort.column], columnType);
+        if (aVal === undefined && bVal === undefined) return 0;
+        if (aVal === undefined) return 1;
+        if (bVal === undefined) return -1;
+        let cmp = 0;
+        if (columnType === "number" || columnType === "modalities") {
+          cmp = (aVal as number) - (bVal as number);
+        } else {
+          cmp = (aVal as string).localeCompare(bVal as string);
+        }
+        return currentSort.direction === "asc" ? cmp : -cmp;
+      });
+    }
+  }
+
+  fullRowStart = 0;
+  fullRowEnd = 0;
+  renderView(true);
+
+  syncChipUI(final);
+  updateFilterUI(final);
+  updateQueryParams(filterStateToURLParams(final));
+}
+
+///////////////////////////
+// Filter Bar Toggle
+///////////////////////////
+function showFilterBar() {
+  filterBar.hidden = false;
+  filterToggle.setAttribute("aria-expanded", "true");
+  document.body.classList.add("filters-visible");
+  const height = filterBar.offsetHeight;
+  document.documentElement.style.setProperty("--filter-bar-height", `${height}px`);
+}
+
+function hideFilterBar() {
+  filterBar.hidden = true;
+  filterToggle.setAttribute("aria-expanded", "false");
+  document.body.classList.remove("filters-visible");
+}
+
+filterToggle.addEventListener("click", () => {
+  if (filterBar.hidden) {
+    showFilterBar();
+  } else {
+    hideFilterBar();
+  }
+});
+
+///////////////////////////
+// Chip Click Handlers
+///////////////////////////
+document.querySelectorAll(".filter-chip").forEach((chip) => {
+  chip.addEventListener("click", () => {
+    const filter = (chip as HTMLElement).dataset.filter!;
+    const toggleFn = CHIP_TOGGLE_MAP[filter];
+    if (toggleFn) {
+      toggleFn(chipState);
+      applyAll();
+    }
+  });
+});
+
+///////////////////////////
+// Clear All Filters
+///////////////////////////
+clearFiltersBtn.addEventListener("click", () => {
+  chipState = createDefaultFilterState();
+  search.value = "";
+  lastParseResult = { state: createDefaultFilterState(), matchedChips: new Set(), sortActions: [] };
+  applyAll();
+});
+
+///////////////////////////
+// Search Input Handler
+///////////////////////////
 search.addEventListener("input", () => {
-  filterTable(search.value);
+  lastParseResult = parseSmartSearch(search.value);
+
+  if (lastParseResult.matchedChips.size > 0 && filterBar.hidden) {
+    showFilterBar();
+  }
+
+  applyAll();
 });
 
 document.addEventListener("keydown", (e) => {
@@ -178,7 +1028,9 @@ document.addEventListener("keydown", (e) => {
 search.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
     search.value = "";
-    search.dispatchEvent(new Event("input"));
+    chipState = createDefaultFilterState();
+    lastParseResult = { state: createDefaultFilterState(), matchedChips: new Set(), sortActions: [] };
+    applyAll();
   }
 });
 
@@ -192,15 +1044,10 @@ search.addEventListener("keydown", (e) => {
   try {
     if (navigator.clipboard) {
       await navigator.clipboard.writeText(modelId);
-
-      // Switch to check icon
       const copyIcon = button.querySelector(".copy-icon") as HTMLElement;
       const checkIcon = button.querySelector(".check-icon") as HTMLElement;
-
       copyIcon.style.display = "none";
       checkIcon.style.display = "block";
-
-      // Switch back after 1 second
       setTimeout(() => {
         copyIcon.style.display = "block";
         checkIcon.style.display = "none";
@@ -212,29 +1059,70 @@ search.addEventListener("keydown", (e) => {
 };
 
 ///////////////////////////////////
-// Initialize State from URL
+// Initialize
 ///////////////////////////////////
-function initializeFromURL() {
+function initialize() {
+  const table = document.querySelector("table")!;
+
+  // Grab refs to all rows, then clear tbody in one shot (avoids per-row reflow)
+  allRows = Array.from(tbody.querySelectorAll("tr")) as HTMLTableRowElement[];
+  tbody.textContent = "";
+
+  // Initialize from URL
   const params = getQueryParams();
 
-  (() => {
-    const searchQuery = params.get("search");
-    if (!searchQuery) return;
+  const searchQuery = params.get("search");
+  if (searchQuery) {
     search.value = searchQuery;
-    filterTable(searchQuery);
-  })();
+    lastParseResult = parseSmartSearch(searchQuery);
+  }
 
-  (() => {
-    const columnName = params.get("sort");
-    if (!columnName) return;
+  chipState = urlParamsToChipState(params);
 
+  const hasChipFilters = countActiveFilters(chipState) > 0;
+  const hasSmartFilters = lastParseResult.matchedChips.size > 0;
+  if (hasChipFilters || hasSmartFilters) {
+    showFilterBar();
+  }
+
+  // Apply all filters and render first batch
+  applyAll();
+
+  // Restore sort
+  const columnName = params.get("sort");
+  if (columnName) {
     const columnIndex = getColumnIndexByUrlName(columnName);
-    if (columnIndex === -1) return;
+    if (columnIndex !== -1) {
+      const direction = (params.get("order") as "asc" | "desc") || "asc";
+      sortFilteredRows(columnIndex, direction);
+    }
+  }
 
-    const direction = (params.get("order") as "asc" | "desc") || "asc";
-    sortTable(columnIndex, direction);
-  })();
+  // Reveal table now that only the first batch is in the DOM
+  table.classList.remove("not-ready");
 }
 
-document.addEventListener("DOMContentLoaded", initializeFromURL);
-window.addEventListener("popstate", initializeFromURL);
+// Run on load
+initialize();
+
+window.addEventListener("popstate", () => {
+  const params = getQueryParams();
+  const searchQuery = params.get("search");
+  search.value = searchQuery || "";
+  if (searchQuery) {
+    lastParseResult = parseSmartSearch(searchQuery);
+  } else {
+    lastParseResult = { state: createDefaultFilterState(), matchedChips: new Set(), sortActions: [] };
+  }
+  chipState = urlParamsToChipState(params);
+  applyAll();
+
+  const columnName = params.get("sort");
+  if (columnName) {
+    const columnIndex = getColumnIndexByUrlName(columnName);
+    if (columnIndex !== -1) {
+      const direction = (params.get("order") as "asc" | "desc") || "asc";
+      sortFilteredRows(columnIndex, direction);
+    }
+  }
+});

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -62,118 +62,59 @@ for (const [providerId] of Object.entries(Providers)) {
   }
 }
 
-function renderProviderLogo(providerId: string) {
-  const svgContent = providerLogos.get(providerId) || "";
-
-  return <span dangerouslySetInnerHTML={{ __html: svgContent }} />;
+// Extract viewBox and inner content from an SVG string for <symbol> creation
+function parseSvgForSymbol(svgStr: string): { viewBox: string; inner: string } {
+  const viewBoxMatch = svgStr.match(/viewBox="([^"]*)"/);
+  const viewBox = viewBoxMatch ? viewBoxMatch[1] : "0 0 24 24";
+  // Extract content between <svg ...> and </svg>
+  const innerMatch = svgStr.match(/<svg[^>]*>([\s\S]*?)<\/svg>/);
+  const inner = innerMatch ? innerMatch[1].trim() : "";
+  return { viewBox, inner };
 }
 
-const getModalityIcon = (modality: string) => {
-  switch (modality) {
-    case "text":
-      return (
-        <span class="modality-icon" data-tooltip="Text">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <polyline points="4,7 4,4 20,4 20,7"></polyline>
-            <line x1="9" y1="20" x2="15" y2="20"></line>
-            <line x1="12" y1="4" x2="12" y2="20"></line>
-          </svg>
-        </span>
-      );
-    case "image":
-      return (
-        <span class="modality-icon" data-tooltip="Image">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect>
-            <circle cx="9" cy="9" r="2"></circle>
-            <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path>
-          </svg>
-        </span>
-      );
-    case "audio":
-      return (
-        <span class="modality-icon" data-tooltip="Audio">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
-            <path d="m19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"></path>
-          </svg>
-        </span>
-      );
-    case "video":
-      return (
-        <span class="modality-icon" data-tooltip="Video">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="m22 8-6 4 6 4V8Z"></path>
-            <rect width="14" height="12" x="2" y="6" rx="2" ry="2"></rect>
-          </svg>
-        </span>
-      );
-    case "pdf":
-      return (
-        <span class="modality-icon" data-tooltip="PDF">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-            <polyline points="14,2 14,8 20,8"></polyline>
-            <line x1="16" y1="13" x2="8" y2="13"></line>
-            <line x1="16" y1="17" x2="8" y2="17"></line>
-            <polyline points="10,9 9,9 8,9"></polyline>
-          </svg>
-        </span>
-      );
-    default:
-      return null;
+// Build SVG defs block with all symbols
+function buildSvgDefs(): string {
+  let symbols = "";
+
+  // Modality icon symbols
+  symbols += `<symbol id="icon-text" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4,7 4,4 20,4 20,7"></polyline><line x1="9" y1="20" x2="15" y2="20"></line><line x1="12" y1="4" x2="12" y2="20"></line></symbol>`;
+  symbols += `<symbol id="icon-image" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect><circle cx="9" cy="9" r="2"></circle><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path></symbol>`;
+  symbols += `<symbol id="icon-audio" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon><path d="m19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"></path></symbol>`;
+  symbols += `<symbol id="icon-video" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 8-6 4 6 4V8Z"></path><rect width="14" height="12" x="2" y="6" rx="2" ry="2"></rect></symbol>`;
+  symbols += `<symbol id="icon-pdf" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14,2 14,8 20,8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10,9 9,9 8,9"></polyline></symbol>`;
+
+  // Copy/check icon symbols
+  symbols += `<symbol id="icon-copy" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="m4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></symbol>`;
+  symbols += `<symbol id="icon-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20,6 9,17 4,12"/></symbol>`;
+
+  // Provider logo symbols
+  for (const [providerId, svgContent] of providerLogos.entries()) {
+    const { viewBox, inner } = parseSvgForSymbol(svgContent);
+    symbols += `<symbol id="logo-${providerId}" viewBox="${viewBox}">${inner}</symbol>`;
   }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" style="display:none"><defs>${symbols}</defs></svg>`;
+}
+
+const svgDefsBlock = buildSvgDefs();
+
+const getModalityIcon = (modality: string) => {
+  const iconId = `icon-${modality}`;
+  const tooltip = modality.charAt(0).toUpperCase() + modality.slice(1);
+  return (
+    <span class="modality-icon" data-tooltip={tooltip}>
+      <svg width="16" height="16"><use href={`#${iconId}`} /></svg>
+    </span>
+  );
 };
+
+function renderProviderLogo(providerId: string) {
+  return (
+    <span class="provider-logo">
+      <svg width="16" height="16"><use href={`#logo-${providerId}`} /></svg>
+    </span>
+  );
+}
 
 const renderCost = (cost?: number) => {
   return cost === undefined ? "-" : `$${cost.toFixed(2)}`;
@@ -208,42 +149,93 @@ export const Rendered = renderToString(
         </a>
         <div class="search-container">
           <input type="text" id="search" placeholder="Search models" />
+          <button id="filter-toggle" class="filter-toggle" aria-expanded="false" title="Toggle filters">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
+            </svg>
+            <span id="filter-badge" class="filter-badge" hidden></span>
+          </button>
           <span class="search-shortcut">⌘K</span>
         </div>
         <button id="help">How to use</button>
       </div>
     </header>
-    <table>
+    <div id="filter-bar" class="filter-bar" hidden>
+      <div class="filter-bar-inner">
+        <div class="filter-group">
+          <span class="filter-group-label">Features</span>
+          <div class="filter-chips">
+            <button class="filter-chip" data-filter="reasoning">Reasoning</button>
+            <button class="filter-chip" data-filter="tool_call">Tool Call</button>
+            <button class="filter-chip" data-filter="open_weights">Open Weights</button>
+            <button class="filter-chip" data-filter="structured_output">Structured Output</button>
+          </div>
+        </div>
+        <div class="filter-group">
+          <span class="filter-group-label">Input</span>
+          <div class="filter-chips">
+            <button class="filter-chip" data-filter="input-text">Text</button>
+            <button class="filter-chip" data-filter="input-image">Image</button>
+            <button class="filter-chip" data-filter="input-audio">Audio</button>
+            <button class="filter-chip" data-filter="input-video">Video</button>
+            <button class="filter-chip" data-filter="input-pdf">PDF</button>
+          </div>
+        </div>
+        <div class="filter-group">
+          <span class="filter-group-label">Output</span>
+          <div class="filter-chips">
+            <button class="filter-chip" data-filter="output-text">Text</button>
+            <button class="filter-chip" data-filter="output-image">Image</button>
+            <button class="filter-chip" data-filter="output-audio">Audio</button>
+            <button class="filter-chip" data-filter="output-video">Video</button>
+          </div>
+        </div>
+        <div class="filter-group">
+          <span class="filter-group-label">Status</span>
+          <div class="filter-chips">
+            <button class="filter-chip" data-filter="hide-deprecated">Hide Deprecated</button>
+            <button class="filter-chip" data-filter="hide-beta">Hide Beta</button>
+          </div>
+        </div>
+        <div class="filter-actions">
+          <span id="filter-count" class="filter-count" hidden></span>
+          <button id="clear-filters" class="filter-clear" hidden>Clear all</button>
+        </div>
+      </div>
+    </div>
+    <span dangerouslySetInnerHTML={{ __html: svgDefsBlock }} />
+    <div id="scroll-sentinel-top" class="scroll-sentinel"></div>
+    <table class="not-ready">
       <thead>
         <tr>
-          <th class="sortable" data-type="text">
+          <th class="sortable" data-type="text" data-column="provider">
             Provider <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="text">
+          <th class="sortable" data-type="text" data-column="model">
             Model <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="text">
+          <th class="sortable" data-type="text" data-column="family">
             Family <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="text">
+          <th class="sortable" data-type="text" data-column="provider-id">
             Provider ID <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="text">
+          <th class="sortable" data-type="text" data-column="model-id">
             Model ID <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="boolean">
+          <th class="sortable" data-type="boolean" data-column="tool-call">
             Tool Call <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="boolean">
+          <th class="sortable" data-type="boolean" data-column="reasoning">
             Reasoning <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="modalities">
+          <th class="sortable" data-type="modalities" data-column="input">
             Input <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="modalities">
+          <th class="sortable" data-type="modalities" data-column="output">
             Output <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="input-cost">
             <div class="header-container">
               <span class="header-text">
                 Input Cost
@@ -253,7 +245,7 @@ export const Rendered = renderToString(
               <span class="sort-indicator"></span>
             </div>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="output-cost">
             <div class="header-container">
               <span class="header-text">
                 Output Cost
@@ -263,7 +255,7 @@ export const Rendered = renderToString(
               <span class="sort-indicator"></span>
             </div>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="reasoning-cost">
             <div class="header-container">
               <span class="header-text">
                 Reasoning Cost
@@ -273,7 +265,7 @@ export const Rendered = renderToString(
               <span class="sort-indicator"></span>
             </div>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="cache-read-cost">
             <div class="header-container">
               <span class="header-text">
                 Cache Read Cost
@@ -283,7 +275,7 @@ export const Rendered = renderToString(
               <span class="sort-indicator"></span>
             </div>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="cache-write-cost">
             <div class="header-container">
               <span class="header-text">
                 Cache Write Cost
@@ -293,7 +285,7 @@ export const Rendered = renderToString(
               <span class="sort-indicator"></span>
             </div>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="audio-input-cost">
             <div class="header-container">
               <span class="header-text">
                 Audio Input Cost
@@ -303,7 +295,7 @@ export const Rendered = renderToString(
               <span class="sort-indicator"></span>
             </div>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="audio-output-cost">
             <div class="header-container">
               <span class="header-text">
                 Audio Output Cost
@@ -313,31 +305,31 @@ export const Rendered = renderToString(
               <span class="sort-indicator"></span>
             </div>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="context-limit">
             Context Limit <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="input-limit">
             Input Limit <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="number">
+          <th class="sortable" data-type="number" data-column="output-limit">
             Output Limit <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="boolean">
+          <th class="sortable" data-type="boolean" data-column="structured-output">
             Structured Output <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="boolean">
+          <th class="sortable" data-type="boolean" data-column="temperature">
             Temperature <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="text">
+          <th class="sortable" data-type="text" data-column="weights">
             Weights <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="text">
+          <th class="sortable" data-type="text" data-column="knowledge">
             Knowledge <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="text">
+          <th class="sortable" data-type="text" data-column="release-date">
             Release Date <span class="sort-indicator"></span>
           </th>
-          <th class="sortable" data-type="text">
+          <th class="sortable" data-type="text" data-column="last-updated">
             Last Updated <span class="sort-indicator"></span>
           </th>
         </tr>
@@ -354,7 +346,27 @@ export const Rendered = renderToString(
                 modelA.name.localeCompare(modelB.name)
               )
               .map(([modelId, model]) => (
-                <tr key={`${providerId}-${modelId}`}>
+                <tr
+                  key={`${providerId}-${modelId}`}
+                  data-provider={provider.name.toLowerCase()}
+                  data-provider-id={providerId}
+                  data-model={model.name.toLowerCase()}
+                  data-model-id={modelId}
+                  data-family={model.family ?? ""}
+                  data-reasoning={model.reasoning ? "1" : "0"}
+                  data-tool-call={model.tool_call ? "1" : "0"}
+                  data-open-weights={model.open_weights ? "1" : "0"}
+                  data-structured-output={model.structured_output === undefined ? "" : model.structured_output ? "1" : "0"}
+                  data-temperature={model.temperature ? "1" : "0"}
+                  data-attachment={model.attachment ? "1" : "0"}
+                  data-input-modalities={model.modalities.input.join(",")}
+                  data-output-modalities={model.modalities.output.join(",")}
+                  data-input-cost={model.cost?.input?.toString() ?? ""}
+                  data-output-cost={model.cost?.output?.toString() ?? ""}
+                  data-context-limit={model.limit.context.toString()}
+                  data-output-limit={model.limit.output.toString()}
+                  data-status={model.status ?? ""}
+                >
                   <td>
                     <div class="provider-cell">
                       {renderProviderLogo(providerId)}
@@ -371,43 +383,8 @@ export const Rendered = renderToString(
                         class="copy-button"
                         onclick={`copyModelId(this, '${modelId}')`}
                       >
-                        <svg
-                          class="copy-icon"
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="14"
-                          height="14"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                        >
-                          <rect
-                            width="14"
-                            height="14"
-                            x="8"
-                            y="8"
-                            rx="2"
-                            ry="2"
-                          />
-                          <path d="m4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-                        </svg>
-                        <svg
-                          class="check-icon"
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="14"
-                          height="14"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          style="display: none;"
-                        >
-                          <polyline points="20,6 9,17 4,12" />
-                        </svg>
+                        <svg class="copy-icon" width="14" height="14"><use href="#icon-copy" /></svg>
+                        <svg class="check-icon" width="14" height="14" style="display: none;"><use href="#icon-check" /></svg>
                       </button>
                     </div>
                   </td>
@@ -441,8 +418,8 @@ export const Rendered = renderToString(
                     {model.structured_output === undefined
                       ? "-"
                       : model.structured_output
-                      ? "Yes"
-                      : "No"}
+                        ? "Yes"
+                        : "No"}
                   </td>
                   <td>{model.temperature ? "Yes" : "No"}</td>
                   <td>{model.open_weights ? "Open" : "Closed"}</td>
@@ -456,6 +433,8 @@ export const Rendered = renderToString(
           )}
       </tbody>
     </table>
+    <div id="scroll-sentinel" class="scroll-sentinel"></div>
+    <div id="ghost-container" class="ghost-container"></div>
     <dialog id="modal">
       <div class="header">
         <h2>How to use</h2>
@@ -500,6 +479,46 @@ export const Rendered = renderToString(
           </a>
           .
         </p>
+        <h2>Search</h2>
+        <p>
+          The search bar supports natural language and keyword filters. Combine them freely.
+        </p>
+        <p><b>Examples</b></p>
+        <div class="code-block">
+          <code>bedrock claude sort:input</code>
+        </div>
+        <div class="code-block">
+          <code>in:image out:text in:&lt;5 out:&lt;15</code>
+        </div>
+        <p><b>Filter keywords</b></p>
+        <table class="help-table">
+          <tbody>
+            <tr><td><code>in:</code></td><td>Input modality or cost — <code>in:image</code>, <code>in:&lt;5</code></td></tr>
+            <tr><td><code>out:</code></td><td>Output modality or cost — <code>out:video</code>, <code>out:&lt;15</code></td></tr>
+            <tr><td><code>ctx:</code></td><td>Context limit — <code>ctx:&gt;100k</code></td></tr>
+            <tr><td><code>p:</code></td><td>Provider — <code>p:openai</code></td></tr>
+            <tr><td><code>f:</code></td><td>Family — <code>f:gpt</code></td></tr>
+            <tr><td><code>status:</code></td><td>Status — <code>status:deprecated</code></td></tr>
+          </tbody>
+        </table>
+        <p><b>Sort keywords</b> — prefix with <code>-</code> for descending (input/ -input)</p>
+        <table class="help-table">
+          <tbody>
+            <tr><td><code>sort:input</code></td><td>Input cost</td></tr>
+            <tr><td><code>sort:output</code></td><td>Output cost</td></tr>
+            <tr><td><code>sort:reasoning</code></td><td>Reasoning cost</td></tr>
+            <tr><td><code>sort:cache-r</code></td><td>Cache read cost</td></tr>
+            <tr><td><code>sort:cache-w</code></td><td>Cache write cost</td></tr>
+            <tr><td><code>sort:audio-in</code></td><td>Audio input cost</td></tr>
+            <tr><td><code>sort:audio-out</code></td><td>Audio output cost</td></tr>
+            <tr><td><code>sort:context</code></td><td>Context limit</td></tr>
+            <tr><td><code>sort:release</code></td><td>Release date</td></tr>
+            <tr><td><code>sort:update</code></td><td>Last updated</td></tr>
+          </tbody>
+        </table>
+        <p>
+          Numbers support <code>k</code> and <code>m</code> suffixes. Multiple words use AND logic.
+        </p>
         <h2>API</h2>
         <p>You can access this data through an API.</p>
         <div class="code-block">
@@ -535,6 +554,7 @@ export const Rendered = renderToString(
         <p>
           If we don't have a provider's logo, a default logo is served instead.
         </p>
+
         <h2>Contribute</h2>
         <p>
           The data is stored in the{" "}


### PR DESCRIPTION
## Motivation

models.dev is great but it's slow, consumes a bunch of memory, doesn't support filters or combinatory search. 

In contrast to similar PRs, this PR addresses all of these issue with a very lightweight approach - without relying on TanStack Table or any other virtualization techniques. It supports in-browser search (Ctrl+F) across the entire dataset with bidirectional infinite-scroll pagination and SVG dedup - reducing browser memory load from ~1.5GB to 0.25GB


## Summary

https://github.com/user-attachments/assets/76d828d8-cedf-4058-aa0f-e3779385cced


- **6x reduction in browser memory** — SVG deduplication via `<symbol>` definitions and `<use>` references reduces HTML payload from ~18MB to ~7MB. Infinite scroll reduces number of DOM elements by up to 40x.
- **Browser search (Ctrl+F) support** — ghost rows with `hidden="until-found"` and `selectionchange` fallback ensure native find works across the full dataset
- **Tested on major browsers** — Chrome, Firefox, Safari; includes `requestIdleCallback` shim and progressive enhancement for older browsers
- **Natural language search** — smart search with AND logic (`bedrock claude`), keyword filters (`in:image out:<5 p:openai`), and sort keywords (`sort:input`, `sort:-output`)

## Details

- Infinite scroll with bidirectional sliding window (500-row cap) instead of rendering all ~4,000 rows
- Filter chip toggles with smart-match highlighting from search keywords
- Deferred ghost row building via `requestIdleCallback` to keep first paint fast
- Layout shift prevention with `table.not-ready` opacity gate
- Sort keywords auto-reset when removed from search; manual header sorts persist
- Help dialog updated with keyword reference tables

## Test plan

- [x] Verify Ctrl+F finds models across the full dataset (not just visible rows)
- [x] Test `sort:input`, `sort:-output`, `sort:context` trigger and reset correctly
- [x] Test keyword filters: `in:image`, `out:<5`, `p:openai`, `f:claude`, `ctx:>100k`
- [x] Test natural language: `bedrock claude`, `reasoning vision`, `free`
- [x] Scroll down past 500 rows, then scroll back up — rows restore in both directions
- [x] Test on Chrome, Firefox, and Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)