### PR TITLE
fix(ollama): set minimax-m2.7 context and output limits to match Ollama API

### DIFF
--- a/providers/ollama-cloud/models/minimax-m2.7.toml
+++ b/providers/ollama-cloud/models/minimax-m2.7.toml
@@ -8,8 +8,8 @@ last_updated = "2026-03-18"
 open_weights = true
 
 [limit]
-context = 204800
-output = 131072
+context = 196608
+output = 196608
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Ollama doesn't impose official output limits. The convention in this repo is to set output equal to context. The Ollama API reports `context=196608` for minimax-m2.7, so both context and output should reflect this.

This can be verified with:
```bash
curl -s -X POST https://ollama.com/api/show -H 'Content-Type: application/json' -d '{"model": "minimax-m2.7"}'
```