### PR TITLE
fix ollama cloud kimi k2.6 model id

### DIFF
--- a/providers/ollama-cloud/models/kimi-k2.6.toml
+++ b/providers/ollama-cloud/models/kimi-k2.6.toml
@@ -1,4 +1,4 @@
-name = "kimi-k2.6:cloud"
+name = "kimi-k2.6"
 family = "kimi"
 attachment = true
 reasoning = true


### PR DESCRIPTION
## What changed

Renamed the Ollama Cloud Kimi K2.6 model file from `kimi-k2.6:cloud.toml` to `kimi-k2.6.toml` and removed the `:cloud` suffix from the display name.

## Why

Model IDs are generated from TOML filenames in this repo. The previous filename caused the generated model ID to include the Ollama tag suffix instead of the base model ID.

## Impact

Consumers will see the Ollama Cloud Kimi K2.6 model as `kimi-k2.6`, matching the display name and repo model ID conventions.

## Validation

- Parsed `providers/ollama-cloud/models/kimi-k2.6.toml` with Bun's TOML parser.
