### PR TITLE
Add image input modality to Xpersona model

### DIFF
--- a/providers/xpersona/models/xpersona-frieren-coder.toml
+++ b/providers/xpersona/models/xpersona-frieren-coder.toml
@@ -20,5 +20,5 @@ context = 400_000
 output = 128_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]


### PR DESCRIPTION
## Summary

Updates the Xpersona Frieren Coder model metadata to advertise image input support in Models.dev/OpenCode.

## Details

- Changes `providers/xpersona/models/xpersona-frieren-coder.toml`
- Updates modalities from `input = [text]` to `input = [text, image]`
- Leaves output modality as text

## Validation

- Verified the diff is one TOML line in the Xpersona model metadata.