### PR TITLE
feat: add Mistral Medium 3.5

### DIFF
--- a/providers/mistral/models/mistral-medium-2604.toml
+++ b/providers/mistral/models/mistral-medium-2604.toml
@@ -1,0 +1,22 @@
+name = "Mistral Medium 3.5"
+family = "mistral-medium"
+release_date = "2026-04-29"
+last_updated = "2026-04-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 1.50
+output = 7.50
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/mistral/models/mistral-medium-latest.toml
+++ b/providers/mistral/models/mistral-medium-latest.toml
@@ -1,22 +1,4 @@
 name = "Mistral Medium (latest)"
-family = "mistral-medium"
-release_date = "2025-05-07"
-last_updated = "2025-05-10"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2025-05"
-tool_call = true
-open_weights = true
 
-[cost]
-input = 0.40
-output = 2.00
-
-[limit]
-context = 128_000
-output = 16_384
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+[extends]
+from = "mistral/mistral-medium-2604"

--- a/providers/nvidia/models/mistralai/mistral-medium-3.5-128b.toml
+++ b/providers/nvidia/models/mistralai/mistral-medium-3.5-128b.toml
@@ -1,0 +1,8 @@
+name = "Mistral Medium 3.5 128B"
+
+[extends]
+from = "mistral/mistral-medium-2604"
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/openrouter/models/mistralai/mistral-medium-3.5.toml
+++ b/providers/openrouter/models/mistralai/mistral-medium-3.5.toml
@@ -1,4 +1,0 @@
-name = "Mistral Medium 3.5"
-
-[extends]
-from = "mistral/mistral-medium-2604"

--- a/providers/openrouter/models/mistralai/mistral-medium-3.5.toml
+++ b/providers/openrouter/models/mistralai/mistral-medium-3.5.toml
@@ -1,0 +1,4 @@
+name = "Mistral Medium 3.5"
+
+[extends]
+from = "mistral/mistral-medium-2604"


### PR DESCRIPTION
- add the new `mistral-medium-2604` model entry for Mistral Medium 3.5
- switch `mistral-medium-latest` to extend that base definition instead of duplicating it
- add NVIDIA NIM's `mistral-medium-3.5-128b`