### PR TITLE
feat(openrouter): add Gemma 4 free models

### DIFF
--- a/providers/openrouter/models/google/gemma-4-26b-a4b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-4-26b-a4b-it:free.toml
@@ -1,0 +1,23 @@
+name = "Gemma 4 26B A4B (free)"
+family = "gemma"
+release_date = "2026-04-03"
+last_updated = "2026-04-03"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/openrouter/models/google/gemma-4-31b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-4-31b-it:free.toml
@@ -1,0 +1,23 @@
+name = "Gemma 4 31B (free)"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add free variants of Gemma 4 models to OpenRouter provider
- Both models support multimodal input (text + image + video) with 256K context

## Changes
- Add `providers/openrouter/models/google/gemma-4-31b-it:free.toml`
- Add `providers/openrouter/models/google/gemma-4-26b-a4b-it:free.toml`

## Model Details

| Field | Gemma 4 31B (free) | Gemma 4 26B A4B (free) |
|-------|-------------------|----------------------|
| **Architecture** | Dense 30.7B | MoE 25.2B (3.8B active) |
| **Context** | 262,144 | 262,144 |
| **Max Output** | 32,768 | 32,768 |
| **Input** | text, image, video | text, image, video |
| **Output** | text | text |
| **Pricing** | $0.00 / $0.00 | $0.00 / $0.00 |
| **Reasoning** | Yes | Yes |
| **Tool Use** | Yes | Yes |
| **Structured Output** | Yes | Yes |

**Source:** https://openrouter.ai/google/gemma-4-31b-it:free
**Source:** https://openrouter.ai/google/gemma-4-26b-a4b-it:free

## Validation
- `bun validate` passes successfully