### PR TITLE
fix(ollama): set glm-5.1 and qwen3.5:397b output limits to match context

### DIFF
--- a/providers/ollama-cloud/models/glm-5.1.toml
+++ b/providers/ollama-cloud/models/glm-5.1.toml
@@ -12,7 +12,7 @@ field = "reasoning_content"
 
 [limit]
 context = 202752
-output = 131072
+output = 202752
 
 [modalities]
 input = ["text"]

--- a/providers/ollama-cloud/models/qwen3.5:397b.toml
+++ b/providers/ollama-cloud/models/qwen3.5:397b.toml
@@ -12,7 +12,7 @@ field = "reasoning_details"
 
 [limit]
 context = 262144
-output = 81920
+output = 262144
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
Ollama doesn't impose official output limits. The convention in this repo is to set output equal to context. GLM-5.1 has context 202,752 and Qwen 3.5 has context 262,144, so their output limits should match.