### PR TITLE
feat(wafer.ai): add DeepSeek V4 Pro

### DIFF
--- a/providers/wafer.ai/models/DeepSeek-V4-Pro.toml
+++ b/providers/wafer.ai/models/DeepSeek-V4-Pro.toml
@@ -1,0 +1,8 @@
+[extends]
+from = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
## Add DeepSeek V4 Pro to Wafer

### Summary
Adds `DeepSeek-V4-Pro` model definition to the `wafer.ai` provider.

### Details
- **File**: `providers/wafer.ai/models/DeepSeek-V4-Pro.toml`
- **Family**: `deepseek-thinking`
- **Context**: 1,000,000 tokens
- **Max output**: 384,000 tokens
- **Reasoning**: yes (thinking mode with interleaved `reasoning_content`)