### PR TITLE
Add Github Copilot Claude Opus 4.7

### DIFF
--- a/providers/github-copilot/models/claude-opus-4.7.toml
+++ b/providers/github-copilot/models/claude-opus-4.7.toml
@@ -1,0 +1,23 @@
+name = "Claude Opus 4.7"
+family = "claude-opus"
+release_date = "2026-04-16"
+last_updated = "2026-04-16"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2026-01-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 144_000
+output = 64_000
+input = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Noticed Claude Opus 4.7 was missing from github copilot, and it is already available through their IDE.