### PR TITLE
Add PDF input modality to Grok models

### DIFF
--- a/packages/core/script/sync/xai.ts
+++ b/packages/core/script/sync/xai.ts
@@ -128,6 +128,7 @@ function modalities(values: string[] | undefined, fallback: Modality[]) {
   const result = (values ?? [])
     .map((value) => value.toLowerCase())
     .filter((value): value is Modality => allowed.has(value as Modality));
+  if (result.includes("image")) result.push("pdf");
   return [...new Set(result.length > 0 ? result : fallback)];
 }
 

--- a/providers/xai/models/grok-4.20-0309-non-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-non-reasoning.toml
@@ -24,5 +24,5 @@ context = 2_000_000
 output = 30_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/xai/models/grok-4.20-0309-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-reasoning.toml
@@ -24,5 +24,5 @@ context = 2_000_000
 output = 30_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/xai/models/grok-4.20-multi-agent-0309.toml
+++ b/providers/xai/models/grok-4.20-multi-agent-0309.toml
@@ -24,5 +24,5 @@ context = 2_000_000
 output = 30_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/xai/models/grok-4.3.toml
+++ b/providers/xai/models/grok-4.3.toml
@@ -24,5 +24,5 @@ context = 1_000_000
 output = 30_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/xai/models/grok-build-0.1.toml
+++ b/providers/xai/models/grok-build-0.1.toml
@@ -19,5 +19,5 @@ context = 256_000
 output = 256_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]


### PR DESCRIPTION
## Summary
- add PDF input modality to xAI Grok models that accepted uploaded PDF attachments
- leave Grok Imagine models unchanged because the Responses API returned model-not-found for those IDs

## Verification
- tested each xAI Grok model with uploaded dashboard.pdf via /v1/files + /v1/responses
- passing models returned PDF_OK: grok-4.20-0309-non-reasoning, grok-4.20-0309-reasoning, grok-4.20-multi-agent-0309, grok-4.3, grok-build-0.1
- ran bun validate >/dev/null