### PR TITLE
[alibaba] Add remaining open Qwen 3.5 and 3.6 models, fix Qwen-3.5 397B-A17B

### DIFF
--- a/providers/alibaba/models/qwen3.5-122b-a10b.toml
+++ b/providers/alibaba/models/qwen3.5-122b-a10b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 122B-A10B"
+family = "qwen"
+release_date = "2026-02-23"
+last_updated = "2026-02-23"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.4
+output = 3.2
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/alibaba/models/qwen3.5-27b.toml
+++ b/providers/alibaba/models/qwen3.5-27b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 27B"
+family = "qwen"
+release_date = "2026-02-23"
+last_updated = "2026-02-23"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 2.4
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/alibaba/models/qwen3.5-35b-a3b.toml
+++ b/providers/alibaba/models/qwen3.5-35b-a3b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 35B-A3B"
+family = "qwen"
+release_date = "2026-02-23"
+last_updated = "2026-02-23"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.25
+output = 2
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/alibaba/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba/models/qwen3.5-397b-a17b.toml
@@ -1,23 +1,22 @@
 name = "Qwen3.5 397B-A17B"
 family = "qwen"
-release_date = "2026-02-16"
-last_updated = "2026-02-16"
-attachment = false
+release_date = "2026-02-15"
+last_updated = "2026-02-15"
+attachment = true
 reasoning = true
 temperature = true
-knowledge = "2025-04"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]
 input = 0.6
 output = 3.6
-reasoning = 3.6
 
 [limit]
 context = 262_144
 output = 65_536
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image", "video", "audio"]
 output = ["text"]

--- a/providers/alibaba/models/qwen3.6-27b.toml
+++ b/providers/alibaba/models/qwen3.6-27b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.6 27B"
+family = "qwen"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 3.6
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/alibaba/models/qwen3.6-35b-a3b.toml
+++ b/providers/alibaba/models/qwen3.6-35b-a3b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.6 35B-A3B"
+family = "qwen"
+release_date = "2026-04-17"
+last_updated = "2026-04-17"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.248
+output = 1.485
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]


### PR DESCRIPTION
- Added Qwen 3.5 122B-A10B
- Added Qwen 3.5 27B
- Added Qwen 3.5 35B-A3B
- Fixed Qwen 3.5 397B-A17B (see below)
- Added Qwen 3.6 27b
- Added Qwen 3.6-35B-A3B

Note: I was not able to find a reliable source for the knowledge cutoff of any of these models. 2025-04 was already set as the cutoff for Qwen 3, and Qwen 3.5 is newer. All data is from the ModelStudio webpage.
It seems to not include audio, but the ModelStudio page clearly has an audio symbol and the model is capable of this. And I found no data for a price for reasoning tokens in particular, unlike what was in the file for Qwen 3.5 397B-A17B. The models are all capable of structured output.

Validated with `bun validate`