### PR TITLE
Venice: Update pricing for Grok 4.20 and Qwen3.5 9B

### DIFF
--- a/providers/venice/models/grok-4-20-multi-agent.toml
+++ b/providers/venice/models/grok-4-20-multi-agent.toml
@@ -6,7 +6,7 @@ tool_call = false
 structured_output = true
 temperature = true
 release_date = "2026-03-12"
-last_updated = "2026-04-12"
+last_updated = "2026-04-19"
 open_weights = false
 
 [cost]
@@ -17,7 +17,7 @@ cache_read = 0.23
 [cost.context_over_200k]
 input = 4.53
 output = 13.6
-cache_read = 0.23
+cache_read = 0.45
 
 [limit]
 context = 2_000_000

--- a/providers/venice/models/grok-4-20.toml
+++ b/providers/venice/models/grok-4-20.toml
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-03-12"
-last_updated = "2026-04-12"
+last_updated = "2026-04-19"
 open_weights = false
 
 [cost]
@@ -17,7 +17,7 @@ cache_read = 0.23
 [cost.context_over_200k]
 input = 4.53
 output = 13.6
-cache_read = 0.23
+cache_read = 0.45
 
 [limit]
 context = 2_000_000

--- a/providers/venice/models/qwen3-5-9b.toml
+++ b/providers/venice/models/qwen3-5-9b.toml
@@ -6,11 +6,11 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-03-05"
-last_updated = "2026-04-04"
+last_updated = "2026-04-19"
 open_weights = true
 
 [cost]
-input = 0.05
+input = 0.1
 output = 0.15
 
 [limit]


### PR DESCRIPTION
- Update cache_read pricing for Grok 4.20 context_over_200k (0.23 → 0.45)
- Update input cost for Qwen3.5 9B (0.05 → 0.1)