### PR TITLE
Update 302ai model metadata and add GPT-5.4 configs

### DIFF
--- a/providers/302ai/models/claude-3-5-haiku-20241022.toml
+++ b/providers/302ai/models/claude-3-5-haiku-20241022.toml
@@ -1,4 +1,5 @@
 name = "claude-3-5-haiku-20241022"
+family = "claude-haiku"
 release_date = "2024-10-22"
 last_updated = "2024-10-22"
 attachment = true
@@ -6,7 +7,7 @@ reasoning = false
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2024-07"
+knowledge = "2024-07-31"
 
 [cost]
 input = 0.800

--- a/providers/302ai/models/claude-3-5-haiku-latest.toml
+++ b/providers/302ai/models/claude-3-5-haiku-latest.toml
@@ -1,4 +1,5 @@
 name = "claude-3-5-haiku-latest"
+family = "claude-haiku"
 release_date = "2024-10-22"
 last_updated = "2024-10-22"
 attachment = true
@@ -6,7 +7,7 @@ reasoning = false
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2024-07"
+knowledge = "2024-07-31"
 
 [cost]
 input = 0.800

--- a/providers/302ai/models/claude-haiku-4-5-20251001.toml
+++ b/providers/302ai/models/claude-haiku-4-5-20251001.toml
@@ -1,4 +1,5 @@
 name = "claude-haiku-4-5-20251001"
+family = "claude-haiku"
 release_date = "2025-10-16"
 last_updated = "2025-10-16"
 attachment = true
@@ -6,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-03"
+knowledge = "2025-02-28"
 
 [cost]
 input = 1.000

--- a/providers/302ai/models/claude-haiku-4-5.toml
+++ b/providers/302ai/models/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 name = "claude-haiku-4-5"
+family = "claude-haiku"
 release_date = "2025-10-16"
 last_updated = "2025-10-16"
 attachment = true
@@ -6,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-02"
+knowledge = "2025-02-28"
 
 [cost]
 input = 1.000

--- a/providers/302ai/models/claude-opus-4-1-20250805.toml
+++ b/providers/302ai/models/claude-opus-4-1-20250805.toml
@@ -1,12 +1,13 @@
 name = "claude-opus-4-1-20250805"
+family = "claude-opus"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-03"
+knowledge = "2025-03-31"
 
 [cost]
 input = 15.000
@@ -17,5 +18,5 @@ context = 200_000
 output = 32_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/302ai/models/claude-opus-4-20250514.toml
+++ b/providers/302ai/models/claude-opus-4-20250514.toml
@@ -1,12 +1,13 @@
 name = "claude-opus-4-20250514"
+family = "claude-opus"
 release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-03"
+knowledge = "2025-03-31"
 
 [cost]
 input = 15.000

--- a/providers/302ai/models/claude-opus-4-5-20251101.toml
+++ b/providers/302ai/models/claude-opus-4-5-20251101.toml
@@ -1,4 +1,5 @@
 name = "claude-opus-4-5-20251101"
+family = "claude-opus"
 release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
@@ -6,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-03"
+knowledge = "2025-03-31"
 
 [cost]
 input = 5.000

--- a/providers/302ai/models/claude-opus-4-5.toml
+++ b/providers/302ai/models/claude-opus-4-5.toml
@@ -1,4 +1,5 @@
 name = "claude-opus-4-5"
+family = "claude-opus"
 release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
@@ -6,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-03"
+knowledge = "2025-03-31"
 
 [cost]
 input = 5.000

--- a/providers/302ai/models/claude-opus-4-6.toml
+++ b/providers/302ai/models/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 name = "claude-opus-4-6"
+family = "claude-opus"
 release_date = "2026-02-06"
 last_updated = "2026-03-13"
 attachment = true
@@ -6,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-05"
+knowledge = "2025-05-31"
 
 [cost]
 input = 5.000

--- a/providers/302ai/models/claude-opus-4-7.toml
+++ b/providers/302ai/models/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 name = "claude-opus-4-7"
+family = "claude-opus"
 release_date = "2026-04-17"
 last_updated = "2026-04-17"
 attachment = true
@@ -6,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-05"
+knowledge = "2026-01-31"
 
 [cost]
 input = 5.000
@@ -21,7 +22,7 @@ cache_read = 1.000
 cache_write = 12.500
 
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/302ai/models/claude-sonnet-4-20250514.toml
+++ b/providers/302ai/models/claude-sonnet-4-20250514.toml
@@ -1,12 +1,13 @@
 name = "claude-sonnet-4-20250514"
+family = "claude-sonnet"
 release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-03"
+knowledge = "2025-03-31"
 
 [cost]
 input = 3.000

--- a/providers/302ai/models/claude-sonnet-4-5-20250929.toml
+++ b/providers/302ai/models/claude-sonnet-4-5-20250929.toml
@@ -1,12 +1,13 @@
 name = "claude-sonnet-4-5-20250929"
+family = "claude-sonnet"
 release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-03"
+knowledge = "2025-07-31"
 
 [cost]
 input = 3.000

--- a/providers/302ai/models/claude-sonnet-4-5.toml
+++ b/providers/302ai/models/claude-sonnet-4-5.toml
@@ -1,12 +1,13 @@
 name = "claude-sonnet-4-5"
+family = "claude-sonnet"
 release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-07"
+knowledge = "2025-07-31"
 
 [cost]
 input = 3.000

--- a/providers/302ai/models/claude-sonnet-4-6.toml
+++ b/providers/302ai/models/claude-sonnet-4-6.toml
@@ -1,12 +1,13 @@
 name = "claude-sonnet-4-6"
+family = "claude-sonnet"
 release_date = "2026-02-18"
 last_updated = "2026-03-13"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
-knowledge = "2025-08"
+knowledge = "2025-08-31"
 
 [cost]
 input = 3.000

--- a/providers/302ai/models/glm-4.5-air.toml
+++ b/providers/302ai/models/glm-4.5-air.toml
@@ -1,11 +1,12 @@
 name = "glm-4.5-air"
+family = "glm-air"
 release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
 knowledge = "2025-04"
 
 [cost]
@@ -13,7 +14,7 @@ input = 0.1143
 output = 0.286
 
 [limit]
-context = 128_000
+context = 131_072
 output = 98_304
 
 [modalities]

--- a/providers/302ai/models/glm-4.5-airx.toml
+++ b/providers/302ai/models/glm-4.5-airx.toml
@@ -1,4 +1,5 @@
 name = "glm-4.5-airx"
+family = "glm"
 release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false

--- a/providers/302ai/models/glm-4.5-x.toml
+++ b/providers/302ai/models/glm-4.5-x.toml
@@ -1,4 +1,5 @@
 name = "glm-4.5-x"
+family = "glm"
 release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false

--- a/providers/302ai/models/glm-4.5.toml
+++ b/providers/302ai/models/glm-4.5.toml
@@ -1,19 +1,20 @@
 name = "GLM-4.5"
+family = "glm"
 release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
-knowledge = "2024-10"
+open_weights = true
+knowledge = "2025-04"
 
 [cost]
 input = 0.286
 output = 1.142
 
 [limit]
-context = 128_000
+context = 131_072
 output = 98_304
 
 [modalities]

--- a/providers/302ai/models/glm-4.5v.toml
+++ b/providers/302ai/models/glm-4.5v.toml
@@ -1,12 +1,13 @@
 name = "GLM-4.5V"
+family = "glm"
 release_date = "2025-08-12"
 last_updated = "2025-08-12"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
-knowledge = "2024-10"
+open_weights = true
+knowledge = "2025-04"
 
 [cost]
 input = 0.290
@@ -17,5 +18,5 @@ context = 64_000
 output = 16_384
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video"]
 output = ["text"]

--- a/providers/302ai/models/glm-4.6.toml
+++ b/providers/302ai/models/glm-4.6.toml
@@ -1,19 +1,20 @@
 name = "glm-4.6"
+family = "glm"
 release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
-knowledge = "2025-03"
+open_weights = true
+knowledge = "2025-04"
 
 [cost]
 input = 0.286
 output = 1.142
 
 [limit]
-context = 200_000
+context = 204_800
 output = 131_072
 
 [modalities]

--- a/providers/302ai/models/glm-4.6v.toml
+++ b/providers/302ai/models/glm-4.6v.toml
@@ -1,12 +1,13 @@
 name = "GLM-4.6V"
+family = "glm"
 release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
-reasoning = false
+reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
-knowledge = "2025-03"
+open_weights = true
+knowledge = "2025-04"
 
 [cost]
 input = 0.145
@@ -17,5 +18,5 @@ context = 128_000
 output = 32_768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video"]
 output = ["text"]

--- a/providers/302ai/models/glm-4.7-flashx.toml
+++ b/providers/302ai/models/glm-4.7-flashx.toml
@@ -1,11 +1,12 @@
 name = "glm-4.7-flashx"
+family = "glm-flash"
 release_date = "2026-01-20"
 last_updated = "2026-01-20"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
 knowledge = "2025-04"
 
 [cost]

--- a/providers/302ai/models/glm-4.7.toml
+++ b/providers/302ai/models/glm-4.7.toml
@@ -1,19 +1,23 @@
 name = "glm-4.7"
+family = "glm"
 release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
-knowledge = "2025-06"
+open_weights = true
+knowledge = "2025-04"
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.286
 output = 1.142
 
 [limit]
-context = 200_000
+context = 204_800
 output = 131_072
 
 [modalities]

--- a/providers/302ai/models/glm-5-turbo.toml
+++ b/providers/302ai/models/glm-5-turbo.toml
@@ -1,11 +1,16 @@
 name = "glm-5-turbo"
+family = "glm"
 release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.720

--- a/providers/302ai/models/glm-5.1.toml
+++ b/providers/302ai/models/glm-5.1.toml
@@ -1,11 +1,16 @@
 name = "glm-5.1"
+family = "glm"
 release_date = "2026-04-10"
 last_updated = "2026-04-10"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.860

--- a/providers/302ai/models/glm-5.toml
+++ b/providers/302ai/models/glm-5.toml
@@ -1,18 +1,22 @@
 name = "glm-5"
+family = "glm"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.600
 output = 2.600
 
 [limit]
-context = 200_000
+context = 204_800
 output = 131_072
 
 [modalities]

--- a/providers/302ai/models/glm-5v-turbo.toml
+++ b/providers/302ai/models/glm-5v-turbo.toml
@@ -1,4 +1,5 @@
 name = "glm-5v-turbo"
+family = "glm"
 release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
@@ -6,6 +7,9 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.720

--- a/providers/302ai/models/glm-for-coding.toml
+++ b/providers/302ai/models/glm-for-coding.toml
@@ -1,4 +1,5 @@
 name = "glm-for-coding"
+family = "glm"
 release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false

--- a/providers/302ai/models/gpt-4.1-mini.toml
+++ b/providers/302ai/models/gpt-4.1-mini.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 knowledge = "2024-04"
 
@@ -14,9 +15,9 @@ input = 0.400
 output = 1.600
 
 [limit]
-context = 1_000_000
+context = 1_047_576
 output = 32_768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/302ai/models/gpt-4.1-nano.toml
+++ b/providers/302ai/models/gpt-4.1-nano.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 knowledge = "2024-04"
 
@@ -14,7 +15,7 @@ input = 0.100
 output = 0.400
 
 [limit]
-context = 1_000_000
+context = 1_047_576
 output = 32_768
 
 [modalities]

--- a/providers/302ai/models/gpt-4.1.toml
+++ b/providers/302ai/models/gpt-4.1.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 knowledge = "2024-04"
 
@@ -14,9 +15,9 @@ input = 2.000
 output = 8.000
 
 [limit]
-context = 1_000_000
+context = 1_047_576
 output = 32_768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/302ai/models/gpt-4o.toml
+++ b/providers/302ai/models/gpt-4o.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 knowledge = "2023-09"
 
@@ -18,5 +19,5 @@ context = 128_000
 output = 16_384
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/302ai/models/gpt-5-mini.toml
+++ b/providers/302ai/models/gpt-5-mini.toml
@@ -1,12 +1,14 @@
 name = "gpt-5-mini"
+family = "gpt-mini"
 release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2024-10"
+knowledge = "2024-05-30"
 
 [cost]
 input = 0.250
@@ -14,6 +16,7 @@ output = 2.000
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/302ai/models/gpt-5-pro.toml
+++ b/providers/302ai/models/gpt-5-pro.toml
@@ -1,12 +1,14 @@
 name = "gpt-5-pro"
+family = "gpt-pro"
 release_date = "2025-10-08"
 last_updated = "2025-10-08"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2024-10"
+knowledge = "2024-09-30"
 
 [cost]
 input = 15.000
@@ -14,6 +16,7 @@ output = 120.000
 
 [limit]
 context = 400_000
+input = 272_000
 output = 272_000
 
 [modalities]

--- a/providers/302ai/models/gpt-5.1-chat-latest.toml
+++ b/providers/302ai/models/gpt-5.1-chat-latest.toml
@@ -1,12 +1,14 @@
 name = "gpt-5.1-chat-latest"
+family = "gpt-codex"
 release_date = "2025-11-14"
 last_updated = "2025-11-14"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2024-10"
+knowledge = "2024-09-30"
 
 [cost]
 input = 1.250

--- a/providers/302ai/models/gpt-5.1.toml
+++ b/providers/302ai/models/gpt-5.1.toml
@@ -1,12 +1,14 @@
 name = "gpt-5.1"
+family = "gpt"
 release_date = "2025-11-14"
 last_updated = "2025-11-14"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2024-10"
+knowledge = "2024-09-30"
 
 [cost]
 input = 1.250
@@ -14,6 +16,7 @@ output = 10.000
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/302ai/models/gpt-5.2-chat-latest.toml
+++ b/providers/302ai/models/gpt-5.2-chat-latest.toml
@@ -1,12 +1,14 @@
 name = "gpt-5.2-chat-latest"
+family = "gpt-codex"
 release_date = "2025-12-12"
 last_updated = "2025-12-12"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2024-10"
+knowledge = "2025-08-31"
 
 [cost]
 input = 1.750

--- a/providers/302ai/models/gpt-5.2.toml
+++ b/providers/302ai/models/gpt-5.2.toml
@@ -1,12 +1,14 @@
 name = "gpt-5.2"
+family = "gpt"
 release_date = "2025-12-12"
 last_updated = "2025-12-12"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2024-10"
+knowledge = "2025-08-31"
 
 [cost]
 input = 1.750
@@ -14,6 +16,7 @@ output = 14.000
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/302ai/models/gpt-5.4-mini-2026-03-17.toml
+++ b/providers/302ai/models/gpt-5.4-mini-2026-03-17.toml
@@ -1,12 +1,14 @@
 name = "gpt-5.4-mini-2026-03-17"
+family = "gpt-mini"
 release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2025-08"
+knowledge = "2025-08-31"
 
 [cost]
 input = 0.750
@@ -14,6 +16,7 @@ output = 4.500
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/302ai/models/gpt-5.4-mini.toml
+++ b/providers/302ai/models/gpt-5.4-mini.toml
@@ -1,12 +1,14 @@
 name = "gpt-5.4-mini"
+family = "gpt-mini"
 release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2025-08"
+knowledge = "2025-08-31"
 
 [cost]
 input = 0.750
@@ -14,6 +16,7 @@ output = 4.500
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/302ai/models/gpt-5.4-nano-2026-03-17.toml
+++ b/providers/302ai/models/gpt-5.4-nano-2026-03-17.toml
@@ -1,12 +1,14 @@
 name = "gpt-5.4-nano-2026-03-17"
+family = "gpt-nano"
 release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2025-08"
+knowledge = "2025-08-31"
 
 [cost]
 input = 0.200
@@ -14,6 +16,7 @@ output = 1.250
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/302ai/models/gpt-5.4-nano.toml
+++ b/providers/302ai/models/gpt-5.4-nano.toml
@@ -1,12 +1,14 @@
 name = "gpt-5.4-nano"
+family = "gpt-nano"
 release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2025-08"
+knowledge = "2025-08-31"
 
 [cost]
 input = 0.200
@@ -14,6 +16,7 @@ output = 1.250
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/302ai/models/gpt-5.4-pro.toml
+++ b/providers/302ai/models/gpt-5.4-pro.toml
@@ -1,0 +1,30 @@
+name = "gpt-5.4-pro"
+family = "gpt-pro"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = false
+open_weights = false
+knowledge = "2025-08-31"
+
+[cost]
+input = 30.000
+output = 180.000
+cache_read = 0
+cache_write = 0
+
+[cost.context_over_200k]
+input = 60.000
+output = 270.000
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/302ai/models/gpt-5.4.toml
+++ b/providers/302ai/models/gpt-5.4.toml
@@ -1,0 +1,30 @@
+name = "gpt-5.4"
+family = "gpt"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+knowledge = "2025-08-31"
+
+[cost]
+input = 2.500
+output = 15.000
+cache_read = 0.250
+cache_write = 0
+
+[cost.context_over_200k]
+input = 5.000
+output = 22.500
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/302ai/models/gpt-5.toml
+++ b/providers/302ai/models/gpt-5.toml
@@ -1,12 +1,14 @@
 name = "gpt-5"
+family = "gpt"
 release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = true
-reasoning = false
-temperature = true
+reasoning = true
+temperature = false
 tool_call = true
+structured_output = true
 open_weights = false
-knowledge = "2024-10"
+knowledge = "2024-09-30"
 
 [cost]
 input = 1.250
@@ -14,6 +16,7 @@ output = 10.000
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
## Summary

This PR updates the `302ai` model catalog to match the latest provider capabilities and metadata.

## Changes

- add `gpt-5.4` and `gpt-5.4-pro` model configs
- add `family` metadata to Claude, GLM, and GPT model definitions
- update capability flags such as `reasoning`, `structured_output`, `temperature`, and `open_weights`
- normalize `knowledge` values to more precise dates
- adjust token limits for context and input sizes
- expand supported modalities for models with `pdf` or `video` input
- add interleaved reasoning metadata for supported GLM models

## Notes

- Claude models now reflect updated reasoning support, knowledge cutoffs, and context windows
- GLM models now reflect open-weight availability, updated limits, and multimodal support
- GPT model configs now reflect reasoning-oriented behavior and current structured output support

## Validation

- Pass
