### PR TITLE
Fix pricing for openrouter/openai gpt-5.4-[mini,nano] off by 10^6

### DIFF
--- a/providers/openrouter/models/openai/gpt-5.4-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-mini.toml
@@ -11,9 +11,9 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.00000075
-output = 0.0000045
-cache_read = 0.000000075
+input = 0.75
+output = 4.5
+cache_read = 0.075
 
 [limit]
 context = 400_000

--- a/providers/openrouter/models/openai/gpt-5.4-nano.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-nano.toml
@@ -11,9 +11,9 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.0000002
-output = 0.00000125
-cache_read = 0.00000002
+input = 0.20
+output = 1.25
+cache_read = 0.02
 
 [limit]
 context = 400_000


### PR DESCRIPTION
Cost is too low by a factor of one million for `openai/gpt-5.4-mini` and `openai/gpt-5.4-nano`.

This PR makes it consistent with the pricing shown at:
- https://openrouter.ai/openai/gpt-5.4-mini
- https://openrouter.ai/openai/gpt-5.4-nano
