### PR TITLE
feat(provider): add Voban AI provider

### DIFF
--- a/providers/voban/logo.svg
+++ b/providers/voban/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Voban signal mark">
+  <rect width="64" height="64" rx="6" fill="#0a0a0a"/>
+  <path d="M13 8.5h38" stroke="#ddd9cf" stroke-opacity="0.4" stroke-width="1.625" stroke-linecap="square"/>
+  <path d="M13 55.5h38" stroke="#ddd9cf" stroke-opacity="0.4" stroke-width="1.625" stroke-linecap="square"/>
+  <text x="32" y="44.5" text-anchor="middle" fill="#faf9f5" font-size="44" font-family="'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace" font-weight="500">v</text>
+</svg>

--- a/providers/voban/models/devstral-2512.toml
+++ b/providers/voban/models/devstral-2512.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "mistral/devstral-2512"

--- a/providers/voban/models/glm-5.1.toml
+++ b/providers/voban/models/glm-5.1.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "zai/glm-5.1"

--- a/providers/voban/models/gpt-5.5.toml
+++ b/providers/voban/models/gpt-5.5.toml
@@ -1,0 +1,3 @@
+[extends]
+from = "openai/gpt-5.5"
+omit = ["experimental.modes.fast"]

--- a/providers/voban/models/gpt-5.5.toml
+++ b/providers/voban/models/gpt-5.5.toml
@@ -1,3 +1,6 @@
 [extends]
 from = "openai/gpt-5.5"
 omit = ["experimental.modes.fast"]
+
+[provider]
+npm = "@ai-sdk/openai"

--- a/providers/voban/models/kimi-k2.5.toml
+++ b/providers/voban/models/kimi-k2.5.toml
@@ -1,7 +1,0 @@
-[extends]
-from = "moonshotai/kimi-k2.5"
-
-[cost]
-input = 0.50
-output = 2.40
-cache_read = 0.12

--- a/providers/voban/models/kimi-k2.5.toml
+++ b/providers/voban/models/kimi-k2.5.toml
@@ -1,0 +1,7 @@
+[extends]
+from = "moonshotai/kimi-k2.5"
+
+[cost]
+input = 0.50
+output = 2.40
+cache_read = 0.12

--- a/providers/voban/models/kimi-k2.6.toml
+++ b/providers/voban/models/kimi-k2.6.toml
@@ -1,0 +1,7 @@
+[extends]
+from = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.95
+output = 4.00
+cache_read = 0.16

--- a/providers/voban/models/minimax-m2.5.toml
+++ b/providers/voban/models/minimax-m2.5.toml
@@ -1,0 +1,7 @@
+[extends]
+from = "minimax/MiniMax-M2.5"
+
+[cost]
+input = 0.28
+output = 1.10
+cache_read = 0.03

--- a/providers/voban/models/minimax-m2.7.toml
+++ b/providers/voban/models/minimax-m2.7.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "minimax/MiniMax-M2.7"

--- a/providers/voban/models/mistral-large-2512.toml
+++ b/providers/voban/models/mistral-large-2512.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "mistral/mistral-large-2512"

--- a/providers/voban/provider.toml
+++ b/providers/voban/provider.toml
@@ -1,0 +1,5 @@
+name = "Voban"
+env = ["VOBAN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.voban.ai/v1"
+doc = "https://voban.ai/"


### PR DESCRIPTION
## Summary
Adds [Voban](https://voban.ai) as a provider,  the control plane for enterprise AI. One OpenAI-compatible gateway, any model, with per-request inspection, policy enforcement, and audit, operated in Europe.

**7 models added:**
- `mistral-large-2512`
- `devstral-2512`
- `glm-5.1`
- `gpt-5.5`
- `minimax-m2.5`
- `minimax-m2.7`
- `kimi-k2.`

**Provider details:**
- API: `https://api.voban.ai/v1` (OpenAI-compatible)
- SDK: `@ai-sdk/openai-compatible`
- Auth: `VOBAN_API_KEY`
- Docs: https://voban.ai/

## Test plan

```
bun install
bun validate
cd packages/web
bun run build
OPENCODE_MODELS_PATH="dist/_api.json" opencode
```

Tested all models