### PR TITLE
Add InferX provider (OpenAI-compatible endpoints)

### DIFF
--- a/providers/inferx/models.toml
+++ b/providers/inferx/models.toml
@@ -1,0 +1,3 @@
+[[models]]
+id = "qwen-27b"
+name = "Qwen/Qwen3.6-27B-FP8"

--- a/providers/inferx/models.toml
+++ b/providers/inferx/models.toml
@@ -1,3 +1,19 @@
 [[models]]
-id = "qwen-27b"
+id = "qwen3.6-27b-fp8"
 name = "Qwen/Qwen3.6-27B-FP8"
+
+[[models]]
+id = "qwen3.6-27b-fp8-1m"
+name = "Qwen/Qwen3.6-27B-FP8-1M"
+
+[[models]]
+id = "qwen3.6-35b-a3b-fp8"
+name = "Qwen/Qwen3.6-35B-A3B-FP8"
+
+[[models]]
+id = "qwen3.6-35b-a3b-fp8-1m"
+name = "Qwen/Qwen3.6-35B-A3B-FP8-1M"
+
+[[models]]
+id = "gemma-4-31b-it-fp8"
+name = "google/gemma-4-31b-it-fp8"

--- a/providers/inferx/provider.toml
+++ b/providers/inferx/provider.toml
@@ -1,0 +1,8 @@
+id = "inferx"
+name = "InferX"
+type = "openai-compatible"
+docs = "https://inferx.net"
+
+[api]
+base_url = "https://model.inferx.net/funccall/{tenant}/endpoints/{endpoint}/v1"
+auth_type = "bearer"


### PR DESCRIPTION
Adds InferX as an OpenAI-compatible provider.

InferX provides dedicated inference endpoints with no cold starts.

Base URL format:
https://model.inferx.net/funccall/{tenant}/endpoints/{endpoint}/v1

Example model:
Qwen/Qwen3.6-27B-FP8

Compatible with OpenAI-style clients (e.g., OpenCode, AI SDK).

Users provide their own endpoint and API key.