### PR TITLE
add chutes gemma 4 31b tee model

### DIFF
--- a/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
+++ b/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
@@ -1,0 +1,25 @@
+name = "Gemma 4 31B Turbo TEE"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.14
+output = 0.40
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
## Summary
- Add Chutes config for `google/gemma-4-31B-turbo-TEE`
- Include pricing, limits, multimodal support, reasoning, and interleaved reasoning field

## Validation
- `bun validate`

Closed #1566