### PR TITLE
feat(ollama-cloud): add GLM-5.1

### DIFF
--- a/providers/ollama-cloud/models/glm-5.1.toml
+++ b/providers/ollama-cloud/models/glm-5.1.toml
@@ -1,0 +1,19 @@
+name = "glm-5.1"
+family = "glm"
+attachment = false
+reasoning = true
+tool_call = true
+release_date = "2026-03-27"
+last_updated = "2026-04-07"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 202752
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
I did not set the` temperature=true` flag because it was also not set for GLM-5 on Ollama Cloud, but it is set in the Huggingface version: https://github.com/gary149/models.dev/blob/df41a38c6f1ca375f01ba1269b053fbdba92d125/providers/huggingface/models/zai-org/GLM-5.1.toml#L7