### PR TITLE
feat(digitalocean): add deepseek-v4-pro model

### DIFF
--- a/providers/digitalocean/models/deepseek-v4-pro.toml
+++ b/providers/digitalocean/models/deepseek-v4-pro.toml
@@ -1,0 +1,26 @@
+name = "DeepSeek V4 Pro"
+family = "deepseek-thinking"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-05"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.74
+output = 3.48
+
+[limit]
+context = 1_048_576
+output = 393_216
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds the DeepSeek V4 Pro model to DigitalOcean provider.

Pricing: $1.74/1M input, $3.48/1M output. Limits: 1,048,576 context, 393,216 output.