### PR TITLE
Add Grok 4.20 reasoning and non-reasoning to Azure

### DIFF
--- a/providers/azure/models/grok-4-20-non-reasoning.toml
+++ b/providers/azure/models/grok-4-20-non-reasoning.toml
@@ -1,0 +1,23 @@
+name = "Grok 4.20 (Non-Reasoning)"
+family = "grok"
+release_date = "2026-04-08"
+last_updated = "2026-04-08"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-09"
+tool_call = true
+open_weights = false
+status = "beta"
+
+[cost]
+input = 2.00
+output = 6.00
+
+[limit]
+context = 262_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/azure/models/grok-4-20-reasoning.toml
+++ b/providers/azure/models/grok-4-20-reasoning.toml
@@ -1,0 +1,23 @@
+name = "Grok 4.20 (Reasoning)"
+family = "grok"
+release_date = "2026-04-08"
+last_updated = "2026-04-08"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-09"
+tool_call = true
+open_weights = false
+status = "beta"
+
+[cost]
+input = 2.00
+output = 6.00
+
+[limit]
+context = 262_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds Grok 4.20 reasoning and non-reasoning variants for Azure AI Foundry (public preview, launched 2026-04-08)
- 262K context window, 8,192 max output tokens
- $2.00 input / $6.00 output per 1M tokens (Global Standard deployment)