### PR TITLE
Add Xpersona provider

### DIFF
--- a/providers/xpersona/logo.svg
+++ b/providers/xpersona/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 4l16 16" />
+  <path d="M20 4L4 20" />
+  <path d="M7 12h10" />
+</svg>

--- a/providers/xpersona/models/xpersona-frieren-coder.toml
+++ b/providers/xpersona/models/xpersona-frieren-coder.toml
@@ -1,0 +1,24 @@
+name = "Xpersona Frieren Coder"
+release_date = "2026-05-01"
+last_updated = "2026-05-13"
+attachment = false
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.50
+output = 6.00
+reasoning = 6.00
+cache_read = 0.15
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/xpersona/provider.toml
+++ b/providers/xpersona/provider.toml
@@ -1,0 +1,5 @@
+name = "Xpersona"
+env = ["XPERSONA_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://xpersona.co/v1"
+doc = "https://xpersona.co/docs"


### PR DESCRIPTION
## Summary

Adds Xpersona as an OpenAI-compatible provider with the `xpersona-frieren-coder` model.

## Details

- Provider API: `https://xpersona.co/v1`
- Auth env: `XPERSONA_API_KEY`
- Docs: `https://xpersona.co/docs`
- Model: `xpersona-frieren-coder`
- Pricing: `$1.50 / 1M` input, `$0.15 / 1M` cache read, `$6.00 / 1M` output/reasoning
- Limits: `128k` context, `16,384` output

## Validation

- Verified `https://xpersona.co/docs` returns 200.
- Verified `https://xpersona.co/v1/models` and `/v1/pricing` are protected and return 401 without a valid API key.