### PR TITLE
feat(azure): add GPT-5.5 model metadata

### DIFF
--- a/providers/azure-cognitive-services/models/gpt-5.5.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.5.toml
@@ -1,25 +1,2 @@
-name = "GPT-5.5"
-family = "gpt"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-attachment = true
-reasoning = true
-temperature = false
-knowledge = "2025-12-01"
-tool_call = true
-structured_output = true
-open_weights = false
-
-[cost]
-input = 5.00
-output = 30.00
-cache_read = 0.50
-
-[limit]
-context = 1_050_000
-input = 922_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]
+[extends]
+from = "azure/gpt-5.5"

--- a/providers/azure-cognitive-services/models/gpt-5.5.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.5.toml
@@ -1,0 +1,25 @@
+name = "GPT-5.5"
+family = "gpt"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-12-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/azure-cognitive-services/models/gpt-5.5.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.5.toml
@@ -1,2 +1,1 @@
-[extends]
-from = "azure/gpt-5.5"
+../../azure/models/gpt-5.5.toml

--- a/providers/azure/models/gpt-5.5.toml
+++ b/providers/azure/models/gpt-5.5.toml
@@ -1,6 +1,6 @@
-[extends]
-from = "openai/gpt-5.5"
-omit = ["cost.context_over_200k", "experimental.modes.fast"]
-
 release_date = "2026-04-24"
 last_updated = "2026-04-24"
+
+[extends]
+from = "openai/gpt-5.5"
+omit = ["experimental.modes.fast"]

--- a/providers/azure/models/gpt-5.5.toml
+++ b/providers/azure/models/gpt-5.5.toml
@@ -1,0 +1,25 @@
+name = "GPT-5.5"
+family = "gpt"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-12-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/azure/models/gpt-5.5.toml
+++ b/providers/azure/models/gpt-5.5.toml
@@ -4,7 +4,3 @@ omit = ["cost.context_over_200k", "experimental.modes.fast"]
 
 release_date = "2026-04-24"
 last_updated = "2026-04-24"
-
-[limit]
-input = 922_000
-output = 128_000

--- a/providers/azure/models/gpt-5.5.toml
+++ b/providers/azure/models/gpt-5.5.toml
@@ -1,25 +1,10 @@
-name = "GPT-5.5"
-family = "gpt"
+[extends]
+from = "openai/gpt-5.5"
+omit = ["cost.context_over_200k", "experimental.modes.fast"]
+
 release_date = "2026-04-24"
 last_updated = "2026-04-24"
-attachment = true
-reasoning = true
-temperature = false
-knowledge = "2025-12-01"
-tool_call = true
-structured_output = true
-open_weights = false
-
-[cost]
-input = 5.00
-output = 30.00
-cache_read = 0.50
 
 [limit]
-context = 1_050_000
 input = 922_000
 output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]


### PR DESCRIPTION
## Summary

Adds GPT-5.5 metadata for:

- Azure
- Azure Cognitive Services

The Azure Cognitive Services entry mirrors the existing local convention of full TOML model definitions.

## Sources

- Microsoft Learn lists `gpt-5.5` for Azure OpenAI / Microsoft Foundry with version `2026-04-24`, `1,050,000` context, `922,000` input, `128,000` output, structured outputs, tools, image input, and December 2025 training data.
- Microsoft’s Azure GPT-5.5 announcement lists pricing at `$5.00` input, `$0.50` cached input, and `$30.00` output per 1M tokens.
- Azure Responses API docs list PDF input support for vision-capable models and include `gpt-5.5` version `2026-04-24`.

## Notes

This intentionally does not add `gpt-5.5-pro`, since Azure Learn currently lists `gpt-5.5` but not `gpt-5.5-pro` in the Azure model catalog.

This also intentionally omits OpenAI-specific `context_over_200k` and `experimental.modes.fast` metadata because the Azure sources confirm the standard pricing and limits, but not those OpenAI-specific fields.