### PR TITLE
feat(provider): add Step Plan provider

### DIFF
--- a/providers/step-plan/models/step-1-32k.toml
+++ b/providers/step-plan/models/step-1-32k.toml
@@ -1,0 +1,23 @@
+name = "Step 1 (32K)"
+release_date = "2025-01-01"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-06"
+open_weights = false
+
+[cost]
+input = 2.05
+output = 9.59
+cache_read = 0.41
+
+[limit]
+context = 32_768
+input = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/step-plan/models/step-2-16k.toml
+++ b/providers/step-plan/models/step-2-16k.toml
@@ -1,0 +1,23 @@
+name = "Step 2 (16K)"
+release_date = "2025-01-01"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-06"
+open_weights = false
+
+[cost]
+input = 5.21
+output = 16.44
+cache_read = 1.04
+
+[limit]
+context = 16_384
+input = 16_384
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/step-plan/models/step-3.5-flash-2603.toml
+++ b/providers/step-plan/models/step-3.5-flash-2603.toml
@@ -1,0 +1,23 @@
+name = "Step 3.5 Flash 2603"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.02
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/step-plan/models/step-3.5-flash.toml
+++ b/providers/step-plan/models/step-3.5-flash.toml
@@ -1,0 +1,23 @@
+name = "Step 3.5 Flash"
+release_date = "2026-01-29"
+last_updated = "2026-02-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.096
+output = 0.288
+cache_read = 0.019
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/step-plan/provider.toml
+++ b/providers/step-plan/provider.toml
@@ -1,0 +1,5 @@
+name = "Step Plan"
+env = ["STEPFUN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://platform.stepfun.ai"
+api = "https://api.stepfun.ai/step_plan/v1"


### PR DESCRIPTION
## Summary
- add a dedicated `step-plan` provider with display name `Step Plan`
- set Step Plan endpoint to `https://api.stepfun.ai/step_plan/v1`
- include Step Plan model definitions (`step-1-32k`, `step-2-16k`, `step-3.5-flash`, `step-3.5-flash-2603`)

## Why
Step Plan API keys are scoped to the Step Plan endpoint and should be represented as a separate provider entry to avoid endpoint mismatch with the existing `stepfun` provider.