### PR TITLE
feat(llmgateway): add deepseek-v4-pro, deepseek-v4-flash, kimi-k2.6

### DIFF
--- a/providers/llmgateway/models/deepseek-v4-flash.toml
+++ b/providers/llmgateway/models/deepseek-v4-flash.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "deepseek/deepseek-v4-flash"

--- a/providers/llmgateway/models/deepseek-v4-pro.toml
+++ b/providers/llmgateway/models/deepseek-v4-pro.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "deepseek/deepseek-v4-pro"

--- a/providers/llmgateway/models/kimi-k2.6.toml
+++ b/providers/llmgateway/models/kimi-k2.6.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "moonshotai/kimi-k2.6"


### PR DESCRIPTION
Adds the 3 text-output models currently missing from providers/llmgateway that are present in https://api.llmgateway.io/v1/models.