### PR TITLE
fix: update structured_output for Bedrock Claude 4.x models

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-7.toml
@@ -6,7 +6,6 @@ attachment = true
 reasoning = true
 temperature = false
 tool_call = true
-structured_output = true
 knowledge = "2026-01-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-6.toml
@@ -1,2 +1,4 @@
+structured_output = true
+
 [extends]
 from = "anthropic/claude-sonnet-4-6"

--- a/providers/amazon-bedrock/models/au.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -1,4 +1,5 @@
 name = "Claude Haiku 4.5 (AU)"
+structured_output = true
 
 [extends]
 from = "anthropic/claude-haiku-4-5-20251001"

--- a/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -1,4 +1,5 @@
 name = "Claude Sonnet 4.5 (AU)"
+structured_output = true
 
 [extends]
 from = "anthropic/claude-sonnet-4-5"

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-7.toml
@@ -6,7 +6,6 @@ attachment = true
 reasoning = true
 temperature = false
 tool_call = true
-structured_output = true
 knowledge = "2026-01-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 name = "Claude Sonnet 4.6 (EU)"
+structured_output = true
 
 [extends]
 from = "anthropic/claude-sonnet-4-6"

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-7.toml
@@ -6,7 +6,6 @@ attachment = true
 reasoning = true
 temperature = false
 tool_call = true
-structured_output = true
 knowledge = "2026-01-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 name = "Claude Sonnet 4.6 (Global)"
+structured_output = true
 
 [extends]
 from = "anthropic/claude-sonnet-4-6"

--- a/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -1,4 +1,5 @@
 name = "Claude Sonnet 4.5 (JP)"
+structured_output = true
 
 [extends]
 from = "anthropic/claude-sonnet-4-5"

--- a/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 name = "Claude Sonnet 4.6 (JP)"
+structured_output = true
 
 [extends]
 from = "anthropic/claude-sonnet-4-6"

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-7.toml
@@ -6,7 +6,6 @@ attachment = true
 reasoning = true
 temperature = false
 tool_call = true
-structured_output = true
 knowledge = "2026-01-31"
 open_weights = false
 

--- a/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 name = "Claude Sonnet 4.6 (US)"
+structured_output = true
 
 [extends]
 from = "anthropic/claude-sonnet-4-6"


### PR DESCRIPTION
Adds `structured_output = true` to Claude 4.1/4.5/4.6 models as supported by Bedrock: https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html

Also removed this flag for Claude Opus 4.7, as Bedrock does not support structured outputs for this model: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html 
(Attempting to do so results in: `invalid_request_error: output_config.format: Extra inputs are not permitted`)