### PR TITLE
feat(openrouter): add Elephant Alpha model

### DIFF
--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -387,6 +387,9 @@ export const ModelFamilyValues = [
 
   // Groq
   "groq",
+
+  // Elephant
+  "elephant",
 ] as const;
 
 export const ModelFamily = z.enum(ModelFamilyValues);

--- a/providers/openrouter/models/openrouter/elephant-alpha.toml
+++ b/providers/openrouter/models/openrouter/elephant-alpha.toml
@@ -1,0 +1,22 @@
+name = "Elephant (free)"
+family = "elephant"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add OpenRouter Elephant Alpha model configuration.

## Changes Made
- Add `providers/openrouter/models/openrouter/elephant-alpha.toml` with model metadata sourced from the OpenRouter API

## Model Details
- **Name:** Elephant
- **Family:** elephant
- **Context:** 262,144 tokens
- **Output:** 32,768 tokens
- **Capabilities:** reasoning, temperature, tool_call, structured_output
- **Modalities:** text → text
- **Cost:** Free (input: $0.00, output: $0.00)

## Testing
- [x] Validated with `bun validate`