### PR TITLE
Add Qwen3.6-35B-A3B to Deep Infra

### DIFF
--- a/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/deepinfra/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.6 35B A3B"
+family = "qwen"
+release_date = "2026-04-01"
+last_updated = "2026-04-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.20
+output = 1.00
+
+[limit]
+context = 262_144
+output = 81_920
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
Adds the newly-released Qwen3.6-35B-A3B model on Deep Infra.

- Model page: https://deepinfra.com/Qwen/Qwen3.6-35B-A3B
- 35B total / 3B active MoE (256 experts, 8 routed + 1 shared)
- 262,144 native context (extensible to ~1M with YaRN)
- Multimodal: text, image, video input
- Thinking mode by default, tool calling supported
- Apache 2.0, open weights
- $0.20 / 1M input, $1.00 / 1M output
