### PR TITLE
providers/wafer.ai: add Qwen3.6-35B-A3B and Kimi-K2.6

### DIFF
--- a/providers/wafer.ai/models/Kimi-K2.6.toml
+++ b/providers/wafer.ai/models/Kimi-K2.6.toml
@@ -1,0 +1,25 @@
+name = "Kimi K2.6"
+family = "kimi"
+release_date = "2026-05-13"
+last_updated = "2026-05-13"
+knowledge = "2025-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 1.10
+output = 4.80
+cache_read = 0.11
+cache_write = 0
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/wafer.ai/models/Qwen3.6-35B-A3B.toml
+++ b/providers/wafer.ai/models/Qwen3.6-35B-A3B.toml
@@ -1,0 +1,25 @@
+name = "Qwen3.6 35B A3B"
+family = "qwen"
+release_date = "2026-05-11"
+last_updated = "2026-05-11"
+knowledge = "2025-04"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.19
+output = 1.25
+cache_read = 0.02
+cache_write = 0
+
+[limit]
+context = 32_768
+output = 16_384
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds two models to the existing `wafer.ai` provider so OpenCode (and any other consumer of `models.dev/api.json`) can discover them. Both are already exposed publicly on `https://pass.wafer.ai/v1/models` as catalog-visible, openai-compatible serverless slugs, but were missing from the registry — so `opencode` listed only `GLM-5.1` and `Qwen3.5-397B-A17B` for the Wafer provider.

### `Qwen3.6-35B-A3B`
Compact Qwen3.6 MoE on 8×AMD MI355X (NVFP4, ATOM). 32K context window, vision/tools/structured-output capable, serverless-priced at $0.19/M input / $1.25/M output / $0.02/M cache read. See https://wafer.ai/blog/qwen36-mi355x for the deploy detail.

### `Kimi-K2.6`
Wafer's NVFP4 Blackwell deployment of Moonshot's Kimi K2.6 (1T sparse MoE, Kimi vision tower). 262K context window, vision/tools/structured-output capable, serverless-priced at $1.10/M input / $4.80/M output / $0.11/M cache read. See https://wafer.ai/blog/kimi-k26-nvfp4 for the quantization/serving detail.

Both files follow the existing wafer.ai TOML style (family, knowledge cutoff, modalities, etc.) and pass `bun validate` locally.

## Test plan

- [x] `bun validate` succeeds with the two new files
- [x] Verified pricing matches the public wafer-edge model catalog (`services/wafer-edge/models.prod.yaml`) on `wafer-ai/wafer@main`
- [x] Verified slug casing matches the public model IDs returned by `https://pass.wafer.ai/v1/models`

Made with [Cursor](https://cursor.com)