### PR TITLE
provider(vivgrid): add GPT-5.3 Codex, GPT-5.4 Mini, and GPT-5.4 Nano models

### DIFF
--- a/providers/vivgrid/models/gpt-5.3-codex.toml
+++ b/providers/vivgrid/models/gpt-5.3-codex.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.3 Codex"
+family = "gpt-codex"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/vivgrid/models/gpt-5.4-mini.toml
+++ b/providers/vivgrid/models/gpt-5.4-mini.toml
@@ -1,0 +1,28 @@
+name = "GPT-5.4 Mini"
+family = "gpt-mini"
+release_date = "2026-03-17"
+last_updated = "2026-03-17"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.75
+output = 4.50
+cache_read = 0.075
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/vivgrid/models/gpt-5.4-nano.toml
+++ b/providers/vivgrid/models/gpt-5.4-nano.toml
@@ -1,0 +1,28 @@
+name = "GPT-5.4 Nano"
+family = "gpt-nano"
+release_date = "2026-03-17"
+last_updated = "2026-03-17"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 1.25
+cache_read = 0.02
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
## Summary

- Add GPT-5.3 Codex model (reasoning, text+image input, 400K context, $1.75/$14.00 per M tokens)
- Add GPT-5.4 Mini model (reasoning, text+image+pdf input, 400K context, $0.75/$4.50 per M tokens)
- Add GPT-5.4 Nano model (reasoning, text+image+pdf input, 400K context, $0.20/$1.25 per M tokens)

## Test plan

- [ ] Verify model TOML files parse correctly
- [ ] Confirm pricing and limits match official documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)