### PR TITLE
Add hermes-4-70b model for cortecs

### DIFF
--- a/providers/cortecs/models/hermes-4-70b.toml
+++ b/providers/cortecs/models/hermes-4-70b.toml
@@ -1,0 +1,21 @@
+name = "Hermes 4 70B"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+knowledge = "2023-12"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.116
+output = 0.358
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add hermes-4-70b model for Cortecs

## Summary

This PR adds the **Hermes 4 70B** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `hermes-4-70b`
- **Name:** Hermes 4 70B
- **Release Date:** 2025-08-26
- **Knowledge Cutoff:** 2023-12

## Capabilities

- ✅ Reasoning (hybrid-mode reasoning with `<think>` tags)
- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Attachments

## Pricing (EUR)

- **Input:** €0.116 per million tokens
- **Output:** €0.358 per million tokens

## Limits

- **Context Window:** 128,000 tokens
- **Max Output:** 128,000 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field        | Value                     | Source                                                                                                                                                                                                                                                                     |
|--------------|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| name         | Hermes 4 70B              | [NousResearch portal](https://portal.nousresearch.com/models)                                                                                                                                                                                                              |
| release_date | 2025-08-26                | [NousResearch releases](https://nousresearch.com/releases/) — "Hermes‑4‑Llama‑3.1‑70B: 08/26/25"; [benchable.ai](https://benchable.ai/models/nousresearch/hermes-4-70b) — "Aug 26, 2025"; [OpenTools](https://opentools.ai/llms/hermes-4-70b) — "Released August 26, 2025" |
| knowledge    | 2023-12                   | Based on Llama 3.1 70B (knowledge cutoff December 2023); NousResearch confirms "This model is based on Llama-3.1-70B" per [portal](https://portal.nousresearch.com/models)                                                                                                 |
| pricing      | input=0.116, output=0.358 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":0.116,"output_token":0.358,"currency":"EUR"}`                                                                                                                                                  |
| context_size | 128,000                   | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":128000`; [NousResearch portal](https://portal.nousresearch.com/models) — "128k tokens ctx"                                                                                                               |
| reasoning    | true                      | [Hermes 4 website](https://hermes4.nousresearch.com/) — "hybrid-mode reasoning model"; supports `<think>` tag reasoning traces                                                                                                                                             |
| tool_call    | true                      | Cortecs API tags: `["Instruct","Tools"]`; [benchable.ai](https://benchable.ai/models/nousresearch/hermes-4-70b) confirms function calling support                                                                                                                          |
| open_weights | true                      | Based on Llama 3.1 (Meta Llama Community License); available on HuggingFace                                                                                                                                                                                                |

## Notes

- Hermes 4 is a hybrid-mode reasoning model: it can toggle between standard responses and reasoning traces via `<think>` tags.
- The Cortecs API tags do NOT include "Reasoning" explicitly, but the model documentation clearly describes it as a reasoning model. Set `reasoning = true` based on documented capability.
