### PR TITLE
Update Xpersona Frieren Coder limits

### DIFF
--- a/providers/xpersona/models/xpersona-frieren-coder.toml
+++ b/providers/xpersona/models/xpersona-frieren-coder.toml
@@ -1,6 +1,6 @@
 name = "Xpersona Frieren Coder"
 release_date = "2026-05-01"
-last_updated = "2026-05-15"
+last_updated = "2026-05-25"
 attachment = false
 reasoning = true
 temperature = false
@@ -16,8 +16,8 @@ reasoning = 6.00
 cache_read = 0.15
 
 [limit]
-context = 400_000
-output = 128_000
+context = 1_000_000
+output = 384_000
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
## Summary

I'm updating this as the Xpersona maintainer so the registry matches the live public API metadata.

- update `xpersona-frieren-coder` context limit from 400k to 1M
- update output limit from 128k to 384k
- refresh `last_updated` for the metadata change

## Verification

- `https://www.xpersona.co/v1/models` reports `context_length: 1000000` and `max_completion_tokens: 384000`
- `https://www.xpersona.co/v1/pricing` reports `contextTokens: 1000000`, `outputTokens: 384000`, and the same token pricing already in this registry entry