### PR TITLE
feat: add new context pricing tiers

### DIFF
--- a/packages/core/script/generate-digitalocean.ts
+++ b/packages/core/script/generate-digitalocean.ts
@@ -209,6 +209,7 @@ interface ExistingModel {
       output?: number;
       cache_read?: number;
       cache_write?: number;
+      context_min?: number;
     };
     tiers?: Array<{
       context: {
@@ -272,6 +273,7 @@ interface MergedModel {
       output: number;
       cache_read?: number;
       cache_write?: number;
+      context_min?: number;
     };
   };
   limit: {
@@ -321,10 +323,33 @@ function inferFamily(modelId: string, modelName: string): string | undefined {
 }
 
 function getExistingLongContextCost(existing: ExistingModel | null) {
-  return (
-    existing?.cost?.tiers?.find((tier) => tier.context.min !== undefined && tier.context.min >= 200_000 && tier.context.max === undefined) ??
-    existing?.cost?.context_over_200k
+  const tier = existing?.cost?.tiers?.find(
+    (tier) =>
+      tier.context.min !== undefined &&
+      tier.context.min >= 200_000 &&
+      tier.context.max === undefined,
   );
+  if (tier) {
+    return {
+      ...tier,
+      context_min: tier.context.min,
+    };
+  }
+
+  return existing?.cost?.context_over_200k === undefined
+    ? undefined
+    : {
+        ...existing.cost.context_over_200k,
+        context_min: 200_000,
+      };
+}
+
+function getLongContextMin(cost: { context_min?: number }) {
+  return cost.context_min ?? 200_000;
+}
+
+function formatInlineNumber(n: number): string {
+  return n >= 1000 ? n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, "_") : n.toString();
 }
 
 // ---------------------------------------------------------------------------
@@ -416,6 +441,7 @@ function mergeModel(
       merged.cost.context_over_200k = {
         input: pricing.inputOver200k,
         output: pricing.outputOver200k,
+        context_min: existingLongContextCost?.context_min ?? 200_000,
         ...(existingLongContextCost?.cache_read !== undefined && {
           cache_read: existingLongContextCost.cache_read,
         }),
@@ -428,6 +454,7 @@ function mergeModel(
       merged.cost.context_over_200k = {
         input: existingLongContextCost.input ?? inputPrice,
         output: existingLongContextCost.output ?? outputPrice,
+        context_min: existingLongContextCost.context_min,
         ...(existingLongContextCost.cache_read !== undefined && {
           cache_read: existingLongContextCost.cache_read,
         }),
@@ -482,7 +509,7 @@ function formatToml(model: MergedModel): string {
     if (model.cost.context_over_200k) {
       lines.push("");
       lines.push(`[[cost.tiers]]`);
-      lines.push(`context = { min = 200_000 }`);
+      lines.push(`context = { min = ${formatInlineNumber(getLongContextMin(model.cost.context_over_200k))} }`);
       lines.push(`input = ${model.cost.context_over_200k.input}`);
       lines.push(`output = ${model.cost.context_over_200k.output}`);
       if (model.cost.context_over_200k.cache_read !== undefined)

--- a/packages/core/script/generate-digitalocean.ts
+++ b/packages/core/script/generate-digitalocean.ts
@@ -212,9 +212,9 @@ interface ExistingModel {
       context_min?: number;
     };
     tiers?: Array<{
-      context: {
-        min?: number;
-        max?: number;
+      tier: {
+        type?: "context";
+        size: number;
       };
       input?: number;
       output?: number;
@@ -325,14 +325,13 @@ function inferFamily(modelId: string, modelName: string): string | undefined {
 function getExistingLongContextCost(existing: ExistingModel | null) {
   const tier = existing?.cost?.tiers?.find(
     (tier) =>
-      tier.context.min !== undefined &&
-      tier.context.min >= 200_000 &&
-      tier.context.max === undefined,
+      (tier.tier.type === undefined || tier.tier.type === "context") &&
+      tier.tier.size >= 200_000,
   );
   if (tier) {
     return {
       ...tier,
-      context_min: tier.context.min,
+      context_min: tier.tier.size,
     };
   }
 
@@ -509,7 +508,7 @@ function formatToml(model: MergedModel): string {
     if (model.cost.context_over_200k) {
       lines.push("");
       lines.push(`[[cost.tiers]]`);
-      lines.push(`context = { min = ${formatInlineNumber(getLongContextMin(model.cost.context_over_200k))} }`);
+      lines.push(`tier = { size = ${formatInlineNumber(getLongContextMin(model.cost.context_over_200k))} }`);
       lines.push(`input = ${model.cost.context_over_200k.input}`);
       lines.push(`output = ${model.cost.context_over_200k.output}`);
       if (model.cost.context_over_200k.cache_read !== undefined)

--- a/packages/core/script/generate-digitalocean.ts
+++ b/packages/core/script/generate-digitalocean.ts
@@ -210,6 +210,16 @@ interface ExistingModel {
       cache_read?: number;
       cache_write?: number;
     };
+    tiers?: Array<{
+      context: {
+        min?: number;
+        max?: number;
+      };
+      input?: number;
+      output?: number;
+      cache_read?: number;
+      cache_write?: number;
+    }>;
   };
   limit?: {
     context?: number;
@@ -310,6 +320,13 @@ function inferFamily(modelId: string, modelName: string): string | undefined {
   return undefined;
 }
 
+function getExistingLongContextCost(existing: ExistingModel | null) {
+  return (
+    existing?.cost?.tiers?.find((tier) => tier.context.min !== undefined && tier.context.min >= 200_000 && tier.context.max === undefined) ??
+    existing?.cost?.context_over_200k
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Merge API data with existing TOML
 // ---------------------------------------------------------------------------
@@ -394,27 +411,28 @@ function mergeModel(
     };
 
     // Context-tiered pricing (>200k) from the static-content API
+    const existingLongContextCost = getExistingLongContextCost(existing);
     if (pricing?.inputOver200k !== undefined && pricing?.outputOver200k !== undefined) {
       merged.cost.context_over_200k = {
         input: pricing.inputOver200k,
         output: pricing.outputOver200k,
-        ...(existing?.cost?.context_over_200k?.cache_read !== undefined && {
-          cache_read: existing.cost.context_over_200k.cache_read,
+        ...(existingLongContextCost?.cache_read !== undefined && {
+          cache_read: existingLongContextCost.cache_read,
         }),
-        ...(existing?.cost?.context_over_200k?.cache_write !== undefined && {
-          cache_write: existing.cost.context_over_200k.cache_write,
+        ...(existingLongContextCost?.cache_write !== undefined && {
+          cache_write: existingLongContextCost.cache_write,
         }),
       };
-    } else if (existing?.cost?.context_over_200k) {
-      // Preserve manually-entered context_over_200k if API has no data
+    } else if (existingLongContextCost) {
+      // Preserve manually-entered tiered pricing if API has no data
       merged.cost.context_over_200k = {
-        input: existing.cost.context_over_200k.input ?? inputPrice,
-        output: existing.cost.context_over_200k.output ?? outputPrice,
-        ...(existing.cost.context_over_200k.cache_read !== undefined && {
-          cache_read: existing.cost.context_over_200k.cache_read,
+        input: existingLongContextCost.input ?? inputPrice,
+        output: existingLongContextCost.output ?? outputPrice,
+        ...(existingLongContextCost.cache_read !== undefined && {
+          cache_read: existingLongContextCost.cache_read,
         }),
-        ...(existing.cost.context_over_200k.cache_write !== undefined && {
-          cache_write: existing.cost.context_over_200k.cache_write,
+        ...(existingLongContextCost.cache_write !== undefined && {
+          cache_write: existingLongContextCost.cache_write,
         }),
       };
     }
@@ -463,7 +481,8 @@ function formatToml(model: MergedModel): string {
 
     if (model.cost.context_over_200k) {
       lines.push("");
-      lines.push(`[cost.context_over_200k]`);
+      lines.push(`[[cost.tiers]]`);
+      lines.push(`context = { min = 200_000 }`);
       lines.push(`input = ${model.cost.context_over_200k.input}`);
       lines.push(`output = ${model.cost.context_over_200k.output}`);
       if (model.cost.context_over_200k.cache_read !== undefined)

--- a/packages/core/script/generate-digitalocean.ts
+++ b/packages/core/script/generate-digitalocean.ts
@@ -569,8 +569,9 @@ function detectChanges(existing: ExistingModel | null, merged: MergedModel): Cha
   compare("status", existing.status, merged.status);
   compare("cost.input", existing.cost?.input, merged.cost?.input);
   compare("cost.output", existing.cost?.output, merged.cost?.output);
-  compare("cost.context_over_200k.input", existing.cost?.context_over_200k?.input, merged.cost?.context_over_200k?.input);
-  compare("cost.context_over_200k.output", existing.cost?.context_over_200k?.output, merged.cost?.context_over_200k?.output);
+  const existingLongContextCost = getExistingLongContextCost(existing);
+  compare("cost.context_over_200k.input", existingLongContextCost?.input, merged.cost?.context_over_200k?.input);
+  compare("cost.context_over_200k.output", existingLongContextCost?.output, merged.cost?.context_over_200k?.output);
   compare("limit.context", existing.limit?.context, merged.limit.context);
   compare("limit.output", existing.limit?.output, merged.limit.output);
   compare("modalities.input", existing.modalities?.input, merged.modalities.input);

--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -163,6 +163,16 @@ interface ExistingModel {
       cache_read?: number;
       cache_write?: number;
     };
+    tiers?: Array<{
+      context: {
+        min?: number;
+        max?: number;
+      };
+      input?: number;
+      output?: number;
+      cache_read?: number;
+      cache_write?: number;
+    }>;
   };
   limit?: {
     context?: number;
@@ -366,7 +376,8 @@ function formatToml(model: MergedModel): string {
 
     if (model.cost.context_over_200k) {
       lines.push("");
-      lines.push(`[cost.context_over_200k]`);
+      lines.push(`[[cost.tiers]]`);
+      lines.push(`context = { min = 200_000 }`);
       lines.push(`input = ${model.cost.context_over_200k.input}`);
       lines.push(`output = ${model.cost.context_over_200k.output}`);
       if (model.cost.context_over_200k.cache_read !== undefined) {

--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -216,6 +216,16 @@ function getExistingLongContextMin(existing: ExistingModel | null) {
   );
 }
 
+function getExistingLongContextCost(existing: ExistingModel | null) {
+  return (
+    existing?.cost?.tiers?.find(
+      (tier) =>
+        (tier.tier.type === undefined || tier.tier.type === "context") &&
+        tier.tier.size >= 200_000,
+    ) ?? existing?.cost?.context_over_200k
+  );
+}
+
 function getLongContextMin(cost: { context_min?: number }) {
   return cost.context_min ?? 200_000;
 }
@@ -466,10 +476,11 @@ function detectChanges(
   compare("cost.output", existing.cost?.output, merged.cost?.output);
   compare("cost.cache_read", existing.cost?.cache_read, merged.cost?.cache_read);
   compare("cost.cache_write", existing.cost?.cache_write, merged.cost?.cache_write);
-  compare("cost.context_over_200k.input", existing.cost?.context_over_200k?.input, merged.cost?.context_over_200k?.input);
-  compare("cost.context_over_200k.output", existing.cost?.context_over_200k?.output, merged.cost?.context_over_200k?.output);
-  compare("cost.context_over_200k.cache_read", existing.cost?.context_over_200k?.cache_read, merged.cost?.context_over_200k?.cache_read);
-  compare("cost.context_over_200k.cache_write", existing.cost?.context_over_200k?.cache_write, merged.cost?.context_over_200k?.cache_write);
+  const existingLongContextCost = getExistingLongContextCost(existing);
+  compare("cost.context_over_200k.input", existingLongContextCost?.input, merged.cost?.context_over_200k?.input);
+  compare("cost.context_over_200k.output", existingLongContextCost?.output, merged.cost?.context_over_200k?.output);
+  compare("cost.context_over_200k.cache_read", existingLongContextCost?.cache_read, merged.cost?.context_over_200k?.cache_read);
+  compare("cost.context_over_200k.cache_write", existingLongContextCost?.cache_write, merged.cost?.context_over_200k?.cache_write);
   compare("limit.context", existing.limit?.context, merged.limit.context);
   compare("limit.output", existing.limit?.output, merged.limit.output);
   compare("modalities.input", existing.modalities?.input, merged.modalities.input);

--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -328,7 +328,7 @@ function mergeModel(
       merged.cost.context_over_200k = {
         input: spec.pricing.extended.input.usd,
         output: spec.pricing.extended.output.usd,
-        context_min: getExistingLongContextMin(existing),
+        context_min: spec.pricing.extended.context_token_threshold,
         ...(spec.pricing.extended.cache_input && { cache_read: spec.pricing.extended.cache_input.usd }),
         ...(spec.pricing.extended.cache_write && { cache_write: spec.pricing.extended.cache_write.usd }),
       };

--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -165,9 +165,9 @@ interface ExistingModel {
       context_min?: number;
     };
     tiers?: Array<{
-      context: {
-        min?: number;
-        max?: number;
+      tier: {
+        type?: "context";
+        size: number;
       };
       input?: number;
       output?: number;
@@ -210,10 +210,9 @@ function getExistingLongContextMin(existing: ExistingModel | null) {
   return (
     existing?.cost?.tiers?.find(
       (tier) =>
-        tier.context.min !== undefined &&
-        tier.context.min >= 200_000 &&
-        tier.context.max === undefined,
-    )?.context.min ?? 200_000
+        (tier.tier.type === undefined || tier.tier.type === "context") &&
+        tier.tier.size >= 200_000,
+    )?.tier.size ?? 200_000
   );
 }
 
@@ -395,7 +394,7 @@ function formatToml(model: MergedModel): string {
     if (model.cost.context_over_200k) {
       lines.push("");
       lines.push(`[[cost.tiers]]`);
-      lines.push(`context = { min = ${formatNumber(getLongContextMin(model.cost.context_over_200k))} }`);
+      lines.push(`tier = { size = ${formatNumber(getLongContextMin(model.cost.context_over_200k))} }`);
       lines.push(`input = ${model.cost.context_over_200k.input}`);
       lines.push(`output = ${model.cost.context_over_200k.output}`);
       if (model.cost.context_over_200k.cache_read !== undefined) {

--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -162,6 +162,7 @@ interface ExistingModel {
       output?: number;
       cache_read?: number;
       cache_write?: number;
+      context_min?: number;
     };
     tiers?: Array<{
       context: {
@@ -205,6 +206,21 @@ async function loadExistingModel(filePath: string): Promise<ExistingModel | null
   }
 }
 
+function getExistingLongContextMin(existing: ExistingModel | null) {
+  return (
+    existing?.cost?.tiers?.find(
+      (tier) =>
+        tier.context.min !== undefined &&
+        tier.context.min >= 200_000 &&
+        tier.context.max === undefined,
+    )?.context.min ?? 200_000
+  );
+}
+
+function getLongContextMin(cost: { context_min?: number }) {
+  return cost.context_min ?? 200_000;
+}
+
 interface MergedModel {
   name: string;
   family?: string;
@@ -229,6 +245,7 @@ interface MergedModel {
       output: number;
       cache_read?: number;
       cache_write?: number;
+      context_min?: number;
     };
   };
   limit: {
@@ -302,6 +319,7 @@ function mergeModel(
       merged.cost.context_over_200k = {
         input: spec.pricing.extended.input.usd,
         output: spec.pricing.extended.output.usd,
+        context_min: getExistingLongContextMin(existing),
         ...(spec.pricing.extended.cache_input && { cache_read: spec.pricing.extended.cache_input.usd }),
         ...(spec.pricing.extended.cache_write && { cache_write: spec.pricing.extended.cache_write.usd }),
       };
@@ -377,7 +395,7 @@ function formatToml(model: MergedModel): string {
     if (model.cost.context_over_200k) {
       lines.push("");
       lines.push(`[[cost.tiers]]`);
-      lines.push(`context = { min = 200_000 }`);
+      lines.push(`context = { min = ${formatNumber(getLongContextMin(model.cost.context_over_200k))} }`);
       lines.push(`input = ${model.cost.context_over_200k.input}`);
       lines.push(`output = ${model.cost.context_over_200k.output}`);
       if (model.cost.context_over_200k.cache_read !== undefined) {

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -177,13 +177,14 @@ function normalizeCost(model: Record<string, unknown>) {
 
   const contextOver200k = tiers.find((tier) => {
     if (tier === null || typeof tier !== "object" || Array.isArray(tier)) return false;
-    const context = (tier as { context?: unknown }).context;
-    if (context === null || typeof context !== "object" || Array.isArray(context)) return false;
-    const min = (context as { min?: unknown }).min;
+    const tierConfig = (tier as { tier?: unknown }).tier;
+    if (tierConfig === null || typeof tierConfig !== "object" || Array.isArray(tierConfig)) return false;
+    const type = (tierConfig as { type?: unknown }).type;
+    const size = (tierConfig as { size?: unknown }).size;
     return (
-      typeof min === "number" &&
-      min >= 200_000 &&
-      (context as { max?: unknown }).max === undefined
+      (type === undefined || type === "context") &&
+      typeof size === "number" &&
+      size >= 200_000
     );
   });
 
@@ -191,7 +192,7 @@ function normalizeCost(model: Record<string, unknown>) {
     return model;
   }
 
-  const { context: _context, ...legacyCost } = contextOver200k as Record<string, unknown>;
+  const { tier: _tier, ...legacyCost } = contextOver200k as Record<string, unknown>;
   return {
     ...model,
     cost: {

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -181,6 +181,8 @@ function normalizeCost(model: Record<string, unknown>) {
     if (tierConfig === null || typeof tierConfig !== "object" || Array.isArray(tierConfig)) return false;
     const type = (tierConfig as { type?: unknown }).type;
     const size = (tierConfig as { size?: unknown }).size;
+    // context_over_200k is a legacy compatibility field. It intentionally
+    // includes higher thresholds; cost.tiers carries the exact threshold.
     return (
       (type === undefined || type === "context") &&
       typeof size === "number" &&

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -2,9 +2,9 @@ import path from "path";
 import { mergeDeep } from "remeda";
 import { z } from "zod";
 
-import { Provider, Model } from "./schema.js";
+import { Provider, Model, AuthoredModel, AuthoredModelShape } from "./schema.js";
 
-const ExtendsModel = Model.sourceType()
+const ExtendsModel = AuthoredModelShape
   .partial()
   .extend({
     extends: z
@@ -71,12 +71,12 @@ export async function generate(directory: string) {
         });
         continue;
       }
-      const model = Model.safeParse(toml);
+      const model = AuthoredModel.safeParse(toml);
       if (!model.success) {
         model.error.cause = { modelPath, toml };
         throw model.error;
       }
-      provider.data.models[modelID] = model.data;
+      provider.data.models[modelID] = normalizeModelCost(model.data);
     }
     result[providerID] = provider.data;
   }
@@ -144,7 +144,7 @@ export async function generate(directory: string) {
       }
     }
 
-    const model = Model.safeParse(merged);
+    const model = Model.safeParse(normalizeCost(merged));
     if (!model.success) {
       model.error.cause = { modelPath: pendingModel.modelPath, toml: merged };
       throw model.error;
@@ -154,4 +154,45 @@ export async function generate(directory: string) {
   }
 
   return result;
+}
+
+function normalizeModelCost(model: z.infer<typeof AuthoredModel>): Model {
+  return normalizeCost(model) as Model;
+}
+
+function normalizeCost(model: Record<string, unknown>) {
+  const cost = model.cost;
+  if (cost === undefined || cost === null || typeof cost !== "object" || Array.isArray(cost)) {
+    return model;
+  }
+
+  const tiers = (cost as { tiers?: unknown }).tiers;
+  if (!Array.isArray(tiers)) {
+    return model;
+  }
+
+  const contextOver200k = tiers.find((tier) => {
+    if (tier === null || typeof tier !== "object" || Array.isArray(tier)) return false;
+    const context = (tier as { context?: unknown }).context;
+    if (context === null || typeof context !== "object" || Array.isArray(context)) return false;
+    const min = (context as { min?: unknown }).min;
+    return (
+      typeof min === "number" &&
+      min >= 200_000 &&
+      (context as { max?: unknown }).max === undefined
+    );
+  });
+
+  if (contextOver200k === undefined) {
+    return model;
+  }
+
+  const { context: _context, ...legacyCost } = contextOver200k as Record<string, unknown>;
+  return {
+    ...model,
+    cost: {
+      ...(cost as Record<string, unknown>),
+      context_over_200k: legacyCost,
+    },
+  };
 }

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -171,6 +171,10 @@ function normalizeCost(model: Record<string, unknown>) {
     return model;
   }
 
+  if (tiers.length !== 1) {
+    return model;
+  }
+
   const contextOver200k = tiers.find((tier) => {
     if (tier === null || typeof tier !== "object" || Array.isArray(tier)) return false;
     const context = (tier as { context?: unknown }).context;

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -21,110 +21,179 @@ const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
   ]),
 );
 
-const Cost = z.object({
-  input: z.number().min(0, "Input price cannot be negative"),
-  output: z.number().min(0, "Output price cannot be negative"),
-  reasoning: z.number().min(0, "Input price cannot be negative").optional(),
-  cache_read: z
-    .number()
-    .min(0, "Cache read price cannot be negative")
+const Cost = z
+  .object({
+    input: z.number().min(0, "Input price cannot be negative"),
+    output: z.number().min(0, "Output price cannot be negative"),
+    reasoning: z
+      .number()
+      .min(0, "Reasoning price cannot be negative")
+      .optional(),
+    cache_read: z
+      .number()
+      .min(0, "Cache read price cannot be negative")
+      .optional(),
+    cache_write: z
+      .number()
+      .min(0, "Cache write price cannot be negative")
+      .optional(),
+    input_audio: z
+      .number()
+      .min(0, "Audio input price cannot be negative")
+      .optional(),
+    output_audio: z
+      .number()
+      .min(0, "Audio output price cannot be negative")
+      .optional(),
+  });
+
+const CostTier = Cost.extend({
+  context: z
+    .object({
+      min: z.number().min(0, "Context tier minimum cannot be negative").optional(),
+      max: z.number().min(0, "Context tier maximum cannot be negative").optional(),
+    })
+    .strict(),
+}).strict();
+
+const AuthoredCost = Cost.extend({
+  context_over_200k: z.never().optional(),
+  tiers: z.array(CostTier).optional(),
+});
+
+const OutputCost = Cost.extend({
+  context_over_200k: Cost.optional(),
+  tiers: z.array(CostTier).optional(),
+});
+
+const ModelBase = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Model name cannot be empty"),
+  family: ModelFamily.optional(),
+  attachment: z.boolean(),
+  reasoning: z.boolean(),
+  tool_call: z.boolean(),
+  interleaved: z
+    .union([
+      z.literal(true),
+      z
+        .object({
+          field: z.enum(["reasoning_content", "reasoning_details"]),
+        })
+        .strict(),
+    ])
     .optional(),
-  cache_write: z
-    .number()
-    .min(0, "Cache write price cannot be negative")
+  structured_output: z.boolean().optional(),
+  temperature: z.boolean().optional(),
+  knowledge: z
+    .string()
+    .regex(/^\d{4}-\d{2}(-\d{2})?$/, {
+      message: "Must be in YYYY-MM or YYYY-MM-DD format",
+    })
     .optional(),
-  input_audio: z
-    .number()
-    .min(0, "Audio input price cannot be negative")
+  release_date: z.string().regex(/^\d{4}-\d{2}(-\d{2})?$/, {
+    message: "Must be in YYYY-MM or YYYY-MM-DD format",
+  }),
+  last_updated: z.string().regex(/^\d{4}-\d{2}(-\d{2})?$/, {
+    message: "Must be in YYYY-MM or YYYY-MM-DD format",
+  }),
+  modalities: z.object({
+    input: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
+    output: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
+  }),
+  open_weights: z.boolean(),
+  limit: z.object({
+    context: z.number().min(0, "Context window must be positive"),
+    input: z.number().min(0, "Input tokens must be positive").optional(),
+    output: z.number().min(0, "Output tokens must be positive"),
+  }),
+  status: z.enum(["alpha", "beta", "deprecated"]).optional(),
+  experimental: z
+    .object({
+      modes: z
+        .record(
+          z.object({
+            cost: Cost.optional(),
+            provider: z
+              .object({
+                body: z.record(JsonValue).optional(),
+                headers: z.record(z.string()).optional(),
+              })
+              .optional(),
+          }),
+        )
+        .optional(),
+    })
     .optional(),
-  output_audio: z
-    .number()
-    .min(0, "Audio output price cannot be negative")
+  provider: z
+    .object({
+      npm: z.string().optional(),
+      api: z.string().optional(),
+      shape: z.enum(["responses", "completions"]).optional(),
+      body: z.record(JsonValue).optional(),
+      headers: z.record(z.string()).optional(),
+    })
     .optional(),
 });
-export const Model = z
+
+function refineModel<T extends z.ZodTypeAny>(schema: T) {
+  return schema
+    .refine(
+      (data) => {
+        return !(data.reasoning === false && data.cost?.reasoning !== undefined);
+      },
+      {
+        message: "Cannot set cost.reasoning when reasoning is false",
+        path: ["cost", "reasoning"],
+      },
+    )
+    .refine(
+      (data) => {
+        return (
+          data.cost?.tiers?.every((tier: { context: { min?: number; max?: number } }) => {
+            const { min, max } = tier.context;
+            return min !== undefined || max !== undefined;
+          }) ?? true
+        );
+      },
+      {
+        message: "Cost tiers must include at least one context bound",
+        path: ["cost", "tiers"],
+      },
+    )
+    .refine(
+      (data) => {
+        return (
+          data.cost?.tiers?.every((tier: { context: { min?: number; max?: number } }) => {
+            const { min, max } = tier.context;
+            return min === undefined || max === undefined || min < max;
+          }) ?? true
+        );
+      },
+      {
+        message: "Cost tier context min must be less than max",
+        path: ["cost", "tiers"],
+      },
+    );
+}
+
+export const ModelShape = z
   .object({
-    id: z.string(),
-    name: z.string().min(1, "Model name cannot be empty"),
-    family: ModelFamily.optional(),
-    attachment: z.boolean(),
-    reasoning: z.boolean(),
-    tool_call: z.boolean(),
-    interleaved: z
-      .union([
-        z.literal(true),
-        z
-          .object({
-            field: z.enum(["reasoning_content", "reasoning_details"]),
-          })
-          .strict(),
-      ])
-      .optional(),
-    structured_output: z.boolean().optional(),
-    temperature: z.boolean().optional(),
-    knowledge: z
-      .string()
-      .regex(/^\d{4}-\d{2}(-\d{2})?$/, {
-        message: "Must be in YYYY-MM or YYYY-MM-DD format",
-      })
-      .optional(),
-    release_date: z.string().regex(/^\d{4}-\d{2}(-\d{2})?$/, {
-      message: "Must be in YYYY-MM or YYYY-MM-DD format",
-    }),
-    last_updated: z.string().regex(/^\d{4}-\d{2}(-\d{2})?$/, {
-      message: "Must be in YYYY-MM or YYYY-MM-DD format",
-    }),
-    modalities: z.object({
-      input: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
-      output: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
-    }),
-    open_weights: z.boolean(),
-    cost: Cost.extend({
-      context_over_200k: Cost.optional(),
-    }).optional(),
-    limit: z.object({
-      context: z.number().min(0, "Context window must be positive"),
-      input: z.number().min(0, "Input tokens must be positive").optional(),
-      output: z.number().min(0, "Output tokens must be positive"),
-    }),
-    status: z.enum(["alpha", "beta", "deprecated"]).optional(),
-    experimental: z
-      .object({
-        modes: z
-          .record(
-            z.object({
-              cost: Cost.optional(),
-              provider: z
-                .object({
-                  body: z.record(JsonValue).optional(),
-                  headers: z.record(z.string()).optional(),
-                })
-                .optional(),
-            }),
-          )
-          .optional(),
-      })
-      .optional(),
-    provider: z
-      .object({
-        npm: z.string().optional(),
-        api: z.string().optional(),
-        shape: z.enum(["responses", "completions"]).optional(),
-        body: z.record(JsonValue).optional(),
-        headers: z.record(z.string()).optional(),
-      })
-      .optional(),
+    ...ModelBase.shape,
+    cost: OutputCost.optional(),
   })
-  .strict()
-  .refine(
-    (data) => {
-      return !(data.reasoning === false && data.cost?.reasoning !== undefined);
-    },
-    {
-      message: "Cannot set cost.reasoning when reasoning is false",
-      path: ["cost", "reasoning"],
-    },
-  );
+  .strict();
+
+export const AuthoredModelShape = z
+  .object({
+    ...ModelBase.shape,
+    cost: AuthoredCost.optional(),
+  })
+  .strict();
+
+export const Model = refineModel(ModelShape);
+
+export const AuthoredModel = refineModel(AuthoredModelShape);
 
 export type Model = z.infer<typeof Model>;
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -48,10 +48,10 @@ const Cost = z
   });
 
 const CostTier = Cost.extend({
-  context: z
+  tier: z
     .object({
-      min: z.number().min(0, "Context tier minimum cannot be negative").optional(),
-      max: z.number().min(0, "Context tier maximum cannot be negative").optional(),
+      type: z.literal("context").default("context"),
+      size: z.number().int().min(0, "Context tier size cannot be negative"),
     })
     .strict(),
 }).strict();
@@ -149,29 +149,14 @@ function refineModel<T extends z.ZodTypeAny>(schema: T) {
     )
     .refine(
       (data) => {
-        return (
-          data.cost?.tiers?.every((tier: { context: { min?: number; max?: number } }) => {
-            const { min, max } = tier.context;
-            return min !== undefined || max !== undefined;
-          }) ?? true
-        );
+        const tiers = data.cost?.tiers;
+        if (tiers === undefined) return true;
+
+        const sizes = tiers.map((tier: { tier: { size: number } }) => tier.tier.size);
+        return new Set(sizes).size === sizes.length;
       },
       {
-        message: "Cost tiers must include at least one context bound",
-        path: ["cost", "tiers"],
-      },
-    )
-    .refine(
-      (data) => {
-        return (
-          data.cost?.tiers?.every((tier: { context: { min?: number; max?: number } }) => {
-            const { min, max } = tier.context;
-            return min === undefined || max === undefined || min < max;
-          }) ?? true
-        );
-      },
-      {
-        message: "Cost tier context min must be less than max",
+        message: "Cost context tiers must not have duplicate sizes",
         path: ["cost", "tiers"],
       },
     );

--- a/providers/302ai/models/claude-opus-4-7.toml
+++ b/providers/302ai/models/claude-opus-4-7.toml
@@ -16,7 +16,7 @@ cache_read = 0.500
 cache_write = 6.250
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.000
 output = 37.500
 cache_read = 1.000

--- a/providers/302ai/models/claude-opus-4-7.toml
+++ b/providers/302ai/models/claude-opus-4-7.toml
@@ -15,7 +15,8 @@ output = 25.000
 cache_read = 0.500
 cache_write = 6.250
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.000
 output = 37.500
 cache_read = 1.000

--- a/providers/302ai/models/gpt-5.4-pro.toml
+++ b/providers/302ai/models/gpt-5.4-pro.toml
@@ -17,7 +17,7 @@ cache_read = 0
 cache_write = 0
 
 [[cost.tiers]]
-context = { min = 272_000 }
+tier = { size = 272_000 }
 input = 60.000
 output = 270.000
 

--- a/providers/302ai/models/gpt-5.4-pro.toml
+++ b/providers/302ai/models/gpt-5.4-pro.toml
@@ -16,7 +16,8 @@ output = 180.000
 cache_read = 0
 cache_write = 0
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 272_000 }
 input = 60.000
 output = 270.000
 

--- a/providers/302ai/models/gpt-5.4.toml
+++ b/providers/302ai/models/gpt-5.4.toml
@@ -16,7 +16,8 @@ output = 15.000
 cache_read = 0.250
 cache_write = 0
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 272_000 }
 input = 5.000
 output = 22.500
 

--- a/providers/302ai/models/gpt-5.4.toml
+++ b/providers/302ai/models/gpt-5.4.toml
@@ -17,7 +17,7 @@ cache_read = 0.250
 cache_write = 0
 
 [[cost.tiers]]
-context = { min = 272_000 }
+tier = { size = 272_000 }
 input = 5.000
 output = 22.500
 

--- a/providers/aihubmix/models/claude-sonnet-4-6-think.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6-think.toml
@@ -16,7 +16,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/aihubmix/models/claude-sonnet-4-6-think.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6-think.toml
@@ -15,7 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/aihubmix/models/claude-sonnet-4-6.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6.toml
@@ -16,7 +16,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/aihubmix/models/claude-sonnet-4-6.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6.toml
@@ -15,7 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/aihubmix/models/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/aihubmix/models/gemini-3.1-pro-preview-customtools.toml
@@ -16,7 +16,7 @@ output = 12
 cache_read = 0.2
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4
 output = 18
 cache_read = 0.4

--- a/providers/aihubmix/models/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/aihubmix/models/gemini-3.1-pro-preview-customtools.toml
@@ -15,7 +15,8 @@ input = 2
 output = 12
 cache_read = 0.2
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4
 output = 18
 cache_read = 0.4

--- a/providers/aihubmix/models/grok-4.3.toml
+++ b/providers/aihubmix/models/grok-4.3.toml
@@ -15,7 +15,7 @@ output = 2.5
 cache_read = 0.2
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 2.5
 output = 5.0
 cache_read = 0.4

--- a/providers/aihubmix/models/grok-4.3.toml
+++ b/providers/aihubmix/models/grok-4.3.toml
@@ -14,7 +14,8 @@ input = 1.25
 output = 2.5
 cache_read = 0.2
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 2.5
 output = 5.0
 cache_read = 0.4

--- a/providers/alibaba-cn/models/qwen3.6-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.6-plus.toml
@@ -16,7 +16,7 @@ cache_read = 0.05
 cache_write = 0.625
 
 [[cost.tiers]]
-context = { min = 256_000 }
+tier = { size = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.20

--- a/providers/alibaba-cn/models/qwen3.6-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.6-plus.toml
@@ -10,10 +10,17 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.276
-output = 1.651
-cache_read = 0.028
-cache_write = 0.344
+input = 0.50
+output = 3.00
+cache_read = 0.05
+cache_write = 0.625
+
+[[cost.tiers]]
+context = { min = 256_000 }
+input = 2.00
+output = 6.00
+cache_read = 0.20
+cache_write = 2.50
 
 [limit]
 context = 1_000_000

--- a/providers/alibaba/models/qwen3.6-plus.toml
+++ b/providers/alibaba/models/qwen3.6-plus.toml
@@ -16,7 +16,7 @@ cache_read = 0.05
 cache_write = 0.625
 
 [[cost.tiers]]
-context = { min = 256_000 }
+tier = { size = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.20

--- a/providers/alibaba/models/qwen3.6-plus.toml
+++ b/providers/alibaba/models/qwen3.6-plus.toml
@@ -10,10 +10,17 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.276
-output = 1.651
-cache_read = 0.028
-cache_write = 0.344
+input = 0.50
+output = 3.00
+cache_read = 0.05
+cache_write = 0.625
+
+[[cost.tiers]]
+context = { min = 256_000 }
+input = 2.00
+output = 6.00
+cache_read = 0.20
+cache_write = 2.50
 
 [limit]
 context = 1_000_000

--- a/providers/azure-cognitive-services/models/claude-opus-4-6.toml
+++ b/providers/azure-cognitive-services/models/claude-opus-4-6.toml
@@ -15,7 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/azure-cognitive-services/models/claude-opus-4-6.toml
+++ b/providers/azure-cognitive-services/models/claude-opus-4-6.toml
@@ -16,7 +16,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/azure/models/claude-opus-4-6.toml
+++ b/providers/azure/models/claude-opus-4-6.toml
@@ -15,7 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/azure/models/claude-opus-4-6.toml
+++ b/providers/azure/models/claude-opus-4-6.toml
@@ -16,7 +16,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
@@ -15,7 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
@@ -16,7 +16,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-6.toml
@@ -16,7 +16,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-6.toml
@@ -17,7 +17,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/digitalocean/models/anthropic-claude-4.5-sonnet.toml
+++ b/providers/digitalocean/models/anthropic-claude-4.5-sonnet.toml
@@ -15,7 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.30

--- a/providers/digitalocean/models/anthropic-claude-4.5-sonnet.toml
+++ b/providers/digitalocean/models/anthropic-claude-4.5-sonnet.toml
@@ -16,7 +16,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.30

--- a/providers/digitalocean/models/anthropic-claude-4.6-sonnet.toml
+++ b/providers/digitalocean/models/anthropic-claude-4.6-sonnet.toml
@@ -15,7 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.30

--- a/providers/digitalocean/models/anthropic-claude-4.6-sonnet.toml
+++ b/providers/digitalocean/models/anthropic-claude-4.6-sonnet.toml
@@ -16,7 +16,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.30

--- a/providers/digitalocean/models/anthropic-claude-opus-4.6.toml
+++ b/providers/digitalocean/models/anthropic-claude-opus-4.6.toml
@@ -16,7 +16,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 0.50

--- a/providers/digitalocean/models/anthropic-claude-opus-4.6.toml
+++ b/providers/digitalocean/models/anthropic-claude-opus-4.6.toml
@@ -15,7 +15,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 0.50

--- a/providers/digitalocean/models/anthropic-claude-sonnet-4.toml
+++ b/providers/digitalocean/models/anthropic-claude-sonnet-4.toml
@@ -15,7 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.30

--- a/providers/digitalocean/models/anthropic-claude-sonnet-4.toml
+++ b/providers/digitalocean/models/anthropic-claude-sonnet-4.toml
@@ -16,7 +16,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.30

--- a/providers/digitalocean/models/openai-gpt-5.5.toml
+++ b/providers/digitalocean/models/openai-gpt-5.5.toml
@@ -16,7 +16,7 @@ output = 30.00
 cache_read = 0.50
 
 [[cost.tiers]]
-context = { min = 272_000 }
+tier = { size = 272_000 }
 input = 10.00
 output = 45.00
 cache_read = 1.00

--- a/providers/digitalocean/models/openai-gpt-5.5.toml
+++ b/providers/digitalocean/models/openai-gpt-5.5.toml
@@ -15,7 +15,8 @@ input = 5.00
 output = 30.00
 cache_read = 0.50
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 272_000 }
 input = 10.00
 output = 45.00
 cache_read = 1.00

--- a/providers/google-vertex-anthropic/models/claude-opus-4-6@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-opus-4-6@default.toml
@@ -8,7 +8,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/google-vertex-anthropic/models/claude-opus-4-6@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-opus-4-6@default.toml
@@ -9,7 +9,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/google-vertex-anthropic/models/claude-opus-4-7@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-opus-4-7@default.toml
@@ -8,7 +8,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/google-vertex-anthropic/models/claude-opus-4-7@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-opus-4-7@default.toml
@@ -7,7 +7,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
@@ -8,7 +8,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
@@ -7,7 +7,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/google-vertex/models/claude-opus-4-6@default.toml
+++ b/providers/google-vertex/models/claude-opus-4-6@default.toml
@@ -8,7 +8,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/google-vertex/models/claude-opus-4-6@default.toml
+++ b/providers/google-vertex/models/claude-opus-4-6@default.toml
@@ -9,7 +9,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/google-vertex/models/claude-opus-4-7@default.toml
+++ b/providers/google-vertex/models/claude-opus-4-7@default.toml
@@ -8,7 +8,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/google-vertex/models/claude-opus-4-7@default.toml
+++ b/providers/google-vertex/models/claude-opus-4-7@default.toml
@@ -7,7 +7,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/google-vertex/models/claude-sonnet-4-6@default.toml
+++ b/providers/google-vertex/models/claude-sonnet-4-6@default.toml
@@ -8,7 +8,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/google-vertex/models/claude-sonnet-4-6@default.toml
+++ b/providers/google-vertex/models/claude-sonnet-4-6@default.toml
@@ -7,7 +7,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/google-vertex/models/gemini-3-pro-preview.toml
+++ b/providers/google-vertex/models/gemini-3-pro-preview.toml
@@ -15,7 +15,8 @@ input = 2.00
 output = 12.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/google-vertex/models/gemini-3-pro-preview.toml
+++ b/providers/google-vertex/models/gemini-3-pro-preview.toml
@@ -16,7 +16,7 @@ output = 12.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/google/models/gemini-2.5-flash-lite.toml
+++ b/providers/google/models/gemini-2.5-flash-lite.toml
@@ -13,7 +13,8 @@ open_weights = false
 [cost]
 input = 0.10
 output = 0.40
-cache_read = 0.025
+cache_read = 0.01
+input_audio = 0.30
 
 [limit]
 context = 1_048_576

--- a/providers/google/models/gemini-2.5-pro.toml
+++ b/providers/google/models/gemini-2.5-pro.toml
@@ -16,7 +16,7 @@ output = 10.00
 cache_read = 0.125
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 2.50
 output = 15.00
 cache_read = 0.25

--- a/providers/google/models/gemini-2.5-pro.toml
+++ b/providers/google/models/gemini-2.5-pro.toml
@@ -15,7 +15,8 @@ input = 1.25
 output = 10.00
 cache_read = 0.125
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 2.50
 output = 15.00
 cache_read = 0.25

--- a/providers/google/models/gemini-3-flash-preview.toml
+++ b/providers/google/models/gemini-3-flash-preview.toml
@@ -14,11 +14,7 @@ open_weights = false
 input = 0.50
 output = 3.00
 cache_read = 0.05
-
-[cost.context_over_200k]
-input = 0.50
-output = 3.00
-cache_read = 0.05
+input_audio = 1.00
 
 [limit]
 context = 1048576

--- a/providers/google/models/gemini-3-pro-preview.toml
+++ b/providers/google/models/gemini-3-pro-preview.toml
@@ -15,7 +15,8 @@ input = 2.00
 output = 12.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/google/models/gemini-3-pro-preview.toml
+++ b/providers/google/models/gemini-3-pro-preview.toml
@@ -16,7 +16,7 @@ output = 12.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/google/models/gemini-3.1-flash-image-preview.toml
+++ b/providers/google/models/gemini-3.1-flash-image-preview.toml
@@ -10,7 +10,7 @@ tool_call = false
 open_weights = false
 
 [cost]
-input = 0.25
+input = 0.50
 output = 60.00
 
 [limit]

--- a/providers/google/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/google/models/gemini-3.1-flash-lite-preview.toml
@@ -14,7 +14,7 @@ open_weights = false
 input = 0.25
 output = 1.50
 cache_read = 0.025
-cache_write = 1.00
+input_audio = 0.50
 
 [limit]
 context = 1048576

--- a/providers/google/models/gemini-3.1-flash-lite.toml
+++ b/providers/google/models/gemini-3.1-flash-lite.toml
@@ -14,7 +14,7 @@ open_weights = false
 input = 0.25
 output = 1.50
 cache_read = 0.025
-cache_write = 1.00
+input_audio = 0.50
 
 [limit]
 context = 1_048_576

--- a/providers/google/models/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/google/models/gemini-3.1-pro-preview-customtools.toml
@@ -15,7 +15,8 @@ input = 2.00
 output = 12.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/google/models/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/google/models/gemini-3.1-pro-preview-customtools.toml
@@ -16,7 +16,7 @@ output = 12.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/google/models/gemini-3.1-pro-preview.toml
+++ b/providers/google/models/gemini-3.1-pro-preview.toml
@@ -15,7 +15,8 @@ input = 2.00
 output = 12.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/google/models/gemini-3.1-pro-preview.toml
+++ b/providers/google/models/gemini-3.1-pro-preview.toml
@@ -16,7 +16,7 @@ output = 12.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/llmgateway/models/gpt-5.4-pro.toml
+++ b/providers/llmgateway/models/gpt-5.4-pro.toml
@@ -1,3 +1,3 @@
 [extends]
 from = "openai/gpt-5.4-pro"
-omit = ["cost.context_over_200k"]
+omit = ["cost.context_over_200k", "cost.tiers"]

--- a/providers/llmgateway/models/gpt-5.4.toml
+++ b/providers/llmgateway/models/gpt-5.4.toml
@@ -1,3 +1,3 @@
 [extends]
 from = "openai/gpt-5.4"
-omit = ["cost.context_over_200k", "experimental.modes.fast"]
+omit = ["cost.context_over_200k", "cost.tiers", "experimental.modes.fast"]

--- a/providers/openai/models/gpt-5.4-pro.toml
+++ b/providers/openai/models/gpt-5.4-pro.toml
@@ -14,7 +14,8 @@ open_weights = false
 input = 30.00
 output = 180.00
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 272_000 }
 input = 60.00
 output = 270.00
 

--- a/providers/openai/models/gpt-5.4-pro.toml
+++ b/providers/openai/models/gpt-5.4-pro.toml
@@ -15,7 +15,7 @@ input = 30.00
 output = 180.00
 
 [[cost.tiers]]
-context = { min = 272_000 }
+tier = { size = 272_000 }
 input = 60.00
 output = 270.00
 

--- a/providers/openai/models/gpt-5.4.toml
+++ b/providers/openai/models/gpt-5.4.toml
@@ -15,7 +15,8 @@ input = 2.50
 output = 15.00
 cache_read = 0.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 272_000 }
 input = 5.00
 output = 22.50
 cache_read = 0.50

--- a/providers/openai/models/gpt-5.4.toml
+++ b/providers/openai/models/gpt-5.4.toml
@@ -16,7 +16,7 @@ output = 15.00
 cache_read = 0.25
 
 [[cost.tiers]]
-context = { min = 272_000 }
+tier = { size = 272_000 }
 input = 5.00
 output = 22.50
 cache_read = 0.50

--- a/providers/openai/models/gpt-5.5-pro.toml
+++ b/providers/openai/models/gpt-5.5-pro.toml
@@ -14,7 +14,8 @@ open_weights = false
 input = 30.00
 output = 180.00
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 272_000 }
 input = 60.00
 output = 270.00
 

--- a/providers/openai/models/gpt-5.5-pro.toml
+++ b/providers/openai/models/gpt-5.5-pro.toml
@@ -15,7 +15,7 @@ input = 30.00
 output = 180.00
 
 [[cost.tiers]]
-context = { min = 272_000 }
+tier = { size = 272_000 }
 input = 60.00
 output = 270.00
 

--- a/providers/openai/models/gpt-5.5.toml
+++ b/providers/openai/models/gpt-5.5.toml
@@ -16,7 +16,7 @@ output = 30.00
 cache_read = 0.50
 
 [[cost.tiers]]
-context = { min = 272_000 }
+tier = { size = 272_000 }
 input = 10.00
 output = 45.00
 cache_read = 1.00

--- a/providers/openai/models/gpt-5.5.toml
+++ b/providers/openai/models/gpt-5.5.toml
@@ -15,7 +15,8 @@ input = 5.00
 output = 30.00
 cache_read = 0.50
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 272_000 }
 input = 10.00
 output = 45.00
 cache_read = 1.00

--- a/providers/opencode-go/models/mimo-v2-pro.toml
+++ b/providers/opencode-go/models/mimo-v2-pro.toml
@@ -19,7 +19,7 @@ output = 3.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 256_000 }
+tier = { size = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.40

--- a/providers/opencode-go/models/mimo-v2-pro.toml
+++ b/providers/opencode-go/models/mimo-v2-pro.toml
@@ -18,7 +18,8 @@ input = 1.00
 output = 3.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.40

--- a/providers/opencode-go/models/mimo-v2.5-pro.toml
+++ b/providers/opencode-go/models/mimo-v2.5-pro.toml
@@ -17,7 +17,8 @@ input = 1.00
 output = 3.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.40

--- a/providers/opencode-go/models/mimo-v2.5-pro.toml
+++ b/providers/opencode-go/models/mimo-v2.5-pro.toml
@@ -18,7 +18,7 @@ output = 3.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 256_000 }
+tier = { size = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.40

--- a/providers/opencode-go/models/mimo-v2.5.toml
+++ b/providers/opencode-go/models/mimo-v2.5.toml
@@ -17,7 +17,8 @@ input = 0.40
 output = 2.00
 cache_read = 0.08
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 256_000 }
 input = 0.80
 output = 4.00
 cache_read = 0.16

--- a/providers/opencode-go/models/mimo-v2.5.toml
+++ b/providers/opencode-go/models/mimo-v2.5.toml
@@ -18,7 +18,7 @@ output = 2.00
 cache_read = 0.08
 
 [[cost.tiers]]
-context = { min = 256_000 }
+tier = { size = 256_000 }
 input = 0.80
 output = 4.00
 cache_read = 0.16

--- a/providers/opencode/models/claude-sonnet-4-5.toml
+++ b/providers/opencode/models/claude-sonnet-4-5.toml
@@ -16,7 +16,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/opencode/models/claude-sonnet-4-5.toml
+++ b/providers/opencode/models/claude-sonnet-4-5.toml
@@ -17,7 +17,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/opencode/models/claude-sonnet-4.toml
+++ b/providers/opencode/models/claude-sonnet-4.toml
@@ -16,7 +16,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/opencode/models/claude-sonnet-4.toml
+++ b/providers/opencode/models/claude-sonnet-4.toml
@@ -15,7 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/opencode/models/gemini-3-pro.toml
+++ b/providers/opencode/models/gemini-3-pro.toml
@@ -16,7 +16,8 @@ input = 2.00
 output = 12.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/opencode/models/gemini-3-pro.toml
+++ b/providers/opencode/models/gemini-3-pro.toml
@@ -17,7 +17,7 @@ output = 12.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/opencode/models/gemini-3.1-pro.toml
+++ b/providers/opencode/models/gemini-3.1-pro.toml
@@ -15,7 +15,8 @@ input = 2.00
 output = 12.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/opencode/models/gemini-3.1-pro.toml
+++ b/providers/opencode/models/gemini-3.1-pro.toml
@@ -16,7 +16,7 @@ output = 12.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/openrouter/models/anthropic/claude-opus-4.6.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.6.toml
@@ -17,7 +17,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/openrouter/models/anthropic/claude-opus-4.6.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.6.toml
@@ -16,7 +16,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/openrouter/models/anthropic/claude-opus-4.7.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.7.toml
@@ -17,7 +17,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/openrouter/models/anthropic/claude-opus-4.7.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.7.toml
@@ -16,7 +16,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
@@ -16,7 +16,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
@@ -17,7 +17,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
@@ -16,7 +16,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
@@ -17,7 +17,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.toml
@@ -16,7 +16,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.toml
@@ -15,7 +15,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/openrouter/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/openrouter/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -19,7 +19,7 @@ output = 12.00
 reasoning = 12.00
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/openrouter/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/openrouter/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -18,7 +18,8 @@ input = 2.00
 output = 12.00
 reasoning = 12.00
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/openrouter/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/openrouter/models/google/gemini-3.1-pro-preview.toml
@@ -19,7 +19,7 @@ output = 12.00
 reasoning = 12.00
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/openrouter/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/openrouter/models/google/gemini-3.1-pro-preview.toml
@@ -18,7 +18,8 @@ input = 2.00
 output = 12.00
 reasoning = 12.00
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/openrouter/models/x-ai/grok-4.20-beta.toml
+++ b/providers/openrouter/models/x-ai/grok-4.20-beta.toml
@@ -15,7 +15,7 @@ output = 6.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 12.00
 cache_read = 0.40

--- a/providers/openrouter/models/x-ai/grok-4.20-beta.toml
+++ b/providers/openrouter/models/x-ai/grok-4.20-beta.toml
@@ -14,9 +14,11 @@ input = 2.00
 output = 6.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 12.00
+cache_read = 0.40
 
 [limit]
 context = 2_000_000
@@ -25,4 +27,3 @@ output = 30_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-

--- a/providers/openrouter/models/x-ai/grok-4.20-multi-agent-beta.toml
+++ b/providers/openrouter/models/x-ai/grok-4.20-multi-agent-beta.toml
@@ -14,9 +14,11 @@ input = 2.00
 output = 6.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 12.00
+cache_read = 0.40
 
 [limit]
 context = 2_000_000

--- a/providers/openrouter/models/x-ai/grok-4.20-multi-agent-beta.toml
+++ b/providers/openrouter/models/x-ai/grok-4.20-multi-agent-beta.toml
@@ -15,7 +15,7 @@ output = 6.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 12.00
 cache_read = 0.40

--- a/providers/openrouter/models/x-ai/grok-4.3.toml
+++ b/providers/openrouter/models/x-ai/grok-4.3.toml
@@ -3,6 +3,16 @@ structured_output = true
 [extends]
 from = "xai/grok-4.3"
 
+[cost]
+input = 1.25
+output = 2.50
+cache_read = 0.20
+
+[[cost.tiers]]
+context = { min = 200_000 }
+input = 2.50
+output = 5.00
+cache_read = 0.40
 
 [limit]
 context = 1_000_000

--- a/providers/openrouter/models/x-ai/grok-4.3.toml
+++ b/providers/openrouter/models/x-ai/grok-4.3.toml
@@ -9,7 +9,7 @@ output = 2.50
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 2.50
 output = 5.00
 cache_read = 0.40

--- a/providers/openrouter/models/x-ai/grok-4.toml
+++ b/providers/openrouter/models/x-ai/grok-4.toml
@@ -16,6 +16,11 @@ output = 15.00
 cache_read = 0.75
 cache_write = 15.00
 
+[[cost.tiers]]
+context = { min = 128_000 }
+input = 6.00
+output = 30.00
+
 [limit]
 context = 256_000
 output = 64_000

--- a/providers/openrouter/models/x-ai/grok-4.toml
+++ b/providers/openrouter/models/x-ai/grok-4.toml
@@ -17,7 +17,7 @@ cache_read = 0.75
 cache_write = 15.00
 
 [[cost.tiers]]
-context = { min = 128_000 }
+tier = { size = 128_000 }
 input = 6.00
 output = 30.00
 

--- a/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
+++ b/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
@@ -15,7 +15,7 @@ output = 10.00
 cache_read = 0.125
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 2.50
 output = 15.00
 cache_read = 0.25

--- a/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
+++ b/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
@@ -14,7 +14,8 @@ input = 1.25
 output = 10.00
 cache_read = 0.125
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 2.50
 output = 15.00
 cache_read = 0.25

--- a/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
@@ -15,7 +15,7 @@ output = 3.00
 cache_read = 0.05
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 0.50
 output = 3.00
 cache_read = 0.05

--- a/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
@@ -14,7 +14,8 @@ input = 0.50
 output = 3.00
 cache_read = 0.05
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 0.50
 output = 3.00
 cache_read = 0.05

--- a/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
@@ -15,7 +15,7 @@ output = 12.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
@@ -14,7 +14,8 @@ input = 2.00
 output = 12.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/poe/models/openai/gpt-5.5.toml
+++ b/providers/poe/models/openai/gpt-5.5.toml
@@ -5,6 +5,7 @@ last_updated = "2026-04-08"
 from = "openai/gpt-5.5"
 omit = [
   "cost.context_over_200k",
+  "cost.tiers",
   "limit.input",
   "experimental",
 ]

--- a/providers/qihang-ai/models/gemini-2.5-flash.toml
+++ b/providers/qihang-ai/models/gemini-2.5-flash.toml
@@ -15,7 +15,7 @@ input = 0.09
 output = 0.71
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 0.09
 output = 0.71
 

--- a/providers/qihang-ai/models/gemini-2.5-flash.toml
+++ b/providers/qihang-ai/models/gemini-2.5-flash.toml
@@ -14,7 +14,8 @@ open_weights = false
 input = 0.09
 output = 0.71
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 0.09
 output = 0.71
 

--- a/providers/qihang-ai/models/gemini-3-flash-preview.toml
+++ b/providers/qihang-ai/models/gemini-3-flash-preview.toml
@@ -14,7 +14,8 @@ open_weights = false
 input = 0.07
 output = 0.43
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 0.07
 output = 0.43
 

--- a/providers/qihang-ai/models/gemini-3-flash-preview.toml
+++ b/providers/qihang-ai/models/gemini-3-flash-preview.toml
@@ -15,7 +15,7 @@ input = 0.07
 output = 0.43
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 0.07
 output = 0.43
 

--- a/providers/requesty/models/anthropic/claude-opus-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-6.toml
@@ -17,7 +17,7 @@ cache_read = 0.50
 cache_write = 6.25
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/requesty/models/anthropic/claude-opus-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-6.toml
@@ -16,7 +16,8 @@ output = 25.00
 cache_read = 0.50
 cache_write = 6.25
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 10.00
 output = 37.50
 cache_read = 1.00

--- a/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
@@ -16,7 +16,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
@@ -17,7 +17,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/venice/models/gemini-3-1-pro-preview.toml
+++ b/providers/venice/models/gemini-3-1-pro-preview.toml
@@ -15,7 +15,8 @@ output = 15
 cache_read = 0.5
 cache_write = 0.5
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 5
 output = 22.5
 cache_read = 0.5

--- a/providers/venice/models/gemini-3-1-pro-preview.toml
+++ b/providers/venice/models/gemini-3-1-pro-preview.toml
@@ -16,7 +16,7 @@ cache_read = 0.5
 cache_write = 0.5
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 5
 output = 22.5
 cache_read = 0.5

--- a/providers/venice/models/grok-4-20-multi-agent.toml
+++ b/providers/venice/models/grok-4-20-multi-agent.toml
@@ -14,7 +14,8 @@ input = 1.42
 output = 2.83
 cache_read = 0.23
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 2.83
 output = 5.67
 cache_read = 0.45

--- a/providers/venice/models/grok-4-20-multi-agent.toml
+++ b/providers/venice/models/grok-4-20-multi-agent.toml
@@ -15,7 +15,7 @@ output = 2.83
 cache_read = 0.23
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 2.83
 output = 5.67
 cache_read = 0.45

--- a/providers/venice/models/grok-4-20.toml
+++ b/providers/venice/models/grok-4-20.toml
@@ -14,7 +14,8 @@ input = 1.42
 output = 2.83
 cache_read = 0.23
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 2.83
 output = 5.67
 cache_read = 0.45

--- a/providers/venice/models/grok-4-20.toml
+++ b/providers/venice/models/grok-4-20.toml
@@ -15,7 +15,7 @@ output = 2.83
 cache_read = 0.23
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 2.83
 output = 5.67
 cache_read = 0.45

--- a/providers/venice/models/grok-4-3.toml
+++ b/providers/venice/models/grok-4-3.toml
@@ -14,7 +14,8 @@ input = 1.42
 output = 2.83
 cache_read = 0.23
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 2.83
 output = 5.67
 cache_read = 0.45

--- a/providers/venice/models/grok-4-3.toml
+++ b/providers/venice/models/grok-4-3.toml
@@ -15,7 +15,7 @@ output = 2.83
 cache_read = 0.23
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 2.83
 output = 5.67
 cache_read = 0.45

--- a/providers/venice/models/openai-gpt-54-pro.toml
+++ b/providers/venice/models/openai-gpt-54-pro.toml
@@ -13,7 +13,8 @@ open_weights = false
 input = 37.5
 output = 225
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 272_000 }
 input = 75
 output = 337.5
 

--- a/providers/venice/models/openai-gpt-54-pro.toml
+++ b/providers/venice/models/openai-gpt-54-pro.toml
@@ -14,7 +14,7 @@ input = 37.5
 output = 225
 
 [[cost.tiers]]
-context = { min = 272_000 }
+tier = { size = 272_000 }
 input = 75
 output = 337.5
 

--- a/providers/venice/models/openai-gpt-55.toml
+++ b/providers/venice/models/openai-gpt-55.toml
@@ -14,7 +14,8 @@ input = 6.25
 output = 37.5
 cache_read = 0.625
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 272_000 }
 input = 12.5
 output = 56.25
 cache_read = 1.25

--- a/providers/venice/models/openai-gpt-55.toml
+++ b/providers/venice/models/openai-gpt-55.toml
@@ -15,7 +15,7 @@ output = 37.5
 cache_read = 0.625
 
 [[cost.tiers]]
-context = { min = 272_000 }
+tier = { size = 272_000 }
 input = 12.5
 output = 56.25
 cache_read = 1.25

--- a/providers/venice/models/qwen-3-6-plus.toml
+++ b/providers/venice/models/qwen-3-6-plus.toml
@@ -16,7 +16,7 @@ cache_read = 0.0625
 cache_write = 0.78
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 2.5
 output = 7.5
 cache_read = 0.0625

--- a/providers/venice/models/qwen-3-6-plus.toml
+++ b/providers/venice/models/qwen-3-6-plus.toml
@@ -15,7 +15,8 @@ output = 3.75
 cache_read = 0.0625
 cache_write = 0.78
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 2.5
 output = 7.5
 cache_read = 0.0625

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -17,7 +17,8 @@ output = 15.00
 cache_read = 0.30
 cache_write = 3.75
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -18,7 +18,7 @@ cache_read = 0.30
 cache_write = 3.75
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 6.00
 output = 22.50
 cache_read = 0.60

--- a/providers/vercel/models/google/gemini-3-pro-preview.toml
+++ b/providers/vercel/models/google/gemini-3-pro-preview.toml
@@ -15,7 +15,7 @@ output = 12.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/vercel/models/google/gemini-3-pro-preview.toml
+++ b/providers/vercel/models/google/gemini-3-pro-preview.toml
@@ -14,7 +14,8 @@ input = 2.00
 output = 12.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/vivgrid/models/gemini-3.1-pro-preview.toml
+++ b/providers/vivgrid/models/gemini-3.1-pro-preview.toml
@@ -15,7 +15,8 @@ input = 2.00
 output = 12.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/vivgrid/models/gemini-3.1-pro-preview.toml
+++ b/providers/vivgrid/models/gemini-3.1-pro-preview.toml
@@ -16,7 +16,7 @@ output = 12.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 18.00
 cache_read = 0.40

--- a/providers/xai/models/grok-4.20-0309-non-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-non-reasoning.toml
@@ -14,7 +14,7 @@ output = 6.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 12.00
 cache_read = 0.40

--- a/providers/xai/models/grok-4.20-0309-non-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-non-reasoning.toml
@@ -13,7 +13,8 @@ input = 2.00
 output = 6.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 12.00
 cache_read = 0.40

--- a/providers/xai/models/grok-4.20-0309-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-reasoning.toml
@@ -14,7 +14,7 @@ output = 6.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 12.00
 cache_read = 0.40

--- a/providers/xai/models/grok-4.20-0309-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-reasoning.toml
@@ -13,7 +13,8 @@ input = 2.00
 output = 6.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 12.00
 cache_read = 0.40

--- a/providers/xai/models/grok-4.20-multi-agent-0309.toml
+++ b/providers/xai/models/grok-4.20-multi-agent-0309.toml
@@ -14,7 +14,7 @@ output = 6.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 4.00
 output = 12.00
 cache_read = 0.40

--- a/providers/xai/models/grok-4.20-multi-agent-0309.toml
+++ b/providers/xai/models/grok-4.20-multi-agent-0309.toml
@@ -13,7 +13,8 @@ input = 2.00
 output = 6.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 4.00
 output = 12.00
 cache_read = 0.40

--- a/providers/xai/models/grok-4.3.toml
+++ b/providers/xai/models/grok-4.3.toml
@@ -13,7 +13,8 @@ input = 1.25
 output = 2.50
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 200_000 }
 input = 2.50
 output = 5.00
 cache_read = 0.40

--- a/providers/xai/models/grok-4.3.toml
+++ b/providers/xai/models/grok-4.3.toml
@@ -14,7 +14,7 @@ output = 2.50
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 200_000 }
+tier = { size = 200_000 }
 input = 2.50
 output = 5.00
 cache_read = 0.40

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
@@ -1,5 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2-pro"
+omit = ["cost.context_over_200k", "cost.tiers"]
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
@@ -1,5 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5-pro"
+omit = ["cost.context_over_200k", "cost.tiers"]
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
@@ -5,8 +5,3 @@ from = "xiaomi/mimo-v2.5-pro"
 input = 0
 output = 0
 cache_read = 0
-
-[cost.context_over_200k]
-input = 0
-output = 0
-cache_read = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
@@ -1,5 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5"
+omit = ["cost.context_over_200k", "cost.tiers"]
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
@@ -5,8 +5,3 @@ from = "xiaomi/mimo-v2.5"
 input = 0
 output = 0
 cache_read = 0
-
-[cost.context_over_200k]
-input = 0
-output = 0
-cache_read = 0

--- a/providers/xiaomi/models/mimo-v2-pro.toml
+++ b/providers/xiaomi/models/mimo-v2-pro.toml
@@ -17,7 +17,8 @@ input = 1.00
 output = 3.00
 cache_read = 0.20
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.40

--- a/providers/xiaomi/models/mimo-v2-pro.toml
+++ b/providers/xiaomi/models/mimo-v2-pro.toml
@@ -18,7 +18,7 @@ output = 3.00
 cache_read = 0.20
 
 [[cost.tiers]]
-context = { min = 256_000 }
+tier = { size = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.40

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -14,7 +14,8 @@ input = 1
 output = 3
 cache_read = 0.2
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.40

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -15,7 +15,7 @@ output = 3
 cache_read = 0.2
 
 [[cost.tiers]]
-context = { min = 256_000 }
+tier = { size = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.40

--- a/providers/xiaomi/models/mimo-v2.5.toml
+++ b/providers/xiaomi/models/mimo-v2.5.toml
@@ -15,7 +15,7 @@ output = 2
 cache_read = 0.08
 
 [[cost.tiers]]
-context = { min = 256_000 }
+tier = { size = 256_000 }
 input = 0.80
 output = 4.00
 cache_read = 0.16

--- a/providers/xiaomi/models/mimo-v2.5.toml
+++ b/providers/xiaomi/models/mimo-v2.5.toml
@@ -14,7 +14,8 @@ input = 0.4
 output = 2
 cache_read = 0.08
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 256_000 }
 input = 0.80
 output = 4.00
 cache_read = 0.16

--- a/providers/zenmux/models/qwen/qwen3.6-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.6-plus.toml
@@ -13,7 +13,8 @@ output = 3.00
 cache_read = 0.05
 cache_write = 0.625
 
-[cost.context_over_200k]
+[[cost.tiers]]
+context = { min = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.20

--- a/providers/zenmux/models/qwen/qwen3.6-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.6-plus.toml
@@ -14,7 +14,7 @@ cache_read = 0.05
 cache_write = 0.625
 
 [[cost.tiers]]
-context = { min = 256_000 }
+tier = { size = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.20


### PR DESCRIPTION
## Summary

Adds authored context pricing tiers so model configs can express long-context pricing at provider-specific thresholds instead of being tied to the legacy 200k field.

## New Authored Format

Base pricing remains on `[cost]` and continues to mean USD per 1M tokens:

```toml
[cost]
input = 5
output = 25
cache_read = 0.5
```

Additional context-based pricing is authored with `[[cost.tiers]]`:

```toml
[[cost.tiers]]
context = { min = 272_000 }
input = 10
output = 45
cache_read = 1
```

The `context.min` value is the request context threshold where that price applies. This allows thresholds like `272_000`, `256_000`, `200_000`, or provider-specific values without encoding them in the field name.

## Compatibility

- Authored TOML should use `[[cost.tiers]]` for long-context pricing.
- Authored TOML rejects the old `[cost.context_over_200k]` field.
- Generated/API output still includes `cost.context_over_200k` when a single compatible open-ended context tier can be represented for legacy clients.
- The generated output also preserves the new `cost.tiers` data for clients that want the exact threshold.

## Notes

- Existing base `cost.input`, `cost.output`, and cache price fields are unchanged.
- Invocation variants such as fast/slow modes remain under `experimental.modes.*`; this PR only models automatic context-based price changes within a cost schedule.