### PR TITLE
Add Z.AI GLM-5.1 to NVIDIA(NIM)

### DIFF
--- a/providers/nvidia/models/z-ai/glm-5.1.toml
+++ b/providers/nvidia/models/z-ai/glm-5.1.toml
@@ -17,7 +17,7 @@ input = 0.0
 output = 0.0
 
 [limit]
-context = 202752
+context = 131072
 output = 131072
 
 [modalities]

--- a/providers/nvidia/models/z-ai/glm-5.1.toml
+++ b/providers/nvidia/models/z-ai/glm-5.1.toml
@@ -1,0 +1,25 @@
+name = "GLM-5.1"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 202752
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add Z.AI GLM-5.1 to NVIDIA NIM provider

### Source
- NVIDIA NIM Modelcard: https://build.nvidia.com/z-ai/glm-5.1/modelcard
- NVIDIA NIM example to call: https://build.nvidia.com/z-ai/glm-5.1

Nvidia NIM Modelcard says `Other Properties Related to Input: Supports multi-turn conversations, tool calling, system prompts, and extended agentic sessions. Input context length: 131,072 tokens.` Need More Confirm

> Locally tested with `OPENCODE_MODELS_PATH`