### PR TITLE
Add qwen3.5-397b-a17b model for cortecs

### DIFF
--- a/providers/cortecs/models/qwen3.5-397b-a17b.toml
+++ b/providers/cortecs/models/qwen3.5-397b-a17b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 397B A17B"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+knowledge = "2026-01"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.6
+output = 3.6
+
+[limit]
+context = 250_000
+output = 250_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add qwen3.5-397b-a17b model for Cortecs

## Summary

This PR adds the **Qwen3.5 397B A17B** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `qwen3.5-397b-a17b`
- **Name:** Qwen3.5 397B A17B
- **Family:** qwen
- **Release Date:** 2026-02-16
- **Knowledge Cutoff:** 2026-01

## Capabilities

- ✅ Reasoning
- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Attachments (text-only on Cortecs)

## Pricing (EUR)

- **Input:** €0.60 per million tokens
- **Output:** €3.60 per million tokens

## Limits

- **Context Window:** 250,000 tokens
- **Max Output:** 250,000 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field | Value | Source |
|-------|-------|--------|
| name | Qwen3.5 397B A17B | [HuggingFace model card](https://huggingface.co/Qwen/Qwen3.5-397B-A17B) |
| release_date | 2026-02-16 | [QwenLM GitHub README](https://github.com/QwenLM/Qwen3.5) — "2026-02-16: We release Qwen3.5. The first release includes a 397B-A17B MoE model." |
| knowledge | 2026-01 | [LLM Registry](https://llm-registry.com/model/qwen-3-5-397b-a17b) — "Training: 2026-01" |
| pricing | input=0.6, output=3.6 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":0.6,"output_token":3.6,"currency":"EUR"}` |
| context_size | 250,000 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":250000` |
| reasoning | true | Cortecs API tags: `["Instruct","Reasoning","Tools","Code"]` |
| tool_call | true | Cortecs API tags include "Tools" |
| open_weights | true | Apache 2.0 license, confirmed via [HuggingFace](https://huggingface.co/Qwen/Qwen3.5-397B-A17B) |
| family | qwen | Qwen model family by Alibaba Cloud |
| attachment | false | Cortecs API tags do not include "Image" for this model |
