### PR TITLE
feat: add Qwen3.6 Plus Preview free on OpenRouter

### DIFF
--- a/providers/openrouter/models/qwen/qwen3.6-plus-preview:free.toml
+++ b/providers/openrouter/models/qwen/qwen3.6-plus-preview:free.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.6 Plus Preview (free)"
+family = "qwen"
+release_date = "2026-03-30"
+last_updated = "2026-03-30"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add free variant of Qwen3.6 Plus Preview to OpenRouter provider
- 1M context, 65K max output, $0.00 pricing
- Text-only modality (OpenRouter API reports text->text)
- Source: OpenRouter /api/v1/models API

## Changes Made
- Add `providers/openrouter/models/qwen/qwen3.6-plus-preview:free.toml` with pricing, limits, and capabilities

## Validation
- `bun validate` passes successfully
- Model appears in generated output with correct ID `qwen/qwen3.6-plus-preview:free`