### PR TITLE
Add Lilac reasoning model modes

### DIFF
--- a/providers/lilac/models/google/gemma-4-31b-it.toml
+++ b/providers/lilac/models/google/gemma-4-31b-it.toml
@@ -19,3 +19,6 @@ output = 262_100
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[experimental.modes.thinking]
+provider = { body = { chat_template_kwargs = { thinking = true, enable_thinking = true } } }

--- a/providers/lilac/models/minimaxai/minimax-m2.7.toml
+++ b/providers/lilac/models/minimaxai/minimax-m2.7.toml
@@ -21,3 +21,6 @@ output = 204_800
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[experimental.modes.non-reasoning]
+provider = { body = { chat_template_kwargs = { thinking = false, enable_thinking = false } } }

--- a/providers/lilac/models/minimaxai/minimax-m2.7.toml
+++ b/providers/lilac/models/minimaxai/minimax-m2.7.toml
@@ -21,6 +21,3 @@ output = 204_800
 [modalities]
 input = ["text"]
 output = ["text"]
-
-[experimental.modes.non-reasoning]
-provider = { body = { chat_template_kwargs = { thinking = false, enable_thinking = false } } }

--- a/providers/lilac/models/moonshotai/kimi-k2.6.toml
+++ b/providers/lilac/models/moonshotai/kimi-k2.6.toml
@@ -9,3 +9,6 @@ cache_read = 0.20
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[experimental.modes.non-reasoning]
+provider = { body = { chat_template_kwargs = { thinking = false, enable_thinking = false } } }

--- a/providers/lilac/models/zai-org/glm-5.1.toml
+++ b/providers/lilac/models/zai-org/glm-5.1.toml
@@ -18,3 +18,6 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[experimental.modes.non-reasoning]
+provider = { body = { chat_template_kwargs = { thinking = false, enable_thinking = false } } }


### PR DESCRIPTION
## Summary
- Add Lilac `non-reasoning` modes for GLM 5.1 and Kimi K2.6. Their base Lilac model IDs already reason by default, so these modes provide an explicit opt-out via request kwargs without inventing fake `:thinking` model IDs or changing Lilac API defaults.
- Use the name `non-reasoning` because existing catalog providers already use that wording for reasoning-off variants, for example `providers/vercel/models/xai/grok-4.1-fast-non-reasoning.toml`, `providers/xai/models/grok-4.20-0309-non-reasoning.toml`, and `providers/azure/models/grok-4-20-non-reasoning.toml`.
- Add a Lilac `thinking` mode for Gemma 4 31B IT. The base model remains non-thinking by default, matching Google's Hugging Face chat-template guidance; the mode is an explicit opt-in that passes `chat_template_kwargs`.
- Leave MiniMax M2.7 without mode variants because it always reasons.
- Remove the separate `:thinking` aliases; Lilac does not serve those as real model IDs.

## Testing
- `bun run validate`
- Generated the Lilac provider subset and confirmed the expected GLM/Kimi/Gemma modes are present, MiniMax has no modes, and no `:thinking` aliases are present.
