### PR TITLE
feat(huggingface): add MiniMax-M2.7

### DIFF
--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M2.7.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M2.7.toml
@@ -1,0 +1,26 @@
+name = "MiniMax-M2.7"
+family = "minimax"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+
+[limit]
+context = 204_800
+output = 131_072
+
+[interleaved]
+field = "reasoning_content"
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add MiniMax-M2.7 for Hugging Face providers (text, reasoning, $0.3/$1.2 per 1M tokens).

I've set `[interleaved] field = "reasoning_content"` since Fireworks AI and Novita AI providers both returns reasoning tokens in `delta.reasoning_content`. Verified via API calls.
