### PR TITLE
fix: add missing pdf modality to supported OpenAI models

### DIFF
--- a/providers/openai/models/gpt-4.1-mini.toml
+++ b/providers/openai/models/gpt-4.1-mini.toml
@@ -20,5 +20,5 @@ context = 1047576
 output = 32768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/openai/models/gpt-4.1.toml
+++ b/providers/openai/models/gpt-4.1.toml
@@ -20,5 +20,5 @@ context = 1_047_576
 output = 32_768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/openai/models/gpt-4o-mini.toml
+++ b/providers/openai/models/gpt-4o-mini.toml
@@ -20,5 +20,5 @@ context = 128_000
 output = 16_384
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/openai/models/gpt-4o.toml
+++ b/providers/openai/models/gpt-4o.toml
@@ -20,5 +20,5 @@ context = 128_000
 output = 16_384
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/openai/models/o1.toml
+++ b/providers/openai/models/o1.toml
@@ -20,5 +20,5 @@ context = 200_000
 output = 100_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/openai/models/o3.toml
+++ b/providers/openai/models/o3.toml
@@ -20,5 +20,5 @@ context = 200_000
 output = 100_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]


### PR DESCRIPTION
Adds the missing `pdf` input modality to the most clearly supported OpenAI multimodal model definitions:

* GPT-4o
* GPT-4.1
* o1
* o3

Kept intentionally minimal and limited to the most obvious PDF-capable models.

Closes #479
