### PR TITLE
feat(fireworks): add GLM 5.1 and Qwen 3.6 Plus models

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p1.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p1.toml
@@ -1,0 +1,25 @@
+name = "GLM 5.1"
+family = "glm"
+release_date = "2026-04-01"
+last_updated = "2026-04-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.26
+
+[limit]
+context = 202_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p6-plus.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p6-plus.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.6 Plus"
+family = "qwen"
+release_date = "2026-04-04"
+last_updated = "2026-04-04"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+cache_read = 0.10
+input = 0.50
+output = 3.00
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- adds `qwen3p6-plus` (Qwen 3.6 Plus) to the Fireworks AI provider
- adds `glm-5p1` (GLM 5.1) to the Fireworks AI provider

## Data sources
- Fireworks AI model pages:
  - [Qwen 3.6 Plus](https://fireworks.ai/models/fireworks/qwen3p6-plus)
  - [GLM 5.1](https://fireworks.ai/models/fireworks/glm-5p1)
- Pricing and capabilities sourced from Fireworks AI; limits inferred from similar models where not explicitly stated

## Testing
- `bun validate` passes
- Tested with Opencode 1.4.0