### PR TITLE
fix: missing google-vertex gemini 3.5 flash extend

### DIFF
--- a/providers/google-vertex/models/gemini-3.5-flash.toml
+++ b/providers/google-vertex/models/gemini-3.5-flash.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "google/gemini-3.5-flash"


### PR DESCRIPTION
Add missing google-vertex provider gemini 3.5 flash extends from google providers