### PR TITLE
chore: automate provider sync jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,3 +35,4 @@ jobs:
       - run: bun sst deploy --stage=dev
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -2,7 +2,7 @@ name: Sync Model Catalogs
 
 on:
   schedule:
-    - cron: "17 8 * * *"
+    - cron: "17 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -13,20 +13,34 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  providers:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.providers.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: List sync providers
+        id: providers
+        run: echo "matrix=$(bun models:sync --list-providers)" >> "$GITHUB_OUTPUT"
+
   sync:
+    needs: providers
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - group: aggregators
-            title: "chore(sync): update aggregator model catalogs"
-            branch: automation/sync-models-aggregators
-            labels: automation,model-sync,sync-group:aggregators,provider:openrouter
-          - group: cloudflare
-            title: "chore(sync): update cloudflare model catalogs"
-            branch: automation/sync-models-cloudflare
-            labels: automation,model-sync,sync-group:cloudflare,provider:cloudflare-workers-ai
+      matrix: ${{ fromJSON(needs.providers.outputs.matrix) }}
 
     steps:
       - name: Checkout code
@@ -43,9 +57,13 @@ jobs:
         run: bun install
 
       - name: Sync model catalogs
-        run: bun models:sync ${{ matrix.group }}
+        run: bun models:sync ${{ matrix.provider }}
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           CLOUDFLARE_WORKERS_AI_SYNC_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_WORKERS_AI_SYNC_ACCOUNT_ID }}
           CLOUDFLARE_WORKERS_AI_SYNC_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_AI_SYNC_API_TOKEN }}
 
@@ -55,9 +73,9 @@ jobs:
       - name: Create pull request
         env:
           GH_TOKEN: ${{ github.token }}
-          BRANCH: ${{ matrix.branch }}
-          LABELS: ${{ matrix.labels }}
-          TITLE: ${{ matrix.title }}
+          BRANCH: automation/sync-models-${{ matrix.provider }}
+          LABELS: automation,model-sync,provider:${{ matrix.provider }}
+          TITLE: "chore(sync): update ${{ matrix.name }} model catalog"
         run: |
           if [ -z "$(git status --porcelain -- providers)" ]; then
             echo "No model catalog changes found."

--- a/packages/core/script/sync-models.ts
+++ b/packages/core/script/sync-models.ts
@@ -225,6 +225,15 @@ export async function syncTargets(target: string, options: SyncOptions = {}) {
   return results;
 }
 
+export function syncProviderMatrix() {
+  return {
+    include: Object.values(providers).map((provider) => ({
+      provider: provider.id,
+      name: provider.name,
+    })),
+  };
+}
+
 async function readExisting(modelsDir: string) {
   const existing = new Map<string, { text: string; toml: ExistingModel; symlink: boolean }>();
 
@@ -450,6 +459,11 @@ function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
 }
 
 export async function main(args = process.argv.slice(2)) {
+  if (args.includes("--list-providers")) {
+    console.log(JSON.stringify(syncProviderMatrix()));
+    return;
+  }
+
   const target = args.find((arg) => !arg.startsWith("-")) ?? "aggregators";
   const results = await syncTargets(target, {
     dryRun: args.includes("--dry-run"),

--- a/sync.md
+++ b/sync.md
@@ -4,7 +4,7 @@ TODO: delete
 
 Model syncs are centralized in `packages/core/script/sync-models.ts`. The runner owns file IO, TOML formatting, validation, reporting, dry runs, and deletion behavior. Individual provider sync modules only fetch source data, parse it, and translate each source model into the catalog schema.
 
-The grouped sync targets are `aggregators`, which runs OpenRouter, and `direct`, which runs direct provider APIs like Google and xAI.
+The grouped sync targets are available for local convenience, but CI syncs each provider separately so every provider gets its own reusable automation PR.
 
 ## Commands
 
@@ -79,7 +79,7 @@ Do not put TOML scanning, writing, deletion, reporting, or generic comparison lo
 3. Export a `SyncProvider` implementation with `fetchModels`, `parseModels`, and `translateModel`.
 4. Add the provider to `providers` in `packages/core/script/sync-models.ts`.
 5. Add the provider ID to an existing group or create a new group in `groups`.
-6. Update `.github/workflows/sync-models.yml` matrix labels and titles if the new group should run in automation.
+6. Add any required API secrets to `.github/workflows/sync-models.yml` if the provider needs new credentials.
 7. Run `bun models:sync <provider> --dry-run` to inspect the first diff.
 8. Run `bun models:sync <provider>` to write files.
 9. Run `bun models:sync <provider> --dry-run` again and expect a clean result.
@@ -89,16 +89,21 @@ Prefer small, provider-specific PRs when adding a provider. If the provider has 
 
 ## Automation
 
-`.github/workflows/sync-models.yml` runs on a daily schedule and manually through `workflow_dispatch`.
+`.github/workflows/sync-models.yml` runs on an hourly schedule and manually through `workflow_dispatch`.
 
 The workflow:
 
 - Checks out `dev`.
 - Installs dependencies with Bun.
-- Runs `bun models:sync ${{ matrix.group }}`.
+- Discovers sync providers with `bun models:sync --list-providers`.
+- Runs one provider per matrix job with `bun models:sync ${{ matrix.provider }}`.
 - Runs `bun validate`.
-- Creates or updates a sync PR only when `providers` changed.
+- Creates or updates a provider-specific sync PR only when `providers` changed.
 - Uses `.sync/model-sync-report.md` as the PR body.
+
+Each provider job checks out `dev` and writes to a fixed provider branch like `automation/sync-models-openrouter`. If that provider's sync PR is already open, later scheduled runs force-update the same branch and edit the existing PR instead of creating another one. Provider jobs do not share unmerged changes with each other; OpenRouter only extends from canonical provider TOMLs already present on `dev`.
+
+CI automatically picks up providers registered in `providers` in `packages/core/script/sync-models.ts`. Adding a new sync provider there is enough to get an hourly provider-specific sync job, branch, labels, title, and PR naming convention. The workflow only needs manual updates when a new provider requires new secrets or other environment variables.
 
 Actions are pinned by commit SHA. Keep new workflow actions pinned the same way.
 


### PR DESCRIPTION
## Summary
- discover sync providers dynamically for the scheduled sync workflow
- run provider-specific hourly sync jobs for Google, xAI, Cloudflare Workers AI, and OpenRouter
- expose Cloudflare default account ID to the deploy action

## Verification
- bun models:sync --list-providers
- git diff --check HEAD~1..HEAD