### PR TITLE
Add Gemma 4 26B and 31B models

### DIFF
--- a/providers/google/models/gemma-4-26b.toml
+++ b/providers/google/models/gemma-4-26b.toml
@@ -1,0 +1,18 @@
+name = "Gemma 4 26B"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[limit]
+context = 256000
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google/models/gemma-4-31b.toml
+++ b/providers/google/models/gemma-4-31b.toml
@@ -1,0 +1,18 @@
+name = "Gemma 4 31B"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[limit]
+context = 256000
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## What

Adds Gemma 4 model definitions for the two larger open-weight models released by Google DeepMind on April 2, 2026.

## Models Added

### Gemma 4 26B (Mixture of Experts)
- 25.2B total params, 3.8B active params
- 256K context window
- Reasoning, function calling, structured output
- Text + image input, text output
- Apache 2.0 license (open weights)

### Gemma 4 31B (Dense)
- 30.7B params
- 256K context window
- Reasoning, function calling, structured output
- Text + image input, text output
- Apache 2.0 license (open weights)

## Source
- Model card: https://ai.google.dev/gemma/docs/core/model_card_4
- Blog post: https://blog.google/innovation-and-ai/technology/developers-tools/gemma-4/
- Hugging Face: https://huggingface.co/google/gemma-4-31B-it, https://huggingface.co/google/gemma-4-26B-A4B-it

## Notes
- Open weights models have no API pricing (free to self-host)
- Set `open_weights = true`
- Followed existing TOML patterns from other Google models in the repo