### PR TITLE
Add qwen-2.5-72b-instruct model for cortecs

### DIFF
--- a/providers/cortecs/models/qwen-2.5-72b-instruct.toml
+++ b/providers/cortecs/models/qwen-2.5-72b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen2.5 72B Instruct"
+family = "qwen"
+release_date = "2024-09-19"
+last_updated = "2024-09-19"
+knowledge = "2024-06"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.062
+output = 0.231
+
+[limit]
+context = 33_000
+output = 33_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add qwen-2.5-72b-instruct model for Cortecs

## Summary

This PR adds the **Qwen2.5 72B Instruct** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `qwen-2.5-72b-instruct`
- **Name:** Qwen2.5 72B Instruct
- **Family:** qwen
- **Release Date:** 2024-09-19
- **Knowledge Cutoff:** 2024-06

## Capabilities

- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Reasoning
- ❌ Attachments

## Pricing (EUR)

- **Input:** €0.062 per million tokens
- **Output:** €0.231 per million tokens

## Limits

- **Context Window:** 33,000 tokens
- **Max Output:** 33,000 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field | Value | Source |
|-------|-------|--------|
| name | Qwen2.5 72B Instruct | [HuggingFace model card](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct) |
| release_date | 2024-09-19 | [Qwen blog](https://qwenlm.github.io/blog/qwen2.5) — "September 2024"; [upend.ai](https://upend.ai/qwen-2.5-72b-instruct) — "Release: 2024-09-19" |
| knowledge | 2024-06 | Estimated from training data cutoff for Qwen2.5 series (released Sep 2024, data cutoff ~mid 2024) |
| pricing | input=0.062, output=0.231 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":0.062,"output_token":0.231,"currency":"EUR"}` |
| context_size | 33,000 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":33000` (note: model natively supports 131K but Cortecs limits to 33K) |
| reasoning | false | Cortecs API tags: `["Instruct","Tools","Code"]` — no "Reasoning" tag |
| tool_call | true | Cortecs API tags include "Tools" |
| open_weights | true | Apache 2.0 license per [HuggingFace](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct) |
| family | qwen | Qwen model family by Alibaba Cloud |
