### PR TITLE
feat(stepfun): add step-3.5-flash-2603 model

### DIFF
--- a/providers/stepfun/models/step-3.5-flash-2603.toml
+++ b/providers/stepfun/models/step-3.5-flash-2603.toml
@@ -1,0 +1,23 @@
+name = "Step 3.5 Flash 2603"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.02
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds the Step 3.5 Flash 2603 model to the StepFun provider. This is an optimized version of Step 3.5 Flash tuned for high-frequency agent workflows and coding tasks.

## Changes

- Add `providers/stepfun/models/step-3.5-flash-2603.toml`

## Details

- **Release date**: April 2, 2026
- **Architecture**: Sparse MoE (196B total / 11B active), same as step-3.5-flash
- **Pricing**: Same as step-3.5-flash ($0.10/$0.30/$0.02 per 1M tokens)
- **Context**: 256K tokens
- **Features**: Low Think Mode for reduced token consumption in cost-sensitive scenarios

## Testing

- [x] Validated with `bun validate`