### PR TITLE
Venice: Update kimi-k2-6 pricing

### DIFF
--- a/providers/venice/models/kimi-k2-6.toml
+++ b/providers/venice/models/kimi-k2-6.toml
@@ -6,16 +6,16 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-20"
-last_updated = "2026-04-20"
+last_updated = "2026-04-24"
 open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.56
-output = 3.5
-cache_read = 0.11
+input = 0.7448
+output = 4.655
+cache_read = 0.1463
 
 [limit]
 context = 256_000


### PR DESCRIPTION
- Update input, output, and cache_read costs to current rates