### PR TITLE
add trinity large thinking to openrouter provider

### DIFF
--- a/providers/openrouter/models/arcee-ai/trinity-large-thinking.toml
+++ b/providers/openrouter/models/arcee-ai/trinity-large-thinking.toml
@@ -9,11 +9,11 @@ last_updated = "2026-04-03"
 open_weights = true
 
 [cost]
-input = 0.25
-output = 0.8999999999999999
+input = 0.22
+output = 0.85
 
 [limit]
-context = 262_100
+context = 262_144
 output = 80_000
 
 [modalities]


### PR DESCRIPTION
**Summary**
This PR adds the Trinity Large Thinking model to the OpenRouter provider and fixes the open_weights flag in the Vercel provider, which was incorrectly set to false.

**Changes**
Added Model Configuration for OpenRouter
- Created new file: providers/openrouter/models/arcee-ai/trinity-large-thinking.toml
- Updated providers/vercel/models/arcee-ai/trinity-large-thinking.toml

**Model Information**
Trinity Large Thinking is a large language model developed by Arcee AI. Key details:
- Release Date: April 1, 2026
- Context Window: 262,144 tokens
- Max Output: 80,000 tokens
- Input Cost: $0.22 per 1M tokens
- Output Cost: $0.85 per 1M tokens
- Open Weights: Yes

**Notes**
This model is distinct from Trinity Large Preview as it has more post-training and dedicated hardware. More information can be found at:
- https://openrouter.ai/arcee-ai/trinity-large-thinking
- https://huggingface.co/arcee-ai/Trinity-Large-Thinking
- https://www.arcee.ai/blog/trinity-large-thinking

**Validation**
The changes were validated by:
1. Running the server locally
2. Pointing an instance of opencode to the local dist/_api.json
3. Verifying the model appears correctly in the UI and functions as expected