### PR TITLE
Update Google provider docs url from pricing page to models page

### DIFF
--- a/providers/google/provider.toml
+++ b/providers/google/provider.toml
@@ -1,4 +1,4 @@
 name = "Google"
 env = ["GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"]
 npm = "@ai-sdk/google"
-doc = "https://ai.google.dev/gemini-api/docs/pricing"
+doc = "https://ai.google.dev/gemini-api/docs/models"


### PR DESCRIPTION
Update Google provider docs URL from the pricing page to the models page as that has more details about the models