### PR TITLE
feat(cloudflare-ai-gateway): add openai/gpt-5.5

### DIFF
--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.5.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.5.toml
@@ -1,0 +1,33 @@
+name = "GPT-5.5"
+family = "gpt"
+release_date = "2026-04-23"
+last_updated = "2026-04-23"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-12-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[cost.context_over_200k]
+input = 10.00
+output = 45.00
+cache_read = 1.00
+
+[limit]
+context = 1_050_000
+input = 920_000
+output = 130_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[provider]
+npm = "ai-gateway-provider"

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.5.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.5.toml
@@ -1,33 +1,3 @@
-name = "GPT-5.5"
-family = "gpt"
-release_date = "2026-04-23"
-last_updated = "2026-04-23"
-attachment = true
-reasoning = true
-temperature = false
-knowledge = "2025-12-01"
-tool_call = true
-structured_output = true
-open_weights = false
-
-[cost]
-input = 5.00
-output = 30.00
-cache_read = 0.50
-
-[cost.context_over_200k]
-input = 10.00
-output = 45.00
-cache_read = 1.00
-
-[limit]
-context = 1_050_000
-input = 920_000
-output = 130_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]
-
-[provider]
-npm = "ai-gateway-provider"
+[extends]
+from = "openai/gpt-5.5"
+omit = ["experimental.modes.fast"]


### PR DESCRIPTION
## What this changes
Adds `providers/cloudflare-ai-gateway/models/openai/gpt-5.5.toml`, mirroring the existing direct `providers/openai/models/gpt-5.5.toml` entry.

## Why
GPT-5.5 launched 2026-04-23 and is already routable via Cloudflare AI Gateway (`openai/gpt-5.5` slug, see https://developers.cloudflare.com/ai/models/openai/gpt-5.5/), but the model is missing from the `cloudflare-ai-gateway` provider entry in this registry. opencode reads models.dev for its model list, so referencing `cloudflare-ai-gateway/openai/gpt-5.5` currently throws `ProviderModelNotFoundError` in CI workflows that route through the gateway.

PRs adding GPT-5.5 to other providers landed earlier this week: #1554 (codex), #1577 (openrouter), #1585 (github-copilot), #1590 (venice). This fills the cloudflare-ai-gateway gap.

## Approach
- Pricing, limits, modalities, knowledge cutoff, and release date copied verbatim from `providers/openai/models/gpt-5.5.toml`.
- Provider stanza (`npm = "ai-gateway-provider"`) follows the sibling `gpt-5.4.toml` under the same directory.
- No `[experimental.modes.fast]` block included since the cloudflare-ai-gateway entries for sibling models do not carry it.

## Validation
- `bun validate` passes; `openai/gpt-5.5` appears under the `cloudflare-ai-gateway` provider in the generated output.