### PR TITLE
feat(azure): add Claude Sonnet 4.6 model

### DIFF
--- a/providers/azure/models/claude-sonnet-4-6.toml
+++ b/providers/azure/models/claude-sonnet-4-6.toml
@@ -1,28 +1,7 @@
-name = "Claude Sonnet 4.6"
-family = "claude-sonnet"
-release_date = "2026-02-17"
-last_updated = "2026-02-17"
-attachment = true
-reasoning = true
-temperature = true
-knowledge = "2025-08-31"
-tool_call = true
 structured_output = true
-open_weights = false
 
-[cost]
-input = 3.00
-output = 15.00
-cache_read = 0.30
-cache_write = 3.75
-
-[limit]
-context = 1_000_000
-output = 64_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]
+[extends]
+from = "anthropic/claude-sonnet-4-6"
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/azure/models/claude-sonnet-4-6.toml
+++ b/providers/azure/models/claude-sonnet-4-6.toml
@@ -1,0 +1,29 @@
+name = "Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 3.75
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/anthropic/v1"


### PR DESCRIPTION
## Summary
- Adds Claude Sonnet 4.6 model configuration for Azure AI
- Pricing matches canonical Anthropic sonnet-4-6 ($3/$15 input/output, $0.30/$3.75 cache read/write)
- Structure follows existing Azure sonnet-4-5 pattern (provider block, structured_output)
- Model-specific fields (context 1M, knowledge date, modalities) match canonical Anthropic definition