### PR TITLE
Added: MiniMax-M2.7 model for wafer.ai

### DIFF
--- a/providers/wafer.ai/models/MiniMax-M2.7.toml
+++ b/providers/wafer.ai/models/MiniMax-M2.7.toml
@@ -1,0 +1,8 @@
+[extends]
+from = "minimax/MiniMax-M2.7"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
- Add MiniMax-M2.7 model to wafer.ai provider

Yup, that's all. Live since an hour or two ago 😉