### PR TITLE
fix(opencode): MiniMax models missing [provider] override and incorrectly have [interleaved]

### DIFF
--- a/providers/opencode/models/minimax-m2.1.toml
+++ b/providers/opencode/models/minimax-m2.1.toml
@@ -10,9 +10,6 @@ knowledge = "2025-01"
 open_weights = true
 status = "deprecated"
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0.3
 output = 1.2
@@ -25,3 +22,6 @@ output = 131072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"

--- a/providers/opencode/models/minimax-m2.5.toml
+++ b/providers/opencode/models/minimax-m2.5.toml
@@ -9,9 +9,6 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0.3
 output = 1.2
@@ -24,3 +21,6 @@ output = 131072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"


### PR DESCRIPTION
## Problem
The `minimax-m2.5.toml` and `minimax-m2.1.toml` files in `providers/opencode/models/` have two inconsistencies compared to their `-free` counterparts and compared to the pattern established in PR #1254 for the ZenMux provider:

1. **Missing `[provider]` override** — The `-free` variants correctly define:
   ```toml
   [provider]
   npm = "@ai-sdk/anthropic"
   ```
   The non-free variants have no [provider] section.

2. **Incorrectly has [interleaved]** — The -free variants do NOT have an [interleaved] section. The non-free variants incorrectly include:
   ```toml
   [interleaved]
   field = "reasoning_content"
   ```
   PR #1254 explicitly removed [interleaved] from all ZenMux MiniMax models when adding the [provider] override, because the @ai-sdk/anthropic route handles this differently.

## Expected
Both minimax-m2.5 and minimax-m2.1 (non-free) should match their -free variants:
- Remove [interleaved] section entirely
- Add [provider] npm = "@ai-sdk/anthropic" section

This aligns with the design decision in PR #1254: MiniMax models should route through @ai-sdk/anthropic with per-model provider overrides, not rely on [interleaved] for reasoning content handling.

## Files affected
- `providers/opencode/models/minimax-m2.5.toml`
- `providers/opencode/models/minimax-m2.1.toml`