### PR TITLE
refactor(opencode): extends mimo models from xiaomi provider

### DIFF
--- a/providers/opencode/models/mimo-v2-flash-free.toml
+++ b/providers/opencode/models/mimo-v2-flash-free.toml
@@ -1,27 +1,10 @@
 name = "MiMo V2 Flash Free"
-family = "mimo-flash-free"
-release_date = "2025-12-16"
-last_updated = "2025-12-16"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 status = "deprecated"
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 
-[limit]
-context = 262_144
-output = 65_536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-flash"

--- a/providers/opencode/models/mimo-v2-omni-free.toml
+++ b/providers/opencode/models/mimo-v2-omni-free.toml
@@ -1,27 +1,10 @@
 name = "MiMo V2 Omni Free"
-family = "mimo-omni-free"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 status = "deprecated"
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 
-[limit]
-context = 262_144
-output = 64_000
-
-[modalities]
-input = ["text", "image", "audio", "pdf"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-omni"

--- a/providers/opencode/models/mimo-v2-pro-free.toml
+++ b/providers/opencode/models/mimo-v2-pro-free.toml
@@ -1,27 +1,10 @@
 name = "MiMo V2 Pro Free"
-family = "mimo-pro-free"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
 status = "deprecated"
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 
-[limit]
-context = 1_048_576
-output = 64_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-pro"


### PR DESCRIPTION
opencode zen breakout commit of #1631

## Notes

- **Context limit changes**: A number of models have had their context windows changed. This is because of incorrectly rounded context windows in the xiaomi root provider.
- **MiMo V2 Pro limit changes**: this carries the same issue of incorrectly rounded numbers in the root provider. Furthermore, I *believe* the output limit must be listed incorrectly because V2 pro is not open weight and Xiaomi therefore can be the only provider and *must* have the same limits (I think??)