### PR TITLE
provider(sarvam): add chat models

### DIFF
--- a/providers/sarvam/models/sarvam-105b.toml
+++ b/providers/sarvam/models/sarvam-105b.toml
@@ -13,7 +13,7 @@ field = "reasoning_content"
 
 [limit]
 context = 131_072
-output = 2_048
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/sarvam/models/sarvam-105b.toml
+++ b/providers/sarvam/models/sarvam-105b.toml
@@ -1,0 +1,20 @@
+name = "Sarvam-105B"
+family = "sarvam"
+release_date = "2026-02-18"
+last_updated = "2026-03-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 131_072
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/sarvam/models/sarvam-30b.toml
+++ b/providers/sarvam/models/sarvam-30b.toml
@@ -1,0 +1,20 @@
+name = "Sarvam-30B"
+family = "sarvam"
+release_date = "2026-02-18"
+last_updated = "2026-03-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 65_536
+output = 2_048
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/sarvam/models/sarvam-30b.toml
+++ b/providers/sarvam/models/sarvam-30b.toml
@@ -13,7 +13,7 @@ field = "reasoning_content"
 
 [limit]
 context = 65_536
-output = 2_048
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/sarvam/provider.toml
+++ b/providers/sarvam/provider.toml
@@ -1,0 +1,5 @@
+name = "Sarvam AI"
+env = ["SARVAM_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://docs.sarvam.ai/api-reference-docs/getting-started/models"
+api = "https://api.sarvam.ai/v1"


### PR DESCRIPTION
## summary
- add Sarvam AI as an OpenAI-compatible provider
- add Sarvam-30B and Sarvam-105B chat model metadata
- omit cost because Sarvam publishes pricing in INR while models.dev stores USD pricing

## testing
- bun validate