### PR TITLE
fix(opencode-go): update deepseek v4 flash cache pricing in Go

### DIFF
--- a/providers/opencode-go/models/deepseek-v4-flash.toml
+++ b/providers/opencode-go/models/deepseek-v4-flash.toml
@@ -16,7 +16,7 @@ field = "reasoning_content"
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.028
+cache_read = 0.0028
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
update deepseek v4 flash cache pricing in Go