### PR TITLE
feat(llmgateway): add gpt-5.5, gpt-5.5-pro, qwen3.6-35b-a3b, qwen3.6-plus, qwen3.6-max-preview

### DIFF
--- a/providers/llmgateway/models/gpt-5.5-pro.toml
+++ b/providers/llmgateway/models/gpt-5.5-pro.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5.5-pro"

--- a/providers/llmgateway/models/gpt-5.5.toml
+++ b/providers/llmgateway/models/gpt-5.5.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5.5"

--- a/providers/llmgateway/models/qwen3.6-35b-a3b.toml
+++ b/providers/llmgateway/models/qwen3.6-35b-a3b.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "alibaba/qwen3.6-35b-a3b"

--- a/providers/llmgateway/models/qwen3.6-max-preview.toml
+++ b/providers/llmgateway/models/qwen3.6-max-preview.toml
@@ -1,0 +1,23 @@
+name = "Qwen3.6 Max Preview"
+family = "qwen"
+release_date = "2026-04-20"
+last_updated = "2026-04-20"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.30
+output = 7.80
+cache_read = 0.13
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llmgateway/models/qwen3.6-plus.toml
+++ b/providers/llmgateway/models/qwen3.6-plus.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "alibaba/qwen3.6-plus"


### PR DESCRIPTION
## Summary
Adds 5 new text models recently launched on LLM Gateway (verified against `api.llmgateway.io/v1/models`):

- **gpt-5.5** — extends `openai/gpt-5.5`
- **gpt-5.5-pro** — extends `openai/gpt-5.5-pro`
- **qwen3.6-35b-a3b** — extends `alibaba/qwen3.6-35b-a3b`
- **qwen3.6-plus** — extends `alibaba/qwen3.6-plus`
- **qwen3.6-max-preview** — defined inline (no parent in `alibaba/`); released 2026-04-20, 256K ctx, $1.30/$7.80 per 1M, text-only, reasoning + tools

## Test plan
- [ ] `bun run generate` succeeds and emits the 5 new models
- [ ] Spot-check that extends-based models inherit pricing/limits/modalities correctly from their parents
- [ ] `qwen3.6-max-preview` renders with correct cost ($1.30 in / $7.80 out / $0.13 cache_read), 262144 context, text-only modalities

🤖 Generated with [Claude Code](https://claude.com/claude-code)