### PR TITLE
Adds support for openrouter/pareto-code

### DIFF
--- a/providers/openrouter/models/openrouter/pareto-code.toml
+++ b/providers/openrouter/models/openrouter/pareto-code.toml
@@ -1,0 +1,17 @@
+name = "Pareto Code Router"
+release_date = "2026-04-21"
+last_updated = "2026-04-21"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 200_000
+output = 200_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
https://openrouter.ai/openrouter/pareto-code

From the site description:

> The Pareto Router is a way to have OpenRouter always pick a strong coding model for your needs without committing to a specific one. You express a single min_coding_score preference between 0 and 1, and the router routes your request to a coding model that meets that bar.
> 
> The Pareto Router is tuned for coding use cases. Under the hood it keeps a curated shortlist of strong coding models currently available on OpenRouter. The exact shortlist and selection logic evolve over time as new models land and benchmarks shift.
