### PR TITLE
Add llama-3.3-70b-instruct model for cortecs

### DIFF
--- a/providers/cortecs/models/llama-3.3-70b-instruct.toml
+++ b/providers/cortecs/models/llama-3.3-70b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.3 70B Instruct"
+family = "llama"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
+knowledge = "2023-12"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.089
+output = 0.275
+
+[limit]
+context = 131_000
+output = 131_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add llama-3.3-70b-instruct model for Cortecs

## Summary

This PR adds the **Llama 3.3 70B Instruct** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `llama-3.3-70b-instruct`
- **Name:** Llama 3.3 70B Instruct
- **Family:** llama
- **Release Date:** 2024-12-06
- **Knowledge Cutoff:** 2023-12

## Capabilities

- ✅ Reasoning
- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Attachments

## Pricing (EUR)

- **Input:** €0.089 per million tokens
- **Output:** €0.275 per million tokens

## Limits

- **Context Window:** 131,000 tokens
- **Max Output:** 131,000 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field | Value | Source |
|-------|-------|--------|
| name | Llama 3.3 70B Instruct | [Meta announcement](https://ai.meta.com/blog/llama-3-3-70b/) — official Meta Llama 3.3 release |
| release_date | 2024-12-06 | [Meta official release](https://ai.meta.com/blog/llama-3-3-70b/) — December 6, 2024 |
| knowledge | 2023-12 | Standard Llama 3.x series knowledge cutoff (December 2023) |
| pricing | input=0.089, output=0.275 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":0.089,"output_token":0.275,"currency":"EUR"}` |
| context_size | 131,000 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":131000` |
| reasoning | true | Cortecs API tags: `["Instruct","Tools","Reasoning"]` |
| tool_call | true | Cortecs API tags include "Tools" |
| open_weights | true | Meta Llama Community License |
| family | llama | Llama model family by Meta |
