### PR TITLE
Add Qwen3.5-9B model configuration file to OVHCloud

### DIFF
--- a/providers/ovhcloud/models/qwen3.5-9b.toml
+++ b/providers/ovhcloud/models/qwen3.5-9b.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.5-9B"
+release_date = "2026-02-15"
+last_updated = "2026-02-15"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.15
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
This pull request adds a new model configuration for `Qwen3.5-9B` to the OVHCloud provider. The configuration specifies the model's capabilities, cost, and supported modalities.

Model configuration addition:

* Added a new TOML file `qwen3.5-9b.toml` defining the `Qwen3.5-9B` model, including its release date, features (such as attachment support, tool calls, structured output, and temperature control), cost per input/output, context and output limits, and supported input/output modalities.