### PR TITLE
fix(stepfun): update provider endpoints and pricing

### DIFF
--- a/providers/stepfun/models/step-3.5-flash.toml
+++ b/providers/stepfun/models/step-3.5-flash.toml
@@ -9,9 +9,9 @@ knowledge = "2025-01"
 open_weights = true
 
 [cost]
-input = 0.096
-output = 0.288
-cache_read = 0.019
+input = 0.10
+output = 0.30
+cache_read = 0.02
 
 [limit]
 context = 256_000

--- a/providers/stepfun/provider.toml
+++ b/providers/stepfun/provider.toml
@@ -1,5 +1,5 @@
 name = "StepFun"
 env = ["STEPFUN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-doc = "https://platform.stepfun.com/docs/zh/overview/concept"
-api = "https://api.stepfun.com/v1"
+doc = "https://platform.stepfun.ai/docs/en/guides/basic-concepts"
+api = "https://api.stepfun.ai/v1"


### PR DESCRIPTION
## Summary

This PR updates the StepFun provider configuration to reflect their platform migration from stepfun.com to stepfun.ai. The API endpoint, documentation URL, and pricing for the step-3.5-flash model are updated to match the current official documentation.

## Changes

- **Provider configuration**: Updated API endpoint from `https://api.stepfun.com/v1` to `https://api.stepfun.ai/v1`
- **Documentation URL**: Updated docs link from Chinese to English documentation at `https://platform.stepfun.ai/docs/en/guides/basic-concepts`
- **Pricing updates**: Adjusted step-3.5-flash model pricing (input: $0.096→$0.10, output: $0.288→$0.30, cache_read: $0.019→$0.02 per 1M tokens)

## Breaking Changes

- API endpoint changed from `api.stepfun.com` to `api.stepfun.ai`. This is a provider-mandated migration — the old domain may stop working. Users should update their configurations.

## Testing

- [x] All configurations validated with `bun validate`