### PR TITLE
Venice: Add DeepSeek V4 Flash and Pro models

### DIFF
--- a/providers/venice/models/deepseek-v4-flash.toml
+++ b/providers/venice/models/deepseek-v4-flash.toml
@@ -1,0 +1,25 @@
+name = "DeepSeek V4 Flash"
+family = "deepseek"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.175
+output = 0.35
+
+[limit]
+context = 1_000_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/venice/models/deepseek-v4-pro.toml
+++ b/providers/venice/models/deepseek-v4-pro.toml
@@ -1,0 +1,25 @@
+name = "DeepSeek V4 Pro"
+family = "deepseek"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.175
+output = 4.35
+
+[limit]
+context = 1_000_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
- Add DeepSeek V4 Flash with 1M context, reasoning, and tool support
- Add DeepSeek V4 Pro with 1M context, reasoning, and tool support
- Set pricing and interleaved reasoning_content field for both