### PR TITLE
feat(dinference): add GLM-5.1 and MiniMax-M2.5 models

### DIFF
--- a/providers/dinference/models/glm-4.7.toml
+++ b/providers/dinference/models/glm-4.7.toml
@@ -1,16 +1,6 @@
-name = "GLM-4.7"
-family = "glm"
-release_date = "2025-12"
-last_updated = "2025-12"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-04"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "zai/glm-4.7"
+omit = ["cost.cache_read", "cost.cache_write"]
 
 [cost]
 input = 0.45
@@ -19,7 +9,3 @@ output = 1.65
 [limit]
 context = 200_000
 output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/dinference/models/glm-5.1.toml
+++ b/providers/dinference/models/glm-5.1.toml
@@ -1,0 +1,25 @@
+name = "GLM-5.1"
+family = "glm"
+release_date = "2026-02"
+last_updated = "2026-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.25
+output = 3.89
+
+[limit]
+context = 200_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/dinference/models/glm-5.1.toml
+++ b/providers/dinference/models/glm-5.1.toml
@@ -1,16 +1,6 @@
-name = "GLM-5.1"
-family = "glm"
-release_date = "2026-02"
-last_updated = "2026-02"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-04"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "zhipuai/glm-5.1"
+omit = ["cost.cache_read", "cost.cache_write"]
 
 [cost]
 input = 1.25
@@ -19,7 +9,3 @@ output = 3.89
 [limit]
 context = 200_000
 output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/dinference/models/glm-5.toml
+++ b/providers/dinference/models/glm-5.toml
@@ -1,16 +1,6 @@
-name = "GLM-5"
-family = "glm"
-release_date = "2026-02"
-last_updated = "2026-02"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-04"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "zhipuai/glm-5"
+omit = ["cost.cache_read", "cost.cache_write"]
 
 [cost]
 input = 0.75
@@ -19,7 +9,3 @@ output = 2.40
 [limit]
 context = 200_000
 output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/dinference/models/minimax-m2.5.toml
+++ b/providers/dinference/models/minimax-m2.5.toml
@@ -1,12 +1,6 @@
-name = "MiniMax-M2.5"
-family = "minimax"
-release_date = "2026-02"
-last_updated = "2026-02"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
+[extends]
+from = "minimax/MiniMax-M2.5"
+omit = ["cost.cache_read", "cost.cache_write"]
 
 [cost]
 input = 0.22
@@ -15,7 +9,3 @@ output = 0.88
 [limit]
 context = 200_000
 output = 32_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/dinference/models/minimax-m2.5.toml
+++ b/providers/dinference/models/minimax-m2.5.toml
@@ -1,0 +1,21 @@
+name = "MiniMax-M2.5"
+family = "minimax"
+release_date = "2026-02"
+last_updated = "2026-02"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 0.88
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Add GLM-5.1 model configuration (200K context, reasoning, tool calling)
- Add MiniMax-M2.5 model configuration (200K context, reasoning, tool calling)

## Model Details

| Model | Context | Output | Input Price | Output Price |
|-------|---------|--------|-------------|--------------|
| GLM-5.1 | 200K | 128K | $1.25/M | $3.89/M |
| MiniMax-M2.5 | 200K | 32K | $0.22/M | $0.88/M |
