### PR TITLE
Update opencode big-pickle context window to 1M

### DIFF
--- a/providers/opencode/models/big-pickle.toml
+++ b/providers/opencode/models/big-pickle.toml
@@ -21,7 +21,8 @@ cache_write = 0.0
 
 [limit]
 context = 1_000_000
-output = 128_000
+input = 1_000_000
+output = 384_000
 
 [modalities]
 input = ["text"]

--- a/providers/opencode/models/big-pickle.toml
+++ b/providers/opencode/models/big-pickle.toml
@@ -20,7 +20,7 @@ cache_read = 0.0
 cache_write = 0.0
 
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/opencode/models/big-pickle.toml
+++ b/providers/opencode/models/big-pickle.toml
@@ -21,7 +21,6 @@ cache_write = 0.0
 
 [limit]
 context = 1_000_000
-input = 1_000_000
 output = 384_000
 
 [modalities]


### PR DESCRIPTION
Updated the big pickle context window due to it using deepseek v4 flash which has a 1M token window and different output and input limits

<img width="1095" height="449" alt="image" src="https://github.com/user-attachments/assets/cc382fc7-c973-4aa4-99f8-2fa1648023ce" />
