### PR TITLE
feat: introduce cost.per_minute

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Models must conform to the following schema, as defined in `packages/core/src/sc
 - `cost.cache_write` _(optional)_: Number — Cost per million cached write tokens (USD)
 - `cost.input_audio` _(optional)_: Number — Cost per million audio input tokens, if billed separately (USD)
 - `cost.output_audio` _(optional)_: Number — Cost per million audio output tokens, if billed separately (USD)
+- `cost.per_minute` _(optional)_: Number — Cost per minute of audio, for models billed by duration (e.g. Whisper) (USD)
 - `limit.context`: Number — Maximum context window (tokens)
 - `limit.input`: Number — Maximum input tokens
 - `limit.output`: Number — Maximum output tokens

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -41,6 +41,10 @@ const Cost = z.object({
     .number()
     .min(0, "Audio output price cannot be negative")
     .optional(),
+  per_minute: z
+    .number()
+    .min(0, "Per-minute price cannot be negative")
+    .optional(),
 });
 export const Model = z
   .object({

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -286,13 +286,14 @@ tbody {
   td:nth-child(13),
   td:nth-child(14),
   td:nth-child(15),
-  td:nth-child(16) {
+  td:nth-child(16),
+  td:nth-child(17) {
     color: var(--color-text);
   }
 
   td:nth-child(5),
   td:nth-child(6),
-  td:nth-child(18) {
+  td:nth-child(19) {
     font-size: 0.8125rem;
     font-family: var(--font-mono);
     text-transform: uppercase;
@@ -308,7 +309,8 @@ tbody {
   td:nth-child(14),
   td:nth-child(15),
   td:nth-child(16),
-  td:nth-child(17) {
+  td:nth-child(17),
+  td:nth-child(18) {
     font-size: 0.8125rem;
     font-family: var(--font-mono);
   }

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -314,6 +314,16 @@ export const Rendered = renderToString(
             </div>
           </th>
           <th class="sortable" data-type="number">
+            <div class="header-container">
+              <span class="header-text">
+                Cost
+                <br />
+                <span class="desc">per minute</span>
+              </span>
+              <span class="sort-indicator"></span>
+            </div>
+          </th>
+          <th class="sortable" data-type="number">
             Context Limit <span class="sort-indicator"></span>
           </th>
           <th class="sortable" data-type="number">
@@ -434,6 +444,7 @@ export const Rendered = renderToString(
                   <td>{renderCost(model.cost?.cache_write)}</td>
                   <td>{renderCost(model.cost?.input_audio)}</td>
                   <td>{renderCost(model.cost?.output_audio)}</td>
+                  <td>{renderCost(model.cost?.per_minute)}</td>
                   <td>{model.limit.context.toLocaleString()}</td>
                   <td>{model.limit.input?.toLocaleString() ?? "-"}</td>
                   <td>{model.limit.output.toLocaleString()}</td>

--- a/providers/openai/models/whisper-1.toml
+++ b/providers/openai/models/whisper-1.toml
@@ -1,0 +1,22 @@
+name = "Whisper"
+family = "whisper"
+release_date = "2023-02"
+last_updated = "2023-02"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+per_minute = 0.006
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["audio"]
+output = ["text"]


### PR DESCRIPTION
For audio model, cost per 1M token is often not available, but rather cost-per-minute -- e.g. https://developers.openai.com/api/docs/models/whisper-1

Therefore this PR introduces this new costs-per-minute column and adds one model which such pricing info.