### PR TITLE
refactor(zenmux): extends mimo models from xiaomi provider

### DIFF
--- a/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
@@ -1,22 +1,5 @@
 name = "MiMo-V2-Flash"
-release_date = "2025-12-17"
-last_updated = "2025-12-17"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-01-01"
-open_weights = false
 
-[cost]
-input = 0.10
-output = 0.30
-cache_read = 0.01
-
-[limit]
-context = 262_000
-output = 64_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "xiaomi/mimo-v2-flash"
+omit = ["interleaved"]

--- a/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
@@ -1,21 +1,9 @@
 name = "MiMo V2 Omni"
-release_date = "2026-03-20"
-last_updated = "2026-03-20"
-attachment = true
-reasoning = false
-temperature = true
-tool_call = true
-knowledge = "2025-01-01"
-open_weights = false
 
-[cost]
-input = 0.40
-output = 2.00
+[extends]
+from = "xiaomi/mimo-v2-omni"
+omit = ["interleaved"]
 
 [limit]
 context = 265_000
 output = 265_000
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
@@ -1,21 +1,9 @@
 name = "MiMo V2 Pro"
-release_date = "2026-03-20"
-last_updated = "2026-03-20"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-01-01"
-open_weights = false
 
-[cost]
-input = 1.50
-output = 4.50
+[extends]
+from = "xiaomi/mimo-v2-pro"
+omit = ["interleaved"]
 
 [limit]
 context = 1_000_000
 output = 256_000
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]


### PR DESCRIPTION
zenmux breakout commit of #1631

## Notes

- **Context limit changes**: A number of models have had their context windows changed. This is because of incorrectly rounded context windows in the xiaomi root provider.
- **MiMo V2 Omni**: see https://zenmux.ai/xiaomi/mimo-v2-omni
- **MiMo V2 Pro**: see https://zenmux.ai/xiaomi/mimo-v2-pro input types were listed incorrectly and price is incorrect. The context limit is strange because it differs from Xiaomi's own documentation, but I am reproducing what is listed on zenmux's website.