### PR TITLE
Venice: Add 4 new AI models

### DIFF
--- a/providers/venice/models/mercury-2.toml
+++ b/providers/venice/models/mercury-2.toml
@@ -1,0 +1,23 @@
+name = "Mercury 2"
+family = "mercury"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-02-20"
+last_updated = "2026-04-09"
+open_weights = false
+
+[cost]
+input = 0.3125
+output = 0.9375
+cache_read = 0.03125
+
+[limit]
+context = 128_000
+output = 50_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/venice/models/mistral-small-2603.toml
+++ b/providers/venice/models/mistral-small-2603.toml
@@ -1,0 +1,22 @@
+name = "Mistral Small 4"
+family = "mistral-small"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-03-16"
+last_updated = "2026-04-09"
+open_weights = true
+
+[cost]
+input = 0.1875
+output = 0.75
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/venice/models/nvidia-nemotron-cascade-2-30b-a3b.toml
+++ b/providers/venice/models/nvidia-nemotron-cascade-2-30b-a3b.toml
@@ -1,0 +1,22 @@
+name = "Nemotron Cascade 2 30B A3B"
+family = "nemotron"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-03-24"
+last_updated = "2026-04-09"
+open_weights = true
+
+[cost]
+input = 0.14
+output = 0.8
+
+[limit]
+context = 256_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/venice/models/qwen3-5-397b-a17b.toml
+++ b/providers/venice/models/qwen3-5-397b-a17b.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.5 397B"
+family = "qwen"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-02-16"
+last_updated = "2026-04-09"
+open_weights = false
+
+[cost]
+input = 0.75
+output = 4.5
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
- Add Mercury 2 (reasoning model)
- Add Mistral Small 4 (multimodal)
- Add Nemotron Cascade 2 30B A3B
- Add Qwen 3.5 397B (multimodal)