### PR TITLE
[Vultr] Update Inference Models

### DIFF
--- a/providers/vultr/models/DeepSeek-V3.2.toml
+++ b/providers/vultr/models/DeepSeek-V3.2.toml
@@ -5,16 +5,16 @@ reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
-knowledge = "2024-10"
-release_date = "2025-01-20"
-last_updated = "2025-01-20"
+knowledge = "2024-07"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
 
 [cost]
 input = 0.55
 output = 1.65
 
 [limit]
-context = 163_000
+context = 127_000
 output = 4_096
 
 [modalities]

--- a/providers/vultr/models/GLM-5-FP8.toml
+++ b/providers/vultr/models/GLM-5-FP8.toml
@@ -5,16 +5,16 @@ reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
-knowledge = "2024-10"
-release_date = "2025-01-20"
-last_updated = "2025-01-20"
+knowledge = "2025-05"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
 
 [cost]
 input = 0.85
 output = 3.10
 
 [limit]
-context = 202_000
+context = 200_000
 output = 131_072
 
 [modalities]

--- a/providers/vultr/models/Kimi-K2.5.toml
+++ b/providers/vultr/models/Kimi-K2.5.toml
@@ -5,16 +5,16 @@ reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
-knowledge = "2024-10"
-release_date = "2024-07-18"
-last_updated = "2024-07-18"
+knowledge = "2024-04"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
 
 [cost]
 input = 0.55
 output = 2.75
 
 [limit]
-context = 261_000
+context = 254_000
 output = 32_768
 
 [modalities]

--- a/providers/vultr/models/MiniMax-M2.5.toml
+++ b/providers/vultr/models/MiniMax-M2.5.toml
@@ -5,16 +5,16 @@ reasoning = false
 tool_call = true
 temperature = true
 open_weights = true
-knowledge = "2024-10"
-release_date = "2025-01-20"
-last_updated = "2025-01-20"
+knowledge = "2024-09"
+release_date = "2025-02-11"
+last_updated = "2025-02-11"
 
 [cost]
 input = 0.30
 output = 1.20
 
 [limit]
-context = 196_000
+context = 194_000
 output = 4_096
 
 [modalities]

--- a/providers/vultr/models/gpt-oss-120b.toml
+++ b/providers/vultr/models/gpt-oss-120b.toml
@@ -1,0 +1,22 @@
+name = "GPT OSS 120B"
+family = "gpt-oss"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = true
+knowledge = "2024-06"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 129_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Vultr Updated their Inference API endpoint with different versions of models, this commit adds in new models and corrects some information

<img width="629" height="362" alt="image" src="https://github.com/user-attachments/assets/ca6d9d37-db0d-4a32-a8ac-bf83966b1747" />

Model Added:
* gpt-oss-120b

Models Excluded for now: 
* Qwen2.5-Coder-32B-Instruct (context window is too small error on their end. Currently supports 16k in and 256 out)
* gemma-4-31B-it (model is not online yet, will be added once online.)

Tested Limits
| Model Name | Verified Avg. Limit | Safe Limit (Floor) | Hard Limit (Ceiling) | In 1M | Out 1M |
|---|---|---|---|---|---|
| MiniMaxAI/MiniMax-M2.5 | 194,929 tokens | 194,000 tokens | 195,000 tokens | $0.30 | $1.20 |
| deepseek-ai/DeepSeek-V3.2 | 127,285 tokens | 127,000 tokens | 128,000 tokens | $0.55 | $1.65 |
| moonshotai/Kimi-K2.5 | 254,562 tokens | 254,000 tokens | 255,000 tokens | $0.55 | $2.75 |
| zai-org/GLM-5-FP8 | 200,866 tokens | 200,000 tokens | 201,000 tokens | $0.85 | $3.10 |
| openai/gpt-oss-120b | 129,338 tokens | 129,000 tokens | 130,000 tokens | $0.15 | $0.60 |