### PR TITLE
Add GLM-5.1 and GLM-5V-Turbo model configurations for siliconflow

### DIFF
--- a/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.1.toml
+++ b/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.1.toml
@@ -1,0 +1,27 @@
+name = "Pro/zai-org/GLM-5.1"
+family = "glm"
+release_date = "2026-04-08"
+last_updated = "2026-04-08"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_input = 0.26
+cache_write = 0
+
+[limit]
+context = 205_000
+output = 205_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/siliconflow/models/zai-org/GLM-5.1.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.1.toml
@@ -1,0 +1,27 @@
+name = "zai-org/GLM-5.1"
+family = "glm"
+release_date = "2026-04-08"
+last_updated = "2026-04-08"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_input = 0.26
+cache_write = 0
+
+[limit]
+context = 205_000
+output = 205_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/siliconflow/models/zai-org/GLM-5V-Turbo.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5V-Turbo.toml
@@ -1,0 +1,26 @@
+name = "zai-org/GLM-5V-Turbo"
+family = "glm"
+release_date = "2026-04-01"
+last_updated = "2026-04-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.2
+output = 4
+cache_input = 0.24
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
This pull request adds support for two new GLM-5.1 and one new GLM-5V-Turbo models from `zai-org` to the SiliconFlow provider. It introduces configuration files for these models, specifying their capabilities, cost, and supported modalities.

**New model configurations:**

*Added GLM-5.1 model config:*
- [`providers/siliconflow/models/zai-org/GLM-5.1.toml`](diffhunk://#diff-548f58e01864ef83cb9558ffba224532c4e515a5b5b924484fa03a23b459d0c9R1-R27): Introduces the `zai-org/GLM-5.1` model with text input/output, advanced features like reasoning and tool calling, and high context/output limits.
- [`providers/siliconflow-cn/models/Pro/zai-org/GLM-5.1.toml`](diffhunk://#diff-02fba0cd33bc2da0335a864cfb354de1170b5feeb977bb15dde9348fd824a073R1-R27): Adds a similar configuration for the `Pro/zai-org/GLM-5.1` variant, likely for a different deployment or region.

*Added GLM-5V-Turbo model config:*
- [`providers/siliconflow/models/zai-org/GLM-5V-Turbo.toml`](diffhunk://#diff-f509d612a7d1cf52f1f4844bc9317e4412b04ad7ece5e0d5c35144e1e8e677b4R1-R26): Adds the `zai-org/GLM-5V-Turbo` model, supporting both text and image input, with attachment capability and slightly different cost and context limits compared to GLM-5.1.