### PR TITLE
feat: add gpt-5.5 pro on openai and openrouter

### DIFF
--- a/providers/openai/models/gpt-5.5-pro.toml
+++ b/providers/openai/models/gpt-5.5-pro.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.5 Pro"
+family = "gpt-pro"
+release_date = "2026-04-23"
+last_updated = "2026-04-23"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-12-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 30.00
+output = 180.00
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/openai/models/gpt-5.5-pro.toml
+++ b/providers/openai/models/gpt-5.5-pro.toml
@@ -20,5 +20,5 @@ input = 922_000
 output = 128_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5.5-pro.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5.5-pro"


### PR DESCRIPTION
Adds GPT-5.5 Pro from the gpt-pro family to OpenAI and OpenRouter (extends from OpenAI).