### PR TITLE
chore(xai): mark grok-4-fast, grok-code-fast-1, and other May-15-deprecated models as deprecated

### DIFF
--- a/providers/xai/models/grok-3-fast-latest.toml
+++ b/providers/xai/models/grok-3-fast-latest.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-11"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 5.00

--- a/providers/xai/models/grok-3-fast.toml
+++ b/providers/xai/models/grok-3-fast.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-11"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 5.00

--- a/providers/xai/models/grok-3-latest.toml
+++ b/providers/xai/models/grok-3-latest.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-11"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 3.00

--- a/providers/xai/models/grok-3-mini-fast-latest.toml
+++ b/providers/xai/models/grok-3-mini-fast-latest.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-11"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.60

--- a/providers/xai/models/grok-3-mini-fast.toml
+++ b/providers/xai/models/grok-3-mini-fast.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-11"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.60

--- a/providers/xai/models/grok-3-mini-latest.toml
+++ b/providers/xai/models/grok-3-mini-latest.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-11"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.30

--- a/providers/xai/models/grok-3-mini.toml
+++ b/providers/xai/models/grok-3-mini.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-11"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.30

--- a/providers/xai/models/grok-3.toml
+++ b/providers/xai/models/grok-3.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-11"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 3.00

--- a/providers/xai/models/grok-4-1-fast-non-reasoning.toml
+++ b/providers/xai/models/grok-4-1-fast-non-reasoning.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2025-07"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.20

--- a/providers/xai/models/grok-4-1-fast.toml
+++ b/providers/xai/models/grok-4-1-fast.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2025-07"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.20

--- a/providers/xai/models/grok-4-fast-non-reasoning.toml
+++ b/providers/xai/models/grok-4-fast-non-reasoning.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2025-07"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.20

--- a/providers/xai/models/grok-4-fast.toml
+++ b/providers/xai/models/grok-4-fast.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2025-07"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.20

--- a/providers/xai/models/grok-4.toml
+++ b/providers/xai/models/grok-4.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2025-07"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 3.00

--- a/providers/xai/models/grok-code-fast-1.toml
+++ b/providers/xai/models/grok-code-fast-1.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2023-10"
 tool_call = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.20


### PR DESCRIPTION
## Summary

xAI is retiring a wave of older Grok text models on **2026-05-15 12:00 PM PT**. Per the [official retirement notice](https://docs.x.ai/developers/migration/may-15-retirement), requests to these slugs will redirect to `grok-4.3` (with `low` reasoning effort for reasoning variants, `none` for non-reasoning) and be billed at `grok-4.3` pricing rather than the original rates.

This PR adds `status = "deprecated"` to the affected models so downstream tools (which currently see them as `status: "ga"`) can warn users / steer them toward `grok-4.3`.

## Models marked deprecated

Per the official xAI list plus their `-latest` aliases:

- `grok-4-1-fast` + `grok-4-1-fast-non-reasoning`
- `grok-4-fast` + `grok-4-fast-non-reasoning`
- `grok-4` (alias for the retiring `grok-4-0709`)
- `grok-code-fast-1`
- `grok-3`, `grok-3-latest`
- `grok-3-mini`, `grok-3-mini-latest`
- `grok-3-fast`, `grok-3-fast-latest`
- `grok-3-mini-fast`, `grok-3-mini-fast-latest`

`grok-imagine-image-pro` is also being retired (redirected to `grok-imagine-image-quality`) but no entry exists for it in `providers/xai/models/`, so nothing to update.

## Convention

Used the same convention as existing deprecated entries (e.g. [`providers/groq/models/llama3-70b-8192.toml`](https://github.com/sst/models.dev/blob/dev/providers/groq/models/llama3-70b-8192.toml)):

```toml
status = "deprecated"
```

`bun validate` passes locally.

## References

- Migration guide: https://docs.x.ai/developers/migration/may-15-retirement
- Models page: https://docs.x.ai/docs/models