### PR TITLE
Add Chuizi.AI provider

### DIFF
--- a/providers/chuizi/logo.svg
+++ b/providers/chuizi/logo.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M7 5C5.9 5 5 5.9 5 7V25C5 26.1 5.9 27 7 27" stroke="currentColor" stroke-width="3.2" stroke-linecap="round"/>
+  <path d="M25 5C26.1 5 27 5.9 27 7V25C27 26.1 26.1 27 25 27" stroke="currentColor" stroke-width="3.2" stroke-linecap="round"/>
+  <rect x="10" y="7" width="12" height="7" rx="2" fill="currentColor"/>
+  <rect x="13.5" y="13" width="5" height="13" rx="1.5" fill="currentColor" opacity="0.45"/>
+</svg>

--- a/providers/chuizi/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/chuizi/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,23 @@
+name = "Claude Haiku 4.5"
+family = "claude"
+release_date = "2025-10-01"
+last_updated = "2025-10-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/chuizi/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/chuizi/models/anthropic/claude-haiku-4-5.toml
@@ -1,7 +1,7 @@
 name = "Claude Haiku 4.5"
 family = "claude"
-release_date = "2025-10-01"
-last_updated = "2025-10-01"
+release_date = "2025-10-15"
+last_updated = "2025-10-15"
 attachment = true
 reasoning = false
 temperature = true
@@ -10,13 +10,14 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 1
-output = 5
-cache_read = 0.1
+input = 1.05
+output = 5.25
+cache_read = 0.105
+cache_write = 1.3125
 
 [limit]
 context = 200_000
-output = 8_192
+output = 32_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/chuizi/models/anthropic/claude-opus-4-6.toml
+++ b/providers/chuizi/models/anthropic/claude-opus-4-6.toml
@@ -1,7 +1,7 @@
 name = "Claude Opus 4.6"
 family = "claude"
-release_date = "2026-03-01"
-last_updated = "2026-03-01"
+release_date = "2026-02-15"
+last_updated = "2026-02-15"
 attachment = true
 reasoning = true
 temperature = true
@@ -10,9 +10,10 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 5
-output = 25
-cache_read = 0.5
+input = 15.75
+output = 78.75
+cache_read = 1.575
+cache_write = 19.6875
 
 [limit]
 context = 200_000

--- a/providers/chuizi/models/anthropic/claude-opus-4-6.toml
+++ b/providers/chuizi/models/anthropic/claude-opus-4-6.toml
@@ -1,0 +1,26 @@
+name = "Claude Opus 4.6"
+family = "claude"
+release_date = "2026-03-01"
+last_updated = "2026-03-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/chuizi/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/chuizi/models/anthropic/claude-sonnet-4-5.toml
@@ -1,7 +1,7 @@
-name = "o4-mini"
-family = "gpt"
-release_date = "2025-04-16"
-last_updated = "2025-04-16"
+name = "Claude Sonnet 4.5"
+family = "claude"
+release_date = "2025-09-29"
+last_updated = "2025-09-29"
 attachment = true
 reasoning = true
 temperature = true
@@ -10,17 +10,15 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 1.155
-output = 4.62
-cache_read = 0.2888
+input = 3.15
+output = 15.75
+cache_read = 0.315
+cache_write = 3.9375
 
 [limit]
 context = 200_000
-output = 100_000
+output = 64_000
 
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/chuizi/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/chuizi/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,23 @@
+name = "Claude Sonnet 4.6"
+family = "claude"
+release_date = "2026-03-01"
+last_updated = "2026-03-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+
+[limit]
+context = 200_000
+output = 16_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/chuizi/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/chuizi/models/anthropic/claude-sonnet-4-6.toml
@@ -1,22 +1,23 @@
 name = "Claude Sonnet 4.6"
 family = "claude"
-release_date = "2026-03-01"
-last_updated = "2026-03-01"
+release_date = "2026-02-15"
+last_updated = "2026-02-15"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
 open_weights = false
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
+input = 3.15
+output = 15.75
+cache_read = 0.315
+cache_write = 3.9375
 
 [limit]
 context = 200_000
-output = 16_000
+output = 64_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/chuizi/models/deepseek/deepseek-chat.toml
+++ b/providers/chuizi/models/deepseek/deepseek-chat.toml
@@ -1,0 +1,23 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2025-12-29"
+last_updated = "2026-01-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.28
+output = 0.42
+cache_read = 0.14
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/chuizi/models/deepseek/deepseek-r1.toml
+++ b/providers/chuizi/models/deepseek/deepseek-r1.toml
@@ -10,9 +10,9 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.28
-output = 0.42
-cache_read = 0.14
+input = 0.588
+output = 2.352
+cache_read = 0.029
 
 [limit]
 context = 131_072

--- a/providers/chuizi/models/deepseek/deepseek-r1.toml
+++ b/providers/chuizi/models/deepseek/deepseek-r1.toml
@@ -1,0 +1,26 @@
+name = "DeepSeek R1"
+family = "deepseek"
+release_date = "2025-01-20"
+last_updated = "2025-05-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.28
+output = 0.42
+cache_read = 0.14
+
+[limit]
+context = 131_072
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/chuizi/models/google/gemini-2.5-flash.toml
+++ b/providers/chuizi/models/google/gemini-2.5-flash.toml
@@ -1,4 +1,4 @@
-name = "Gemini 2.5 Pro"
+name = "Gemini 2.5 Flash"
 family = "gemini"
 release_date = "2025-06-17"
 last_updated = "2025-06-17"
@@ -10,17 +10,14 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 1.3125
-output = 10.5
-cache_read = 0.328
+input = 0.315
+output = 2.625
+cache_read = 0.0788
 
 [limit]
-context = 2_097_152
+context = 1_048_576
 output = 65_536
 
 [modalities]
 input = ["text", "image", "audio", "video"]
 output = ["text"]
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/chuizi/models/google/gemini-2.5-pro.toml
+++ b/providers/chuizi/models/google/gemini-2.5-pro.toml
@@ -1,0 +1,25 @@
+name = "Gemini 2.5 Pro"
+family = "gemini"
+release_date = "2025-03-25"
+last_updated = "2025-06-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/chuizi/models/meta/llama-4-maverick.toml
+++ b/providers/chuizi/models/meta/llama-4-maverick.toml
@@ -1,0 +1,22 @@
+name = "Llama 4 Maverick"
+family = "llama"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.1995
+output = 0.7875
+
+[limit]
+context = 1_048_576
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/chuizi/models/moonshot/kimi-k2.5.toml
+++ b/providers/chuizi/models/moonshot/kimi-k2.5.toml
@@ -1,0 +1,25 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2025-11-01"
+last_updated = "2025-11-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 2.52
+output = 12.6
+
+[limit]
+context = 200_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/chuizi/models/openai/gpt-4.1-mini.toml
+++ b/providers/chuizi/models/openai/gpt-4.1-mini.toml
@@ -1,26 +1,23 @@
-name = "o4-mini"
+name = "GPT-4.1 mini"
 family = "gpt"
-release_date = "2025-04-16"
-last_updated = "2025-04-16"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
 attachment = true
-reasoning = true
+reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
 open_weights = false
 
 [cost]
-input = 1.155
-output = 4.62
-cache_read = 0.2888
+input = 0.42
+output = 1.68
+cache_read = 0.105
 
 [limit]
 context = 200_000
-output = 100_000
+output = 32_768
 
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/chuizi/models/openai/gpt-4.1.toml
+++ b/providers/chuizi/models/openai/gpt-4.1.toml
@@ -1,0 +1,22 @@
+name = "GPT-4.1"
+family = "gpt"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2
+output = 8
+
+[limit]
+context = 200_000
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/chuizi/models/openai/gpt-5-mini.toml
+++ b/providers/chuizi/models/openai/gpt-5-mini.toml
@@ -1,7 +1,7 @@
-name = "o4-mini"
+name = "GPT-5 mini"
 family = "gpt"
-release_date = "2025-04-16"
-last_updated = "2025-04-16"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
 attachment = true
 reasoning = true
 temperature = true
@@ -10,13 +10,13 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 1.155
-output = 4.62
-cache_read = 0.2888
+input = 0.2625
+output = 2.1
+cache_read = 0.02625
 
 [limit]
-context = 200_000
-output = 100_000
+context = 400_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/chuizi/models/openai/gpt-5.1.toml
+++ b/providers/chuizi/models/openai/gpt-5.1.toml
@@ -1,7 +1,7 @@
-name = "o4-mini"
+name = "GPT-5.1"
 family = "gpt"
-release_date = "2025-04-16"
-last_updated = "2025-04-16"
+release_date = "2025-11-20"
+last_updated = "2025-11-20"
 attachment = true
 reasoning = true
 temperature = true
@@ -10,13 +10,13 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 1.155
-output = 4.62
-cache_read = 0.2888
+input = 1.3125
+output = 10.5
+cache_read = 0.13125
 
 [limit]
-context = 200_000
-output = 100_000
+context = 400_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/chuizi/models/openai/gpt-5.toml
+++ b/providers/chuizi/models/openai/gpt-5.toml
@@ -1,7 +1,7 @@
-name = "o4-mini"
+name = "GPT-5"
 family = "gpt"
-release_date = "2025-04-16"
-last_updated = "2025-04-16"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
 attachment = true
 reasoning = true
 temperature = true
@@ -10,13 +10,13 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 1.155
-output = 4.62
-cache_read = 0.2888
+input = 1.3125
+output = 10.5
+cache_read = 0.13125
 
 [limit]
-context = 200_000
-output = 100_000
+context = 400_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/chuizi/models/openai/o4-mini.toml
+++ b/providers/chuizi/models/openai/o4-mini.toml
@@ -1,0 +1,25 @@
+name = "o4-mini"
+family = "gpt"
+release_date = "2025-04-16"
+last_updated = "2025-04-16"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.1
+output = 4.4
+
+[limit]
+context = 200_000
+output = 100_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/chuizi/models/qwen/qwen3-coder.toml
+++ b/providers/chuizi/models/qwen/qwen3-coder.toml
@@ -1,7 +1,7 @@
-name = "DeepSeek V3.2"
-family = "deepseek"
-release_date = "2025-12-01"
-last_updated = "2026-02-28"
+name = "Qwen3 Coder"
+family = "qwen"
+release_date = "2025-07-22"
+last_updated = "2025-07-22"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,13 +10,12 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.294
-output = 1.176
-cache_read = 0.029
+input = 2.1
+output = 8.4
 
 [limit]
-context = 131_072
-output = 8_192
+context = 262_144
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/chuizi/models/qwen/qwen3-max.toml
+++ b/providers/chuizi/models/qwen/qwen3-max.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 Max"
+family = "qwen"
+release_date = "2025-09-05"
+last_updated = "2025-09-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.52
+output = 10.08
+
+[limit]
+context = 1_048_576
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/chuizi/models/xai/grok-3.toml
+++ b/providers/chuizi/models/xai/grok-3.toml
@@ -1,7 +1,7 @@
-name = "GPT-4.1"
-family = "gpt"
-release_date = "2025-04-14"
-last_updated = "2025-04-14"
+name = "Grok 3"
+family = "grok"
+release_date = "2025-02-17"
+last_updated = "2025-02-17"
 attachment = true
 reasoning = false
 temperature = true
@@ -10,13 +10,12 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 2.1
-output = 8.4
-cache_read = 0.525
+input = 3.15
+output = 15.75
 
 [limit]
-context = 200_000
-output = 32_768
+context = 131_072
+output = 16_384
 
 [modalities]
 input = ["text", "image"]

--- a/providers/chuizi/models/xai/grok-4.toml
+++ b/providers/chuizi/models/xai/grok-4.toml
@@ -1,7 +1,7 @@
-name = "o4-mini"
-family = "gpt"
-release_date = "2025-04-16"
-last_updated = "2025-04-16"
+name = "Grok 4"
+family = "grok"
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
 attachment = true
 reasoning = true
 temperature = true
@@ -10,13 +10,13 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 1.155
-output = 4.62
-cache_read = 0.2888
+input = 3.15
+output = 15.75
+cache_read = 0.7875
 
 [limit]
-context = 200_000
-output = 100_000
+context = 256_000
+output = 32_768
 
 [modalities]
 input = ["text", "image"]

--- a/providers/chuizi/models/zhipu/glm-4.6.toml
+++ b/providers/chuizi/models/zhipu/glm-4.6.toml
@@ -1,0 +1,22 @@
+name = "GLM-4.6"
+family = "glm"
+release_date = "2025-10-01"
+last_updated = "2025-10-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.525
+output = 2.1
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/chuizi/provider.toml
+++ b/providers/chuizi/provider.toml
@@ -1,0 +1,5 @@
+name = "Chuizi.AI"
+env = ["CHUIZI_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.chuizi.ai/v1"
+doc = "https://chuizi.ai/docs"


### PR DESCRIPTION
Add Chuizi.AI as a provider. Unified AI gateway with 100+ models across Anthropic, OpenAI, Google, DeepSeek via a single OpenAI-compatible endpoint.

- provider.toml: OpenAI-compatible via @ai-sdk/openai-compatible
- logo.svg: currentColor for theme support
- 8 model definitions with pricing and capabilities