### PR TITLE
Venice: Update DeepSeek v4 and Qwen 3.6 model pricing and metadata

### DIFF
--- a/providers/venice/models/deepseek-v4-flash.toml
+++ b/providers/venice/models/deepseek-v4-flash.toml
@@ -6,15 +6,16 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-24"
-last_updated = "2026-04-25"
-open_weights = false
+last_updated = "2026-04-29"
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.175
+input = 0.17
 output = 0.35
+cache_read = 0.028
 
 [limit]
 context = 1_000_000

--- a/providers/venice/models/deepseek-v4-pro.toml
+++ b/providers/venice/models/deepseek-v4-pro.toml
@@ -6,15 +6,16 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-24"
-last_updated = "2026-04-24"
-open_weights = false
+last_updated = "2026-04-29"
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 2.175
-output = 4.35
+input = 1.73
+output = 3.796
+cache_read = 0.33
 
 [limit]
 context = 1_000_000

--- a/providers/venice/models/qwen3-6-27b.toml
+++ b/providers/venice/models/qwen3-6-27b.toml
@@ -1,4 +1,4 @@
-name = "Qwen3.6 27B"
+name = "Qwen 3.6 27B"
 family = "qwen"
 attachment = true
 reasoning = true
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-24"
-last_updated = "2026-04-25"
+last_updated = "2026-04-29"
 open_weights = false
 
 [cost]


### PR DESCRIPTION
- Reduce DeepSeek v4 Flash/Pro input and output pricing
- Add cache_read pricing for DeepSeek v4 models
- Fix Qwen 3.6 27B model name formatting