### PR TITLE
Add deepseek-v4-flash model for cortecs

### DIFF
--- a/providers/cortecs/models/deepseek-v4-flash.toml
+++ b/providers/cortecs/models/deepseek-v4-flash.toml
@@ -1,0 +1,25 @@
+name = "DeepSeek V4 Flash"
+family = "deepseek-flash"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+knowledge = "2025-05"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.133
+output = 0.266
+
+[limit]
+context = 1_048_576
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# PR: Add deepseek-v4-flash model for Cortecs

## Summary

This PR adds the **DeepSeek V4 Flash** model configuration for the Cortecs provider.

## Model Details

- **Model ID:** `deepseek-v4-flash`
- **Name:** DeepSeek V4 Flash
- **Family:** deepseek-flash
- **Release Date:** 2026-04-24
- **Knowledge Cutoff:** 2025-05

## Capabilities

- ✅ Reasoning (interleaved `reasoning_content` field)
- ✅ Tool Calling
- ✅ Temperature Control
- ✅ Open Weights
- ❌ Attachments (text-only for now)

## Pricing (EUR)

- **Input:** €0.133 per million tokens
- **Output:** €0.266 per million tokens

## Limits

- **Context Window:** 1,048,576 tokens (1M)
- **Max Output:** 384,000 tokens

## Modalities

- **Input:** Text
- **Output:** Text

## Validation

- ✅ Configuration validated with `bun validate`
- ✅ Schema compliance verified

---

## Sources

| Field | Value | Source |
|-------|-------|--------|
| name | DeepSeek V4 Flash | [DeepSeek announcement](https://api-docs.deepseek.com/news/news260424) — "DeepSeek-V4-Flash" |
| family | deepseek-flash | Consistent with other providers (DeepSeek official uses `family = "deepseek-flash"`) |
| release_date | 2026-04-24 | [DeepSeek announcement](https://api-docs.deepseek.com/news/news260424) — April 24, 2026 |
| knowledge | 2025-05 | Consistent with DeepSeek official provider config |
| pricing | input=0.133, output=0.266 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"pricing":{"input_token":0.133,"output_token":0.266,"currency":"EUR"}` |
| context_size | 1,048,576 | [Cortecs API](https://api.cortecs.ai/v1/models) — `"context_size":1048576`; [DeepSeek](https://api-docs.deepseek.com/news/news260424) — "1M context" |
| output limit | 384,000 | Consistent with DeepSeek official provider (output = 384K) |
| reasoning | true | Cortecs API tags: `["Instruct","Tools","Reasoning"]`; supports thinking/non-thinking dual modes |
| tool_call | true | Cortecs API tags include "Tools" |
| open_weights | true | MIT License per [HuggingFace](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash) |

## Notes

- DeepSeek-V4-Flash: 284B total parameters / 13B active (MoE architecture).
- Reasoning capabilities closely approach V4-Pro; performs on par on simple Agent tasks.
- Designed for speed and cost efficiency — significantly cheaper than V4-Pro.
- Text-only for now; multimodal capabilities are in development.
- Currently routes `deepseek-chat` (non-thinking) and `deepseek-reasoner` (thinking) on DeepSeek's API.
