### PR TITLE
feat: add AU Sonnet and Opus models for Amazon Bedrock

### DIFF
--- a/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-6-v1.toml
@@ -1,0 +1,25 @@
+name = "AU Anthropic Claude Opus 4.6"
+family = "claude-opus"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-05"
+open_weights = false
+
+[cost]
+input = 16.50
+output = 82.50
+cache_read = 1.65
+cache_write = 20.625
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,25 @@
+name = "AU Anthropic Claude Sonnet 4.6"
+family = "claude-sonnet"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-08"
+open_weights = false
+
+[cost]
+input = 3.30
+output = 16.50
+cache_read = 0.33
+cache_write = 4.125
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
Fixes #1195

Adds AU region support for Anthropic Sonnet 4.6 and Opus 4.6 models on Amazon Bedrock.

- Added au.anthropic.claude-sonnet-4-6.toml
- Added au.anthropic.claude-opus-4-6-v1.toml
- Followed existing naming and structure pattern