### PR TITLE
provider(baseten): use extends for kimi-k2.6 instead of duplicating fields

### DIFF
--- a/providers/baseten/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.6.toml
@@ -1,27 +1,2 @@
-name = "Kimi K2.6"
-family = "kimi-k2.6"
-release_date = "2026-04-21"
-last_updated = "2026-04-21"
-attachment = true
-reasoning = true
-structured_output = true
-temperature = true
-tool_call = true
-knowledge = "2025-01"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 0.95
-output = 4.0
-cache_read = 0.16
-
-[limit]
-context = 262_144
-output = 262_144
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]
+[extends]
+from = "moonshotai/kimi-k2.6"


### PR DESCRIPTION
## Summary
- `providers/baseten/models/moonshotai/Kimi-K2.6.toml` was a byte-for-byte duplicate of `providers/moonshotai/models/kimi-k2.6.toml`. Replaced it with a one-line `[extends]` so future upstream changes (pricing, dates, modalities) propagate automatically.

## Test plan
- [x] `bun validate` passes
- [x] Verified the merged JSON output for `baseten.models["moonshotai/Kimi-K2.6"]` is identical to the previous standalone definition (same name, family, dates, capabilities, cost, limits, modalities, interleaved field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)