### PR TITLE
feat(core): expose provider baseURL from api metadata

### DIFF
--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -42,6 +42,9 @@ export async function generate(directory: string) {
       }
       provider.data.models[modelID] = model.data;
     }
+    if (provider.data.api) {
+      (provider.data as any).baseURL = provider.data.api;
+    }
     result[providerID] = provider.data;
   }
 


### PR DESCRIPTION
## Summary

Exposes `baseURL` in generated provider JSON by aliasing the existing provider `api` metadata field.

This keeps the current `api` field fully intact while giving downstream consumers a clearer globally unique provider identifier.

## Changes

* added additive `baseURL` alias in provider generation path
* reuses existing `provider.data.api`
* no TOML schema changes
* fully backward compatible

Closes #596
