### PR TITLE
fix: set correct structured output values for Amazon Bedrock models

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-02-28"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-03-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-05"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-07-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-07"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-02-28"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-03-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-05"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-07-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/global.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-02-28"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-03-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-05"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-07-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = false
+structured_output = true
 knowledge = "2024-12"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
@@ -3,6 +3,7 @@ family = "gemma"
 attachment = true
 reasoning = false
 tool_call = true
+structured_output = true
 temperature = true
 knowledge = "2025-07"
 release_date = "2025-07-27"

--- a/providers/amazon-bedrock/models/mistral.magistral-small-2509.toml
+++ b/providers/amazon-bedrock/models/mistral.magistral-small-2509.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/mistral.ministral-3-14b-instruct.toml
+++ b/providers/amazon-bedrock/models/mistral.ministral-3-14b-instruct.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/mistral.ministral-3-3b-instruct.toml
+++ b/providers/amazon-bedrock/models/mistral.ministral-3-3b-instruct.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/mistral.ministral-3-8b-instruct.toml
+++ b/providers/amazon-bedrock/models/mistral.ministral-3-8b-instruct.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/mistral.mistral-large-3-675b-instruct.toml
+++ b/providers/amazon-bedrock/models/mistral.mistral-large-3-675b-instruct.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/mistral.voxtral-mini-3b-2507.toml
+++ b/providers/amazon-bedrock/models/mistral.voxtral-mini-3b-2507.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/mistral.voxtral-small-24b-2507.toml
+++ b/providers/amazon-bedrock/models/mistral.voxtral-small-24b-2507.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 interleaved = true
 open_weights = true
 

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-12b-v2.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-12b-v2.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-9b-v2.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-9b-v2.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-04"
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = true
 knowledge = "2024-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-02-28"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-03-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-05"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-07-31"
 open_weights = false
 


### PR DESCRIPTION
Adds `structured_output = true` to all model files that `amazon-bedrock` officially supports it for.

Per AWS docs: https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html#structured-output-supported-models