### PR TITLE
Remove Fire Pass from Fireworks Kimi K2.5 Turbo description

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p5-turbo.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p5-turbo.toml
@@ -1,4 +1,4 @@
-name = "Kimi K2.5 Turbo (firepass)"
+name = "Kimi K2.5 Turbo"
 family = "kimi-thinking"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"


### PR DESCRIPTION
The Kimi K2.5 Turbo model is independent of Fire Pass and tagging the model name with `(firepass)` is confusing users.