### PR TITLE
fix(neuralwatt): update Qwen3.6 pricing to match API

### DIFF
--- a/providers/neuralwatt/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/neuralwatt/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -9,8 +9,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.05
-output = 0.10
+input = 0.29
+output = 1.15
 
 [limit]
 context = 131_056

--- a/providers/neuralwatt/models/qwen3.6-35b-fast.toml
+++ b/providers/neuralwatt/models/qwen3.6-35b-fast.toml
@@ -9,8 +9,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.05
-output = 0.10
+input = 0.29
+output = 1.15
 
 [limit]
 context = 131_056


### PR DESCRIPTION
## Description

Updates the per-token cost for Neuralwatt's Qwen3.6 models to reflect the actual API pricing. The previous values were placeholders set during initial provider onboarding.

## Changes

| Model | Before (input/output per 1M) | After (input/output per 1M) |
|-------|------------------------------|-----------------------------|
| `Qwen/Qwen3.6-35B-A3B` | $0.05 / $0.10 | $0.29 / $1.15 |
| `qwen3.6-35b-fast` | $0.05 / $0.10 | $0.29 / $1.15 |

## Source

These prices are sourced from the `pi-neuralwatt-provider` extension (commit `f634286`), which periodically syncs model data from the Neuralwatt API via stale-while-revalidate. The models.dev TOML files were out of sync with the extension's embedded `models.json`.

## Validation

```
bun validate  # passes cleanly
```

**Note:** Canary models (`glm-5.1-canary`, `kimi-k2.6-canary`) are excluded as they exist only in the provider extension, not in models.dev.