### PR TITLE
feat: add Mistral Medium 3.5 128B to berget.ai

### DIFF
--- a/providers/berget/models/mistralai/Mistral-Medium-3.5-128B.toml
+++ b/providers/berget/models/mistralai/Mistral-Medium-3.5-128B.toml
@@ -1,0 +1,23 @@
+name = "Mistral Medium 3.5 128B"
+family = "mistral-medium"
+release_date = "2026-04-29"
+last_updated = "2026-04-29"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-04"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 1.65
+output = 5.5
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["image", "text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add Mistral Medium 3.5 128B model to berget.ai provider

### New model:
- **Mistral Medium 3.5 128B** (`mistralai/Mistral-Medium-3.5-128B`)
  - Release date: 2026-04-29
  - Pricing: $1.65/M input, $5.50/M output (EUR→USD conversion)
  - Context: 262,144 tokens (256K)
  - Output: 131,072 tokens
  - Vision support (image input)
  - Function calling, JSON mode, structured output
  - Open weights