### PR TITLE
Add Kimi K2.6 model for NVIDIA provider

### DIFF
--- a/providers/nvidia/models/moonshotai/kimi-k2.6.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,26 @@
+name = "Kimi K2.6"
+family = "kimi-k2.6"
+release_date = "2026-04-21"
+last_updated = "2026-04-21"
+attachment = true
+reasoning = true
+structured_output = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
Adds the Kimi K2.6 model (moonshotai) to the NVIDIA provider.

Based on:
- Moonshot AI provider's kimi-k2.6.toml for model specs
- NVIDIA provider's kimi-k2.5.toml for NVIDIA-specific conventions (free tier pricing)

Key details:
- 256K context window, 256K max output
- Text, image, and video input modalities
- Reasoning support with interleaved reasoning_content field
- Structured output support
- Free tier on NVIDIA NIM (cost: 0.0/0.0)