### PR TITLE
feat(sap-ai-core): add Claude Opus 4.7 and sync model specs

### DIFF
--- a/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
@@ -1,0 +1,24 @@
+name = "anthropic--claude-4.7-opus"
+family = "claude-opus"
+release_date = "2026-04-16"
+last_updated = "2026-04-16"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2026-01-31"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/sap-ai-core/models/gemini-2.5-flash-lite.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-flash-lite.toml
@@ -13,7 +13,8 @@ open_weights = false
 [cost]
 input = 0.10
 output = 0.40
-cache_read = 0.025
+cache_read = 0.01
+input_audio = 0.30
 
 [limit]
 context = 1_048_576

--- a/providers/sap-ai-core/models/gemini-2.5-flash.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-flash.toml
@@ -1,6 +1,6 @@
 name = "gemini-2.5-flash"
 family = "gemini-flash"
-release_date = "2025-03-25"
+release_date = "2025-04-17"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true

--- a/providers/sap-ai-core/models/gemini-2.5-pro.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-pro.toml
@@ -15,6 +15,12 @@ input = 1.25
 output = 10.00
 cache_read = 0.125
 
+[[cost.tiers]]
+tier = { size = 200_000 }
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
 [limit]
 context = 1_048_576
 output = 65_536

--- a/providers/sap-ai-core/models/gpt-4.1-mini.toml
+++ b/providers/sap-ai-core/models/gpt-4.1-mini.toml
@@ -20,5 +20,5 @@ context = 1_047_576
 output = 32_768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/sap-ai-core/models/gpt-4.1.toml
+++ b/providers/sap-ai-core/models/gpt-4.1.toml
@@ -20,5 +20,5 @@ context = 1_047_576
 output = 32_768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/sap-ai-core/models/gpt-5-mini.toml
+++ b/providers/sap-ai-core/models/gpt-5-mini.toml
@@ -17,6 +17,7 @@ cache_read = 0.025
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/sap-ai-core/models/gpt-5-nano.toml
+++ b/providers/sap-ai-core/models/gpt-5-nano.toml
@@ -17,6 +17,7 @@ cache_read = 0.005
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/sap-ai-core/models/gpt-5.toml
+++ b/providers/sap-ai-core/models/gpt-5.toml
@@ -17,6 +17,7 @@ cache_read = 0.125
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
**Add** `anthropic--claude-4.7-opus` ([Anthropic announcement](https://www.anthropic.com/news/claude-opus-4-7)).

**Sync existing model specs with official sources:**

- `gemini-2.5-flash-lite`: `cache_read` 0.025 → 0.01, add `input_audio` 0.30 ([ai.google.dev/pricing](https://ai.google.dev/gemini-api/docs/pricing))
- `gemini-2.5-flash`: `release_date` → 2025-04-17 (preview launch) ([blog.google](https://blog.google/products-and-platforms/products/gemini/gemini-2-5-flash-preview/))
- `gemini-2.5-pro`: add `[[cost.tiers]]` >200K (input=2.50, output=15.00, cache_read=0.25)
- `gpt-4.1`, `gpt-4.1-mini`: add `pdf` to `modalities.input` ([OpenAI PDF guide](https://platform.openai.com/docs/guides/pdf-files))
- `gpt-5`, `gpt-5-mini`, `gpt-5-nano`: add `limit.input` = 272_000 ([GPT-5 launch blog](https://openai.com/index/introducing-gpt-5-for-developers/))