### PR TITLE
Fix Vertex Sonnet 4.6 token limits

### DIFF
--- a/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
@@ -15,5 +15,5 @@ cache_read = 0.60
 cache_write = 7.50
 
 [limit]
-context = 200_000
-output = 64_000
+context = 1_000_000
+output = 128_000

--- a/providers/google-vertex/models/claude-sonnet-4-6@default.toml
+++ b/providers/google-vertex/models/claude-sonnet-4-6@default.toml
@@ -15,8 +15,8 @@ cache_read = 0.60
 cache_write = 7.50
 
 [limit]
-context = 200_000
-output = 64_000
+context = 1_000_000
+output = 128_000
 
 [provider]
 npm = "@ai-sdk/google-vertex/anthropic"


### PR DESCRIPTION
## Summary
- update Claude Sonnet 4.6 Vertex limits to 1M context and 128K output
- keep google-vertex and google-vertex-anthropic entries aligned

## Validation
- bun validate
- compared generated shared Vertex Anthropic limits across both providers