### PR TITLE
Add routing.run provider

### DIFF
--- a/providers/routing-run/logo.svg
+++ b/providers/routing-run/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M4 12a8 8 0 0 1 8-8h8v8a8 8 0 0 1-8 8H4v-8Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M8 12h8M12 8v8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/providers/routing-run/models/route/deepseek-v3.2.toml
+++ b/providers/routing-run/models/route/deepseek-v3.2.toml
@@ -1,0 +1,23 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2024-07"
+open_weights = true
+
+[cost]
+input = 0.4928
+output = 0.7392
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/routing-run/models/route/deepseek-v4-flash-full.toml
+++ b/providers/routing-run/models/route/deepseek-v4-flash-full.toml
@@ -1,0 +1,12 @@
+name = "DeepSeek V4 Flash Full"
+
+[extends]
+from = "deepseek/deepseek-v4-flash"
+
+[cost]
+input = 0.4928
+output = 0.7392
+
+[limit]
+context = 1_000_000
+output = 131_072

--- a/providers/routing-run/models/route/deepseek-v4-flash.toml
+++ b/providers/routing-run/models/route/deepseek-v4-flash.toml
@@ -1,0 +1,12 @@
+name = "DeepSeek V4 Flash"
+
+[extends]
+from = "deepseek/deepseek-v4-flash"
+
+[cost]
+input = 0.4928
+output = 0.7392
+
+[limit]
+context = 1_000_000
+output = 131_072

--- a/providers/routing-run/models/route/deepseek-v4-pro-precision.toml
+++ b/providers/routing-run/models/route/deepseek-v4-pro-precision.toml
@@ -1,0 +1,12 @@
+name = "DeepSeek V4 Pro Precision"
+
+[extends]
+from = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 0.7392
+output = 1.1088
+
+[limit]
+context = 1_000_000
+output = 131_072

--- a/providers/routing-run/models/route/deepseek-v4-pro.toml
+++ b/providers/routing-run/models/route/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+name = "DeepSeek V4 Pro"
+
+[extends]
+from = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 0.4928
+output = 0.7392
+
+[limit]
+context = 1_000_000
+output = 131_072

--- a/providers/routing-run/models/route/gemma-4-31b-it.toml
+++ b/providers/routing-run/models/route/gemma-4-31b-it.toml
@@ -1,0 +1,12 @@
+name = "Gemma 4 31B IT"
+
+[extends]
+from = "google/gemma-4-31b-it"
+
+[cost]
+input = 0.10
+output = 0.30
+
+[limit]
+context = 131_072
+output = 65_536

--- a/providers/routing-run/models/route/glm-4.7-flash.toml
+++ b/providers/routing-run/models/route/glm-4.7-flash.toml
@@ -1,0 +1,12 @@
+name = "GLM 4.7 Flash"
+
+[extends]
+from = "zai/glm-4.7-flash"
+
+[cost]
+input = 1.32
+output = 4.40
+
+[limit]
+context = 128_000
+output = 128_000

--- a/providers/routing-run/models/route/glm-4.7.toml
+++ b/providers/routing-run/models/route/glm-4.7.toml
@@ -1,0 +1,12 @@
+name = "GLM 4.7"
+
+[extends]
+from = "zai/glm-4.7"
+
+[cost]
+input = 1.32
+output = 4.40
+
+[limit]
+context = 128_000
+output = 128_000

--- a/providers/routing-run/models/route/glm-5-highspeed.toml
+++ b/providers/routing-run/models/route/glm-5-highspeed.toml
@@ -1,0 +1,12 @@
+name = "GLM 5 Highspeed"
+
+[extends]
+from = "zai/glm-5"
+
+[cost]
+input = 1.1088
+output = 3.542
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/routing-run/models/route/glm-5.1-fp16.toml
+++ b/providers/routing-run/models/route/glm-5.1-fp16.toml
@@ -1,0 +1,12 @@
+name = "GLM 5.1 FP16"
+
+[extends]
+from = "zai/glm-5.1"
+
+[cost]
+input = 1.20
+output = 3.50
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/routing-run/models/route/glm-5.1-full.toml
+++ b/providers/routing-run/models/route/glm-5.1-full.toml
@@ -1,0 +1,12 @@
+name = "GLM 5.1 Full"
+
+[extends]
+from = "zai/glm-5.1"
+
+[cost]
+input = 1.20
+output = 3.50
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/routing-run/models/route/glm-5.1-precision.toml
+++ b/providers/routing-run/models/route/glm-5.1-precision.toml
@@ -1,0 +1,12 @@
+name = "GLM 5.1 Precision"
+
+[extends]
+from = "zai/glm-5.1"
+
+[cost]
+input = 1.20
+output = 3.50
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/routing-run/models/route/glm-5.1.toml
+++ b/providers/routing-run/models/route/glm-5.1.toml
@@ -1,0 +1,12 @@
+name = "GLM 5.1"
+
+[extends]
+from = "zai/glm-5.1"
+
+[cost]
+input = 1.00
+output = 3.00
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/routing-run/models/route/glm-5.toml
+++ b/providers/routing-run/models/route/glm-5.toml
@@ -1,0 +1,12 @@
+name = "GLM 5"
+
+[extends]
+from = "zai/glm-5"
+
+[cost]
+input = 0.792
+output = 2.53
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/routing-run/models/route/kimi-k2.5-highspeed.toml
+++ b/providers/routing-run/models/route/kimi-k2.5-highspeed.toml
@@ -1,0 +1,16 @@
+name = "Kimi K2.5 Highspeed"
+
+[extends]
+from = "moonshotai/kimi-k2.5"
+
+[cost]
+input = 0.6468
+output = 3.388
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/routing-run/models/route/kimi-k2.5.toml
+++ b/providers/routing-run/models/route/kimi-k2.5.toml
@@ -1,0 +1,16 @@
+name = "Kimi K2.5"
+
+[extends]
+from = "moonshotai/kimi-k2.5"
+
+[cost]
+input = 0.462
+output = 2.42
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/routing-run/models/route/kimi-k2.6-full.toml
+++ b/providers/routing-run/models/route/kimi-k2.6-full.toml
@@ -1,0 +1,16 @@
+name = "Kimi K2.6 Full"
+
+[extends]
+from = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.462
+output = 2.42
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/routing-run/models/route/kimi-k2.6-precision.toml
+++ b/providers/routing-run/models/route/kimi-k2.6-precision.toml
@@ -1,0 +1,16 @@
+name = "Kimi K2.6 Precision"
+
+[extends]
+from = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.6468
+output = 3.388
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/routing-run/models/route/kimi-k2.6.toml
+++ b/providers/routing-run/models/route/kimi-k2.6.toml
@@ -1,0 +1,16 @@
+name = "Kimi K2.6"
+
+[extends]
+from = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.462
+output = 2.42
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/routing-run/models/route/mimo-v2.5-pro-precision.toml
+++ b/providers/routing-run/models/route/mimo-v2.5-pro-precision.toml
@@ -1,0 +1,12 @@
+name = "MiMo V2.5 Pro Precision"
+
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 0.45
+output = 1.35
+
+[limit]
+context = 1_000_000
+output = 131_072

--- a/providers/routing-run/models/route/mimo-v2.5-pro.toml
+++ b/providers/routing-run/models/route/mimo-v2.5-pro.toml
@@ -1,0 +1,12 @@
+name = "MiMo V2.5 Pro"
+
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 0.45
+output = 1.35
+
+[limit]
+context = 1_000_000
+output = 262_144

--- a/providers/routing-run/models/route/mimo-v2.5.toml
+++ b/providers/routing-run/models/route/mimo-v2.5.toml
@@ -1,0 +1,8 @@
+name = "MiMo V2.5"
+
+[extends]
+from = "xiaomi/mimo-v2.5"
+
+[limit]
+context = 256_000
+output = 65_536

--- a/providers/routing-run/models/route/minimax-m2.5-highspeed.toml
+++ b/providers/routing-run/models/route/minimax-m2.5-highspeed.toml
@@ -1,0 +1,12 @@
+name = "MiniMax M2.5 Highspeed"
+
+[extends]
+from = "minimax/MiniMax-M2.5-highspeed"
+
+[cost]
+input = 0.193
+output = 1.238
+
+[limit]
+context = 100_000
+output = 131_072

--- a/providers/routing-run/models/route/minimax-m2.5.toml
+++ b/providers/routing-run/models/route/minimax-m2.5.toml
@@ -1,0 +1,12 @@
+name = "MiniMax M2.5"
+
+[extends]
+from = "minimax/MiniMax-M2.5"
+
+[cost]
+input = 0.193
+output = 1.238
+
+[limit]
+context = 100_000
+output = 131_072

--- a/providers/routing-run/models/route/minimax-m2.7-highspeed.toml
+++ b/providers/routing-run/models/route/minimax-m2.7-highspeed.toml
@@ -1,0 +1,12 @@
+name = "MiniMax M2.7 Highspeed"
+
+[extends]
+from = "minimax/MiniMax-M2.7-highspeed"
+
+[cost]
+input = 0.33
+output = 1.32
+
+[limit]
+context = 100_000
+output = 131_072

--- a/providers/routing-run/models/route/minimax-m2.7.toml
+++ b/providers/routing-run/models/route/minimax-m2.7.toml
@@ -1,0 +1,12 @@
+name = "MiniMax M2.7"
+
+[extends]
+from = "minimax/MiniMax-M2.7"
+
+[cost]
+input = 0.33
+output = 1.32
+
+[limit]
+context = 100_000
+output = 131_072

--- a/providers/routing-run/models/route/mistral-large-3.toml
+++ b/providers/routing-run/models/route/mistral-large-3.toml
@@ -1,0 +1,8 @@
+name = "Mistral Large 3"
+
+[extends]
+from = "mistral/mistral-large-2512"
+
+[limit]
+context = 128_000
+output = 32_768

--- a/providers/routing-run/models/route/mistral-medium-2505.toml
+++ b/providers/routing-run/models/route/mistral-medium-2505.toml
@@ -1,0 +1,8 @@
+name = "Mistral Medium 2505"
+
+[extends]
+from = "mistral/mistral-medium-2505"
+
+[limit]
+context = 128_000
+output = 32_768

--- a/providers/routing-run/models/route/mistral-small-2503.toml
+++ b/providers/routing-run/models/route/mistral-small-2503.toml
@@ -1,0 +1,8 @@
+name = "Mistral Small 2503"
+
+[extends]
+from = "mistral/mistral-small-2603"
+
+[limit]
+context = 128_000
+output = 32_768

--- a/providers/routing-run/models/route/qwen3.5-397b-a17b.toml
+++ b/providers/routing-run/models/route/qwen3.5-397b-a17b.toml
@@ -1,0 +1,12 @@
+name = "Qwen3.5 397B-A17B"
+
+[extends]
+from = "alibaba/qwen3.5-397b-a17b"
+
+[cost]
+input = 1.10
+output = 3.30
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/routing-run/models/route/qwen3.5-9b-chat.toml
+++ b/providers/routing-run/models/route/qwen3.5-9b-chat.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 9B Chat"
+family = "qwen3.5"
+release_date = "2026-03-10"
+last_updated = "2026-03-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.20
+output = 0.60
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/routing-run/models/route/qwen3.5-9b.toml
+++ b/providers/routing-run/models/route/qwen3.5-9b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 9B"
+family = "qwen3.5"
+release_date = "2026-03-10"
+last_updated = "2026-03-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.20
+output = 0.60
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/routing-run/models/route/qwen3.6-27b.toml
+++ b/providers/routing-run/models/route/qwen3.6-27b.toml
@@ -1,0 +1,12 @@
+name = "Qwen3.6 27B"
+
+[extends]
+from = "alibaba/qwen3.6-27b"
+
+[cost]
+input = 1.10
+output = 3.30
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/routing-run/models/route/step-3.5-flash-2603.toml
+++ b/providers/routing-run/models/route/step-3.5-flash-2603.toml
@@ -1,0 +1,8 @@
+name = "Step 3.5 Flash 2603"
+
+[extends]
+from = "stepfun/step-3.5-flash-2603"
+
+[limit]
+context = 262_144
+output = 65_536

--- a/providers/routing-run/models/route/step-3.5-flash-full.toml
+++ b/providers/routing-run/models/route/step-3.5-flash-full.toml
@@ -1,0 +1,8 @@
+name = "Step 3.5 Flash Full"
+
+[extends]
+from = "stepfun/step-3.5-flash"
+
+[limit]
+context = 262_144
+output = 65_536

--- a/providers/routing-run/models/route/step-3.5-flash.toml
+++ b/providers/routing-run/models/route/step-3.5-flash.toml
@@ -1,0 +1,8 @@
+name = "Step 3.5 Flash"
+
+[extends]
+from = "stepfun/step-3.5-flash"
+
+[limit]
+context = 262_144
+output = 65_536

--- a/providers/routing-run/models/route/stepfun-3.5-flash.toml
+++ b/providers/routing-run/models/route/stepfun-3.5-flash.toml
@@ -1,0 +1,8 @@
+name = "StepFun 3.5 Flash"
+
+[extends]
+from = "stepfun/step-3.5-flash"
+
+[limit]
+context = 262_144
+output = 65_536

--- a/providers/routing-run/provider.toml
+++ b/providers/routing-run/provider.toml
@@ -1,0 +1,5 @@
+name = "routing.run"
+env = ["ROUTING_RUN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.routing.run/v1"
+doc = "https://docs.routing.run/api-reference/models"


### PR DESCRIPTION
Add routing.run as an OpenAI-compatible provider for Models.dev.

Includes the supported routing.run chat models with model metadata, pricing, context limits, and output limits.

Validated with `bun run validate`.