### PR TITLE
Venice: Update model configs and pricing

### DIFF
--- a/providers/venice/models/kimi-k2-5.toml
+++ b/providers/venice/models/kimi-k2-5.toml
@@ -7,8 +7,8 @@ structured_output = true
 temperature = true
 knowledge = "2024-04"
 release_date = "2026-01-27"
-last_updated = "2026-03-16"
-open_weights = true
+last_updated = "2026-04-12"
+open_weights = false
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/venice/models/minimax-m25.toml
+++ b/providers/venice/models/minimax-m25.toml
@@ -5,8 +5,8 @@ reasoning = true
 tool_call = true
 temperature = true
 release_date = "2026-02-12"
-last_updated = "2026-03-16"
-open_weights = true
+last_updated = "2026-04-12"
+open_weights = false
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/venice/models/minimax-m27.toml
+++ b/providers/venice/models/minimax-m27.toml
@@ -5,8 +5,8 @@ reasoning = true
 tool_call = true
 temperature = true
 release_date = "2026-03-18"
-last_updated = "2026-03-18"
-open_weights = true
+last_updated = "2026-04-12"
+open_weights = false
 
 [cost]
 input = 0.375

--- a/providers/venice/models/qwen-3-6-plus.toml
+++ b/providers/venice/models/qwen-3-6-plus.toml
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-06"
-last_updated = "2026-04-09"
+last_updated = "2026-04-12"
 open_weights = false
 
 [cost]
@@ -18,6 +18,8 @@ cache_write = 0.78
 [cost.context_over_200k]
 input = 2.5
 output = 7.5
+cache_read = 0.0625
+cache_write = 0.78
 
 [limit]
 context = 1_000_000

--- a/providers/venice/models/qwen3-5-35b-a3b.toml
+++ b/providers/venice/models/qwen3-5-35b-a3b.toml
@@ -6,8 +6,8 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-02-25"
-last_updated = "2026-03-09"
-open_weights = true
+last_updated = "2026-04-12"
+open_weights = false
 
 [cost]
 input = 0.3125


### PR DESCRIPTION
- Set open_weights to false for 4 models
- Add context_over_200k cache pricing for qwen-3-6-plus