### PR TITLE
feat: add GLM-5-Turbo model in OpenRouter AI provider

### DIFF
--- a/providers/openrouter/models/z-ai/glm-5-turbo.toml
+++ b/providers/openrouter/models/z-ai/glm-5-turbo.toml
@@ -1,0 +1,27 @@
+name = "GLM-5-Turbo"
+family = "glm"
+release_date = "2026-03-16"
+last_updated = "2026-03-16"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.20
+output = 4.00
+cache_read = 0.24
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add GLM-5-Turbo model in OpenRouter AI provider

Model specs from [GLM-5-Turbo doc](https://docs.z.ai/guides/llm/glm-5-turbo):

Context: 200,000 tokens
Input: $1.20/M
Output: $4.00/M
Reasoning: true (thinking model)
Open weights: false 
Tool call: true