### PR TITLE
fix xAI long-context pricing

### DIFF
--- a/packages/core/script/sync/xai.ts
+++ b/packages/core/script/sync/xai.ts
@@ -137,6 +137,11 @@ function tokenPrice(value: number | undefined) {
   return value / 10_000;
 }
 
+function preservedCostTiers(existing: ExistingModel) {
+  // The xAI models API exposes base pricing only; long-context tiers are curated from xAI docs/console.
+  return existing.cost?.tiers;
+}
+
 function cost(model: XAIModel, existing: ExistingModel) {
   const input = tokenPrice(model.prompt_text_token_price);
   const output = tokenPrice(model.completion_text_token_price);
@@ -150,7 +155,7 @@ function cost(model: XAIModel, existing: ExistingModel) {
     cache_write: existing.cost?.cache_write,
     input_audio: existing.cost?.input_audio,
     output_audio: existing.cost?.output_audio,
-    tiers: existing.cost?.tiers,
+    tiers: preservedCostTiers(existing),
   };
 }
 

--- a/providers/xai/models/grok-4.20-0309-non-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-non-reasoning.toml
@@ -15,8 +15,8 @@ cache_read = 0.2
 
 [[cost.tiers]]
 tier = { size = 200_000 }
-input = 4
-output = 12
+input = 2.5
+output = 5
 cache_read = 0.4
 
 [limit]

--- a/providers/xai/models/grok-4.20-0309-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-reasoning.toml
@@ -15,8 +15,8 @@ cache_read = 0.2
 
 [[cost.tiers]]
 tier = { size = 200_000 }
-input = 4
-output = 12
+input = 2.5
+output = 5
 cache_read = 0.4
 
 [limit]

--- a/providers/xai/models/grok-4.20-multi-agent-0309.toml
+++ b/providers/xai/models/grok-4.20-multi-agent-0309.toml
@@ -15,8 +15,8 @@ cache_read = 0.2
 
 [[cost.tiers]]
 tier = { size = 200_000 }
-input = 4
-output = 12
+input = 2.5
+output = 5
 cache_read = 0.4
 
 [limit]

--- a/providers/xai/models/grok-build-0.1.toml
+++ b/providers/xai/models/grok-build-0.1.toml
@@ -14,6 +14,12 @@ input = 1.00
 output = 2.00
 cache_read = 0.20
 
+[[cost.tiers]]
+tier = { size = 200_000 }
+input = 2.00
+output = 4.00
+cache_read = 0.40
+
 [limit]
 context = 256_000
 output = 256_000


### PR DESCRIPTION
## Summary
- add the 200k+ long-context tier for Grok Build 0.1
- update Grok 4.20 long-context tiers to the current 200k+ pricing
- make xAI sync tier preservation explicit because the models API only returns base pricing

## Validation
- bun validate