### PR TITLE
feat: add Nemotron 3 Nano Omni model

### DIFF
--- a/providers/nvidia/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/providers/nvidia/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -16,7 +16,7 @@ output = 0.0
 
 [limit]
 context = 256_000
-output = 20_480
+output = 65_536
 
 [modalities]
 input = ["text", "image", "video", "audio"]

--- a/providers/nvidia/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/providers/nvidia/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -1,4 +1,4 @@
-name = "nemotron-3-nano-omni-30b-a3b-reasoning"
+name = "Nemotron 3 Nano Omni"
 family = "nemotron"
 
 release_date = "2026-04-28"

--- a/providers/nvidia/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/providers/nvidia/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -1,0 +1,23 @@
+name = "nemotron-3-nano-omni-30b-a3b-reasoning"
+family = "nemotron"
+
+release_date = "2026-04-28"
+last_updated = "2026-04-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 256_000
+output = 20_480
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/openrouter/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
@@ -1,5 +1,6 @@
 name = "Nemotron 3 Nano Omni (free)"
 family = "nemotron"
+
 release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true

--- a/providers/openrouter/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
@@ -1,0 +1,22 @@
+name = "NVIDIA: Nemotron 3 Nano Omni (free)"
+family = "nemotron"
+release_date = "2026-04-28"
+last_updated = "2026-04-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/openrouter/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
+++ b/providers/openrouter/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
@@ -1,4 +1,4 @@
-name = "NVIDIA: Nemotron 3 Nano Omni (free)"
+name = "Nemotron 3 Nano Omni (free)"
 family = "nemotron"
 release_date = "2026-04-28"
 last_updated = "2026-04-28"


### PR DESCRIPTION
## Summary
Add NVIDIA Nemotron 3 Nano Omni to OpenRouter and NVIDIA NIM.

## Changes
- Added `providers/openrouter/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml`
- Added `providers/nvidia/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml`

## Sources
- OpenRouter: https://openrouter.ai/nvidia/nemotron-3-nano-30b-a3b:free
- NVIDIA NIM: https://build.nvidia.com/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning/modelcard

## Validation
- `bun install`
- `bun validate`