### PR TITLE
providers/ollama-cloud: add kimi-k2.6:cloud

### DIFF
--- a/providers/ollama-cloud/models/kimi-k2.6:cloud.toml
+++ b/providers/ollama-cloud/models/kimi-k2.6:cloud.toml
@@ -1,0 +1,16 @@
+name = "kimi-k2.6:cloud"
+family = "kimi"
+attachment = true
+reasoning = true
+tool_call = true
+release_date = "2026-04-20"
+last_updated = "2026-04-20"
+open_weights = true
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Agrego la definición del modelo kimi-k2.6:cloud bajo providers/ollama-cloud/models.

- Nuevo archivo: providers/ollama-cloud/models/kimi-k2.6:cloud.toml
- Soporta text+image, reasoning, tool_call, attachment, open_weights y contexto 256K (262144 tokens).
- Referencia: https://ollama.com/library/kimi-k2.6