### PR TITLE
feat(azure): add Kimi K2.6 model

### DIFF
--- a/providers/azure/models/kimi-k2.6.toml
+++ b/providers/azure/models/kimi-k2.6.toml
@@ -1,0 +1,29 @@
+name = "Kimi K2.6"
+family = "kimi"
+release_date = "2026-04-20"
+last_updated = "2026-04-20"
+attachment = false
+reasoning = true
+structured_output = true
+temperature = true
+tool_call = true
+interleaved = true
+open_weights = true
+license = "Other"
+
+[cost]
+input = 0.95
+output = 4.00
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[provider]
+shape = "completions"
+npm = "@ai-sdk/openai-compatible"
+api = "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/models"


### PR DESCRIPTION
Adds Kimi K2.6 model configuration to the Azure provider. #1551 