### PR TITLE
feat: add FuturMix as a provider

### DIFF
--- a/providers/futurmix/models/anthropic/claude-3-5-haiku-20241022.toml
+++ b/providers/futurmix/models/anthropic/claude-3-5-haiku-20241022.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-3-5-haiku-20241022"

--- a/providers/futurmix/models/anthropic/claude-haiku-4-5-20251001.toml
+++ b/providers/futurmix/models/anthropic/claude-haiku-4-5-20251001.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-haiku-4-5-20251001"

--- a/providers/futurmix/models/anthropic/claude-opus-4-1-20250805.toml
+++ b/providers/futurmix/models/anthropic/claude-opus-4-1-20250805.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-opus-4-1-20250805"

--- a/providers/futurmix/models/anthropic/claude-opus-4-5-20251101.toml
+++ b/providers/futurmix/models/anthropic/claude-opus-4-5-20251101.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-opus-4-5-20251101"

--- a/providers/futurmix/models/anthropic/claude-opus-4-6.toml
+++ b/providers/futurmix/models/anthropic/claude-opus-4-6.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-opus-4-6"

--- a/providers/futurmix/models/anthropic/claude-opus-4-7.toml
+++ b/providers/futurmix/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-opus-4-7"

--- a/providers/futurmix/models/anthropic/claude-sonnet-4-20250514.toml
+++ b/providers/futurmix/models/anthropic/claude-sonnet-4-20250514.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-sonnet-4-20250514"

--- a/providers/futurmix/models/anthropic/claude-sonnet-4-5-20250929.toml
+++ b/providers/futurmix/models/anthropic/claude-sonnet-4-5-20250929.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-sonnet-4-5-20250929"

--- a/providers/futurmix/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/futurmix/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-sonnet-4-6"

--- a/providers/futurmix/models/google/gemini-2.5-flash-image.toml
+++ b/providers/futurmix/models/google/gemini-2.5-flash-image.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-2.5-flash-image"

--- a/providers/futurmix/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/futurmix/models/google/gemini-2.5-flash-lite.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-2.5-flash-lite"

--- a/providers/futurmix/models/google/gemini-2.5-flash.toml
+++ b/providers/futurmix/models/google/gemini-2.5-flash.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-2.5-flash"

--- a/providers/futurmix/models/google/gemini-2.5-pro.toml
+++ b/providers/futurmix/models/google/gemini-2.5-pro.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-2.5-pro"

--- a/providers/futurmix/models/google/gemini-3-flash-preview.toml
+++ b/providers/futurmix/models/google/gemini-3-flash-preview.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-3-flash-preview"

--- a/providers/futurmix/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/futurmix/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-3.1-flash-image-preview"

--- a/providers/futurmix/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/futurmix/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-3.1-flash-lite-preview"

--- a/providers/futurmix/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/futurmix/models/google/gemini-3.1-pro-preview.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-3.1-pro-preview"

--- a/providers/futurmix/models/openai/gpt-5.4-mini.toml
+++ b/providers/futurmix/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5.4-mini"

--- a/providers/futurmix/models/openai/gpt-5.4-nano.toml
+++ b/providers/futurmix/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5.4-nano"

--- a/providers/futurmix/models/openai/gpt-5.4.toml
+++ b/providers/futurmix/models/openai/gpt-5.4.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5.4"

--- a/providers/futurmix/models/openai/gpt-image-2.toml
+++ b/providers/futurmix/models/openai/gpt-image-2.toml
@@ -1,0 +1,17 @@
+name = "GPT-Image-2"
+family = "gpt-image"
+release_date = "2026-04-21"
+last_updated = "2026-04-21"
+attachment = true
+reasoning = false
+temperature = false
+open_weights = false
+tool_call = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/futurmix/provider.toml
+++ b/providers/futurmix/provider.toml
@@ -1,0 +1,5 @@
+name = "FuturMix"
+env = ["FUTURMIX_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://futurmix.ai/v1"
+doc = "https://futurmix.ai/models"


### PR DESCRIPTION
## Summary

Add FuturMix as a provider in models.dev.

FuturMix is an AI platform that provides access to multiple leading models . It offers another provider option for users who want one platform layer instead of managing many direct providers.

## Changes

- Add `providers/futurmix/provider.toml` with OpenAI-compatible configuration
- Add 20 model definition files using `extends` to reference canonical definitions:
 - 9 Anthropic models (Claude 3.5 Haiku through Opus 4-7)
 - 8 Google models (Gemini 2.5 Flash through 3.1 Pro)
 - 3 OpenAI models (GPT-5.4 family)

## Provider Details

- **Name:** FuturMix
- **API:** (see [futurmix.ai](https://futurmix.ai))
- **Auth:** `FUTURMIX_API_KEY` environment variable
- **SDK:** `@ai-sdk/openai-compatible`
- **Docs:** [futurmix.ai/models](https://futurmix.ai/models)

## Notes

- All model definitions use `extends` to reference canonical models — no duplication
- Verified against the live FuturMix `/v1/models` endpoint