### PR TITLE
chore(sync): add cloudflare workers ai sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "validate": "bun ./packages/core/script/validate.ts",
     "compare:migrations": "bun ./packages/core/script/compare-model-migrations.ts",
+    "cloudflare:sync": "bun ./packages/core/script/sync-models.ts cloudflare-workers-ai",
     "chutes:generate": "bun ./packages/core/script/generate-chutes.ts",
     "databricks:generate": "bun ./packages/core/script/generate-databricks.ts",
     "helicone:generate": "bun ./packages/core/script/generate-helicone.ts",

--- a/packages/core/script/sync-models.ts
+++ b/packages/core/script/sync-models.ts
@@ -5,6 +5,7 @@ import { mkdir, readdir, rm } from "node:fs/promises";
 import { z } from "zod";
 
 import { AuthoredModel, AuthoredModelShape } from "../src/schema.js";
+import { cloudflareWorkersAi } from "./sync/cloudflare-workers-ai.js";
 import { google } from "./sync/google.js";
 import { openrouter } from "./sync/openrouter.js";
 import { xai } from "./sync/xai.js";
@@ -52,10 +53,12 @@ export interface SyncResult {
 }
 
 export const providers: {
+  "cloudflare-workers-ai": SyncProvider<any>;
   google: SyncProvider<any>;
   openrouter: SyncProvider<any>;
   xai: SyncProvider<any>;
 } = {
+  "cloudflare-workers-ai": cloudflareWorkersAi,
   google,
   openrouter,
   xai,
@@ -63,6 +66,7 @@ export const providers: {
 
 export const groups = {
   aggregators: ["openrouter"],
+  cloudflare: ["cloudflare-workers-ai"],
   direct: ["google", "xai"],
 } as const;
 

--- a/packages/core/script/sync/cloudflare-workers-ai.ts
+++ b/packages/core/script/sync/cloudflare-workers-ai.ts
@@ -1,0 +1,174 @@
+import { z } from "zod";
+
+import type { ExistingModel, SyncProvider } from "../sync-models.js";
+import {
+  buildOpenRouterModel,
+  OpenRouterModel,
+  OpenRouterResponse,
+} from "./openrouter.js";
+
+const API_BASE = "https://api.cloudflare.com/client/v4/accounts";
+
+const CloudflareOpenRouterResponse = z.object({
+  result: z.union([OpenRouterResponse, z.array(OpenRouterModel)]).optional(),
+  result_info: z.object({
+    page: z.number().optional(),
+    total_pages: z.number().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+const CloudflareModel = z.object({
+  id: z.string(),
+  name: z.string(),
+  created: z.number(),
+  hugging_face_id: z.string().nullable().optional(),
+  context_length: z.number(),
+  max_output_length: z.number().nullable().optional(),
+  input_modalities: z.array(z.string()).optional(),
+  output_modalities: z.array(z.string()).optional(),
+  pricing: z.object({
+    prompt: z.string(),
+    completion: z.string(),
+    internal_reasoning: z.string().optional(),
+    input_cache_read: z.string().optional(),
+    input_cache_write: z.string().optional(),
+  }),
+  supported_features: z.array(z.string()).optional(),
+  supported_sampling_parameters: z.array(z.string()).optional(),
+}).passthrough();
+
+const CloudflareResponse = z.object({
+  data: z.array(CloudflareModel),
+}).passthrough();
+
+type CloudflareModel = z.infer<typeof CloudflareModel>;
+
+export const cloudflareWorkersAi = {
+  id: "cloudflare-workers-ai",
+  name: "Cloudflare Workers AI",
+  modelsDir: "providers/cloudflare-workers-ai/models",
+  async fetchModels() {
+    const accountID = process.env.CLOUDFLARE_ACCOUNT_ID;
+    const token = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CLOUDFLARE_API_KEY;
+    if (accountID === undefined || token === undefined) {
+      throw new Error("Cloudflare Workers AI sync requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN");
+    }
+
+    const first = await fetchPage(accountID, token, 1);
+    const models = parseCloudflareModels(first);
+    const pageInfo = CloudflareOpenRouterResponse.safeParse(first).success
+      ? CloudflareOpenRouterResponse.parse(first).result_info
+      : undefined;
+
+    for (let page = 2; page <= (pageInfo?.total_pages ?? 1); page++) {
+      models.push(...parseCloudflareModels(await fetchPage(accountID, token, page)));
+    }
+
+    return { data: models };
+  },
+  parseModels(raw) {
+    return parseCloudflareModels(raw);
+  },
+  translateModel(model, context) {
+    const normalized = normalizeModel(model);
+    const id = normalized.id.replace(/^workers-ai\//, "");
+    return {
+      id,
+      model: buildWorkersAiModel(normalized, context.existing(id)),
+    };
+  },
+} satisfies SyncProvider<CloudflareModel>;
+
+function buildWorkersAiModel(model: z.infer<typeof OpenRouterModel>, existing: ExistingModel | undefined) {
+  const synced = buildOpenRouterModel(model, existing);
+  return {
+    ...synced,
+    name: existing?.name ?? synced.name,
+    release_date: existing?.release_date ?? synced.release_date,
+    last_updated: existing?.last_updated ?? synced.last_updated,
+    limit: {
+      ...synced.limit,
+      output: existing?.limit?.output ?? synced.limit.output,
+    },
+  };
+}
+
+async function fetchPage(accountID: string, token: string, page: number) {
+  const url = new URL(`${API_BASE}/${accountID}/ai/models/search`);
+  url.searchParams.set("format", "openrouter");
+  url.searchParams.set("per_page", "1000");
+  url.searchParams.set("page", String(page));
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Cloudflare Workers AI models request failed: ${response.status} ${response.statusText}${await responseDetails(response)}`,
+    );
+  }
+  return response.json();
+}
+
+function parseCloudflareModels(raw: unknown) {
+  const cloudflare = CloudflareResponse.safeParse(raw);
+  if (cloudflare.success) return cloudflare.data.data;
+
+  const direct = OpenRouterResponse.safeParse(raw);
+  if (direct.success) return direct.data.data;
+
+  const wrapped = CloudflareOpenRouterResponse.parse(raw);
+  if (wrapped.result === undefined) {
+    throw new Error("Cloudflare Workers AI response did not include model data");
+  }
+  return Array.isArray(wrapped.result) ? wrapped.result : wrapped.result.data;
+}
+
+function normalizeModel(model: CloudflareModel) {
+  if ("architecture" in model && "top_provider" in model && "supported_parameters" in model) {
+    return OpenRouterModel.parse(model);
+  }
+
+  return OpenRouterModel.parse({
+    id: model.id.startsWith("@cf/") ? model.id : `@cf/${model.id.replace(/^@cf\//, "")}`,
+    name: model.name,
+    created: model.created,
+    hugging_face_id: model.hugging_face_id ?? null,
+    knowledge_cutoff: null,
+    context_length: model.context_length,
+    architecture: {
+      input_modalities: model.input_modalities ?? ["text"],
+      output_modalities: model.output_modalities ?? ["text"],
+    },
+    pricing: model.pricing,
+    top_provider: {
+      context_length: model.context_length,
+      max_completion_tokens: model.max_output_length ?? null,
+    },
+    supported_parameters: [
+      ...model.supported_sampling_parameters ?? [],
+      ...model.supported_features ?? [],
+    ],
+  });
+}
+
+async function responseDetails(response: Response) {
+  const text = await response.text();
+  if (text.length === 0) return "";
+
+  try {
+    const body = z.object({
+      errors: z.array(z.object({
+        code: z.union([z.string(), z.number()]).optional(),
+        message: z.string().optional(),
+      }).passthrough()).optional(),
+    }).passthrough().parse(JSON.parse(text));
+    const details = body.errors
+      ?.map((error) => [error.code, error.message].filter(Boolean).join(": "))
+      .filter((message) => message.length > 0)
+      .join("; ");
+    return details === undefined || details.length === 0 ? "" : ` (${details})`;
+  } catch {
+    return "";
+  }
+}

--- a/packages/core/script/sync/openrouter.ts
+++ b/packages/core/script/sync/openrouter.ts
@@ -5,7 +5,7 @@ import type { ExistingModel, SyncProvider } from "../sync-models.js";
 
 const API_ENDPOINT = "https://openrouter.ai/api/v1/models";
 
-const OpenRouterModel = z.object({
+export const OpenRouterModel = z.object({
   id: z.string(),
   name: z.string(),
   created: z.number(),
@@ -30,11 +30,11 @@ const OpenRouterModel = z.object({
   supported_parameters: z.array(z.string()),
 });
 
-const OpenRouterResponse = z.object({
+export const OpenRouterResponse = z.object({
   data: z.array(OpenRouterModel),
 }).passthrough();
 
-type OpenRouterModel = z.infer<typeof OpenRouterModel>;
+export type OpenRouterModel = z.infer<typeof OpenRouterModel>;
 
 export const openrouter = {
   id: "openrouter",
@@ -56,7 +56,7 @@ export const openrouter = {
   translateModel(model, context) {
     return {
       id: model.id,
-      model: buildModel(model, context.existing(model.id)),
+      model: buildOpenRouterModel(model, context.existing(model.id)),
     };
   },
 } satisfies SyncProvider<OpenRouterModel>;
@@ -97,7 +97,7 @@ function inferFamily(model: OpenRouterModel, name: string) {
     });
 }
 
-function buildModel(model: OpenRouterModel, existing: ExistingModel | undefined) {
+export function buildOpenRouterModel(model: OpenRouterModel, existing: ExistingModel | undefined) {
   const params = new Set(model.supported_parameters);
   const name = model.name.replace(/^[^:]+:\s+/, "");
   const input = modalities(model.architecture.input_modalities, ["text"]);

--- a/providers/cloudflare-workers-ai/models/@cf/aisingapore/gemma-sea-lion-v4-27b-it.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/aisingapore/gemma-sea-lion-v4-27b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma Sea Lion V4 27B It"
+family = "gemma"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.351
+output = 0.555
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b.toml
@@ -1,0 +1,22 @@
+name = "Deepseek R1 Distill Qwen 32B"
+family = "deepseek"
+release_date = "2025-01-22"
+last_updated = "2025-01-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.497
+output = 4.881
+
+[limit]
+context = 80_000
+output = 80_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/google/gemma-3-12b-it.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/google/gemma-3-12b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma 3 12B It"
+family = "gemma"
+release_date = "2025-03-18"
+last_updated = "2025-03-18"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.345
+output = 0.556
+
+[limit]
+context = 80_000
+output = 80_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/google/gemma-4-26b-a4b-it.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/google/gemma-4-26b-a4b-it.toml
@@ -6,15 +6,16 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]
-input = 0.10
-output = 0.30
+input = 0.1
+output = 0.3
 
 [limit]
-context = 256000
-output = 16384
+context = 256_000
+output = 16_384
 
 [modalities]
 input = ["text", "image"]

--- a/providers/cloudflare-workers-ai/models/@cf/ibm-granite/granite-4.0-h-micro.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/ibm-granite/granite-4.0-h-micro.toml
@@ -1,0 +1,22 @@
+name = "Granite 4.0 H Micro"
+family = "granite"
+release_date = "2025-10-07"
+last_updated = "2025-10-07"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.017
+output = 0.112
+
+[limit]
+context = 131_000
+output = 131_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-2-7b-chat-fp16.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-2-7b-chat-fp16.toml
@@ -1,0 +1,22 @@
+name = "Llama 2 7B Chat fp16"
+family = "llama"
+release_date = "2023-11-07"
+last_updated = "2023-11-07"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.556
+output = 6.667
+
+[limit]
+context = 4_096
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-3-8b-instruct-awq.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-3-8b-instruct-awq.toml
@@ -1,0 +1,22 @@
+name = "Llama 3 8B Instruct Awq"
+family = "llama"
+release_date = "2024-05-09"
+last_updated = "2024-05-09"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.123
+output = 0.266
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-3-8b-instruct.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-3-8b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Llama 3 8B Instruct"
+family = "llama"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.282
+output = 0.827
+
+[limit]
+context = 7_968
+output = 7_968
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.1-8b-instruct-awq.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.1-8b-instruct-awq.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.1 8B Instruct Awq"
+family = "llama"
+release_date = "2024-07-25"
+last_updated = "2024-07-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.123
+output = 0.266
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.1-8b-instruct-fp8.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.1-8b-instruct-fp8.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.1 8B Instruct fp8"
+family = "llama"
+release_date = "2024-07-25"
+last_updated = "2024-07-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.152
+output = 0.287
+
+[limit]
+context = 32_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.2-11b-vision-instruct.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.2-11b-vision-instruct.toml
@@ -1,21 +1,21 @@
-name = "Llama 4 Scout 17B 16E Instruct"
+name = "Llama 3.2 11B Vision Instruct"
 family = "llama"
-release_date = "2025-04-16"
-last_updated = "2025-04-16"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
 attachment = true
 reasoning = false
 temperature = true
-tool_call = true
+tool_call = false
 structured_output = false
 open_weights = true
 
 [cost]
-input = 0.27
-output = 0.85
+input = 0.0485
+output = 0.676
 
 [limit]
-context = 131_000
-output = 16_384
+context = 128_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.2-1b-instruct.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.2-1b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.2 1B Instruct"
+family = "llama"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.027
+output = 0.201
+
+[limit]
+context = 60_000
+output = 60_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.2-3b-instruct.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.2-3b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.2 3B Instruct"
+family = "llama"
+release_date = "2024-09-25"
+last_updated = "2024-09-25"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.0509
+output = 0.335
+
+[limit]
+context = 80_000
+output = 80_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.3-70b-instruct-fp8-fast.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-3.3-70b-instruct-fp8-fast.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.3 70B Instruct fp8 Fast"
+family = "llama"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.293
+output = 2.253
+
+[limit]
+context = 24_000
+output = 24_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/meta/llama-guard-3-8b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/meta/llama-guard-3-8b.toml
@@ -1,0 +1,22 @@
+name = "Llama Guard 3 8B"
+family = "llama"
+release_date = "2025-01-22"
+last_updated = "2025-01-22"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.484
+output = 0.03
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/mistral/mistral-7b-instruct-v0.1.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/mistral/mistral-7b-instruct-v0.1.toml
@@ -1,0 +1,22 @@
+name = "Mistral 7B Instruct V0.1"
+family = "mistral"
+release_date = "2023-11-07"
+last_updated = "2023-11-07"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.11
+output = 0.19
+
+[limit]
+context = 2_824
+output = 2_824
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/mistralai/mistral-small-3.1-24b-instruct.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/mistralai/mistral-small-3.1-24b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Mistral Small 3.1 24B Instruct"
+family = "mistral-small"
+release_date = "2025-03-18"
+last_updated = "2025-03-18"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.351
+output = 0.555
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/moonshotai/kimi-k2.6.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/moonshotai/kimi-k2.6.toml
@@ -4,9 +4,9 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = true
 reasoning = true
-structured_output = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-01"
 open_weights = true
 
@@ -15,11 +15,11 @@ field = "reasoning_content"
 
 [cost]
 input = 0.95
-output = 4.00
+output = 4
 cache_read = 0.16
 
 [limit]
-context = 256_000
+context = 262_144
 output = 256_000
 
 [modalities]

--- a/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
@@ -6,14 +6,15 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.50
-output = 1.50
+input = 0.5
+output = 1.5
 
 [limit]
 context = 256_000

--- a/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-120b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-120b.toml
@@ -1,10 +1,12 @@
 name = "GPT OSS 120B"
+family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]
@@ -12,8 +14,8 @@ input = 0.35
 output = 0.75
 
 [limit]
-context = 128000
-output = 16384
+context = 128_000
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-20b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-20b.toml
@@ -1,10 +1,12 @@
 name = "GPT OSS 20B"
+family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]
@@ -12,8 +14,8 @@ input = 0.2
 output = 0.3
 
 [limit]
-context = 128000
-output = 16384
+context = 128_000
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/qwen/qwen2.5-coder-32b-instruct.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/qwen/qwen2.5-coder-32b-instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen2.5 Coder 32B Instruct"
+family = "qwen"
+release_date = "2025-02-27"
+last_updated = "2025-02-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.66
+output = 1
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/qwen/qwen3-30b-a3b-fp8.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/qwen/qwen3-30b-a3b-fp8.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 30B A3b fp8"
+family = "qwen"
+release_date = "2025-04-30"
+last_updated = "2025-04-30"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.0509
+output = 0.335
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/qwen/qwq-32b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/qwen/qwq-32b.toml
@@ -1,0 +1,22 @@
+name = "Qwq 32B"
+family = "qwen"
+release_date = "2025-03-05"
+last_updated = "2025-03-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.66
+output = 1
+
+[limit]
+context = 24_000
+output = 24_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
@@ -6,12 +6,13 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-04"
 open_weights = true
 
 [cost]
-input = 0.06
-output = 0.40
+input = 0.0605
+output = 0.4
 
 [limit]
 context = 131_072

--- a/sync.md
+++ b/sync.md
@@ -10,6 +10,8 @@ The grouped sync targets are `aggregators`, which runs OpenRouter, and `direct`,
 
 - `bun models:sync aggregators` syncs every provider in the `aggregators` group.
 - `bun models:sync openrouter` syncs only OpenRouter.
+- `bun models:sync cloudflare-workers-ai` syncs only Cloudflare Workers AI.
+- `bun models:sync cloudflare` syncs the Cloudflare sync group.
 - `bun models:sync direct` syncs every provider in the `direct` group.
 - `bun models:sync google` syncs only Google.
 - `bun models:sync xai` syncs only xAI.
@@ -110,6 +112,16 @@ OpenRouter is implemented in `packages/core/script/sync/openrouter.ts`.
 - API prices are per-token strings and are converted to per-1M-token numbers.
 - `structured_output` comes from `supported_parameters.includes("structured_outputs")` only.
 - Existing `status`, `interleaved`, `knowledge`, `limit.input`, and `cost.tiers` may be preserved when OpenRouter is not authoritative enough for those fields.
+
+## Cloudflare Workers AI Notes
+
+Cloudflare Workers AI is implemented in `packages/core/script/sync/cloudflare-workers-ai.ts`.
+
+- Source endpoint: `https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/models/search?format=openrouter`.
+- Required auth: `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` (or `CLOUDFLARE_API_KEY`).
+- The endpoint is parsed as Cloudflare's OpenRouter-like Workers AI metadata.
+- Model IDs map directly to TOML paths under `providers/cloudflare-workers-ai/models`.
+- This sync target does not manage `providers/cloudflare-ai-gateway`, because the AI Gateway `/compat/models` endpoint does not support `format=openrouter` and does not provide enough model metadata for authoritative catalog sync.
 
 ## Google Notes
 


### PR DESCRIPTION
## Summary
- add Cloudflare Workers AI to the centralized model sync runner
- normalize Cloudflare's OpenRouter-like model search response into catalog TOMLs
- sync current Workers AI model files and document the new sync target

## Verification
- bun models:sync cloudflare-workers-ai --dry-run
- bun models:sync cloudflare-workers-ai
- bun validate