### PR TITLE
Fix Xpersona API base URL

### DIFF
--- a/providers/xpersona/provider.toml
+++ b/providers/xpersona/provider.toml
@@ -1,5 +1,5 @@
 name = "Xpersona"
 env = ["XPERSONA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-api = "https://xpersona.co/v1"
-doc = "https://xpersona.co/docs"
+api = "https://www.xpersona.co/v1"
+doc = "https://www.xpersona.co/docs"


### PR DESCRIPTION
Updates the Xpersona provider metadata to use the canonical www API base URL.\n\nWhy:\n- https://xpersona.co/v1 redirects to https://www.xpersona.co/v1 at the Vercel edge.\n- Some OpenAI-compatible clients can lose Authorization headers across redirects.\n- The www endpoint responds directly and avoids redirect-sensitive auth failures.\n\nValidation:\n- Confirmed https://www.xpersona.co/v1/models returns 200.\n- Confirmed https://xpersona.co/v1/models returns 307 to the www endpoint.\n- Could not run the full bun validator locally because Bun is not installed on this Windows machine.