### PR TITLE
feat: add support for Amazon Bedrock models script and update schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 data/tokenspeed-monitor.sqlite
 data/tokenspeed-monitor.sqlite-shm
 data/tokenspeed-monitor.sqlite-wal
+packages/core/script/scrape-bedrock-regions.json

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "models.dev",
       "dependencies": {
+        "@aws-sdk/client-bedrock": "^3.1045.0",
         "@cloudflare/workers-types": "^4.20260424.1",
         "sst": "3.17.23",
       },
@@ -49,6 +50,70 @@
     "zod": "3.24.2",
   },
   "packages": {
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock": ["@aws-sdk/client-bedrock@3.1045.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.8", "@aws-sdk/credential-provider-node": "^3.972.39", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/token-providers": "3.1045.0", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.24", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-r5yL2OrEVkLmB3riv064cK0z/WxzDNbTZtd6iSp21G7EWxbPt6umpynsDuDVkjjhxrPZoePfXpUv+45EjjDJ6g=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.22", "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.34", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.1", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-stream": "^4.5.25", "tslib": "^2.6.2" } }, "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/credential-provider-env": "^3.972.34", "@aws-sdk/credential-provider-http": "^3.972.36", "@aws-sdk/credential-provider-login": "^3.972.38", "@aws-sdk/credential-provider-process": "^3.972.34", "@aws-sdk/credential-provider-sso": "^3.972.38", "@aws-sdk/credential-provider-web-identity": "^3.972.38", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.39", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.34", "@aws-sdk/credential-provider-http": "^3.972.36", "@aws-sdk/credential-provider-ini": "^3.972.38", "@aws-sdk/credential-provider-process": "^3.972.34", "@aws-sdk/credential-provider-sso": "^3.972.38", "@aws-sdk/credential-provider-web-identity": "^3.972.38", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.34", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/token-providers": "3.1041.0", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.37", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@smithy/core": "^3.23.17", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-retry": "^4.3.6", "tslib": "^2.6.2" } }, "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.6", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.8", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/signature-v4-multi-region": "^3.996.25", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.24", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/config-resolver": "^4.4.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.25", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.37", "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1045.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+
+    "@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.972.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-endpoints": "^3.4.2", "tslib": "^2.6.2" } }, "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.24", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/types": "^3.973.8", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.22", "", { "dependencies": { "@nodable/entities": "2.1.0", "@smithy/types": "^4.14.1", "fast-xml-parser": "5.7.2", "tslib": "^2.6.2" } }, "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260424.1", "", {}, "sha512-0DLJ9yEk1KKzPbqop80Gw/P1wkKKzawmipULiJWdBXIBCoMvE0OVWms3IrL/Q/G7tfmPop9yF4XlZ69k9JLYng=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.6.1", "", { "dependencies": { "content-type": "^1.0.5", "cors": "^2.8.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^4.1.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA=="],
@@ -56,6 +121,74 @@
     "@models.dev/function": ["@models.dev/function@workspace:packages/function"],
 
     "@models.dev/web": ["@models.dev/web@workspace:packages/web"],
+
+    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
+
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.5.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-abXk3LhODsvRHsk0ZS9ztrg/fZatTa9Z/z4pgx65YSLR+rY6kvUG/1IgcDKEUciR8MfdnkT5oPeHJTy/HhzDIQ=="],
+
+    "@smithy/core": ["@smithy/core@3.24.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-0S/acwHnqX4WrjXzhdiDRxsG2s9SC0cpPIK9nZ1R6UOHd+j7uL28+4bHu22urbLk2TVw3fkp6na/+fkUt/pLNQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-r7bN6spQ+caZC8AnyvSxkRUb57zt2jhhRw3Z+2Ez8hjq6coIikDBFUUI/+CQ1xx9K6eX1Gx6wUKo4ylU66TIqw=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-u0/zo11mg7yNneoYgTkH4sXwSmcBpbl49o4UNCtQ7hYsXxynsN25KYHmXzqi7TPk5HQL5klGnpU5koOY0O+9hw=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-cLmwtDoulyZvRepAfyV+3rx5oMvuh51dbE+6En3vGC09j3uVSRt1U4oguNu32ub3soGX0oYtBs8E7S2Q4SxTqg=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-l4BUIP+wljW/Ar+0/QcGdmElI9lalrywfzNijXMBG34Z510FRzPyrDLx/blNTZOAm0C4Mvx5t/bf760CZo1ajg=="],
+
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.5.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-qtqu5TS+8Y18ZDkJoiXN5AMW1G4JAg1+xytzpsUvIR5a4EUsgd5HQg12lekEHWpm2TDUmOgg+hBaHK7dvyWdkA=="],
+
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.6.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-eTaQhxs0rfUuAkL2MSKrH8DTO7YCeAgrdN0B2/RAeuHmXQ+x52dk5qUBsi/jtcqe5LxItgq5AG5tI6Cp8c0sow=="],
+
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-t7YtUe076zWVypVmy1rX91oKi2TFJCkpfFpfMhJFpEIRPP0iL9JxjeSyFQ+1bF45JUfDzOzslUJa150WcSrBug=="],
+
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-1jKwiKZxCMQNqmp4uVPYA6r+MLGjEtH07gnOUdPgbnjuOIrl/0JY/ICdpQtFgeBsQ/Up01gnSv8GYEL0fb8yvg=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-q7tDJEJXcaSG/8TVpu2f2l9bzxTzDM9geWmltbzsY6Hfh3yiuXXTpLIO8+zwYASPPVFaTJpdKwjSSjdoDoccgw=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-BdEYko85f/ldp68uH8XEyIvo810xFk6eyPH81SRggTOApYHWA+Xu7B2EzLuHbe37WVLaUA7F1fWR3/zBeme2WA=="],
+
+    "@smithy/property-provider": ["@smithy/property-provider@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-3NHoqVBhzpY2b4YBx9AqyKC4C8nnEjl5FyKuxrCjvnjinG0ODj+yg1xX360nNahT6wghYjSw1SooCt3kIdnqIA=="],
+
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-8irPNCQgYxcSFp1aGcnDNFkTwSA+xPUaFq9V/v1+JXWu8sKr5b3cFmg2kBTkjkvypDmGeNffuNu0x5iqw1NoAw=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.5.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-FKoKxVzdFPhyynFI+SPTWrgOP60fZ4l1UwukWYj4eyhpSmEI7MJ6p58hawIIt9bwp+aek9NEm8Zika7E+GEoeg=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-728lZZEWYWubBESrfntNslZQYDKRlJDY4dcDnYbL50+gu35pGPLblu4S0/RH/RDLF6me1M87ECHsHELGL7dA/Q=="],
+
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.13.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ=="],
+
+    "@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@smithy/url-parser": ["@smithy/url-parser@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-tuelFlF2PZR/wogFC58NIrPOv+Zna4N1+3kA161/33D1Gbwvl6Nh4WsAsW05ZyPp0O6CMGsdbb0S2b/qVjRMCw=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-fTHiwW2xbiRiWzfSk4IGAr3gNZCH4fuRYqt8+IuarsP/YON35576iVdePraZ6yJlFxlCL0eMec3/F7xYqoKzlg=="],
+
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-1scg5t4nV3hV7CZs996/XHb80aDZ5YotH4NcvkW/w/rHj+cSz0aCIzwz8aUNKB4nCDPSHRCbrKoj+TvycYefmw=="],
+
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-VRC8MKVPKrgUYThTA7ughcKMfjW6/X92H0wXGJoda0Apw4O5xbXL0GMLz40DTWlsb5hh2iItk6+XL72uJdxYcw=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-config-provider": ["@smithy/util-config-provider@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-lw6L5GF5+W19vO6o3fZwRT2cXEG+8b2LH0b9ppjDT6nIxjUgmljEQGninx5XorylwKZZ4XLVABeroJ8oaF9RmQ=="],
+
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-1rA7w+LjK1WJClsffC81Z/ZtjFt22QsKhBjUYEnZsGVS2nOTfOENKBzdg4SxhdwFvBCjcbpjscUfXOPwE3UHWQ=="],
+
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-1fk1wfQHBenQD5NitVKOFgW0wsISYAFPIXGyStJWAeCtMyRhgHYvtJxBk2rwGWA0L5QX6oM6yeHSLKPFMk59ww=="],
+
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.5.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-yORYzJD5zoGbSDkAACr0dIjDiSEA3X8h8lggDENl1dkKpCG0TQIoItPBqtvuJHzFFjRXumcoH+/09xIuixGyCw=="],
+
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-SRRMDcIgVXVhVbxviBaSZbuWuVW3jD08wv4ESV0V2oiw0Mki8TPVQ5IxwD3MvSTPg52QYsRP+JoMw5WdUdeWAg=="],
+
+    "@smithy/util-retry": ["@smithy/util-retry@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-qkgWgwn1xw0GoY9Ea/B6FrYSPfHA0zyOtJkokwxZuvucRf2+2lfTut6adi4e4Y7LEAaxsFG7r6i05mtDCxbHKA=="],
+
+    "@smithy/util-stream": ["@smithy/util-stream@4.6.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-GjZfEft0M0V3n2YM/LGkr5LeLd8gxHUIzW0rUz6VtTtlAq245GxHlJghvoPEjJHKTj255iHFAiA4IsIdK40Ueg=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA=="],
 
     "@tsconfig/bun": ["@tsconfig/bun@1.0.8", "", {}, "sha512-JlJaRaS4hBTypxtFe8WhnwV8blf0R+3yehLk8XuyxUYNx6VXsKCjACSCvOYEFUiqlhlBWxtYCn/zRlOb8BzBQg=="],
 
@@ -76,6 +209,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "buffer": ["buffer@4.9.2", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4", "isarray": "^1.0.0" } }, "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg=="],
 
@@ -132,6 +267,10 @@
     "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
 
     "express-rate-limit": ["express-rate-limit@7.5.0", "", { "peerDependencies": { "express": "^4.11 || 5 || ^5.0.0-beta.1" } }, "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
 
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
 
@@ -223,6 +362,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
 
     "pkce-challenge": ["pkce-challenge@4.1.0", "", {}, "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ=="],
@@ -289,7 +430,11 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
+    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -309,6 +454,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+
     "xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
 
     "xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
@@ -318,6 +465,12 @@
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.3", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1041.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw=="],
 
     "@models.dev/function/@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250522.0", "", {}, "sha512-9RIffHobc35JWeddzBguGgPa4wLDr5x5F94+0/qy7LiV6pTBQ/M5qGEN9VA16IDT3EUpYI0WKh6VpcmeVEtVtw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "venice:generate": "bun ./packages/core/script/generate-venice.ts",
     "vercel:generate": "bun ./packages/core/script/generate-vercel.ts",
     "wandb:generate": "bun ./packages/core/script/generate-wandb.ts",
-    "digitalocean:generate": "bun ./packages/core/script/generate-digitalocean.ts"
+    "digitalocean:generate": "bun ./packages/core/script/generate-digitalocean.ts",
+    "bedrock:generate": "bun ./packages/core/script/generate-bedrock.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock": "^3.1045.0",
     "@cloudflare/workers-types": "^4.20260424.1",
     "sst": "3.17.23"
   }

--- a/packages/core/script/generate-bedrock.ts
+++ b/packages/core/script/generate-bedrock.ts
@@ -1,0 +1,703 @@
+#!/usr/bin/env bun
+
+/**
+ * Generates Amazon Bedrock model TOML files by listing foundation models
+ * via the AWS SDK and mapping them to upstream providers when possible.
+ *
+ * Based on https://github.com/OpeOginni/amazon-bedrock-models-script
+ *
+ * Usage:
+ *   bun run bedrock:generate
+ *
+ * Flags:
+ *   --dry-run         Preview changes without writing files
+ *   --new-only        Only create new models, skip updating existing ones
+ *   --refresh-regions Re-fetch AWS region-compatibility docs before generating
+ */
+
+import {
+  BedrockClient,
+  FoundationModelLifecycleStatus,
+  ListFoundationModelsCommand,
+  ModelModality,
+  type FoundationModelSummary,
+} from "@aws-sdk/client-bedrock";
+import path from "node:path";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const newOnly = args.includes("--new-only");
+const refreshRegions = args.includes("--refresh-regions");
+
+const PROVIDERS_DIR = path.join(import.meta.dirname, "..", "..", "..", "providers");
+const MODELS_DIR = path.join(PROVIDERS_DIR, "amazon-bedrock", "models");
+const REGION_CACHE_PATH = path.join(
+  import.meta.dirname,
+  "scrape-bedrock-regions.json",
+);
+
+const AWS_REGION_DOCS_URL =
+  "https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html#inference-options-glance";
+
+const REGIONS = [
+  "us-east-1",
+  "us-east-2",
+  "us-west-1",
+  "us-west-2",
+  "af-south-1",
+  "ap-east-1",
+  "ap-south-2",
+  "ap-southeast-3",
+  "ap-southeast-5",
+  "ap-southeast-4",
+  "ap-south-1",
+  "ap-southeast-6",
+  "ap-northeast-3",
+  "ap-northeast-2",
+  "ap-southeast-1",
+  "ap-southeast-2",
+  "ap-east-2",
+  "ap-southeast-7",
+  "ap-northeast-1",
+  "ca-central-1",
+  "ca-west-1",
+  "eu-central-1",
+  "eu-west-1",
+  "eu-west-2",
+  "eu-south-1",
+  "eu-west-3",
+  "eu-south-2",
+  "eu-north-1",
+  "eu-central-2",
+  "il-central-1",
+  "mx-central-1",
+  "me-south-1",
+  "me-central-1",
+  "sa-east-1",
+];
+
+const IMPORTANT_PROVIDERS = new Set([
+  "Amazon",
+  "Anthropic",
+  "DeepSeek",
+  "Google",
+  "Meta",
+  "MiniMax",
+  "Mistral AI",
+  "Moonshot AI",
+  "NVIDIA",
+  "OpenAI",
+  "Qwen",
+  "Writer",
+  "Z.AI",
+]);
+
+const EXCLUDED_MODEL_NAME_PARTS = [
+  "safeguard",
+  "embedding",
+  "rerank",
+  "canvas",
+  "image generator",
+  "reel",
+];
+
+// Exclude context-window size variants (e.g. :24k, :128k, :1m, :10m)
+const CONTEXT_VARIANT_RE = /:\d+[km]$/i;
+
+const REGION_REQUEST_TIMEOUT_MS = 20_000;
+
+type RegionSupport = {
+  inRegion: string[];
+  geo: string[];
+  global: string[];
+};
+
+type ModelRecord = {
+  summary: FoundationModelSummary;
+  regionsFromApi: Set<string>;
+};
+
+type TomlModel = {
+  id: string;
+  baseId: string;
+  name: string;
+  inference: "in-region" | "geo" | "global";
+  supportedRegions: string[];
+};
+
+const uniq = <T>(values: Iterable<T>) => [...new Set(values)];
+
+const normalizeName = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+// ---------------------------------------------------------------------------
+// Scrape AWS docs for region support
+// ---------------------------------------------------------------------------
+
+const parseAvailabilityCell = (value: string) =>
+  /yes|legacy/i.test(value) && !/no/i.test(value);
+
+const stripHtml = (value: string) =>
+  value
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const htmlCellText = (value: string) =>
+  `${[...value.matchAll(/alt="([^"]+)"/g)].map((match) => match[1]).join(" ")} ${stripHtml(value)}`.trim();
+
+const parseAwsRegionDocsHtml = (html: string) => {
+  const supportByName: Record<string, RegionSupport> = {};
+  const tables = html.matchAll(
+    /<table[^>]*>.*?<caption>(.*?)<\/caption>(.*?)<\/table>/gis,
+  );
+
+  for (const table of tables) {
+    const modelName = stripHtml(table[1]!);
+    const tableHtml = table[2]!;
+    if (
+      !modelName ||
+      !/In-Region/.test(tableHtml) ||
+      !/Geo/.test(tableHtml) ||
+      !/Global/.test(tableHtml)
+    )
+      continue;
+
+    const support: RegionSupport = { inRegion: [], geo: [], global: [] };
+    const rows = tableHtml.matchAll(/<tr[^>]*>(.*?)<\/tr>/gis);
+
+    for (const row of rows) {
+      const cells = [...row[1]!.matchAll(/<td[^>]*>(.*?)<\/td>/gis)].map(
+        (cell) => cell[1]!,
+      );
+      if (cells.length !== 4) continue;
+
+      const region = stripHtml(cells[0]!).match(
+        /^(us-gov-[a-z]+-\d|[a-z]{2}(?:-[a-z]+)+-\d)/,
+      )?.[1];
+      if (!region) continue;
+
+      if (parseAvailabilityCell(htmlCellText(cells[1]!)))
+        support.inRegion.push(region);
+      if (parseAvailabilityCell(htmlCellText(cells[2]!)))
+        support.geo.push(region);
+      if (parseAvailabilityCell(htmlCellText(cells[3]!)))
+        support.global.push(region);
+    }
+
+    supportByName[normalizeName(modelName)] = {
+      inRegion: support.inRegion.sort(),
+      geo: support.geo.sort(),
+      global: support.global.sort(),
+    };
+  }
+
+  return supportByName;
+};
+
+async function scrapeRegionSupport(): Promise<Map<string, RegionSupport>> {
+  console.log("Fetching AWS region-compatibility docs...");
+  const response = await fetch(AWS_REGION_DOCS_URL);
+  if (!response.ok)
+    throw new Error(`AWS docs request failed: ${response.status}`);
+
+  const html = await response.text();
+  const regionSupport = parseAwsRegionDocsHtml(html);
+
+  if (!dryRun) {
+    await mkdir(path.dirname(REGION_CACHE_PATH), { recursive: true });
+    await writeFile(
+      REGION_CACHE_PATH,
+      `${JSON.stringify(regionSupport, null, 2)}\n`,
+    );
+  }
+
+  console.log(
+    `${dryRun ? "Parsed" : "Wrote"} ${Object.keys(regionSupport).length} model region-support records${dryRun ? "" : ` to ${REGION_CACHE_PATH}`}`,
+  );
+  return new Map(Object.entries(regionSupport));
+}
+
+async function loadRegionSupport(): Promise<Map<string, RegionSupport>> {
+  if (refreshRegions || !existsSync(REGION_CACHE_PATH)) {
+    return scrapeRegionSupport();
+  }
+
+  const raw = JSON.parse(
+    await readFile(REGION_CACHE_PATH, "utf8"),
+  ) as Record<string, RegionSupport>;
+  return new Map(Object.entries(raw));
+}
+
+// ---------------------------------------------------------------------------
+// List Bedrock models across regions
+// ---------------------------------------------------------------------------
+
+const isImportantModel = (model: FoundationModelSummary) => {
+  const name = model.modelName?.toLowerCase() ?? "";
+  const modelId = model.modelId?.toLowerCase() ?? "";
+  return (
+    Boolean(model.modelId) &&
+    Boolean(model.providerName && IMPORTANT_PROVIDERS.has(model.providerName)) &&
+    model.modelLifecycle?.status === FoundationModelLifecycleStatus.ACTIVE &&
+    !model.outputModalities?.includes(ModelModality.EMBEDDING) &&
+    !EXCLUDED_MODEL_NAME_PARTS.some((part) => name.includes(part)) &&
+    !CONTEXT_VARIANT_RE.test(modelId)
+  );
+};
+
+const listModelsByRegion = async () => {
+  // Use a single canonical region to decide which models are important,
+  // because lifecycle status can differ across regions.
+  const canonicalClient = new BedrockClient({ region: "us-east-1" });
+  const canonicalResponse = await canonicalClient.send(
+    new ListFoundationModelsCommand({}),
+  );
+  const canonicalModels =
+    canonicalResponse.modelSummaries?.filter(isImportantModel) ?? [];
+  const allowedModelIds = new Set(canonicalModels.map((m) => m.modelId!));
+  console.log(
+    `Canonical list from us-east-1 has ${allowedModelIds.size} important models`,
+  );
+
+  const records = new Map<string, ModelRecord>();
+  const results = await Promise.all(
+    REGIONS.map(async (region) => {
+      const client = new BedrockClient({ region });
+      const abortController = new AbortController();
+      const timeout = setTimeout(
+        () => abortController.abort(),
+        REGION_REQUEST_TIMEOUT_MS,
+      );
+
+      try {
+        const response = await client.send(
+          new ListFoundationModelsCommand({}),
+          {
+            abortSignal: abortController.signal,
+          },
+        );
+        // Only keep models that are in the canonical allowed set
+        const models = (response.modelSummaries ?? []).filter(
+          (m) => m.modelId && allowedModelIds.has(m.modelId),
+        );
+        console.log(`Found ${models.length} allowed models in ${region}`);
+        return { region, models };
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message.split("\n")[0]
+            : String(error);
+        console.error(`Could not list models in ${region}: ${message}`);
+        return { region, models: [] };
+      } finally {
+        clearTimeout(timeout);
+      }
+    }),
+  );
+
+  for (const { region, models } of results) {
+    for (const summary of models) {
+      const id = summary.modelId!;
+      const current = records.get(id) ?? {
+        summary,
+        regionsFromApi: new Set<string>(),
+      };
+      current.regionsFromApi.add(region);
+      records.set(id, current);
+    }
+  }
+
+  return records;
+};
+
+const geoPrefixesForRegions = (regions: string[]) => {
+  const prefixes = new Set<string>();
+  for (const region of regions) {
+    if (region.startsWith("us-")) prefixes.add("us");
+    if (region.startsWith("eu-")) prefixes.add("eu");
+    if (region.startsWith("ap-")) prefixes.add("apac");
+    if (region.startsWith("ap-northeast-")) prefixes.add("jp");
+    if (region === "ap-southeast-2" || region === "ap-southeast-4")
+      prefixes.add("au");
+  }
+  return [...prefixes].sort();
+};
+
+const familyFromModelId = (modelId: string) => {
+  const withoutProvider = modelId
+    .replace(/^(global|us|eu|apac|jp|au)\./, "")
+    .split(".")
+    .slice(1)
+    .join(".");
+  return withoutProvider
+    .replace(/-?\d{8}/g, "")
+    .replace(/-?v\d(?::\d)?$/g, "")
+    .replace(/:\d+$/g, "")
+    .replace(/\.+/g, "-");
+};
+
+const toTomlArray = (values: string[]) =>
+  `[${values.map((value) => JSON.stringify(value)).join(", ")}]`;
+
+const renderSupportedRegions = (regions: string[]) =>
+  `supported_regions = ${toTomlArray(regions)}`;
+
+const upsertSupportedRegions = (content: string, regions: string[]) => {
+  const line = renderSupportedRegions(regions);
+  const withoutExisting = content.replace(/^supported_regions\s*=.*\n?/m, "");
+  if (/^name\s*=.*$/m.test(withoutExisting)) {
+    return withoutExisting.replace(/^name\s*=.*$/m, (match) => `${match}\n${line}`);
+  }
+  return `${line}\n${withoutExisting}`;
+};
+
+// ---------------------------------------------------------------------------
+// Upstream provider resolution
+// ---------------------------------------------------------------------------
+
+type Resolution =
+  | { type: "extends"; from: string }
+  | { type: "inline"; content: string }
+  | null;
+
+async function resolveUpstream(
+  baseId: string,
+  providerName: string | undefined,
+): Promise<Resolution> {
+  // Anthropic models extend directly from the anthropic provider
+  if (providerName === "Anthropic" || baseId.startsWith("anthropic.")) {
+    const bare = baseId.replace(/^anthropic\./, "");
+    // Strip dated suffixes and version suffixes to find upstream match
+    const upstreamId = bare
+      .replace(/-\d{8}/g, "")
+      .replace(/-v1(:0)?$/g, "");
+    const exactPath = path.join(
+      PROVIDERS_DIR,
+      "anthropic",
+      "models",
+      `${upstreamId}.toml`,
+    );
+    if (existsSync(exactPath)) {
+      return { type: "extends", from: `anthropic/${upstreamId}` };
+    }
+    // Fuzzy match in anthropic provider directory
+    const files: string[] = [];
+    try {
+      for await (const f of new Bun.Glob("*.toml").scan({
+        cwd: path.join(PROVIDERS_DIR, "anthropic", "models"),
+      })) {
+        files.push(f.replace(/\.toml$/, ""));
+      }
+    } catch {
+      // directory may not exist
+    }
+    const match = files
+      .filter(
+        (id) =>
+          upstreamId.startsWith(id) ||
+          id.startsWith(upstreamId) ||
+          bare.startsWith(id) ||
+          id.startsWith(bare),
+      )
+      .sort((a, b) => b.length - a.length)[0];
+    if (match) {
+      return { type: "extends", from: `anthropic/${match}` };
+    }
+  }
+
+  // Meta Llama models
+  if (providerName === "Meta" || baseId.startsWith("meta.")) {
+    const bare = baseId.replace(/^meta\./, "");
+    // Try common llama ID conversions
+    const llamaId = bare
+      .replace(/^llama/, "llama")
+      .replace(/^(llama\d+)-(\d+)-/, "$1.$2-");
+    const exactPath = path.join(
+      PROVIDERS_DIR,
+      "llama",
+      "models",
+      `${llamaId}.toml`,
+    );
+    if (existsSync(exactPath)) {
+      return { type: "extends", from: `llama/${llamaId}` };
+    }
+    // Fuzzy match in llama directory
+    const files: string[] = [];
+    try {
+      for await (const f of new Bun.Glob("*.toml").scan({
+        cwd: path.join(PROVIDERS_DIR, "llama", "models"),
+      })) {
+        files.push(f.replace(/\.toml$/, ""));
+      }
+    } catch {
+      // directory may not exist
+    }
+    const match = files
+      .filter(
+        (id) =>
+          llamaId.startsWith(id) ||
+          id.startsWith(llamaId) ||
+          bare.startsWith(id) ||
+          id.startsWith(bare),
+      )
+      .sort((a, b) => b.length - a.length)[0];
+    if (match) {
+      return { type: "extends", from: `llama/${match}` };
+    }
+  }
+
+  return null;
+}
+
+function renderToml(
+  model: TomlModel,
+  resolution: Resolution,
+): string {
+  if (model.id !== model.baseId) {
+    // Regional variant
+    const baseResolution =
+      resolution?.type === "extends"
+        ? resolution
+        : { type: "extends" as const, from: `amazon-bedrock/${model.baseId}` };
+    return `${[
+      `name = ${JSON.stringify(model.name)}`,
+      renderSupportedRegions(model.supportedRegions),
+      "",
+      "[extends]",
+      `from = ${JSON.stringify(baseResolution.from)}`,
+    ].join("\n")}\n`;
+  }
+
+  if (resolution?.type === "extends") {
+    return `${[
+      `name = ${JSON.stringify(model.name)}`,
+      renderSupportedRegions(model.supportedRegions),
+      "",
+      "[extends]",
+      `from = ${JSON.stringify(resolution.from)}`,
+    ].join("\n")}\n`;
+  }
+
+  return `${[
+    `name = ${JSON.stringify(model.name)}`,
+    renderSupportedRegions(model.supportedRegions),
+    `family = ${JSON.stringify(familyFromModelId(model.id))}`,
+    `# TODO: fill in release_date, last_updated, cost, limit, modalities, etc.`,
+  ].join("\n")}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Build and write TOML models
+// ---------------------------------------------------------------------------
+
+const buildTomlModels = (
+  records: Map<string, ModelRecord>,
+  docs: Map<string, RegionSupport>,
+): TomlModel[] => {
+  const models: TomlModel[] = [];
+
+  for (const [baseId, record] of records) {
+    const summary = record.summary;
+    const modelName = summary.modelName ?? baseId;
+    const docSupport = docs.get(normalizeName(modelName));
+    const inRegion = uniq(
+      docSupport?.inRegion.length ? docSupport.inRegion : record.regionsFromApi,
+    ).sort();
+    const geo = uniq(docSupport?.geo ?? []).sort();
+    const globalRegions = uniq(docSupport?.global ?? []).sort();
+
+    const common = {
+      baseId,
+    };
+
+    if (inRegion.length) {
+      models.push({
+        ...common,
+        id: baseId,
+        name: modelName,
+        inference: "in-region",
+        supportedRegions: inRegion,
+      });
+    }
+
+    for (const prefix of geoPrefixesForRegions(geo)) {
+      models.push({
+        ...common,
+        id: `${prefix}.${baseId}`,
+        name: `${modelName} (${prefix.toUpperCase()})`,
+        inference: "geo",
+        supportedRegions: geo.filter((region) =>
+          geoPrefixesForRegions([region]).includes(prefix),
+        ),
+      });
+    }
+
+    if (globalRegions.length) {
+      models.push({
+        ...common,
+        id: `global.${baseId}`,
+        name: `${modelName} (Global)`,
+        inference: "global",
+        supportedRegions: globalRegions,
+      });
+    }
+  }
+
+  return models.sort((a, b) => a.id.localeCompare(b.id));
+};
+
+async function writeTomlModels(
+  models: TomlModel[],
+  records: Map<string, ModelRecord>,
+) {
+  await mkdir(MODELS_DIR, { recursive: true });
+
+  // Clean up orphaned TOML files that are no longer in the API
+  const existingFiles = new Set<string>();
+  try {
+    for await (const f of new Bun.Glob("*.toml").scan({ cwd: MODELS_DIR })) {
+      existingFiles.add(f);
+    }
+  } catch {
+    // directory may not exist yet
+  }
+
+  const apiModelIds = new Set<string>();
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+  let orphaned = 0;
+
+  for (const model of models) {
+    const filename = `${model.id}.toml`;
+    apiModelIds.add(filename);
+    const filePath = path.join(MODELS_DIR, filename);
+    const record = records.get(model.baseId);
+    const resolution = await resolveUpstream(
+      model.baseId,
+      record?.summary.providerName,
+    );
+    const newContent = renderToml(model, resolution);
+    const tag = resolution?.type === "extends" ? `extends ${resolution.from}` : "stub";
+
+    if (!existsSync(filePath)) {
+      created++;
+      if (dryRun) {
+        console.log(`[DRY RUN] Would create: ${filename}  →  ${tag}`);
+      } else {
+        await Bun.write(filePath, newContent);
+        console.log(`Created: ${filename}  →  ${tag}`);
+      }
+      continue;
+    }
+
+    if (newOnly) {
+      unchanged++;
+      continue;
+    }
+
+    const existingContent = await readFile(filePath, "utf8");
+    if (existingContent === newContent) {
+      unchanged++;
+      continue;
+    }
+
+    // Preserve existing files that contain manually-curated metadata
+    // (cost, limit, modalities, release_date, etc.) or [extends] overrides
+    const isSimpleExtends =
+      /^name\s*=/.test(existingContent) &&
+      /^\[extends\]$/m.test(existingContent) &&
+      /^from\s*=/.test(existingContent) &&
+      !/^omit\s*=/.test(existingContent) &&
+      !/\[cost\]/i.test(existingContent) &&
+      !/\[limit\]/i.test(existingContent) &&
+      !/\[modalities\]/i.test(existingContent) &&
+      !/\[provider\]/i.test(existingContent) &&
+      !/\[experimental\]/i.test(existingContent) &&
+      !/release_date\s*=/.test(existingContent) &&
+      !/last_updated\s*=/.test(existingContent) &&
+      !/knowledge\s*=/.test(existingContent);
+
+    if (!isSimpleExtends) {
+      const patchedContent = upsertSupportedRegions(
+        existingContent,
+        model.supportedRegions,
+      );
+      if (existingContent === patchedContent) {
+        unchanged++;
+        continue;
+      }
+
+      updated++;
+      if (dryRun) {
+        console.log(
+          `[DRY RUN] Would update supported_regions: ${filename}`,
+        );
+      } else {
+        await Bun.write(filePath, patchedContent);
+        console.log(`Updated supported_regions: ${filename}`);
+      }
+      continue;
+    }
+
+    updated++;
+    if (dryRun) {
+      console.log(`[DRY RUN] Would update: ${filename}  →  ${tag}`);
+    } else {
+      await Bun.write(filePath, newContent);
+      console.log(`Updated: ${filename}  →  ${tag}`);
+    }
+  }
+
+  for (const file of existingFiles) {
+    if (!apiModelIds.has(file)) {
+      orphaned++;
+      const filePath = path.join(MODELS_DIR, file);
+      if (dryRun) {
+        console.log(`[DRY RUN] Would remove orphaned: ${file}`);
+      } else {
+        await rm(filePath, { force: true });
+        console.log(`Removed orphaned: ${file}`);
+      }
+    }
+  }
+
+  console.log("");
+  if (dryRun) {
+    console.log(
+      `Summary: ${created} would be created, ${updated} would be updated, ${unchanged} unchanged, ${orphaned} orphaned`,
+    );
+  } else {
+    console.log(
+      `Summary: ${created} created, ${updated} updated, ${unchanged} unchanged, ${orphaned} orphaned`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log(
+    `${dryRun ? "[DRY RUN] " : ""}${newOnly ? "[NEW ONLY] " : ""}${refreshRegions ? "[REFRESH REGIONS] " : ""}Fetching Bedrock foundation models...`,
+  );
+
+  const docs = await loadRegionSupport();
+  const records = await listModelsByRegion();
+  const tomlModels = buildTomlModels(records, docs);
+  await writeTomlModels(tomlModels, records);
+
+  console.log(`\nDone. ${tomlModels.length} model(s) processed.`);
+}
+
+await main();

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -47,6 +47,7 @@ export const Model = z
     id: z.string(),
     name: z.string().min(1, "Model name cannot be empty"),
     family: ModelFamily.optional(),
+    supported_regions: z.array(z.string()).optional(),
     attachment: z.boolean(),
     reasoning: z.boolean(),
     tool_call: z.boolean(),


### PR DESCRIPTION
- Added "@aws-sdk/client-bedrock" dependency to package.json and bun.lock.
- Introduced "bedrock:generate" script for generating Bedrock models.
- Updated schema to include optional "supported_regions" field for models.
- Added scrape-bedrock-regions.json to .gitignore.