### PR TITLE
Add NeuralWatt provider with 9 models

### DIFF
--- a/providers/neuralwatt/models/devstral-small-2-24b-instruct-2512.toml
+++ b/providers/neuralwatt/models/devstral-small-2-24b-instruct-2512.toml
@@ -1,0 +1,21 @@
+name = "Devstral Small 2 24B"
+family = "devstral"
+release_date = "2025-12"
+last_updated = "2026-03"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/neuralwatt/models/glm-5-fast.toml
+++ b/providers/neuralwatt/models/glm-5-fast.toml
@@ -1,0 +1,20 @@
+name = "GLM-5 Fast"
+family = "glm-flash"
+release_date = "2025-01"
+last_updated = "2026-03"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.90
+output = 2.90
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/neuralwatt/models/glm-5.toml
+++ b/providers/neuralwatt/models/glm-5.toml
@@ -1,0 +1,20 @@
+name = "GLM-5"
+family = "glm"
+release_date = "2025-01"
+last_updated = "2026-03"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.90
+output = 2.90
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/neuralwatt/models/gpt-oss-20b.toml
+++ b/providers/neuralwatt/models/gpt-oss-20b.toml
@@ -1,0 +1,21 @@
+name = "GPT-OSS 20B"
+family = "gpt-oss"
+release_date = "2025-01"
+last_updated = "2026-03"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.20
+
+[limit]
+context = 16_384
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/neuralwatt/models/kimi-k2.5-fast.toml
+++ b/providers/neuralwatt/models/kimi-k2.5-fast.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2.5 Fast"
+family = "kimi"
+release_date = "2025-01"
+last_updated = "2026-03"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.50
+output = 2.60
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/neuralwatt/models/kimi-k2.5.toml
+++ b/providers/neuralwatt/models/kimi-k2.5.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2025-01"
+last_updated = "2026-03"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.50
+output = 2.60
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/neuralwatt/models/minimax-m2.5.toml
+++ b/providers/neuralwatt/models/minimax-m2.5.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2.5"
+family = "minimax-m2.5"
+release_date = "2025-01"
+last_updated = "2026-03"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.40
+
+[limit]
+context = 196_608
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/neuralwatt/models/qwen3.5-397b-fast.toml
+++ b/providers/neuralwatt/models/qwen3.5-397b-fast.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.5 397B Fast"
+family = "qwen"
+release_date = "2025-01"
+last_updated = "2026-03"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.70
+output = 4.10
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/neuralwatt/models/qwen3.5-397b.toml
+++ b/providers/neuralwatt/models/qwen3.5-397b.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.5 397B"
+family = "qwen"
+release_date = "2025-01"
+last_updated = "2026-03"
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.70
+output = 4.10
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/neuralwatt/provider.toml
+++ b/providers/neuralwatt/provider.toml
@@ -1,0 +1,5 @@
+name = "NeuralWatt"
+env = ["NEURALWATT_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://portal.neuralwatt.com/docs"
+api = "https://api.neuralwatt.com"


### PR DESCRIPTION
## Summary

Adds NeuralWatt as a new provider to models.dev. NeuralWatt is an energy-efficient AI inference provider with an OpenAI-compatible API, featuring energy-based pricing and real-time energy metrics per request.

**Provider Details:**
- API: `https://api.neuralwatt.com` (OpenAI-compatible)
- Environment variable: `NEURALWATT_API_KEY`
- NPM package: `@ai-sdk/openai-compatible`
- Documentation: https://portal.neuralwatt.com/docs

**Models Added (9):**

| Model | Family | Context | Input/Output (per 1M) | Features |
|-------|--------|---------|----------------------|----------|
| Devstral Small 2 24B | devstral | 262K | $0.10 / $0.30 | Vision, Tools, JSON |
| GLM-5 | glm | 200K | $0.90 / $2.90 | Tools |
| GLM-5 Fast | glm-flash | 200K | $0.90 / $2.90 | Tools |
| GPT-OSS 20B | gpt-oss | 16K | $0.00 / $0.20 | Tools, JSON |
| Kimi K2.5 | kimi | 262K | $0.50 / $2.60 | Vision, Tools, JSON |
| Kimi K2.5 Fast | kimi | 262K | $0.50 / $2.60 | Vision, Tools, JSON |
| MiniMax M2.5 | minimax-m2.5 | 196K | $0.30 / $1.40 | Tools, JSON |
| Qwen3.5 397B | qwen | 262K | $0.70 / $4.10 | Tools, JSON |
| Qwen3.5 397B Fast | qwen | 262K | $0.70 / $4.10 | Tools, JSON |

**Validation:** All configurations pass `bun validate`