### PR TITLE
Add deepseek-v4-pro model for cortecs

### DIFF
--- a/providers/cortecs/models/deepseek-v4-pro.toml
+++ b/providers/cortecs/models/deepseek-v4-pro.toml
@@ -1,0 +1,25 @@
+name = "DeepSeek V4 Pro"
+family = "deepseek-thinking"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+knowledge = "2025-05"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.553
+output = 3.106
+
+[limit]
+context = 1_048_576
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add deepseek-v4-pro model for Cortecs

## Summary

This PR adds the **DeepSeek V4 Pro** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `deepseek-v4-pro`
- **Name:** DeepSeek V4 Pro
- **Family:** deepseek-thinking
- **Release Date:** 2026-04-24
- **Knowledge Cutoff:** 2025-05

## Capabilities

- ✅ Reasoning (interleaved `reasoning_content` field)
- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Attachments (text-only for now)

## Pricing (EUR)

- **Input:** €1.553 per million tokens
- **Output:** €3.106 per million tokens

## Limits

- **Context Window:** 1,048,576 tokens (1M)
- **Max Output:** 384,000 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field | Value | Source |
|-------|-------|--------|
| name | DeepSeek V4 Pro | [DeepSeek announcement](https://api-docs.deepseek.com/news/news260424) — "DeepSeek-V4-Pro" |
| family | deepseek-thinking | Consistent with other providers (DeepSeek official uses `family = "deepseek-thinking"`) |
| release_date | 2026-04-24 | [DeepSeek announcement](https://api-docs.deepseek.com/news/news260424) — April 24, 2026; [CNBC](https://www.cnbc.com/2026/04/24/deepseek-v4-llm-preview-open-source-ai-competition-china.html) confirms same date |
| knowledge | 2025-05 | Consistent with DeepSeek official provider config |
| pricing | input=1.553, output=3.106 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":1.553,"output_token":3.106,"currency":"EUR"}` |
| context_size | 1,048,576 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":1048576`; [DeepSeek](https://api-docs.deepseek.com/news/news260424) — "1M context" |
| output limit | 384,000 | Consistent with DeepSeek official provider (output = 384K) |
| reasoning | true | Cortecs API tags: `["Instruct","Tools","Reasoning"]`; supports thinking/non-thinking dual modes |
| tool_call | true | Cortecs API tags include "Tools" |
| open_weights | true | MIT License per [HuggingFace](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro) |

## Notes

- DeepSeek-V4-Pro: 1.6T total parameters / 49B active (MoE architecture).
- Supports dual modes: Thinking (chain-of-thought) and Non-Thinking.
- Open-source SOTA in Agentic Coding benchmarks per DeepSeek.
- Text-only for now; multimodal capabilities are in development.
