### PR TITLE
poe: update GPT-5.5 context limits

### DIFF
--- a/providers/poe/models/openai/gpt-5.5-pro.toml
+++ b/providers/poe/models/openai/gpt-5.5-pro.toml
@@ -1,6 +1,6 @@
 name = "GPT-5.5-Pro"
 release_date = "2026-04-08"
-last_updated = "2026-04-08"
+last_updated = "2026-04-28"
 
 [extends]
 from = "opencode/gpt-5.5-pro"
@@ -15,7 +15,7 @@ input = 27.2727
 output = 163.6364
 
 [limit]
-context = 400_000
+context = 1_050_000
 output = 128_000
 
 [modalities]

--- a/providers/poe/models/openai/gpt-5.5.toml
+++ b/providers/poe/models/openai/gpt-5.5.toml
@@ -1,5 +1,5 @@
 release_date = "2026-04-08"
-last_updated = "2026-04-08"
+last_updated = "2026-04-28"
 
 [extends]
 from = "openai/gpt-5.5"
@@ -15,7 +15,7 @@ output = 27.2727
 cache_read = 0.4545
 
 [limit]
-context = 400_000
+context = 1_050_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
## Summary
- Update Poe GPT-5.5 and GPT-5.5 Pro context limit overrides from `400_000` to `1_050_000`.
- Align the Poe wrappers with their inherited OpenAI/OpenCode GPT-5.5 metadata while keeping the `128_000` output limit unchanged.

## Source
- OpenAI GPT-5.5 model docs list a `1,050,000` token context window and `128,000` max output tokens: https://developers.openai.com/api/docs/models/gpt-5.5

## Validation
- `bun validate`
- Confirmed generated Poe records resolve to:
  - `openai/gpt-5.5`: `{ context: 1050000, output: 128000 }`
  - `openai/gpt-5.5-pro`: `{ context: 1050000, output: 128000 }`