### PR TITLE
feat(gitlab): add duo-chat-opus-4-7 model definition

### DIFF
--- a/providers/gitlab/models/duo-chat-opus-4-7.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-7.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (Claude Opus 4.7)"
+family = "claude-opus"
+release_date = "2026-04-16"
+last_updated = "2026-04-16"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2026-01-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Add `duo-chat-opus-4-7` model definition for the GitLab provider

Claude Opus 4.7 has been added to the GitLab AI Gateway and is now available as a selectable model in the Duo Agent Platform. This adds the corresponding model definition so it appears in OpenCode's model list for the GitLab provider.

Modeled after the existing `duo-chat-opus-4-6.toml` with same context window (1M), output limit (64K), and zero cost (proxied through GitLab).