### PR TITLE
providers(minimax): rename Coding Plan → Token Plan in display labels

### DIFF
--- a/providers/minimax-cn-coding-plan/provider.toml
+++ b/providers/minimax-cn-coding-plan/provider.toml
@@ -1,5 +1,5 @@
-name = "MiniMax Coding Plan (minimaxi.com)"
+name = "MiniMax Token Plan (minimaxi.com)"
 env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"
-doc = "https://platform.minimaxi.com/docs/coding-plan/intro"
+doc = "https://platform.minimaxi.com/docs/token-plan/intro"
 api = "https://api.minimaxi.com/anthropic/v1"

--- a/providers/minimax-coding-plan/provider.toml
+++ b/providers/minimax-coding-plan/provider.toml
@@ -1,5 +1,5 @@
-name = "MiniMax Coding Plan (minimax.io)"
+name = "MiniMax Token Plan (minimax.io)"
 env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"
-doc = "https://platform.minimax.io/docs/coding-plan/intro"
+doc = "https://platform.minimax.io/docs/token-plan/intro"
 api = "https://api.minimax.io/anthropic/v1"


### PR DESCRIPTION
## Summary

MiniMax renamed its subscription product from "Coding Plan" to "Token Plan" when scope expanded to cover all modalities (text/speech/video/music/image), not just coding. This PR updates the display label and documentation URL for the two affected provider catalog entries.

## Changes

- `providers/minimax-coding-plan/provider.toml`
  - `name`: `MiniMax Coding Plan (minimax.io)` → `MiniMax Token Plan (minimax.io)`
  - `doc`: `…/coding-plan/intro` → `…/token-plan/intro`
- `providers/minimax-cn-coding-plan/provider.toml`
  - `name`: `MiniMax Coding Plan (minimaxi.com)` → `MiniMax Token Plan (minimaxi.com)`
  - `doc`: `…/coding-plan/intro` → `…/token-plan/intro`

Region disambiguation stays as the URL in parens — matching the existing `minimax` / `minimax-cn` convention. No "China" word added; the URL conveys the region cleanly in the provider picker.

## Backward compatibility

Provider IDs `minimax-coding-plan` and `minimax-cn-coding-plan` are intentionally **unchanged**. Existing `opencode.json` configs and other consumers referencing these IDs keep working. Old `/coding-plan/*` documentation URLs continue to 307-redirect to the new `/token-plan/*` paths upstream.

Reference: <https://platform.minimax.io/docs/token-plan/intro> — *"Token Plan extends upon our former Coding Plan."*

## Verification

- `bun validate` passes
- New doc URLs return HTTP 200 on both global and CN platforms
- Generated JSON inspected — only `name` and `doc` fields changed for the two providers; all model definitions, costs, and logos untouched

## Companion PR

Plugin in opencode that adds OAuth + API key auth methods to these two providers: anomalyco/opencode#27460