### PR TITLE
An/add gemini embedding 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ cache_read = 0.30           # Cost per million cached read tokens (USD)
 cache_write = 3.75          # Cost per million cached write tokens (USD)
 input_audio = 1.00          # Cost per million audio input tokens (USD)
 output_audio = 10.00        # Cost per million audio output tokens (USD)
+input_image = 0.45          # Cost per million image input tokens (USD)
+input_video = 12.00         # Cost per million video input tokens (USD)
 
 [limit]
 context = 400_000           # Maximum context window (tokens)
@@ -202,6 +204,8 @@ Models must conform to the following schema, as defined in `packages/core/src/sc
 - `cost.cache_write` _(optional)_: Number — Cost per million cached write tokens (USD)
 - `cost.input_audio` _(optional)_: Number — Cost per million audio input tokens, if billed separately (USD)
 - `cost.output_audio` _(optional)_: Number — Cost per million audio output tokens, if billed separately (USD)
+- `cost.input_image` _(optional)_: Number — Cost per million image input tokens, if billed separately (USD)
+- `cost.input_video` _(optional)_: Number — Cost per million video input tokens, if billed separately (USD)
 - `limit.context`: Number — Maximum context window (tokens)
 - `limit.input`: Number — Maximum input tokens
 - `limit.output`: Number — Maximum output tokens

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -45,6 +45,14 @@ const Cost = z
       .number()
       .min(0, "Audio output price cannot be negative")
       .optional(),
+    input_image: z
+      .number()
+      .min(0, "Image input price cannot be negative")
+      .optional(),
+    input_video: z
+      .number()
+      .min(0, "Video input price cannot be negative")
+      .optional(),
   });
 
 const CostTier = Cost.extend({

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -294,13 +294,15 @@ tbody {
   td:nth-child(13),
   td:nth-child(14),
   td:nth-child(15),
-  td:nth-child(16) {
+  td:nth-child(16),
+  td:nth-child(17),
+  td:nth-child(18) {
     color: var(--color-text);
   }
 
   td:nth-child(5),
   td:nth-child(6),
-  td:nth-child(18) {
+  td:nth-child(24) {
     font-size: 0.8125rem;
     font-family: var(--font-mono);
     text-transform: uppercase;
@@ -316,7 +318,9 @@ tbody {
   td:nth-child(14),
   td:nth-child(15),
   td:nth-child(16),
-  td:nth-child(17) {
+  td:nth-child(17),
+  td:nth-child(18),
+  td:nth-child(19) {
     font-size: 0.8125rem;
     font-family: var(--font-mono);
   }

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -145,6 +145,8 @@ function prepareRow(row: TableRow): VirtualizedRow {
     row.cacheWriteCost,
     row.audioInputCost,
     row.audioOutputCost,
+    row.imageInputCost,
+    row.videoInputCost,
     row.contextLimit,
     row.inputLimit,
     row.outputLimit,

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -90,6 +90,8 @@ export const TableRows: TableRow[] = Object.entries(Providers)
         cacheWriteCost: model.cost?.cache_write,
         audioInputCost: model.cost?.input_audio,
         audioOutputCost: model.cost?.output_audio,
+        imageInputCost: model.cost?.input_image,
+        videoInputCost: model.cost?.input_video,
         contextLimit: model.limit.context,
         inputLimit: model.limit.input,
         outputLimit: model.limit.output,
@@ -233,6 +235,26 @@ export const Rendered = renderToString(
             <div class="header-container">
               <span class="header-text">
                 Audio Output Cost
+                <br />
+                <span class="desc">per 1M tokens</span>
+              </span>
+              <span class="sort-indicator"></span>
+            </div>
+          </th>
+          <th class="sortable" data-type="number">
+            <div class="header-container">
+              <span class="header-text">
+                Image Input Cost
+                <br />
+                <span class="desc">per 1M tokens</span>
+              </span>
+              <span class="sort-indicator"></span>
+            </div>
+          </th>
+          <th class="sortable" data-type="number">
+            <div class="header-container">
+              <span class="header-text">
+                Video Input Cost
                 <br />
                 <span class="desc">per 1M tokens</span>
               </span>

--- a/packages/web/src/shared.ts
+++ b/packages/web/src/shared.ts
@@ -16,6 +16,8 @@ export interface TableRow {
   cacheWriteCost?: number;
   audioInputCost?: number;
   audioOutputCost?: number;
+  imageInputCost?: number;
+  videoInputCost?: number;
   contextLimit: number;
   inputLimit?: number;
   outputLimit: number;
@@ -121,6 +123,8 @@ export function renderRow(row: TableRow, index: number) {
     <td>${formatCost(row.cacheWriteCost)}</td>
     <td>${formatCost(row.audioInputCost)}</td>
     <td>${formatCost(row.audioOutputCost)}</td>
+    <td>${formatCost(row.imageInputCost)}</td>
+    <td>${formatCost(row.videoInputCost)}</td>
     <td>${formatNumber(row.contextLimit)}</td>
     <td>${formatNumber(row.inputLimit)}</td>
     <td>${formatNumber(row.outputLimit)}</td>
@@ -164,6 +168,8 @@ export function getLargestRow(rows: TableRow[]): TableRow {
     if (costWider(worst.cacheWriteCost, row.cacheWriteCost)) worst.cacheWriteCost = row.cacheWriteCost;
     if (costWider(worst.audioInputCost, row.audioInputCost)) worst.audioInputCost = row.audioInputCost;
     if (costWider(worst.audioOutputCost, row.audioOutputCost)) worst.audioOutputCost = row.audioOutputCost;
+    if (costWider(worst.imageInputCost, row.imageInputCost)) worst.imageInputCost = row.imageInputCost;
+    if (costWider(worst.videoInputCost, row.videoInputCost)) worst.videoInputCost = row.videoInputCost;
 
     const numWider = (a: number | undefined, b: number | undefined) =>
       b !== undefined && (a === undefined || formatNumber(b).length > formatNumber(a).length);

--- a/providers/google/models/gemini-embedding-2.toml
+++ b/providers/google/models/gemini-embedding-2.toml
@@ -1,0 +1,24 @@
+name = "Gemini Embedding 2"
+family = "gemini"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.00
+input_audio = 6.50
+input_image = 0.45
+input_video = 12.00
+
+[limit]
+context = 8_192
+output = 3_072
+
+[modalities]
+input = ["text", "image", "video", "audio", "pdf"]
+output = ["text"]

--- a/providers/vercel/models/google/gemini-embedding-2.toml
+++ b/providers/vercel/models/google/gemini-embedding-2.toml
@@ -1,17 +1,2 @@
-name = "Gemini Embedding 2"
-family = "gemini-embedding"
-attachment = false
-reasoning = false
-tool_call = false
-temperature = true
-release_date = "2026-03-10"
-last_updated = "2026-03-23"
-open_weights = false
-
-[limit]
-context = 0
-output = 0
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[extends]
+from = "google/gemini-embedding-2"


### PR DESCRIPTION
## Summary
Adds Google's new multimodal embedding model `gemini-embedding-2` and extends the cost schema with `input_image` / `input_video` fields so per-modality input pricing can be represented.
## Changes
### New model
- `providers/google/models/gemini-embedding-2.toml` — Google's first multimodal embedding model. Maps text, images, video, audio, and PDFs into a unified 3072-dim embedding space.
  - Pricing (per 1M tokens): text $0.20, image $0.45, audio $6.50, video $12.00
  - Context: 8,192 input tokens, 3,072 output dimensions
  - Modalities: text, image, video, audio, pdf → text
- `providers/vercel/models/google/gemini-embedding-2.toml` — wrapper using `[extends]` from the canonical Google entry.
### Schema
- `packages/core/src/schema.ts` — added optional `cost.input_image` and `cost.input_video` fields to the `Cost` schema, mirroring the existing `input_audio` pattern.
- `README.md` — documented the new fields and added them to the example.
### Web rendering
- `packages/web/src/render.tsx` — added two new sortable columns: **Image Input Cost** and **Video Input Cost** (placed after Audio Output Cost).
- `packages/web/src/index.css` — updated `nth-child` selectors to include the new cost columns in the dark-text/mono-font rules, and shifted the Weights-column reference from col 18 → col 24.
## Source
Pricing and capabilities sourced from:
- https://ai.google.dev/gemini-api/docs/pricing#gemini-embedding-2
- https://ai.google.dev/gemini-api/docs/embeddings
## Notes
- Google publishes image/video pricing in both per-token and per-unit forms ($0.00012/image, $0.00079/frame). Only the per-token rates are encoded since the `Cost` schema is token-based.
- Batch tier pricing is not available for this model yet.
- Existing `gemini-embedding-001` files in wrapper provider dirs were left as-is (full duplicates rather than `extends`) to keep this PR scoped.