### PR TITLE
chore: update openai cache rates

### DIFF
--- a/providers/openai/models/gpt-3.5-turbo.toml
+++ b/providers/openai/models/gpt-3.5-turbo.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 0.50
 output = 1.50
-cache_read = 1.25
+cache_read = 0
 
 [limit]
 context = 16_385

--- a/providers/openai/models/gpt-4.1-nano.toml
+++ b/providers/openai/models/gpt-4.1-nano.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 0.10
 output = 0.40
-cache_read = 0.03
+cache_read = 0.025
 
 [limit]
 context = 1047576

--- a/providers/openai/models/gpt-4o-mini.toml
+++ b/providers/openai/models/gpt-4o-mini.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 0.15
 output = 0.60
-cache_read = 0.08
+cache_read = 0.075
 
 [limit]
 context = 128_000

--- a/providers/openai/models/gpt-5-chat-latest.toml
+++ b/providers/openai/models/gpt-5-chat-latest.toml
@@ -13,6 +13,7 @@ open_weights = false
 [cost]
 input = 1.25
 output = 10.00
+cache_read = 0.125
 
 [limit]
 context = 400_000

--- a/providers/openai/models/gpt-5.1.toml
+++ b/providers/openai/models/gpt-5.1.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 1.25
 output = 10.00
-cache_read = 0.13
+cache_read = 0.125
 
 [limit]
 context = 400_000

--- a/providers/openai/models/o4-mini.toml
+++ b/providers/openai/models/o4-mini.toml
@@ -13,7 +13,7 @@ open_weights = false
 [cost]
 input = 1.10
 output = 4.40
-cache_read = 0.28
+cache_read = 0.275
 
 [limit]
 context = 200_000


### PR DESCRIPTION
- updating cache_read rates for openai
- sources in the comments based on https://developers.openai.com/api/docs/pricing
- adding more than 2 decimal places (since we already have it for other models)
https://github.com/anomalyco/models.dev/blob/97c71f16633d9a7e0f672b5a78bd10a08d745e20/providers/deepseek/models/deepseek-v4-flash.toml#L19