### PR TITLE
feat(openai): add openai gpt-image models

### DIFF
--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -14,6 +14,7 @@ export const ModelFamilyValues = [
   "gpt-mini",
   "gpt-nano",
   "gpt-oss",
+  "gpt-image",
 
   // OpenAI o-series (reasoning models)
   "o",

--- a/providers/openai/models/chatgpt-image-latest.toml
+++ b/providers/openai/models/chatgpt-image-latest.toml
@@ -1,0 +1,19 @@
+name = "chatgpt-image-latest"
+family = "gpt-image"
+attachment = true
+tool_call = false
+reasoning = false 
+temperature = false
+open_weights = false
+release_date = "2025-12-16" 
+last_updated = "2025-12-16" 
+
+[limit]
+context = 0
+input = 0
+output = 0
+
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]

--- a/providers/openai/models/gpt-image-1-mini.toml
+++ b/providers/openai/models/gpt-image-1-mini.toml
@@ -1,0 +1,18 @@
+name = "gpt-image-1-mini"
+family = "gpt-image"
+attachment = true
+tool_call = false
+reasoning = false 
+temperature = false         
+release_date = "2025-09-26" 
+last_updated = "2025-09-26" 
+open_weights = false
+
+[limit]
+context = 0
+input = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]

--- a/providers/openai/models/gpt-image-1.5.toml
+++ b/providers/openai/models/gpt-image-1.5.toml
@@ -1,0 +1,18 @@
+name = "gpt-image-1.5"
+family = "gpt-image"
+attachment = true
+tool_call = false
+reasoning = false 
+temperature = false         
+release_date = "2025-11-25" 
+last_updated = "2025-11-25" 
+open_weights = false
+
+[limit]
+context = 0
+input = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]

--- a/providers/openai/models/gpt-image-1.toml
+++ b/providers/openai/models/gpt-image-1.toml
@@ -1,0 +1,18 @@
+name = "gpt-image-1"
+family = "gpt-image"
+attachment = true
+tool_call = false
+reasoning = false 
+temperature = false 
+release_date = "2025-04-24" 
+last_updated = "2025-04-24"
+open_weights = false
+
+[limit]
+context = 0
+input = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/poe/models/openai/gpt-image-1.5.toml
+++ b/providers/poe/models/openai/gpt-image-1.5.toml
@@ -5,7 +5,7 @@ attachment = true
 reasoning = false
 temperature = false
 open_weights = false
-tool_call = true
+tool_call = false
 
 [limit]
 context = 128_000


### PR DESCRIPTION
**Missing GPT Image Models Have Been Added**

- I used the following URL to compare and fill the .toml files : https://developers.openai.com/api/docs/models/compare?model=gpt-image-1-mini
- Where release dates are not available, I used GPT blog or google to find the release date