### PR TITLE
Venice: Update Kimi K2.5 and K2.6 pricing and dates

### DIFF
--- a/providers/venice/models/kimi-k2-5.toml
+++ b/providers/venice/models/kimi-k2-5.toml
@@ -7,7 +7,7 @@ structured_output = true
 temperature = true
 knowledge = "2024-04"
 release_date = "2026-01-27"
-last_updated = "2026-04-12"
+last_updated = "2026-04-30"
 open_weights = false
 
 [interleaved]
@@ -16,7 +16,7 @@ field = "reasoning_content"
 [cost]
 input = 0.56
 output = 3.5
-cache_read = 0.11
+cache_read = 0.22
 
 [limit]
 context = 256_000

--- a/providers/venice/models/kimi-k2-6.toml
+++ b/providers/venice/models/kimi-k2-6.toml
@@ -6,16 +6,16 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-20"
-last_updated = "2026-04-24"
+last_updated = "2026-04-30"
 open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.7448
+input = 0.85
 output = 4.655
-cache_read = 0.1463
+cache_read = 0.22
 
 [limit]
 context = 256_000


### PR DESCRIPTION
- Bump kimi-k2-5 cache_read from 0.11 to 0.22
- Bump kimi-k2-6 input from 0.7448 to 0.85 and cache_read from 0.1463 to 0.22