### PR TITLE
deepinfra: Add support for Qwen3.5 models

### DIFF
--- a/providers/deepinfra/models/Qwen/Qwen3.5-0.8B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.5-0.8B.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.5 0.8B"
+family = "qwen"
+release_date = "2026-03-02"
+last_updated = "2026-04-05"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.05
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/deepinfra/models/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.5-122B-A10B.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.5 122B-A10B"
+family = "qwen"
+release_date = "2026-02-24"
+last_updated = "2026-04-05"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.29
+output = 2.90
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/deepinfra/models/Qwen/Qwen3.5-27B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.5-27B.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.5 27B"
+family = "qwen"
+release_date = "2026-02-24"
+last_updated = "2026-04-05"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.26
+output = 2.60
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/deepinfra/models/Qwen/Qwen3.5-2B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.5-2B.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.5 2B"
+family = "qwen"
+release_date = "2026-03-02"
+last_updated = "2026-04-05"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.10
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/deepinfra/models/Qwen/Qwen3.5-35B-A3B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.5-35B-A3B.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.5 35B A3B"
+family = "qwen"
+release_date = "2026-02-24"
+last_updated = "2026-04-05"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 2.20
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/deepinfra/models/Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.5-397B-A17B.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.5 397B A17B"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-04-05"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.54
+output = 3.40
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/deepinfra/models/Qwen/Qwen3.5-4B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.5-4B.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.5 4B"
+family = "qwen"
+release_date = "2026-02-24"
+last_updated = "2026-04-05"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.15
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/deepinfra/models/Qwen/Qwen3.5-9B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.5-9B.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.5 9B"
+family = "qwen"
+release_date = "2026-02-24"
+last_updated = "2026-04-05"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.20
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
This adds support for the new Qwen3.5 models - they're actually featured models in the DeepInfra dashboard.

Only thing of interest here (for output length limit), per the Qwen team:

>We recommend using an output length of 32,768 tokens for most queries. For benchmarking on highly complex problems, such as those found in math and programming competitions, we suggest setting the max output length to 81,920 tokens.