### PR TITLE
Venice: Add Grok 4.3 model configuration

### DIFF
--- a/providers/venice/models/grok-4-3.toml
+++ b/providers/venice/models/grok-4-3.toml
@@ -1,0 +1,28 @@
+name = "Grok 4.3"
+family = "grok"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-04-18"
+last_updated = "2026-05-04"
+open_weights = false
+
+[cost]
+input = 1.42
+output = 2.83
+cache_read = 0.23
+
+[cost.context_over_200k]
+input = 2.83
+output = 5.67
+cache_read = 0.45
+
+[limit]
+context = 1_000_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
- Add Grok 4.3 model with 1M context and 32K output
- Configure standard and >200K cost tiers
- Enable text+image input with text output modalities