### PR TITLE
feat(siliconflow): add DeepSeek v4 models

### DIFF
--- a/providers/siliconflow/models/deepseek-ai/deepseek-v4-flash.toml
+++ b/providers/siliconflow/models/deepseek-ai/deepseek-v4-flash.toml
@@ -1,0 +1,9 @@
+[extends]
+from = "deepseek/deepseek-v4-flash"
+
+# Source: https://www.siliconflow.com/models/deepseek-v4-flash
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028

--- a/providers/siliconflow/models/deepseek-ai/deepseek-v4-pro.toml
+++ b/providers/siliconflow/models/deepseek-ai/deepseek-v4-pro.toml
@@ -1,0 +1,9 @@
+[extends]
+from = "deepseek/deepseek-v4-pro"
+
+# Source: https://www.siliconflow.com/models/deepseek-v4-pro
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.145


### PR DESCRIPTION
### Description
Adds SiliconFlow support for **DeepSeek V4 Pro** and **DeepSeek V4 Flash**.

### Changes
- Created `providers/siliconflow/models/deepseek-v4-pro.toml`
- Created `providers/siliconflow/models/deepseek-v4-flash.toml`
- Used `[extends]` to inherit metadata from the base DeepSeek provider.
- Overrode `[cost]` to align with SiliconFlow’s current pricing.
- Retained base model `[limit]` for consistency with the upstream provider.

### Links
- https://www.siliconflow.com/models/deepseek-v4-pro
- https://www.siliconflow.com/models/deepseek-v4-flash
- Closes #1634 