### PR TITLE
Add deepseek, gemma, ling, llama, kimi on NovitaAI

### DIFF
--- a/providers/novita-ai/models/deepseek/deepseek-r1-distill-qwen-14b.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-r1-distill-qwen-14b.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek R1 Distill Qwen 14B"
+family = "deepseek-thinking"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.15
+
+[limit]
+context = 32_768
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/novita-ai/models/deepseek/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-r1-distill-qwen-32b.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek R1 Distill Qwen 32B"
+family = "deepseek-thinking"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 0.3
+
+[limit]
+context = 64_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/novita-ai/models/google/gemma-3-12b-it.toml
+++ b/providers/novita-ai/models/google/gemma-3-12b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma 3 12B"
+family = "gemma"
+release_date = "2025-03-13"
+last_updated = "2025-03-13"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/novita-ai/models/inclusionai/ling-2.6-1t.toml
+++ b/providers/novita-ai/models/inclusionai/ling-2.6-1t.toml
@@ -1,0 +1,22 @@
+name = "Ling-2.6-1T"
+family = "ling"
+release_date = "2026-04-23"
+last_updated = "2026-04-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/novita-ai/models/meta-llama/llama-3.2-3b-instruct.toml
+++ b/providers/novita-ai/models/meta-llama/llama-3.2-3b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.2 3B Instruct"
+family = "llama"
+release_date = "2024-09-18"
+last_updated = "2024-09-18"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.05
+
+[limit]
+context = 32_768
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/novita-ai/models/moonshotai/kimi-k2.6.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,27 @@
+name = "Kimi K2.6"
+family = "kimi"
+release_date = "2026-04-21"
+last_updated = "2026-04-21"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.95
+output = 4.0
+cache_read = 0.16
+
+[limit]
+context = 262_144
+output = 262_144
+
+[interleaved]
+field = "reasoning_content"
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Add the missing Novita model configs for:

- `deepseek/deepseek-r1-distill-qwen-14b`
- `deepseek/deepseek-r1-distill-qwen-32b`
- `google/gemma-3-12b-it`
- `inclusionai/ling-2.6-1t`
- `meta-llama/llama-3.2-3b-instruct`
- `moonshotai/kimi-k2.6`

Also rename the existing Novita path for:

- `sao10k/L3-8B-Stheno-v3.2` → `Sao10K/L3-8B-Stheno-v3.2`

Excluded from this PR:

- `elephant`

## Notes

- Capability fields were cross-checked against existing entries in the repo and Novita's live `/v1/models` response.
- For `inclusionai/ling-2.6-1t`, pricing is currently `0/0` in the live Novita model response, so the config mirrors that.

## Test plan

- [x] `bun validate`
