### PR TITLE
fix: modify the deepseek v4 flash/pro price

### DIFF
--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -16,7 +16,7 @@ field = "reasoning_content"
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.028
+cache_read = 0.0028
 
 [limit]
 context = 1_000_000

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -14,9 +14,9 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 1.74
-output = 3.48
-cache_read = 0.145
+input = 0.435
+output = 0.87
+cache_read = 0.003625
 
 [limit]
 context = 1_000_000

--- a/providers/opencode-go/models/deepseek-v4-pro.toml
+++ b/providers/opencode-go/models/deepseek-v4-pro.toml
@@ -14,9 +14,9 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 1.74
-output = 3.48
-cache_read = 0.0145
+input = 0.435
+output = 0.87
+cache_read = 0.003625
 
 [limit]
 context = 1_000_000

--- a/providers/opencode-go/models/deepseek-v4-pro.toml
+++ b/providers/opencode-go/models/deepseek-v4-pro.toml
@@ -14,9 +14,9 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 0.435
-output = 0.87
-cache_read = 0.003625
+input = 1.74
+output = 3.48
+cache_read = 0.0145
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
According to the official documentation, the price of deepseek v4 flash/pro has decreased permanently. And the known provider deepseek and opencod-go matche that.