### PR TITLE
fix(xiaomi): swap modalities for MiMo-V2.5 and MiMo-V2.5-Pro

### DIFF
--- a/providers/opencode-go/models/mimo-v2.5.toml
+++ b/providers/opencode-go/models/mimo-v2.5.toml
@@ -27,5 +27,5 @@ context = 1_000_000
 output = 128_000
 
 [modalities]
-input = ["text", "image", "audio", "pdf"]
+input = ["text", "image", "audio", "video"]
 output = ["text"]

--- a/providers/vercel/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2.5-pro.toml
@@ -18,5 +18,5 @@ context = 1_050_000
 output = 131_000
 
 [modalities]
-input = ["text", "image", "pdf"]
+input = ["text"]
 output = ["text"]

--- a/providers/vercel/models/xiaomi/mimo-v2.5.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2.5.toml
@@ -18,5 +18,5 @@ context = 1_050_000
 output = 131_100
 
 [modalities]
-input = ["text", "image", "pdf"]
+input = ["text", "image", "audio", "video"]
 output = ["text"]

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -24,7 +24,7 @@ context = 1_048_576
 output = 131_072
 
 [modalities]
-input = ["text", "image", "audio", "video", "pdf"]
+input = ["text"]
 output = ["text"]
 
 [interleaved]

--- a/providers/xiaomi/models/mimo-v2.5.toml
+++ b/providers/xiaomi/models/mimo-v2.5.toml
@@ -24,7 +24,7 @@ context = 1_048_576
 output = 131_072
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "audio", "video"]
 output = ["text"]
 
 [interleaved]


### PR DESCRIPTION
## Problem

Multiple issues with Xiaomi MiMo V2.5 model modality flags across providers:

1. **MiMo-V2.5 and MiMo-V2.5-Pro modalities are swapped** in the `xiaomi` canonical source (also affects OpenRouter/ZenMux via `extends`)
2. **`pdf` listed as supported input** for V2.5 — MiMo V2.5 does not support direct PDF upload
3. **Vercel provider**: V2.5-Pro incorrectly marked as multimodal
4. **opencode-go / vercel**: V2.5 missing `video` modality

## Correct Modalities

| Model | Input |
|-------|-------|
| MiMo-V2.5 | text, image, audio, video |
| MiMo-V2.5-Pro | text |

## Files Changed (5 files across 3 providers)

- `providers/xiaomi/models/mimo-v2.5.toml`
- `providers/xiaomi/models/mimo-v2.5-pro.toml`
- `providers/opencode-go/models/mimo-v2.5.toml`
- `providers/vercel/models/xiaomi/mimo-v2.5.toml`
- `providers/vercel/models/xiaomi/mimo-v2.5-pro.toml`

OpenRouter and ZenMux providers inherit from `xiaomi` via `extends`, so they are automatically fixed.

Fixes #1708