### PR TITLE
feat(provider): add Staik provider

### DIFF
--- a/providers/staik/models/bge-m3:latest.toml
+++ b/providers/staik/models/bge-m3:latest.toml
@@ -1,0 +1,17 @@
+name = "bge-m3:latest"
+family = "text-embedding"
+release_date = "2024-02-01"
+last_updated = "2024-02-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[limit]
+context = 8_192
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/staik/models/gemma4:31b.toml
+++ b/providers/staik/models/gemma4:31b.toml
@@ -1,0 +1,17 @@
+name = "gemma4:31b"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 262_144
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/staik/models/qwen3.5:9b.toml
+++ b/providers/staik/models/qwen3.5:9b.toml
@@ -1,0 +1,17 @@
+name = "qwen3.5:9b"
+family = "qwen"
+release_date = "2026-02-01"
+last_updated = "2026-02-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 262_144
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/staik/models/qwen3.6:35b-a3b.toml
+++ b/providers/staik/models/qwen3.6:35b-a3b.toml
@@ -1,0 +1,17 @@
+name = "qwen3.6:35b-a3b"
+family = "qwen"
+release_date = "2026-04-17"
+last_updated = "2026-04-17"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 262_144
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/staik/provider.toml
+++ b/providers/staik/provider.toml
@@ -1,0 +1,5 @@
+name = "Staik"
+env = ["STAIK_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://api.staik.se/en/docs"
+api = "https://api.staik.se/v1"


### PR DESCRIPTION
## Summary
Adds [Staik](https://api.staik.se/en/docs) as a provider with its documented OpenAI-compatible endpoint.

**4 models added:**
- `gemma4:31b`
- `qwen3.6:35b-a3b`
- `qwen3.5:9b`
- `bge-m3:latest`

**Provider details:**
- API: `https://api.staik.se/v1` (OpenAI-compatible)
- SDK: `@ai-sdk/openai-compatible`
- Auth: `STAIK_API_KEY`
- Docs: https://api.staik.se/en/docs

## Test plan
- [x] `bun validate`