### PR TITLE
feat(provider): add CrofAI with 12 models

### DIFF
--- a/providers/crofai/models/deepseek-v3.2.toml
+++ b/providers/crofai/models/deepseek-v3.2.toml
@@ -1,0 +1,29 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2024-07"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+open_weights = true
+
+[cost]
+input = 0.28
+output = 0.38
+cache_read = 0.06
+cache_write = 0.06
+
+[limit]
+context = 163_840
+input = 163_840
+output = 163_840
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/gemma-4-31b-it.toml
+++ b/providers/crofai/models/gemma-4-31b-it.toml
@@ -1,0 +1,29 @@
+name = "Gemma 4 31B IT (Vision)"
+family = "gemma"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = false
+temperature = true
+knowledge = "2024-01"
+release_date = "2025-02-01"
+last_updated = "2025-02-01"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.02
+cache_write = 0.02
+
+[limit]
+context = 262_144
+input = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/glm-4.7-flash.toml
+++ b/providers/crofai/models/glm-4.7-flash.toml
@@ -1,0 +1,29 @@
+name = "GLM-4.7 Flash"
+family = "glm"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-04"
+release_date = "2025-01-10"
+last_updated = "2025-01-10"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+cache_read = 0.00
+cache_write = 0.00
+
+[limit]
+context = 202_752
+input = 202_752
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/glm-4.7.toml
+++ b/providers/crofai/models/glm-4.7.toml
@@ -1,0 +1,29 @@
+name = "GLM-4.7"
+family = "glm"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = false
+temperature = true
+knowledge = "2024-01"
+release_date = "2025-01-10"
+last_updated = "2025-01-10"
+open_weights = true
+
+[cost]
+input = 0.25
+output = 1.10
+cache_read = 0.05
+cache_write = 0.05
+
+[limit]
+context = 202_752
+input = 202_752
+output = 202_752
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/glm-5.1-precision.toml
+++ b/providers/crofai/models/glm-5.1-precision.toml
@@ -1,0 +1,30 @@
+name = "GLM-5.1 Precision (Beta)"
+family = "glm"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = false
+temperature = true
+knowledge = "2024-01"
+release_date = "2025-01-15"
+last_updated = "2025-01-15"
+open_weights = true
+status = "beta"
+
+[cost]
+input = 0.70
+output = 2.50
+cache_read = 0.14
+cache_write = 0.14
+
+[limit]
+context = 202_752
+input = 202_752
+output = 202_752
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/glm-5.1.toml
+++ b/providers/crofai/models/glm-5.1.toml
@@ -1,0 +1,29 @@
+name = "GLM-5.1"
+family = "glm"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = false
+temperature = true
+knowledge = "2024-01"
+release_date = "2025-01-15"
+last_updated = "2025-01-15"
+open_weights = true
+
+[cost]
+input = 0.50
+output = 2.10
+cache_read = 0.10
+cache_write = 0.10
+
+[limit]
+context = 202_752
+input = 202_752
+output = 202_752
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/glm-5.toml
+++ b/providers/crofai/models/glm-5.toml
@@ -1,0 +1,29 @@
+name = "GLM-5"
+family = "glm"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = false
+temperature = true
+knowledge = "2024-01"
+release_date = "2025-01-10"
+last_updated = "2025-01-10"
+open_weights = true
+
+[cost]
+input = 0.48
+output = 1.90
+cache_read = 0.10
+cache_write = 0.10
+
+[limit]
+context = 202_752
+input = 202_752
+output = 202_752
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/kimi-k2.5-lightning.toml
+++ b/providers/crofai/models/kimi-k2.5-lightning.toml
@@ -1,0 +1,30 @@
+name = "Kimi k2.5 Lightning (Beta)"
+family = "kimi"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-01"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+open_weights = true
+status = "beta"
+
+[cost]
+input = 1.00
+output = 3.00
+cache_read = 0.20
+cache_write = 0.20
+
+[limit]
+context = 131_072
+input = 131_072
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/kimi-k2.5.toml
+++ b/providers/crofai/models/kimi-k2.5.toml
@@ -1,0 +1,29 @@
+name = "Kimi k2.5 (Vision)"
+family = "kimi"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-01"
+release_date = "2025-01-15"
+last_updated = "2025-01-15"
+open_weights = true
+
+[cost]
+input = 0.35
+output = 1.70
+cache_read = 0.07
+cache_write = 0.07
+
+[limit]
+context = 262_144
+input = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/minimax-m2.5.toml
+++ b/providers/crofai/models/minimax-m2.5.toml
@@ -1,0 +1,29 @@
+name = "MiniMax M2.5"
+family = "minimax"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2026-01"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+open_weights = true
+
+[cost]
+input = 0.11
+output = 0.95
+cache_read = 0.02
+cache_write = 0.02
+
+[limit]
+context = 204_800
+input = 204_800
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/qwen3.5-397b-a17b.toml
+++ b/providers/crofai/models/qwen3.5-397b-a17b.toml
@@ -1,0 +1,29 @@
+name = "Qwen3.5 397B (Vision)"
+family = "qwen"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-04"
+release_date = "2025-01-30"
+last_updated = "2025-01-30"
+open_weights = true
+
+[cost]
+input = 0.35
+output = 1.75
+cache_read = 0.07
+cache_write = 0.07
+
+[limit]
+context = 262_144
+input = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/models/qwen3.5-9b.toml
+++ b/providers/crofai/models/qwen3.5-9b.toml
@@ -1,0 +1,29 @@
+name = "Qwen3.5 9B (Vision)"
+family = "qwen"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = false
+temperature = true
+knowledge = "2024-01"
+release_date = "2025-01-25"
+last_updated = "2025-01-25"
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+cache_read = 0.00
+cache_write = 0.00
+
+[limit]
+context = 262_144
+input = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/crofai/provider.toml
+++ b/providers/crofai/provider.toml
@@ -1,0 +1,5 @@
+name = "CrofAI"
+npm = "@ai-sdk/openai-compatible"
+env = ["CROFAI_API_KEY"]
+doc = "https://crof.ai/docs"
+api = "https://crof.ai/v1"


### PR DESCRIPTION
## What is CrofAI?
CrofAI is an OpenAI-compatible inference provider for hosted LLMs. It exposes multiple existing model families behind a single API endpoint.

- API: `https://crof.ai/v1`
- Docs: `https://crof.ai/docs`
- Discord: `https://discord.gg/e8UeP7YdJW`
- Auth: `CROFAI_API_KEY`
- SDK: `@ai-sdk/openai-compatible`

## Models included (12)
Adds Kimi, GLM, Gemma, MiniMax, Qwen, and DeepSeek variants currently listed by CrofAI.

## Notes
Pricing was taken from `https://crof.ai/pricing`.

Capabilities were set conservatively using:
- CrofAI docs
- CrofAI pricing/model listings
- matching model entries already present in this repo

## Structure
Follows the standard provider layout:
- `provider.toml`
- `models/*.toml`

Partially addresses #447