### PR TITLE
deepinfra: Add support for Nvidia Nemotron 3 models

### DIFF
--- a/providers/deepinfra/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.toml
+++ b/providers/deepinfra/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.toml
@@ -1,0 +1,27 @@
+name = "Nemotron 3 Super 120B"
+family = "nemotron"
+release_date = "2026-03-11"
+last_updated = "2026-03-11"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.10
+output = 0.50
+cache_read = 0.10
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/deepinfra/models/nvidia/Nemotron-3-Nano-30B-A3B.toml
+++ b/providers/deepinfra/models/nvidia/Nemotron-3-Nano-30B-A3B.toml
@@ -1,0 +1,23 @@
+name = "Nemotron 3 Nano 30B"
+family = "nemotron"
+release_date = "2025-12-15"
+last_updated = "2025-12-15"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-06"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.20
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This change adds support for Nvidia's Nemotron 3 models from Deep Infra:

- **nvidia/NVIDIA-Nemotron-3-Super-120B-A12B:** https://deepinfra.com/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B
- **nvidia/Nemotron-3-Nano-30B-A3B:** https://deepinfra.com/nvidia/Nemotron-3-Nano-30B-A3B