### PR TITLE
fix: Output tokens for Bedrock GPT-OSS models

### DIFF
--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
@@ -1,7 +1,7 @@
 name = "gpt-oss-120b"
 family = "gpt-oss"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
 attachment = false
 reasoning = false
 temperature = true
@@ -15,7 +15,7 @@ output = 0.60
 
 [limit]
 context = 128_000
-output = 4_096
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
@@ -1,7 +1,7 @@
 name = "gpt-oss-20b"
 family = "gpt-oss"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
 attachment = false
 reasoning = false
 temperature = true
@@ -15,7 +15,7 @@ output = 0.30
 
 [limit]
 context = 128_000
-output = 4_096
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
@@ -1,7 +1,7 @@
 name = "GPT OSS Safeguard 120B"
 family = "gpt-oss"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-10-29"
+last_updated = "2025-10-29"
 attachment = false
 reasoning = false
 temperature = true
@@ -15,7 +15,7 @@ output = 0.60
 
 [limit]
 context = 128_000
-output = 4_096
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
@@ -1,7 +1,7 @@
 name = "GPT OSS Safeguard 20B"
 family = "gpt-oss"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
+release_date = "2025-10-29"
+last_updated = "2025-10-29"
 attachment = false
 reasoning = false
 temperature = true
@@ -15,7 +15,7 @@ output = 0.20
 
 [limit]
 context = 128_000
-output = 4_096
+output = 16_384
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Fixes the output tokens limits (4k -> 16k) + model release dates for Bedrock-hosted GPT-OSS models.

Docs: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-safeguard-120b.html