### PR TITLE
feat(stepfun-plan): add StepFun Step Plan provider

### DIFF
--- a/providers/stepfun-step-plan/models/step-3.5-flash-2603.toml
+++ b/providers/stepfun-step-plan/models/step-3.5-flash-2603.toml
@@ -1,0 +1,22 @@
+name = "Step 3.5 Flash 2603"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/stepfun-step-plan/models/step-3.5-flash.toml
+++ b/providers/stepfun-step-plan/models/step-3.5-flash.toml
@@ -1,0 +1,22 @@
+name = "Step 3.5 Flash"
+release_date = "2026-01-29"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/stepfun-step-plan/provider.toml
+++ b/providers/stepfun-step-plan/provider.toml
@@ -1,0 +1,5 @@
+name = "StepFun Step Plan"
+env = ["STEPFUN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://platform.stepfun.ai/docs/en/step-plan/overview"
+api = "https://api.stepfun.ai/step_plan/v1"


### PR DESCRIPTION
## Summary

Adds StepFun Step Plan as a new provider. Step Plan is a subscription-based AI service with a dedicated API endpoint, separate from the standard StepFun pay-per-token API.

## Changes

- Add `providers/stepfun-step-plan/provider.toml`
- Add `providers/stepfun-step-plan/models/step-3.5-flash.toml`
- Add `providers/stepfun-step-plan/models/step-3.5-flash-2603.toml`

## Details

- **API endpoint**: `https://api.stepfun.ai/step_plan/v1` (separate from standard API at `/v1`)
- **Pricing**: Subscription-based ($6.99–$99/month), cost set to 0 per token
- **Models**: step-3.5-flash and step-3.5-flash-2603 (optimized for agent workflows)
- **Auth**: Same `STEPFUN_API_KEY` env var
- **Docs**: https://platform.stepfun.ai/docs/en/step-plan/overview

## Testing

- [x] Validated with `bun validate`