### PR TITLE
Add deepseek-v3.2 model for cortecs

### DIFF
--- a/providers/cortecs/models/deepseek-v3.2.toml
+++ b/providers/cortecs/models/deepseek-v3.2.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+knowledge = "2024-07"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.266
+output = 0.444
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add deepseek-v3.2 model for Cortecs

## Summary

This PR adds the **DeepSeek V3.2** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `deepseek-v3.2`
- **Name:** DeepSeek V3.2
- **Family:** deepseek
- **Release Date:** 2025-12-01
- **Knowledge Cutoff:** 2024-07

## Capabilities

- ✅ Reasoning
- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Attachments

## Pricing (EUR)

- **Input:** €0.266 per million tokens
- **Output:** €0.444 per million tokens

## Limits

- **Context Window:** 163,840 tokens
- **Max Output:** 163,840 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field | Value | Source |
|-------|-------|--------|
| name | DeepSeek V3.2 | Consistent with other providers (e.g., Azure `deepseek-v3.2.toml` uses `name = "DeepSeek-V3.2"`) |
| family | deepseek | Consistent with other providers (Azure uses `family = "deepseek"`) |
| release_date | 2025-12-01 | Confirmed by Azure provider config |
| knowledge | 2024-07 | Consistent with DeepSeek V3 model family; confirmed by Azure provider config |
| pricing | input=0.266, output=0.444 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":0.266,"output_token":0.444,"currency":"EUR"}` |
| context_size | 163,840 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":163840` |
| reasoning | true | Cortecs API tags: `["Instruct","Tools","Reasoning"]` |
| tool_call | true | Cortecs API tags include "Tools" |
| open_weights | true | MIT License per DeepSeek |

## Notes

- DeepSeek V3.2 supports both thinking and non-thinking modes (hybrid reasoning).
- Cortecs pricing is significantly lower than Azure ($0.58/$1.68) for the same model.
