### PR TITLE
Venice: Add Claude Opus 4.7 Fast model

### DIFF
--- a/providers/venice/models/claude-opus-4-7-fast.toml
+++ b/providers/venice/models/claude-opus-4-7-fast.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.7 Fast"
+family = "claude-opus"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-05-14"
+last_updated = "2026-05-14"
+open_weights = false
+
+[cost]
+input = 36
+output = 180
+cache_read = 3.6
+cache_write = 45
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
- New pricing with 36/180 input/output per million tokens
- 1M context window with 128K output limit
- Text+image input, text-only output