### PR TITLE
Add new Vercel AI Gateway models

### DIFF
--- a/providers/vercel/models/alibaba/qwen3.7-max.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-max.toml
@@ -1,0 +1,23 @@
+name = "Qwen 3.7 Max"
+family = "qwen"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-05-21"
+last_updated = "2026-05-21"
+open_weights = false
+
+[cost]
+input = 2.5
+output = 7.5
+cache_read = 0.5
+cache_write = 3.125
+
+[limit]
+context = 991_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/vercel/models/google/gemini-3.5-flash.toml
+++ b/providers/vercel/models/google/gemini-3.5-flash.toml
@@ -1,0 +1,22 @@
+name = "Gemini 3.5 Flash"
+family = "gemini"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-05-19"
+last_updated = "2026-05-21"
+open_weights = false
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/vercel/models/mistral/mistral-medium-3.5.toml
+++ b/providers/vercel/models/mistral/mistral-medium-3.5.toml
@@ -1,0 +1,21 @@
+name = "Mistral Medium Latest"
+family = "mistral-medium"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-05-21"
+last_updated = "2026-05-21"
+open_weights = false
+
+[cost]
+input = 1.5
+output = 7.5
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vercel/models/xai/grok-build-0.1.toml
+++ b/providers/vercel/models/xai/grok-build-0.1.toml
@@ -1,0 +1,22 @@
+name = "Grok Build 0.1"
+family = "grok-build"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-05-20"
+last_updated = "2026-05-21"
+open_weights = false
+
+[cost]
+input = 1
+output = 2
+cache_read = 0.19999999999999998
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Sync new Vercel AI Gateway model entries from the gateway API
- Add google/gemini-3.5-flash so it appears for Vercel AI Gateway users
- Include other new gateway models returned by the new-only sync

Fixes anomalyco/opencode#28516

## Validation
- bun validate