### PR TITLE
Add Kimi K2.6 to Azure

### DIFF
--- a/providers/azure/models/kimi-k2.6.toml
+++ b/providers/azure/models/kimi-k2.6.toml
@@ -1,0 +1,29 @@
+name = "Kimi K2.6"
+family = "kimi"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
+attachment = false
+reasoning = true
+structured_output = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+interleaved = true
+open_weights = true
+
+[cost]
+input = 0.95
+output = 4.00
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[provider]
+shape = "completions"
+npm = "@ai-sdk/openai-compatible"
+api = "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/models"


### PR DESCRIPTION
## Summary
- Adds Kimi K2.6 for Azure AI Foundry (Microsoft Foundry), launched 2026-04-22
- 262K context window, $0.95 input / $4.00 output per 1M tokens (Azure Foundry pricing)
- Text + image input, text output; reasoning, tool calling, structured output, open weights