### PR TITLE
Add generator script for Amazon Bedrock models

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,8 @@
       "name": "models.dev",
       "version": "0.0.0",
       "dependencies": {
+        "@aws-sdk/client-bedrock": "^3.1028.0",
+        "@aws-sdk/client-pricing": "^3.1028.0",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -48,6 +50,64 @@
     "zod": "3.24.2",
   },
   "packages": {
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock": ["@aws-sdk/client-bedrock@3.1028.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.27", "@aws-sdk/credential-provider-node": "^3.972.30", "@aws-sdk/middleware-host-header": "^3.972.9", "@aws-sdk/middleware-logger": "^3.972.9", "@aws-sdk/middleware-recursion-detection": "^3.972.10", "@aws-sdk/middleware-user-agent": "^3.972.29", "@aws-sdk/region-config-resolver": "^3.972.11", "@aws-sdk/token-providers": "3.1028.0", "@aws-sdk/types": "^3.973.7", "@aws-sdk/util-endpoints": "^3.996.6", "@aws-sdk/util-user-agent-browser": "^3.972.9", "@aws-sdk/util-user-agent-node": "^3.973.15", "@smithy/config-resolver": "^4.4.14", "@smithy/core": "^3.23.14", "@smithy/fetch-http-handler": "^5.3.16", "@smithy/hash-node": "^4.2.13", "@smithy/invalid-dependency": "^4.2.13", "@smithy/middleware-content-length": "^4.2.13", "@smithy/middleware-endpoint": "^4.4.29", "@smithy/middleware-retry": "^4.5.0", "@smithy/middleware-serde": "^4.2.17", "@smithy/middleware-stack": "^4.2.13", "@smithy/node-config-provider": "^4.3.13", "@smithy/node-http-handler": "^4.5.2", "@smithy/protocol-http": "^5.3.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "@smithy/url-parser": "^4.2.13", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.45", "@smithy/util-defaults-mode-node": "^4.2.49", "@smithy/util-endpoints": "^3.3.4", "@smithy/util-middleware": "^4.2.13", "@smithy/util-retry": "^4.3.0", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-YEUikjoImgUjv2UEpnD/WP0JiLdoLRnkajnSQR9LPCa8+BGy3+j879jimPlAuypOux1/CgqMA7Fwt13IpF2+UA=="],
+
+    "@aws-sdk/client-pricing": ["@aws-sdk/client-pricing@3.1028.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.27", "@aws-sdk/credential-provider-node": "^3.972.30", "@aws-sdk/middleware-host-header": "^3.972.9", "@aws-sdk/middleware-logger": "^3.972.9", "@aws-sdk/middleware-recursion-detection": "^3.972.10", "@aws-sdk/middleware-user-agent": "^3.972.29", "@aws-sdk/region-config-resolver": "^3.972.11", "@aws-sdk/types": "^3.973.7", "@aws-sdk/util-endpoints": "^3.996.6", "@aws-sdk/util-user-agent-browser": "^3.972.9", "@aws-sdk/util-user-agent-node": "^3.973.15", "@smithy/config-resolver": "^4.4.14", "@smithy/core": "^3.23.14", "@smithy/fetch-http-handler": "^5.3.16", "@smithy/hash-node": "^4.2.13", "@smithy/invalid-dependency": "^4.2.13", "@smithy/middleware-content-length": "^4.2.13", "@smithy/middleware-endpoint": "^4.4.29", "@smithy/middleware-retry": "^4.5.0", "@smithy/middleware-serde": "^4.2.17", "@smithy/middleware-stack": "^4.2.13", "@smithy/node-config-provider": "^4.3.13", "@smithy/node-http-handler": "^4.5.2", "@smithy/protocol-http": "^5.3.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "@smithy/url-parser": "^4.2.13", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.45", "@smithy/util-defaults-mode-node": "^4.2.49", "@smithy/util-endpoints": "^3.3.4", "@smithy/util-middleware": "^4.2.13", "@smithy/util-retry": "^4.3.0", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-EzjT764449lzJNwVa490wT637AmXYn4913tnhcZmrM3Yx1JXWjJSUGjjzrtjOQi/9IBcCPKGpiVsIeknREz4dQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.973.27", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@aws-sdk/xml-builder": "^3.972.17", "@smithy/core": "^3.23.14", "@smithy/node-config-provider": "^4.3.13", "@smithy/property-provider": "^4.2.13", "@smithy/protocol-http": "^5.3.13", "@smithy/signature-v4": "^5.3.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.13", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.25", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/types": "^3.973.7", "@smithy/property-provider": "^4.2.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.27", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/types": "^3.973.7", "@smithy/fetch-http-handler": "^5.3.16", "@smithy/node-http-handler": "^4.5.2", "@smithy/property-provider": "^4.2.13", "@smithy/protocol-http": "^5.3.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "@smithy/util-stream": "^4.5.22", "tslib": "^2.6.2" } }, "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.29", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/credential-provider-env": "^3.972.25", "@aws-sdk/credential-provider-http": "^3.972.27", "@aws-sdk/credential-provider-login": "^3.972.29", "@aws-sdk/credential-provider-process": "^3.972.25", "@aws-sdk/credential-provider-sso": "^3.972.29", "@aws-sdk/credential-provider-web-identity": "^3.972.29", "@aws-sdk/nested-clients": "^3.996.19", "@aws-sdk/types": "^3.973.7", "@smithy/credential-provider-imds": "^4.2.13", "@smithy/property-provider": "^4.2.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.29", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/nested-clients": "^3.996.19", "@aws-sdk/types": "^3.973.7", "@smithy/property-provider": "^4.2.13", "@smithy/protocol-http": "^5.3.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.30", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.25", "@aws-sdk/credential-provider-http": "^3.972.27", "@aws-sdk/credential-provider-ini": "^3.972.29", "@aws-sdk/credential-provider-process": "^3.972.25", "@aws-sdk/credential-provider-sso": "^3.972.29", "@aws-sdk/credential-provider-web-identity": "^3.972.29", "@aws-sdk/types": "^3.973.7", "@smithy/credential-provider-imds": "^4.2.13", "@smithy/property-provider": "^4.2.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.25", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/types": "^3.973.7", "@smithy/property-provider": "^4.2.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.29", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/nested-clients": "^3.996.19", "@aws-sdk/token-providers": "3.1026.0", "@aws-sdk/types": "^3.973.7", "@smithy/property-provider": "^4.2.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.29", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/nested-clients": "^3.996.19", "@aws-sdk/types": "^3.973.7", "@smithy/property-provider": "^4.2.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.9", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/protocol-http": "^5.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.9", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.29", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/types": "^3.973.7", "@aws-sdk/util-endpoints": "^3.996.6", "@smithy/core": "^3.23.14", "@smithy/protocol-http": "^5.3.13", "@smithy/types": "^4.14.0", "@smithy/util-retry": "^4.3.0", "tslib": "^2.6.2" } }, "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.996.19", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.27", "@aws-sdk/middleware-host-header": "^3.972.9", "@aws-sdk/middleware-logger": "^3.972.9", "@aws-sdk/middleware-recursion-detection": "^3.972.10", "@aws-sdk/middleware-user-agent": "^3.972.29", "@aws-sdk/region-config-resolver": "^3.972.11", "@aws-sdk/types": "^3.973.7", "@aws-sdk/util-endpoints": "^3.996.6", "@aws-sdk/util-user-agent-browser": "^3.972.9", "@aws-sdk/util-user-agent-node": "^3.973.15", "@smithy/config-resolver": "^4.4.14", "@smithy/core": "^3.23.14", "@smithy/fetch-http-handler": "^5.3.16", "@smithy/hash-node": "^4.2.13", "@smithy/invalid-dependency": "^4.2.13", "@smithy/middleware-content-length": "^4.2.13", "@smithy/middleware-endpoint": "^4.4.29", "@smithy/middleware-retry": "^4.5.0", "@smithy/middleware-serde": "^4.2.17", "@smithy/middleware-stack": "^4.2.13", "@smithy/node-config-provider": "^4.3.13", "@smithy/node-http-handler": "^4.5.2", "@smithy/protocol-http": "^5.3.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "@smithy/url-parser": "^4.2.13", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.45", "@smithy/util-defaults-mode-node": "^4.2.49", "@smithy/util-endpoints": "^3.3.4", "@smithy/util-middleware": "^4.2.13", "@smithy/util-retry": "^4.3.0", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/config-resolver": "^4.4.14", "@smithy/node-config-provider": "^4.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1028.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/nested-clients": "^3.996.19", "@aws-sdk/types": "^3.973.7", "@smithy/property-provider": "^4.2.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-2vDFrEhJDlUHyvDxqDyOk97cejMM8GJDyQbFfOCEWclGwhTjlj1mdyj36xsxh7DYyuquhjqfbvhpl6ZzsVol0w=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.7", "", { "dependencies": { "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.6", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/types": "^4.14.0", "@smithy/url-parser": "^4.2.13", "@smithy/util-endpoints": "^3.3.4", "tslib": "^2.6.2" } }, "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.9", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/types": "^4.14.0", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.15", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.29", "@aws-sdk/types": "^3.973.7", "@smithy/node-config-provider": "^4.3.13", "@smithy/types": "^4.14.0", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.17", "", { "dependencies": { "@smithy/types": "^4.14.0", "fast-xml-parser": "5.5.8", "tslib": "^2.6.2" } }, "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250801.0", "", {}, "sha512-BQmMdoOGClY23TesgkR1PeGrPvPsSFD/zW7pDzWZHkOEsqkPk2A91h52bP8GbtKYTl1vdaYjQgJlGsP6Ih4G0w=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.6.1", "", { "dependencies": { "content-type": "^1.0.5", "cors": "^2.8.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^4.1.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA=="],
@@ -55,6 +115,84 @@
     "@models.dev/function": ["@models.dev/function@workspace:packages/function"],
 
     "@models.dev/web": ["@models.dev/web@workspace:packages/web"],
+
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.4.14", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.13", "@smithy/types": "^4.14.0", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-endpoints": "^3.3.4", "@smithy/util-middleware": "^4.2.13", "tslib": "^2.6.2" } }, "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ=="],
+
+    "@smithy/core": ["@smithy/core@3.23.14", "", { "dependencies": { "@smithy/protocol-http": "^5.3.13", "@smithy/types": "^4.14.0", "@smithy/url-parser": "^4.2.13", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-middleware": "^4.2.13", "@smithy/util-stream": "^4.5.22", "@smithy/util-utf8": "^4.2.2", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.2.13", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.13", "@smithy/property-provider": "^4.2.13", "@smithy/types": "^4.14.0", "@smithy/url-parser": "^4.2.13", "tslib": "^2.6.2" } }, "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.16", "", { "dependencies": { "@smithy/protocol-http": "^5.3.13", "@smithy/querystring-builder": "^4.2.13", "@smithy/types": "^4.14.0", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.2.13", "", { "dependencies": { "@smithy/types": "^4.14.0", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.13", "", { "dependencies": { "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.13", "", { "dependencies": { "@smithy/protocol-http": "^5.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig=="],
+
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.29", "", { "dependencies": { "@smithy/core": "^3.23.14", "@smithy/middleware-serde": "^4.2.17", "@smithy/node-config-provider": "^4.3.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "@smithy/url-parser": "^4.2.13", "@smithy/util-middleware": "^4.2.13", "tslib": "^2.6.2" } }, "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw=="],
+
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.5.1", "", { "dependencies": { "@smithy/core": "^3.23.14", "@smithy/node-config-provider": "^4.3.13", "@smithy/protocol-http": "^5.3.13", "@smithy/service-error-classification": "^4.2.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "@smithy/util-middleware": "^4.2.13", "@smithy/util-retry": "^4.3.1", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA=="],
+
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.17", "", { "dependencies": { "@smithy/core": "^3.23.14", "@smithy/protocol-http": "^5.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ=="],
+
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.13", "", { "dependencies": { "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.13", "", { "dependencies": { "@smithy/property-provider": "^4.2.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.5.2", "", { "dependencies": { "@smithy/protocol-http": "^5.3.13", "@smithy/querystring-builder": "^4.2.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA=="],
+
+    "@smithy/property-provider": ["@smithy/property-provider@4.2.13", "", { "dependencies": { "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ=="],
+
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.3.13", "", { "dependencies": { "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg=="],
+
+    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.13", "", { "dependencies": { "@smithy/types": "^4.14.0", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ=="],
+
+    "@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.13", "", { "dependencies": { "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA=="],
+
+    "@smithy/service-error-classification": ["@smithy/service-error-classification@4.2.13", "", { "dependencies": { "@smithy/types": "^4.14.0" } }, "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.8", "", { "dependencies": { "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.3.13", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.13", "@smithy/types": "^4.14.0", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.13", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg=="],
+
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.12.9", "", { "dependencies": { "@smithy/core": "^3.23.14", "@smithy/middleware-endpoint": "^4.4.29", "@smithy/middleware-stack": "^4.2.13", "@smithy/protocol-http": "^5.3.13", "@smithy/types": "^4.14.0", "@smithy/util-stream": "^4.5.22", "tslib": "^2.6.2" } }, "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ=="],
+
+    "@smithy/types": ["@smithy/types@4.14.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ=="],
+
+    "@smithy/url-parser": ["@smithy/url-parser@4.2.13", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.3.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ=="],
+
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ=="],
+
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.2.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@smithy/util-config-provider": ["@smithy/util-config-provider@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ=="],
+
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.3.45", "", { "dependencies": { "@smithy/property-provider": "^4.2.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw=="],
+
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.2.49", "", { "dependencies": { "@smithy/config-resolver": "^4.4.14", "@smithy/credential-provider-imds": "^4.2.13", "@smithy/node-config-provider": "^4.3.13", "@smithy/property-provider": "^4.2.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ=="],
+
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.3.4", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog=="],
+
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg=="],
+
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.2.13", "", { "dependencies": { "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow=="],
+
+    "@smithy/util-retry": ["@smithy/util-retry@4.3.1", "", { "dependencies": { "@smithy/service-error-classification": "^4.2.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ=="],
+
+    "@smithy/util-stream": ["@smithy/util-stream@4.5.22", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.16", "@smithy/node-http-handler": "^4.5.2", "@smithy/types": "^4.14.0", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew=="],
+
+    "@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
+    "@smithy/uuid": ["@smithy/uuid@1.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g=="],
 
     "@tsconfig/bun": ["@tsconfig/bun@1.0.8", "", {}, "sha512-JlJaRaS4hBTypxtFe8WhnwV8blf0R+3yehLk8XuyxUYNx6VXsKCjACSCvOYEFUiqlhlBWxtYCn/zRlOb8BzBQg=="],
 
@@ -75,6 +213,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "buffer": ["buffer@4.9.2", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4", "isarray": "^1.0.0" } }, "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg=="],
 
@@ -131,6 +271,10 @@
     "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
 
     "express-rate-limit": ["express-rate-limit@7.5.0", "", { "peerDependencies": { "express": "^4.11 || 5 || ^5.0.0-beta.1" } }, "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.5.8", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ=="],
 
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
 
@@ -222,6 +366,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
 
     "pkce-challenge": ["pkce-challenge@4.1.0", "", {}, "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ=="],
@@ -286,7 +432,11 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
+    "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -316,6 +466,12 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.3", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A=="],
 
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1026.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.27", "@aws-sdk/nested-clients": "^3.996.19", "@aws-sdk/types": "^3.973.7", "@smithy/property-provider": "^4.2.13", "@smithy/shared-ini-file-loader": "^4.4.8", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA=="],
+
     "@models.dev/function/@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250522.0", "", {}, "sha512-9RIffHobc35JWeddzBguGgPa4wLDr5x5F94+0/qy7LiV6pTBQ/M5qGEN9VA16IDT3EUpYI0WKh6VpcmeVEtVtw=="],
 
     "bun-types/@types/node": ["@types/node@24.0.3", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg=="],
@@ -330,9 +486,17 @@
 
     "openid-client/jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
 
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 
     "models.dev/@types/bun/bun-types": ["bun-types@1.3.0", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "models.dev/@types/bun/bun-types/@types/node": ["@types/node@24.0.3", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "helicone:generate": "bun ./packages/core/script/generate-helicone.ts",
     "venice:generate": "bun ./packages/core/script/generate-venice.ts",
     "vercel:generate": "bun ./packages/core/script/generate-vercel.ts",
-    "wandb:generate": "bun ./packages/core/script/generate-wandb.ts"
+    "wandb:generate": "bun ./packages/core/script/generate-wandb.ts",
+    "bedrock:generate": "bun ./packages/core/script/generate-bedrock.ts"
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.20250801.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,8 @@
   "$schema": "https://json.schemastore.org/package.json",
   "type": "module",
   "dependencies": {
+    "@aws-sdk/client-bedrock": "^3.1028.0",
+    "@aws-sdk/client-pricing": "^3.1028.0",
     "zod": "catalog:"
   },
   "main": "./src/index.ts",

--- a/packages/core/script/generate-bedrock.ts
+++ b/packages/core/script/generate-bedrock.ts
@@ -1,0 +1,1068 @@
+#!/usr/bin/env bun
+
+/**
+ * Generate Amazon Bedrock model TOML files by combining data from the
+ * Bedrock ListFoundationModels API (multi-region) and the AWS Pricing API.
+ *
+ * ⚠️ IMPORTANT CAVEATS:
+ * 1. Bedrock's ListFoundationModels API does not expose whether 'pdf' or
+ *    'audio' modalities are supported, so this generator preserves those if
+ *    already manually listed in the TOML, but won't be able to add them.
+ * 2. Bedrock model prices may vary by AWS Region and selected service tier.
+ *    Since the models.dev schema doesn't currently provide a way to list
+ *    multiple prices per model, we list the cheapest available on-demand,
+ *    online (non-batch) price across the tested regions - which is usually
+ *    equivalent to using flex tier inference in the US.
+ * 3. This script currently only captures text-generation models - doesn't
+ *    populate media generation models e.g. Stable Diffusion, Nova Reel, etc.
+ *
+ * Flags:
+ * --dry-run: Preview changes without writing files
+ * --new-only: Only create new models, skip updating existing ones
+ */
+
+import path from "node:path";
+import { mkdir } from "node:fs/promises";
+import {
+  BedrockClient,
+  ListFoundationModelsCommand,
+  type FoundationModelSummary,
+} from "@aws-sdk/client-bedrock";
+import { PricingClient, GetProductsCommand } from "@aws-sdk/client-pricing";
+import { ModelFamilyValues } from "../src/family";
+
+/**
+ * Combine the model lists from these regions
+ *
+ * Different models may be available in different regions, but at the time of
+ * writing this set should cover all supported models.
+ */
+const BEDROCK_REGIONS = ["us-east-1", "us-west-2"];
+
+/**
+ * Map Bedrock API modality strings (uppercase) to schema values (lowercase).
+ */
+const MODALITIES_API_MAP: Map<string, string> = new Map([
+  ["TEXT", "text"],
+  ["IMAGE", "image"],
+]);
+
+const MODELS_DIR = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "providers",
+  "amazon-bedrock",
+  "models",
+);
+
+export interface BedrockModel {
+  modelId: string;
+  modelName: string;
+  inputModalities: string[];
+  outputModalities: string[];
+  releaseDate?: Date;
+}
+
+/**
+ * Product attributes as returned by AWS Pricing API
+ */
+interface PricingProductAttributes {
+  /**
+   * Feature
+   * @example "On-demand Inference"
+   */
+  feature?: string;
+  /**
+   * Type of inference
+   * @example "Output tokens priority"
+   */
+  inferenceType?: string;
+  /**
+   * Specific location the pricing applies to
+   * @example "US East (N. Virginia)"
+   */
+  location?: string;
+  /**
+   * Type of location the pricing applies to
+   * @example "AWS Region"
+   */
+  locationType?: string;
+  /**
+   * Name of the Foundation Model
+   * @example "Qwen3 Coder 30B A3B"
+   */
+  model?: string;
+  /**
+   * API Operation corresponding to the pricing (may be empty for Mantle)
+   * @example ""
+   */
+  operation?: string;
+  /**
+   * Foundation Model provider
+   * @example "Qwen"
+   */
+  provider?: string;
+  /**
+   * AWS Region
+   * @example "us-east-1"
+   */
+  regionCode?: string;
+  /**
+   * Service tier (missing in some cases)
+   * @example "batch"
+   */
+  service_tier?: string;
+  /**
+   * AWS Service
+   * @example "AmazonBedrock"
+   */
+  servicecode: string;
+  /**
+   * Name of the AWS Service
+   * @example "Amazon Bedrock"
+   */
+  servicename?: string;
+  /**
+   * Listed type of usage for AWS Billing
+   * @example "USE1-Qwen3Coder-30B-A3B-output-tokens-priority"
+   */
+  usagetype: string;
+}
+
+export interface PricingRecord {
+  inputPrice: number | null;
+  outputPrice: number | null;
+}
+
+export interface ExistingModel {
+  name?: string;
+  family?: string;
+  attachment?: boolean;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  structured_output?: boolean;
+  temperature?: boolean;
+  knowledge?: string;
+  release_date?: string;
+  last_updated?: string;
+  open_weights?: boolean;
+  interleaved?: boolean | { field: string };
+  status?: string;
+  cost?: {
+    input?: number;
+    output?: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
+  limit?: {
+    context?: number;
+    input?: number;
+    output?: number;
+  };
+  modalities?: {
+    input?: string[];
+    output?: string[];
+  };
+}
+
+export interface MergedModel {
+  name: string;
+  family?: string;
+  attachment: boolean;
+  reasoning: boolean;
+  tool_call: boolean;
+  structured_output?: boolean;
+  temperature: boolean;
+  knowledge?: string;
+  release_date: string;
+  last_updated: string;
+  open_weights: boolean;
+  interleaved?: boolean | { field: string };
+  status?: string;
+  cost?: {
+    input: number;
+    output: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
+  limit: {
+    context: number;
+    output: number;
+  };
+  modalities: {
+    input: string[];
+    output: string[];
+  };
+}
+
+export interface Changes {
+  field: string;
+  oldValue: string;
+  newValue: string;
+}
+
+export function getTodayDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function formatNumber(n: number): string {
+  if (n >= 1000) {
+    return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, "_");
+  }
+  return n.toString();
+}
+
+/**
+ * Avoid machine precision-related rounding issues in output pricing
+ */
+export function formatPriceNumber(n:number): string {
+  return (Math.round(n * 1e8) / 1e8).toString();
+}
+
+// ---------------------------------------------------------------------------
+// Pricing utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the model slug from a Pricing API `usagetype` string.
+ * Strips the region prefix (e.g. `USE1-`) and token-type suffix
+ * (e.g. `-input-tokens`, `-mantle-output-tokens-standard`).
+ *
+ * Returns `null` when usagetype doesn't match the expected token pattern.
+ */
+export function extractModelSlug(usagetype: string): string | null {
+  // Must contain a token-type suffix to be relevant
+  const tokenSuffix = /-(?:mantle-)?(input|output)-tokens(?:-\w+)?$/;
+  if (!tokenSuffix.test(usagetype)) return null;
+
+  let slug = usagetype;
+
+  // Strip region prefix (e.g. USE1-, EUW1-, APN1-)
+  slug = slug.replace(/^[A-Z]{2,4}\d+-/, "");
+
+  // Strip token-type suffix
+  slug = slug.replace(tokenSuffix, "");
+
+  return slug || null;
+}
+
+/**
+ * Normalize a price value to per-1M-tokens.
+ * - "1K tokens" → price * 1000
+ * - "1M tokens" → price as-is
+ * - Returns null for zero, negative, or unrecognized units.
+ */
+export function normalizePrice(price: number, unit: string): number | null {
+  if (price <= 0 || !Number.isFinite(price)) return null;
+
+  switch (unit) {
+    case "1K tokens":
+      return price * 1000;
+    case "1M tokens":
+      return price;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Check whether a pricing API product is eligible for our listing
+ *
+ * Since the other fields are sometimes absent, we use the usagetype field as
+ * the main basis for testing. Rejects e.g. custom model imports, batch
+ * inference, etc. At this level we currently allow records of different
+ * on-demand inference tiers (flex, priority, standard, etc).
+ *
+ * Example usagetype patterns:
+ *   `USE1-ModelSlug-input-tokens`              (bare — no tier suffix)
+ *   `USE1-slug-mantle-output-tokens-standard`  (explicit -standard tier)
+ *   `USE1-slug-mantle-output-tokens-flex`      (explicit -flex tier)
+ *
+ * @returns true if the listing is eligible for models.dev, false otherwise
+ */
+export function isExpectedProductType(
+  attrs?: PricingProductAttributes,
+): boolean {
+  if (!attrs) return false;
+  if (!attrs.usagetype) return false;
+
+  // Exclude batch inference, model import records, etc.
+  if (attrs.feature && attrs.feature.toLowerCase() !== "on-demand inference")
+    return false;
+
+  // Usage type must end with a token suffix we recognise
+  const standardBare = /-(?:input|output)-tokens$/;
+  const explicitTier =
+    /-(?:mantle-)?(input|output)-tokens-(flex|priority|standard)$/;
+
+  if (
+    standardBare.test(attrs.usagetype) ||
+    explicitTier.test(attrs.usagetype)
+  ) {
+    // Reject if it also contains known non-standard markers anywhere
+    const rejectPatterns =
+      /-(batch|custom-model|cross-region|latency-optimized)/;
+    return !rejectPatterns.test(attrs.usagetype);
+  }
+
+  return false;
+}
+
+/**
+ * Match pricing for a model ID. Tries exact match, then strips region
+ * prefix (us., eu., global.) and retries.
+ */
+export function matchPricing(
+  modelId: string,
+  pricing: Map<string, PricingRecord>,
+): PricingRecord | undefined {
+  // Try exact match first
+  const exact = pricing.get(modelId);
+  if (exact) return exact;
+
+  // If model ID has a region prefix, strip it and retry
+  const regionPrefixPattern = /^(us|eu|global)\./;
+  if (regionPrefixPattern.test(modelId)) {
+    const stripped = modelId.replace(regionPrefixPattern, "");
+    return pricing.get(stripped);
+  }
+
+  // Look for more generic entries in pricing map e.g.
+  // "Llama3-8B" in place of model ID "meta.llama3-8b-instruct-v1:0"
+  const keysLongToShort = [...pricing.keys()].sort(
+    (a, b) => b.length - a.length,
+  );
+  for (const key of keysLongToShort) {
+    if (modelId.toLowerCase().includes(key.toLowerCase())) {
+      return pricing.get(key);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Fetch pricing data from the AWS Pricing API for Amazon Bedrock.
+ *
+ * Creates a PricingClient in us-east-1 (the only region the Pricing API
+ * is available in), calls GetProductsCommand with ServiceCode=AmazonBedrock
+ * filtered by regionCode, paginates through all results, parses real-time
+ * on-demand records, extracts model slugs, normalizes prices to per-1M-tokens,
+ * and returns a Map<slug, PricingRecord>.
+ */
+export async function fetchPricing(
+  regions: string[],
+): Promise<Map<string, PricingRecord>> {
+  const pricingMap = new Map<string, PricingRecord>();
+
+  try {
+    const client = new PricingClient({ region: "us-east-1" });
+
+    let nextToken: string | undefined;
+
+    do {
+      const command = new GetProductsCommand({
+        ServiceCode: "AmazonBedrock",
+        Filters: [
+          {
+            Type: "ANY_OF",
+            Field: "regionCode",
+            Value: regions.join(","),
+          },
+        ],
+        MaxResults: 100,
+        ...(nextToken && { NextToken: nextToken }),
+      });
+
+      const response = await client.send(command);
+      const priceList = response.PriceList ?? [];
+
+      for (const item of priceList) {
+        try {
+          // The SDK may return items as boxed String objects (typeof === "object")
+          // so always coerce to primitive string before parsing.
+          const product = JSON.parse(String(item));
+
+          // Ignore records for unexpected product types e.g. batch inference:
+          if (!isExpectedProductType(product?.product?.attributes)) continue;
+          const usagetype = product?.product?.attributes?.usagetype ?? "";
+
+          const slug = extractModelSlug(usagetype);
+          if (!slug) continue;
+
+          // Determine if this is an input or output record
+          const isInput = /-(?:mantle-)?input-tokens(?:-\w+)?$/.test(usagetype);
+
+          // Extract price from On-Demand terms
+          const terms = product?.terms?.OnDemand;
+          if (!terms) continue;
+
+          // Navigate the nested pricing structure:
+          // terms.OnDemand -> { <skuTermCode>: { priceDimensions: { <rateCode>: { pricePerUnit, unit } } } }
+          const termValues = Object.values(terms) as Array<{
+            priceDimensions?: Record<
+              string,
+              {
+                beginRange?: string;
+                pricePerUnit?: { USD?: string };
+                unit?: string;
+              }
+            >;
+          }>;
+
+          for (const term of termValues) {
+            const dimensions = term?.priceDimensions;
+            if (!dimensions) continue;
+
+            for (const dim of Object.values(dimensions)) {
+              // Ignore volume discount price listings:
+              if (dim?.beginRange) {
+                const beginRange = parseFloat(dim?.beginRange ?? "");
+                if (beginRange > 0) continue;
+              }
+
+              // Normalize price to per 1M tokens:
+              const rawPrice = parseFloat(dim?.pricePerUnit?.USD ?? "");
+              const unit = dim?.unit ?? "";
+              const normalizedPrice = normalizePrice(rawPrice, unit);
+              if (normalizedPrice === null) continue;
+
+              // Get or create the record for this slug
+              const existing = pricingMap.get(slug) ?? {
+                inputPrice: null,
+                outputPrice: null,
+              };
+
+              // Keep the cheapest available price (may vary between regions)
+              if (isInput) {
+                if (
+                  existing.inputPrice === null ||
+                  normalizedPrice < existing.inputPrice
+                )
+                  existing.inputPrice = normalizedPrice;
+              } else {
+                if (
+                  existing.outputPrice === null ||
+                  normalizedPrice < existing.outputPrice
+                )
+                  existing.outputPrice = normalizedPrice;
+              }
+
+              pricingMap.set(slug, existing);
+            }
+          }
+        } catch {
+          // Skip malformed price items
+        }
+      }
+
+      nextToken = response.NextToken;
+    } while (nextToken);
+  } catch (err) {
+    console.warn(
+      `  Warning: Failed to fetch pricing data: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return pricingMap;
+}
+
+// ---------------------------------------------------------------------------
+// Model list fetching, filtering, and deduplication
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter Bedrock models to only those with "TEXT" in outputModalities.
+ */
+export function filterTextModels(models: BedrockModel[]): BedrockModel[] {
+  return models.filter((m) => m.outputModalities.includes("TEXT"));
+}
+
+/**
+ * Deduplicate models by model ID (first-seen wins).
+ */
+export function deduplicateModels(
+  models: BedrockModel[],
+): Map<string, BedrockModel> {
+  const seen = new Map<string, BedrockModel>();
+  for (const model of models) {
+    if (!seen.has(model.modelId)) {
+      seen.set(model.modelId, model);
+    }
+  }
+  return seen;
+}
+
+/**
+ * Merge a list of supported modalities with new information from Bedrock API
+ *
+ * Maps Bedrock API modalities to models.dev format. Preserves listed
+ * modalities that aren't documented in Bedrock API (e.g. audio, pdf - which
+ * could be supported or not by models but aren't specified). Preserves
+ * existing listed order where possible and inserts in alphabetical order.
+ */
+export function mergeModalities(
+  existing: string[] | undefined,
+  fromApi: string[],
+): string[] {
+  // Map API result to models.dev modalities:
+  const proposed = fromApi
+    .map((m_raw) => MODALITIES_API_MAP.get(m_raw))
+    .filter((m): m is string => !!m);
+
+  // Drop any from existing that API says aren't supported, but keep any that
+  // the API isn't able to confirm or deny:
+  const MODALITIES_SUPPORTED = [...MODALITIES_API_MAP.values()];
+  const result = [...(existing || [])].filter((m) => {
+    if (proposed.indexOf(m) >= 0) return true;
+    if (MODALITIES_SUPPORTED.indexOf(m) < 0) return true;
+    return false;
+  });
+
+  // Insert any from API that aren't yet present in existing, at the first
+  // location that would be alphabetically ordered (given the list might be
+  // unsorted and we don't want to change that unnecessarily)
+  for (const m of proposed) {
+    if (!result.includes(m)) {
+      const ixInsert = result.findIndex((mCurr) => mCurr > m);
+      if (ixInsert >= 0) {
+        result.splice(ixInsert, 0, m);
+      } else {
+        result.push(m);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Merge API model data with an existing TOML model (if any) and pricing.
+ */
+export function mergeModel(
+  apiModel: BedrockModel,
+  existing: ExistingModel | null,
+  pricing: PricingRecord | undefined,
+): MergedModel {
+  // Preserve manually-set fields from existing, or use defaults for new models
+  const name = existing?.name ?? apiModel.modelName;
+  const family =
+    existing?.family ?? inferFamily(apiModel.modelId, apiModel.modelName);
+  const attachment =
+    existing?.attachment ?? apiModel.inputModalities.includes("IMAGE");
+  const reasoning = existing?.reasoning ?? false;
+  const toolCall = existing?.tool_call ?? false;
+  const temperature = existing?.temperature ?? true;
+  const openWeights = existing?.open_weights ?? false;
+  const releaseDate = apiModel.releaseDate
+    ? apiModel.releaseDate.toISOString().slice(0, 10)
+    : (existing?.release_date ?? getTodayDate());
+  const knowledge = existing?.knowledge;
+  const structuredOutput = existing?.structured_output;
+  const interleaved = existing?.interleaved;
+  const status = existing?.status;
+
+  const inputModalities = mergeModalities(
+    existing?.modalities?.input,
+    apiModel.inputModalities,
+  );
+  const outputModalities = mergeModalities(
+    existing?.modalities?.output,
+    apiModel.outputModalities,
+  );
+
+  const merged: MergedModel = {
+    name,
+    ...(family !== undefined && { family }),
+    attachment,
+    reasoning,
+    tool_call: toolCall,
+    temperature,
+    release_date: releaseDate,
+    last_updated: getTodayDate(),
+    open_weights: openWeights,
+    ...(structuredOutput !== undefined && {
+      structured_output: structuredOutput,
+    }),
+    ...(knowledge !== undefined && { knowledge }),
+    ...(interleaved !== undefined && { interleaved }),
+    ...(status !== undefined && { status }),
+    limit: {
+      context: existing?.limit?.context ?? 0,
+      output: existing?.limit?.output ?? 0,
+    },
+    modalities: {
+      input: inputModalities,
+      output: outputModalities,
+    },
+  };
+
+  // Apply pricing if matched
+  if (pricing) {
+    const cost: MergedModel["cost"] = {
+      input: pricing.inputPrice ?? 0,
+      output: pricing.outputPrice ?? 0,
+    };
+    // Preserve cache pricing from existing
+    if (existing?.cost?.cache_read !== undefined) {
+      cost.cache_read = existing.cost.cache_read;
+    }
+    if (existing?.cost?.cache_write !== undefined) {
+      cost.cache_write = existing.cost.cache_write;
+    }
+    merged.cost = cost;
+  } else if (existing?.cost) {
+    // Preserve existing cost entirely if no new pricing matched
+    const cost: MergedModel["cost"] = {
+      input: existing.cost.input ?? 0,
+      output: existing.cost.output ?? 0,
+    };
+    if (existing.cost.cache_read !== undefined) {
+      cost.cache_read = existing.cost.cache_read;
+    }
+    if (existing.cost.cache_write !== undefined) {
+      cost.cache_write = existing.cost.cache_write;
+    }
+    merged.cost = cost;
+  }
+
+  return merged;
+}
+
+function matchesFamilySubsequence(target: string, family: string): boolean {
+  const targetLower = target.toLowerCase();
+  const familyLower = family.toLowerCase();
+  let familyIdx = 0;
+
+  for (
+    let i = 0;
+    i < targetLower.length && familyIdx < familyLower.length;
+    i++
+  ) {
+    if (targetLower[i] === familyLower[familyIdx]) {
+      familyIdx++;
+    }
+  }
+
+  return familyIdx === familyLower.length;
+}
+
+/**
+ * Infer the model family from model ID and name using ModelFamilyValues.
+ */
+export function inferFamily(
+  modelId: string,
+  modelName: string,
+): string | undefined {
+  const sortedFamilies = [...ModelFamilyValues]
+    .filter((f) => f.length >= 3) // Avoid spurious matches on 'o' family
+    .sort((a, b) => b.length - a.length);
+
+  // First pass: try exact substring matches
+  const isSubstring = (target: string, family: string): boolean =>
+    target.toLowerCase().includes(family.toLowerCase());
+  for (const family of sortedFamilies) {
+    if (isSubstring(modelId, family)) {
+      return family;
+    }
+  }
+
+  for (const family of sortedFamilies) {
+    if (isSubstring(modelName, family)) {
+      return family;
+    }
+  }
+
+  // Second pass: fall back to subsequence matching
+  for (const family of sortedFamilies) {
+    if (matchesFamilySubsequence(modelId, family)) {
+      return family;
+    }
+  }
+
+  for (const family of sortedFamilies) {
+    if (matchesFamilySubsequence(modelName, family)) {
+      return family;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Fetch all text-output models from Bedrock across multiple regions.
+ * Creates a BedrockClient per region, calls ListFoundationModels,
+ * filters to text-output models, and deduplicates by model ID
+ * (first-seen wins). Logs warnings for failed regions and continues.
+ */
+export async function fetchAllModels(
+  regions: string[],
+): Promise<Map<string, BedrockModel>> {
+  const allModels: BedrockModel[] = [];
+
+  for (const region of regions) {
+    try {
+      const client = new BedrockClient({ region });
+      const command = new ListFoundationModelsCommand({});
+      const response = await client.send(command);
+
+      const summaries = response.modelSummaries ?? [];
+      const models: BedrockModel[] = summaries.map(
+        (s: FoundationModelSummary) => ({
+          modelId: s.modelId ?? "",
+          modelName: s.modelName ?? "",
+          inputModalities: s.inputModalities ?? [],
+          outputModalities: s.outputModalities ?? [],
+          releaseDate: s.modelLifecycle?.startOfLifeTime,
+        }),
+      );
+
+      const textModels = filterTextModels(models);
+      console.log(
+        `  ${region}: ${summaries.length} models, ${textModels.length} text-output`,
+      );
+      allModels.push(...textModels);
+    } catch (err) {
+      console.warn(
+        `  Warning: Failed to fetch models from ${region}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return deduplicateModels(allModels);
+}
+
+// ---------------------------------------------------------------------------
+// TOML formatting and change detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a MergedModel as a TOML string following established field ordering.
+ *
+ * Field order matches existing Bedrock TOML files:
+ *   name, family, release_date, last_updated,
+ *   attachment, reasoning, temperature, tool_call, structured_output,
+ *   interleaved (boolean only), knowledge, open_weights, status,
+ *   [interleaved] (object form), [cost], [limit], [modalities]
+ */
+export function formatToml(model: MergedModel): string {
+  const lines: string[] = [];
+
+  lines.push(`name = "${model.name.replace(/"/g, '\\"')}"`);
+  if (model.family) {
+    lines.push(`family = "${model.family}"`);
+  }
+  lines.push(`release_date = "${model.release_date}"`);
+  lines.push(`last_updated = "${model.last_updated}"`);
+  lines.push(`attachment = ${model.attachment}`);
+  lines.push(`reasoning = ${model.reasoning}`);
+  lines.push(`temperature = ${model.temperature}`);
+  if (model.knowledge) {
+    lines.push(`knowledge = "${model.knowledge}"`);
+  }
+  lines.push(`tool_call = ${model.tool_call}`);
+  if (model.structured_output !== undefined) {
+    lines.push(`structured_output = ${model.structured_output}`);
+  }
+  // interleaved = true goes inline with the booleans
+  if (model.interleaved === true) {
+    lines.push(`interleaved = true`);
+  }
+  lines.push(`open_weights = ${model.open_weights}`);
+  if (model.status) {
+    lines.push(`status = "${model.status}"`);
+  }
+
+  // interleaved as object gets its own section
+  if (typeof model.interleaved === "object" && model.interleaved !== null) {
+    lines.push("");
+    lines.push(`[interleaved]`);
+    lines.push(`field = "${model.interleaved.field}"`);
+  }
+
+  if (model.cost) {
+    lines.push("");
+    lines.push(`[cost]`);
+    lines.push(`input = ${formatPriceNumber(model.cost.input)}`);
+    lines.push(`output = ${formatPriceNumber(model.cost.output)}`);
+    if (model.cost.cache_read !== undefined) {
+      lines.push(`cache_read = ${model.cost.cache_read}`);
+    }
+    if (model.cost.cache_write !== undefined) {
+      lines.push(`cache_write = ${model.cost.cache_write}`);
+    }
+  }
+
+  lines.push("");
+  lines.push(`[limit]`);
+  lines.push(`context = ${formatNumber(model.limit.context)}`);
+  lines.push(`output = ${formatNumber(model.limit.output)}`);
+
+  lines.push("");
+  lines.push(`[modalities]`);
+  lines.push(
+    `input = [${model.modalities.input.map((m) => `"${m}"`).join(", ")}]`,
+  );
+  lines.push(
+    `output = [${model.modalities.output.map((m) => `"${m}"`).join(", ")}]`,
+  );
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Detect field-level changes between an existing model and a merged model.
+ * Returns an empty array when existing is null (new model — no changes to report).
+ * Uses epsilon for price comparisons to avoid noise from floating-point rounding.
+ */
+export function detectChanges(
+  existing: ExistingModel | null,
+  merged: MergedModel,
+): Changes[] {
+  if (!existing) return [];
+
+  const changes: Changes[] = [];
+  const EPSILON = 0.001;
+
+  // Fields where a zero value is a placeholder — skip comparison when either
+  // side is zero so we don't report noise for unset limits.
+  const zeroSkipFields = new Set([
+    "limit.context",
+    "limit.input",
+    "limit.output",
+  ]);
+
+  const fmt = (val: unknown): string => {
+    if (typeof val === "number") return formatNumber(val);
+    if (Array.isArray(val)) return `[${val.join(", ")}]`;
+    if (val === undefined) return "(none)";
+    return String(val);
+  };
+
+  const isPriceDiff = (oldPrice: unknown, newPrice: unknown): boolean => {
+    // 0 → undefined is not material
+    if (oldPrice === 0 && newPrice === undefined) return false;
+    if (typeof oldPrice === "number" && typeof newPrice === "number") {
+      return Math.abs(oldPrice - newPrice) > EPSILON;
+    }
+    return oldPrice !== newPrice;
+  };
+
+  const compare = (field: string, oldVal: unknown, newVal: unknown) => {
+    if (zeroSkipFields.has(field)) {
+      if (
+        (typeof oldVal === "number" && oldVal === 0) ||
+        (typeof newVal === "number" && newVal === 0)
+      )
+        return;
+    }
+
+    const isDiff = field.startsWith("cost.")
+      ? isPriceDiff(oldVal, newVal)
+      : JSON.stringify(oldVal) !== JSON.stringify(newVal);
+
+    if (isDiff) {
+      changes.push({ field, oldValue: fmt(oldVal), newValue: fmt(newVal) });
+    }
+  };
+
+  compare("name", existing.name, merged.name);
+  compare("family", existing.family, merged.family);
+  compare("attachment", existing.attachment, merged.attachment);
+  compare("reasoning", existing.reasoning, merged.reasoning);
+  compare("tool_call", existing.tool_call, merged.tool_call);
+  compare(
+    "structured_output",
+    existing.structured_output,
+    merged.structured_output,
+  );
+  compare("open_weights", existing.open_weights, merged.open_weights);
+  compare("release_date", existing.release_date, merged.release_date);
+  compare("cost.input", existing.cost?.input, merged.cost?.input);
+  compare("cost.output", existing.cost?.output, merged.cost?.output);
+  compare(
+    "cost.cache_read",
+    existing.cost?.cache_read,
+    merged.cost?.cache_read,
+  );
+  compare(
+    "cost.cache_write",
+    existing.cost?.cache_write,
+    merged.cost?.cache_write,
+  );
+  compare("limit.context", existing.limit?.context, merged.limit.context);
+  compare("limit.output", existing.limit?.output, merged.limit.output);
+  compare(
+    "modalities.input",
+    existing.modalities?.input,
+    merged.modalities.input,
+  );
+  compare(
+    "modalities.output",
+    existing.modalities?.output,
+    merged.modalities.output,
+  );
+
+  return changes;
+}
+
+/**
+ * Load and parse an existing TOML model file.
+ * Returns null if the file doesn't exist or fails to parse (logs warning on parse failure).
+ */
+export async function loadExistingModel(
+  filePath: string,
+): Promise<ExistingModel | null> {
+  try {
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) {
+      return null;
+    }
+    const toml = await import(filePath, { with: { type: "toml" } }).then(
+      (mod) => mod.default,
+    );
+    return toml as ExistingModel;
+  } catch (e) {
+    console.warn(`Warning: Failed to parse existing file ${filePath}:`, e);
+    return null;
+  }
+}
+
+/**
+ * Detect orphaned TOML files — files that exist on disk but whose model ID
+ * is not present in the API response. Returns the list of orphaned relative
+ * file paths sorted alphabetically. Never deletes any files.
+ */
+export function detectOrphans(
+  existingFiles: Set<string>,
+  apiModelIds: Set<string>,
+): string[] {
+  const orphans: string[] = [];
+  for (const file of existingFiles) {
+    if (!apiModelIds.has(file)) {
+      orphans.push(file);
+    }
+  }
+  return orphans.sort();
+}
+
+/**
+ * Generate/update data files for Amazon Bedrock models, querying AWS APIs
+ */
+export async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+  const newOnly = args.includes("--new-only");
+
+  console.log(
+    `${dryRun ? "[DRY RUN] " : ""}${newOnly ? "[NEW ONLY] " : ""}Fetching Amazon Bedrock models...`,
+  );
+
+  // Fetch models and pricing in parallel
+  const [models, pricing] = await Promise.all([
+    fetchAllModels(BEDROCK_REGIONS),
+    fetchPricing(BEDROCK_REGIONS),
+  ]);
+
+  console.log(
+    `Found ${models.size} models from API, fetched ${pricing.size} pricing records\n`,
+  );
+
+  // Scan existing files
+  const existingFiles = new Set<string>();
+  try {
+    for await (const file of new Bun.Glob("**/*.toml").scan({
+      cwd: MODELS_DIR,
+      absolute: false,
+    })) {
+      existingFiles.add(file);
+    }
+  } catch {
+    // Directory may not exist yet
+  }
+
+  const apiModelIds = new Set<string>();
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+
+  for (const [modelId, apiModel] of models) {
+    const relativePath = `${modelId}.toml`;
+    const filePath = path.join(MODELS_DIR, relativePath);
+    const dirPath = path.dirname(filePath);
+
+    apiModelIds.add(relativePath);
+
+    const existing = await loadExistingModel(filePath);
+    const matchedPricing = matchPricing(modelId, pricing);
+    const merged = mergeModel(apiModel, existing, matchedPricing);
+    const tomlContent = formatToml(merged);
+
+    if (existing === null) {
+      created++;
+      if (dryRun) {
+        console.log(`[DRY RUN] Would create: ${relativePath}`);
+        console.log(`  name = "${merged.name}"`);
+        if (merged.family) {
+          console.log(`  family = "${merged.family}" (inferred)`);
+        }
+        console.log("");
+      } else {
+        await mkdir(dirPath, { recursive: true });
+        await Bun.write(filePath, tomlContent);
+        console.log(`Created: ${relativePath}`);
+      }
+    } else {
+      if (newOnly) {
+        unchanged++;
+        continue;
+      }
+
+      const changes = detectChanges(existing, merged);
+
+      if (changes.length > 0) {
+        updated++;
+        if (dryRun) {
+          console.log(`[DRY RUN] Would update: ${relativePath}`);
+        } else {
+          await mkdir(dirPath, { recursive: true });
+          await Bun.write(filePath, tomlContent);
+          console.log(`Updated: ${relativePath}`);
+        }
+        for (const change of changes) {
+          console.log(
+            `  ${change.field}: ${change.oldValue} → ${change.newValue}`,
+          );
+        }
+        console.log("");
+      } else {
+        unchanged++;
+      }
+    }
+  }
+
+  // Orphan detection
+  const orphaned = detectOrphans(existingFiles, apiModelIds);
+  for (const file of orphaned) {
+    console.log(`Warning: Orphaned file (not in API): ${file}`);
+  }
+
+  // Summary
+  console.log("");
+  if (dryRun) {
+    console.log(
+      `Summary: ${created} would be created, ${updated} would be updated, ${unchanged} unchanged, ${orphaned.length} orphaned`,
+    );
+  } else {
+    console.log(
+      `Summary: ${created} created, ${updated} updated, ${unchanged} unchanged, ${orphaned.length} orphaned`,
+    );
+  }
+}
+
+// Only run when executed directly, not when imported for testing
+if (import.meta.main) {
+  await main();
+}

--- a/providers/amazon-bedrock/models/ai21.jamba-1-5-large-v1:0.toml
+++ b/providers/amazon-bedrock/models/ai21.jamba-1-5-large-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Jamba 1.5 Large"
+family = "jamba"
+release_date = "2024-09-23"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/ai21.jamba-1-5-mini-v1:0.toml
+++ b/providers/amazon-bedrock/models/ai21.jamba-1-5-mini-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Jamba 1.5 Mini"
+family = "jamba"
+release_date = "2024-09-23"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-2-lite-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Nova 2 Lite"
 family = "nova"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/amazon-bedrock/models/amazon.nova-2-lite-v1:0:256k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-2-lite-v1:0:256k.toml
@@ -1,0 +1,17 @@
+name = "Nova 2 Lite"
+family = "nova"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-2-sonic-v1:0.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-2-sonic-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Nova 2 Sonic"
+family = "nova"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = []
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-lite-v1:0:24k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-lite-v1:0:24k.toml
@@ -1,0 +1,17 @@
+name = "Nova Lite"
+family = "nova-lite"
+release_date = "2024-12-03"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-lite-v1:0:300k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-lite-v1:0:300k.toml
@@ -1,0 +1,17 @@
+name = "Nova Lite"
+family = "nova-lite"
+release_date = "2024-12-03"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-micro-v1:0:128k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-micro-v1:0:128k.toml
@@ -1,0 +1,17 @@
+name = "Nova Micro"
+family = "nova-micro"
+release_date = "2024-12-03"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-micro-v1:0:24k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-micro-v1:0:24k.toml
@@ -1,0 +1,17 @@
+name = "Nova Micro"
+family = "nova-micro"
+release_date = "2024-12-03"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-premier-v1:0:1000k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-premier-v1:0:1000k.toml
@@ -1,0 +1,17 @@
+name = "Nova Premier"
+family = "nova"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-premier-v1:0:20k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-premier-v1:0:20k.toml
@@ -1,0 +1,17 @@
+name = "Nova Premier"
+family = "nova"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-premier-v1:0:8k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-premier-v1:0:8k.toml
@@ -1,0 +1,17 @@
+name = "Nova Premier"
+family = "nova"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-premier-v1:0:mm.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-premier-v1:0:mm.toml
@@ -1,0 +1,17 @@
+name = "Nova Premier"
+family = "nova"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-pro-v1:0:24k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-pro-v1:0:24k.toml
@@ -1,0 +1,17 @@
+name = "Nova Pro"
+family = "nova-pro"
+release_date = "2024-12-03"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-pro-v1:0:300k.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-pro-v1:0:300k.toml
@@ -1,0 +1,17 @@
+name = "Nova Pro"
+family = "nova-pro"
+release_date = "2024-12-03"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-sonic-v1:0.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-sonic-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Nova Sonic"
+family = "nova"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = []
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.rerank-v1:0.toml
+++ b/providers/amazon-bedrock/models/amazon.rerank-v1:0.toml
@@ -1,0 +1,16 @@
+name = "Rerank 1.0"
+release_date = "2025-04-03"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.titan-tg1-large.toml
+++ b/providers/amazon-bedrock/models/amazon.titan-tg1-large.toml
@@ -1,0 +1,17 @@
+name = "Titan Text Large"
+family = "titan"
+release_date = "2023-11-29"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/anthropic.claude-3-5-haiku-20241022-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-3-5-haiku-20241022-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Claude Haiku 3.5"
 family = "claude-haiku"
 release_date = "2024-10-22"
-last_updated = "2024-10-22"
+last_updated = "2026-04-13"
 attachment = true
 reasoning = false
 temperature = true
@@ -10,15 +10,15 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.80
-output = 4.00
+input = 0.8
+output = 4
 cache_read = 0.08
-cache_write = 1.00
+cache_write = 1
 
 [limit]
 context = 200_000
 output = 8_192
 
 [modalities]
-input = ["text", "image", "pdf"]
+input = ["text", "pdf"]
 output = ["text"]

--- a/providers/amazon-bedrock/models/anthropic.claude-3-haiku-20240307-v1:0:200k.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-3-haiku-20240307-v1:0:200k.toml
@@ -1,0 +1,17 @@
+name = "Claude 3 Haiku"
+family = "claude"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/anthropic.claude-3-haiku-20240307-v1:0:48k.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-3-haiku-20240307-v1:0:48k.toml
@@ -1,0 +1,17 @@
+name = "Claude 3 Haiku"
+family = "claude"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/anthropic.claude-3-sonnet-20240229-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-3-sonnet-20240229-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Claude 3 Sonnet"
+family = "claude"
+release_date = "2024-03-04"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/anthropic.claude-3-sonnet-20240229-v1:0:200k.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-3-sonnet-20240229-v1:0:200k.toml
@@ -1,0 +1,17 @@
+name = "Claude 3 Sonnet"
+family = "claude"
+release_date = "2024-03-04"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/anthropic.claude-3-sonnet-20240229-v1:0:28k.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-3-sonnet-20240229-v1:0:28k.toml
@@ -1,0 +1,17 @@
+name = "Claude 3 Sonnet"
+family = "claude"
+release_date = "2024-03-04"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/cohere.command-r-plus-v1:0.toml
+++ b/providers/amazon-bedrock/models/cohere.command-r-plus-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Command R+"
+family = "command-r"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/cohere.command-r-v1:0.toml
+++ b/providers/amazon-bedrock/models/cohere.command-r-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Command R"
+family = "command-r"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/cohere.rerank-v3-5:0.toml
+++ b/providers/amazon-bedrock/models/cohere.rerank-v3-5:0.toml
@@ -1,0 +1,16 @@
+name = "Rerank 3.5"
+release_date = "2024-12-01"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/deepseek.r1-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.r1-v1:0.toml
@@ -1,7 +1,7 @@
 name = "DeepSeek-R1"
 family = "deepseek-thinking"
-release_date = "2025-01-20"
-last_updated = "2025-05-29"
+release_date = "2025-03-10"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
@@ -1,7 +1,7 @@
 name = "DeepSeek-V3.1"
 family = "deepseek"
-release_date = "2025-09-18"
-last_updated = "2025-09-18"
+release_date = "2025-09-15"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/amazon-bedrock/models/deepseek.v3.2.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3.2.toml
@@ -1,7 +1,7 @@
 name = "DeepSeek-V3.2"
 family = "deepseek"
 release_date = "2026-02-06"
-last_updated = "2026-02-06"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -10,8 +10,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.62
-output = 1.85
+input = 0.31
+output = 0.925
 
 [limit]
 context = 163_840

--- a/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
@@ -1,22 +1,22 @@
 name = "Google Gemma 3 12B"
 family = "gemma"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
+knowledge = "2024-12"
 tool_call = false
 structured_output = true
-knowledge = "2024-12"
 open_weights = false
 
 [cost]
-input = 0.049999999999999996
-output = 0.09999999999999999
+input = 0.05
+output = 0.15
 
 [limit]
-context = 131072
-output = 8192
+context = 131_072
+output = 8_192
 
 [modalities]
 input = ["text", "image"]

--- a/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
@@ -1,18 +1,18 @@
 name = "Google Gemma 3 27B Instruct"
 family = "gemma"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = true
 reasoning = false
-tool_call = true
-structured_output = true
 temperature = true
 knowledge = "2025-07"
-release_date = "2025-07-27"
-last_updated = "2025-07-27"
+tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]
 input = 0.12
-output = 0.2
+output = 0.19
 
 [limit]
 context = 202_752

--- a/providers/amazon-bedrock/models/google.gemma-3-4b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-4b-it.toml
@@ -1,7 +1,7 @@
 name = "Gemma 3 4B IT"
 family = "gemma"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -9,8 +9,8 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.04
-output = 0.08
+input = 0.02
+output = 0.04
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/meta.llama3-1-70b-instruct-v1:0:128k.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-1-70b-instruct-v1:0:128k.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.1 70B Instruct"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.72
+output = 0.72
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/meta.llama3-1-8b-instruct-v1:0:128k.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-1-8b-instruct-v1:0:128k.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.1 8B Instruct"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.22
+output = 0.22
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/meta.llama3-2-11b-instruct-v1:0:128k.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-2-11b-instruct-v1:0:128k.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.2 11B Instruct"
+family = "llama"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.16
+output = 0.16
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/meta.llama3-2-1b-instruct-v1:0:128k.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-2-1b-instruct-v1:0:128k.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.2 1B Instruct"
+family = "llama"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.1
+output = 0.1
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/meta.llama3-2-3b-instruct-v1:0:128k.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-2-3b-instruct-v1:0:128k.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.2 3B Instruct"
+family = "llama"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.15
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/meta.llama3-2-90b-instruct-v1:0:128k.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-2-90b-instruct-v1:0:128k.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.2 90B Instruct"
+family = "llama"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.72
+output = 0.72
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/meta.llama3-3-70b-instruct-v1:0.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-3-70b-instruct-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Llama 3.3 70B Instruct"
 family = "llama"
-release_date = "2024-12-06"
-last_updated = "2024-12-06"
+release_date = "2024-12-19"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/amazon-bedrock/models/meta.llama3-3-70b-instruct-v1:0:128k.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-3-70b-instruct-v1:0:128k.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.3 70B Instruct"
+family = "llama"
+release_date = "2024-12-19"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.72
+output = 0.72
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/meta.llama3-70b-instruct-v1:0.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-70b-instruct-v1:0.toml
@@ -1,0 +1,21 @@
+name = "Llama 3 70B Instruct"
+family = "llama"
+release_date = "2024-04-23"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 2.65
+output = 3.5
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/meta.llama3-8b-instruct-v1:0.toml
+++ b/providers/amazon-bedrock/models/meta.llama3-8b-instruct-v1:0.toml
@@ -1,0 +1,21 @@
+name = "Llama 3 8B Instruct"
+family = "llama"
+release_date = "2024-04-23"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.3
+output = 0.6
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/meta.llama4-maverick-17b-instruct-v1:0.toml
+++ b/providers/amazon-bedrock/models/meta.llama4-maverick-17b-instruct-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Llama 4 Maverick 17B Instruct"
 family = "llama"
-release_date = "2025-04-05"
-last_updated = "2025-04-05"
+release_date = "2025-04-28"
+last_updated = "2026-04-13"
 attachment = true
 reasoning = false
 temperature = true

--- a/providers/amazon-bedrock/models/meta.llama4-scout-17b-instruct-v1:0.toml
+++ b/providers/amazon-bedrock/models/meta.llama4-scout-17b-instruct-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Llama 4 Scout 17B Instruct"
 family = "llama"
-release_date = "2025-04-05"
-last_updated = "2025-04-05"
+release_date = "2025-04-28"
+last_updated = "2026-04-13"
 attachment = true
 reasoning = false
 temperature = true

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
@@ -1,7 +1,7 @@
 name = "MiniMax M2.1"
 family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
+release_date = "2026-02-06"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -10,8 +10,8 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.30
-output = 1.20
+input = 0.15
+output = 0.6
 
 [limit]
 context = 204_800

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
@@ -1,7 +1,7 @@
 name = "MiniMax M2.5"
 family = "minimax"
 release_date = "2026-03-18"
-last_updated = "2026-03-18"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -10,8 +10,8 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.30
-output = 1.20
+input = 0.15
+output = 0.6
 
 [limit]
 context = 196_608

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.toml
@@ -1,7 +1,7 @@
 name = "MiniMax M2"
 family = "minimax"
-release_date = "2025-10-27"
-last_updated = "2025-10-27"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -10,8 +10,8 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.30
-output = 1.20
+input = 0.15
+output = 0.6
 
 [limit]
 context = 204_608

--- a/providers/amazon-bedrock/models/mistral.devstral-2-123b.toml
+++ b/providers/amazon-bedrock/models/mistral.devstral-2-123b.toml
@@ -1,7 +1,7 @@
 name = "Devstral 2 123B"
 family = "devstral"
 release_date = "2026-02-17"
-last_updated = "2026-02-17"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -9,8 +9,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.40
-output = 2.00
+input = 0.2
+output = 1
 
 [limit]
 context = 256_000

--- a/providers/amazon-bedrock/models/mistral.magistral-small-2509.toml
+++ b/providers/amazon-bedrock/models/mistral.magistral-small-2509.toml
@@ -1,7 +1,7 @@
 name = "Magistral Small 1.2"
 family = "magistral"
 release_date = "2025-12-02"
-last_updated = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.50
-output = 1.50
+input = 0.25
+output = 0.75
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/mistral.ministral-3-14b-instruct.toml
+++ b/providers/amazon-bedrock/models/mistral.ministral-3-14b-instruct.toml
@@ -1,7 +1,7 @@
 name = "Ministral 14B 3.0"
 family = "ministral"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,13 +10,13 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.20
-output = 0.20
+input = 0.1
+output = 0.1
 
 [limit]
 context = 128_000
 output = 4_096
 
 [modalities]
-input = ["text"]
+input = ["image", "text"]
 output = ["text"]

--- a/providers/amazon-bedrock/models/mistral.ministral-3-3b-instruct.toml
+++ b/providers/amazon-bedrock/models/mistral.ministral-3-3b-instruct.toml
@@ -1,7 +1,7 @@
 name = "Ministral 3 3B"
 family = "ministral"
 release_date = "2025-12-02"
-last_updated = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.10
-output = 0.10
+input = 0.05
+output = 0.05
 
 [limit]
 context = 256_000

--- a/providers/amazon-bedrock/models/mistral.ministral-3-8b-instruct.toml
+++ b/providers/amazon-bedrock/models/mistral.ministral-3-8b-instruct.toml
@@ -1,7 +1,7 @@
 name = "Ministral 3 8B"
 family = "ministral"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,13 +10,13 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.15
-output = 0.15
+input = 0.07
+output = 0.07
 
 [limit]
 context = 128_000
 output = 4_096
 
 [modalities]
-input = ["text"]
+input = ["image", "text"]
 output = ["text"]

--- a/providers/amazon-bedrock/models/mistral.mistral-7b-instruct-v0:2.toml
+++ b/providers/amazon-bedrock/models/mistral.mistral-7b-instruct-v0:2.toml
@@ -1,0 +1,17 @@
+name = "Mistral 7B Instruct"
+family = "mistral"
+release_date = "2024-03-01"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/mistral.mistral-large-2402-v1:0.toml
+++ b/providers/amazon-bedrock/models/mistral.mistral-large-2402-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Mistral Large (24.02)"
+family = "mistral-large"
+release_date = "2024-04-03"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/mistral.mistral-large-2407-v1:0.toml
+++ b/providers/amazon-bedrock/models/mistral.mistral-large-2407-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Mistral Large (24.07)"
+family = "mistral-large"
+release_date = "2024-07-24"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/mistral.mistral-large-3-675b-instruct.toml
+++ b/providers/amazon-bedrock/models/mistral.mistral-large-3-675b-instruct.toml
@@ -1,7 +1,7 @@
 name = "Mistral Large 3"
 family = "mistral"
 release_date = "2025-12-02"
-last_updated = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.50
-output = 1.50
+input = 0.25
+output = 0.75
 
 [limit]
 context = 256_000

--- a/providers/amazon-bedrock/models/mistral.mistral-small-2402-v1:0.toml
+++ b/providers/amazon-bedrock/models/mistral.mistral-small-2402-v1:0.toml
@@ -1,0 +1,17 @@
+name = "Mistral Small (24.02)"
+family = "mistral-small"
+release_date = "2024-05-24"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/mistral.mixtral-8x7b-instruct-v0:1.toml
+++ b/providers/amazon-bedrock/models/mistral.mixtral-8x7b-instruct-v0:1.toml
@@ -1,0 +1,17 @@
+name = "Mixtral 8x7B Instruct"
+family = "mistral"
+release_date = "2024-03-01"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/mistral.voxtral-mini-3b-2507.toml
+++ b/providers/amazon-bedrock/models/mistral.voxtral-mini-3b-2507.toml
@@ -1,7 +1,7 @@
 name = "Voxtral Mini 3B 2507"
 family = "mistral"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.04
-output = 0.04
+input = 0.02
+output = 0.02
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/mistral.voxtral-small-24b-2507.toml
+++ b/providers/amazon-bedrock/models/mistral.voxtral-small-24b-2507.toml
@@ -1,7 +1,7 @@
 name = "Voxtral Small 24B 2507"
 family = "mistral"
-release_date = "2025-07-01"
-last_updated = "2025-07-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = true
 reasoning = false
 temperature = true
@@ -10,12 +10,12 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.15
-output = 0.35
+input = 0.05
+output = 0.15
 
 [limit]
 context = 32_000
-output = 8192
+output = 8_192
 
 [modalities]
 input = ["text", "audio"]

--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -1,7 +1,7 @@
 name = "Kimi K2 Thinking"
-release_date = "2025-12-02"
 family = "kimi-thinking"
-last_updated = "2025-12-02"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -11,8 +11,8 @@ interleaved = true
 open_weights = true
 
 [cost]
-input = 0.6
-output = 2.5
+input = 0.3
+output = 1.25
 
 [limit]
 context = 256_000

--- a/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
+++ b/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
@@ -1,7 +1,7 @@
 name = "Kimi K2.5"
 family = "kimi"
 release_date = "2026-02-06"
-last_updated = "2026-02-06"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -10,8 +10,8 @@ interleaved = true
 open_weights = true
 
 [cost]
-input = 0.6
-output = 3
+input = 0.3
+output = 1.5
 
 [limit]
 context = 256_000

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-12b-v2.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-12b-v2.toml
@@ -1,7 +1,7 @@
 name = "NVIDIA Nemotron Nano 12B v2 VL BF16"
 family = "nemotron"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.20
-output = 0.60
+input = 0.1
+output = 0.3
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
@@ -1,7 +1,7 @@
 name = "NVIDIA Nemotron Nano 3 30B"
 family = "nemotron"
 release_date = "2025-12-23"
-last_updated = "2025-12-23"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -9,8 +9,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.06
-output = 0.24
+input = 0.03
+output = 0.12
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-9b-v2.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-9b-v2.toml
@@ -1,7 +1,7 @@
 name = "NVIDIA Nemotron Nano 9B v2"
 family = "nemotron"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.06
-output = 0.23
+input = 0.03
+output = 0.12
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
@@ -1,7 +1,7 @@
 name = "NVIDIA Nemotron 3 Super 120B A12B"
 family = "nemotron"
-release_date = "2026-03-11"
-last_updated = "2026-03-11"
+release_date = "2026-03-18"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -9,8 +9,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.15
-output = 0.65
+input = 0.075
+output = 0.325
 
 [limit]
 context = 262_144

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
@@ -1,7 +1,7 @@
 name = "gpt-oss-120b"
 family = "gpt-oss"
 release_date = "2024-12-01"
-last_updated = "2024-12-01"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.15
-output = 0.60
+input = 0.075
+output = 0.3
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
@@ -1,7 +1,7 @@
 name = "gpt-oss-20b"
 family = "gpt-oss"
 release_date = "2024-12-01"
-last_updated = "2024-12-01"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.07
-output = 0.30
+input = 0.035
+output = 0.15
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
@@ -1,7 +1,7 @@
 name = "GPT OSS Safeguard 120B"
 family = "gpt-oss"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.15
-output = 0.60
+input = 0.07
+output = 0.3
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
@@ -1,7 +1,7 @@
 name = "GPT OSS Safeguard 20B"
 family = "gpt-oss"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.07
-output = 0.20
+input = 0.03
+output = 0.1
 
 [limit]
 context = 128_000

--- a/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Qwen3 235B A22B 2507"
 family = "qwen"
-release_date = "2025-09-18"
-last_updated = "2025-09-18"
+release_date = "2025-09-15"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true
@@ -11,8 +11,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.22
-output = 0.88
+input = 0.11
+output = 0.44
 
 [limit]
 context = 262_144

--- a/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Qwen3 32B (dense)"
 family = "qwen"
-release_date = "2025-09-18"
-last_updated = "2025-09-18"
+release_date = "2025-09-15"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -11,8 +11,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.15
-output = 0.6
+input = 0.075
+output = 0.3
 
 [limit]
 context = 16_384

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Qwen3 Coder 30B A3B Instruct"
 family = "qwen"
-release_date = "2025-09-18"
-last_updated = "2025-09-18"
+release_date = "2025-09-15"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Qwen3 Coder 480B A35B Instruct"
 family = "qwen"
-release_date = "2025-09-18"
-last_updated = "2025-09-18"
+release_date = "2025-09-15"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-next.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-next.toml
@@ -1,7 +1,7 @@
 name = "Qwen3 Coder Next"
 family = "qwen"
 release_date = "2026-02-06"
-last_updated = "2026-02-06"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.22
-output = 1.8
+input = 0.25
+output = 0.6
 
 [limit]
 context = 131_072

--- a/providers/amazon-bedrock/models/qwen.qwen3-next-80b-a3b.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-next-80b-a3b.toml
@@ -1,7 +1,7 @@
 name = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 family = "qwen"
-release_date = "2025-09-18"
-last_updated = "2025-11-25"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/amazon-bedrock/models/qwen.qwen3-vl-235b-a22b.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-vl-235b-a22b.toml
@@ -1,7 +1,7 @@
 name = "Qwen/Qwen3-VL-235B-A22B-Instruct"
 family = "qwen"
-release_date = "2025-10-04"
-last_updated = "2025-11-25"
+release_date = "2025-12-02"
+last_updated = "2026-04-13"
 attachment = true
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.3
-output = 1.5
+input = 0.26
+output = 1.33
 
 [limit]
 context = 262_000

--- a/providers/amazon-bedrock/models/twelvelabs.pegasus-1-2-v1:0.toml
+++ b/providers/amazon-bedrock/models/twelvelabs.pegasus-1-2-v1:0.toml
@@ -1,0 +1,16 @@
+name = "Pegasus v1.2"
+release_date = "2025-12-16"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/writer.palmyra-vision-7b.toml
+++ b/providers/amazon-bedrock/models/writer.palmyra-vision-7b.toml
@@ -1,0 +1,21 @@
+name = "Writer Palmyra Vision 7B"
+family = "palmyra"
+release_date = "2026-03-20"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.075
+output = 0.3
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/writer.palmyra-x4-v1:0.toml
+++ b/providers/amazon-bedrock/models/writer.palmyra-x4-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Palmyra X4"
 family = "palmyra"
-release_date = "2025-04-28"
-last_updated = "2025-04-28"
+release_date = "2025-11-21"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/amazon-bedrock/models/writer.palmyra-x5-v1:0.toml
+++ b/providers/amazon-bedrock/models/writer.palmyra-x5-v1:0.toml
@@ -1,7 +1,7 @@
 name = "Palmyra X5"
 family = "palmyra"
-release_date = "2025-04-28"
-last_updated = "2025-04-28"
+release_date = "2025-11-21"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
@@ -1,17 +1,17 @@
 name = "GLM-4.7-Flash"
 family = "glm-flash"
-release_date = "2026-01-19"
-last_updated = "2026-01-19"
+release_date = "2026-02-06"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
-tool_call = true
 knowledge = "2025-04"
+tool_call = true
 open_weights = true
 
 [cost]
-input = 0.07
-output = 0.40
+input = 0.035
+output = 0.2
 
 [limit]
 context = 200_000

--- a/providers/amazon-bedrock/models/zai.glm-4.7.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7.toml
@@ -1,20 +1,20 @@
 name = "GLM-4.7"
 family = "glm"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
+release_date = "2026-02-06"
+last_updated = "2026-04-13"
 attachment = false
 reasoning = true
 temperature = true
-tool_call = true
 knowledge = "2025-04"
+tool_call = true
 open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.60
-output = 2.20
+input = 0.3
+output = 1.1
 
 [limit]
 context = 204_800


### PR DESCRIPTION
Hi folks! For up-front transparency, I work at AWS - though not in the actual Bedrock product team.

I came across models.dev recently and noticed a couple of gaps & inconsistencies in the Bedrock model listings... so rather than fixing them as a one-off, this PR attempts to introduce an automatic generator script for Bedrock similar to the ones already set up for other providers.

Keen to get your initial feedback before I do the last manual tidy-ups, as mentioned below 🙏

### Implementation overview

This script:
1. Crawls the [Bedrock ListFoundationModels API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_ListFoundationModels.html) in a couple of regions to fetch the full list of supported models (some are supported in us-west-2 but not us-east-1, and vice-versa - but AFAIK those two regions should generally provide the complete list between them)
2. Fetches pricing information from the [AWS Pricing GetProducts API](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_pricing_GetProducts.html) for the regions tested, 
3. Tries to match the pricing records to the listed models, which is unfortunately non-trivial due to the setup of the pricing API...
4. Checks and merges changes to the TOMLs, similar to the existing `generate-*` scripts.

Since it calls APIs, users will need an AWS Account/credentials set up to run the generator - but there should be no cost associated with doing so, as it's just fetching listings.

### Known to-dos

There's some outstanding manual work to go through the new model files, especially, and add in some missing information that's not available through the APIs this script uses (e.g. audio/pdf modality support, reasoning & tool-calling support, etc) - and cases where the price mapping has come up empty. I'm OK to do that, but wanted to show & get feedback on the automated portion first. I also figured delaying those edits would help show the limitations of what the current script is(n't) able to populate.

### Key call-outs & questions

(See also the docstring at the top of `generate-bedrock.ts`)
1. AWS API auth ([sigv4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html)) is nice and secure but unpleasantly complex to re-implement from scratch - so this PR introduces dependencies on the official `@aws-sdk/client-bedrock` and `@aws-sdk/client-pricing` libraries.
2. As noted in #1006, Bedrock prices vary by AWS Region and inference tier, but the schema currently has no way to reflect multiple prices for a model.
    - This PR aims to standardize on the lowest available on-demand, online inference price - ignoring any volume discounts, commitments, or batch inference options - across the checked regions and [service tiers](https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html)... Which I think seems fair?
3. ListFoundationModels returns separate results for models that support explicitly different IDs for different context lengths - which in some cases drives different pricing (e.g. "Claude Sonnet 4.5 - Long Context") and/or latency characteristics. This script has ended up creating quite a few new TOML files with context length suffixes e.g. `:8k` for these endpoints... Not sure if there's appetite for this, or we need to consolidate?
4. Some formatting points like underscore thousands separators (e.g. `1_000_000`), key ordering, etc. seemed to be inconsistently applied in the existing TOMLs... Of course it should be pretty easy to change how the script standardizes these if wanted.
5. A lot of the extra information (like reasoning, temperature, etc) we could automatically validate with test model invocations - but I avoided this for now because then running the script would cost money.