### PR TITLE
revert: alibaba-cn MiniMax-M2.5 to MiniMax-M2.7

### DIFF
--- a/providers/alibaba-cn/models/MiniMax/MiniMax-M2.7.toml
+++ b/providers/alibaba-cn/models/MiniMax/MiniMax-M2.7.toml
@@ -1,7 +1,7 @@
-name = "MiniMax M2.5"
+name = "MiniMax-M2.7"
 family = "minimax"
-release_date = "2026-02-12"
-last_updated = "2026-02-12"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
 attachment = false
 reasoning = true
 temperature = true
@@ -9,8 +9,10 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.301
-output = 1.205
+input = 0.30
+output = 1.20
+cache_read = 0.06
+cache_write = 0.375
 
 [limit]
 context = 204_800


### PR DESCRIPTION
## Summary
Revert PR #1002 - MiniMax/MiniMax-M2.5 is no longer available in Alibaba Bailian, now using MiniMax-M2.7 instead.

**Changes:**
- Remove `MiniMax-M2.5` model from alibaba-cn provider
- Add `MiniMax-M2.7` model to alibaba-cn provider