### PR TITLE
[google] Fix cache_read cost in gemini-2.5-flash model

### DIFF
--- a/providers/google/models/gemini-2.5-flash.toml
+++ b/providers/google/models/gemini-2.5-flash.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 0.30
 output = 2.50
-cache_read = 0.075
+cache_read = 0.03
 input_audio = 1.00
 
 [limit]


### PR DESCRIPTION
https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash

There's no `cache_read_audio`, is there?