### PR TITLE
Add qwen3-coder-next model for cortecs

### DIFF
--- a/providers/cortecs/models/qwen3-coder-next.toml
+++ b/providers/cortecs/models/qwen3-coder-next.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 Coder Next 80B"
+family = "qwen"
+release_date = "2026-02-04"
+last_updated = "2026-02-04"
+knowledge = "2025-04"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.158
+output = 0.84
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

This PR adds the **Qwen3 Coder Next 80B** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `qwen3-coder-next`
- **Name:** Qwen3 Coder Next 80B
- **Family:** qwen
- **Release Date:** 2026-02-04
- **Knowledge Cutoff:** 2025-04

## Capabilities

- ✅ Reasoning
- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights

## Pricing (EUR)

- **Input:** €0.158 per million tokens
- **Output:** €0.84 per million tokens

## Limits

- **Context Window:** 256,000 tokens
- **Max Output:** 65,536 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified