### PR TITLE
restore qwen3.5-plus and qwen3.6-plus models

### DIFF
--- a/providers/opencode-go/models/qwen3.5-plus.toml
+++ b/providers/opencode-go/models/qwen3.5-plus.toml
@@ -1,0 +1,30 @@
+name = "Qwen3.5 Plus"
+family = "qwen3.5"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.20
+output = 1.20
+cache_read = 0.02
+cache_write = 0.25
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/alibaba"

--- a/providers/opencode-go/models/qwen3.6-plus.toml
+++ b/providers/opencode-go/models/qwen3.6-plus.toml
@@ -1,0 +1,30 @@
+name = "Qwen3.6 Plus"
+family = "qwen3.6"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.50
+output = 3.00
+cache_read = 0.05
+cache_write = 0.625
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/alibaba"


### PR DESCRIPTION
## Summary
- Restore mistakenly deleted `qwen3.5-plus.toml` and `qwen3.6-plus.toml` models from `providers/opencode-go/models/`
- These models were deleted in commit 0ce000a

## Verification
Both models are confirmed working via OpenCode API test.