### PR TITLE
chore(sync): isolate cloudflare credentials

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -23,6 +23,10 @@ jobs:
             title: "chore(sync): update aggregator model catalogs"
             branch: automation/sync-models-aggregators
             labels: automation,model-sync,sync-group:aggregators,provider:openrouter
+          - group: cloudflare
+            title: "chore(sync): update cloudflare model catalogs"
+            branch: automation/sync-models-cloudflare
+            labels: automation,model-sync,sync-group:cloudflare,provider:cloudflare-workers-ai
 
     steps:
       - name: Checkout code
@@ -42,6 +46,8 @@ jobs:
         run: bun models:sync ${{ matrix.group }}
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          CLOUDFLARE_WORKERS_AI_SYNC_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_WORKERS_AI_SYNC_ACCOUNT_ID }}
+          CLOUDFLARE_WORKERS_AI_SYNC_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_AI_SYNC_API_TOKEN }}
 
       - name: Validate models
         run: bun validate

--- a/packages/core/script/sync/cloudflare-workers-ai.ts
+++ b/packages/core/script/sync/cloudflare-workers-ai.ts
@@ -48,10 +48,12 @@ export const cloudflareWorkersAi = {
   name: "Cloudflare Workers AI",
   modelsDir: "providers/cloudflare-workers-ai/models",
   async fetchModels() {
-    const accountID = process.env.CLOUDFLARE_ACCOUNT_ID;
-    const token = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CLOUDFLARE_API_KEY;
+    const accountID = process.env.CLOUDFLARE_WORKERS_AI_SYNC_ACCOUNT_ID;
+    const token = process.env.CLOUDFLARE_WORKERS_AI_SYNC_API_TOKEN;
     if (accountID === undefined || token === undefined) {
-      throw new Error("Cloudflare Workers AI sync requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN");
+      throw new Error(
+        "Cloudflare Workers AI sync requires CLOUDFLARE_WORKERS_AI_SYNC_ACCOUNT_ID and CLOUDFLARE_WORKERS_AI_SYNC_API_TOKEN",
+      );
     }
 
     const first = await fetchPage(accountID, token, 1);

--- a/sync.md
+++ b/sync.md
@@ -117,8 +117,9 @@ OpenRouter is implemented in `packages/core/script/sync/openrouter.ts`.
 
 Cloudflare Workers AI is implemented in `packages/core/script/sync/cloudflare-workers-ai.ts`.
 
-- Source endpoint: `https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/models/search?format=openrouter`.
-- Required auth: `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` (or `CLOUDFLARE_API_KEY`).
+- Source endpoint: `https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_WORKERS_AI_SYNC_ACCOUNT_ID/ai/models/search?format=openrouter`.
+- Required auth: `CLOUDFLARE_WORKERS_AI_SYNC_ACCOUNT_ID` and `CLOUDFLARE_WORKERS_AI_SYNC_API_TOKEN`.
+- Use a dedicated token scoped to Workers AI read access so sync automation does not share deploy credentials.
 - The endpoint is parsed as Cloudflare's OpenRouter-like Workers AI metadata.
 - Model IDs map directly to TOML paths under `providers/cloudflare-workers-ai/models`.
 - This sync target does not manage `providers/cloudflare-ai-gateway`, because the AI Gateway `/compat/models` endpoint does not support `format=openrouter` and does not provide enough model metadata for authoritative catalog sync.


### PR DESCRIPTION
## Summary
- require dedicated Cloudflare Workers AI sync env vars instead of shared deploy credentials
- add Cloudflare as its own scheduled sync matrix target using dedicated secrets
- document the dedicated sync credential names and token intent

## Verification
- set -a && source .env && set +a && bun models:sync cloudflare-workers-ai --dry-run
- bun validate