### PR TITLE
fix: cache read costs for friendliAI models

### DIFF
--- a/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -15,6 +15,7 @@ field = "reasoning_content"
 [cost]
 input = 0.3
 output = 1.2
+cache_read = 0.06
 
 [limit]
 context = 196_608

--- a/providers/friendli/models/zai-org/GLM-5.1.toml
+++ b/providers/friendli/models/zai-org/GLM-5.1.toml
@@ -15,6 +15,7 @@ field = "reasoning_content"
 [cost]
 input = 1.4
 output = 4.4
+cache_read = 0.26
 
 [limit]
 context = 202_752

--- a/providers/friendli/models/zai-org/GLM-5.toml
+++ b/providers/friendli/models/zai-org/GLM-5.toml
@@ -15,6 +15,7 @@ field = "reasoning_content"
 [cost]
 input = 1
 output = 3.2
+cache_read = 0.50
 
 [limit]
 context = 202_752


### PR DESCRIPTION


* Added `cache_read = 0.06` to the `[cost]` section in `providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml`.
* Added `cache_read = 0.26` to the `[cost]` section in `providers/friendli/models/zai-org/GLM-5.1.toml`.
* Added `cache_read = 0.50` to the `[cost]` section in `providers/friendli/models/zai-org/GLM-5.toml`