### PR TITLE
Add mixtral-8x7B-instruct-v0.1 model for cortecs

### DIFF
--- a/providers/cortecs/models/mixtral-8x7B-instruct-v0.1.toml
+++ b/providers/cortecs/models/mixtral-8x7B-instruct-v0.1.toml
@@ -1,0 +1,21 @@
+name = "Mixtral 8x7B Instruct v0.1"
+release_date = "2023-12-11"
+last_updated = "2023-12-11"
+knowledge = "2023-09"
+attachment = false
+reasoning = true
+tool_call = false
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.438
+output = 0.68
+
+[limit]
+context = 32_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add mixtral-8x7B-instruct-v0.1 model for Cortecs

## Summary

This PR adds the **Mixtral 8x7B Instruct v0.1** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `mixtral-8x7B-instruct-v0.1`
- **Name:** Mixtral 8x7B Instruct v0.1
- **Release Date:** 2023-12-11
- **Knowledge Cutoff:** 2023-09

## Capabilities

- ✅ Reasoning
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Tool Calling
- ❌ Attachments

## Pricing (EUR)

- **Input:** €0.438 per million tokens
- **Output:** €0.68 per million tokens

## Limits

- **Context Window:** 32,000 tokens
- **Max Output:** 32,000 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field | Value | Source |
|-------|-------|--------|
| name | Mixtral 8x7B Instruct v0.1 | [Mistral AI](https://mistral.ai/news/mixtral-of-experts/) — original Mixtral announcement |
| release_date | 2023-12-11 | Official Mistral AI release date for Mixtral 8x7B (December 2023) |
| knowledge | 2023-09 | Estimated from training data cutoff for models released Dec 2023 |
| pricing | input=0.438, output=0.68 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":0.438,"output_token":0.68,"currency":"EUR"}` |
| context_size | 32,000 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":32000` |
| reasoning | true | Cortecs API tags: `["Instruct","Reasoning"]` |
| tool_call | false | Cortecs API tags: `["Instruct","Reasoning"]` — no "Tools" tag. Mixtral 8x7B v0.1 predates native tool calling support |
| open_weights | true | Apache 2.0 license (original Mistral release) |

## Notes

- Mixtral 8x7B is a sparse mixture-of-experts model with 46.7B total parameters (12.9B active per token).
- This is the v0.1 version — the original release. It does NOT have native tool calling support (that was added in later Mistral models).
- The "Reasoning" tag in the Cortecs API indicates general reasoning capability, not dedicated chain-of-thought reasoning.
