### PR TITLE
feat(sap-ai-core): add GPT-5.4

### DIFF
--- a/providers/sap-ai-core/models/gemini-2.5-pro.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-pro.toml
@@ -15,12 +15,6 @@ input = 1.25
 output = 10.00
 cache_read = 0.125
 
-[[cost.tiers]]
-tier = { size = 200_000 }
-input = 2.50
-output = 15.00
-cache_read = 0.25
-
 [limit]
 context = 1_048_576
 output = 65_536

--- a/providers/sap-ai-core/models/gpt-5.4.toml
+++ b/providers/sap-ai-core/models/gpt-5.4.toml
@@ -1,0 +1,25 @@
+name = "gpt-5.4"
+family = "gpt"
+release_date = "2026-04-27"
+last_updated = "2026-04-27"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-08-31"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
**Add** `gpt-5.4` ([SAP AI Core Service Guide](https://help.sap.com/doc/c31b38b32a5d4e07a4488cb0f8bb55d9/CLOUD/en-US/f17fa8568d0448c685f2a0301061a6ee.pdf), available 2026-04-27; [Java SDK `OpenAiModel.GPT_54`](https://github.com/SAP/ai-sdk-java/blob/main/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiModel.java); [Python SDK supported models](https://help.sap.com/doc/generative-ai-hub-sdk/CLOUD/en-US/_reference/README_sphynx.html)).

Specs (context, output, cost, modalities, capabilities) mirror the canonical [`openai/gpt-5.4`](../blob/dev/providers/openai/models/gpt-5.4.toml) — SAP Note 3437766 (login-gated) is the only authoritative source for SAP-side capacity-unit conversion and is not publicly verifiable.

**Sync:**
- `gemini-2.5-pro`: remove `[[cost.tiers]]` — SAP-side tiered pricing not confirmed; `sap-ai-core` now declares no per-model tiers pending SAP Note 3437766 verification.