### PR TITLE
feat(google-vertex): add moonshotai/kimi-k2-thinking-maas model

### DIFF
--- a/providers/google-vertex/models/moonshotai/kimi-k2-thinking-maas.toml
+++ b/providers/google-vertex/models/moonshotai/kimi-k2-thinking-maas.toml
@@ -1,0 +1,30 @@
+name = "Kimi K2 Thinking"
+family = "kimi-thinking"
+release_date = "2025-11-13"
+last_updated = "2025-11-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2024-08"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.60
+output = 2.50
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"


### PR DESCRIPTION
Adds Kimi K2 Thinking (Moonshot AI) as a Vertex AI MaaS model entry under the `google-vertex` provider.

Kimi K2 Thinking is available on Vertex AI Model Garden at the global endpoint as `moonshotai/kimi-k2-thinking-maas`. Without this entry, OpenCode does not recognize the model as a MaaS model and incorrectly routes requests to the Gemini API endpoint, resulting in a 404. Adding the TOML entry here enables the correct MaaS routing path.

The model has been verified working via direct API call against the Vertex MaaS endpoint.

References:
- Vertex AI model card: https://console.cloud.google.com/vertex-ai/publishers/moonshotai/model-garden/kimi-k2-thinking-maas
- Vertex AI MaaS docs: https://cloud.google.com/vertex-ai/generative-ai/docs/maas/kimi