### PR TITLE
fix(github-copilot): correct Claude Opus 4.5/4.6/4.7 token limits

### DIFF
--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -14,9 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 160_000
+context = 200_000
 output = 32_000
-input = 128_000
+input = 168_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-opus-4.6.toml
+++ b/providers/github-copilot/models/claude-opus-4.6.toml
@@ -14,9 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 144_000
-output = 64_000
-input = 128_000
+context = 200_000
+output = 32_000
+input = 168_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/github-copilot/models/claude-opus-4.7.toml
+++ b/providers/github-copilot/models/claude-opus-4.7.toml
@@ -14,9 +14,9 @@ input = 0
 output = 0
 
 [limit]
-context = 144_000
-output = 64_000
-input = 128_000
+context = 200_000
+output = 32_000
+input = 168_000
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
## Summary

The token limits for `claude-opus-4.5`, `claude-opus-4.6`, and `claude-opus-4.7` under the `github-copilot` provider don't match what the live Copilot API (`https://api.githubcopilot.com/models`) response. 

## Source

Values verified against the GitHub Copilot `/models` endpoint. Example response for `claude-opus-4.7`:

```json
{
  "id": "claude-opus-4.7",
  "capabilities": {
    "limits": {
      "max_context_window_tokens": 200000,
      "max_prompt_tokens": 168000,
      "max_output_tokens": 32000,
      "max_non_streaming_output_tokens": 16000
    }
  }
}
```