### PR TITLE
fix: correct context/output limits for GitHub Copilot Claude models

### DIFF
--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -1,7 +1,7 @@
 name = "Claude Haiku 4.5"
 family = "claude-haiku"
 release_date = "2025-10-15"
-last_updated = "2025-10-15"
+last_updated = "2026-03-31"
 attachment = true
 reasoning = true
 temperature = true
@@ -14,8 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 144_000
-output = 32_000
+context = 200_000
+output = 64_000
 input = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -1,7 +1,7 @@
 name = "Claude Opus 4.5"
 family = "claude-opus"
 release_date = "2025-11-24"
-last_updated = "2025-08-01"
+last_updated = "2026-03-31"
 attachment = true
 reasoning = true
 temperature = true
@@ -14,8 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 160_000
-output = 32_000
+context = 200_000
+output = 64_000
 input = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-opus-4.6.toml
+++ b/providers/github-copilot/models/claude-opus-4.6.toml
@@ -1,7 +1,7 @@
 name = "Claude Opus 4.6"
 family = "claude-opus"
 release_date = "2026-02-05"
-last_updated = "2026-02-05"
+last_updated = "2026-03-31"
 attachment = true
 reasoning = true
 temperature = true
@@ -14,8 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 144_000
-output = 64_000
+context = 1_000_000
+output = 128_000
 input = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-opus-41.toml
+++ b/providers/github-copilot/models/claude-opus-41.toml
@@ -1,7 +1,7 @@
 name = "Claude Opus 4.1"
 family = "claude-opus"
 release_date = "2025-08-05"
-last_updated = "2025-08-05"
+last_updated = "2026-03-31"
 attachment = true
 reasoning = true
 temperature = true
@@ -14,8 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 80_000
-output = 16_000
+context = 200_000
+output = 32_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -1,7 +1,7 @@
 name = "Claude Sonnet 4.5"
 family = "claude-sonnet"
 release_date = "2025-09-29"
-last_updated = "2025-09-29"
+last_updated = "2026-03-31"
 attachment = true
 reasoning = true
 temperature = true
@@ -14,8 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 144_000
-output = 32_000
+context = 200_000
+output = 64_000
 input = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-sonnet-4.6.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.6.toml
@@ -1,7 +1,7 @@
 name = "Claude Sonnet 4.6"
 family = "claude-sonnet"
 release_date = "2026-02-17"
-last_updated = "2026-02-17"
+last_updated = "2026-03-31"
 attachment = true
 reasoning = true
 temperature = true
@@ -13,8 +13,8 @@ input = 0
 output = 0
 
 [limit]
-context = 200_000
-output = 32_000
+context = 1_000_000
+output = 64_000
 input = 128_000
 
 [modalities]

--- a/providers/github-copilot/models/claude-sonnet-4.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.toml
@@ -1,7 +1,7 @@
 name = "Claude Sonnet 4"
 family = "claude-sonnet"
 release_date = "2025-05-22"
-last_updated = "2025-05-22"
+last_updated = "2026-03-31"
 attachment = true
 reasoning = true
 temperature = true
@@ -14,8 +14,8 @@ input = 0
 output = 0
 
 [limit]
-context = 216_000
-output = 16_000
+context = 200_000
+output = 64_000
 input = 128_000
 
 [modalities]


### PR DESCRIPTION
The GitHub Copilot Claude model TOML files had incorrect `context` and `output` limit values. These have been corrected to match Anthropic's official documentation.

| Model | context (before→after) | output (before→after) |
|---|---|---|
| `claude-opus-4.6` | 144k → 1M | 64k → 128k |
| `claude-sonnet-4.6` | 200k → 1M | 32k → 64k |
| `claude-haiku-4.5` | 144k → 200k | 32k → 64k |
| `claude-opus-4.5` | 160k → 200k | 32k → 64k |
| `claude-sonnet-4.5` | 144k → 200k | 32k → 64k |
| `claude-sonnet-4` | 216k → 200k | 16k → 64k |
| `claude-opus-41` | 80k → 200k | 16k → 32k |

Reference: https://platform.claude.com/docs/en/about-claude/models/overview

Verified with `bun validate` — no errors.