### PR TITLE
feat(providers): add Rapid-MLX provider

### DIFF
--- a/providers/rapid-mlx/models/mlx-community/Qwen3-0.6B-4bit.toml
+++ b/providers/rapid-mlx/models/mlx-community/Qwen3-0.6B-4bit.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 0.6B 4bit"
+family = "qwen"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 40_960
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/rapid-mlx/models/mlx-community/Qwen3.5-4B-MLX-4bit.toml
+++ b/providers/rapid-mlx/models/mlx-community/Qwen3.5-4B-MLX-4bit.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.5 4B MLX 4bit"
+family = "qwen"
+release_date = "2026-03-02"
+last_updated = "2026-03-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/rapid-mlx/models/mlx-community/gemma-4-26b-a4b-it-4bit.toml
+++ b/providers/rapid-mlx/models/mlx-community/gemma-4-26b-a4b-it-4bit.toml
@@ -1,0 +1,21 @@
+name = "Gemma 4 26B A4B Instruct 4bit"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-03"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/rapid-mlx/provider.toml
+++ b/providers/rapid-mlx/provider.toml
@@ -1,0 +1,5 @@
+name = "Rapid-MLX"
+env = ["RAPID_MLX_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "http://127.0.0.1:8000/v1"
+doc = "https://github.com/raullenchai/Rapid-MLX"


### PR DESCRIPTION
## Summary

Adds [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) as a new local
provider. Rapid-MLX is an OpenAI-compatible inference server for Apple
Silicon, built on `mlx-lm`.

- Install: `pip install rapid-mlx`
- Run: `rapid-mlx serve <model>`
- Endpoint: `http://127.0.0.1:8000/v1`
- API: OpenAI chat completions, streaming, tool calling
- Repo: https://github.com/raullenchai/Rapid-MLX

## Files

- `providers/rapid-mlx/provider.toml` — provider entry, mirrors the
  existing `lmstudio` provider (uses `@ai-sdk/openai-compatible`).
- `providers/rapid-mlx/models/...` — a small set of representative
  MLX-quantized models. More can be added incrementally.

## Notes

- Pattern follows the existing `lmstudio` provider. No code changes.
- Model IDs match the exact strings users pass to `rapid-mlx serve`.
- Tool calling is supported via Rapid-MLX's parser layer.