### PR TITLE
feat(models): add DeepSeek V4 Flash & DeepSeek V4 Pro

### DIFF
--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek-V4-Flash"
+family = "deepseek"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028
+
+[limit]
+context = 1_048_576
+output = 393_216
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek-V4-Pro"
+family = "deepseek"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.145
+
+[limit]
+context = 1_048_576
+output = 393_216
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds model metadata for two new DeepSeek V4 models:

- `DeepSeek-V4-Flash`
- `DeepSeek-V4-Pro`

## Reference

- https://api-docs.deepseek.com/quick_start/pricing