### PR TITLE
Venice: Update pricing and limits for 4 models

### DIFF
--- a/providers/venice/models/gemini-3-5-flash.toml
+++ b/providers/venice/models/gemini-3-5-flash.toml
@@ -6,14 +6,14 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-05-22"
-last_updated = "2026-05-22"
+last_updated = "2026-05-25"
 open_weights = false
 
 [cost]
-input = 1.8
-output = 11
-cache_read = 0.18
-cache_write = 0.1
+input = 1.55
+output = 9.45
+cache_read = 0.155
+cache_write = 0.086
 
 [limit]
 context = 1_000_000

--- a/providers/venice/models/google-gemma-4-31b-it.toml
+++ b/providers/venice/models/google-gemma-4-31b-it.toml
@@ -6,12 +6,12 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-04-03"
-last_updated = "2026-04-12"
+last_updated = "2026-05-25"
 open_weights = true
 
 [cost]
-input = 0.175
-output = 0.5
+input = 0.155
+output = 0.44
 
 [limit]
 context = 256_000

--- a/providers/venice/models/qwen-3-7-max.toml
+++ b/providers/venice/models/qwen-3-7-max.toml
@@ -5,14 +5,14 @@ reasoning = true
 tool_call = true
 temperature = true
 release_date = "2026-05-22"
-last_updated = "2026-05-22"
+last_updated = "2026-05-25"
 open_weights = false
 
 [cost]
-input = 3.125
-output = 9.375
-cache_read = 0.3125
-cache_write = 3.90625
+input = 2.7
+output = 8.05
+cache_read = 0.27
+cache_write = 3.35
 
 [limit]
 context = 1_000_000

--- a/providers/venice/models/qwen3-5-35b-a3b.toml
+++ b/providers/venice/models/qwen3-5-35b-a3b.toml
@@ -6,7 +6,7 @@ tool_call = true
 structured_output = true
 temperature = true
 release_date = "2026-02-25"
-last_updated = "2026-04-16"
+last_updated = "2026-05-25"
 open_weights = true
 
 [cost]
@@ -16,7 +16,7 @@ cache_read = 0.15625
 
 [limit]
 context = 256_000
-output = 65_536
+output = 16_384
 
 [modalities]
 input = ["text", "image", "video"]


### PR DESCRIPTION
- Reduce input/output/cache prices for gemini-3-5-flash, google-gemma-4-31b-it, and qwen-3-7-max
- Lower max output tokens from 65,536 to 16,384 for qwen3-5-35b-a3b