### PR TITLE
chutes: add Qwen 3.6 and Gemma 4 models

### DIFF
--- a/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
@@ -1,22 +1,14 @@
+[extends]
+from = "alibaba/qwen3.6-27b"
+
 name = "Qwen3.6 27B TEE"
-family = "qwen"
 release_date = "2026-04-28"
 last_updated = "2026-04-28"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [cost]
 input = 0.5
 output = 2
 cache_read = 0.25
-
-[limit]
-context = 262_144
-output = 65_536
 
 [modalities]
 input = ["text", "image"]

--- a/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
@@ -1,0 +1,26 @@
+name = "Qwen3.6 27B TEE"
+family = "qwen"
+release_date = "2026-04-28"
+last_updated = "2026-04-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.5
+output = 2
+cache_read = 0.25
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
+++ b/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
@@ -1,13 +1,10 @@
+[extends]
+from = "google/gemma-4-31b-it"
+
 name = "Gemma 4 31B Turbo TEE"
-family = "gemma"
 release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [cost]
 input = 0.13
@@ -17,10 +14,6 @@ cache_read = 0.065
 [limit]
 context = 131_072
 output = 65_536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
+++ b/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
@@ -1,0 +1,26 @@
+name = "Gemma 4 31B Turbo TEE"
+family = "gemma"
+release_date = "2026-04-28"
+last_updated = "2026-04-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.13
+output = 0.38
+cache_read = 0.065
+
+[limit]
+context = 131_072
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
Adds two live Chutes API models that are currently missing from the models.dev Chutes provider source:

- Qwen/Qwen3.6-27B-TEE
- google/gemma-4-31B-turbo-TEE

Leaves existing unsloth/gemma-3-* entries untouched because they are on the internal hold/removal list.

Validation:
- Parsed new TOMLs with the local Chutes sync parser
- Ran git diff --check
- bun validate skipped locally because Bun is not installed