### PR TITLE
feat: add Kyma API provider with 16 open-source models

### DIFF
--- a/providers/kyma/models/deepseek-r1.toml
+++ b/providers/kyma/models/deepseek-r1.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek R1"
+family = "deepseek"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.68
+output = 2.90
+
+[limit]
+context = 65_536
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/deepseek-v3.toml
+++ b/providers/kyma/models/deepseek-v3.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek V3"
+family = "deepseek"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.81
+output = 2.30
+
+[limit]
+context = 163_840
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/gemini-2.5-flash.toml
+++ b/providers/kyma/models/gemini-2.5-flash.toml
@@ -1,0 +1,22 @@
+name = "Gemini 2.5 Flash"
+family = "gemini"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.41
+output = 3.38
+
+[limit]
+context = 1_048_576
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kyma/models/gemini-3-flash.toml
+++ b/providers/kyma/models/gemini-3-flash.toml
@@ -1,0 +1,22 @@
+name = "Gemini 3 Flash"
+family = "gemini"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.68
+output = 4.05
+
+[limit]
+context = 1_048_576
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kyma/models/gemma-4-31b.toml
+++ b/providers/kyma/models/gemma-4-31b.toml
@@ -1,0 +1,22 @@
+name = "Gemma 4 31B"
+family = "gemma"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.19
+output = 0.54
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/glm-4.5-air.toml
+++ b/providers/kyma/models/glm-4.5-air.toml
@@ -1,0 +1,22 @@
+name = "GLM 4.5 Air"
+family = "glm"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.18
+output = 1.15
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/glm-4.7-flash.toml
+++ b/providers/kyma/models/glm-4.7-flash.toml
@@ -1,0 +1,22 @@
+name = "GLM 4.7 Flash"
+family = "glm"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.54
+
+[limit]
+context = 203_776
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/glm-5.1.toml
+++ b/providers/kyma/models/glm-5.1.toml
@@ -1,0 +1,22 @@
+name = "GLM 5.1"
+family = "glm"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.89
+output = 5.94
+
+[limit]
+context = 203_776
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/gpt-oss-120b.toml
+++ b/providers/kyma/models/gpt-oss-120b.toml
@@ -1,0 +1,22 @@
+name = "GPT-OSS 120B"
+family = "gpt-oss"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.20
+output = 0.81
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/kimi-k2.5.toml
+++ b/providers/kyma/models/kimi-k2.5.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2.5"
+family = "kimi"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.68
+output = 3.78
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/llama-3.3-70b.toml
+++ b/providers/kyma/models/llama-3.3-70b.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.3 70B"
+family = "llama"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.19
+output = 1.19
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/minimax-m2.5.toml
+++ b/providers/kyma/models/minimax-m2.5.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2.5"
+family = "minimax"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.41
+output = 1.62
+
+[limit]
+context = 196_608
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/minimax-m2.7.toml
+++ b/providers/kyma/models/minimax-m2.7.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M2.7"
+family = "minimax"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.41
+output = 1.62
+
+[limit]
+context = 204_800
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/qwen-3-32b.toml
+++ b/providers/kyma/models/qwen-3-32b.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3 32B"
+family = "qwen"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.39
+output = 0.81
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/qwen-3-coder.toml
+++ b/providers/kyma/models/qwen-3-coder.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3 Coder"
+family = "qwen"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.68
+output = 2.16
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/qwen-3.6-plus.toml
+++ b/providers/kyma/models/qwen-3.6-plus.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.6 Plus"
+family = "qwen"
+release_date = "2025-01-01"
+last_updated = "2026-04-18"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-03"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.68
+output = 4.05
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/provider.toml
+++ b/providers/kyma/provider.toml
@@ -1,0 +1,4 @@
+name = "Kyma API"
+env = ["KYMA_API_KEY"]
+npm = "@kyma-api/ai-sdk"
+doc = "https://docs.kymaapi.com"


### PR DESCRIPTION
## Summary

Add Kyma API as a provider with 16 open-source LLM models.

**Kyma API** is an LLM gateway providing access to open-source models through a single OpenAI-compatible endpoint with multi-provider auto-failover.

- npm: `@kyma-api/ai-sdk` (published on npm)
- Docs: https://docs.kymaapi.com
- OpenAPI spec: https://kymaapi.com/v1/openapi.json
- Free $0.50 credit on signup, no credit card required

## Models (16)

| Model | Family | Context | Input $/1M | Output $/1M |
|-------|--------|---------|-----------|------------|
| Qwen 3.6 Plus | qwen | 128K | $0.68 | $4.05 |
| Qwen 3 Coder | qwen | 128K | $0.68 | $2.16 |
| Qwen 3 32B | qwen | 32K | $0.39 | $0.81 |
| Gemma 4 31B | gemma | 128K | $0.19 | $0.54 |
| MiniMax M2.5 | minimax | 196K | $0.41 | $1.62 |
| MiniMax M2.7 | minimax | 204K | $0.41 | $1.62 |
| DeepSeek V3 | deepseek | 160K | $0.81 | $2.30 |
| DeepSeek R1 | deepseek | 64K | $0.68 | $2.90 |
| Gemini 2.5 Flash | gemini | 1M | $0.41 | $3.38 |
| Gemini 3 Flash | gemini | 1M | $0.68 | $4.05 |
| Llama 3.3 70B | llama | 128K | $1.19 | $1.19 |
| GPT-OSS 120B | gpt-oss | 128K | $0.20 | $0.81 |
| Kimi K2.5 | kimi | 262K | $0.68 | $3.78 |
| GLM 5.1 | glm | 203K | $1.89 | $5.94 |
| GLM 4.5 Air | glm | 131K | $0.18 | $1.15 |
| GLM 4.7 Flash | glm | 203K | $0.08 | $0.54 |