### PR TITLE
feat: add DeepSeek-V4-Pro to deepinfra

### DIFF
--- a/providers/deepinfra/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/deepinfra/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -1,0 +1,8 @@
+attachment = false
+
+[extends]
+from = "deepseek/deepseek-v4-pro"
+
+[limit]
+context = 65_536
+output = 65_536


### PR DESCRIPTION
## Summary

- Add DeepSeek-V4-Pro model to deepinfra provider
- 1.6T total parameters (49B active) MoE model
- Pricing: $1.74 in / $3.48 out / $0.145 cache read per 1M tokens
- Context: 65,536 tokens
- Supports reasoning and tool calling