### PR TITLE
feat(openrouter): add DeepSeek V4 Pro and V4 Flash

### DIFF
--- a/providers/openrouter/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,24 @@
+name = "DeepSeek V4 Flash"
+family = "deepseek"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-10"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028
+
+[limit]
+context = 1_048_576
+output = 393_216
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-flash.toml
@@ -1,24 +1,11 @@
-name = "DeepSeek V4 Flash"
-family = "deepseek"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
 attachment = false
-reasoning = true
-temperature = true
-knowledge = "2025-10"
-tool_call = true
-structured_output = true
-open_weights = true
 
-[cost]
-input = 0.14
-output = 0.28
-cache_read = 0.028
+[extends]
+from = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_details"
 
 [limit]
 context = 1_048_576
 output = 393_216
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,24 @@
+name = "DeepSeek V4 Pro"
+family = "deepseek"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-10"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.145
+
+[limit]
+context = 1_048_576
+output = 393_216
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
@@ -1,24 +1,11 @@
-name = "DeepSeek V4 Pro"
-family = "deepseek"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
 attachment = false
-reasoning = true
-temperature = true
-knowledge = "2025-10"
-tool_call = true
-structured_output = true
-open_weights = true
 
-[cost]
-input = 1.74
-output = 3.48
-cache_read = 0.145
+[extends]
+from = "deepseek/deepseek-v4-pro"
+
+[interleaved]
+field = "reasoning_details"
 
 [limit]
 context = 1_048_576
 output = 393_216
-
-[modalities]
-input = ["text"]
-output = ["text"]


### PR DESCRIPTION
Adds OpenRouter entries for `deepseek/deepseek-v4-pro` and `deepseek/deepseek-v4-flash` per [OpenRouter model pages](https://openrouter.ai/deepseek/deepseek-v4-pro):

- **Context / output**: 1,048,576 context, 384K max output
- **Pricing**: list (non–cache-hit) input/output per $1M tokens; `cache_read` from OpenRouter’s published cache-read rates
- **Capabilities**: reasoning, tools, structured output; text-only modalities; aligned with existing DeepSeek OpenRouter models (`deepseek-v3.2.toml`)

Validated with `bun validate`.

Made with [Cursor](https://cursor.com)