### PR TITLE
feat(nvidia): add MiniMax-M2.7

### DIFF
--- a/providers/nvidia/models/minimaxai/minimax-m2.7.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m2.7.toml
@@ -1,0 +1,21 @@
+name = "MiniMax-M2.7"
+family = "minimax"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add MiniMax-M2.7 model to NVIDIA provider. This is a Sparse MoE model with 230B total parameters (10B active), 204.8K context length, and support for reasoning and tool calling. Pricing: /bin/zsh.3/.2 per 1M input/output tokens.