### PR TITLE
Add `deepseek-v4-flash` model for Ollama Cloud.

### DIFF
--- a/providers/ollama-cloud/models/deepseek-v4-flash.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-flash.toml
@@ -1,0 +1,5 @@
+name = "deepseek-v4-flash"
+
+[extends]
+from = "deepseek/deepseek-v4-flash"
+omit = ["cost"]


### PR DESCRIPTION
Adds the Ollama Cloud-definition for [the DeepSeek V4 Flash model](https://ollama.com/library/deepseek-v4-flash).

This new definition extends from the official DeepSeek's:
* with an override for naming to stay consistent with the other Ollama Cloud definitions,
* and "cost" details omitted since Ollama Cloud is subscription-based.