### PR TITLE
fix(vercel): accept reranking model type from API

### DIFF
--- a/packages/core/script/generate-vercel.ts
+++ b/packages/core/script/generate-vercel.ts
@@ -20,6 +20,7 @@ enum ModelType {
   Embedding = "embedding",
   Image = "image",
   Video = "video",
+  Reranking = "reranking",
 }
 
 enum SkipZeroFields {
@@ -505,8 +506,12 @@ async function main() {
   let unchanged = 0;
 
   for (const apiModel of apiModels) {
-    // Skip these since OpenCode does not support image / video generation yet
-    if (apiModel.type === ModelType.Image || apiModel.type === ModelType.Video) {
+    // Skip these since OpenCode does not support image / video / reranking yet
+    if (
+      apiModel.type === ModelType.Image ||
+      apiModel.type === ModelType.Video ||
+      apiModel.type === ModelType.Reranking
+    ) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
The Vercel AI Gateway API at `https://ai-gateway.vercel.sh/v1/models` now returns models with `type: "reranking"`, which isn't in the Zod enum used by `packages/core/script/generate-vercel.ts`. Running the script today fails with:

```
Invalid enum value. Expected 'language' | 'embedding' | 'image' | 'video', received 'reranking'
```

This PR:
- Adds `reranking` to the `ModelType` enum so parsing succeeds.
- Skips reranking models in the main loop — same pattern already used for `image` / `video`, since OpenCode doesn't consume them.

The same fix was already merged into the Vercel fork as https://github.com/vercel/models.dev/pull/5; opening this against upstream so anyone else running the script gets the fix too.

## Test plan
- [ ] Run `bun run vercel:generate --new-only --dry-run` and confirm it completes without the `invalid_enum_value` error.
- [ ] Confirm no new TOML files are generated for reranking models under `providers/vercel/models/`.