### PR TITLE
providers(nano-gpt): add Kimi K2.6 and Qwen3.6-35B-A3B models

### DIFF
--- a/providers/nano-gpt/models/moonshotai/kimi-k2.6.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2.6"
+family = "kimi"
+release_date = "2026-04-16"
+last_updated = "2026-04-16"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = false
+open_weights = false
+
+[cost]
+input = 0.53
+output = 2.73
+
+[limit]
+context = 256_000
+input = 256_000
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.6:thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.6:thinking.toml
@@ -1,0 +1,22 @@
+name = "Kimi K2.6 Thinking"
+family = "kimi-thinking"
+release_date = "2026-04-16"
+last_updated = "2026-04-16"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = false
+open_weights = false
+
+[cost]
+input = 0.53
+output = 2.73
+
+[limit]
+context = 256_000
+input = 256_000
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.6 35B A3B"
+family = "qwen"
+release_date = "2026-04-17"
+last_updated = "2026-04-17"
+attachment = true
+reasoning = false
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.83
+
+[limit]
+context = 262_144
+input = 262_144
+output = 16_384
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
+++ b/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.6 35B A3B Thinking"
+family = "qwen"
+release_date = "2026-04-19"
+last_updated = "2026-04-19"
+attachment = true
+reasoning = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.83
+
+[limit]
+context = 262_144
+input = 262_144
+output = 16_384
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add Nano-GPT entries for Kimi K2.6 and Kimi K2.6 Thinking under `moonshotai`
- add Nano-GPT entries for Qwen3.6-35B-A3B and Qwen3.6-35B-A3B Thinking under `qwen`
- align pricing, context limits, modalities, and reasoning flags with the current Nano-GPT model pages

## Validation
- `bun validate`