### PR TITLE
fix: mark OpenCode Go interleaved reasoning

### DIFF
--- a/providers/opencode-go/models/minimax-m2.7.toml
+++ b/providers/opencode-go/models/minimax-m2.7.toml
@@ -22,5 +22,8 @@ output = 131_072
 input = ["text"]
 output = ["text"]
 
+[interleaved]
+field = "reasoning_content"
+
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/opencode-go/models/qwen3.6-plus.toml
+++ b/providers/opencode-go/models/qwen3.6-plus.toml
@@ -23,5 +23,8 @@ output = 65_536
 input = ["text", "image", "video"]
 output = ["text"]
 
+[interleaved]
+field = "reasoning_content"
+
 [provider]
 npm = "@ai-sdk/anthropic"


### PR DESCRIPTION
## Summary
- Add `interleaved.field = "reasoning_content"` for OpenCode Go Qwen3.6 Plus.
- Add `interleaved.field = "reasoning_content"` for OpenCode Go MiniMax M2.7.

## Validation
- `bun run validate`