### PR TITLE
Update Kimi K2.5 Turbo display name for Firepass clarity

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p5-turbo.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p5-turbo.toml
@@ -1,4 +1,4 @@
-name = "Kimi K2.5 Turbo"
+name = "Kimi K2.5 Turbo (firepass)"
 family = "kimi-thinking"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"


### PR DESCRIPTION
## Summary

Updates the display name for the Kimi K2.5 Turbo router to include `(firepass)` suffix for clarity.

## Background

Follow-up to #1256 which added the Fireworks Kimi K2.5 Turbo router model. This update clarifies in the model name that this is the Firepass/Developer Pass endpoint, distinguishing it from standard pay-per-token offerings.

## Changes

- Display name: `Kimi K2.5 Turbo` → `Kimi K2.5 Turbo (firepass)`

The model ID remains unchanged: `accounts/fireworks/routers/kimi-k2p5-turbo`