### PR TITLE
Add NEAR AI Cloud provider

### DIFF
--- a/providers/nearai/models/Qwen/Qwen3-30B-A3B-Instruct-2507.toml
+++ b/providers/nearai/models/Qwen/Qwen3-30B-A3B-Instruct-2507.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 30B-A3B Instruct 2507"
+family = "qwen"
+release_date = "2025-07-29"
+last_updated = "2025-07-29"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.55
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nearai/models/Qwen/Qwen3-Embedding-0.6B.toml
+++ b/providers/nearai/models/Qwen/Qwen3-Embedding-0.6B.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 Embedding 0.6B"
+family = "text-embedding"
+release_date = "2025-06-03"
+last_updated = "2025-06-03"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.00
+
+[limit]
+context = 40_960
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nearai/models/Qwen/Qwen3-Reranker-0.6B.toml
+++ b/providers/nearai/models/Qwen/Qwen3-Reranker-0.6B.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 Reranker 0.6B"
+family = "qwen"
+release_date = "2025-06-03"
+last_updated = "2025-06-03"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.01
+
+[limit]
+context = 40_960
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nearai/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
+++ b/providers/nearai/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen3-VL 30B-A3B Instruct"
+family = "qwen"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.55
+
+[limit]
+context = 256_000
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
@@ -1,0 +1,14 @@
+[extends]
+from = "alibaba/qwen3.5-122b-a10b"
+
+[cost]
+input = 0.40
+output = 3.20
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nearai/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-haiku-4-5"

--- a/providers/nearai/models/anthropic/claude-opus-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-6.toml
@@ -1,0 +1,7 @@
+[extends]
+from = "anthropic/claude-opus-4-6"
+omit = ["experimental.modes.fast"]
+
+[limit]
+context = 200_000
+output = 128_000

--- a/providers/nearai/models/anthropic/claude-opus-4-7.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,3 @@
+[extends]
+from = "anthropic/claude-opus-4-7"
+omit = ["experimental.modes.fast"]

--- a/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
@@ -1,0 +1,8 @@
+[extends]
+from = "anthropic/claude-sonnet-4-5"
+
+[cost]
+input = 3.00
+output = 15.50
+cache_read = 0.30
+cache_write = 3.75

--- a/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "anthropic/claude-sonnet-4-6"

--- a/providers/nearai/models/black-forest-labs/FLUX.2-klein-4B.toml
+++ b/providers/nearai/models/black-forest-labs/FLUX.2-klein-4B.toml
@@ -1,0 +1,21 @@
+name = "FLUX.2 Klein 4B"
+family = "flux"
+release_date = "2026-01-14"
+last_updated = "2026-01-14"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 1.00
+output = 1.00
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/nearai/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash-lite.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-2.5-flash-lite"

--- a/providers/nearai/models/google/gemini-2.5-flash.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-2.5-flash"

--- a/providers/nearai/models/google/gemini-2.5-pro.toml
+++ b/providers/nearai/models/google/gemini-2.5-pro.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-2.5-pro"

--- a/providers/nearai/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-3.1-flash-lite.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-3.1-flash-lite"

--- a/providers/nearai/models/openai/gpt-4.1-mini.toml
+++ b/providers/nearai/models/openai/gpt-4.1-mini.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-4.1-mini"

--- a/providers/nearai/models/openai/gpt-4.1-nano.toml
+++ b/providers/nearai/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-4.1-nano"

--- a/providers/nearai/models/openai/gpt-4.1.toml
+++ b/providers/nearai/models/openai/gpt-4.1.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-4.1"

--- a/providers/nearai/models/openai/gpt-5-mini.toml
+++ b/providers/nearai/models/openai/gpt-5-mini.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5-mini"

--- a/providers/nearai/models/openai/gpt-5-nano.toml
+++ b/providers/nearai/models/openai/gpt-5-nano.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5-nano"

--- a/providers/nearai/models/openai/gpt-5.1.toml
+++ b/providers/nearai/models/openai/gpt-5.1.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5.1"

--- a/providers/nearai/models/openai/gpt-5.2.toml
+++ b/providers/nearai/models/openai/gpt-5.2.toml
@@ -1,0 +1,7 @@
+[extends]
+from = "openai/gpt-5.2"
+
+[cost]
+input = 1.80
+output = 15.50
+cache_read = 0.18

--- a/providers/nearai/models/openai/gpt-5.4-mini.toml
+++ b/providers/nearai/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,3 @@
+[extends]
+from = "openai/gpt-5.4-mini"
+omit = ["experimental.modes.fast"]

--- a/providers/nearai/models/openai/gpt-5.4-nano.toml
+++ b/providers/nearai/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5.4-nano"

--- a/providers/nearai/models/openai/gpt-5.4.toml
+++ b/providers/nearai/models/openai/gpt-5.4.toml
@@ -1,0 +1,3 @@
+[extends]
+from = "openai/gpt-5.4"
+omit = ["experimental.modes.fast"]

--- a/providers/nearai/models/openai/gpt-5.5.toml
+++ b/providers/nearai/models/openai/gpt-5.5.toml
@@ -1,0 +1,3 @@
+[extends]
+from = "openai/gpt-5.5"
+omit = ["experimental.modes.fast"]

--- a/providers/nearai/models/openai/gpt-5.toml
+++ b/providers/nearai/models/openai/gpt-5.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/gpt-5"

--- a/providers/nearai/models/openai/gpt-oss-120b.toml
+++ b/providers/nearai/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,22 @@
+name = "GPT-OSS 120B"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.55
+
+[limit]
+context = 131_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nearai/models/openai/o3-mini.toml
+++ b/providers/nearai/models/openai/o3-mini.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/o3-mini"

--- a/providers/nearai/models/openai/o3.toml
+++ b/providers/nearai/models/openai/o3.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/o3"

--- a/providers/nearai/models/openai/o4-mini.toml
+++ b/providers/nearai/models/openai/o4-mini.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "openai/o4-mini"

--- a/providers/nearai/models/openai/whisper-large-v3.toml
+++ b/providers/nearai/models/openai/whisper-large-v3.toml
@@ -1,0 +1,21 @@
+name = "Whisper Large v3"
+family = "whisper"
+release_date = "2023-11-06"
+last_updated = "2023-11-06"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.00
+
+[limit]
+context = 448
+output = 448
+
+[modalities]
+input = ["audio"]
+output = ["text"]

--- a/providers/nearai/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/nearai/models/zai-org/GLM-5.1-FP8.toml
@@ -1,0 +1,25 @@
+name = "GLM-5.1 FP8"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.85
+output = 3.30
+
+[limit]
+context = 202_752
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nearai/provider.toml
+++ b/providers/nearai/provider.toml
@@ -1,0 +1,5 @@
+name = "NEAR AI Cloud"
+npm = "@ai-sdk/openai-compatible"
+api = "https://cloud-api.near.ai/v1"
+env = ["NEARAI_API_KEY"]
+doc = "https://docs.near.ai/"


### PR DESCRIPTION
## Summary

Adds [NEAR AI Cloud](https://cloud-api.near.ai/) (`nearai`) as a new OpenAI-compatible provider, serving 33 models at `https://cloud-api.near.ai/v1`.

## Approach

- **First-party mirrors** (`anthropic/*`, `openai/*`, `google/*`) use `extends` with overrides only where cloud-api pricing or limits differ from canonical (per the README guidance — wrappers shouldn't duplicate first-party defs).
- **NEAR-hosted open-weight models** (Qwen3 family, `zai-org/GLM-5.1-FP8`, `openai/gpt-oss-120b`, `openai/whisper-large-v3`, `black-forest-labs/FLUX.2-klein-4B`) ship with full TOML definitions.
- One alibaba mirror (`Qwen/Qwen3.5-122B-A10B`) uses `extends` against the canonical alibaba entry, with cost/limit overrides for cloud-api pricing and context size.

Pricing, context windows, and modalities are sourced from `GET https://cloud-api.near.ai/v1/models`.

## Validation

`bun validate` passes locally with exit code 0; the generated `nearai` entry materialises all 33 models with the expected pricing and limits.

## Test plan

- [x] `bun install`
- [x] `bun validate` (exit 0)
- [ ] CI validate workflow on the PR