### PR TITLE
Revert "fix(ollama): set glm-5.1 and qwen3.5:397b output limits to match context"

### DIFF
--- a/providers/ollama-cloud/models/glm-5.1.toml
+++ b/providers/ollama-cloud/models/glm-5.1.toml
@@ -12,7 +12,7 @@ field = "reasoning_content"
 
 [limit]
 context = 202752
-output = 202752
+output = 131072
 
 [modalities]
 input = ["text"]

--- a/providers/ollama-cloud/models/qwen3.5:397b.toml
+++ b/providers/ollama-cloud/models/qwen3.5:397b.toml
@@ -12,7 +12,7 @@ field = "reasoning_details"
 
 [limit]
 context = 262144
-output = 262144
+output = 81920
 
 [modalities]
 input = ["text", "image"]

--- a/providers/ollama-cloud/models/qwen3.5:397b.toml
+++ b/providers/ollama-cloud/models/qwen3.5:397b.toml
@@ -12,7 +12,7 @@ field = "reasoning_details"
 
 [limit]
 context = 262144
-output = 81920
+output = 65536
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
Reverts anomalyco/models.dev#1664

Noticed that glm stopped working when I was using models.dev as a source and sending max tokens:

```
{"error":"max_tokens (202752) exceeds model's maximum output tokens (131072) for model glm-5.1 (ref: dd793cb9-4998-49d4-994b-5a7e0d67e733)"}

{"error":"max_tokens (262144) exceeds model's maximum output tokens (65536) for model qwen3.5:397b (ref: 8554a681-e6a8-45d7-9fdd-433785eb6c67)"}
```

Opencode is sending 32k so its not even using the value anyway but the description of the original PR is wrong, you do get an error in ollama cloud

(also the qwen max tokens is wrong even after the revert so i fixed that too)