### PR TITLE
refactor(kilo/xiaomi): extends mimo models from xiaomi provider

### DIFF
--- a/providers/kilo/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-flash.toml
@@ -1,11 +1,8 @@
 name = "Xiaomi: MiMo-V2-Flash"
-release_date = "2025-12-14"
-last_updated = "2026-03-15"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
+
+[extends]
+from = "xiaomi/mimo-v2-flash"
+omit = ["interleaved"]
 
 [cost]
 input = 0.09
@@ -15,7 +12,3 @@ cache_read = 0.045
 [limit]
 context = 262144
 output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/kilo/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-omni.toml
@@ -1,21 +1,9 @@
 name = "Xiaomi: MiMo-V2-Omni"
-release_date = "2026-03-18"
-last_updated = "2026-04-11"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
 
-[cost]
-input = 0.4
-output = 2
-cache_read = 0.08
+[extends]
+from = "xiaomi/mimo-v2-omni"
+omit = ["interleaved"]
 
 [limit]
 context = 262144
 output = 65536
-
-[modalities]
-input = ["audio", "image", "text", "video"]
-output = ["text"]

--- a/providers/kilo/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-pro.toml
@@ -1,21 +1,5 @@
 name = "Xiaomi: MiMo-V2-Pro"
-release_date = "2026-03-18"
-last_updated = "2026-04-11"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
 
-[cost]
-input = 1
-output = 3
-cache_read = 0.2
-
-[limit]
-context = 1048576
-output = 131072
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-pro"
+omit = ["interleaved"]

--- a/providers/kilo/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,30 +1,4 @@
 name = "Xiaomi: MiMo V2.5 Pro"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 1.00
-output = 3.00
-cache_read = 0.20
-
-[cost.context_over_200k]
-input = 2.00
-output = 6.00
-cache_read = 0.40
-
-[limit]
-context = 1_048_576
-output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2.5-pro"

--- a/providers/kilo/models/xiaomi/mimo-v2.5.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2.5.toml
@@ -1,31 +1,4 @@
 name = "Xiaomi: MiMo-V2.5"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = false
 
-[cost]
-input = 0.4
-output = 2
-cache_read = 0.08
-
-[cost.context_over_200k]
-input = 0.80
-output = 4.00
-cache_read = 0.16
-
-[limit]
-context = 1_048_576
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]
-
-[interleaved]
-field = "reasoning_content"
-
+[extends]
+from = "xiaomi/mimo-v2.5"


### PR DESCRIPTION
Kilo breakout commit of #1631

## Notes

- **MiMo V2 pro context limit changes**: This is because the xiaomi root model for V2 pro currently has an error in its context limit where the numbers are not properly rounded to powers of two. These numbers *must* match because V2 pro **is not open weights** and the only provider for this model is xiaomi and therefore their limits must match