### PR TITLE
Add General Compute provider

### DIFF
--- a/providers/general-compute/models/deepseek-v3.1.toml
+++ b/providers/general-compute/models/deepseek-v3.1.toml
@@ -1,0 +1,23 @@
+name = "DeepSeek V3.1"
+family = "deepseek"
+release_date = "2025-08-21"
+last_updated = "2025-08-21"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.21
+output = 0.79
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/general-compute/models/deepseek-v3.2.toml
+++ b/providers/general-compute/models/deepseek-v3.2.toml
@@ -1,0 +1,23 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.25
+output = 0.38
+
+[limit]
+context = 32_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/general-compute/models/minimax-m2.7.toml
+++ b/providers/general-compute/models/minimax-m2.7.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2.7"
+family = "minimax"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.28
+output = 1.20
+
+[limit]
+context = 196_608
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/general-compute/provider.toml
+++ b/providers/general-compute/provider.toml
@@ -1,0 +1,5 @@
+name = "General Compute"
+env = ["GENERALCOMPUTE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.generalcompute.com/v1"
+doc = "https://docs.generalcompute.com/models"


### PR DESCRIPTION
## Add General Compute provider

We are an in inference platform that uses alternatives to GPUs to get 5x faster e2e latency on the same models.

### Cool feature
Customers can have OpenCode sign up on their behalf and get the API key for them.                         
                                                                                                             
### Models included:                                                                                           
  - MiniMax M2.7

We currently run Minimax 5x faster than competitors and will be bringing on more compute / models in the coming days
                                                                                  
                        
### Provider details:                                                                                          
  - npm: @ai-sdk/openai-compatible                                                                           
  - API: https://api.generalcompute.com/v1
  - Auth: GENERALCOMPUTE_API_KEY 