### PR TITLE
feat(openrouter): add Gemini 3.1 flash image preview (Nano Banana 2)

### DIFF
--- a/providers/openrouter/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/openrouter/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,23 @@
+name = "Gemini 3.1 Flash Image Preview (Nano Banana 2)"
+family = "gemini-flash"
+release_date = "2026-02-26"
+last_updated = "2026-02-26"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-01"
+tool_call = false
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.50
+output = 3.00
+
+[limit]
+context = 65_536
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]


### PR DESCRIPTION
This PR adds the model definition under providers/openrouter/models/google/, including its pricing,
 context/output limits, supported modalities, and capability metadata. 

 Validation was run successfully with:

 ```bash
   bun validate
 ```
