### PR TITLE
feat(wandb): Add GLM-5.1

### DIFF
--- a/providers/wandb/models/zai-org/GLM-5.1.toml
+++ b/providers/wandb/models/zai-org/GLM-5.1.toml
@@ -1,0 +1,27 @@
+name = "GLM-5.1"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+cache_write = 0
+
+[limit]
+context = 200000
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/wandb/models/zai-org/GLM-5.1.toml
+++ b/providers/wandb/models/zai-org/GLM-5.1.toml
@@ -1,27 +1,2 @@
-name = "GLM-5.1"
-family = "glm"
-release_date = "2026-03-27"
-last_updated = "2026-03-27"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 1.4
-output = 4.4
-cache_read = 0.26
-cache_write = 0
-
-[limit]
-context = 200000
-output = 131072
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "zai/glm-5.1"


### PR DESCRIPTION
Add GLM-5.1 model to wandb provider.

GLM-5.1 settings referenced from zai provider: https://github.com/anomalyco/models.dev/blob/dev/providers/zai/models/glm-5.1.toml

Pricing referenced from https://wandb.ai/inference/coreweave/cw_zai-org_GLM-5.1