### PR TITLE
Add AIgateway provider (84 text & vision models)

### DIFF
--- a/providers/aigateway/logo.svg
+++ b/providers/aigateway/logo.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="AIgateway">
+  <rect x="1" y="1" width="30" height="30" rx="7" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity="0.45"/>
+  <line x1="8" y1="11" x2="22" y2="11" stroke="currentColor" stroke-width="2" stroke-linecap="round" transform="rotate(-22 16 11)"/>
+  <line x1="8" y1="21" x2="22" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round" transform="rotate(22 16 21)"/>
+</svg>

--- a/providers/aigateway/models/aisingapore/gemma-sea-lion-v4-27b-it.toml
+++ b/providers/aigateway/models/aisingapore/gemma-sea-lion-v4-27b-it.toml
@@ -1,0 +1,23 @@
+name = "Gemma-Sea-Lion-V4-27b-IT"
+family = "gemma"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.35
+output = 0.56
+
+[limit]
+context = 128000
+input = 123904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/alibaba/qwen3-max.toml
+++ b/providers/aigateway/models/alibaba/qwen3-max.toml
@@ -1,0 +1,23 @@
+name = "Qwen 3 Max"
+family = "qwen"
+release_date = "2026-04-15"
+last_updated = "2026-04-15"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 1.2
+output = 6
+
+[limit]
+context = 262144
+input = 258048
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/alibaba/qwen3.5-397b-a17b.toml
+++ b/providers/aigateway/models/alibaba/qwen3.5-397b-a17b.toml
@@ -1,0 +1,23 @@
+name = "Qwen 3.5 397B A17B"
+family = "qwen"
+release_date = "2026-04-15"
+last_updated = "2026-04-15"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 3.6
+
+[limit]
+context = 262144
+input = 258048
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/aigateway/models/anthropic/claude-haiku-4.5.toml
@@ -1,0 +1,23 @@
+name = "Claude Haiku 4.5"
+family = "claude-4"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1
+output = 5
+
+[limit]
+context = 200000
+input = 191808
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/anthropic/claude-opus-4.6.toml
+++ b/providers/aigateway/models/anthropic/claude-opus-4.6.toml
@@ -1,0 +1,23 @@
+name = "Claude Opus 4.6"
+family = "claude-4"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5
+output = 25
+
+[limit]
+context = 1000000
+input = 872000
+output = 128000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/anthropic/claude-opus-4.7.toml
+++ b/providers/aigateway/models/anthropic/claude-opus-4.7.toml
@@ -1,0 +1,23 @@
+name = "Claude Opus 4.7"
+family = "claude-4"
+release_date = "2026-04-16"
+last_updated = "2026-04-16"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5
+output = 25
+
+[limit]
+context = 1000000
+input = 872000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/aigateway/models/anthropic/claude-sonnet-4.5.toml
@@ -1,0 +1,23 @@
+name = "Claude Sonnet 4.5"
+family = "claude-4"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3
+output = 15
+
+[limit]
+context = 200000
+input = 191808
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/aigateway/models/anthropic/claude-sonnet-4.6.toml
@@ -1,0 +1,23 @@
+name = "Claude Sonnet 4.6"
+family = "claude-4"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3
+output = 15
+
+[limit]
+context = 200000
+input = 72000
+output = 128000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/anthropic/claude-sonnet-4.toml
+++ b/providers/aigateway/models/anthropic/claude-sonnet-4.toml
@@ -1,0 +1,23 @@
+name = "Claude Sonnet 4"
+family = "claude-4"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3
+output = 15
+
+[limit]
+context = 200000
+input = 184000
+output = 16000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/deepseek/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/aigateway/models/deepseek/deepseek-r1-distill-qwen-32b.toml
@@ -1,0 +1,23 @@
+name = "Deepseek-R1-Distill-Qwen-32b"
+family = "qwen"
+release_date = "2025-01-22"
+last_updated = "2025-01-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.5
+output = 4.88
+
+[limit]
+context = 80000
+input = 75904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/defog/sqlcoder-7b-2.toml
+++ b/providers/aigateway/models/defog/sqlcoder-7b-2.toml
@@ -1,0 +1,23 @@
+name = "Sqlcoder-7b-2"
+family = "sqlcoder"
+release_date = "2024-02-27"
+last_updated = "2024-02-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 10000
+input = 5904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/fblgit/una-cybertron-7b-v2-bf16.toml
+++ b/providers/aigateway/models/fblgit/una-cybertron-7b-v2-bf16.toml
@@ -1,0 +1,23 @@
+name = "Una-Cybertron-7b-V2-Bf16"
+family = "fblgit"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/google/gemini-3-flash.toml
+++ b/providers/aigateway/models/google/gemini-3-flash.toml
@@ -1,0 +1,23 @@
+name = "Gemini 3 Flash"
+family = "gemini-3"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.5
+output = 3
+
+[limit]
+context = 1000000
+input = 991808
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/aigateway/models/google/gemini-3.1-flash-lite.toml
@@ -1,0 +1,23 @@
+name = "Gemini 3.1 Flash Lite"
+family = "gemini-3"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.25
+output = 1.5
+
+[limit]
+context = 1000000
+input = 991808
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/google/gemini-3.1-pro.toml
+++ b/providers/aigateway/models/google/gemini-3.1-pro.toml
@@ -1,0 +1,23 @@
+name = "Gemini 3.1 Pro"
+family = "gemini-3"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 2
+output = 12
+
+[limit]
+context = 1000000
+input = 934464
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/google/gemma-2b-it-lora.toml
+++ b/providers/aigateway/models/google/gemma-2b-it-lora.toml
@@ -1,0 +1,23 @@
+name = "Gemma-2b-IT-Lora"
+family = "gemma"
+release_date = "2024-04-02"
+last_updated = "2024-04-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.06
+
+[limit]
+context = 8192
+input = 4096
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/google/gemma-3-12b-it.toml
+++ b/providers/aigateway/models/google/gemma-3-12b-it.toml
@@ -1,0 +1,23 @@
+name = "Gemma-3-12b-IT"
+family = "gemma"
+release_date = "2025-03-18"
+last_updated = "2025-03-18"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.35
+output = 0.56
+
+[limit]
+context = 80000
+input = 75904
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/aigateway/models/google/gemma-4-26b-a4b-it.toml
@@ -1,0 +1,23 @@
+name = "Gemma-4-26b-A4b-IT"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.3
+
+[limit]
+context = 256000
+input = 251904
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/google/gemma-7b-it-lora.toml
+++ b/providers/aigateway/models/google/gemma-7b-it-lora.toml
@@ -1,0 +1,23 @@
+name = "Gemma-7b-IT-Lora"
+family = "gemma"
+release_date = "2024-04-02"
+last_updated = "2024-04-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.16
+
+[limit]
+context = 3500
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/google/gemma-7b-it.toml
+++ b/providers/aigateway/models/hf/google/gemma-7b-it.toml
@@ -1,0 +1,23 @@
+name = "Gemma-7b-IT"
+family = "gemma"
+release_date = "2024-04-01"
+last_updated = "2024-04-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.16
+
+[limit]
+context = 8192
+input = 4096
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/meta-llama/meta-llama-3-8b-instruct.toml
+++ b/providers/aigateway/models/hf/meta-llama/meta-llama-3-8b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Meta-Llama-3-8b-Instruct"
+family = "llama-3"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/mistral/mistral-7b-instruct-v0.2.toml
+++ b/providers/aigateway/models/hf/mistral/mistral-7b-instruct-v0.2.toml
@@ -1,0 +1,23 @@
+name = "Mistral-7b-Instruct-V0.2"
+family = "mistral"
+release_date = "2024-04-02"
+last_updated = "2024-04-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 3072
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/nexusflow/starling-lm-7b-beta.toml
+++ b/providers/aigateway/models/hf/nexusflow/starling-lm-7b-beta.toml
@@ -1,0 +1,23 @@
+name = "Starling-LM-7b-Beta"
+family = "hf"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/nousresearch/hermes-2-pro-mistral-7b.toml
+++ b/providers/aigateway/models/hf/nousresearch/hermes-2-pro-mistral-7b.toml
@@ -1,0 +1,23 @@
+name = "Hermes-2-Pro-Mistral-7b"
+family = "mistral"
+release_date = "2024-04-01"
+last_updated = "2024-04-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 24000
+input = 19904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/thebloke/deepseek-coder-6.7b-base-awq.toml
+++ b/providers/aigateway/models/hf/thebloke/deepseek-coder-6.7b-base-awq.toml
@@ -1,0 +1,23 @@
+name = "Deepseek-Coder-6.7b-Base-Awq"
+family = "deepseek"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/thebloke/deepseek-coder-6.7b-instruct-awq.toml
+++ b/providers/aigateway/models/hf/thebloke/deepseek-coder-6.7b-instruct-awq.toml
@@ -1,0 +1,23 @@
+name = "Deepseek-Coder-6.7b-Instruct-Awq"
+family = "deepseek"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/thebloke/llama-2-13b-chat-awq.toml
+++ b/providers/aigateway/models/hf/thebloke/llama-2-13b-chat-awq.toml
@@ -1,0 +1,23 @@
+name = "Llama-2-13b-Chat-Awq"
+family = "llama-2"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.14
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/thebloke/llamaguard-7b-awq.toml
+++ b/providers/aigateway/models/hf/thebloke/llamaguard-7b-awq.toml
@@ -1,0 +1,23 @@
+name = "Llamaguard-7b-Awq"
+family = "hf"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.08
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/thebloke/mistral-7b-instruct-v0.1-awq.toml
+++ b/providers/aigateway/models/hf/thebloke/mistral-7b-instruct-v0.1-awq.toml
@@ -1,0 +1,23 @@
+name = "Mistral-7b-Instruct-V0.1-Awq"
+family = "mistral"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/thebloke/neural-chat-7b-v3-1-awq.toml
+++ b/providers/aigateway/models/hf/thebloke/neural-chat-7b-v3-1-awq.toml
@@ -1,0 +1,23 @@
+name = "Neural-Chat-7b-V3-1-Awq"
+family = "hf"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/thebloke/openhermes-2.5-mistral-7b-awq.toml
+++ b/providers/aigateway/models/hf/thebloke/openhermes-2.5-mistral-7b-awq.toml
@@ -1,0 +1,23 @@
+name = "Openhermes-2.5-Mistral-7b-Awq"
+family = "mistral"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/hf/thebloke/zephyr-7b-beta-awq.toml
+++ b/providers/aigateway/models/hf/thebloke/zephyr-7b-beta-awq.toml
@@ -1,0 +1,23 @@
+name = "Zephyr-7b-Beta-Awq"
+family = "hf"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/ibm-granite/granite-4.0-h-micro.toml
+++ b/providers/aigateway/models/ibm-granite/granite-4.0-h-micro.toml
@@ -1,0 +1,23 @@
+name = "Granite-4.0-H-Micro"
+family = "granite"
+release_date = "2025-10-07"
+last_updated = "2025-10-07"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.017
+output = 0.11
+
+[limit]
+context = 131000
+input = 126904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/llava-hf/llava-1.5-7b-hf.toml
+++ b/providers/aigateway/models/llava-hf/llava-1.5-7b-hf.toml
@@ -1,0 +1,23 @@
+name = "Llava-1.5-7b-HF"
+family = "llava-hf"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.5
+output = 0
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/meta-llama/llama-2-7b-chat-hf-lora.toml
+++ b/providers/aigateway/models/meta-llama/llama-2-7b-chat-hf-lora.toml
@@ -1,0 +1,23 @@
+name = "Llama-2-7b-Chat-HF-Lora"
+family = "llama-2"
+release_date = "2024-04-02"
+last_updated = "2024-04-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.08
+
+[limit]
+context = 8192
+input = 4096
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-2-7b-chat-fp16.toml
+++ b/providers/aigateway/models/meta/llama-2-7b-chat-fp16.toml
@@ -1,0 +1,23 @@
+name = "Llama-2-7b-Chat-Fp16"
+family = "llama-2"
+release_date = "2023-11-07"
+last_updated = "2023-11-07"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.56
+output = 6.67
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-2-7b-chat-int8.toml
+++ b/providers/aigateway/models/meta/llama-2-7b-chat-int8.toml
@@ -1,0 +1,23 @@
+name = "Llama-2-7b-Chat-Int8"
+family = "llama-2"
+release_date = "2023-09-25"
+last_updated = "2023-09-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.08
+
+[limit]
+context = 8192
+input = 4096
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3-8b-instruct-awq.toml
+++ b/providers/aigateway/models/meta/llama-3-8b-instruct-awq.toml
@@ -1,0 +1,23 @@
+name = "Llama-3-8b-Instruct-Awq"
+family = "llama-3"
+release_date = "2024-05-09"
+last_updated = "2024-05-09"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.12
+output = 0.27
+
+[limit]
+context = 8192
+input = 4096
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3-8b-instruct.toml
+++ b/providers/aigateway/models/meta/llama-3-8b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Llama-3-8b-Instruct"
+family = "llama-3"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.28
+output = 0.83
+
+[limit]
+context = 7968
+input = 3872
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3.1-70b-instruct.toml
+++ b/providers/aigateway/models/meta/llama-3.1-70b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.1-70b-Instruct"
+family = "llama-3"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.29
+output = 0.6
+
+[limit]
+context = 131072
+input = 122880
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3.1-8b-instruct-awq.toml
+++ b/providers/aigateway/models/meta/llama-3.1-8b-instruct-awq.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.1-8b-Instruct-Awq"
+family = "llama-3"
+release_date = "2024-07-25"
+last_updated = "2024-07-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.12
+output = 0.27
+
+[limit]
+context = 8192
+input = 4096
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3.1-8b-instruct-fast.toml
+++ b/providers/aigateway/models/meta/llama-3.1-8b-instruct-fast.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.1-8b-Instruct-Fast"
+family = "llama-3"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 131072
+input = 126976
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3.1-8b-instruct-fp8.toml
+++ b/providers/aigateway/models/meta/llama-3.1-8b-instruct-fp8.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.1-8b-Instruct-Fp8"
+family = "llama-3"
+release_date = "2024-07-25"
+last_updated = "2024-07-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.29
+
+[limit]
+context = 32000
+input = 27904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3.1-8b-instruct.toml
+++ b/providers/aigateway/models/meta/llama-3.1-8b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.1-8b-Instruct"
+family = "llama-3"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 131072
+input = 126976
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3.2-11b-vision-instruct.toml
+++ b/providers/aigateway/models/meta/llama-3.2-11b-vision-instruct.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.2-11b-Vision-Instruct"
+family = "llama-3"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.049
+output = 0.68
+
+[limit]
+context = 128000
+input = 123904
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3.2-1b-instruct.toml
+++ b/providers/aigateway/models/meta/llama-3.2-1b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.2-1b-Instruct"
+family = "llama-3"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.027
+output = 0.2
+
+[limit]
+context = 60000
+input = 55904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3.2-3b-instruct.toml
+++ b/providers/aigateway/models/meta/llama-3.2-3b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.2-3b-Instruct"
+family = "llama-3"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.051
+output = 0.34
+
+[limit]
+context = 80000
+input = 75904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-3.3-70b-instruct-fp8-fast.toml
+++ b/providers/aigateway/models/meta/llama-3.3-70b-instruct-fp8-fast.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.3-70b-Instruct-Fp8-Fast"
+family = "llama-3"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.29
+output = 2.25
+
+[limit]
+context = 24000
+input = 15808
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-4-scout-17b-16e-instruct.toml
+++ b/providers/aigateway/models/meta/llama-4-scout-17b-16e-instruct.toml
@@ -1,0 +1,23 @@
+name = "Llama-4-Scout-17b-16e-Instruct"
+family = "llama-4"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.27
+output = 0.85
+
+[limit]
+context = 131000
+input = 126904
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/meta/llama-guard-3-8b.toml
+++ b/providers/aigateway/models/meta/llama-guard-3-8b.toml
@@ -1,0 +1,23 @@
+name = "Llama-Guard-3-8b"
+family = "llama-guard"
+release_date = "2025-01-22"
+last_updated = "2025-01-22"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.48
+output = 0.03
+
+[limit]
+context = 131072
+input = 126976
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/microsoft/phi-2.toml
+++ b/providers/aigateway/models/microsoft/phi-2.toml
@@ -1,0 +1,23 @@
+name = "Phi-2"
+family = "phi"
+release_date = "2024-02-27"
+last_updated = "2024-02-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.04
+
+[limit]
+context = 2048
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/minimax/m2.7.toml
+++ b/providers/aigateway/models/minimax/m2.7.toml
@@ -1,0 +1,23 @@
+name = "M2.7"
+family = "minimax"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 128000
+input = 123904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/mistral/mistral-7b-instruct-v0.1.toml
+++ b/providers/aigateway/models/mistral/mistral-7b-instruct-v0.1.toml
@@ -1,0 +1,23 @@
+name = "Mistral-7b-Instruct-V0.1"
+family = "mistral-7b"
+release_date = "2023-11-07"
+last_updated = "2023-11-07"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.11
+output = 0.19
+
+[limit]
+context = 2824
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/mistral/mistral-7b-instruct-v0.2-lora.toml
+++ b/providers/aigateway/models/mistral/mistral-7b-instruct-v0.2-lora.toml
@@ -1,0 +1,23 @@
+name = "Mistral-7b-Instruct-V0.2-Lora"
+family = "mistral-7b"
+release_date = "2024-04-01"
+last_updated = "2024-04-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 15000
+input = 10904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/mistral/mistral-small-4-0-26-03.toml
+++ b/providers/aigateway/models/mistral/mistral-small-4-0-26-03.toml
@@ -1,0 +1,23 @@
+name = "Mistral Small 4"
+family = "mistral"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.2
+output = 0.6
+
+[limit]
+context = 131072
+input = 114688
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/mistralai/mistral-small-3.1-24b-instruct.toml
+++ b/providers/aigateway/models/mistralai/mistral-small-3.1-24b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Mistral-Small-3.1-24b-Instruct"
+family = "mistral-small"
+release_date = "2025-03-18"
+last_updated = "2025-03-18"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.35
+output = 0.55
+
+[limit]
+context = 128000
+input = 123904
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/moonshot/kimi-k2.5.toml
+++ b/providers/aigateway/models/moonshot/kimi-k2.5.toml
@@ -1,0 +1,23 @@
+name = "Kimi-K2.5"
+family = "kimi"
+release_date = "2026-04-08"
+last_updated = "2026-04-08"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 3
+
+[limit]
+context = 128000
+input = 119808
+output = 8192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/moonshot/kimi-k2.6.toml
+++ b/providers/aigateway/models/moonshot/kimi-k2.6.toml
@@ -1,0 +1,23 @@
+name = "Kimi K2.6"
+family = "kimi"
+release_date = "2026-04-20"
+last_updated = "2026-04-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.95
+output = 4
+
+[limit]
+context = 262144
+input = 245760
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/nvidia/nemotron-3-120b-a12b.toml
+++ b/providers/aigateway/models/nvidia/nemotron-3-120b-a12b.toml
@@ -1,0 +1,23 @@
+name = "Nemotron-3-120b-A12b"
+family = "nemotron"
+release_date = "2026-02-24"
+last_updated = "2026-02-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.5
+output = 1.5
+
+[limit]
+context = 256000
+input = 251904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/openai/gpt-4.1-mini.toml
+++ b/providers/aigateway/models/openai/gpt-4.1-mini.toml
@@ -1,0 +1,23 @@
+name = "GPT-4.1 Mini"
+family = "gpt-4"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.4
+output = 1.6
+
+[limit]
+context = 1047576
+input = 1014808
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/openai/gpt-4.1.toml
+++ b/providers/aigateway/models/openai/gpt-4.1.toml
@@ -1,0 +1,23 @@
+name = "GPT-4.1"
+family = "gpt-4"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2
+output = 8
+
+[limit]
+context = 1047576
+input = 1014808
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/openai/gpt-5.4-mini.toml
+++ b/providers/aigateway/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.4 Mini"
+family = "gpt-5"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.75
+output = 4.5
+
+[limit]
+context = 128000
+input = 111616
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/openai/gpt-5.4-nano.toml
+++ b/providers/aigateway/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.4 Nano"
+family = "gpt-5"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 1.25
+
+[limit]
+context = 128000
+input = 111616
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/openai/gpt-5.4.toml
+++ b/providers/aigateway/models/openai/gpt-5.4.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.4"
+family = "gpt-5"
+release_date = "2026-04-08"
+last_updated = "2026-04-08"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.5
+output = 15
+
+[limit]
+context = 128000
+input = 111616
+output = 16384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aigateway/models/openai/gpt-5.toml
+++ b/providers/aigateway/models/openai/gpt-5.toml
@@ -1,0 +1,23 @@
+name = "GPT-5"
+family = "gpt-5"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10
+
+[limit]
+context = 128000
+input = 111616
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/openai/gpt-oss-120b.toml
+++ b/providers/aigateway/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,23 @@
+name = "Gpt-Oss-120b"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.35
+output = 0.75
+
+[limit]
+context = 128000
+input = 123904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/openai/gpt-oss-20b.toml
+++ b/providers/aigateway/models/openai/gpt-oss-20b.toml
@@ -1,0 +1,23 @@
+name = "Gpt-Oss-20b"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.3
+
+[limit]
+context = 128000
+input = 123904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/openai/o4-mini.toml
+++ b/providers/aigateway/models/openai/o4-mini.toml
@@ -1,0 +1,23 @@
+name = "o4-mini"
+family = "openai"
+release_date = "2026-04-13"
+last_updated = "2026-04-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = false
+
+[cost]
+input = 1.1
+output = 4.4
+
+[limit]
+context = 200000
+input = 100000
+output = 100000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/openchat/openchat-3.5-0106.toml
+++ b/providers/aigateway/models/openchat/openchat-3.5-0106.toml
@@ -1,0 +1,23 @@
+name = "Openchat-3.5-0106"
+family = "openchat"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/perplexity/sonar-deep-research.toml
+++ b/providers/aigateway/models/perplexity/sonar-deep-research.toml
@@ -1,0 +1,23 @@
+name = "Sonar Deep Research"
+family = "perplexity"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = false
+
+[cost]
+input = 2
+output = 8
+
+[limit]
+context = 127000
+input = 110616
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/aigateway/models/perplexity/sonar-reasoning-pro.toml
@@ -1,0 +1,23 @@
+name = "Sonar Reasoning Pro"
+family = "perplexity"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = false
+
+[cost]
+input = 2
+output = 8
+
+[limit]
+context = 127000
+input = 118808
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/qwen/qwen1.5-0.5b-chat.toml
+++ b/providers/aigateway/models/qwen/qwen1.5-0.5b-chat.toml
@@ -1,0 +1,23 @@
+name = "Qwen1.5-0.5b-Chat"
+family = "qwen"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.02
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/qwen/qwen1.5-1.8b-chat.toml
+++ b/providers/aigateway/models/qwen/qwen1.5-1.8b-chat.toml
@@ -1,0 +1,23 @@
+name = "Qwen1.5-1.8b-Chat"
+family = "qwen"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.02
+output = 0.04
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/qwen/qwen1.5-14b-chat-awq.toml
+++ b/providers/aigateway/models/qwen/qwen1.5-14b-chat-awq.toml
@@ -1,0 +1,23 @@
+name = "Qwen1.5-14b-Chat-Awq"
+family = "qwen"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.12
+output = 0.24
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/qwen/qwen1.5-7b-chat-awq.toml
+++ b/providers/aigateway/models/qwen/qwen1.5-7b-chat-awq.toml
@@ -1,0 +1,23 @@
+name = "Qwen1.5-7b-Chat-Awq"
+family = "qwen"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.12
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/qwen/qwen2.5-coder-32b-instruct.toml
+++ b/providers/aigateway/models/qwen/qwen2.5-coder-32b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Qwen2.5-Coder-32b-Instruct"
+family = "qwen"
+release_date = "2025-02-27"
+last_updated = "2025-02-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.66
+output = 1
+
+[limit]
+context = 32768
+input = 28672
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/qwen/qwen3-30b-a3b-fp8.toml
+++ b/providers/aigateway/models/qwen/qwen3-30b-a3b-fp8.toml
@@ -1,0 +1,23 @@
+name = "Qwen3-30b-A3b-Fp8"
+family = "qwen"
+release_date = "2025-04-30"
+last_updated = "2025-04-30"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.051
+output = 0.34
+
+[limit]
+context = 32768
+input = 28672
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/qwen/qwq-32b.toml
+++ b/providers/aigateway/models/qwen/qwq-32b.toml
@@ -1,0 +1,23 @@
+name = "Qwq-32b"
+family = "qwen"
+release_date = "2025-03-05"
+last_updated = "2025-03-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.66
+output = 1
+
+[limit]
+context = 24000
+input = 19904
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/thebloke/discolm-german-7b-v1-awq.toml
+++ b/providers/aigateway/models/thebloke/discolm-german-7b-v1-awq.toml
@@ -1,0 +1,23 @@
+name = "Discolm-German-7b-V1-Awq"
+family = "thebloke"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/tiiuae/falcon-7b-instruct.toml
+++ b/providers/aigateway/models/tiiuae/falcon-7b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Falcon-7b-Instruct"
+family = "tiiuae"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.1
+
+[limit]
+context = 4096
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/tinyllama/tinyllama-1.1b-chat-v1.0.toml
+++ b/providers/aigateway/models/tinyllama/tinyllama-1.1b-chat-v1.0.toml
@@ -1,0 +1,23 @@
+name = "Tinyllama-1.1b-Chat-V1.0"
+family = "tinyllama"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.008
+output = 0.016
+
+[limit]
+context = 2048
+input = 1
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/xai/grok-4-fast.toml
+++ b/providers/aigateway/models/xai/grok-4-fast.toml
@@ -1,0 +1,23 @@
+name = "Grok 4 Fast"
+family = "grok-4"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.5
+output = 2
+
+[limit]
+context = 256000
+input = 239616
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/xai/grok-4.toml
+++ b/providers/aigateway/models/xai/grok-4.toml
@@ -1,0 +1,23 @@
+name = "Grok 4"
+family = "grok-4"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3
+output = 15
+
+[limit]
+context = 256000
+input = 239616
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/models/zai-org/glm-4.7-flash.toml
+++ b/providers/aigateway/models/zai-org/glm-4.7-flash.toml
@@ -1,0 +1,23 @@
+name = "Glm-4.7-Flash"
+family = "glm"
+release_date = "2026-01-28"
+last_updated = "2026-01-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.06
+output = 0.4
+
+[limit]
+context = 131072
+input = 126976
+output = 4096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aigateway/provider.toml
+++ b/providers/aigateway/provider.toml
@@ -1,0 +1,5 @@
+name = "AIgateway"
+env = ["AIGATEWAY_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.aigateway.sh/v1"
+doc = "https://aigateway.sh/models"


### PR DESCRIPTION
## Summary

Adds **AIgateway** ([aigateway.sh](https://aigateway.sh)) as a provider. AIgateway is a universal, OpenAI-compatible inference API that aggregates 100+ AI models across every modality, reached at `api.aigateway.sh/v1`.

This PR contributes:

- `providers/aigateway/provider.toml` — OpenAI-compatible (`@ai-sdk/openai-compatible`), `env = ["AIGATEWAY_API_KEY"]`, doc: `https://aigateway.sh/models`
- `providers/aigateway/logo.svg` — theme-safe SVG using `currentColor`
- **84 model TOMLs** across text + vision modalities covering Anthropic (Claude Opus/Sonnet/Haiku 4.x), OpenAI (GPT-5 / 5.4 / 4.1 / o4-mini / gpt-oss), Google (Gemini 3.x, Gemma 3/4), Meta (Llama 3.x / 4), Mistral, xAI (Grok 4 / 4 Fast), Moonshot (Kimi K2.5 / K2.6), DeepSeek, Microsoft Phi-2, Alibaba Qwen 2.5 / 3 / 3.5, IBM Granite, Perplexity Sonar, NVIDIA, MiniMax, AI Singapore SEA-Lion, Zhipu GLM, and more.

## Testing

- All 85 TOML files parse with `tomllib` locally.
- Each model entry includes the required `name`, `family`, `release_date`, `last_updated`, `attachment`, `reasoning`, `tool_call`, `structured_output`, `temperature`, `open_weights`, `[cost]` (input/output in USD/Mtok), `[limit]` (context/input/output), `[modalities]`.
- Generated by a script in the aigateway repo so we can keep this entry fresh as pricing and the catalog evolve.

## Notes for reviewers

- A small subset of open-weight community models (some HuggingFace / older Meta Llama / Qwen 1.5 variants) default `release_date` to `2024-01-01` where the upstream catalog does not track a specific date. Happy to tighten those in a follow-up if you'd prefer strict dates only.
- The `aigateway` catalog also includes audio (STT/TTS), image, video, embedding, translation, rerank, classification and OCR models. Those are **not** included here because the current `models.dev` schema targets chat models. If/when the schema grows to cover other modalities, I'll send a follow-up.
- Follows the same shape as existing aggregator providers on models.dev — see `providers/openrouter`, `providers/helicone`, `providers/requesty`, `providers/llmgateway`, `providers/fastrouter`. We register as a provider rather than duplicating canonical entries. Happy to convert everything to `[extends]` in a follow-up if that's preferred.

Thanks for maintaining this — AIgateway relies on the models.dev JSON feed for our own catalog page and we want to contribute back. 🙏