### PR TITLE
refactor(xiaomi): all mimo models extend from the xiaomi root provider

### DIFF
--- a/providers/kilo/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-flash.toml
@@ -1,21 +1,10 @@
 name = "Xiaomi: MiMo-V2-Flash"
-release_date = "2025-12-14"
-last_updated = "2026-03-15"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
+
+[extends]
+from = "xiaomi/mimo-v2-flash"
+omit = ["interleaved"]
 
 [cost]
 input = 0.09
 output = 0.29
 cache_read = 0.045
-
-[limit]
-context = 262144
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/kilo/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-omni.toml
@@ -1,21 +1,5 @@
 name = "Xiaomi: MiMo-V2-Omni"
-release_date = "2026-03-18"
-last_updated = "2026-04-11"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
 
-[cost]
-input = 0.4
-output = 2
-cache_read = 0.08
-
-[limit]
-context = 262144
-output = 65536
-
-[modalities]
-input = ["audio", "image", "text", "video"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-omni"
+omit = ["interleaved"]

--- a/providers/kilo/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-pro.toml
@@ -1,21 +1,5 @@
 name = "Xiaomi: MiMo-V2-Pro"
-release_date = "2026-03-18"
-last_updated = "2026-04-11"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
 
-[cost]
-input = 1
-output = 3
-cache_read = 0.2
-
-[limit]
-context = 1048576
-output = 131072
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-pro"
+omit = ["interleaved"]

--- a/providers/opencode-go/models/mimo-v2-omni.toml
+++ b/providers/opencode-go/models/mimo-v2-omni.toml
@@ -1,26 +1,4 @@
 name = "MiMo V2 Omni"
-family = "mimo-v2-omni"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 0.40
-output = 2.00
-cache_read = 0.08
-
-[limit]
-context = 262_144
-output = 128_000
-
-[modalities]
-input = ["text", "image", "audio", "pdf"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-omni"

--- a/providers/opencode-go/models/mimo-v2-pro.toml
+++ b/providers/opencode-go/models/mimo-v2-pro.toml
@@ -1,31 +1,4 @@
 name = "MiMo V2 Pro"
-family = "mimo-v2-pro"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 1.00
-output = 3.00
-cache_read = 0.20
-
-[cost.context_over_200k]
-input = 2.00
-output = 6.00
-cache_read = 0.40
-
-[limit]
-context = 1_048_576
-output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-pro"

--- a/providers/opencode-go/models/mimo-v2.5-pro.toml
+++ b/providers/opencode-go/models/mimo-v2.5-pro.toml
@@ -1,31 +1,4 @@
 name = "MiMo V2.5 Pro"
-family = "mimo-v2.5-pro"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 1.00
-output = 3.00
-cache_read = 0.20
-
-[cost.context_over_200k]
-input = 2.00
-output = 6.00
-cache_read = 0.40
-
-[limit]
-context = 1_048_576
-output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2.5-pro"

--- a/providers/opencode-go/models/mimo-v2.5.toml
+++ b/providers/opencode-go/models/mimo-v2.5.toml
@@ -1,31 +1,4 @@
 name = "MiMo V2.5"
-family = "mimo-v2.5"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 0.40
-output = 2.00
-cache_read = 0.08
-
-[cost.context_over_200k]
-input = 0.80
-output = 4.00
-cache_read = 0.16
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "audio", "pdf"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2.5"

--- a/providers/opencode/models/mimo-v2-omni-free.toml
+++ b/providers/opencode/models/mimo-v2-omni-free.toml
@@ -1,27 +1,10 @@
 name = "MiMo V2 Omni Free"
-family = "mimo-omni-free"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 status = "deprecated"
 
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "xiaomi/mimo-v2-omni"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
-
-[limit]
-context = 262_144
-output = 64_000
-
-[modalities]
-input = ["text", "image", "audio", "pdf"]
-output = ["text"]

--- a/providers/opencode/models/mimo-v2-pro-free.toml
+++ b/providers/opencode/models/mimo-v2-pro-free.toml
@@ -1,27 +1,10 @@
 name = "MiMo V2 Pro Free"
-family = "mimo-pro-free"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 status = "deprecated"
 
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "xiaomi/mimo-v2-pro"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
-
-[limit]
-context = 1_048_576
-output = 64_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
@@ -1,24 +1,7 @@
-name = "MiMo-V2-Flash"
-family = "mimo"
-release_date = "2025-12-14"
-last_updated = "2025-12-14"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-knowledge = "2024-12"
-open_weights = true
+name = "Xiaomi: MiMo-V2-Flash"
 
-[cost]
-input = 0.10
-output = 0.30
-cache_read = 0.01
+[extends]
+from = "xiaomi/mimo-v2-flash"
 
-[limit]
-context = 262_144
-output = 65_536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[interleaved]
+field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-omni.toml
@@ -1,26 +1,7 @@
-name = "MiMo-V2-Omni"
-family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
+name = "Xiaomi: MiMo-V2-Omni"
 
-[cost]
-input = 0.40
-output = 2.00
-cache_read = 0.08
-
-[limit]
-context = 262_144
-output = 65_536
-
-[modalities]
-input = ["text", "image", "video", "audio"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-omni"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-pro.toml
@@ -1,26 +1,7 @@
-name = "MiMo-V2-Pro"
-family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
+name = "Xiaomi: MiMo-V2-Pro"
 
-[cost]
-input = 1.00
-output = 3.00
-cache_read = 0.20
-
-[limit]
-context = 1_048_576
-output = 65_536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-pro"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,2 +1,7 @@
+name = "Xiaomi: MiMo-V2.5-Pro"
+
 [extends]
 from = "xiaomi/mimo-v2.5-pro"
+
+[interleaved]
+field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2.5.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2.5.toml
@@ -1,2 +1,7 @@
+name = "Xiaomi: MiMo-V2.5"
+
 [extends]
 from = "xiaomi/mimo-v2.5"
+
+[interleaved]
+field = "reasoning_details"

--- a/providers/qiniu-ai/models/mimo-v2-flash.toml
+++ b/providers/qiniu-ai/models/mimo-v2-flash.toml
@@ -1,17 +1,5 @@
 name = "Mimo-V2-Flash"
-release_date = "2025-12-17"
-last_updated = "2025-12-17"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-structured_output = false
-open_weights = false
 
-[limit]
-context = 256_000
-output = 256_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-flash"
+omit = ["cost", "interleaved"]

--- a/providers/qiniu-ai/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/qiniu-ai/models/xiaomi/mimo-v2-flash.toml
@@ -1,17 +1,5 @@
 name = "Xiaomi/Mimo-V2-Flash"
-release_date = "2025-12-26"
-last_updated = "2025-12-26"
-attachment = false
-reasoning = true
-tool_call = false
-temperature = true
-structured_output = false
-open_weights = false
 
-[limit]
-context = 256_000
-output = 256_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-flash"
+omit = ["cost", "interleaved"]

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2-flash.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2-flash.toml
@@ -1,6 +1,3 @@
-name = "MiMo V2 Flash Free"
-status = "deprecated"
-
 [extends]
 from = "xiaomi/mimo-v2-flash"
 

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-pro.toml
@@ -1,2 +1,12 @@
 [extends]
-from = "xiaomi-token-plan-cn/mimo-v2.5-pro"
+from = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[cost.context_over_200k]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5.toml
@@ -1,2 +1,12 @@
 [extends]
-from = "xiaomi-token-plan-cn/mimo-v2.5"
+from = "xiaomi/mimo-v2.5"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[cost.context_over_200k]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-flash.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-flash.toml
@@ -1,6 +1,3 @@
-name = "MiMo V2 Flash Free"
-status = "deprecated"
-
 [extends]
 from = "xiaomi/mimo-v2-flash"
 

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-omni.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-omni.toml
@@ -1,26 +1,7 @@
-name = "MiMo-V2-Omni"
-family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "xiaomi/mimo-v2-omni"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
-
-[limit]
-context = 256_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "audio", "video", "pdf"]
-output = ["text"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
@@ -1,26 +1,7 @@
-name = "MiMo-V2-Pro"
-family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "xiaomi/mimo-v2-pro"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
@@ -1,26 +1,12 @@
-name = "MiMo-V2.5-Pro"
-family = "mimo-v2.5-pro"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[cost.context_over_200k]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
@@ -1,26 +1,12 @@
-name = "MiMo-V2.5"
-family = "mimo-v2.5"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "xiaomi/mimo-v2.5"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "audio", "video", "pdf"]
-output = ["text"]
+[cost.context_over_200k]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2-flash.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2-flash.toml
@@ -1,6 +1,3 @@
-name = "MiMo V2 Flash Free"
-status = "deprecated"
-
 [extends]
 from = "xiaomi/mimo-v2-flash"
 

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-pro.toml
@@ -1,2 +1,12 @@
 [extends]
-from = "xiaomi-token-plan-cn/mimo-v2.5-pro"
+from = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[cost.context_over_200k]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5.toml
@@ -1,2 +1,12 @@
 [extends]
-from = "xiaomi-token-plan-cn/mimo-v2.5"
+from = "xiaomi/mimo-v2.5"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[cost.context_over_200k]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/xiaomi/models/mimo-v2-flash.toml
+++ b/providers/xiaomi/models/mimo-v2-flash.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-12-01"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]
@@ -15,8 +16,8 @@ output = 0.30
 cache_read = 0.01
 
 [limit]
-context = 256_000
-output = 64_000
+context = 262_144
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/xiaomi/models/mimo-v2-omni.toml
+++ b/providers/xiaomi/models/mimo-v2-omni.toml
@@ -6,8 +6,9 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-12"
-open_weights = true
+open_weights = false
 
 [interleaved]
 field = "reasoning_content"
@@ -18,8 +19,8 @@ output = 2.00
 cache_read = 0.08
 
 [limit]
-context = 256_000
-output = 128_000
+context = 262_144
+output = 65_536
 
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]

--- a/providers/xiaomi/models/mimo-v2-pro.toml
+++ b/providers/xiaomi/models/mimo-v2-pro.toml
@@ -6,8 +6,9 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-12"
-open_weights = true
+open_weights = false
 
 [interleaved]
 field = "reasoning_content"
@@ -17,9 +18,14 @@ input = 1.00
 output = 3.00
 cache_read = 0.20
 
+[cost.context_over_200k]
+input = 2.00
+output = 6.00
+cache_read = 0.40
+
 [limit]
-context = 1_000_000
-output = 128_000
+context = 1_048_576
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -6,8 +6,9 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-12"
-open_weights = false
+open_weights = true
 
 [cost]
 input = 1
@@ -24,9 +25,8 @@ context = 1_048_576
 output = 131_072
 
 [modalities]
-input = ["text", "image", "audio", "video", "pdf"]
+input = ["text"]
 output = ["text"]
 
 [interleaved]
 field = "reasoning_content"
-

--- a/providers/xiaomi/models/mimo-v2.5.toml
+++ b/providers/xiaomi/models/mimo-v2.5.toml
@@ -6,8 +6,9 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2024-12"
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.4
@@ -24,9 +25,8 @@ context = 1_048_576
 output = 131_072
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
 
 [interleaved]
 field = "reasoning_content"
-

--- a/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
@@ -1,22 +1,9 @@
-name = "MiMo-V2-Flash"
-release_date = "2025-12-17"
-last_updated = "2025-12-17"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-01-01"
-open_weights = false
+name = "MiMo V2 Flash"
 
-[cost]
-input = 0.10
-output = 0.30
-cache_read = 0.01
+[extends]
+from = "xiaomi/mimo-v2-flash"
+omit = ["interleaved"]
 
 [limit]
 context = 262_000
 output = 64_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
@@ -1,21 +1,9 @@
 name = "MiMo V2 Omni"
-release_date = "2026-03-20"
-last_updated = "2026-03-20"
-attachment = true
-reasoning = false
-temperature = true
-tool_call = true
-knowledge = "2025-01-01"
-open_weights = false
 
-[cost]
-input = 0.40
-output = 2.00
+[extends]
+from = "xiaomi/mimo-v2-omni"
+omit = ["interleaved"]
 
 [limit]
 context = 265_000
 output = 265_000
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
@@ -1,21 +1,9 @@
 name = "MiMo V2 Pro"
-release_date = "2026-03-20"
-last_updated = "2026-03-20"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-01-01"
-open_weights = false
 
-[cost]
-input = 1.50
-output = 4.50
+[extends]
+from = "xiaomi/mimo-v2-pro"
+omit = ["interleaved"]
 
 [limit]
 context = 1_000_000
 output = 256_000
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]


### PR DESCRIPTION
Refactor all MiMo models to extend from the Xiaomi provider as a single source of truth. Draft PR until I can 100% verify I have not made any errors. This PR is the first of potentially a series of commits intended to create single sources of truths for most models behind wrappers.

🤖 PR generated with the help of MiMo V2.5 Pro