### PR TITLE
Add fast mode for Anthropic Opus 4.7

### DIFF
--- a/providers/amazon-bedrock/models/jp.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-opus-4-7.toml
@@ -2,3 +2,4 @@ name = "Claude Opus 4.7 (JP)"
 
 [extends]
 from = "anthropic/claude-opus-4-7"
+omit = ["experimental.modes.fast"]

--- a/providers/anthropic/models/claude-opus-4-7.toml
+++ b/providers/anthropic/models/claude-opus-4-7.toml
@@ -22,3 +22,7 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[experimental.modes.fast]
+cost = { input = 30.00, output = 150.00, cache_read = 3.00, cache_write = 37.50 }
+provider = { body = { speed = "fast" }, headers = { anthropic-beta = "fast-mode-2026-02-01" } }

--- a/providers/google-vertex-anthropic/models/claude-opus-4-7@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-opus-4-7@default.toml
@@ -1,5 +1,6 @@
 [extends]
 from = "anthropic/claude-opus-4-7"
+omit = ["experimental.modes.fast"]
 
 [cost]
 input = 5.00

--- a/providers/google-vertex/models/claude-opus-4-7@default.toml
+++ b/providers/google-vertex/models/claude-opus-4-7@default.toml
@@ -1,5 +1,6 @@
 [extends]
 from = "anthropic/claude-opus-4-7"
+omit = ["experimental.modes.fast"]
 
 [cost]
 input = 5.00

--- a/providers/llmgateway/models/claude-opus-4-7.toml
+++ b/providers/llmgateway/models/claude-opus-4-7.toml
@@ -1,2 +1,3 @@
 [extends]
 from = "anthropic/claude-opus-4-7"
+omit = ["experimental.modes.fast"]


### PR DESCRIPTION
## Summary
- Add Anthropic Opus 4.7 fast mode with the same API configuration and pricing as Opus 4.6.
- Omit inherited fast mode from provider variants where the Opus 4.6 configs already avoid exposing it.

## Validation
- bun validate