### PR TITLE
fix: Token limits for Amazon Bedrock Kimi K2 models

### DIFF
--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -15,8 +15,8 @@ input = 0.6
 output = 2.5
 
 [limit]
-context = 256_000
-output = 256_000
+context = 262_143
+output = 16_000
 
 [modalities]
 input = ["text"]

--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -1,3 +1,4 @@
+# See https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html
 name = "Kimi K2 Thinking"
 release_date = "2025-12-02"
 family = "kimi-thinking"

--- a/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
+++ b/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
@@ -14,8 +14,8 @@ input = 0.6
 output = 3
 
 [limit]
-context = 256_000
-output = 256_000
+context = 262_143
+output = 16_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
+++ b/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
@@ -1,3 +1,4 @@
+# See https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html
 name = "Kimi K2.5"
 family = "kimi"
 release_date = "2026-02-06"


### PR DESCRIPTION
## Summary

Corrects the context window and max output token limits for two Kimi K2 models on Amazon Bedrock:

- `moonshot.kimi-k2-thinking`
- `moonshotai.kimi-k2.5`

### Changes

| Field | Before | After |
|-------|--------|-------|
| `limit.context` | 256,000 | 262,143 |
| `limit.output` | 256,000 | 16,000 |

The previous values appeared to be placeholders. The corrected values match the actual limits advertised by Amazon Bedrock for these models.

https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html
https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html