### PR TITLE
provider(clarifai): add Kimi-K2.6 (moonshotai/chat-completion)

### DIFF
--- a/providers/clarifai/models/moonshotai/chat-completion/models/Kimi-K2_6.toml
+++ b/providers/clarifai/models/moonshotai/chat-completion/models/Kimi-K2_6.toml
@@ -2,10 +2,6 @@
 from = "moonshotai/kimi-k2.6"
 omit = ["cost.cache_read"]
 
-[cost]
-input = 1.50
-output = 1.50
-
 [modalities]
 input = ["text", "image"]
 output = ["text"]

--- a/providers/clarifai/models/moonshotai/chat-completion/models/Kimi-K2_6.toml
+++ b/providers/clarifai/models/moonshotai/chat-completion/models/Kimi-K2_6.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "moonshotai/kimi-k2.6"
+omit = ["cost.cache_read"]
+
+[cost]
+input = 1.50
+output = 1.50
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Adds Moonshot's Kimi K2.6 to the Clarifai provider, hosted at [clarifai.com/moonshotai/chat-completion/models/Kimi-K2_6](https://clarifai.com/moonshotai/chat-completion/models/Kimi-K2_6).

The entry uses `[extends]` from the canonical `moonshotai/kimi-k2.6` and overrides only the fields that differ on Clarifai:

- `[modalities]`: `text` + `image` only. Clarifai's model notes describe text and image inputs; video isn't documented as supported there.
- `omit = ["cost.cache_read"]`: Clarifai doesn't expose cache pricing for this model.

Pricing on Clarifai (\$0.95 / \$4.00 per 1M tokens) matches the upstream `moonshotai/kimi-k2.6` exactly, so the `[cost]` block is inherited as-is — no override needed.

## Test plan
- [x] `bun validate` passes
- [x] Merged JSON has `id = "moonshotai/chat-completion/models/Kimi-K2_6"` (matches the literal Clarifai model slug used in the OpenAI-compatible endpoint)
- [x] Confirmed model exists on Clarifai (status: trained and ready, created 2026-04-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)