### PR TITLE
feat: add Snowflake Cortex provider with 23 models

### DIFF
--- a/providers/snowflake-anthropic/models/claude-4-sonnet.toml
+++ b/providers/snowflake-anthropic/models/claude-4-sonnet.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake-anthropic/models/claude-haiku-4-5.toml
+++ b/providers/snowflake-anthropic/models/claude-haiku-4-5.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 1.00
+output = 5.00
+cache_read = 0.10
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake-anthropic/models/claude-opus-4-5.toml
+++ b/providers/snowflake-anthropic/models/claude-opus-4-5.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-opus-4-5"
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake-anthropic/models/claude-opus-4-6.toml
+++ b/providers/snowflake-anthropic/models/claude-opus-4-6.toml
@@ -1,0 +1,12 @@
+[extends]
+from = "anthropic/claude-opus-4-6"
+omit = ["experimental.modes.fast"]
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake-anthropic/models/claude-opus-4-7.toml
+++ b/providers/snowflake-anthropic/models/claude-opus-4-7.toml
@@ -1,0 +1,14 @@
+status = "alpha"
+
+[extends]
+from = "anthropic/claude-opus-4-7"
+omit = ["experimental.modes.fast"]
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake-anthropic/models/claude-sonnet-4-5.toml
+++ b/providers/snowflake-anthropic/models/claude-sonnet-4-5.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-sonnet-4-5"
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake-anthropic/models/claude-sonnet-4-6.toml
+++ b/providers/snowflake-anthropic/models/claude-sonnet-4-6.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake-anthropic/provider.toml
+++ b/providers/snowflake-anthropic/provider.toml
@@ -1,0 +1,5 @@
+name = "Snowflake Cortex (Anthropic)"
+npm = "@ai-sdk/anthropic"
+api = "https://${SNOWFLAKE_ACCOUNT_URL}/api/v2/cortex"
+env = ["SNOWFLAKE_ACCOUNT_URL", "SNOWFLAKE_PAT"]
+doc = "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api"

--- a/providers/snowflake/models/claude-4-sonnet.toml
+++ b/providers/snowflake/models/claude-4-sonnet.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake/models/claude-haiku-4-5.toml
+++ b/providers/snowflake/models/claude-haiku-4-5.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 1.00
+output = 5.00
+cache_read = 0.10
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake/models/claude-opus-4-5.toml
+++ b/providers/snowflake/models/claude-opus-4-5.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-opus-4-5"
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake/models/claude-opus-4-6.toml
+++ b/providers/snowflake/models/claude-opus-4-6.toml
@@ -1,0 +1,12 @@
+[extends]
+from = "anthropic/claude-opus-4-6"
+omit = ["experimental.modes.fast"]
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake/models/claude-opus-4-7.toml
+++ b/providers/snowflake/models/claude-opus-4-7.toml
@@ -1,0 +1,14 @@
+status = "alpha"
+
+[extends]
+from = "anthropic/claude-opus-4-7"
+omit = ["experimental.modes.fast"]
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake/models/claude-sonnet-4-5.toml
+++ b/providers/snowflake/models/claude-sonnet-4-5.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-sonnet-4-5"
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake/models/claude-sonnet-4-6.toml
+++ b/providers/snowflake/models/claude-sonnet-4-6.toml
@@ -1,0 +1,11 @@
+[extends]
+from = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+
+[limit]
+context = 200_000
+output = 16_384

--- a/providers/snowflake/models/deepseek-r1.toml
+++ b/providers/snowflake/models/deepseek-r1.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek R1"
+family = "deepseek-thinking"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 1.35
+output = 5.40
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/models/llama3.1-405b.toml
+++ b/providers/snowflake/models/llama3.1-405b.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.1 405B"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.20
+output = 1.20
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/models/llama3.1-70b.toml
+++ b/providers/snowflake/models/llama3.1-70b.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.1 70B"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.72
+output = 0.72
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/models/llama3.1-8b.toml
+++ b/providers/snowflake/models/llama3.1-8b.toml
@@ -1,0 +1,21 @@
+name = "Llama 3.1 8B"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.24
+output = 0.24
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/models/llama4-maverick.toml
+++ b/providers/snowflake/models/llama4-maverick.toml
@@ -1,0 +1,21 @@
+name = "Llama 4 Maverick"
+family = "llama"
+release_date = "2025-04-05"
+last_updated = "2025-04-05"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.24
+output = 0.97
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/mistral-7b.toml
+++ b/providers/snowflake/models/mistral-7b.toml
@@ -1,0 +1,21 @@
+name = "Mistral 7B"
+family = "mistral"
+release_date = "2023-09-27"
+last_updated = "2023-09-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.18
+output = 0.18
+
+[limit]
+context = 32_768
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/models/mistral-large.toml
+++ b/providers/snowflake/models/mistral-large.toml
@@ -1,0 +1,21 @@
+name = "Mistral Large"
+family = "mistral-large"
+release_date = "2024-02-26"
+last_updated = "2024-02-26"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 6.00
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/models/mistral-large2.toml
+++ b/providers/snowflake/models/mistral-large2.toml
@@ -1,0 +1,22 @@
+name = "Mistral Large 2"
+family = "mistral-large"
+release_date = "2024-07-24"
+last_updated = "2024-07-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 6.00
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-4.1.toml
+++ b/providers/snowflake/models/openai-gpt-4.1.toml
@@ -1,0 +1,23 @@
+name = "GPT-4.1"
+family = "gpt"
+release_date = "2025-04-14"
+last_updated = "2025-04-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 8.00
+cache_read = 0.50
+
+[limit]
+context = 300_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5-mini.toml
+++ b/providers/snowflake/models/openai-gpt-5-mini.toml
@@ -1,0 +1,23 @@
+status = "alpha"
+name = "GPT-5 Mini"
+family = "gpt-mini"
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 1_000_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5-nano.toml
+++ b/providers/snowflake/models/openai-gpt-5-nano.toml
@@ -1,0 +1,23 @@
+status = "alpha"
+name = "GPT-5 Nano"
+family = "gpt-nano"
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 5_000_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5.1.toml
+++ b/providers/snowflake/models/openai-gpt-5.1.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.1"
+family = "gpt"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125
+
+[limit]
+context = 300_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5.2.toml
+++ b/providers/snowflake/models/openai-gpt-5.2.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.2"
+family = "gpt"
+release_date = "2025-10-01"
+last_updated = "2025-10-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125
+
+[limit]
+context = 300_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5.4.toml
+++ b/providers/snowflake/models/openai-gpt-5.4.toml
@@ -1,0 +1,24 @@
+status = "alpha"
+name = "GPT-5.4"
+family = "gpt"
+release_date = "2026-02-01"
+last_updated = "2026-02-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 10.00
+cache_read = 0.20
+
+[limit]
+context = 300_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/openai-gpt-5.toml
+++ b/providers/snowflake/models/openai-gpt-5.toml
@@ -1,0 +1,24 @@
+status = "alpha"
+name = "GPT-5"
+family = "gpt"
+release_date = "2025-07-10"
+last_updated = "2025-07-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125
+
+[limit]
+context = 300_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/snowflake/models/snowflake-llama-3.3-70b.toml
+++ b/providers/snowflake/models/snowflake-llama-3.3-70b.toml
@@ -1,0 +1,21 @@
+name = "Snowflake Llama 3.3 70B"
+family = "llama"
+release_date = "2025-01-01"
+last_updated = "2025-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.72
+output = 0.72
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/snowflake/provider.toml
+++ b/providers/snowflake/provider.toml
@@ -1,0 +1,5 @@
+name = "Snowflake Cortex"
+npm = "@ai-sdk/openai-compatible"
+api = "https://${SNOWFLAKE_ACCOUNT_URL}/api/v2/cortex/v1"
+env = ["SNOWFLAKE_ACCOUNT_URL", "SNOWFLAKE_PAT"]
+doc = "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api"


### PR DESCRIPTION
## Summary

Adds **Snowflake Cortex** as a new provider using the OpenAI-compatible REST API.

### Provider configuration

- **npm**: `@ai-sdk/openai-compatible`
- **API**: `https://${SNOWFLAKE_ACCOUNT_URL}/api/v2/cortex/v1`
- **Auth**: `SNOWFLAKE_PAT` (Programmatic Access Token)
- **Docs**: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api

### Models (23 total)

| Family | Models |
|--------|--------|
| **Claude** | claude-sonnet-4-5, claude-sonnet-4-6, claude-4-sonnet, claude-opus-4-5, claude-opus-4-6, claude-opus-4-7*, claude-haiku-4-5 |
| **OpenAI via Snowflake** | openai-gpt-4.1, openai-gpt-5*, openai-gpt-5.1, openai-gpt-5.2, openai-gpt-5.4*, openai-gpt-5-mini*, openai-gpt-5-nano* |
| **Meta Llama** | llama3.1-8b, llama3.1-70b, llama3.1-405b, llama4-maverick |
| **Mistral** | mistral-7b, mistral-large, mistral-large2 |
| **DeepSeek** | deepseek-r1 |
| **Snowflake-native** | snowflake-llama-3.3-70b |

`*` = preview (`status = "alpha"`)

### Implementation notes

- Claude models use `[extends]` from `anthropic/` with Snowflake-specific `[cost]` and `[limit]` overrides
- All models capped at `output = 16_384` tokens (Snowflake platform limit)
- `experimental.modes.fast` omitted for opus models (not supported by Snowflake Cortex)
- Pricing sourced from the [Snowflake Service Consumption Table](https://www.snowflake.com/legal-files/CreditConsumptionTable.pdf)
- `bun validate` passes cleanly