### PR TITLE
feat(schema): add bearer auth_type for MiniMax providers

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -134,6 +134,7 @@ export const Provider = z
     env: z.array(z.string()).min(1, "Provider env cannot be empty"),
     npm: z.string().min(1, "Provider npm module cannot be empty"),
     api: z.string().optional(),
+    auth_type: z.enum(["bearer"]).optional(),
     name: z.string().min(1, "Provider name cannot be empty"),
     doc: z
       .string()

--- a/providers/minimax-cn-coding-plan/provider.toml
+++ b/providers/minimax-cn-coding-plan/provider.toml
@@ -3,3 +3,4 @@ env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"
 doc = "https://platform.minimaxi.com/docs/coding-plan/intro"
 api = "https://api.minimaxi.com/anthropic/v1"
+auth_type = "bearer"

--- a/providers/minimax-cn/provider.toml
+++ b/providers/minimax-cn/provider.toml
@@ -3,3 +3,4 @@ env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"
 doc = "https://platform.minimaxi.com/docs/guides/quickstart"
 api = "https://api.minimaxi.com/anthropic/v1"
+auth_type = "bearer"

--- a/providers/minimax-coding-plan/provider.toml
+++ b/providers/minimax-coding-plan/provider.toml
@@ -3,3 +3,4 @@ env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"
 doc = "https://platform.minimax.io/docs/coding-plan/intro"
 api = "https://api.minimax.io/anthropic/v1"
+auth_type = "bearer"

--- a/providers/minimax/provider.toml
+++ b/providers/minimax/provider.toml
@@ -3,3 +3,4 @@ env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"
 doc = "https://platform.minimax.io/docs/guides/quickstart"
 api = "https://api.minimax.io/anthropic/v1"
+auth_type = "bearer"


### PR DESCRIPTION
Fixes #1398

Adds optional `auth_type` provider metadata so bearer-auth providers can declare their authentication mechanism.

This updates all 4 MiniMax providers with:

auth_type = "bearer"

This remains fully backward-compatible because providers without this field preserve existing behavior.
