### PR TITLE
feat(fireworks-ai): add deepseek-v4-pro

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro.toml
@@ -1,0 +1,7 @@
+[extends]
+from = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.15


### PR DESCRIPTION
extends `deepseek/deepseek-v4-pro` with fireworks pricing

[fireworks](https://app.fireworks.ai/models/fireworks/deepseek-v4-pro) lists $0.15/M for cached input vs $0.145/M from deepseek

lmk if anything needs to be adjusted

