### PR TITLE
Add qwen3-235b-a22b-instruct-2507 model for cortecs

### DIFF
--- a/providers/cortecs/models/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/cortecs/models/qwen3-235b-a22b-instruct-2507.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 235B A22B Instruct 2507"
+family = "qwen"
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+knowledge = "2025-04"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.062
+output = 0.408
+
+[limit]
+context = 131_000
+output = 131_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add qwen3-235b-a22b-instruct-2507 model for Cortecs

## Summary

This PR adds the **Qwen3 235B A22B Instruct 2507** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `qwen3-235b-a22b-instruct-2507`
- **Name:** Qwen3 235B A22B Instruct 2507
- **Family:** qwen
- **Release Date:** 2025-07-23
- **Knowledge Cutoff:** 2025-04

## Capabilities

- ✅ Reasoning
- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Attachments

## Pricing (EUR)

- **Input:** €0.062 per million tokens
- **Output:** €0.408 per million tokens

## Limits

- **Context Window:** 131,000 tokens
- **Max Output:** 131,000 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field | Value | Source |
|-------|-------|--------|
| name | Qwen3 235B A22B Instruct 2507 | [HuggingFace model card](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507) |
| release_date | 2025-07-23 | [SiliconFlow](https://www.siliconflow.com/models/qwen-qwen3-235b-a22b-instruct-2507) — "Jul 23, 2025" |
| knowledge | 2025-04 | Estimated from Qwen3 family (Qwen3 Technical Report: arXiv:2505.09388); "2507" in model name indicates July 2025 update of training completed ~April 2025 |
| pricing | input=0.062, output=0.408 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":0.062,"output_token":0.408,"currency":"EUR"}` |
| context_size | 131,000 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":131000` (note: model natively supports 262K but Cortecs shows 131K) |
| reasoning | true | Cortecs API tags: `["Instruct","Tools","Reasoning"]` |
| tool_call | true | Cortecs API tags include "Tools" |
| open_weights | true | Apache 2.0 license per [HuggingFace](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507) |
| family | qwen | Qwen model family by Alibaba Cloud |

## Notes

- This is the non-thinking mode version of Qwen3-235B-A22B. It does NOT generate `<think>` blocks.
- The "2507" suffix indicates this is the July 2025 update with improved reasoning, instruction following, and long-context understanding.
