### PR TITLE
fix(ollama-cloud): correct deepseek-v4-pro model config

### DIFF
--- a/providers/ollama-cloud/models/deepseek-v4-pro.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-pro.toml
@@ -1,21 +1,15 @@
 name = "deepseek-v4-pro"
 family = "deepseek-thinking"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-temperature = true
-knowledge = "2025-05"
 tool_call = true
-structured_output = true
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
 open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
 [limit]
-context = 1_000_000
-output = 384_000
+context = 1048576
+output = 1048576
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
## Summary

The current `deepseek-v4-pro.toml` in `ollama-cloud` contains fields copied from other providers that don't apply to Ollama Cloud, and incorrect limit values.

This mirrors the exact same reasoning from #1586 (`deepseek-v4-flash`)

## Changes

| Field | Before | After | Reason |
|---|---|---|---|
| `temperature` | `true` | **removed** | Not an ollama-cloud concept |
| `structured_output` | `true` | **removed** | Not an ollama-cloud concept |
| `knowledge` | `"2025-05"` | **removed** | Not sourced from the Ollama API |
| `[interleaved]` | `field = "reasoning_content"` | **removed** | No other ollama-cloud model includes this field. |
| `limit.context` | `1_000_000` | `1048576` | Value from the Ollama `/api/show` endpoint |
| `limit.output` | `384_000` | `1048576` | Ollama doesn't impose output limits. Per ollama-cloud convention: `output = context` |