### PR TITLE
Add deepseek-r1-0528 model for cortecs

### DIFF
--- a/providers/cortecs/models/deepseek-r1-0528.toml
+++ b/providers/cortecs/models/deepseek-r1-0528.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek R1 0528"
+family = "deepseek-thinking"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+knowledge = "2024-07"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.585
+output = 2.307
+
+[limit]
+context = 164_000
+output = 164_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add deepseek-r1-0528 model for Cortecs

## Summary

This PR adds the **DeepSeek R1 0528** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `deepseek-r1-0528`
- **Name:** DeepSeek R1 0528
- **Family:** deepseek-thinking
- **Release Date:** 2025-05-28
- **Knowledge Cutoff:** 2024-07

## Capabilities

- ✅ Reasoning
- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Attachments

## Pricing (EUR)

- **Input:** €0.585 per million tokens
- **Output:** €2.307 per million tokens

## Limits

- **Context Window:** 164,000 tokens
- **Max Output:** 164,000 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field | Value | Source |
|-------|-------|--------|
| name | DeepSeek R1 0528 | [DeepSeek announcement](https://api-docs.deepseek.com/news/news0528) — "DeepSeek-R1-0528" |
| family | deepseek-thinking | Consistent with other providers (e.g., Azure `deepseek-r1-0528.toml` uses `family = "deepseek-thinking"`) |
| release_date | 2025-05-28 | Official DeepSeek release (May 28, 2025); confirmed by Azure provider config |
| knowledge | 2024-07 | Consistent with DeepSeek model family; confirmed by Azure provider config |
| pricing | input=0.585, output=2.307 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":0.585,"output_token":2.307,"currency":"EUR"}` |
| context_size | 164,000 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":164000` |
| reasoning | true | Cortecs API tags: `["Instruct","Tools","Reasoning"]`; R1 is DeepSeek's dedicated reasoning model |
| tool_call | true | Cortecs API tags include "Tools" |
| open_weights | true | MIT License per [HuggingFace](https://huggingface.co/deepseek-ai/DeepSeek-R1-0528) |
