### PR TITLE
feat(digitalocean): add kimi-k2.6 model

### DIFF
--- a/providers/digitalocean/models/kimi-k2.6.toml
+++ b/providers/digitalocean/models/kimi-k2.6.toml
@@ -1,0 +1,26 @@
+name = "Kimi K2.6"
+family = "kimi"
+release_date = "2026-04-21"
+last_updated = "2026-04-21"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2025-01"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4.00
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Adds Moonshot AI's Kimi K2.6 model to the DigitalOcean provider
- 1T-parameter native multimodal MoE; text + image input, 262K context/output
- Pricing: \$0.95/M input, \$4.00/M output

## Test plan
- [x] `bun validate` passes