### PR TITLE
Add OpenRouter DeepSeek V4 models

### DIFF
--- a/providers/openrouter/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-flash.toml
@@ -4,7 +4,7 @@ attachment = false
 from = "deepseek/deepseek-v4-flash"
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [limit]
 context = 1_048_576

--- a/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
@@ -4,7 +4,7 @@ attachment = false
 from = "deepseek/deepseek-v4-pro"
 
 [interleaved]
-field = "reasoning_details"
+field = "reasoning_content"
 
 [limit]
 context = 1_048_576


### PR DESCRIPTION
## Summary
- Add OpenRouter DeepSeek V4 Pro and V4 Flash model overrides extending the official DeepSeek definitions.
- Set OpenRouter-specific limits and disable attachment support.
- Use `reasoning_content` for interleaved DeepSeek thinking content so reasoning can be passed back correctly.

## Validation
- `bun validate`