### PR TITLE
fix: use proper GLM family casing for GLM-5V-Turbo

### DIFF
--- a/providers/zai/models/glm-5v-turbo.toml
+++ b/providers/zai/models/glm-5v-turbo.toml
@@ -1,4 +1,4 @@
-name = "glm-5v-turbo"
+name = "GLM-5V-Turbo"
 family = "glm"
 release_date = "2026-04-01"
 last_updated = "2026-04-01"

--- a/providers/zhipuai-coding-plan/models/glm-5v-turbo.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5v-turbo.toml
@@ -1,7 +1,7 @@
 name = "GLM-5V-Turbo"
 family = "glm"
-release_date = "2026-04-02"
-last_updated = "2026-04-02"
+release_date = "2026-04-01"
+last_updated = "2026-04-01"
 attachment = true
 reasoning = true
 temperature = true
@@ -12,13 +12,15 @@ open_weights = false
 field = "reasoning_content"
 
 [cost]
-input = 0.720
-output = 3.200
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
 
 [limit]
-context = 200_000
-output = 131_072
+context = 200000
+output = 131072
 
 [modalities]
-input = ["text", "image", "video", "audio", "pdf"]
+input = ["text", "image", "video", "pdf"]
 output = ["text"]

--- a/providers/zhipuai/models/glm-5v-turbo.toml
+++ b/providers/zhipuai/models/glm-5v-turbo.toml
@@ -1,4 +1,4 @@
-name = "glm-5v-turbo"
+name = "GLM-5V-Turbo"
 family = "glm"
 release_date = "2026-04-01"
 last_updated = "2026-04-01"


### PR DESCRIPTION
## Summary

- Fix lowercase `name = "glm-5v-turbo"` to `name = "GLM-5V-Turbo"` in **zai**, **zhipuai**, and **302ai** providers to follow the GLM family naming convention (e.g. `GLM-5-Turbo`, `GLM-4.7`, `GLM-4.6V`)
- Add `GLM-5V-Turbo` back to **zhipuai-coding-plan** provider (was removed in #1589)

## Changes

| File | Change |
|------|--------|
| `providers/zai/models/glm-5v-turbo.toml` | `name` fix |
| `providers/zhipuai/models/glm-5v-turbo.toml` | `name` fix |
| `providers/302ai/models/glm-5v-turbo.toml` | `name` fix |
| `providers/zhipuai-coding-plan/models/glm-5v-turbo.toml` | new file |

Ref: #1589
