### PR TITLE
Sync routing.run model catalog

### DIFF
--- a/providers/routing-run/models/route/glm-5.1-6bit.toml
+++ b/providers/routing-run/models/route/glm-5.1-6bit.toml
@@ -13,4 +13,4 @@ output = 3.00
 
 [limit]
 context = 202_752
-output = 202_752
+output = 65_536

--- a/providers/routing-run/models/route/glm-5.1.toml
+++ b/providers/routing-run/models/route/glm-5.1.toml
@@ -13,4 +13,4 @@ output = 3.00
 
 [limit]
 context = 202_752
-output = 202_752
+output = 65_536

--- a/providers/routing-run/models/route/mimo-v2.5.toml
+++ b/providers/routing-run/models/route/mimo-v2.5.toml
@@ -1,0 +1,21 @@
+name = "MiMo V2.5"
+attachment = true
+reasoning = true
+
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.45
+output = 1.35
+
+[limit]
+context = 1_000_000
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/routing-run/models/route/qwen3.6-27b-202k.toml
+++ b/providers/routing-run/models/route/qwen3.6-27b-202k.toml
@@ -1,4 +1,4 @@
-name = "Qwen3.6 27B"
+name = "Qwen3.6 27B 202K"
 attachment = false
 reasoning = false
 


### PR DESCRIPTION
Sync routing.run model metadata with the live /v1/models endpoint.

Validated with `bun run validate >/dev/null`.