### PR TITLE
feat(openrouter): add z-ai/glm-5.1 model

### DIFF
--- a/providers/openrouter/models/z-ai/glm-5.1.toml
+++ b/providers/openrouter/models/z-ai/glm-5.1.toml
@@ -1,0 +1,26 @@
+name = "GLM-5.1"
+family = "glm"
+release_date = "2026-04-07"
+last_updated = "2026-04-07"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.26
+
+[limit]
+context = 202_752
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds GLM-5.1 by Z.ai to the OpenRouter provider.

## Changes

- Add `providers/openrouter/models/z-ai/glm-5.1.toml`

## Details

- **Context**: 202,752 tokens
- **Pricing**: $1.40/M input, $4.40/M output, $0.26/M cache read
- **Capabilities**: Reasoning, tool call, structured output
- **Open weights**: Yes ([HuggingFace](https://huggingface.co/zai-org/GLM-5.1))
- **Release date**: April 7, 2026

## Testing

- [x] Validated with `bun validate`