### PR TITLE
add kimi-K2.6 for OpenRouter provider

### DIFF
--- a/providers/openrouter/models/moonshotai/kimi-k2.6.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,26 @@
+name = "Kimi K2.6"
+family = "kimi"
+release_date = "2026-04-20"
+last_updated = "2026-04-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_details"
+
+[cost]
+input = 0.95
+output = 4.00
+cache_read = 0.16
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add the `moonshotai/kimi-k2.6` model to the OpenRouter provider
- populate pricing, limits, modalities, and reasoning metadata directly from OpenRouter
- keep the model definition minimal by omitting fields OpenRouter does not publish explicitly
## Validation
- run `bun validate`