### PR TITLE
feat(github-copilot): add gpt-5.5

### DIFF
--- a/providers/github-copilot/models/gpt-5.5.toml
+++ b/providers/github-copilot/models/gpt-5.5.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.5"
+family = "gpt"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
GitHub Copilot now serves `gpt-5.5` for Copilot accounts (verified by querying `GET https://api.githubcopilot.com/models` with a Copilot Enterprise token — `gpt-5.5` is returned in the model list).

This PR adds the catalog entry so downstream consumers (pi-ai, OpenClaw, etc.) can route to it.

Mirrored the existing `gpt-5.4.toml` shape — same context window (400k), reasoning, image input. Will happily update if anything is wrong.