### PR TITLE
Add gemma family for google provider

### DIFF
--- a/providers/google/models/gemma-3-12b-it.toml
+++ b/providers/google/models/gemma-3-12b-it.toml
@@ -1,0 +1,23 @@
+name = "Gemma 3 12B"
+family = "gemma"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google/models/gemma-3-27b-it.toml
+++ b/providers/google/models/gemma-3-27b-it.toml
@@ -1,0 +1,23 @@
+name = "Gemma 3 27B"
+family = "gemma"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google/models/gemma-3-4b-it.toml
+++ b/providers/google/models/gemma-3-4b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma 3 4B"
+family = "gemma"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google/models/gemma-3n-e2b-it.toml
+++ b/providers/google/models/gemma-3n-e2b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma 3n 2B"
+family = "gemma"
+release_date = "2025-07-09"
+last_updated = "2025-07-09"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 2_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/google/models/gemma-3n-e4b-it.toml
+++ b/providers/google/models/gemma-3n-e4b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma 3n 4B"
+family = "gemma"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+
+[cost]  
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 2_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Add Gemma 3 Family Models for Google Provider

### Summary
Added configuration files for the new **Gemma 3** and **Gemma 3n** model families to the Google provider.

### Models Added
| Model File | Model Name | Parameters | Context | Output | Multimodal |
|------------|-----------|------------|---------|--------|-----------|
| `gemma-3-4b-it.toml` | Gemma 3 4B | 4B | 32K | 8K | ✅ Text + Image |
| `gemma-3-12b-it.toml` | Gemma 3 12B | 12B | 32K | 8K | ✅ Text + Image |
| `gemma-3-27b-it.toml` | Gemma 3 27B | 27B | 128K | 8K | ✅ Text + Image |
| `gemma-3n-e2b-it.toml` | Gemma 3n 2B | 2B | 8K | 2K | ❌ Text only |
| `gemma-3n-e4b-it.toml` | Gemma 3n 4B | 4B | 8K | 2K | ❌ Text only |

### Key Features Enabled
- ✅ `attachment`: All models support file/image attachments (where applicable)
- ✅ `structured_output`: Supported on 12B and 27B variants
- ✅ `tool_call`: Enabled for Gemma 3 27B
- ✅ `open_weights`: All models marked as open weights
- ✅ `temperature`: Configurable sampling supported

### Sources
- Model metadata sourced from official documentation: https://ai.google.dev/
- Verified against live API response:
  ```bash
  curl "https://generativelanguage.googleapis.com/v1beta/models" \
    -H "Content-Type: application/json" \
    -H "x-goog-api-key: $GOOGLE_API_KEY" | jq '.models[].name'
  ```

### Validation
- ✅ TOML syntax validated
- ✅ Field consistency checked against provider schema
- ✅ Model names match API identifiers (`models/gemma-3-*-it`, `models/gemma-3n-*-it`)
- ✅ Cost fields set to `0` (free tier / open weights)
- ✅ bun validate passes with no errors
- ✅ Verify models render correctly on models.dev