### PR TITLE
Add Google Gemma 4 models (OpenRouter sync)

### DIFF
--- a/providers/openrouter/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/openrouter/models/google/gemma-4-26b-a4b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma 4 26B A4B"
+family = "gemma"
+release_date = "2026-04-03"
+last_updated = "2026-04-03"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.13
+output = 0.40
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/openrouter/models/google/gemma-4-31b-it.toml
+++ b/providers/openrouter/models/google/gemma-4-31b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma 4 31B"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.14
+output = 0.40
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
Adds two new Gemma 4 models from OpenRouter. All fields sourced from the OpenRouter `/api/v1/models` API. `knowledge` omitted (`null` in API).

| File | OpenRouter ID | Input | Output |
|---|---|---|---|
| `providers/openrouter/models/google/gemma-4-31b-it.toml` | `google/gemma-4-31b-it` | \$0.14/M | \$0.40/M |
| `providers/openrouter/models/google/gemma-4-26b-a4b-it.toml` | `google/gemma-4-26b-a4b-it` | \$0.13/M | \$0.40/M |