### PR TITLE
feat: add DeepSeek V4 Pro on Fireworks AI

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek-V4-Pro"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+open_weights = true
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.15
+
+[limit]
+context = 1_000_000
+input = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Followed the formatting guide. Noticed it wasn't in models.dev site and thus Opencode didn't have it.
Pulling.