### PR TITLE
fix(aihubmix): zod-validation-error

### DIFF
--- a/providers/aihubmix/provider.toml
+++ b/providers/aihubmix/provider.toml
@@ -1,5 +1,5 @@
 name = "AIHubMix"
-npm = "aihubmix/ai-sdk-provider"
+npm = "@aihubmix/ai-sdk-provider"
 env = ["AIHUBMIX_API_KEY"]
 doc = "https://docs.aihubmix.com"
 

--- a/providers/aihubmix/provider.toml
+++ b/providers/aihubmix/provider.toml
@@ -1,6 +1,5 @@
 name = "AIHubMix"
-npm = "@ai-sdk/openai-compatible"
+npm = "aihubmix/ai-sdk-provider"
 env = ["AIHUBMIX_API_KEY"]
-api = "https://aihubmix.com/v1"
 doc = "https://docs.aihubmix.com"
 


### PR DESCRIPTION
Replace @ai-sdk/openai-compatible with the official aihubmix/ai-sdk-provider package and remove the hardcoded api URL, as the dedicated package handles schema validation and endpoint configuration internally.