### PR TITLE
chore(copilot): mark deprecated models

### DIFF
--- a/providers/github-copilot/models/claude-opus-41.toml
+++ b/providers/github-copilot/models/claude-opus-41.toml
@@ -1,5 +1,6 @@
 name = "Claude Opus 4.1"
 family = "claude-opus"
+status = "deprecated"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true

--- a/providers/github-copilot/models/claude-sonnet-4.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.toml
@@ -1,5 +1,6 @@
 name = "Claude Sonnet 4"
 family = "claude-sonnet"
+status = "deprecated"
 release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true

--- a/providers/github-copilot/models/gemini-3-pro-preview.toml
+++ b/providers/github-copilot/models/gemini-3-pro-preview.toml
@@ -1,5 +1,6 @@
 name = "Gemini 3 Pro Preview"
 family = "gemini-pro"
+status = "deprecated"
 release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = true

--- a/providers/github-copilot/models/gpt-5.1-codex-max.toml
+++ b/providers/github-copilot/models/gpt-5.1-codex-max.toml
@@ -1,5 +1,6 @@
 name = "GPT-5.1-Codex-max"
 family = "gpt-codex"
+status = "deprecated"
 release_date = "2025-12-04"
 last_updated = "2025-12-04"
 attachment = true

--- a/providers/github-copilot/models/gpt-5.1-codex-mini.toml
+++ b/providers/github-copilot/models/gpt-5.1-codex-mini.toml
@@ -1,5 +1,6 @@
 name = "GPT-5.1-Codex-mini"
 family = "gpt-codex"
+status = "deprecated"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = false

--- a/providers/github-copilot/models/gpt-5.1-codex.toml
+++ b/providers/github-copilot/models/gpt-5.1-codex.toml
@@ -1,5 +1,6 @@
 name = "GPT-5.1-Codex"
 family = "gpt-codex"
+status = "deprecated"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = false

--- a/providers/github-copilot/models/gpt-5.1.toml
+++ b/providers/github-copilot/models/gpt-5.1.toml
@@ -1,5 +1,6 @@
 name = "GPT-5.1"
 family = "gpt"
+status = "deprecated"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true

--- a/providers/github-copilot/models/gpt-5.toml
+++ b/providers/github-copilot/models/gpt-5.toml
@@ -1,5 +1,6 @@
 name = "GPT-5"
 family = "gpt"
+status = "deprecated"
 release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true


### PR DESCRIPTION
Marked models as deprecated looking at [these](https://docs.github.com/en/copilot/reference/ai-models/supported-models) docs