### PR TITLE
fix(openrouter): add missing cache_read pricing for xiaomi/mimo-v2-pro and xiaomi/mimo-v2-omni

### DIFF
--- a/providers/openrouter/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-omni.toml
@@ -12,6 +12,7 @@ open_weights = true
 [cost]
 input = 0.40
 output = 2.00
+cache_read = 0.08
 
 [limit]
 context = 262_144

--- a/providers/openrouter/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-pro.toml
@@ -12,6 +12,7 @@ open_weights = true
 [cost]
 input = 1.00
 output = 3.00
+cache_read = 0.20
 
 [limit]
 context = 1_048_576


### PR DESCRIPTION
## Problem

OpenRouter charges cache_read tokens for Xiaomi MiMo models, but the `cache_read` field was missing from their cost definitions in models.dev. This causes downstream tools like OpenCode to undercharge users by not accounting for cache read costs.

## Changes

| Model | Field Added | Value | Source |
|---|---|---|---|
| `xiaomi/mimo-v2-pro` | `cache_read` | `0.20` ($0.20/M) | OpenRouter API |
| `xiaomi/mimo-v2-omni` | `cache_read` | `0.08` ($0.08/M) | OpenRouter API |

## Verification

Pricing verified against OpenRouter's live API:
```
# mimo-v2-pro:   prompt=$0.000001, completion=$0.000003, input_cache_read=$0.0000002
# mimo-v2-omni:  prompt=$0.0000004, completion=$0.000002, input_cache_read=$0.00000008
```

## Impact

In a real OpenCode session with 89 messages using `openrouter/xiaomi/mimo-v2-pro`:
- **3.46M cache_read tokens** were used
- **$0.69 was undercharged** (66% less than actual cost)
- Stored cost: $0.36 vs Actual cost: $1.05

`mimo-v2-flash` already had correct `cache_read = 0.01` — no changes needed.