### PR TITLE
chore: update novita deepseek-v4-pro prices

### DIFF
--- a/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
@@ -2,9 +2,9 @@
 from = "deepseek/deepseek-v4-pro"
 
 [cost]
-input = 1.74
-output = 3.48
-cache_read = 0.145
+input = 1.69
+output = 3.38
+cache_read = 0.13
 
 [limit]
 context = 1_048_576


### PR DESCRIPTION
updating prices for deepseek on novita

Price change source: https://novita.ai/models/model-detail/deepseek-deepseek-v4-pro

<img width="748" height="337" alt="image" src="https://github.com/user-attachments/assets/d6958a50-90c4-4ce5-a25b-f7cd74b5aaf9" />

Price changed in the last hour: https://x.com/narev_bot/status/2052648148808683550?s=20

