### PR TITLE
refactor(opencode-go): extends mimo models from xiaomi provider

### DIFF
--- a/providers/opencode-go/models/mimo-v2-omni.toml
+++ b/providers/opencode-go/models/mimo-v2-omni.toml
@@ -1,26 +1,4 @@
 name = "MiMo V2 Omni"
-family = "mimo-v2-omni"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 0.40
-output = 2.00
-cache_read = 0.08
-
-[limit]
-context = 262_144
-output = 128_000
-
-[modalities]
-input = ["text", "image", "audio", "pdf"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-omni"

--- a/providers/opencode-go/models/mimo-v2-pro.toml
+++ b/providers/opencode-go/models/mimo-v2-pro.toml
@@ -1,31 +1,4 @@
 name = "MiMo V2 Pro"
-family = "mimo-v2-pro"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 1.00
-output = 3.00
-cache_read = 0.20
-
-[cost.context_over_200k]
-input = 2.00
-output = 6.00
-cache_read = 0.40
-
-[limit]
-context = 1_048_576
-output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-pro"

--- a/providers/opencode-go/models/mimo-v2.5-pro.toml
+++ b/providers/opencode-go/models/mimo-v2.5-pro.toml
@@ -1,31 +1,4 @@
 name = "MiMo V2.5 Pro"
-family = "mimo-v2.5-pro"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 1.00
-output = 3.00
-cache_read = 0.20
-
-[cost.context_over_200k]
-input = 2.00
-output = 6.00
-cache_read = 0.40
-
-[limit]
-context = 1_048_576
-output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2.5-pro"

--- a/providers/opencode-go/models/mimo-v2.5.toml
+++ b/providers/opencode-go/models/mimo-v2.5.toml
@@ -1,31 +1,4 @@
 name = "MiMo V2.5"
-family = "mimo-v2.5"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 0.40
-output = 2.00
-cache_read = 0.08
-
-[cost.context_over_200k]
-input = 0.80
-output = 4.00
-cache_read = 0.16
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "audio", "video"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2.5"


### PR DESCRIPTION
opencode go breakout commit of #1631 

## Notes

- **Context limit changes**: A number of models have had their context windows changed. According to https://opencode.ai/go the provider for MiMo models *is* xiaomi so context windows *should* be the same. Some errors propogate because a few of the models in the xiaomi root provider have context limit errors such as not rounding to powers of two
- **MiMo V2 Pro Pricing**: Currently the Xiaomi provider does not have the correct context_over_200k pricing

I believe these are acceptable regressions/changes as they will be fixed when I create my commit to fix all the minor bugs the xiaomi root provider has