### PR TITLE
Add Tensorix provider

### DIFF
--- a/providers/tensorix/models/deepseek/deepseek-chat-v3.1.toml
+++ b/providers/tensorix/models/deepseek/deepseek-chat-v3.1.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek V3.1"
+family = "deepseek"
+release_date = "2025-10-01"
+last_updated = "2025-10-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.8
+
+[limit]
+context = 163_840
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/tensorix/models/deepseek/deepseek-r1-0528.toml
@@ -1,0 +1,23 @@
+name = "DeepSeek R1 0528"
+family = "deepseek"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.66
+output = 2.6
+
+[limit]
+context = 163_840
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/deepseek/deepseek-v3.2.toml
+++ b/providers/tensorix/models/deepseek/deepseek-v3.2.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2026-02-01"
+last_updated = "2026-02-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 0.5
+
+[limit]
+context = 163_840
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/meta-llama/llama-3.3-70b-instruct.toml
+++ b/providers/tensorix/models/meta-llama/llama-3.3-70b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Llama 3.3 70B"
+family = "llama"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.31
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/meta-llama/llama-4-maverick.toml
+++ b/providers/tensorix/models/meta-llama/llama-4-maverick.toml
@@ -1,0 +1,20 @@
+name = "Llama 4 Maverick"
+family = "llama"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.14
+output = 0.68
+
+[limit]
+context = 1_048_576
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/minimax/minimax-m2.1.toml
+++ b/providers/tensorix/models/minimax/minimax-m2.1.toml
@@ -1,0 +1,20 @@
+name = "MiniMax M2.1"
+family = "minimax"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = true
+reasoning = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 2.4
+
+[limit]
+context = 196_608
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/tensorix/models/minimax/minimax-m2.5.toml
+++ b/providers/tensorix/models/minimax/minimax-m2.5.toml
@@ -1,0 +1,20 @@
+name = "MiniMax M2.5"
+family = "minimax"
+release_date = "2026-03-01"
+last_updated = "2026-03-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 65_536
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/minimax/minimax-m2.toml
+++ b/providers/tensorix/models/minimax/minimax-m2.toml
@@ -1,0 +1,20 @@
+name = "MiniMax M2"
+family = "minimax"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1.0
+
+[limit]
+context = 196_608
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/moonshotai/kimi-k2.5.toml
+++ b/providers/tensorix/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,20 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+attachment = true
+reasoning = false
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.5
+output = 2.8
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/tensorix/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/tensorix/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,20 @@
+name = "Nemotron 3 Super 120B"
+family = "nemotron"
+release_date = "2025-10-01"
+last_updated = "2025-10-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 0.9
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/openai/gpt-oss-120b.toml
+++ b/providers/tensorix/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,20 @@
+name = "GPT-OSS 120B"
+family = "gpt"
+release_date = "2026-02-01"
+last_updated = "2026-02-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.2
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/openai/gpt-oss-20b.toml
+++ b/providers/tensorix/models/openai/gpt-oss-20b.toml
@@ -1,0 +1,20 @@
+name = "GPT-OSS 20B"
+family = "gpt"
+release_date = "2026-02-01"
+last_updated = "2026-02-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.14
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/qwen/qwen3-235b-a22b-2507.toml
+++ b/providers/tensorix/models/qwen/qwen3-235b-a22b-2507.toml
@@ -1,0 +1,20 @@
+name = "Qwen3 235B 2507"
+family = "qwen"
+release_date = "2025-07-01"
+last_updated = "2025-07-01"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.46
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/qwen/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/tensorix/models/qwen/qwen3-coder-30b-a3b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen3 Coder 30B"
+family = "qwen"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.25
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/qwen/qwen3-vl-235b-a22b-instruct.toml
+++ b/providers/tensorix/models/qwen/qwen3-vl-235b-a22b-instruct.toml
@@ -1,0 +1,20 @@
+name = "Qwen3 VL 235B"
+family = "qwen"
+release_date = "2025-08-01"
+last_updated = "2025-08-01"
+attachment = true
+reasoning = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.21
+output = 1.9
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/tensorix/models/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/tensorix/models/qwen/qwen3.5-122b-a10b.toml
@@ -1,0 +1,20 @@
+name = "Qwen3.5 122B"
+family = "qwen"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.5
+output = 3.5
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/qwen/qwen3.5-9b.toml
+++ b/providers/tensorix/models/qwen/qwen3.5-9b.toml
@@ -1,0 +1,20 @@
+name = "Qwen3.5 9B"
+family = "qwen"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.2
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/z-ai/glm-4.6.toml
+++ b/providers/tensorix/models/z-ai/glm-4.6.toml
@@ -1,0 +1,20 @@
+name = "GLM 4.6"
+family = "glm"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.4
+output = 1.75
+
+[limit]
+context = 204_800
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/z-ai/glm-4.7.toml
+++ b/providers/tensorix/models/z-ai/glm-4.7.toml
@@ -1,0 +1,20 @@
+name = "GLM 4.7"
+family = "glm"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 2.2
+
+[limit]
+context = 204_800
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/z-ai/glm-5.1.toml
+++ b/providers/tensorix/models/z-ai/glm-5.1.toml
@@ -1,0 +1,20 @@
+name = "GLM 5.1"
+family = "glm"
+release_date = "2026-03-15"
+last_updated = "2026-03-15"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.4
+output = 4.4
+
+[limit]
+context = 204_800
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/models/z-ai/glm-5.toml
+++ b/providers/tensorix/models/z-ai/glm-5.toml
@@ -1,0 +1,20 @@
+name = "GLM 5"
+family = "glm"
+release_date = "2026-02-11"
+last_updated = "2026-02-11"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.0
+output = 3.2
+
+[limit]
+context = 204_800
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorix/provider.toml
+++ b/providers/tensorix/provider.toml
@@ -1,0 +1,5 @@
+name = "Tensorix"
+npm = "@ai-sdk/openai-compatible"
+env = ["TENSORIX_API_KEY"]
+doc = "https://docs.tensorix.ai"
+api = "https://api.tensorix.ai/v1"


### PR DESCRIPTION
Adds [Tensorix](https://tensorix.ai) as a provider with 21 models.

Tensorix is an OpenAI-compatible inference API hosted in the EU with zero data retention. We run open-source models across multiple GPU clusters with automatic failover.

### Provider config

- **npm**: `@ai-sdk/openai-compatible`
- **API**: `https://api.tensorix.ai/v1`
- **Auth**: `TENSORIX_API_KEY`

### Models included

| Family | Models |
|--------|--------|
| GLM | glm-5.1, glm-5, glm-4.7, glm-4.6 |
| DeepSeek | deepseek-r1-0528, deepseek-chat-v3.1, deepseek-v3.2 |
| Kimi | kimi-k2.5 |
| MiniMax | minimax-m2.5, minimax-m2.1, minimax-m2 |
| Llama | llama-4-maverick, llama-3.3-70b-instruct |
| Qwen | qwen3-235b, qwen3.5-122b, qwen3.5-9b, qwen3-vl-235b, qwen3-coder-30b |
| Other | gpt-oss-120b, gpt-oss-20b, nemotron-3-super-120b |

No logo included yet — happy to add one in a follow-up if needed.