### PR TITLE
Fix incorrect model ID for Gemma 4 26B (Google provider)

### DIFF
--- a/providers/google/models/gemma-4-26b-a4b-it.toml
+++ b/providers/google/models/gemma-4-26b-a4b-it.toml
@@ -1,3 +1,4 @@
+id = "gemma-4-26b-a4b-it"
 name = "Gemma 4 26B"
 family = "gemma"
 release_date = "2026-04-02"

--- a/providers/google/models/gemma-4-26b-a4b-it.toml
+++ b/providers/google/models/gemma-4-26b-a4b-it.toml
@@ -1,4 +1,3 @@
-id = "gemma-4-26b-a4b-it"
 name = "Gemma 4 26B"
 family = "gemma"
 release_date = "2026-04-02"


### PR DESCRIPTION
Fixes #1446

Updated incorrect model ID from gemma-4-26b-it to gemma-4-26b-a4b-it to match actual Gemini API.

- Renamed file to match correct model ID