### PR TITLE
fix(ollama): set gemma4:31b output limit to match context

### DIFF
--- a/providers/ollama-cloud/models/gemma4:31b.toml
+++ b/providers/ollama-cloud/models/gemma4:31b.toml
@@ -10,7 +10,7 @@ open_weights = true
 
 [limit]
 context = 262144
-output = 8192
+output = 262144
 
 [modalities]
 input = ["text","image"]


### PR DESCRIPTION
## Summary
Fixes the output limit for `gemma4:31b` on Ollama from `8192` to `262144` (matching context).

## Rationale
- Ollama does **not** impose official output token limits
- All existing Gemma models on Ollama (`gemma3:4b`, `gemma3:12b`, `gemma3:27b`) already follow the convention `output = context` (all use `131072` for both)
- `gemma4:31b` was the only exception, with `output = 8192` vs `context = 262144`
- This change aligns it with the established convention