### PR TITLE
Add Pro/zai-org/GLM-5.1 model metadata (siliconflow-cn)

### DIFF
--- a/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.1.toml
+++ b/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.1.toml
@@ -1,0 +1,27 @@
+name = "GLM-5.1"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+cache_write = 0
+
+[limit]
+context = 200000
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add metadata for Pro/zai-org/GLM-5.1 to enable discovery in clients that sync from models.dev.

## File added
providers/siliconflow-cn/models/Pro/zai-org/GLM-5.1.toml

## Key details
- **Display name**: GLM 5.1
- **Provider**: siliconflow-cn (Z.ai)
- **Capabilities**: chat, completion, code, reasoning, tool_call, streaming
- **Context limit**: 205K tokens (total)
- **Max output**: 131K tokens
- **Example cost**: Input $1.4 / 1M tokens, Output $4.4 / 1M tokens (USD)
- **Homepage**: https://cloud.siliconflow.cn/me/models?target=Pro%2Fzai-org%2FGLM-5.1

## Notes
- The **cost** and **limit** fields are taken from the public SiliconFlow model page and should be verified by siliconflow-cn / Z.ai before merging.
- `open_weights` set to true per public listing; please confirm licensing if this is incorrect.
- Endpoint and auth hints included; some features may require Coding Plan binding or dedicated endpoints.

## Testing
1. Place the TOML locally under `providers/siliconflow-cn/models/Pro/zai-org/` and run the repository's model validation script (if available) or a TOML linter.
2. After merge, clients that sync from models.dev will pick up the new entry.
3. Locally, to force-refresh client caches:
   - Stop client process (e.g., opencode)
   - Remove local models cache (e.g., `rm -f ~/.cache/opencode/models.json`)
   - Restart client and verify model appears in `/models` or `opencode models --verbose`

## Links
- Model console: https://cloud.siliconflow.cn/me/models?target=Pro%2Fzai-org%2FGLM-5.1