### PR TITLE
Venice: Update model configs with refreshed pricing and limits

### DIFF
--- a/providers/venice/models/google.gemma-4-26b-a4b-it.toml
+++ b/providers/venice/models/google.gemma-4-26b-a4b-it.toml
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-02"
-last_updated = "2026-04-04"
+last_updated = "2026-04-09"
 open_weights = true
 
 [cost]
@@ -15,7 +15,7 @@ output = 0.5
 
 [limit]
 context = 256_000
-output = 12_288
+output = 8_192
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/venice/models/google.gemma-4-31b-it.toml
+++ b/providers/venice/models/google.gemma-4-31b-it.toml
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-03"
-last_updated = "2026-04-04"
+last_updated = "2026-04-09"
 open_weights = true
 
 [cost]
@@ -15,7 +15,7 @@ output = 0.5
 
 [limit]
 context = 256_000
-output = 12_288
+output = 8_192
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/venice/models/grok-4-20-beta.toml
+++ b/providers/venice/models/grok-4-20-beta.toml
@@ -6,18 +6,18 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-03-12"
-last_updated = "2026-03-16"
+last_updated = "2026-04-09"
 open_weights = false
 
 [cost]
-input = 2.5
-output = 7.5
-cache_read = 0.25
+input = 2.27
+output = 6.8
+cache_read = 0.23
 
 [cost.context_over_200k]
-input = 5
-output = 15
-cache_read = 0.25
+input = 4.53
+output = 13.6
+cache_read = 0.23
 
 [limit]
 context = 2_000_000

--- a/providers/venice/models/grok-4-20-multi-agent-beta.toml
+++ b/providers/venice/models/grok-4-20-multi-agent-beta.toml
@@ -6,18 +6,18 @@ tool_call = false
 structured_output = true
 temperature = true
 release_date = "2026-03-12"
-last_updated = "2026-03-16"
+last_updated = "2026-04-09"
 open_weights = false
 
 [cost]
-input = 2.5
-output = 7.5
-cache_read = 0.25
+input = 2.27
+output = 6.8
+cache_read = 0.23
 
 [cost.context_over_200k]
-input = 5
-output = 15
-cache_read = 0.25
+input = 4.53
+output = 13.6
+cache_read = 0.23
 
 [limit]
 context = 2_000_000

--- a/providers/venice/models/grok-41-fast.toml
+++ b/providers/venice/models/grok-41-fast.toml
@@ -7,13 +7,13 @@ structured_output = true
 temperature = true
 knowledge = "2025-07"
 release_date = "2025-12-01"
-last_updated = "2026-03-12"
+last_updated = "2026-04-09"
 open_weights = false
 
 [cost]
-input = 0.25
-output = 0.625
-cache_read = 0.0625
+input = 0.23
+output = 0.57
+cache_read = 0.06
 
 [limit]
 context = 1_000_000

--- a/providers/venice/models/qwen-3-6-plus.toml
+++ b/providers/venice/models/qwen-3-6-plus.toml
@@ -1,4 +1,4 @@
-name = "Qwen 3.6 Plus"
+name = "Qwen 3.6 Plus Uncensored"
 family = "qwen"
 attachment = true
 reasoning = true
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-06"
-last_updated = "2026-04-07"
+last_updated = "2026-04-09"
 open_weights = false
 
 [cost]
@@ -14,6 +14,10 @@ input = 0.625
 output = 3.75
 cache_read = 0.0625
 cache_write = 0.78
+
+[cost.context_over_200k]
+input = 2.5
+output = 7.5
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
- Adjust Grok pricing to reflect current rates
- Correct Gemma 4 output limits from 12288 to 8192
- Add context_over_200k pricing for Qwen 3.6 Plus
- Rename Qwen 3.6 Plus to "Uncensored" variant