### PR TITLE
Fix: Kimi k2.6 definition on Kilo Gateway

### DIFF
--- a/providers/kilo/models/moonshotai/kimi-k2.6.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2.6.toml
@@ -1,6 +1,7 @@
 name = "MoonshotAI: Kimi K2.6"
 release_date = "2026-04-20"
-last_updated = "2026-04-20"
+last_updated = "2026-05-12"
+
 attachment = true
 reasoning = true
 temperature = true
@@ -8,17 +9,14 @@ tool_call = true
 structured_output = true
 open_weights = true
 
-[interleaved]
-field = "reasoning_details"
-
 [cost]
-input = 0.95
-output = 4.00
-cache_read = 0.16
+input = 0.75
+output = 3.50
+cache_read = 0.375
 
 [limit]
 context = 262144
-output = 262144
+output = 65535
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
# Fix MoonshotAI Kimi K2.6 model definition for Kilo gateway compatibility

## Summary

This PR fixes the `moonshotai/kimi-k2.6` model definition for compatibility with OpenCode agent loops when used through the Kilo gateway.

The current model definition enables interleaved reasoning serialization:

```toml id="s3z4yo"
[interleaved]
field = "reasoning_details"
```

However, Kilo's OpenAI-compatible gateway currently does not properly support replaying assistant messages that contain both:

* tool calls
* interleaved reasoning fields

during multi-step agent loops.

This causes OpenCode sessions to fail with HTTP 500 errors after the first tool execution round.

---

## Root Cause

The first assistant response succeeds and emits valid tool calls.

Example:

* `bash: ls -la`
* `bash: ls -la docs/`

The failure occurs on the second completion request after tool results are returned to the model.

The gateway crashes when replaying assistant messages containing:

```json id="6mjlwm"
{
  "tool_calls": [...],
  "reasoning_details": "..."
}
```

Removing the interleaved reasoning field restores compatibility with standard OpenAI-style tool replay.

---

## Gateway `/models` Metadata

The following is the actual metadata returned by the Kilo gateway for `moonshotai/kimi-k2.6`:

```json id="34pzzt"
{
  "id": "moonshotai/kimi-k2.6",
  "name": "MoonshotAI: Kimi K2.6",
  "created": 1776699402,
  "description": "Kimi K2.6 is Moonshot AI's next-generation multimodal model...",
  "architecture": {
    "input_modalities": [
      "text",
      "image"
    ],
    "output_modalities": [
      "text"
    ],
    "tokenizer": "Other"
  },
  "top_provider": {
    "is_moderated": false,
    "context_length": 262144,
    "max_completion_tokens": 65535
  },
  "pricing": {
    "prompt": "0.00000075",
    "completion": "0.0000035",
    "input_cache_read": "0.000000375"
  },
  "context_length": 262144,
  "supported_parameters": [
    "frequency_penalty",
    "include_reasoning",
    "logit_bias",
    "logprobs",
    "max_tokens",
    "min_p",
    "parallel_tool_calls",
    "presence_penalty",
    "reasoning",
    "reasoning_effort",
    "repetition_penalty",
    "response_format",
    "seed",
    "stop",
    "structured_outputs",
    "temperature",
    "tool_choice",
    "tools",
    "top_k",
    "top_logprobs",
    "top_p"
  ]
}
```

Notably:

* the gateway supports reasoning
* the gateway supports tools
* the gateway supports structured outputs

However, there is no advertised support for interleaved reasoning replay serialization.

---

## Changes

### Removed unsupported interleaved reasoning serialization

Removed:

```toml id="9vzxj0"
[interleaved]
field = "reasoning_details"
```

---

### Corrected pricing metadata

Updated pricing to match the actual Kilo gateway `/models` endpoint values.

Before:

```toml id="t8v9e2"
[cost]
input = 0.95
output = 4.00
cache_read = 0.16
```

After:

```toml id="0z2p3g"
[cost]
input = 0.75
output = 3.50
cache_read = 0.375
```

---

### Corrected max output tokens

Before:

```toml id="xg5hsl"
[limit]
output = 262144
```

After:

```toml id="n8ydn2"
[limit]
output = 65535
```

The previous value incorrectly duplicated the context window instead of the gateway's actual `max_completion_tokens`.

---

## Result

After these changes:

* OpenCode agent loops work correctly
* tool calling works correctly
* bash/edit/read tools continue functioning
* multi-step execution no longer crashes with HTTP 500

---

## Verification

Verified against:

* Kilo gateway `/models` endpoint metadata
* OpenCode runtime logs
* multi-step tool execution flows
* tool replay behavior after assistant tool calls

---

## Notes

The issue is not with Kimi K2.6 itself, but with the gateway compatibility layer handling interleaved reasoning replay during tool-assisted conversations.
