### PR TITLE
providers/wafer.ai: Remove DeepSeek-V4-Pro and MiniMax-M2.7 models

### DIFF
--- a/providers/wafer.ai/models/DeepSeek-V4-Pro.toml
+++ b/providers/wafer.ai/models/DeepSeek-V4-Pro.toml
@@ -1,8 +1,0 @@
-[extends]
-from = "deepseek/deepseek-v4-pro"
-
-[cost]
-input = 0
-output = 0
-cache_read = 0
-cache_write = 0

--- a/providers/wafer.ai/models/MiniMax-M2.7.toml
+++ b/providers/wafer.ai/models/MiniMax-M2.7.toml
@@ -1,8 +1,0 @@
-[extends]
-from = "minimax/MiniMax-M2.7"
-
-[cost]
-input = 0
-output = 0
-cache_read = 0
-cache_write = 0


### PR DESCRIPTION
Remove two models from wafer.ai provider:
- `DeepSeek-V4-Pro`
- `MiniMax-M2.7`

**Changes:**
- Delete `providers/wafer.ai/models/DeepSeek-V4-Pro.toml`
- Delete `providers/wafer.ai/models/MiniMax-M2.7.toml`

**Note:** Models are being removed to focus compute resources on GLM on Wafer's end. Future models will be instated based on community voting.