### PR TITLE
Add OpenRouter Qwen cache pricing

### DIFF
--- a/providers/openrouter/models/qwen/qwen-plus.toml
+++ b/providers/openrouter/models/qwen/qwen-plus.toml
@@ -1,0 +1,25 @@
+name = "Qwen: Qwen-Plus"
+family = "qwen"
+release_date = "2025-01-25"
+last_updated = "2025-01-25"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-04"
+tool_call = true
+structured_output = false
+open_weights = false
+
+[cost]
+input = 0.26
+output = 0.78
+cache_read = 0.052
+cache_write = 0.325
+
+[limit]
+context = 1_000_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen3-coder-flash.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder-flash.toml
@@ -13,6 +13,8 @@ open_weights = false
 [cost]
 input = 0.30
 output = 1.50
+cache_read = 0.039
+cache_write = 0.24375
 
 [limit]
 context = 128_000

--- a/providers/openrouter/models/qwen/qwen3-coder-plus.toml
+++ b/providers/openrouter/models/qwen/qwen3-coder-plus.toml
@@ -1,0 +1,25 @@
+name = "Qwen3 Coder Plus"
+family = "qwen"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.65
+output = 3.25
+cache_read = 0.13
+cache_write = 0.8125
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openrouter/models/qwen/qwen3-max.toml
+++ b/providers/openrouter/models/qwen/qwen3-max.toml
@@ -14,6 +14,8 @@ open_weights = false
 # output = 5
 input = 1.20
 output = 6.00
+cache_read = 0.156
+cache_write = 0.975
 
 [limit]
 context = 262_144

--- a/providers/openrouter/models/qwen/qwen3.6-plus.toml
+++ b/providers/openrouter/models/qwen/qwen3.6-plus.toml
@@ -13,6 +13,8 @@ open_weights = false
 [cost]
 input = 0.325
 output = 1.95
+cache_read = 0.0325
+cache_write = 0.40625
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
## Summary

Adds missing OpenRouter cache pricing for Alibaba Qwen explicit prompt-caching models documented by OpenRouter. Values are converted from OpenRouter's per-token pricing fields to models.dev's per-million-token `cost.cache_read` / `cost.cache_write` convention.

This includes `qwen/qwen3.6-plus`, where OpenRouter's model API exposes `input_cache_write` but omits `input_cache_read`; the read price is derived from OpenRouter's Alibaba Qwen prompt-caching docs, which state cache reads are charged at 0.1x input price.

Also adds missing OpenRouter catalog entries for `qwen/qwen-plus` and `qwen/qwen3-coder-plus`, both listed by OpenRouter as explicit-caching-capable.

## Validation

- `bun run validate`
- `git diff --check`