### PR TITLE
feat(chutes): add zai-org/GLM-5.1-TEE model

### DIFF
--- a/providers/chutes/models/zai-org/GLM-5.1-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-5.1-TEE.toml
@@ -1,0 +1,26 @@
+name = "GLM 5.1 TEE"
+family = "glm"
+release_date = "2026-04-08"
+last_updated = "2026-04-08"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.95
+output = 3.15
+cache_read = 0.475
+
+[limit]
+context = 202_752
+output = 65_535
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
This PR adds support for the **GLM-5.1-TEE** model (by zai-org) to the Chutes provider ecosystem.

## Model Details
- **Model**: GLM 5.1 TEE (`zai-org/GLM-5.1-TEE`)
- **Family**: GLM
- **Context Length**: 202,752 tokens
- **Max Output**: 65,535 tokens
- **Input Modalities**: Text
- **Output Modalities**: Text

## Pricing (per million tokens)
| Type | USD |
|------|-----|
| Input | $0.95 |
| Output | $3.15 |
| Cache Read | $0.475 |

## Supported Features
- Reasoning (interleaved via `reasoning_content` field)
- Tool calling
- Structured output / JSON mode
- Temperature control

## Source
Data sourced from the [Chutes API](https://llm.chutes.ai/v1/models).