### PR TITLE
refactor(xiaomi): round xiaomi models to powers of 2 & fix small errors

### DIFF
--- a/providers/xiaomi/models/mimo-v2-flash.toml
+++ b/providers/xiaomi/models/mimo-v2-flash.toml
@@ -15,8 +15,8 @@ output = 0.30
 cache_read = 0.01
 
 [limit]
-context = 256_000
-output = 64_000
+context = 262_144
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/xiaomi/models/mimo-v2-omni.toml
+++ b/providers/xiaomi/models/mimo-v2-omni.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 knowledge = "2024-12"
-open_weights = true
+open_weights = false
 
 [interleaved]
 field = "reasoning_content"
@@ -18,8 +18,8 @@ output = 2.00
 cache_read = 0.08
 
 [limit]
-context = 256_000
-output = 128_000
+context = 262_144
+output = 131_072
 
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]

--- a/providers/xiaomi/models/mimo-v2-pro.toml
+++ b/providers/xiaomi/models/mimo-v2-pro.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 knowledge = "2024-12"
-open_weights = true
+open_weights = false
 
 [interleaved]
 field = "reasoning_content"
@@ -17,9 +17,14 @@ input = 1.00
 output = 3.00
 cache_read = 0.20
 
+[cost.context_over_200k]
+input = 2.00
+output = 6.00
+cache_read = 0.40
+
 [limit]
-context = 1_000_000
-output = 128_000
+context = 1_048_576
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 knowledge = "2024-12"
-open_weights = false
+open_weights = true
 
 [cost]
 input = 1
@@ -29,4 +29,3 @@ output = ["text"]
 
 [interleaved]
 field = "reasoning_content"
-

--- a/providers/xiaomi/models/mimo-v2.5.toml
+++ b/providers/xiaomi/models/mimo-v2.5.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 knowledge = "2024-12"
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.4
@@ -29,4 +29,3 @@ output = ["text"]
 
 [interleaved]
 field = "reasoning_content"
-


### PR DESCRIPTION
Standardizes context limits to powers of 2, adds cost context_over_200k for v2 pro, and correct open_weights declarations for v2 omni and v2 pro

see https://platform.xiaomimimo.com/docs/en-US/pricing

see
- #1712 
- #1713 
- #1714 
- #1715 
- #1716 