### PR TITLE
fix: opencode go mimo-v2.5 context limit to 1,000,000

### DIFF
--- a/providers/opencode-go/models/mimo-v2.5.toml
+++ b/providers/opencode-go/models/mimo-v2.5.toml
@@ -23,7 +23,7 @@ output = 4.00
 cache_read = 0.16
 
 [limit]
-context = 262_144
+context = 1_000_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
<img width="985" height="744" alt="image" src="https://github.com/user-attachments/assets/8292504e-3b8c-474c-a86b-b9ac38be04cc" />

https://platform.xiaomimimo.com/docs/pricing