### PR TITLE
Fix MiniMax M2.5 output token limit for context budgeting

### DIFF
--- a/providers/cloudferro-sherlock/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/cloudferro-sherlock/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -15,7 +15,7 @@ output = 1.20
 
 [limit]
 context = 196_000
-output = 196_000
+output = 32_000
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Set limit.output to 32,000 tokens to enable accurate context management in opencode. Reserving ~16% of the 196k context window for output mirrors the Claude balance (32k / 200k) and gives opencode a realistic budget split between input and output tokens. 