### PR TITLE
feat(deepinfra): add Xiaomi MiMo v2.5 and v2.5 Pro

### DIFF
--- a/providers/deepinfra/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/deepinfra/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,0 +1,14 @@
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
+
+# Source: https://deepinfra.com/XiaomiMiMo/MiMo-V2.5-Pro
+# Note: Overriding costs and limits for DeepInfra provider.
+
+[cost]
+input = 1.00
+output = 3.00
+cache_read = 0.20
+
+[limit]
+# https://docs.deepinfra.com/chat/overview#max-output-tokens
+output = 16_384

--- a/providers/deepinfra/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/deepinfra/models/xiaomi/mimo-v2.5-pro.toml
@@ -11,4 +11,5 @@ cache_read = 0.20
 
 [limit]
 # https://docs.deepinfra.com/chat/overview#max-output-tokens
+context = 1_048_576
 output = 16_384

--- a/providers/deepinfra/models/xiaomi/mimo-v2.5.toml
+++ b/providers/deepinfra/models/xiaomi/mimo-v2.5.toml
@@ -1,15 +1,14 @@
 [extends]
-from = "xiaomi/mimo-v2.5-pro"
+from = "xiaomi/mimo-v2.5"
 
-# Source: https://deepinfra.com/XiaomiMiMo/MiMo-V2.5-Pro
-# Note: Overriding limits to match DeepInfra's provider-specific API constraints.
+# Source: https://deepinfra.com/XiaomiMiMo/MiMo-V2.5
+# Note: Overriding costs and limits for DeepInfra provider.
 
 [cost]
-# DeepInfra pricing for MiMo-V2.5-Pro
-input = 1.00
-output = 3.00
-cache_read = 0.20
+input = 0.40
+output = 2.00
+cache_read = 0.08
 
 [limit]
-# Hard cap for DeepInfra API requests
+# https://docs.deepinfra.com/chat/overview#max-output-tokens
 output = 16_384

--- a/providers/deepinfra/models/xiaomi/mimo-v2.5.toml
+++ b/providers/deepinfra/models/xiaomi/mimo-v2.5.toml
@@ -11,4 +11,5 @@ cache_read = 0.08
 
 [limit]
 # https://docs.deepinfra.com/chat/overview#max-output-tokens
+context = 262_144
 output = 16_384

--- a/providers/deepinfra/models/xiaomi/mimo-v2.5.toml
+++ b/providers/deepinfra/models/xiaomi/mimo-v2.5.toml
@@ -1,0 +1,15 @@
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
+
+# Source: https://deepinfra.com/XiaomiMiMo/MiMo-V2.5-Pro
+# Note: Overriding limits to match DeepInfra's provider-specific API constraints.
+
+[cost]
+# DeepInfra pricing for MiMo-V2.5-Pro
+input = 1.00
+output = 3.00
+cache_read = 0.20
+
+[limit]
+# Hard cap for DeepInfra API requests
+output = 16_384


### PR DESCRIPTION
### Description
Adds support for the new Xiaomi MiMo v2.5 and v2.5 Pro models on the DeepInfra provider.

### Changes
- Created `xiaomi/mimo-v2.5.toml` and `xiaomi/mimo-v2.5-pro.toml` under `providers/deepinfra/models/`.
- Used `[extends]` to inherit model metadata from the base Xiaomi definitions.
- Overrode `[cost]` and `[limit]` fields to align with DeepInfra's API-specific pricing and the hard output token limit of 16,384.

### Verification
- Costs updated to match DeepInfra pricing.
- Limits adjusted to comply with DeepInfra API constraints (16,384 tokens).

Links: 
- https://deepinfra.com/XiaomiMiMo/MiMo-V2.5
- https://deepinfra.com/XiaomiMiMo/MiMo-V2.5-Pro
- https://docs.deepinfra.com/chat/overview#max-output-tokens