### PR TITLE
add crof.ai provider with 21 models

### DIFF
--- a/providers/crof/models/deepseek-v3.2.toml
+++ b/providers/crof/models/deepseek-v3.2.toml
@@ -1,0 +1,22 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2025-07-22"
+last_updated = "2025-07-22"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.28
+output = 0.38
+cache_read = 0.06
+
+[limit]
+context = 163_840
+output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/crof/models/deepseek-v4-flash.toml
+++ b/providers/crof/models/deepseek-v4-flash.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "deepseek/deepseek-v4-flash"
+
+[cost]
+input = 0.12
+output = 0.21
+cache_read = 0.02
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/deepseek-v4-flash.toml
+++ b/providers/crof/models/deepseek-v4-flash.toml
@@ -6,5 +6,9 @@ input = 0.12
 output = 0.21
 cache_read = 0.02
 
+[limit]
+context = 1_000_000
+output = 131_072
+
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/deepseek-v4-pro-precision.toml
+++ b/providers/crof/models/deepseek-v4-pro-precision.toml
@@ -1,0 +1,26 @@
+name = "DeepSeek V4 Pro (Precision)"
+family = "deepseek-thinking"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.25
+output = 2.50
+cache_read = 0.10
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/crof/models/deepseek-v4-pro.toml
+++ b/providers/crof/models/deepseek-v4-pro.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 0.40
+output = 0.85
+cache_read = 0.003
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/deepseek-v4-pro.toml
+++ b/providers/crof/models/deepseek-v4-pro.toml
@@ -6,5 +6,9 @@ input = 0.40
 output = 0.85
 cache_read = 0.003
 
+[limit]
+context = 1_000_000
+output = 131_072
+
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/gemma-4-31b-it.toml
+++ b/providers/crof/models/gemma-4-31b-it.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "google/gemma-4-31b-it"
+
+[cost]
+input = 0.10
+output = 0.30
+cache_read = 0.02
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/gemma-4-31b-it.toml
+++ b/providers/crof/models/gemma-4-31b-it.toml
@@ -6,5 +6,9 @@ input = 0.10
 output = 0.30
 cache_read = 0.02
 
+[limit]
+context = 262_144
+output = 262_144
+
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/glm-4.7-flash.toml
+++ b/providers/crof/models/glm-4.7-flash.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "zhipuai/glm-4.7-flash"
+
+[cost]
+input = 0.04
+output = 0.30
+cache_read = 0.008
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/glm-4.7.toml
+++ b/providers/crof/models/glm-4.7.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "zhipuai/glm-4.7"
+
+[cost]
+input = 0.25
+output = 1.10
+cache_read = 0.05
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/glm-4.7.toml
+++ b/providers/crof/models/glm-4.7.toml
@@ -6,5 +6,9 @@ input = 0.25
 output = 1.10
 cache_read = 0.05
 
+[limit]
+context = 202_752
+output = 202_752
+
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/glm-5.1-precision.toml
+++ b/providers/crof/models/glm-5.1-precision.toml
@@ -1,0 +1,26 @@
+name = "GLM 5.1 (Precision)"
+family = "glm"
+release_date = "2026-03-27"
+last_updated = "2026-03-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.75
+output = 2.90
+cache_read = 0.15
+
+[limit]
+context = 202_752
+output = 202_752
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/crof/models/glm-5.1.toml
+++ b/providers/crof/models/glm-5.1.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "zhipuai/glm-5.1"
+
+[cost]
+input = 0.45
+output = 2.10
+cache_read = 0.09
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/glm-5.1.toml
+++ b/providers/crof/models/glm-5.1.toml
@@ -6,5 +6,9 @@ input = 0.45
 output = 2.10
 cache_read = 0.09
 
+[limit]
+context = 202_752
+output = 202_752
+
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/glm-5.toml
+++ b/providers/crof/models/glm-5.toml
@@ -6,5 +6,9 @@ input = 0.48
 output = 1.90
 cache_read = 0.10
 
+[limit]
+context = 202_752
+output = 202_752
+
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/glm-5.toml
+++ b/providers/crof/models/glm-5.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "zhipuai/glm-5"
+
+[cost]
+input = 0.48
+output = 1.90
+cache_read = 0.10
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/greg.toml
+++ b/providers/crof/models/greg.toml
@@ -1,0 +1,21 @@
+name = "Experiment!: Greg"
+release_date = "2026-01-27"
+last_updated = "2026-01-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.10
+output = 0.20
+cache_read = 0.02
+
+[limit]
+context = 229_376
+output = 229_376
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/crof/models/kimi-k2.5-lightning.toml
+++ b/providers/crof/models/kimi-k2.5-lightning.toml
@@ -1,0 +1,26 @@
+name = "Kimi K2.5 (Lightning)"
+family = "kimi-k2.5"
+release_date = "2026-02-06"
+last_updated = "2026-02-06"
+attachment = false
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.00
+output = 3.00
+cache_read = 0.20
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/crof/models/kimi-k2.5.toml
+++ b/providers/crof/models/kimi-k2.5.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "moonshotai/kimi-k2.5"
+
+[cost]
+input = 0.35
+output = 1.70
+cache_read = 0.07
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/kimi-k2.6-precision.toml
+++ b/providers/crof/models/kimi-k2.6-precision.toml
@@ -1,0 +1,26 @@
+name = "Kimi K2.6 (Precision)"
+family = "kimi-k2.6"
+release_date = "2026-04-21"
+last_updated = "2026-04-21"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.55
+output = 2.70
+cache_read = 0.11
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/crof/models/kimi-k2.6.toml
+++ b/providers/crof/models/kimi-k2.6.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.50
+output = 1.99
+cache_read = 0.10
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/mimo-v2.5-pro-precision.toml
+++ b/providers/crof/models/mimo-v2.5-pro-precision.toml
@@ -1,0 +1,25 @@
+name = "MiMo-V2.5-Pro (Precision)"
+family = "mimo"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.80
+output = 2.50
+cache_read = 0.16
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/crof/models/mimo-v2.5-pro.toml
+++ b/providers/crof/models/mimo-v2.5-pro.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 0.50
+output = 1.50
+cache_read = 0.10
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/minimax-m2.5.toml
+++ b/providers/crof/models/minimax-m2.5.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "minimax/MiniMax-M2.5"
+
+[cost]
+input = 0.11
+output = 0.95
+cache_read = 0.02
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/minimax-m2.5.toml
+++ b/providers/crof/models/minimax-m2.5.toml
@@ -1,3 +1,5 @@
+reasoning = false
+
 [extends]
 from = "minimax/MiniMax-M2.5"
 

--- a/providers/crof/models/qwen3.5-397b-a17b.toml
+++ b/providers/crof/models/qwen3.5-397b-a17b.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "alibaba/qwen3.5-397b-a17b"
+
+[cost]
+input = 0.35
+output = 1.75
+cache_read = 0.07
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/qwen3.5-397b-a17b.toml
+++ b/providers/crof/models/qwen3.5-397b-a17b.toml
@@ -6,5 +6,9 @@ input = 0.35
 output = 1.75
 cache_read = 0.07
 
+[limit]
+context = 262_144
+output = 262_144
+
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/qwen3.5-9b.toml
+++ b/providers/crof/models/qwen3.5-9b.toml
@@ -1,0 +1,26 @@
+name = "Qwen3.5 9B"
+family = "qwen"
+release_date = "2026-03-13"
+last_updated = "2026-03-13"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.04
+output = 0.15
+cache_read = 0.008
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/crof/models/qwen3.6-27b.toml
+++ b/providers/crof/models/qwen3.6-27b.toml
@@ -6,5 +6,9 @@ input = 0.20
 output = 1.50
 cache_read = 0.04
 
+[limit]
+context = 262_144
+output = 262_144
+
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/qwen3.6-27b.toml
+++ b/providers/crof/models/qwen3.6-27b.toml
@@ -1,0 +1,10 @@
+[extends]
+from = "alibaba/qwen3.6-27b"
+
+[cost]
+input = 0.20
+output = 1.50
+cache_read = 0.04
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/provider.toml
+++ b/providers/crof/provider.toml
@@ -1,0 +1,5 @@
+name = "CrofAI"
+env = ["CROF_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://crof.ai/v1"
+doc = "https://crof.ai/docs"


### PR DESCRIPTION
## Summary

Adds the [CrofAI](https://crof.ai/docs) provider — an OpenAI-compatible API at `https://crof.ai/v1` — with **21 models**.

## Details

- **Provider**: `providers/crof/provider.toml` — uses `@ai-sdk/openai-compatible`, auth via `CROF_API_KEY`
- **13 models** use `extends` from canonical sources (deepseek, xiaomi, zhipuai, moonshotai, google, minimax, alibaba) with Crof's own pricing and limits overridden where different
- **8 models** have full TOML definitions (precision variants, deepseek-v3.2, kimi-k2.5-lightning, greg, qwen3.5-9b) where no canonical source exists
- All pricing sourced from `https://crof.ai/v1/models`
- Validated with `bun validate` ✅