### PR TITLE
fix(openrouter): replace discontinued qwen3.6-plus free with paid model

### DIFF
--- a/providers/openrouter/models/qwen/qwen3.6-plus.toml
+++ b/providers/openrouter/models/qwen/qwen3.6-plus.toml
@@ -1,17 +1,18 @@
-name = "Qwen3.6 Plus (free)"
+name = "Qwen3.6 Plus"
 family = "qwen"
 release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
 temperature = true
+knowledge = "2025-04"
 tool_call = true
 structured_output = true
 open_weights = false
 
 [cost]
-input = 0.00
-output = 0.00
+input = 0.325
+output = 1.95
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
## Summary
- adds the missing paid OpenRouter model `qwen/qwen3.6-plus`
- removes the discontinued free model `qwen/qwen3.6-plus:free`
- aligns models.dev with the current OpenRouter catalog for Qwen3.6 Plus
## Data sources
- OpenRouter model page: https://openrouter.ai/qwen/qwen3.6-plus
- OpenRouter free variant deprecation pages:
  - https://openrouter.ai/qwen/qwen3.6-plus:free/providers
  - https://openrouter.ai/qwen/qwen3.6-plus:free/pricing
## Test plan
- `bun install`
- `bun validate` passes with exit code 0
- confirmed `qwen/qwen3.6-plus` is present in the validated output
- confirmed `qwen/qwen3.6-plus:free` no longer appears in the validated output

Closes #1388