### PR TITLE
fix: correct glm-5-turbo pricing and context for openrouter

### DIFF
--- a/providers/openrouter/models/z-ai/glm-5-turbo.toml
+++ b/providers/openrouter/models/z-ai/glm-5-turbo.toml
@@ -13,13 +13,13 @@ open_weights = false
 field = "reasoning_content"
 
 [cost]
-input = 1.20
-output = 4.00
-cache_read = 0.24
+input = 0.96
+output = 3.20
+cache_read = 0.192
 cache_write = 0
 
 [limit]
-context = 200_000
+context = 202_752
 output = 131_072
 
 [modalities]


### PR DESCRIPTION
## Summary

Corrects the `glm-5-turbo` OpenRouter metadata to match the latest provider values.

### Changes

* updated pricing values
* corrected cache read cost
* updated context window from `200_000` to `202_752`

Closes #1212
