### PR TITLE
feat: add Qwen3.6 Plus free on OpenRouter

### DIFF
--- a/providers/openrouter/models/qwen/qwen3.6-plus:free.toml
+++ b/providers/openrouter/models/qwen/qwen3.6-plus:free.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.6 Plus (free)"
+family = "qwen"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add free variant of Qwen3.6 Plus to OpenRouter provider
- 1M context, 65K max output, $0.00 pricing
- Multimodal input: text + image + video (key difference from text-only preview)

## Changes Made
- Add `providers/openrouter/models/qwen/qwen3.6-plus:free.toml`

## Model Details

**Source:** https://openrouter.ai/qwen/qwen3.6-plus:free
**API:** https://openrouter.ai/api/v1/models

| Field | Value |
|-------|-------|
| **Architecture** | Hybrid linear attention + sparse MoE |
| **Tokenizer** | Qwen3 |
| **Context** | 1,000,000 tokens |
| **Max Output** | 65,536 tokens |
| **Input** | `["text", "image", "video"]` |
| **Output** | `["text"]` |
| **Pricing** | $0.00 input / $0.00 output |
| **Reasoning** | Yes (`include_reasoning`) |
| **Tool Use** | Yes (`tools`, `tool_choice`) |
| **Structured Output** | Yes (`response_format`, `structured_outputs`) |
| **SWE-bench Verified** | 78.8 |

**Note:** This is the non-preview release. Unlike the preview variant (`qwen/qwen3.6-plus-preview:free`) which is text-only, this model supports multimodal input (image + video) per the OpenRouter API.

## Supported Parameters
`include_reasoning`, `max_tokens`, `presence_penalty`, `reasoning`, `response_format`, `seed`, `structured_outputs`, `temperature`, `tool_choice`, `tools`, `top_p`

## Validation
- `bun validate` passes successfully
- Model appears in generated output with correct ID `qwen/qwen3.6-plus:free`