### PR TITLE
fix: correct deepseek-chat context window to 131072

### DIFF
--- a/providers/deepseek/models/deepseek-chat.toml
+++ b/providers/deepseek/models/deepseek-chat.toml
@@ -15,7 +15,7 @@ output = 0.42
 cache_read = 0.028
 
 [limit]
-context = 128_000
+context = 131_072
 output = 8_192
 
 [modalities]


### PR DESCRIPTION
## Summary

Updates the `deepseek-chat` context limit from `128_000` to `131_072` so it matches the actual supported maximum token window.

Closes #1295
