### PR TITLE
Add Claude Opus 4.7 and GPT-5.5 models for perplexity-agent

### DIFF
--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-7.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,23 @@
+name = "Claude Opus 4.7"
+family = "claude-opus"
+release_date = "2026-04-16"
+last_updated = "2026-04-16"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2026-01-31"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/perplexity-agent/models/openai/gpt-5.5.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.5.toml
@@ -1,0 +1,24 @@
+name = "GPT-5.5"
+family = "gpt"
+release_date = "2026-04-23"
+last_updated = "2026-04-23"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2025-12-01"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Add Claude Opus 4.7 model definition for perplexity-agent provider
- Add GPT-5.5 model definition for perplexity-agent provider

## Details
Pricing and specs sourced from [Perplexity Agent API docs](https://docs.perplexity.ai/docs/agent-api/models).

### Claude Opus 4.7
- Input: $5.00/1M | Output: $25.00/1M | Cache Read: $0.50/1M
- Context: 1M | Output: 128K

### GPT-5.5
- Input: $5.00/1M | Output: $30.00/1M | Cache Read: $0.50/1M
- Context: 1.05M | Input: 922K | Output: 128K

Both follow existing perplexity-agent TOML patterns (full inline definitions, matching sibling model files).