### PR TITLE
refactor(xiaomi-token-plan): extends xiaomi base provider for xiaomi token plans

### DIFF
--- a/providers/xiaomi-token-plan-ams/models/mimo-v2-flash.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2-flash.toml
@@ -1,0 +1,1 @@
+../../xiaomi-token-plan-cn/models/mimo-v2-flash.toml

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-pro.toml
@@ -1,2 +1,1 @@
-[extends]
-from = "xiaomi-token-plan-cn/mimo-v2.5-pro"
+../../xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5.toml
@@ -1,2 +1,1 @@
-[extends]
-from = "xiaomi-token-plan-cn/mimo-v2.5"
+../../xiaomi-token-plan-cn/models/mimo-v2.5.toml

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-flash.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-flash.toml
@@ -1,5 +1,5 @@
 [extends]
-from = "xiaomi/mimo-v2-pro"
+from = "xiaomi/mimo-v2-flash"
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-omni.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-omni.toml
@@ -1,26 +1,7 @@
-name = "MiMo-V2-Omni"
-family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "xiaomi/mimo-v2-omni"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
-
-[limit]
-context = 256_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "audio", "video", "pdf"]
-output = ["text"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-tts.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-tts.toml
@@ -12,8 +12,8 @@ input = 0
 output = 0
 
 [limit]
-context = 8_000
-output = 16_000
+context = 8_192
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
@@ -1,26 +1,12 @@
-name = "MiMo-V2.5-Pro"
-family = "mimo-v2.5-pro"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[cost.context_over_200k]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
@@ -1,26 +1,12 @@
-name = "MiMo-V2.5"
-family = "mimo-v2.5"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-12"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+[extends]
+from = "xiaomi/mimo-v2.5"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "audio", "video", "pdf"]
-output = ["text"]
+[cost.context_over_200k]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2-flash.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2-flash.toml
@@ -1,0 +1,1 @@
+../../xiaomi-token-plan-cn/models/mimo-v2-flash.toml

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-pro.toml
@@ -1,2 +1,1 @@
-[extends]
-from = "xiaomi-token-plan-cn/mimo-v2.5-pro"
+../../xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5.toml
@@ -1,2 +1,1 @@
-[extends]
-from = "xiaomi-token-plan-cn/mimo-v2.5"
+../../xiaomi-token-plan-cn/models/mimo-v2.5.toml


### PR DESCRIPTION
This PR refactors all token plans excluding the chinese token plan to have the models folder be a symlink to reduce duplication since all three are identical. This is a bit more of an experimental PR and idk how open you are to accepting a change like this, but LMK. Sort of breakout commit of #1631 