### PR TITLE
Add abliteration.ai provider

### DIFF
--- a/providers/abliteration-ai/logo.svg
+++ b/providers/abliteration-ai/logo.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 220 32" xmlns="http://www.w3.org/2000/svg">
+  <text x="0" y="24" fill="currentColor">
+    <tspan font-size="24">Abliteration</tspan>
+    <tspan dx="8" dy="2" font-size="12" fill-opacity="0.6">.ai</tspan>
+  </text>
+</svg>

--- a/providers/abliteration-ai/models/abliterated-model.toml
+++ b/providers/abliteration-ai/models/abliterated-model.toml
@@ -1,0 +1,22 @@
+name = "Abliterated Model"
+release_date = "2026-01-06"
+last_updated = "2026-01-06"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = false
+temperature = true
+open_weights = true
+
+[cost]
+input = 3.00
+output = 3.00
+
+[limit]
+context = 150_000
+input = 150_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/abliteration-ai/provider.toml
+++ b/providers/abliteration-ai/provider.toml
@@ -1,0 +1,5 @@
+name = "abliteration.ai"
+env = ["ABLIT_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.abliteration.ai/v1"
+doc = "https://docs.abliteration.ai/models"


### PR DESCRIPTION
## What changed

Adds `abliteration.ai` as an OpenAI-compatible provider with:

- provider metadata for `https://api.abliteration.ai/v1`
- the published `abliterated-model` entry
- a current-color SVG wordmark

## Source data

- Contribution guide requires provider TOML, model TOML, optional current-color SVG logo, and schema validation.
- Abliteration quickstart and API docs publish bearer-token auth with `ABLIT_KEY` and base URL `https://api.abliteration.ai/v1`.
- Abliteration model docs list `abliterated-model`, 150K context, streaming, tool/function calling, and vision support.
- Abliteration model/pricing pages describe usage billing by total input + output tokens at about  per 1M tokens.

## Validation

- `bun validate`
- `cd packages/web && bun run build`