### PR TITLE
Kilo Gateway: Add GLM 5.1, Remove MiniMax M2.5 Free

### DIFF
--- a/providers/kilo/models/z-ai/glm-5.1.toml
+++ b/providers/kilo/models/z-ai/glm-5.1.toml
@@ -1,6 +1,6 @@
-name = "MiniMax: MiniMax M2.5 (free)"
-release_date = "2026-02-12"
-last_updated = "2026-02-12"
+name = "Z.ai: GLM 5.1"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
 attachment = false
 reasoning = true
 temperature = true
@@ -8,12 +8,11 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0
-output = 0
-cache_read = 0
+input = 1.26
+output = 3.96
 
 [limit]
-context = 204800
+context = 202752
 output = 131072
 
 [modalities]


### PR DESCRIPTION
# Kilo Gateway: Add GLM 5.1, Remove MiniMax M2.5 Free

## Summary

Two model changes for the Kilo Gateway provider:

1. **Add** `z-ai/glm-5.1` — GLM 5.1 is available on the Kilo API and already listed by other providers on models.dev (OpenRouter, Zenmux), but was missing from the Kilo entry.
2. **Remove** `minimax/minimax-m2.5:free` — the free tier of MiniMax M2.5 has been removed from the Kilo API and the TOML file is deleted accordingly.

## Changes

- **New file:** `providers/kilo/models/z-ai/glm-5.1.toml`
- **Deleted file:** `providers/kilo/models/minimax/minimax-m2.5:free.toml`

## Model Details

| Field | Value |
|-------|-------|
| Name | Z.ai: GLM 5.1 |
| Provider | Kilo Gateway |
| Model ID | `z-ai/glm-5.1` |
| Release date | 2026-03-27 |
| Context window | 202,752 tokens |
| Max output | 131,072 tokens |
| Input cost | $1.26 / 1M tokens |
| Output cost | $3.96 / 1M tokens |
| Reasoning | Yes |
| Tool calling | Yes |
| Temperature | Yes |
| Open weights | Yes |
| Modalities | Text → Text |

## Field Rationale

- **Naming:** Follows the `"Z.ai: <Model>"` convention used by all other Kilo z-ai models (GLM 5, GLM 4.7, GLM 4.5, etc.)
- **Costs:** Derived from Kilo API pricing data — $0.00000126/token input → $1.26/M, $0.00000396/token output → $3.96/M
- **Context / output limits:** `context = 202752` matches the API's `context_length`; `output = 131072` matches GLM 5 on Kilo (the API returns null for max output, so the GLM 5 value is used as a conservative ceiling)
- **Capabilities:** `reasoning`, `tool_call`, and `temperature` are all confirmed by the Kilo API's supported params list for this model
- **`open_weights = true`:** Consistent with GLM 5.1 on OpenRouter and all other Kilo z-ai models
- **`attachment = false`:** Text-only input/output; no image or file attachment support listed by the API

## Fields Intentionally Omitted

- `family`: No existing Kilo z-ai model uses this field
- `structured_output`: Not used by any Kilo z-ai model (even though the API supports it)
- `[interleaved]`: Not used by any Kilo z-ai model
- `cache_read` / `cache_write`: Not present in Kilo API pricing data for this model

## Validation

`bun validate` passes with no errors. The model appears correctly in the validated output as:

```json
"z-ai/glm-5.1": {
  "id": "z-ai/glm-5.1",
  "name": "Z.ai: GLM 5.1",
  "attachment": false,
  "reasoning": true,
  "tool_call": true,
  "temperature": true,
  ...
}
```
