### PR TITLE
fix(neuralwatt): sync context window and output limits with upstream API

### DIFF
--- a/providers/neuralwatt/README.md
+++ b/providers/neuralwatt/README.md
@@ -14,7 +14,6 @@ Reasoning Models (with interleaved thinking):
 - zai-org/GLM-5.1-FP8 — GLM 5.1 FP8, reasoning enabled
 - moonshotai/Kimi-K2.5 — Kimi K2.5, reasoning + image input
 - moonshotai/Kimi-K2.6 — Kimi K2.6, reasoning + image input
-- kimi-k2.6-fast — Kimi K2.6 Fast, reasoning + image input
 - MiniMaxAI/MiniMax-M2.5 — MiniMax M2.5, reasoning enabled
 - Qwen/Qwen3.5-397B-A17B-FP8 — Qwen3.5 397B, reasoning enabled
 - Qwen/Qwen3.6-35B-A3B — Qwen3.6 35B A3B, reasoning enabled
@@ -24,6 +23,7 @@ Fast Variants (optimized for speed, non-reasoning):
 - glm-5-fast — GLM 5 Fast
 - glm-5.1-fast — GLM 5.1 Fast
 - kimi-k2.5-fast — Kimi K2.5 Fast, image input
+- kimi-k2.6-fast — Kimi K2.6 Fast, image input
 - qwen3.5-397b-fast — Qwen3.5 397B Fast
 - qwen3.6-35b-fast — Qwen3.6 35B Fast
 
@@ -31,7 +31,7 @@ Other:
 - mistralai/Devstral-Small-2-24B-Instruct-2512 — Devstral Small 2, code-focused + image input
 
 Notes
-- Model IDs and pricing sourced directly from the Neuralwatt API (now fully accurate)
+- Model IDs, pricing, and limits sourced directly from the Neuralwatt API
 - Neuralwatt provides real-time energy consumption data (Joules/kWh) per request
-- "Fast" variants are optimized for lower latency; some fast variants also support reasoning (kimi-k2.6-fast)
+- "Fast" variants are optimized for lower latency without reasoning
 - Vision models support image input via OpenAI-compatible API

--- a/providers/neuralwatt/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/neuralwatt/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -13,8 +13,8 @@ input = 0.35
 output = 1.38
 
 [limit]
-context = 196_608
-output = 196_608
+context = 196_592
+output = 196_592
 
 [modalities]
 input = ["text"]

--- a/providers/neuralwatt/models/Qwen/Qwen3.5-397B-A17B-FP8.toml
+++ b/providers/neuralwatt/models/Qwen/Qwen3.5-397B-A17B-FP8.toml
@@ -13,8 +13,8 @@ input = 0.69
 output = 4.14
 
 [limit]
-context = 262_144
-output = 262_144
+context = 262_128
+output = 262_128
 
 [modalities]
 input = ["text"]

--- a/providers/neuralwatt/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/neuralwatt/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -13,8 +13,8 @@ input = 0.05
 output = 0.10
 
 [limit]
-context = 131_072
-output = 131_072
+context = 131_056
+output = 131_056
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neuralwatt/models/glm-5-fast.toml
+++ b/providers/neuralwatt/models/glm-5-fast.toml
@@ -13,8 +13,8 @@ input = 1.1
 output = 3.6
 
 [limit]
-context = 200_000
-output = 200_000
+context = 202_736
+output = 202_736
 
 [modalities]
 input = ["text"]

--- a/providers/neuralwatt/models/glm-5.1-fast.toml
+++ b/providers/neuralwatt/models/glm-5.1-fast.toml
@@ -13,8 +13,8 @@ input = 1.1
 output = 3.6
 
 [limit]
-context = 200_000
-output = 200_000
+context = 202_736
+output = 202_736
 
 [modalities]
 input = ["text"]

--- a/providers/neuralwatt/models/kimi-k2.5-fast.toml
+++ b/providers/neuralwatt/models/kimi-k2.5-fast.toml
@@ -13,8 +13,8 @@ input = 0.52
 output = 2.59
 
 [limit]
-context = 262_144
-output = 262_144
+context = 262_128
+output = 262_128
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neuralwatt/models/kimi-k2.6-fast.toml
+++ b/providers/neuralwatt/models/kimi-k2.6-fast.toml
@@ -13,8 +13,8 @@ input = 0.69
 output = 3.22
 
 [limit]
-context = 262_144
-output = 262_144
+context = 262_128
+output = 262_128
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neuralwatt/models/mistralai/Devstral-Small-2-24B-Instruct-2512.toml
+++ b/providers/neuralwatt/models/mistralai/Devstral-Small-2-24B-Instruct-2512.toml
@@ -13,8 +13,8 @@ input = 0.12
 output = 0.35
 
 [limit]
-context = 262_144
-output = 262_144
+context = 262_128
+output = 262_128
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neuralwatt/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/neuralwatt/models/moonshotai/Kimi-K2.5.toml
@@ -13,8 +13,8 @@ input = 0.52
 output = 2.59
 
 [limit]
-context = 262_144
-output = 262_144
+context = 262_128
+output = 262_128
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neuralwatt/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/neuralwatt/models/moonshotai/Kimi-K2.6.toml
@@ -13,8 +13,8 @@ input = 0.69
 output = 3.22
 
 [limit]
-context = 262_144
-output = 262_144
+context = 262_128
+output = 262_128
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neuralwatt/models/openai/gpt-oss-20b.toml
+++ b/providers/neuralwatt/models/openai/gpt-oss-20b.toml
@@ -13,8 +13,8 @@ input = 0.03
 output = 0.16
 
 [limit]
-context = 16_384
-output = 16_384
+context = 16_368
+output = 16_368
 
 [modalities]
 input = ["text"]

--- a/providers/neuralwatt/models/qwen3.5-397b-fast.toml
+++ b/providers/neuralwatt/models/qwen3.5-397b-fast.toml
@@ -13,8 +13,8 @@ input = 0.69
 output = 4.14
 
 [limit]
-context = 262_144
-output = 262_144
+context = 262_128
+output = 262_128
 
 [modalities]
 input = ["text"]

--- a/providers/neuralwatt/models/qwen3.6-35b-fast.toml
+++ b/providers/neuralwatt/models/qwen3.6-35b-fast.toml
@@ -13,8 +13,8 @@ input = 0.05
 output = 0.10
 
 [limit]
-context = 131_072
-output = 131_072
+context = 131_056
+output = 131_056
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neuralwatt/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/neuralwatt/models/zai-org/GLM-5.1-FP8.toml
@@ -13,8 +13,8 @@ input = 1.1
 output = 3.6
 
 [limit]
-context = 200_000
-output = 200_000
+context = 202_736
+output = 202_736
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Sync neuralwatt model context window and max output token limits with values reported by the Neuralwatt API (`GET /v1/models`).

### Changes

**15 files updated** — 14 model TOMLs + README

| Model | Old | New |
|-------|-----|-----|
| Devstral-Small-2-24B-Instruct-2512 | 262,144 | **262,128** |
| GLM-5 / GLM-5.1 (all variants) | 200,000 | **202,736** |
| GPT-OSS-20B | 16,384 | **16,368** |
| Kimi-K2.5 / K2.6 (all variants) | 262,144 | **262,128** |
| MiniMax-M2.5 | 196,608 | **196,592** |
| Qwen3.5-397B (all variants) | 262,144 | **262,128** |
| Qwen3.6-35B (all variants) | 131,072 | **131,056** |

### README fixes
- Moved `kimi-k2.6-fast` from "Reasoning Models" to "Fast Variants" — the model has `reasoning = false`
- Removed incorrect note about fast variants supporting reasoning