### PR TITLE
feat(zai): add GLM-5.1 model

### DIFF
--- a/providers/zai/models/glm-5.1.toml
+++ b/providers/zai/models/glm-5.1.toml
@@ -1,0 +1,27 @@
+name = "GLM-5.1"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200000
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Add GLM-5.1 model definition to the `zai` provider
- GLM-5.1 already exists under the `zai-coding-plan` provider but was missing from the main `zai` provider
- The model is available via the ZhipuAI API with 200K context window and 131K output limit

## Details

GLM-5.1 is a reasoning model released on 2026-03-27. This PR adds the corresponding TOML configuration to `providers/zai/models/` so that the model is properly listed for the `zai` provider, matching its availability through the ZhipuAI API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)