### PR TITLE
fix: add structured_output=True for more supported Bedrock models

### DIFF
--- a/providers/amazon-bedrock/models/deepseek.v3.2.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3.2.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 knowledge = "2024-07"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/mistral.devstral-2-123b.toml
+++ b/providers/amazon-bedrock/models/mistral.devstral-2-123b.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
+++ b/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 interleaved = true
 open_weights = true
 

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]

--- a/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-04"
 open_weights = true
 

--- a/providers/amazon-bedrock/models/zai.glm-4.7.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-04"
 open_weights = true
 

--- a/providers/amazon-bedrock/models/zai.glm-5.toml
+++ b/providers/amazon-bedrock/models/zai.glm-5.toml
@@ -6,6 +6,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [interleaved]


### PR DESCRIPTION
Apologies for the spam - following up to #1765 by updating the remaining Bedrock model files needing `structured_output=True` (as of today).