### PR TITLE
Add Poolside Laguna series models (OpenRouter)

### DIFF
--- a/providers/openrouter/models/poolside/laguna-m.1:free.toml
+++ b/providers/openrouter/models/poolside/laguna-m.1:free.toml
@@ -1,0 +1,25 @@
+name = "Laguna M.1"
+release_date = "2026-04-28"
+last_updated = "2026-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0
+cache_read = 0.0
+cache_write = 0.0
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/poolside/laguna-xs.2:free.toml
+++ b/providers/openrouter/models/poolside/laguna-xs.2:free.toml
@@ -1,0 +1,25 @@
+name = "Laguna XS.2"
+release_date = "2026-04-28"
+last_updated = "2026-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0
+cache_read = 0.0
+cache_write = 0.0
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adding Poolside's latest Laguna M.1 and XS.2 models via OpenRouter:

https://poolside.ai/blog/introducing-laguna-xs2-m1