### PR TITLE
Venice: Update model naming convention

### DIFF
--- a/providers/venice/models/aion-labs-aion-2-0.toml
+++ b/providers/venice/models/aion-labs-aion-2-0.toml
@@ -5,7 +5,7 @@ reasoning = true
 tool_call = false
 temperature = true
 release_date = "2026-03-24"
-last_updated = "2026-03-31"
+last_updated = "2026-04-12"
 open_weights = false
 
 [cost]

--- a/providers/venice/models/claude-opus-4-5.toml
+++ b/providers/venice/models/claude-opus-4-5.toml
@@ -5,9 +5,8 @@ reasoning = true
 tool_call = true
 structured_output = true
 temperature = true
-knowledge = "2025-03"
 release_date = "2025-12-06"
-last_updated = "2026-01-28"
+last_updated = "2026-04-12"
 open_weights = false
 
 [cost]
@@ -18,8 +17,8 @@ cache_write = 7.5
 
 [limit]
 context = 198_000
-output = 49_500
+output = 32_768
 
 [modalities]
-input = ["text", "image", "pdf"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/venice/models/claude-sonnet-4-5.toml
+++ b/providers/venice/models/claude-sonnet-4-5.toml
@@ -5,13 +5,9 @@ reasoning = true
 tool_call = true
 structured_output = true
 temperature = true
-knowledge = "2025-09"
 release_date = "2025-01-15"
-last_updated = "2026-01-28"
+last_updated = "2026-04-12"
 open_weights = false
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 3.75
@@ -21,7 +17,7 @@ cache_write = 4.69
 
 [limit]
 context = 198_000
-output = 49_500
+output = 64_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/venice/models/google-gemma-4-26b-a4b-it.toml
+++ b/providers/venice/models/google-gemma-4-26b-a4b-it.toml
@@ -1,16 +1,16 @@
-name = "Google Gemma 4 31B Instruct"
+name = "Google Gemma 4 26B A4B Instruct"
 family = "gemma"
 attachment = true
 reasoning = true
 tool_call = true
 structured_output = true
 temperature = true
-release_date = "2026-04-03"
-last_updated = "2026-04-09"
+release_date = "2026-04-02"
+last_updated = "2026-04-12"
 open_weights = true
 
 [cost]
-input = 0.175
+input = 0.1625
 output = 0.5
 
 [limit]

--- a/providers/venice/models/google-gemma-4-31b-it.toml
+++ b/providers/venice/models/google-gemma-4-31b-it.toml
@@ -1,16 +1,16 @@
-name = "Google Gemma 4 26B A4B Instruct"
+name = "Google Gemma 4 31B Instruct"
 family = "gemma"
 attachment = true
 reasoning = true
 tool_call = true
 structured_output = true
 temperature = true
-release_date = "2026-04-02"
-last_updated = "2026-04-09"
+release_date = "2026-04-03"
+last_updated = "2026-04-12"
 open_weights = true
 
 [cost]
-input = 0.1625
+input = 0.175
 output = 0.5
 
 [limit]

--- a/providers/venice/models/grok-4-20-multi-agent.toml
+++ b/providers/venice/models/grok-4-20-multi-agent.toml
@@ -1,12 +1,12 @@
-name = "Grok 4.20 Beta"
-family = "grok-beta"
+name = "Grok 4.20 Multi-Agent"
+family = "grok"
 attachment = true
 reasoning = true
-tool_call = true
+tool_call = false
 structured_output = true
 temperature = true
 release_date = "2026-03-12"
-last_updated = "2026-04-09"
+last_updated = "2026-04-12"
 open_weights = false
 
 [cost]

--- a/providers/venice/models/grok-4-20.toml
+++ b/providers/venice/models/grok-4-20.toml
@@ -1,12 +1,12 @@
-name = "Grok 4.20 Multi-Agent Beta"
-family = "grok-beta"
+name = "Grok 4.20"
+family = "grok"
 attachment = true
 reasoning = true
-tool_call = false
+tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-03-12"
-last_updated = "2026-04-09"
+last_updated = "2026-04-12"
 open_weights = false
 
 [cost]


### PR DESCRIPTION
- Rename files to use dashes instead of dots
- Rename opus/sonnet 45 to 4-5 format
- Remove beta suffix from Grok 4.20 models
- Update family from grok-beta to grok
- Update output limits