### PR TITLE
Add Kwaipilot KAT-Coder-Pro V2 to OpenRouter

### DIFF
--- a/providers/openrouter/models/kwaipilot/kat-coder-pro-v2.toml
+++ b/providers/openrouter/models/kwaipilot/kat-coder-pro-v2.toml
@@ -1,0 +1,20 @@
+name = "KAT-Coder-Pro V2"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.095
+output = 1.20
+
+[limit]
+context = 256_000
+output = 81_920
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/kwaipilot/kat-coder-pro-v2.toml
+++ b/providers/openrouter/models/kwaipilot/kat-coder-pro-v2.toml
@@ -8,8 +8,9 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.095
+input = 0.30
 output = 1.20
+cache_read = 0.06
 
 [limit]
 context = 256_000


### PR DESCRIPTION
## Summary
- Add `kwaipilot/kat-coder-pro-v2` to OpenRouter provider
- Cost: $0.095 input / $1.20 output per 1M tokens
- Context: 256K, Output: 81,920 tokens
- Tool calling: yes, Reasoning: no, Open weights: no
- Released: 2026-03-27