### PR TITLE
Add Poolside provider with Laguna M.1 and XS.2 models

### DIFF
--- a/providers/poolside/logo.svg
+++ b/providers/poolside/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15l-4-4 1.41-1.41L11 14.17l5.59-5.59L18 10l-7 7z"/>
+</svg>

--- a/providers/poolside/models/poolside/laguna-m.1.toml
+++ b/providers/poolside/models/poolside/laguna-m.1.toml
@@ -1,0 +1,25 @@
+name = "Laguna M.1"
+release_date = "2026-04-28"
+last_updated = "2026-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0
+cache_read = 0.0
+cache_write = 0.0
+
+[limit]
+context = 131_040
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/poolside/models/poolside/laguna-xs.2.toml
+++ b/providers/poolside/models/poolside/laguna-xs.2.toml
@@ -1,0 +1,25 @@
+name = "Laguna XS.2"
+release_date = "2026-04-28"
+last_updated = "2026-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0
+cache_read = 0.0
+cache_write = 0.0
+
+[limit]
+context = 131_040
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/poolside/provider.toml
+++ b/providers/poolside/provider.toml
@@ -1,0 +1,5 @@
+name = "Poolside"
+env = ["POOLSIDE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://inference.poolside.ai/v1"
+doc = "https://platform.poolside.ai"


### PR DESCRIPTION
Adding Poolside as a provider with their API endpoint at `https://inference.poolside.ai/v1` (OpenAI-compatible).

Models:
- `poolside/laguna-m.1` — 225B (23B active), reasoning, free for limited time
- `poolside/laguna-xs.2` — 33B (3B active), open-weights (Apache 2.0), free for limited time

Context limit set to 131,040 tokens (max allowed input length).

https://poolside.ai/blog/introducing-laguna-xs2-m1