### PR TITLE
zenmux: add KAT-Coder-Pro-V2, Qwen3.6-Plus, and GLM 5V Turbo

### DIFF
--- a/providers/zenmux/models/kuaishou/kat-coder-pro-v2.toml
+++ b/providers/zenmux/models/kuaishou/kat-coder-pro-v2.toml
@@ -1,0 +1,21 @@
+name = "KAT-Coder-Pro-V2"
+release_date = "2026-03-30"
+last_updated = "2026-03-30"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+
+[limit]
+context = 256_000
+output = 80_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/qwen/qwen3.6-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.6-plus.toml
@@ -1,0 +1,28 @@
+name = "Qwen3.6-Plus"
+release_date = "2026-03-30"
+last_updated = "2026-03-30"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.50
+output = 3.00
+cache_read = 0.05
+cache_write = 0.625
+
+[cost.context_over_200k]
+input = 2.00
+output = 6.00
+cache_read = 0.20
+cache_write = 2.50
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/z-ai/glm-5v-turbo.toml
+++ b/providers/zenmux/models/z-ai/glm-5v-turbo.toml
@@ -1,0 +1,24 @@
+name = "GLM 5V Turbo"
+release_date = "2026-04-01"
+last_updated = "2026-04-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.726
+output = 3.1946
+cache_read = 0.1743
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add the KAT-Coder-Pro-V2 model definition under Zenmux Kuaishou models
- add the Qwen3.6-Plus model definition under Zenmux Qwen models
- add the GLM 5V Turbo model definition under Zenmux Z-AI models

## Validation
- All new models are tested manually.