### PR TITLE
feat: add Kimi K2.6 to berget.ai

### DIFF
--- a/providers/berget/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/berget/models/moonshotai/Kimi-K2.6.toml
@@ -1,0 +1,9 @@
+release_date = "2026-05-07"
+last_updated = "2026-05-07"
+
+[extends]
+from = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.83
+output = 3.85


### PR DESCRIPTION
## Summary

Add Moonshot AI Kimi K2.6 model to berget.ai provider catalog.

### New model:

- **Kimi K2.6** (`moonshotai/Kimi-K2.6`)
  - Release date: 2026-05-07
  - Pricing: $0.83/M input, $3.85/M output (EUR-based)
  - Context: 262,144 tokens (256K)
  - Output: 16,384 tokens
  - Vision support (image input)
  - Function calling, JSON mode, structured output
  - Open weights

### Changes:

- Add `providers/berget/models/moonshotai/Kimi-K2.6.toml`