### PR TITLE
[GitHub Copilot] add Gemini 3.5 Flash

### DIFF
--- a/providers/github-copilot/models/gemini-3.5-flash.toml
+++ b/providers/github-copilot/models/gemini-3.5-flash.toml
@@ -1,0 +1,24 @@
+name = "Gemini 3.5 Flash"
+family = "gemini-flash"
+release_date = "2026-05-19"
+last_updated = "2026-05-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-01"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 64_000
+input = 128_000
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add support for `github-copilot/gemini-3.5-flash`
- follow existing GitHub Copilot Gemini model metadata and limits

## Validation
- `PATH="$HOME/.bun/bin:$PATH" "$HOME/.bun/bin/bun" validate`
