### PR TITLE
feat(nano-gpt): add glm-5.1 and glm-5.1:thinking models

### DIFF
--- a/providers/nano-gpt/models/zai-org/glm-5.1.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.1.toml
@@ -1,0 +1,22 @@
+name = "GLM 5.1"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 2.55
+
+[limit]
+context = 200_000
+input = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nano-gpt/models/zai-org/glm-5.1:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.1:thinking.toml
@@ -1,0 +1,22 @@
+name = "GLM 5.1 Thinking"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 2.55
+
+[limit]
+context = 200_000
+input = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Add `zai-org/glm-5.1` and `zai-org/glm-5.1:thinking` models to the NanoGPT provider

Model specs sourced from https://nano-gpt.com/models/text:
- Context: 200K, Max output: 131,072
- Input: $0.30/1M, Output: $2.55/1M
- Reasoning, tool call, structured output supported
- Release date: 2026-03-27