### PR TITLE
Add Google Gemma 4 31B IT to NVIDIA(NIM) provider

### DIFF
--- a/providers/nvidia/models/google/gemma-4-31b-it.toml
+++ b/providers/nvidia/models/google/gemma-4-31b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma-4-31B-IT"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 256000
+output = 16384
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
Add Google Gemma 4 31B IT to NVIDIA NIM provider

### Source
- NVIDIA NIM: https://build.nvidia.com/google/gemma-4-31b-it/modelcard
- NVIDIA NIM Docs: https://docs.api.nvidia.com/nim/reference/google-gemma-4-31b-it
- NVIDIA NIM example to call: https://build.nvidia.com/google/gemma-4-31b-it

> Locally tested with `OPENCODE_MODELS_PATH`