### PR TITLE
Feat: Kilo Gateway: Add MiniMax M2.7

### DIFF
--- a/providers/kilo/models/minimax/minimax-m2.7.toml
+++ b/providers/kilo/models/minimax/minimax-m2.7.toml
@@ -1,0 +1,22 @@
+name = "MiniMax: MiniMax M2.7"
+family = "minimax-m2.7"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# feat: Add MiniMax M2.7 to Kilo Gateway

## Summary

Adds `providers/kilo/models/minimax/minimax-m2.7.toml` — the MiniMax M2.7 model is available on the Kilo gateway API but was missing from the models.dev database for the Kilo provider.

## File created

`providers/kilo/models/minimax/minimax-m2.7.toml`

## Field-by-field rationale

| Field | Value | Reason |
|---|---|---|
| `name` | `"MiniMax: MiniMax M2.7"` | Follows the Kilo naming convention used in all other Kilo MiniMax models (e.g. `"MiniMax: MiniMax M2.5"`, `"MiniMax: MiniMax M2.1"`). The prefix `"MiniMax: "` is Kilo-specific and differs from other providers. |
| `family` | `"minimax-m2.7"` | Valid enum in `packages/core/src/family.ts`. |
| `release_date` | `"2026-03-18"` | Consensus date across all providers that already carry this model (novita-ai, opencode-go, ollama-cloud). |
| `last_updated` | `"2026-03-18"` | Same as release date; no known patch revision at time of addition. |
| `attachment` | `false` | Kilo API reports text-only input modality. No image, audio, or file input supported. |
| `reasoning` | `true` | Kilo API lists both `reasoning` and `include_reasoning` as supported parameters for this model. |
| `temperature` | `true` | Kilo API explicitly lists `temperature` as a supported parameter. |
| `tool_call` | `true` | Kilo API lists `tools` and `tool_choice` as supported parameters. Confirmed by official MiniMax M2.7 function-calling documentation. |
| `open_weights` | `true` | MiniMax M2.7 is open-weights. Consistent with all other Kilo MiniMax models. |
| `cost.input` | `0.3` | Kilo API reports $0.0000003/token → $0.30/M tokens. |
| `cost.output` | `1.2` | Kilo API reports $0.0000012/token → $1.20/M tokens. |
| `cost.cache_read` | `0.06` | Kilo API reports $0.00000006/token → $0.06/M tokens. |
| `limit.context` | `204_800` | Kilo API: context window = 204,800 tokens. Matches all other providers. |
| `limit.output` | `131_072` | Kilo API: max completion tokens = 131,072. Matches all other providers. |
| `modalities.input` | `["text"]` | Kilo API reports text-only input. |
| `modalities.output` | `["text"]` | Kilo API reports text-only output. |

## Fields intentionally omitted

**`structured_output`** — Kilo's API surface lists `response_format` as a parameter, but the official MiniMax API documentation explicitly states that `response_format` (JSON schema structured output) is *"only supported by MiniMax-Text-01"*, not M2.7. No other Kilo MiniMax model carries this field, and the two other providers with M2.7 (opencode-go, ollama-cloud) also omit it. The field was removed to stay consistent and avoid claiming a capability the model does not formally support.

**`interleaved`** — novita-ai sets `interleaved.field = "reasoning_content"` for M2.7, reflecting MiniMax's native API behaviour. Kilo exposes reasoning via an `include_reasoning` parameter rather than a named field, and no other Kilo MiniMax model uses `interleaved`. Omitted until Kilo's reasoning output field name is confirmed.

**`knowledge`** — Not reported by the Kilo API for this model. Omitted to avoid guessing.

## Verification

```
docker run --rm -v $(pwd):/app -w /app oven/bun bun validate
```

Exits with code 0. The new model appears correctly in the generated output:

```json
"minimax/minimax-m2.7": {
  "id": "minimax/minimax-m2.7",
  "name": "MiniMax: MiniMax M2.7",
  "family": "minimax-m2.7",
  "attachment": false,
  "reasoning": true,
  "tool_call": true,
  "temperature": true,
  "release_date": "2026-03-18",
  "last_updated": "2026-03-18",
  "modalities": { "input": ["text"], "output": ["text"] },
  "open_weights": true,
  "cost": { "input": 0.3, "output": 1.2, "cache_read": 0.06 },
  "limit": { "context": 204800, "output": 131072 }
}
```
