### PR TITLE
feat: Add DiscreteStack provider

### DIFF
--- a/providers/discretestack/logo.svg
+++ b/providers/discretestack/logo.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.5, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 393.9 328" style="enable-background:new 0 0 393.9 328;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:#E74902;}
+	.st2{fill:#132646;}
+</style>
+<g>
+	<path class="st0" d="M261.6,73.3h-68.8v47.5h68.2c53.7,0,79.7,33.1,79.7,79.8c0,46.2-26,79.8-79.7,79.8H156.7v0.1L8.4,207.3H0v43.2
+		L156.7,328h104.9c79.7,0,132.3-50.6,132.3-127.3C393.9,123.9,341.3,73.3,261.6,73.3z"/>
+	<polygon class="st1" points="156.7,179.7 156.7,224 150.4,224 0,149.6 0,106.3 8.5,106.3 	"/>
+	<polygon class="st1" points="156.7,73.4 156.7,117.7 150.4,117.7 0,43.3 0,0 8.5,0 	"/>
+</g>
+</svg>

--- a/providers/discretestack/models/discretestack-stable-fast.toml
+++ b/providers/discretestack/models/discretestack-stable-fast.toml
@@ -1,0 +1,22 @@
+name = "discretestack-stable-fast"
+family = "glm"
+release_date = "2026-05-01"
+last_updated = "2026-05-01"
+
+reasoning = false
+temperature = true
+tool_call = true
+attachment = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/discretestack/models/discretestack-stable.toml
+++ b/providers/discretestack/models/discretestack-stable.toml
@@ -1,0 +1,22 @@
+name = "discretestack-stable"
+family = "glm"
+release_date = "2026-05-01"
+last_updated = "2026-05-01"
+
+reasoning = true
+temperature = true
+tool_call = true
+attachment = true
+open_weights = true
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 200_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/discretestack/provider.toml
+++ b/providers/discretestack/provider.toml
@@ -1,0 +1,5 @@
+name = "DiscreteStack"
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.discretestack.com/v1"
+env = ["DISCRETESTACK_API_KEY"]
+doc = "https://setup.discretestack.com"


### PR DESCRIPTION
Added DiscreteStack as provider. This should enable easier setup of OpenCode through `/connect` command. 

Run the test locally and it worked:
<img width="682" height="477" alt="Screenshot 2026-05-01 at 9 53 06" src="https://github.com/user-attachments/assets/aa7ec873-e621-4849-a2bc-8096e9497b9e" />
