### PR TITLE
Feat/add litellm provider

### DIFF
--- a/providers/litellm/models/anthropic/claude-3-5-sonnet-20241022.toml
+++ b/providers/litellm/models/anthropic/claude-3-5-sonnet-20241022.toml
@@ -1,0 +1,4 @@
+name = "Claude 3.5 Sonnet v2 (via LiteLLM)"
+
+[extends]
+from = "anthropic/claude-3-5-sonnet-20241022"

--- a/providers/litellm/models/anthropic/claude-3-7-sonnet-20250219.toml
+++ b/providers/litellm/models/anthropic/claude-3-7-sonnet-20250219.toml
@@ -1,0 +1,4 @@
+name = "Claude 3.7 Sonnet (via LiteLLM)"
+
+[extends]
+from = "anthropic/claude-3-7-sonnet-20250219"

--- a/providers/litellm/models/anthropic/claude-3-haiku-20240307.toml
+++ b/providers/litellm/models/anthropic/claude-3-haiku-20240307.toml
@@ -1,0 +1,4 @@
+name = "Claude 3 Haiku (via LiteLLM)"
+
+[extends]
+from = "anthropic/claude-3-haiku-20240307"

--- a/providers/litellm/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/litellm/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,4 @@
+name = "Claude Haiku 4.5 (via LiteLLM)"
+
+[extends]
+from = "anthropic/claude-haiku-4-5"

--- a/providers/litellm/models/anthropic/claude-opus-4-1.toml
+++ b/providers/litellm/models/anthropic/claude-opus-4-1.toml
@@ -1,0 +1,4 @@
+name = "Claude Opus 4.1 (via LiteLLM)"
+
+[extends]
+from = "anthropic/claude-opus-4-1"

--- a/providers/litellm/models/anthropic/claude-opus-4-5.toml
+++ b/providers/litellm/models/anthropic/claude-opus-4-5.toml
@@ -1,0 +1,4 @@
+name = "Claude Opus 4.5 (via LiteLLM)"
+
+[extends]
+from = "anthropic/claude-opus-4-5"

--- a/providers/litellm/models/anthropic/claude-opus-4-6.toml
+++ b/providers/litellm/models/anthropic/claude-opus-4-6.toml
@@ -1,0 +1,4 @@
+name = "Claude Opus 4.6 (via LiteLLM)"
+
+[extends]
+from = "anthropic/claude-opus-4-6"

--- a/providers/litellm/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/litellm/models/anthropic/claude-sonnet-4-5.toml
@@ -1,0 +1,4 @@
+name = "Claude Sonnet 4.5 (via LiteLLM)"
+
+[extends]
+from = "anthropic/claude-sonnet-4-5"

--- a/providers/litellm/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/litellm/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,4 @@
+name = "Claude Sonnet 4.6 (via LiteLLM)"
+
+[extends]
+from = "anthropic/claude-sonnet-4-6"

--- a/providers/litellm/models/cohere/command-a-03-2025.toml
+++ b/providers/litellm/models/cohere/command-a-03-2025.toml
@@ -1,0 +1,4 @@
+name = "Command A (via LiteLLM)"
+
+[extends]
+from = "cohere/command-a-03-2025"

--- a/providers/litellm/models/cohere/command-r-plus-08-2024.toml
+++ b/providers/litellm/models/cohere/command-r-plus-08-2024.toml
@@ -1,0 +1,4 @@
+name = "Command R+ (via LiteLLM)"
+
+[extends]
+from = "cohere/command-r-plus-08-2024"

--- a/providers/litellm/models/deepseek/deepseek-chat.toml
+++ b/providers/litellm/models/deepseek/deepseek-chat.toml
@@ -1,0 +1,4 @@
+name = "DeepSeek Chat (via LiteLLM)"
+
+[extends]
+from = "deepseek/deepseek-chat"

--- a/providers/litellm/models/deepseek/deepseek-reasoner.toml
+++ b/providers/litellm/models/deepseek/deepseek-reasoner.toml
@@ -1,0 +1,4 @@
+name = "DeepSeek Reasoner (via LiteLLM)"
+
+[extends]
+from = "deepseek/deepseek-reasoner"

--- a/providers/litellm/models/gemini/gemini-1.5-flash.toml
+++ b/providers/litellm/models/gemini/gemini-1.5-flash.toml
@@ -1,0 +1,4 @@
+name = "Gemini 1.5 Flash (via LiteLLM)"
+
+[extends]
+from = "google/gemini-1.5-flash"

--- a/providers/litellm/models/gemini/gemini-1.5-pro.toml
+++ b/providers/litellm/models/gemini/gemini-1.5-pro.toml
@@ -1,0 +1,4 @@
+name = "Gemini 1.5 Pro (via LiteLLM)"
+
+[extends]
+from = "google/gemini-1.5-pro"

--- a/providers/litellm/models/gemini/gemini-2.0-flash.toml
+++ b/providers/litellm/models/gemini/gemini-2.0-flash.toml
@@ -1,0 +1,4 @@
+name = "Gemini 2.0 Flash (via LiteLLM)"
+
+[extends]
+from = "google/gemini-2.0-flash"

--- a/providers/litellm/models/gemini/gemini-2.5-flash.toml
+++ b/providers/litellm/models/gemini/gemini-2.5-flash.toml
@@ -1,0 +1,4 @@
+name = "Gemini 2.5 Flash (via LiteLLM)"
+
+[extends]
+from = "google/gemini-2.5-flash"

--- a/providers/litellm/models/gemini/gemini-2.5-pro.toml
+++ b/providers/litellm/models/gemini/gemini-2.5-pro.toml
@@ -1,0 +1,4 @@
+name = "Gemini 2.5 Pro (via LiteLLM)"
+
+[extends]
+from = "google/gemini-2.5-pro"

--- a/providers/litellm/models/groq/llama-3.1-8b-instant.toml
+++ b/providers/litellm/models/groq/llama-3.1-8b-instant.toml
@@ -1,0 +1,4 @@
+name = "Llama 3.1 8B (via LiteLLM)"
+
+[extends]
+from = "groq/llama-3.1-8b-instant"

--- a/providers/litellm/models/groq/llama-3.3-70b-versatile.toml
+++ b/providers/litellm/models/groq/llama-3.3-70b-versatile.toml
@@ -1,0 +1,4 @@
+name = "Llama 3.3 70B (via LiteLLM)"
+
+[extends]
+from = "groq/llama-3.3-70b-versatile"

--- a/providers/litellm/models/mistral/codestral-latest.toml
+++ b/providers/litellm/models/mistral/codestral-latest.toml
@@ -1,0 +1,4 @@
+name = "Codestral (via LiteLLM)"
+
+[extends]
+from = "mistral/codestral-latest"

--- a/providers/litellm/models/mistral/devstral-small-2505.toml
+++ b/providers/litellm/models/mistral/devstral-small-2505.toml
@@ -1,0 +1,4 @@
+name = "Devstral Small (via LiteLLM)"
+
+[extends]
+from = "mistral/devstral-small-2505"

--- a/providers/litellm/models/mistral/mistral-large-latest.toml
+++ b/providers/litellm/models/mistral/mistral-large-latest.toml
@@ -1,0 +1,4 @@
+name = "Mistral Large (via LiteLLM)"
+
+[extends]
+from = "mistral/mistral-large-latest"

--- a/providers/litellm/models/mistral/mistral-nemo.toml
+++ b/providers/litellm/models/mistral/mistral-nemo.toml
@@ -1,0 +1,4 @@
+name = "Mistral NeMo (via LiteLLM)"
+
+[extends]
+from = "mistral/mistral-nemo"

--- a/providers/litellm/models/mistral/mistral-small-latest.toml
+++ b/providers/litellm/models/mistral/mistral-small-latest.toml
@@ -1,0 +1,4 @@
+name = "Mistral Small (via LiteLLM)"
+
+[extends]
+from = "mistral/mistral-small-latest"

--- a/providers/litellm/models/openai/gpt-4-turbo.toml
+++ b/providers/litellm/models/openai/gpt-4-turbo.toml
@@ -1,0 +1,4 @@
+name = "GPT-4 Turbo (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-4-turbo"

--- a/providers/litellm/models/openai/gpt-4.1-mini.toml
+++ b/providers/litellm/models/openai/gpt-4.1-mini.toml
@@ -1,0 +1,4 @@
+name = "GPT-4.1 Mini (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-4.1-mini"

--- a/providers/litellm/models/openai/gpt-4.1-nano.toml
+++ b/providers/litellm/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,4 @@
+name = "GPT-4.1 Nano (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-4.1-nano"

--- a/providers/litellm/models/openai/gpt-4.1.toml
+++ b/providers/litellm/models/openai/gpt-4.1.toml
@@ -1,0 +1,4 @@
+name = "GPT-4.1 (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-4.1"

--- a/providers/litellm/models/openai/gpt-4o-mini.toml
+++ b/providers/litellm/models/openai/gpt-4o-mini.toml
@@ -1,0 +1,4 @@
+name = "GPT-4o Mini (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-4o-mini"

--- a/providers/litellm/models/openai/gpt-4o.toml
+++ b/providers/litellm/models/openai/gpt-4o.toml
@@ -1,0 +1,4 @@
+name = "GPT-4o (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-4o"

--- a/providers/litellm/models/openai/gpt-5-mini.toml
+++ b/providers/litellm/models/openai/gpt-5-mini.toml
@@ -1,0 +1,4 @@
+name = "GPT-5 Mini (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5-mini"

--- a/providers/litellm/models/openai/gpt-5-nano.toml
+++ b/providers/litellm/models/openai/gpt-5-nano.toml
@@ -1,0 +1,4 @@
+name = "GPT-5 Nano (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5-nano"

--- a/providers/litellm/models/openai/gpt-5-pro.toml
+++ b/providers/litellm/models/openai/gpt-5-pro.toml
@@ -1,0 +1,4 @@
+name = "GPT-5 Pro (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5-pro"

--- a/providers/litellm/models/openai/gpt-5.1-codex.toml
+++ b/providers/litellm/models/openai/gpt-5.1-codex.toml
@@ -1,0 +1,4 @@
+name = "GPT-5.1 Codex (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5.1-codex"

--- a/providers/litellm/models/openai/gpt-5.1.toml
+++ b/providers/litellm/models/openai/gpt-5.1.toml
@@ -1,0 +1,4 @@
+name = "GPT-5.1 (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5.1"

--- a/providers/litellm/models/openai/gpt-5.2.toml
+++ b/providers/litellm/models/openai/gpt-5.2.toml
@@ -1,0 +1,4 @@
+name = "GPT-5.2 (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5.2"

--- a/providers/litellm/models/openai/gpt-5.3-codex.toml
+++ b/providers/litellm/models/openai/gpt-5.3-codex.toml
@@ -1,0 +1,4 @@
+name = "GPT-5.3 Codex (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5.3-codex"

--- a/providers/litellm/models/openai/gpt-5.4.toml
+++ b/providers/litellm/models/openai/gpt-5.4.toml
@@ -1,0 +1,4 @@
+name = "GPT-5.4 (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5.4"

--- a/providers/litellm/models/openai/gpt-5.5.toml
+++ b/providers/litellm/models/openai/gpt-5.5.toml
@@ -1,0 +1,4 @@
+name = "GPT-5.5 (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5.5"

--- a/providers/litellm/models/openai/gpt-5.toml
+++ b/providers/litellm/models/openai/gpt-5.toml
@@ -1,0 +1,4 @@
+name = "GPT-5 (via LiteLLM)"
+
+[extends]
+from = "openai/gpt-5"

--- a/providers/litellm/models/openai/o3-mini.toml
+++ b/providers/litellm/models/openai/o3-mini.toml
@@ -1,0 +1,4 @@
+name = "o3-mini (via LiteLLM)"
+
+[extends]
+from = "openai/o3-mini"

--- a/providers/litellm/models/openai/o3-pro.toml
+++ b/providers/litellm/models/openai/o3-pro.toml
@@ -1,0 +1,4 @@
+name = "o3 Pro (via LiteLLM)"
+
+[extends]
+from = "openai/o3-pro"

--- a/providers/litellm/models/openai/o3.toml
+++ b/providers/litellm/models/openai/o3.toml
@@ -1,0 +1,4 @@
+name = "o3 (via LiteLLM)"
+
+[extends]
+from = "openai/o3"

--- a/providers/litellm/models/openai/o4-mini.toml
+++ b/providers/litellm/models/openai/o4-mini.toml
@@ -1,0 +1,4 @@
+name = "o4-mini (via LiteLLM)"
+
+[extends]
+from = "openai/o4-mini"

--- a/providers/litellm/models/xai/grok-2.toml
+++ b/providers/litellm/models/xai/grok-2.toml
@@ -1,0 +1,4 @@
+name = "Grok 2 (via LiteLLM)"
+
+[extends]
+from = "xai/grok-2"

--- a/providers/litellm/models/xai/grok-3-mini.toml
+++ b/providers/litellm/models/xai/grok-3-mini.toml
@@ -1,0 +1,4 @@
+name = "Grok 3 Mini (via LiteLLM)"
+
+[extends]
+from = "xai/grok-3-mini"

--- a/providers/litellm/models/xai/grok-3.toml
+++ b/providers/litellm/models/xai/grok-3.toml
@@ -1,0 +1,4 @@
+name = "Grok 3 (via LiteLLM)"
+
+[extends]
+from = "xai/grok-3"

--- a/providers/litellm/provider.toml
+++ b/providers/litellm/provider.toml
@@ -1,0 +1,5 @@
+name = "LiteLLM"
+env = ["LITELLM_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "http://localhost:4000/v1"
+doc = "https://docs.litellm.ai/docs/providers"


### PR DESCRIPTION
  Adds LiteLLM as a provider with 48 models across 8 providers.
                                                                                                                                                                                                                     
  LiteLLM is an AI gateway/proxy that routes to 100+ LLM providers through a single OpenAI-compatible endpoint. Users who run a LiteLLM proxy server can connect it to opencode and access any model behind it.      
                                                                                                                                                                                                                     
  ## Provider config                                                                                                                                                                                                 
  - npm: `@ai-sdk/openai-compatible`      
  - env: `LITELLM_API_KEY`                                                                                                                                                                                           
  - api: `http://localhost:4000/v1` (default proxy URL)
                                                                                                                                                                                                                     
  ## Models added (48)                    
  - **Anthropic** (9): Claude Opus 4.6/4.5/4.1, Sonnet 4.6/4.5, Haiku 4.5, 3.7 Sonnet, 3.5 Sonnet v2, 3 Haiku                                                                                                        
  - **OpenAI** (20): GPT-5.5 through GPT-4 Turbo, o3/o4 series, Codex variants                                                                                                                                       
  - **Google** (5): Gemini 2.5/2.0/1.5 Flash & Pro                                                                                                                                                                   
  - **DeepSeek** (2): Chat, Reasoner                                                                                                                                                                                 
  - **Mistral** (5): Large, Small, NeMo, Codestral, Devstral                                                                                                                                                         
  - **Cohere** (2): Command A, Command R+                                                                                                                                                                            
  - **xAI** (3): Grok 3, 3 Mini, 2        
  - **Groq** (2): Llama 3.3 70B, 3.1 8B                                                                                                                                                                              
                                                                                                                                                                                                                     
  All models use `extends` to inherit definitions from existing providers. `bun validate` passes.  