### PR TITLE
add Qwen 3.6 35B A3B to Deep Infra

### DIFF
--- a/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,10 +1,9 @@
-id = "Qwen/Qwen3.6-35B-A3B"
 name = "Qwen 3.6 35B A3B"
 family = "qwen"
 release_date = "2026-04-20"
 last_updated = "2026-04-20"
-attachment = false
-reasoning = false
+attachment = true
+reasoning = true
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,3 +1,4 @@
+id = "Qwen/Qwen3.6-35B-A3B"
 name = "Qwen 3.6 35B A3B"
 family = "qwen"
 release_date = "2026-04-20"

--- a/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,0 +1,22 @@
+name = "Qwen 3.6 35B A3B"
+family = "qwen"
+release_date = "2025-04-20"
+last_updated = "2025-04-20"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-01"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.1
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,7 +1,7 @@
 name = "Qwen 3.6 35B A3B"
 family = "qwen"
-release_date = "2025-04-20"
-last_updated = "2025-04-20"
+release_date = "2026-04-20"
+last_updated = "2026-04-20"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -18,5 +18,5 @@ context = 131_072
 output = 8_192
 
 [modalities]
-input = ["text"]
+input = ["text","image","video"]
 output = ["text"]

--- a/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -14,8 +14,8 @@ input = 0.2
 output = 1.0
 
 [limit]
-context = 131_072
-output = 8_192
+context = 262_144
+output = 81_920
 
 [modalities]
 input = ["text","image","video"]

--- a/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -10,8 +10,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.1
-output = 0.1
+input = 0.2
+output = 1.0
 
 [limit]
 context = 131_072


### PR DESCRIPTION
Adds the Qwen 3.6 35B A3B model configuration to Deep Infra.

Fixes #1502