### PR TITLE
Poe: add GLM-5 model

### DIFF
--- a/providers/poe/models/novita/glm-5.toml
+++ b/providers/poe/models/novita/glm-5.toml
@@ -1,0 +1,16 @@
+name = "glm-5"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = true
+reasoning = true
+temperature = false
+open_weights = false
+tool_call = true
+
+[limit]
+context = 205_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/poe/models/novita/glm-5.toml
+++ b/providers/poe/models/novita/glm-5.toml
@@ -3,7 +3,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = true
 reasoning = true
-temperature = false
+temperature = true
 open_weights = false
 tool_call = true
 


### PR DESCRIPTION
~this is still a draft PR, im hoping to get the ok from @fhennerkes and @kamilio before marking it as ready for review~ edit: ready for review

i noticed from https://poe.com/api/models that `glm-5` is available via Novita AI, and i would like to try out using `glm-5` using Poe as a provider on Opencode, which pulls its models from models.dev

as much as possible i followed the existing conventions for other GLM models provided by Poe via Novita AI, but i cant help but notice a few things
- `glm-4.7` should be deprecated in favor of `glm-4.7-n` according to https://poe.com/api/models. `glm-4.7` is broken on Opencode while `glm-4.7-n` works.
- other GLM providers have set `temperature = true` and `open_weights = true`, whereas Poe has them set to `false`. is that accurate or should Poe change these fields to be consistent with other providers as well?

i dont mind helping to address these issues, either in this PR or in separate PRs

this PR references
- https://github.com/anomalyco/models.dev/pull/374
- https://github.com/anomalyco/models.dev/pull/1374

thanks for all the great work!