### PR TITLE
Sync OpenRouter models with extends

### DIFF
--- a/packages/core/script/sync-models.ts
+++ b/packages/core/script/sync-models.ts
@@ -10,20 +10,39 @@ import { google } from "./sync/google.js";
 import { openrouter } from "./sync/openrouter.js";
 import { xai } from "./sync/xai.js";
 
-const ExistingModel = AuthoredModelShape.partial()
-  .extend({
-    extends: z
-      .object({
-        from: z.string(),
-        omit: z.array(z.string()).optional(),
-      })
-      .strict()
-      .optional(),
+const ExtendsConfig = z
+  .object({
+    from: z.string(),
+    omit: z.array(z.string()).optional(),
   })
   .strict();
 
+const ExistingExtendsConfig = z
+  .object({
+    from: z.string(),
+    omit: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+const ExistingModel = AuthoredModelShape.partial()
+  .extend({
+    extends: ExistingExtendsConfig.optional(),
+  })
+  .strict();
+
+const SyncedExtendsModel = AuthoredModelShape.partial()
+  .extend({
+    id: z.string(),
+    extends: ExtendsConfig,
+  })
+  .strict();
+
+const SyncedAuthoredModel = z.union([AuthoredModel, SyncedExtendsModel]);
+
 export type ExistingModel = z.infer<typeof ExistingModel>;
-export type SyncedModel = Omit<z.infer<typeof AuthoredModelShape>, "id">;
+export type SyncedFullModel = Omit<z.infer<typeof AuthoredModelShape>, "id">;
+export type SyncedExtendsModel = Omit<z.infer<typeof SyncedExtendsModel>, "id">;
+export type SyncedModel = SyncedFullModel | SyncedExtendsModel;
 
 export interface SyncProvider<SourceModel> {
   id: string;
@@ -89,7 +108,7 @@ export async function syncProvider<SourceModel>(
 
   const existing = await readExisting(provider.modelsDir);
   const sourceModels = provider.parseModels(await provider.fetchModels());
-  const desired = new Map<string, { model: z.infer<typeof AuthoredModel>; content: string }>();
+  const desired = new Map<string, { model: z.infer<typeof SyncedAuthoredModel>; content: string }>();
   const skippedRemote: string[] = [];
 
   for (const sourceModel of sourceModels) {
@@ -113,7 +132,7 @@ export async function syncProvider<SourceModel>(
       throw new Error(`Duplicate synced model path: ${provider.id}/${relativePath}`);
     }
 
-    const parsed = AuthoredModel.safeParse({
+    const parsed = SyncedAuthoredModel.safeParse({
       id: translated.id,
       ...translated.model,
     });
@@ -259,9 +278,9 @@ function summarize(
 function sameModel(
   relativePath: string,
   current: ExistingModel,
-  desired: z.infer<typeof AuthoredModel>,
+  desired: z.infer<typeof SyncedAuthoredModel>,
 ) {
-  const parsed = AuthoredModel.safeParse({
+  const parsed = SyncedAuthoredModel.safeParse({
     id: relativePath.slice(0, -5),
     ...current,
   });
@@ -337,23 +356,37 @@ function formatNumber(n: number) {
   return Number.isInteger(n) ? formatInteger(n) : String(n);
 }
 
-function formatToml(model: z.infer<typeof AuthoredModel>) {
+function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
   const lines: string[] = [];
+  const extendsLines: string[] = [];
 
-  lines.push(`name = ${quote(model.name)}`);
+  if ("extends" in model) {
+    extendsLines.push("[extends]");
+    extendsLines.push(`from = ${quote(model.extends.from)}`);
+    if (model.extends.omit !== undefined) {
+      extendsLines.push(`omit = [${model.extends.omit.map(quote).join(", ")}]`);
+    }
+  }
+
+  if (model.name !== undefined) lines.push(`name = ${quote(model.name)}`);
   if (model.family !== undefined) lines.push(`family = ${quote(model.family)}`);
-  lines.push(`release_date = ${quote(model.release_date)}`);
-  lines.push(`last_updated = ${quote(model.last_updated)}`);
-  lines.push(`attachment = ${model.attachment}`);
-  lines.push(`reasoning = ${model.reasoning}`);
+  if (model.release_date !== undefined) lines.push(`release_date = ${quote(model.release_date)}`);
+  if (model.last_updated !== undefined) lines.push(`last_updated = ${quote(model.last_updated)}`);
+  if (model.attachment !== undefined) lines.push(`attachment = ${model.attachment}`);
+  if (model.reasoning !== undefined) lines.push(`reasoning = ${model.reasoning}`);
   if (model.temperature !== undefined) lines.push(`temperature = ${model.temperature}`);
-  lines.push(`tool_call = ${model.tool_call}`);
+  if (model.tool_call !== undefined) lines.push(`tool_call = ${model.tool_call}`);
   if (model.structured_output !== undefined) {
     lines.push(`structured_output = ${model.structured_output}`);
   }
   if (model.knowledge !== undefined) lines.push(`knowledge = ${quote(model.knowledge)}`);
-  lines.push(`open_weights = ${model.open_weights}`);
+  if (model.open_weights !== undefined) lines.push(`open_weights = ${model.open_weights}`);
   if (model.status !== undefined) lines.push(`status = ${quote(model.status)}`);
+
+  if (extendsLines.length > 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push(...extendsLines);
+  }
 
   if (model.interleaved !== undefined) {
     lines.push("");
@@ -396,14 +429,22 @@ function formatToml(model: z.infer<typeof AuthoredModel>) {
     }
   }
 
-  lines.push("", "[limit]");
-  lines.push(`context = ${formatInteger(model.limit.context)}`);
-  if (model.limit.input !== undefined) lines.push(`input = ${formatInteger(model.limit.input)}`);
-  lines.push(`output = ${formatInteger(model.limit.output)}`);
+  if (model.limit !== undefined) {
+    lines.push("", "[limit]");
+    if (model.limit.context !== undefined) lines.push(`context = ${formatInteger(model.limit.context)}`);
+    if (model.limit.input !== undefined) lines.push(`input = ${formatInteger(model.limit.input)}`);
+    if (model.limit.output !== undefined) lines.push(`output = ${formatInteger(model.limit.output)}`);
+  }
 
-  lines.push("", "[modalities]");
-  lines.push(`input = [${model.modalities.input.map(quote).join(", ")}]`);
-  lines.push(`output = [${model.modalities.output.map(quote).join(", ")}]`);
+  if (model.modalities !== undefined) {
+    lines.push("", "[modalities]");
+    if (model.modalities.input !== undefined) {
+      lines.push(`input = [${model.modalities.input.map(quote).join(", ")}]`);
+    }
+    if (model.modalities.output !== undefined) {
+      lines.push(`output = [${model.modalities.output.map(quote).join(", ")}]`);
+    }
+  }
 
   return `${lines.join("\n")}\n`;
 }

--- a/packages/core/script/sync/openrouter.ts
+++ b/packages/core/script/sync/openrouter.ts
@@ -1,9 +1,32 @@
 import { z } from "zod";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
 
 import { ModelFamilyValues } from "../../src/family.js";
-import type { ExistingModel, SyncProvider } from "../sync-models.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../sync-models.js";
 
 const API_ENDPOINT = "https://openrouter.ai/api/v1/models";
+const PROVIDERS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "providers");
+const modelFilesByProvider = new Map<string, Set<string>>();
+const canonicalTomlByModel = new Map<string, Record<string, unknown>>();
+
+const CANONICAL_PROVIDER_PREFIXES = {
+  anthropic: "anthropic",
+  cohere: "cohere",
+  deepseek: "deepseek",
+  google: "google",
+  meta: "llama",
+  "meta-llama": "llama",
+  minimax: "minimax",
+  mistralai: "mistral",
+  moonshotai: "moonshotai",
+  openai: "openai",
+  "x-ai": "xai",
+  xai: "xai",
+  xiaomi: "xiaomi",
+  zai: "zai",
+  "z-ai": "zai",
+} as const;
 
 export const OpenRouterModel = z.object({
   id: z.string(),
@@ -97,7 +120,7 @@ function inferFamily(model: OpenRouterModel, name: string) {
     });
 }
 
-export function buildOpenRouterModel(model: OpenRouterModel, existing: ExistingModel | undefined) {
+export function buildOpenRouterModel(model: OpenRouterModel, existing: ExistingModel | undefined): SyncedModel {
   const params = new Set(model.supported_parameters);
   const name = model.name.replace(/^[^:]+:\s+/, "");
   const input = modalities(model.architecture.input_modalities, ["text"]);
@@ -107,38 +130,205 @@ export function buildOpenRouterModel(model: OpenRouterModel, existing: ExistingM
   const reasoning = params.has("reasoning") || params.has("include_reasoning");
   const context = model.top_provider.context_length ?? model.context_length;
   const family = inferFamily(model, name);
+  const releaseDate = dateFromTimestamp(model.created);
+  const familyValue = existing?.family === "o" && family !== "o"
+    ? family
+    : (existing?.family ?? family);
+  const attachment = input.some((value) => value !== "text");
+  const toolCall = params.has("tools") || params.has("tool_choice");
+  const structuredOutput = params.has("structured_outputs");
+  const knowledge = model.knowledge_cutoff?.slice(0, 10) ?? existing?.knowledge;
+  const openWeights = Boolean(model.hugging_face_id);
+  const cost = prompt !== undefined && completion !== undefined
+    ? {
+        input: prompt,
+        output: completion,
+        reasoning: reasoning ? price(model.pricing.internal_reasoning) : undefined,
+        cache_read: price(model.pricing.input_cache_read),
+        cache_write: price(model.pricing.input_cache_write),
+        tiers: existing?.cost?.tiers,
+      }
+    : existing?.cost;
+  const limit = {
+    context,
+    input: existing?.limit?.input,
+    output: model.top_provider.max_completion_tokens ?? existing?.limit?.output ?? context,
+  };
+  const canonical = resolveCanonicalModel(model.id);
+
+  if (canonical !== undefined) {
+    return {
+      extends: {
+        from: canonical.from,
+        omit: canonicalOmit(canonical.provider, canonical.modelID, cost, limit),
+      },
+      ...canonicalRuntimeOverrides(canonical.provider, canonical.modelID, {
+        name: model.id.endsWith(":free") ? name : undefined,
+        attachment,
+        reasoning,
+      }),
+      temperature: params.has("temperature"),
+      tool_call: toolCall,
+      structured_output: structuredOutput,
+      status: existing?.status,
+      interleaved: existing?.interleaved,
+      cost,
+      limit,
+      modalities: { input, output },
+    };
+  }
 
   return {
     name,
-    family: existing?.family === "o" && family !== "o"
-      ? family
-      : (existing?.family ?? family),
-    release_date: dateFromTimestamp(model.created),
-    last_updated: dateFromTimestamp(model.created),
-    attachment: input.some((value) => value !== "text"),
+    family: familyValue,
+    release_date: releaseDate,
+    last_updated: releaseDate,
+    attachment,
     reasoning,
     temperature: params.has("temperature"),
-    tool_call: params.has("tools") || params.has("tool_choice"),
-    structured_output: params.has("structured_outputs"),
-    knowledge: model.knowledge_cutoff?.slice(0, 10) ?? existing?.knowledge,
-    open_weights: Boolean(model.hugging_face_id),
+    tool_call: toolCall,
+    structured_output: structuredOutput,
+    knowledge,
+    open_weights: openWeights,
     status: existing?.status,
     interleaved: existing?.interleaved,
-    cost: prompt !== undefined && completion !== undefined
-      ? {
-          input: prompt,
-          output: completion,
-          reasoning: reasoning ? price(model.pricing.internal_reasoning) : undefined,
-          cache_read: price(model.pricing.input_cache_read),
-          cache_write: price(model.pricing.input_cache_write),
-          tiers: existing?.cost?.tiers,
-        }
-      : existing?.cost,
-    limit: {
-      context,
-      input: existing?.limit?.input,
-      output: model.top_provider.max_completion_tokens ?? existing?.limit?.output ?? context,
-    },
+    cost,
+    limit,
     modalities: { input, output },
-  };
+  } satisfies SyncedFullModel;
+}
+
+function resolveCanonicalModel(openrouterID: string) {
+  const [prefix, ...modelParts] = openrouterID.split("/");
+  if (prefix === undefined || modelParts.length === 0) return undefined;
+  if (openrouterID.startsWith("~/") || prefix.startsWith("~")) return undefined;
+
+  const provider = CANONICAL_PROVIDER_PREFIXES[prefix as keyof typeof CANONICAL_PROVIDER_PREFIXES];
+  if (provider === undefined) return undefined;
+
+  const modelID = modelParts.join("/").replace(/:free$/, "");
+  const candidates = canonicalCandidates(provider, modelID);
+  const match = candidates.find((candidate) => {
+    return canonicalModelExists(provider, candidate);
+  });
+
+  return match === undefined
+    ? undefined
+    : {
+        from: `${provider}/${match}`,
+        provider,
+        modelID: match,
+      };
+}
+
+function canonicalModelExists(provider: string, modelID: string) {
+  let files = modelFilesByProvider.get(provider);
+  if (files === undefined) {
+    try {
+      files = new Set(readdirSync(path.join(PROVIDERS_DIR, provider, "models")));
+    } catch {
+      files = new Set();
+    }
+    modelFilesByProvider.set(provider, files);
+  }
+  return files.has(`${modelID}.toml`);
+}
+
+function canonicalOmit(
+  provider: string,
+  modelID: string,
+  cost: SyncedFullModel["cost"],
+  limit: SyncedFullModel["limit"],
+) {
+  const toml = canonicalToml(provider, modelID);
+  const omit = ["provider", "experimental"].filter((key) => toml[key] !== undefined);
+
+  const baseCost = toml.cost;
+  if (baseCost !== undefined && baseCost !== null && typeof baseCost === "object" && !Array.isArray(baseCost)) {
+    if (cost === undefined) {
+      omit.push("cost");
+    } else {
+      for (const key of ["reasoning", "cache_read", "cache_write", "input_audio", "output_audio", "tiers"] as const) {
+        if ((baseCost as Record<string, unknown>)[key] !== undefined && cost[key] === undefined) {
+          omit.push(`cost.${key}`);
+        }
+      }
+      if (hasLegacyContextOver200k(baseCost) && cost.tiers === undefined) {
+        omit.push("cost.context_over_200k");
+      }
+    }
+  }
+
+  const baseLimit = toml.limit;
+  if (
+    baseLimit !== undefined &&
+    baseLimit !== null &&
+    typeof baseLimit === "object" &&
+    !Array.isArray(baseLimit) &&
+    (baseLimit as Record<string, unknown>).input !== undefined &&
+    limit.input === undefined
+  ) {
+    omit.push("limit.input");
+  }
+
+  return omit.length > 0 ? omit : undefined;
+}
+
+function hasLegacyContextOver200k(cost: object) {
+  const tiers = (cost as { tiers?: unknown }).tiers;
+  if (!Array.isArray(tiers) || tiers.length !== 1) return false;
+
+  const tier = tiers[0];
+  if (tier === null || typeof tier !== "object" || Array.isArray(tier)) return false;
+  const tierConfig = (tier as { tier?: unknown }).tier;
+  if (tierConfig === null || typeof tierConfig !== "object" || Array.isArray(tierConfig)) return false;
+
+  const size = (tierConfig as { size?: unknown }).size;
+  return typeof size === "number" && size >= 200_000;
+}
+
+function canonicalRuntimeOverrides(
+  provider: string,
+  modelID: string,
+  values: Pick<SyncedFullModel, "name" | "attachment" | "reasoning">,
+) {
+  const toml = canonicalToml(provider, modelID);
+  return Object.fromEntries(
+    Object.entries(values).filter(([key, value]) => value !== undefined && toml[key] !== value),
+  );
+}
+
+function canonicalToml(provider: string, modelID: string) {
+  const key = `${provider}/${modelID}`;
+  let toml = canonicalTomlByModel.get(key);
+  if (toml === undefined) {
+    const filePath = path.join(PROVIDERS_DIR, provider, "models", `${modelID}.toml`);
+    toml = Bun.TOML.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+    canonicalTomlByModel.set(key, toml);
+  }
+  return toml;
+}
+
+function canonicalCandidates(provider: string, modelID: string) {
+  const candidates = [modelID];
+
+  if (provider === "anthropic") {
+    candidates.push(modelID.replace(/(claude-(?:opus|sonnet|haiku)-\d+)\.(\d+)/, "$1-$2"));
+    candidates.push(modelID.replace(/^claude-3\.5-/, "claude-3-5-"));
+  }
+
+  if (provider === "llama") {
+    candidates.push(modelID.replace(/^llama-(\d+)-(\d+)/, "llama-$1.$2"));
+    candidates.push(modelID.replace(/^llama-(4)-(maverick|scout)$/, "llama-$1-$2-17b"));
+  }
+
+  if (provider === "mistral") {
+    candidates.push(modelID.replace(/-latest$/, ""));
+  }
+
+  if (provider === "minimax") {
+    candidates.push(modelID.replace(/^minimax-m/, "MiniMax-M"));
+  }
+
+  return [...new Set(candidates)];
 }

--- a/providers/openrouter/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-haiku-4.5.toml
@@ -1,14 +1,9 @@
-name = "Claude Haiku 4.5"
-family = "claude-haiku"
-release_date = "2025-10-15"
-last_updated = "2025-10-15"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-02-28"
-open_weights = false
+
+[extends]
+from = "anthropic/claude-haiku-4-5"
 
 [cost]
 input = 1

--- a/providers/openrouter/models/anthropic/claude-opus-4.1.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.1.toml
@@ -1,14 +1,9 @@
-name = "Claude Opus 4.1"
-family = "claude-opus"
-release_date = "2025-08-05"
-last_updated = "2025-08-05"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01-31"
-open_weights = false
+
+[extends]
+from = "anthropic/claude-opus-4-1"
 
 [cost]
 input = 15

--- a/providers/openrouter/models/anthropic/claude-opus-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.5.toml
@@ -1,14 +1,9 @@
-name = "Claude Opus 4.5"
-family = "claude-opus"
-release_date = "2025-11-24"
-last_updated = "2025-11-24"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-05-30"
-open_weights = false
+
+[extends]
+from = "anthropic/claude-opus-4-5"
 
 [cost]
 input = 5

--- a/providers/openrouter/models/anthropic/claude-opus-4.6.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.6.toml
@@ -1,14 +1,10 @@
-name = "Claude Opus 4.6"
-family = "claude-opus"
-release_date = "2026-02-04"
-last_updated = "2026-02-04"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-05-31"
-open_weights = false
+
+[extends]
+from = "anthropic/claude-opus-4-6"
+omit = ["experimental"]
 
 [cost]
 input = 5

--- a/providers/openrouter/models/anthropic/claude-opus-4.7.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-4.7.toml
@@ -1,14 +1,10 @@
-name = "Claude Opus 4.7"
-family = "claude-opus"
-release_date = "2026-04-16"
-last_updated = "2026-04-16"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2026-01-31"
-open_weights = false
+
+[extends]
+from = "anthropic/claude-opus-4-7"
+omit = ["experimental"]
 
 [cost]
 input = 5

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
@@ -1,14 +1,9 @@
-name = "Claude Sonnet 4.5"
-family = "claude-sonnet"
-release_date = "2025-09-29"
-last_updated = "2025-09-29"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01-31"
-open_weights = false
+
+[extends]
+from = "anthropic/claude-sonnet-4-5"
 
 [cost]
 input = 3

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
@@ -1,14 +1,9 @@
-name = "Claude Sonnet 4.6"
-family = "claude-sonnet"
-release_date = "2026-02-17"
-last_updated = "2026-02-17"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-08-31"
-open_weights = false
+
+[extends]
+from = "anthropic/claude-sonnet-4-6"
 
 [cost]
 input = 3

--- a/providers/openrouter/models/cohere/command-r-08-2024.toml
+++ b/providers/openrouter/models/cohere/command-r-08-2024.toml
@@ -1,14 +1,9 @@
-name = "Command R (08-2024)"
-family = "command-r"
-release_date = "2024-08-30"
-last_updated = "2024-08-30"
-attachment = false
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2024-03-31"
-open_weights = false
+
+[extends]
+from = "cohere/command-r-08-2024"
 
 [cost]
 input = 0.15

--- a/providers/openrouter/models/cohere/command-r-plus-08-2024.toml
+++ b/providers/openrouter/models/cohere/command-r-plus-08-2024.toml
@@ -1,14 +1,9 @@
-name = "Command R+ (08-2024)"
-family = "command-r"
-release_date = "2024-08-30"
-last_updated = "2024-08-30"
-attachment = false
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2024-03-31"
-open_weights = false
+
+[extends]
+from = "cohere/command-r-plus-08-2024"
 
 [cost]
 input = 2.5

--- a/providers/openrouter/models/cohere/command-r7b-12-2024.toml
+++ b/providers/openrouter/models/cohere/command-r7b-12-2024.toml
@@ -1,14 +1,9 @@
-name = "Command R7B (12-2024)"
-family = "command-r"
-release_date = "2024-12-14"
-last_updated = "2024-12-14"
-attachment = false
-reasoning = false
 temperature = true
 tool_call = false
 structured_output = true
-knowledge = "2024-08-31"
-open_weights = false
+
+[extends]
+from = "cohere/command-r7b-12-2024"
 
 [cost]
 input = 0.0375

--- a/providers/openrouter/models/deepseek/deepseek-chat.toml
+++ b/providers/openrouter/models/deepseek/deepseek-chat.toml
@@ -1,14 +1,11 @@
-name = "DeepSeek V3"
-family = "deepseek"
-release_date = "2024-12-26"
-last_updated = "2024-12-26"
 attachment = false
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2024-07-31"
-open_weights = true
+
+[extends]
+from = "deepseek/deepseek-chat"
+omit = ["cost.cache_read"]
 
 [cost]
 input = 0.32

--- a/providers/openrouter/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-flash.toml
@@ -1,13 +1,9 @@
-name = "DeepSeek V4 Flash"
-family = "deepseek"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "deepseek/deepseek-v4-flash"
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/openrouter/models/deepseek/deepseek-v4-flash:free.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-flash:free.toml
@@ -1,13 +1,11 @@
 name = "DeepSeek V4 Flash (free)"
-family = "deepseek"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-attachment = false
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = false
-open_weights = true
+
+[extends]
+from = "deepseek/deepseek-v4-flash"
+omit = ["cost.cache_read"]
 
 [cost]
 input = 0

--- a/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
@@ -1,13 +1,9 @@
-name = "DeepSeek V4 Pro"
-family = "deepseek"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "deepseek/deepseek-v4-pro"
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/openrouter/models/google/gemini-2.5-flash-image.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-image.toml
@@ -1,14 +1,10 @@
-name = "Nano Banana (Gemini 2.5 Flash Image)"
-family = "gemini"
-release_date = "2025-10-07"
-last_updated = "2025-10-07"
-attachment = true
 reasoning = false
 temperature = true
 tool_call = false
 structured_output = true
-knowledge = "2025-01-31"
-open_weights = false
+
+[extends]
+from = "google/gemini-2.5-flash-image"
 
 [cost]
 input = 0.3

--- a/providers/openrouter/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-lite.toml
@@ -1,14 +1,10 @@
-name = "Gemini 2.5 Flash Lite"
-family = "gemini-flash-lite"
-release_date = "2025-07-22"
-last_updated = "2025-07-22"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01-31"
-open_weights = false
+
+[extends]
+from = "google/gemini-2.5-flash-lite"
+omit = ["cost.input_audio"]
 
 [cost]
 input = 0.1

--- a/providers/openrouter/models/google/gemini-2.5-flash.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash.toml
@@ -1,14 +1,10 @@
-name = "Gemini 2.5 Flash"
-family = "gemini-flash"
-release_date = "2025-06-17"
-last_updated = "2025-06-17"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01-31"
-open_weights = false
+
+[extends]
+from = "google/gemini-2.5-flash"
+omit = ["cost.input_audio"]
 
 [cost]
 input = 0.3

--- a/providers/openrouter/models/google/gemini-2.5-pro.toml
+++ b/providers/openrouter/models/google/gemini-2.5-pro.toml
@@ -1,14 +1,10 @@
-name = "Gemini 2.5 Pro"
-family = "gemini"
-release_date = "2025-06-17"
-last_updated = "2025-06-17"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01-31"
-open_weights = false
+
+[extends]
+from = "google/gemini-2.5-pro"
+omit = ["cost.tiers", "cost.context_over_200k"]
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/google/gemini-3-flash-preview.toml
+++ b/providers/openrouter/models/google/gemini-3-flash-preview.toml
@@ -1,14 +1,10 @@
-name = "Gemini 3 Flash Preview"
-family = "gemini-flash"
-release_date = "2025-12-17"
-last_updated = "2025-12-17"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01"
-open_weights = false
+
+[extends]
+from = "google/gemini-3-flash-preview"
+omit = ["cost.input_audio"]
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/openrouter/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,14 +1,9 @@
-name = "Nano Banana 2 (Gemini 3.1 Flash Image Preview)"
-family = "gemini-flash"
-release_date = "2026-02-26"
-last_updated = "2026-02-26"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = false
 structured_output = true
-knowledge = "2025-01"
-open_weights = false
+
+[extends]
+from = "google/gemini-3.1-flash-image-preview"
 
 [cost]
 input = 0.5

--- a/providers/openrouter/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/openrouter/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,13 +1,10 @@
-name = "Gemini 3.1 Flash Lite Preview"
-family = "gemini-flash-lite"
-release_date = "2026-03-03"
-last_updated = "2026-03-03"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+
+[extends]
+from = "google/gemini-3.1-flash-lite-preview"
+omit = ["cost.input_audio"]
 
 [cost]
 input = 0.25

--- a/providers/openrouter/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/openrouter/models/google/gemini-3.1-flash-lite.toml
@@ -1,13 +1,10 @@
-name = "Gemini 3.1 Flash Lite"
-family = "gemini"
-release_date = "2026-05-07"
-last_updated = "2026-05-07"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+
+[extends]
+from = "google/gemini-3.1-flash-lite"
+omit = ["cost.input_audio"]
 
 [cost]
 input = 0.25

--- a/providers/openrouter/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/openrouter/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,14 +1,9 @@
-name = "Gemini 3.1 Pro Preview Custom Tools"
-family = "gemini-pro"
-release_date = "2026-02-25"
-last_updated = "2026-02-25"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01"
-open_weights = false
+
+[extends]
+from = "google/gemini-3.1-pro-preview-customtools"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/openrouter/models/google/gemini-3.1-pro-preview.toml
@@ -1,14 +1,9 @@
-name = "Gemini 3.1 Pro Preview"
-family = "gemini-pro"
-release_date = "2026-02-19"
-last_updated = "2026-02-19"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01"
-open_weights = false
+
+[extends]
+from = "google/gemini-3.1-pro-preview"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/google/gemini-3.5-flash.toml
+++ b/providers/openrouter/models/google/gemini-3.5-flash.toml
@@ -1,14 +1,10 @@
-name = "Gemini 3.5 Flash"
-family = "gemini"
-release_date = "2026-05-19"
-last_updated = "2026-05-19"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01-01"
-open_weights = false
+
+[extends]
+from = "google/gemini-3.5-flash"
+omit = ["cost.input_audio"]
 
 [cost]
 input = 1.5

--- a/providers/openrouter/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/openrouter/models/google/gemma-4-26b-a4b-it.toml
@@ -1,14 +1,9 @@
-name = "Gemma 4 26B A4B "
-family = "gemma"
-release_date = "2026-04-03"
-last_updated = "2026-04-03"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01"
-open_weights = true
+
+[extends]
+from = "google/gemma-4-26b-a4b-it"
 
 [cost]
 input = 0.06

--- a/providers/openrouter/models/google/gemma-4-26b-a4b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-4-26b-a4b-it:free.toml
@@ -1,14 +1,10 @@
 name = "Gemma 4 26B A4B  (free)"
-family = "gemma"
-release_date = "2026-04-03"
-last_updated = "2026-04-03"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-knowledge = "2025-01"
-open_weights = true
+
+[extends]
+from = "google/gemma-4-26b-a4b-it"
 
 [cost]
 input = 0

--- a/providers/openrouter/models/google/gemma-4-31b-it.toml
+++ b/providers/openrouter/models/google/gemma-4-31b-it.toml
@@ -1,14 +1,9 @@
-name = "Gemma 4 31B"
-family = "gemma"
-release_date = "2026-04-02"
-last_updated = "2026-04-02"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01"
-open_weights = true
+
+[extends]
+from = "google/gemma-4-31b-it"
 
 [cost]
 input = 0.12

--- a/providers/openrouter/models/google/gemma-4-31b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-4-31b-it:free.toml
@@ -1,14 +1,10 @@
 name = "Gemma 4 31B (free)"
-family = "gemma"
-release_date = "2026-04-02"
-last_updated = "2026-04-02"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-knowledge = "2025-01"
-open_weights = true
+
+[extends]
+from = "google/gemma-4-31b-it"
 
 [cost]
 input = 0

--- a/providers/openrouter/models/inclusionai/ling-2.6-1t.toml
+++ b/providers/openrouter/models/inclusionai/ling-2.6-1t.toml
@@ -10,9 +10,9 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.3
-output = 2.5
-cache_read = 0.06
+input = 0.075
+output = 0.625
+cache_read = 0.015
 
 [limit]
 context = 262_144

--- a/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct.toml
@@ -1,14 +1,10 @@
-name = "Llama 3.3 70B Instruct"
-family = "llama"
-release_date = "2024-12-06"
-last_updated = "2024-12-06"
 attachment = false
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2023-12-31"
-open_weights = true
+
+[extends]
+from = "llama/llama-3.3-70b-instruct"
 
 [cost]
 input = 0.1

--- a/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct:free.toml
+++ b/providers/openrouter/models/meta-llama/llama-3.3-70b-instruct:free.toml
@@ -1,14 +1,11 @@
 name = "Llama 3.3 70B Instruct (free)"
-family = "llama"
-release_date = "2024-12-06"
-last_updated = "2024-12-06"
 attachment = false
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = false
-knowledge = "2023-12-31"
-open_weights = true
+
+[extends]
+from = "llama/llama-3.3-70b-instruct"
 
 [cost]
 input = 0

--- a/providers/openrouter/models/minimax/minimax-m2.1.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.1.toml
@@ -1,13 +1,9 @@
-name = "MiniMax M2.1"
-family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "minimax/MiniMax-M2.1"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/minimax/minimax-m2.5.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.5.toml
@@ -1,13 +1,10 @@
-name = "MiniMax M2.5"
-family = "minimax"
-release_date = "2026-02-12"
-last_updated = "2026-02-12"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "minimax/MiniMax-M2.5"
+omit = ["cost.cache_read", "cost.cache_write"]
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/minimax/minimax-m2.5:free.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.5:free.toml
@@ -1,13 +1,11 @@
 name = "MiniMax M2.5 (free)"
-family = "minimax"
-release_date = "2026-02-12"
-last_updated = "2026-02-12"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = true
+
+[extends]
+from = "minimax/MiniMax-M2.5"
+omit = ["cost.cache_read", "cost.cache_write"]
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/minimax/minimax-m2.7.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.7.toml
@@ -1,13 +1,10 @@
-name = "MiniMax M2.7"
-family = "minimax"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "minimax/MiniMax-M2.7"
+omit = ["cost.cache_read", "cost.cache_write"]
 
 [cost]
 input = 0.279

--- a/providers/openrouter/models/minimax/minimax-m2.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.toml
@@ -1,13 +1,9 @@
-name = "MiniMax M2"
-family = "minimax"
-release_date = "2025-10-23"
-last_updated = "2025-10-23"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "minimax/MiniMax-M2"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/mistralai/devstral-2512.toml
+++ b/providers/openrouter/models/mistralai/devstral-2512.toml
@@ -1,14 +1,10 @@
-name = "Devstral 2 2512"
-family = "devstral"
-release_date = "2025-12-09"
-last_updated = "2025-12-09"
 attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-12"
-open_weights = true
+
+[extends]
+from = "mistral/devstral-2512"
 
 [cost]
 input = 0.4

--- a/providers/openrouter/models/mistralai/mistral-large-2512.toml
+++ b/providers/openrouter/models/mistralai/mistral-large-2512.toml
@@ -1,13 +1,9 @@
-name = "Mistral Large 3 2512"
-family = "mistral-large"
-release_date = "2025-12-01"
-last_updated = "2025-12-01"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+
+[extends]
+from = "mistral/mistral-large-2512"
 
 [cost]
 input = 0.5

--- a/providers/openrouter/models/mistralai/mistral-nemo.toml
+++ b/providers/openrouter/models/mistralai/mistral-nemo.toml
@@ -1,14 +1,9 @@
-name = "Mistral Nemo"
-family = "mistral-nemo"
-release_date = "2024-07-19"
-last_updated = "2024-07-19"
-attachment = false
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2024-04-30"
-open_weights = true
+
+[extends]
+from = "mistral/mistral-nemo"
 
 [cost]
 input = 0.02

--- a/providers/openrouter/models/mistralai/mistral-small-2603.toml
+++ b/providers/openrouter/models/mistralai/mistral-small-2603.toml
@@ -1,14 +1,9 @@
-name = "Mistral Small 4"
-family = "mistral-small"
-release_date = "2026-03-16"
-last_updated = "2026-03-16"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-06"
-open_weights = true
+
+[extends]
+from = "mistral/mistral-small-2603"
 
 [cost]
 input = 0.15

--- a/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-thinking.toml
@@ -1,14 +1,10 @@
-name = "Kimi K2 Thinking"
-family = "kimi-thinking"
-release_date = "2025-11-06"
-last_updated = "2025-11-06"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2024-08"
-open_weights = true
+
+[extends]
+from = "moonshotai/kimi-k2-thinking"
+omit = ["cost.cache_read"]
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.5.toml
@@ -1,14 +1,10 @@
-name = "Kimi K2.5"
-family = "kimi"
-release_date = "2026-01-27"
-last_updated = "2026-01-27"
 attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01"
-open_weights = true
+
+[extends]
+from = "moonshotai/kimi-k2.5"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/moonshotai/kimi-k2.6.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.6.toml
@@ -1,13 +1,9 @@
-name = "Kimi K2.6"
-family = "kimi"
-release_date = "2026-04-20"
-last_updated = "2026-04-20"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "moonshotai/kimi-k2.6"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/openai/gpt-3.5-turbo.toml
+++ b/providers/openrouter/models/openai/gpt-3.5-turbo.toml
@@ -1,14 +1,10 @@
-name = "GPT-3.5 Turbo"
-family = "gpt"
-release_date = "2023-05-28"
-last_updated = "2023-05-28"
-attachment = false
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2021-09-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-3.5-turbo"
+omit = ["cost.cache_read"]
 
 [cost]
 input = 0.5

--- a/providers/openrouter/models/openai/gpt-4-turbo.toml
+++ b/providers/openrouter/models/openai/gpt-4-turbo.toml
@@ -1,14 +1,9 @@
-name = "GPT-4 Turbo"
-family = "gpt"
-release_date = "2024-04-09"
-last_updated = "2024-04-09"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2023-12-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4-turbo"
 
 [cost]
 input = 10

--- a/providers/openrouter/models/openai/gpt-4.1-mini.toml
+++ b/providers/openrouter/models/openai/gpt-4.1-mini.toml
@@ -1,14 +1,9 @@
-name = "GPT-4.1 Mini"
-family = "gpt-mini"
-release_date = "2025-04-14"
-last_updated = "2025-04-14"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2024-06-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4.1-mini"
 
 [cost]
 input = 0.4

--- a/providers/openrouter/models/openai/gpt-4.1-nano.toml
+++ b/providers/openrouter/models/openai/gpt-4.1-nano.toml
@@ -1,14 +1,9 @@
-name = "GPT-4.1 Nano"
-family = "gpt"
-release_date = "2025-04-14"
-last_updated = "2025-04-14"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2024-06-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4.1-nano"
 
 [cost]
 input = 0.1

--- a/providers/openrouter/models/openai/gpt-4.1.toml
+++ b/providers/openrouter/models/openai/gpt-4.1.toml
@@ -1,14 +1,9 @@
-name = "GPT-4.1"
-family = "gpt"
-release_date = "2025-04-14"
-last_updated = "2025-04-14"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2024-06-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4.1"
 
 [cost]
 input = 2

--- a/providers/openrouter/models/openai/gpt-4.toml
+++ b/providers/openrouter/models/openai/gpt-4.toml
@@ -1,14 +1,10 @@
-name = "GPT-4"
-family = "gpt"
-release_date = "2023-05-28"
-last_updated = "2023-05-28"
 attachment = false
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2021-09-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4"
 
 [cost]
 input = 30

--- a/providers/openrouter/models/openai/gpt-4o-2024-05-13.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-05-13.toml
@@ -1,14 +1,9 @@
-name = "GPT-4o (2024-05-13)"
-family = "gpt"
-release_date = "2024-05-13"
-last_updated = "2024-05-13"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2023-10-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4o-2024-05-13"
 
 [cost]
 input = 5

--- a/providers/openrouter/models/openai/gpt-4o-2024-08-06.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-08-06.toml
@@ -1,14 +1,9 @@
-name = "GPT-4o (2024-08-06)"
-family = "gpt"
-release_date = "2024-08-06"
-last_updated = "2024-08-06"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2023-10-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4o-2024-08-06"
 
 [cost]
 input = 2.5

--- a/providers/openrouter/models/openai/gpt-4o-2024-11-20.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-11-20.toml
@@ -1,14 +1,9 @@
-name = "GPT-4o (2024-11-20)"
-family = "gpt"
-release_date = "2024-11-20"
-last_updated = "2024-11-20"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2023-10-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4o-2024-11-20"
 
 [cost]
 input = 2.5

--- a/providers/openrouter/models/openai/gpt-4o-mini.toml
+++ b/providers/openrouter/models/openai/gpt-4o-mini.toml
@@ -1,14 +1,9 @@
-name = "GPT-4o-mini"
-family = "gpt-mini"
-release_date = "2024-07-18"
-last_updated = "2024-07-18"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2023-10-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4o-mini"
 
 [cost]
 input = 0.15

--- a/providers/openrouter/models/openai/gpt-4o.toml
+++ b/providers/openrouter/models/openai/gpt-4o.toml
@@ -1,14 +1,10 @@
-name = "GPT-4o"
-family = "gpt"
-release_date = "2024-05-13"
-last_updated = "2024-05-13"
-attachment = true
-reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2023-10-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-4o"
+omit = ["cost.cache_read"]
 
 [cost]
 input = 2.5

--- a/providers/openrouter/models/openai/gpt-5-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5-codex.toml
@@ -1,14 +1,11 @@
-name = "GPT-5 Codex"
-family = "gpt-codex"
-release_date = "2025-09-23"
-last_updated = "2025-09-23"
 attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-09-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5-codex"
+omit = ["limit.input"]
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/openai/gpt-5-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5-mini.toml
@@ -1,14 +1,10 @@
-name = "GPT-5 Mini"
-family = "gpt-mini"
-release_date = "2025-08-07"
-last_updated = "2025-08-07"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-05-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5-mini"
+omit = ["limit.input"]
 
 [cost]
 input = 0.25

--- a/providers/openrouter/models/openai/gpt-5-nano.toml
+++ b/providers/openrouter/models/openai/gpt-5-nano.toml
@@ -1,14 +1,10 @@
-name = "GPT-5 Nano"
-family = "gpt-nano"
-release_date = "2025-08-07"
-last_updated = "2025-08-07"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-05-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5-nano"
+omit = ["limit.input"]
 
 [cost]
 input = 0.05

--- a/providers/openrouter/models/openai/gpt-5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5-pro.toml
@@ -1,14 +1,10 @@
-name = "GPT-5 Pro"
-family = "gpt-pro"
-release_date = "2025-10-06"
-last_updated = "2025-10-06"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-09-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5-pro"
+omit = ["limit.input"]
 
 [cost]
 input = 15

--- a/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.1-Codex-Max"
-family = "gpt-codex"
-release_date = "2025-12-04"
-last_updated = "2025-12-04"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-09-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.1-codex-max"
+omit = ["limit.input"]
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex-mini.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.1-Codex-Mini"
-family = "gpt-codex"
-release_date = "2025-11-13"
-last_updated = "2025-11-13"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-09-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.1-codex-mini"
+omit = ["limit.input"]
 
 [cost]
 input = 0.25

--- a/providers/openrouter/models/openai/gpt-5.1-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.1-Codex"
-family = "gpt-codex"
-release_date = "2025-11-13"
-last_updated = "2025-11-13"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-09-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.1-codex"
+omit = ["limit.input"]
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/openai/gpt-5.1.toml
+++ b/providers/openrouter/models/openai/gpt-5.1.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.1"
-family = "gpt"
-release_date = "2025-11-13"
-last_updated = "2025-11-13"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-09-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.1"
+omit = ["limit.input"]
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/openai/gpt-5.2-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.2-codex.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.2-Codex"
-family = "gpt-codex"
-release_date = "2026-01-14"
-last_updated = "2026-01-14"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2025-08-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.2-codex"
+omit = ["limit.input"]
 
 [cost]
 input = 1.75

--- a/providers/openrouter/models/openai/gpt-5.2-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5.2-pro.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.2 Pro"
-family = "gpt-pro"
-release_date = "2025-12-10"
-last_updated = "2025-12-10"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2025-08-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.2-pro"
+omit = ["limit.input"]
 
 [cost]
 input = 21

--- a/providers/openrouter/models/openai/gpt-5.2.toml
+++ b/providers/openrouter/models/openai/gpt-5.2.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.2"
-family = "gpt"
-release_date = "2025-12-10"
-last_updated = "2025-12-10"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2025-08-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.2"
+omit = ["limit.input"]
 
 [cost]
 input = 1.75

--- a/providers/openrouter/models/openai/gpt-5.3-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.3-codex.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.3-Codex"
-family = "gpt-codex"
-release_date = "2026-02-24"
-last_updated = "2026-02-24"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2025-08-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.3-codex"
+omit = ["limit.input"]
 
 [cost]
 input = 1.75

--- a/providers/openrouter/models/openai/gpt-5.4-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-mini.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.4 Mini"
-family = "gpt-mini"
-release_date = "2026-03-17"
-last_updated = "2026-03-17"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2025-08-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.4-mini"
+omit = ["experimental", "limit.input"]
 
 [cost]
 input = 0.75

--- a/providers/openrouter/models/openai/gpt-5.4-nano.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-nano.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.4 Nano"
-family = "gpt-nano"
-release_date = "2026-03-17"
-last_updated = "2026-03-17"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2025-08-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.4-nano"
+omit = ["limit.input"]
 
 [cost]
 input = 0.2

--- a/providers/openrouter/models/openai/gpt-5.4-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-pro.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.4 Pro"
-family = "gpt-pro"
-release_date = "2026-03-05"
-last_updated = "2026-03-05"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2025-08-31"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.4-pro"
+omit = ["cost.tiers", "cost.context_over_200k"]
 
 [cost]
 input = 30

--- a/providers/openrouter/models/openai/gpt-5.4.toml
+++ b/providers/openrouter/models/openai/gpt-5.4.toml
@@ -1,13 +1,10 @@
-name = "GPT-5.4"
-family = "gpt"
-release_date = "2026-03-05"
-last_updated = "2026-03-05"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.4"
+omit = ["experimental", "cost.tiers", "cost.context_over_200k", "limit.input"]
 
 [cost]
 input = 2.5

--- a/providers/openrouter/models/openai/gpt-5.5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5.5-pro.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.5 Pro"
-family = "gpt"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2025-12-01"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.5-pro"
+omit = ["cost.tiers", "cost.context_over_200k", "limit.input"]
 
 [cost]
 input = 30

--- a/providers/openrouter/models/openai/gpt-5.5.toml
+++ b/providers/openrouter/models/openai/gpt-5.5.toml
@@ -1,14 +1,10 @@
-name = "GPT-5.5"
-family = "gpt"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2025-12-01"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5.5"
+omit = ["experimental", "cost.tiers", "cost.context_over_200k", "limit.input"]
 
 [cost]
 input = 5

--- a/providers/openrouter/models/openai/gpt-5.toml
+++ b/providers/openrouter/models/openai/gpt-5.toml
@@ -1,14 +1,10 @@
-name = "GPT-5"
-family = "gpt"
-release_date = "2025-08-07"
-last_updated = "2025-08-07"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-09-30"
-open_weights = false
+
+[extends]
+from = "openai/gpt-5"
+omit = ["limit.input"]
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/openai/o1-pro.toml
+++ b/providers/openrouter/models/openai/o1-pro.toml
@@ -1,14 +1,9 @@
-name = "o1-pro"
-family = "o"
-release_date = "2025-03-19"
-last_updated = "2025-03-19"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = false
 structured_output = true
-knowledge = "2023-10-31"
-open_weights = false
+
+[extends]
+from = "openai/o1-pro"
 
 [cost]
 input = 150

--- a/providers/openrouter/models/openai/o1.toml
+++ b/providers/openrouter/models/openai/o1.toml
@@ -1,14 +1,9 @@
-name = "o1"
-family = "o"
-release_date = "2024-12-17"
-last_updated = "2024-12-17"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2023-10-31"
-open_weights = false
+
+[extends]
+from = "openai/o1"
 
 [cost]
 input = 15

--- a/providers/openrouter/models/openai/o3-deep-research.toml
+++ b/providers/openrouter/models/openai/o3-deep-research.toml
@@ -1,13 +1,9 @@
-name = "o3 Deep Research"
-family = "o"
-release_date = "2025-10-10"
-last_updated = "2025-10-10"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+
+[extends]
+from = "openai/o3-deep-research"
 
 [cost]
 input = 10

--- a/providers/openrouter/models/openai/o3-mini.toml
+++ b/providers/openrouter/models/openai/o3-mini.toml
@@ -1,14 +1,10 @@
-name = "o3 Mini"
-family = "o"
-release_date = "2025-01-31"
-last_updated = "2025-01-31"
 attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2023-10-31"
-open_weights = false
+
+[extends]
+from = "openai/o3-mini"
 
 [cost]
 input = 1.1

--- a/providers/openrouter/models/openai/o3-pro.toml
+++ b/providers/openrouter/models/openai/o3-pro.toml
@@ -1,14 +1,9 @@
-name = "o3 Pro"
-family = "o"
-release_date = "2025-06-10"
-last_updated = "2025-06-10"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-06-30"
-open_weights = false
+
+[extends]
+from = "openai/o3-pro"
 
 [cost]
 input = 20

--- a/providers/openrouter/models/openai/o3.toml
+++ b/providers/openrouter/models/openai/o3.toml
@@ -1,14 +1,9 @@
-name = "o3"
-family = "o"
-release_date = "2025-04-16"
-last_updated = "2025-04-16"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-06-30"
-open_weights = false
+
+[extends]
+from = "openai/o3"
 
 [cost]
 input = 2

--- a/providers/openrouter/models/openai/o4-mini-deep-research.toml
+++ b/providers/openrouter/models/openai/o4-mini-deep-research.toml
@@ -1,13 +1,9 @@
-name = "o4 Mini Deep Research"
-family = "o"
-release_date = "2025-10-10"
-last_updated = "2025-10-10"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+
+[extends]
+from = "openai/o4-mini-deep-research"
 
 [cost]
 input = 2

--- a/providers/openrouter/models/openai/o4-mini.toml
+++ b/providers/openrouter/models/openai/o4-mini.toml
@@ -1,14 +1,9 @@
-name = "o4 Mini"
-family = "o-mini"
-release_date = "2025-04-16"
-last_updated = "2025-04-16"
-attachment = true
-reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
-knowledge = "2024-06-30"
-open_weights = false
+
+[extends]
+from = "openai/o4-mini"
 
 [cost]
 input = 1.1

--- a/providers/openrouter/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/openrouter/models/qwen/qwen3.5-397b-a17b.toml
@@ -13,7 +13,6 @@ open_weights = true
 [cost]
 input = 0.39
 output = 2.34
-cache_read = 0.195
 
 [limit]
 context = 262_144

--- a/providers/openrouter/models/stepfun/step-3.5-flash.toml
+++ b/providers/openrouter/models/stepfun/step-3.5-flash.toml
@@ -11,12 +11,13 @@ knowledge = "2025-01"
 open_weights = true
 
 [cost]
-input = 0.1
+input = 0.09
 output = 0.3
+cache_read = 0.02
 
 [limit]
 context = 262_144
-output = 65_536
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/x-ai/grok-4.3.toml
+++ b/providers/openrouter/models/x-ai/grok-4.3.toml
@@ -1,13 +1,9 @@
-name = "Grok 4.3"
-family = "grok"
-release_date = "2026-04-30"
-last_updated = "2026-04-30"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+
+[extends]
+from = "xai/grok-4.3"
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/x-ai/grok-build-0.1.toml
+++ b/providers/openrouter/models/x-ai/grok-build-0.1.toml
@@ -1,20 +1,19 @@
-attachment = true
 temperature = true
 tool_call = true
 structured_output = true
 
 [extends]
-from = "mistral/mistral-large-2411"
+from = "xai/grok-build-0.1"
 
 [cost]
-input = 2
-output = 6
+input = 1
+output = 2
 cache_read = 0.2
 
 [limit]
-context = 131_072
-output = 131_072
+context = 256_000
+output = 256_000
 
 [modalities]
-input = ["text", "pdf"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-flash.toml
@@ -1,13 +1,9 @@
-name = "MiMo-V2-Flash"
-family = "mimo"
-release_date = "2025-12-14"
-last_updated = "2025-12-14"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = true
+
+[extends]
+from = "xiaomi/mimo-v2-flash"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-omni.toml
@@ -1,13 +1,9 @@
-name = "MiMo-V2-Omni"
-family = "mimo-v2-omni"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = false
+
+[extends]
+from = "xiaomi/mimo-v2-omni"
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2-pro.toml
@@ -1,13 +1,10 @@
-name = "MiMo-V2-Pro"
-family = "mimo-v2-pro"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = false
+
+[extends]
+from = "xiaomi/mimo-v2-pro"
+omit = ["cost.tiers", "cost.context_over_200k"]
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,13 +1,10 @@
-name = "MiMo-V2.5-Pro"
-family = "mimo-v2.5-pro"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
+omit = ["cost.tiers", "cost.context_over_200k"]
 
 [cost]
 input = 1

--- a/providers/openrouter/models/xiaomi/mimo-v2.5.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2.5.toml
@@ -1,13 +1,10 @@
-name = "MiMo-V2.5"
-family = "mimo-v2.5"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = true
+
+[extends]
+from = "xiaomi/mimo-v2.5"
+omit = ["cost.tiers", "cost.context_over_200k"]
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/z-ai/glm-4.5-air.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5-air.toml
@@ -1,14 +1,10 @@
-name = "GLM 4.5 Air"
-family = "glm-air"
-release_date = "2025-07-25"
-last_updated = "2025-07-25"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-knowledge = "2024-12-31"
-open_weights = true
+
+[extends]
+from = "zai/glm-4.5-air"
+omit = ["cost.cache_write"]
 
 [cost]
 input = 0.13

--- a/providers/openrouter/models/z-ai/glm-4.5-air:free.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5-air:free.toml
@@ -1,14 +1,11 @@
 name = "GLM 4.5 Air (free)"
-family = "glm-air"
-release_date = "2025-07-25"
-last_updated = "2025-07-25"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-knowledge = "2024-12-31"
-open_weights = true
+
+[extends]
+from = "zai/glm-4.5-air"
+omit = ["cost.cache_read", "cost.cache_write"]
 
 [cost]
 input = 0

--- a/providers/openrouter/models/z-ai/glm-4.5.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5.toml
@@ -1,14 +1,10 @@
-name = "GLM 4.5"
-family = "glm"
-release_date = "2025-07-25"
-last_updated = "2025-07-25"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-knowledge = "2024-12-31"
-open_weights = true
+
+[extends]
+from = "zai/glm-4.5"
+omit = ["cost.cache_write"]
 
 [cost]
 input = 0.6

--- a/providers/openrouter/models/z-ai/glm-4.5v.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5v.toml
@@ -1,14 +1,9 @@
-name = "GLM 4.5V"
-family = "glm"
-release_date = "2025-08-11"
-last_updated = "2025-08-11"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-knowledge = "2024-12-31"
-open_weights = true
+
+[extends]
+from = "zai/glm-4.5v"
 
 [cost]
 input = 0.6

--- a/providers/openrouter/models/z-ai/glm-4.6.toml
+++ b/providers/openrouter/models/z-ai/glm-4.6.toml
@@ -1,14 +1,10 @@
-name = "GLM 4.6"
-family = "glm"
-release_date = "2025-09-30"
-last_updated = "2025-09-30"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-03-31"
-open_weights = true
+
+[extends]
+from = "zai/glm-4.6"
+omit = ["cost.cache_write"]
 
 [cost]
 input = 0.43

--- a/providers/openrouter/models/z-ai/glm-4.6v.toml
+++ b/providers/openrouter/models/z-ai/glm-4.6v.toml
@@ -1,13 +1,9 @@
-name = "GLM 4.6V"
-family = "glm"
-release_date = "2025-12-08"
-last_updated = "2025-12-08"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = true
+
+[extends]
+from = "zai/glm-4.6v"
 
 [cost]
 input = 0.3

--- a/providers/openrouter/models/z-ai/glm-4.7-flash.toml
+++ b/providers/openrouter/models/z-ai/glm-4.7-flash.toml
@@ -1,13 +1,10 @@
-name = "GLM 4.7 Flash"
-family = "glm"
-release_date = "2026-01-19"
-last_updated = "2026-01-19"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "zai/glm-4.7-flash"
+omit = ["cost.cache_write"]
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/z-ai/glm-4.7.toml
+++ b/providers/openrouter/models/z-ai/glm-4.7.toml
@@ -1,14 +1,10 @@
-name = "GLM 4.7"
-family = "glm"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-04"
-open_weights = true
+
+[extends]
+from = "zai/glm-4.7"
+omit = ["cost.cache_write"]
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/openrouter/models/z-ai/glm-5-turbo.toml
+++ b/providers/openrouter/models/z-ai/glm-5-turbo.toml
@@ -1,13 +1,10 @@
-name = "GLM 5 Turbo"
-family = "glm"
-release_date = "2026-03-15"
-last_updated = "2026-03-15"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = false
+
+[extends]
+from = "zai/glm-5-turbo"
+omit = ["cost.cache_write"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/openrouter/models/z-ai/glm-5.1.toml
+++ b/providers/openrouter/models/z-ai/glm-5.1.toml
@@ -1,13 +1,10 @@
-name = "GLM 5.1"
-family = "glm"
-release_date = "2026-04-07"
-last_updated = "2026-04-07"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "zai/glm-5.1"
+omit = ["cost.cache_read", "cost.cache_write"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/openrouter/models/z-ai/glm-5.toml
+++ b/providers/openrouter/models/z-ai/glm-5.toml
@@ -1,13 +1,10 @@
-name = "GLM 5"
-family = "glm"
-release_date = "2026-02-11"
-last_updated = "2026-02-11"
-attachment = false
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+
+[extends]
+from = "zai/glm-5"
+omit = ["cost.cache_write"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/openrouter/models/z-ai/glm-5v-turbo.toml
+++ b/providers/openrouter/models/z-ai/glm-5v-turbo.toml
@@ -1,13 +1,10 @@
-name = "GLM 5V Turbo"
-family = "glm"
-release_date = "2026-04-01"
-last_updated = "2026-04-01"
-attachment = true
-reasoning = true
 temperature = true
 tool_call = true
 structured_output = false
-open_weights = false
+
+[extends]
+from = "zai/glm-5v-turbo"
+omit = ["cost.cache_write"]
 
 [cost]
 input = 1.2


### PR DESCRIPTION
Updates the sync runner to support generated [extends] TOMLs and teaches OpenRouter sync to inherit from canonical provider models when a conservative provider-prefix mapping resolves locally.\n\nAlso regenerates OpenRouter models so matching lab-owned models inherit canonical metadata while retaining OpenRouter-specific costs, limits, modalities, and supported parameters.\n\nValidation:\n- bun ./packages/core/script/sync-models.ts openrouter --dry-run\n- bun validate