### PR TITLE
Add gemini-3.1-flash-preview for google-vertex

### DIFF
--- a/providers/google-vertex/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/google-vertex/models/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-3.1-flash-lite-preview"

--- a/providers/google-vertex/models/gemini-3.1-flash-preview.toml
+++ b/providers/google-vertex/models/gemini-3.1-flash-preview.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-3.1-flash-preview"

--- a/providers/google-vertex/models/gemini-3.1-flash-preview.toml
+++ b/providers/google-vertex/models/gemini-3.1-flash-preview.toml
@@ -1,2 +1,0 @@
-[extends]
-from = "google/gemini-3.1-flash-preview"


### PR DESCRIPTION
Fix #1605 issue, by adding gemini-3.1-flash-preview model (extending from Google) in Google Vertex