### PR TITLE
[codex] Add GPT-5.5

### DIFF
--- a/providers/openai/models/gpt-5.5.toml
+++ b/providers/openai/models/gpt-5.5.toml
@@ -1,0 +1,29 @@
+name = "GPT-5.5"
+family = "gpt"
+release_date = "2026-04-23"
+last_updated = "2026-04-23"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-12-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[limit]
+context = 1_050_000
+input = 920_000
+output = 130_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[experimental.modes.fast]
+cost = { input = 12.50, output = 75.00, cache_read = 1.25 }
+provider = { body = { service_tier = "priority" } }


### PR DESCRIPTION
## Summary

- Adds the OpenAI gpt-5.5 model definition.
- Captures pricing, token limits, knowledge cutoff, modality support, and priority/fast mode pricing from the issue and OpenAI release information.

## Validation

- bun validate

Closes #1553.