### PR TITLE
Venice: Add Z-AI GLM-5 Turbo and GLM-5V Turbo models

### DIFF
--- a/providers/venice/models/z-ai-glm-5-turbo.toml
+++ b/providers/venice/models/z-ai-glm-5-turbo.toml
@@ -1,0 +1,23 @@
+name = "GLM 5 Turbo"
+family = "glm"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-03-15"
+last_updated = "2026-04-12"
+open_weights = true
+
+[cost]
+input = 1.2
+output = 4
+cache_read = 0.24
+
+[limit]
+context = 200_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/venice/models/z-ai-glm-5v-turbo.toml
+++ b/providers/venice/models/z-ai-glm-5v-turbo.toml
@@ -1,0 +1,23 @@
+name = "GLM 5V Turbo"
+family = "glmv"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-04-01"
+last_updated = "2026-04-12"
+open_weights = false
+
+[cost]
+input = 1.5
+output = 5
+cache_read = 0.3
+
+[limit]
+context = 200_000
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
- Add Z-AI GLM-5 Turbo (text-only, reasoning, tool_call)

- Add Z-AI GLM-5V Turbo (vision, reasoning, tool_call)