### PR TITLE
feat(nano-gpt): add Kimi K2.6 and Qwen 3.6 models

### DIFF
--- a/providers/nano-gpt/models/alibaba/qwen3.6-flash.toml
+++ b/providers/nano-gpt/models/alibaba/qwen3.6-flash.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.6 Flash"
+family = "qwen3.6"
+release_date = "2026-04-17"
+last_updated = "2026-04-17"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+open_weights = false
+
+[cost]
+input = 0.19
+output = 1.16
+
+[limit]
+context = 991_800
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.6.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2.6"
+family = "kimi-k2.6"
+release_date = "2026-04-16"
+last_updated = "2026-04-21"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.53
+output = 2.73
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.6:thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.6:thinking.toml
@@ -1,0 +1,21 @@
+name = "Kimi K2.6 Thinking"
+family = "kimi-thinking"
+release_date = "2026-04-16"
+last_updated = "2026-04-21"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.53
+output = 2.73
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nano-gpt/models/qwen-3.6-plus.toml
+++ b/providers/nano-gpt/models/qwen-3.6-plus.toml
@@ -1,0 +1,21 @@
+name = "Qwen 3.6 Plus"
+family = "qwen3.6"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+open_weights = false
+
+[cost]
+input = 0.45
+output = 2.70
+
+[limit]
+context = 991_800
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.6 35B A3B"
+family = "qwen3.6"
+release_date = "2026-04-17"
+last_updated = "2026-04-21"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.29
+output = 1.74
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
+++ b/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.6 35B A3B Thinking"
+family = "qwen3.6"
+release_date = "2026-04-19"
+last_updated = "2026-04-21"
+attachment = false
+reasoning = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.29
+output = 1.74
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/nano-gpt/models/qwen3.6-max-preview.toml
+++ b/providers/nano-gpt/models/qwen3.6-max-preview.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.6 Max Preview"
+family = "qwen3.6"
+release_date = "2026-04-20"
+last_updated = "2026-04-21"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+open_weights = false
+
+[cost]
+input = 1.30
+output = 7.80
+
+[limit]
+context = 245_800
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add Kimi K2.6 (`moonshotai/kimi-k2.6`) and Kimi K2.6 Thinking (`moonshotai/kimi-k2.6:thinking`) to the NanoGPT provider
- Add Qwen 3.6 model family to the NanoGPT provider:
  - `qwen-3.6-plus` — commercial multimodal agent model, ~1M context
  - `qwen3.6-max-preview` — flagship Qwen 3.6 model
  - `qwen/Qwen3.6-35B-A3B` — open-weights MoE vision-language model
  - `qwen/Qwen3.6-35B-A3B:thinking` — reasoning variant of the 35B A3B
  - `alibaba/qwen3.6-flash` — fast vision-language model, ~1M context

All model metadata (pricing, context limits, modalities, capabilities) sourced from nano-gpt.com model pages.

## Validation
- `bun validate` passes with exit code 0