### PR TITLE
Venice: Add GPT-5.5 and Qwen3.6 model configs

### DIFF
--- a/providers/venice/models/openai-gpt-55-pro.toml
+++ b/providers/venice/models/openai-gpt-55-pro.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.5 Pro"
+family = "gpt-pro"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-04-24"
+last_updated = "2026-04-25"
+open_weights = false
+
+[cost]
+input = 37.5
+output = 225
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/venice/models/openai-gpt-55.toml
+++ b/providers/venice/models/openai-gpt-55.toml
@@ -1,0 +1,28 @@
+name = "GPT-5.5"
+family = "gpt"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-04-23"
+last_updated = "2026-04-25"
+open_weights = false
+
+[cost]
+input = 6.25
+output = 37.5
+cache_read = 0.625
+
+[cost.context_over_200k]
+input = 12.5
+output = 56.25
+cache_read = 1.25
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/venice/models/qwen3-6-27b.toml
+++ b/providers/venice/models/qwen3-6-27b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.6 27B"
+family = "qwen"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-04-24"
+last_updated = "2026-04-25"
+open_weights = false
+
+[cost]
+input = 0.325
+output = 3.25
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
- Add OpenAI GPT-5.5 with 1M context window and tiered pricing
- Add OpenAI GPT-5.5 Pro with premium pricing and 128K output limit
- Add Qwen3.6 27B with text, image, and video input modalities