### PR TITLE
feat(ollama-cloud): add deepseek-v4-flash model

### DIFF
--- a/providers/ollama-cloud/models/deepseek-v4-flash.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-flash.toml
@@ -1,0 +1,16 @@
+name = "deepseek-v4-flash"
+family = "deepseek-flash"
+attachment = false
+reasoning = true
+tool_call = true
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+open_weights = true
+
+[limit]
+context = 1048576
+output = 1048576
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
This model is already available on Ollama Cloud's API (/api/tags) but was missing from the repository. Values are sourced directly from the API (/api/show) and aligned with the ollama-cloud model conventions:

- Context length (1,048,576) comes from the Ollama API, not copied from other providers
- Output matches context per ollama-cloud convention
- No extends — standalone file keeps it clean and avoids inheriting fields (temperature, structured_output, interleaved, etc.) that don't belong in ollama-cloud models
- bun validate passes clean