### PR TITLE
Add current NEAR AI Cloud models

### DIFF
--- a/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
+++ b/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
@@ -1,0 +1,17 @@
+name = "Qwen 3.6 35B A3B FP8"
+
+[extends]
+from = "alibaba/qwen3.6-35b-a3b"
+
+[cost]
+input = 0.17
+output = 1.10
+cache_read = 0.056
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nearai/models/google/gemini-3-pro.toml
+++ b/providers/nearai/models/google/gemini-3-pro.toml
@@ -1,0 +1,8 @@
+[extends]
+from = "google/gemini-3-pro-preview"
+omit = ["cost.tiers", "cost.context_over_200k"]
+
+[cost]
+input = 1.25
+output = 15.00
+cache_read = 0.00

--- a/providers/nearai/models/google/gemini-3.5-flash.toml
+++ b/providers/nearai/models/google/gemini-3.5-flash.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-3.5-flash"

--- a/providers/nearai/models/google/gemma-4-31B-it.toml
+++ b/providers/nearai/models/google/gemma-4-31B-it.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "google/gemma-4-31b-it"
+
+[cost]
+input = 0.13
+output = 0.40
+cache_read = 0.026
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds the NEAR AI Cloud models currently exposed by the public model catalog but missing from `providers/nearai`:

- `Qwen/Qwen3.6-35B-A3B-FP8`
- `google/gemini-3-pro`
- `google/gemini-3.5-flash`
- `google/gemma-4-31B-it`

The new entries reuse existing canonical model definitions with `extends` where possible, with NEAR-specific pricing and modality overrides where the catalog differs.

## Testing

- `npm exec --yes bun -- validate`