### PR TITLE
Venice: Add Gemini 3.5 Flash and Qwen 3.7 Max, update Grok Build 0.1 pricing

### DIFF
--- a/providers/venice/models/gemini-3-5-flash.toml
+++ b/providers/venice/models/gemini-3-5-flash.toml
@@ -1,0 +1,24 @@
+name = "Gemini 3.5 Flash"
+family = "gemini-flash"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-05-22"
+last_updated = "2026-05-22"
+open_weights = false
+
+[cost]
+input = 1.8
+output = 11
+cache_read = 0.18
+cache_write = 0.1
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/venice/models/grok-build-0-1.toml
+++ b/providers/venice/models/grok-build-0-1.toml
@@ -6,19 +6,19 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-05-21"
-last_updated = "2026-05-21"
+last_updated = "2026-05-22"
 open_weights = false
 
 [cost]
-input = 0.95
-output = 1.95
-cache_read = 0.19
+input = 1
+output = 2
+cache_read = 0.2
 
 [[cost.tiers]]
 tier = { size = 200_000 }
-input = 1.9
-output = 3.9
-cache_read = 0.38
+input = 2
+output = 4
+cache_read = 0.4
 
 [limit]
 context = 256_000

--- a/providers/venice/models/qwen-3-7-max.toml
+++ b/providers/venice/models/qwen-3-7-max.toml
@@ -1,0 +1,23 @@
+name = "Qwen 3.7 Max"
+family = "qwen"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-05-22"
+last_updated = "2026-05-22"
+open_weights = false
+
+[cost]
+input = 3.125
+output = 9.375
+cache_read = 0.3125
+cache_write = 3.90625
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
- Add Gemini 3.5 Flash model (1M context, multimodal input)
- Add Qwen 3.7 Max model (1M context, text-only)
- Update Grok Build 0.1 cost tiers and pricing