### PR TITLE
feat(gitlab): add Agentic Chat (GPT-5.5) model

### DIFF
--- a/providers/gitlab/models/duo-chat-gpt-5-5.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-5.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (GPT-5.5)"
+family = "gpt"
+release_date = "2026-04-23"
+last_updated = "2026-04-23"
+knowledge = "2025-08-31"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds `duo-chat-gpt-5-5` to the GitLab provider.

GitLab AI Gateway proxies this model id to OpenAI's `gpt-5.5-2026-04-23` backend with a 1.05M token context window (922k input + 128k output, text + image + pdf input).

## Source

Confirmed against the upstream GitLab models manifest at [gitlab-org/modelops/applied-ml/code-suggestions/ai-assist `ai_gateway/model_selection/models.yml`](https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/blob/main/ai_gateway/model_selection/models.yml) — the `gpt_5_5` entry has `proxy_provider: openai`, model param `gpt-5.5-2026-04-23`, and `max_context_tokens: 1_050_000`.

## Consumer support

The `gitlab-ai-provider` npm package exposes `duo-chat-gpt-5-5` starting in v6.7.0 ([changelog](https://gitlab.com/vglafirov/gitlab-ai-provider/-/blob/main/CHANGELOG.md)).

## Validation

`bun packages/core/script/validate.ts` passes — TOML is valid and conforms to the schema.