### PR TITLE
Added Mistral Medium 3.5 128B from Scaleway

### DIFF
--- a/providers/scaleway/models/mistral-medium-3.5-128b.toml
+++ b/providers/scaleway/models/mistral-medium-3.5-128b.toml
@@ -1,0 +1,21 @@
+name = "Mistral Medium 3.5 128B"
+family = "mistral-medium"
+release_date = "2026-04-29"
+last_updated = "2026-04-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.50
+output = 7.50
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/scaleway/models/mistral-medium-3.5-128b.toml
+++ b/providers/scaleway/models/mistral-medium-3.5-128b.toml
@@ -1,21 +1,8 @@
 name = "Mistral Medium 3.5 128B"
-family = "mistral-medium"
-release_date = "2026-04-29"
-last_updated = "2026-04-29"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
 
-[cost]
-input = 1.50
-output = 7.50
+[extends]
+from = "mistral/mistral-medium-2604"
 
 [limit]
-context = 262_144
+context = 256_000
 output = 16_384
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]


### PR DESCRIPTION
Added support for the newly available Mistral Medium 3.5 128B model from Scaleway. This update ensures compatibility with the latest offerings in their catalog.