### PR TITLE
Venice: Remove private field fallback for open weights

### DIFF
--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -241,9 +241,7 @@ function mergeModel(
   const contextTokens = spec.availableContextTokens;
   const outputTokens = spec.maxCompletionTokens ?? Math.floor(contextTokens / 4);
 
-  const openWeights = spec.modelSource
-    ? spec.modelSource.toLowerCase().includes("huggingface")
-    : spec.privacy === "private";
+  const openWeights = spec.modelSource?.toLowerCase().includes("huggingface") ?? false;
 
   const inputModalities = buildInputModalities(caps);
 


### PR DESCRIPTION
- Rely solely on modelSource for open weights detection
- With the new ZDR policies, the field privacy field cant be use to infer if the model is open weights