### PR TITLE
refactor(openrouter): extends mimo models from xiaomi provider

### DIFF
--- a/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
@@ -1,24 +1,7 @@
-name = "MiMo-V2-Flash"
-family = "mimo"
-release_date = "2025-12-14"
-last_updated = "2025-12-14"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-knowledge = "2024-12"
-open_weights = true
+name = "Xiaomi: MiMo-V2-Flash"
 
-[cost]
-input = 0.10
-output = 0.30
-cache_read = 0.01
+[extends]
+from = "xiaomi/mimo-v2-flash"
 
-[limit]
-context = 262_144
-output = 65_536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[interleaved]
+field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-omni.toml
@@ -1,26 +1,7 @@
-name = "MiMo-V2-Omni"
-family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
+name = "Xiaomi: MiMo-V2-Omni"
 
-[cost]
-input = 0.40
-output = 2.00
-cache_read = 0.08
-
-[limit]
-context = 262_144
-output = 65_536
-
-[modalities]
-input = ["text", "image", "video", "audio"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-omni"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-pro.toml
@@ -1,26 +1,7 @@
-name = "MiMo-V2-Pro"
-family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
+name = "Xiaomi: MiMo-V2-Pro"
 
-[cost]
-input = 1.00
-output = 3.00
-cache_read = 0.20
-
-[limit]
-context = 1_048_576
-output = 65_536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-pro"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,2 +1,4 @@
+name = "Xiaomi: MiMo-V2.5-Pro"
+
 [extends]
 from = "xiaomi/mimo-v2.5-pro"

--- a/providers/openrouter/models/xiaomi/mimo-v2.5.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2.5.toml
@@ -1,2 +1,7 @@
+name = "Xiaomi: MiMo-V2.5"
+
 [extends]
 from = "xiaomi/mimo-v2.5"
+
+[interleaved]
+field = "reasoning_details"


### PR DESCRIPTION
openrouter breakout commit of #1631

## Notes

- **Context limit changes**: A number of models have had their context windows changed. This is because of incorrectly rounded context windows in the xiaomi root provider.