### PR TITLE
add chutes qwen3.6 27b tee model

### DIFF
--- a/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
@@ -1,0 +1,25 @@
+name = "Qwen3.6 27B TEE"
+family = "qwen3.6"
+release_date = "2026-04-22"
+last_updated = "2026-04-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.195
+output = 1.56
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
## Summary
- Add Chutes config for `Qwen/Qwen3.6-27B-TEE`
- Include pricing, limits, multimodal support, reasoning, and interleaved reasoning field

## Validation
- `bun validate`

Closed #1565