### PR TITLE
Venice: Add Gemma 4 and Venice Uncensored 1.2 models

### DIFF
--- a/providers/venice/models/gemma-4-uncensored.toml
+++ b/providers/venice/models/gemma-4-uncensored.toml
@@ -1,0 +1,22 @@
+name = "Gemma 4 Uncensored"
+family = "gemma"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-04-13"
+last_updated = "2026-04-19"
+open_weights = true
+
+[cost]
+input = 0.1625
+output = 0.5
+
+[limit]
+context = 256_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/venice/models/venice-uncensored-1-2.toml
+++ b/providers/venice/models/venice-uncensored-1-2.toml
@@ -1,0 +1,22 @@
+name = "Venice Uncensored 1.2"
+family = "venice"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-04-01"
+last_updated = "2026-04-19"
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.9
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
- Add Gemma 4 Uncensored with 256K context, image support
- Add Venice Uncensored 1.2 with 128K context, image support
- Both models support tool calls and structured output