### PR TITLE
Add MiniMax M2.5 (free) configuration file

### DIFF
--- a/providers/openrouter/models/minimax/minimax-m2.5:free.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.5:free.toml
@@ -1,0 +1,25 @@
+name = "MiniMax M2.5 (free)"
+family = "minimax"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+open_weights = true
+
+[interleaved]
+field = "reasoning_details"
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Added missing components to the :free variant models provided by Open Inference on OpenRouter, confirmed functionality with OpenCode, and copied the standard variant file data as is, except for `cost.*` details.

ref. https://openrouter.ai/provider/open-inference
ref. https://openrouter.ai/minimax/minimax-m2.5:free

Covered by #1349 and #1405 maybe.