### PR TITLE
feat(stepfun-ai): add international StepFun platform

### DIFF
--- a/providers/stepfun-ai/models/step-3.5-flash-2603.toml
+++ b/providers/stepfun-ai/models/step-3.5-flash-2603.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-3.5-flash-2603.toml

--- a/providers/stepfun-ai/models/step-3.5-flash.toml
+++ b/providers/stepfun-ai/models/step-3.5-flash.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-3.5-flash.toml

--- a/providers/stepfun-ai/provider.toml
+++ b/providers/stepfun-ai/provider.toml
@@ -1,0 +1,5 @@
+name = "StepFun"
+env = ["STEPFUN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://platform.stepfun.ai/docs/en/step-plan/integrations/open-code"
+api = "https://api.stepfun.ai/step_plan/v1"


### PR DESCRIPTION
StepFun runs two platforms with separate accounts: `platform.stepfun.com` (already covered by `providers/stepfun`) and `platform.stepfun.ai`. Keys are not interchangeable — `.ai` keys get rejected by `api.stepfun.com` as `invalid_api_key`.

Stepfun's [Open Code integration guide](https://platform.stepfun.ai/docs/en/step-plan/integrations/open-code) tells users to point opencode at `https://api.stepfun.ai/step_plan/v1`. This adds `providers/stepfun-ai` for that endpoint and symlinks the shared chat models. Same shape as `moonshotai-cn`.

## Verification

With a live `.ai` key:

```
POST https://api.stepfun.com/v1/chat/completions          → 401 invalid_api_key
POST https://api.stepfun.ai/step_plan/v1/chat/completions → 200 OK
```

End-to-end against opencode with `provider.stepfun.options.baseURL = "https://api.stepfun.ai/step_plan/v1"`:

```
$ opencode run -m stepfun/step-3.5-flash-2603 "Reply with exactly: PONG"
> build · step-3.5-flash-2603
PONG
```