### PR TITLE
fix Xiaomi Token Plan model catalog

### DIFF
--- a/providers/xiaomi-token-plan-ams/models/mimo-v2-flash.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2-flash.toml
@@ -1,1 +1,0 @@
-../../xiaomi-token-plan-cn/models/mimo-v2-flash.toml

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,1 @@
+../../xiaomi-token-plan-cn/models/mimo-v2.5-tts-voiceclone.toml

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,1 @@
+../../xiaomi-token-plan-cn/models/mimo-v2.5-tts-voicedesign.toml

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts.toml
@@ -1,0 +1,1 @@
+../../xiaomi-token-plan-cn/models/mimo-v2.5-tts.toml

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-flash.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-flash.toml
@@ -1,7 +1,0 @@
-[extends]
-from = "xiaomi/mimo-v2-flash"
-
-[cost]
-input = 0
-output = 0
-cache_read = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,7 +1,7 @@
-name = "MiMo-V2-TTS"
+name = "MiMo-V2.5-TTS-VoiceClone"
 family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
 attachment = false
 reasoning = false
 tool_call = false

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,7 +1,7 @@
-name = "MiMo-V2-TTS"
+name = "MiMo-V2.5-TTS-VoiceDesign"
 family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
 attachment = false
 reasoning = false
 tool_call = false

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts.toml
@@ -1,7 +1,7 @@
-name = "MiMo-V2-TTS"
+name = "MiMo-V2.5-TTS"
 family = "mimo"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
 attachment = false
 reasoning = false
 tool_call = false

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2-flash.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2-flash.toml
@@ -1,1 +1,0 @@
-../../xiaomi-token-plan-cn/models/mimo-v2-flash.toml

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,1 @@
+../../xiaomi-token-plan-cn/models/mimo-v2.5-tts-voiceclone.toml

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,1 @@
+../../xiaomi-token-plan-cn/models/mimo-v2.5-tts-voicedesign.toml

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts.toml
@@ -1,0 +1,1 @@
+../../xiaomi-token-plan-cn/models/mimo-v2.5-tts.toml


### PR DESCRIPTION
## Summary
- remove unsupported `mimo-v2-flash` from the China, Singapore, and Europe Xiaomi Token Plan providers
- add documented `mimo-v2.5-tts`, `mimo-v2.5-tts-voiceclone`, and `mimo-v2.5-tts-voicedesign` entries for each Token Plan region
- correct the shared `mimo-v2-tts` output limit to the documented 8K tokens

## Source
- Xiaomi Token Plan supported models: https://platform.xiaomimimo.com/docs/en-US/price/tokenplan/subscription
- Xiaomi TTS IDs and limits: https://platform.xiaomimimo.com/docs/en-US/usage-guide/speech-synthesis-v2.5 and https://platform.xiaomimimo.com/docs/en-US/quick-start/model
- Reported upstream in https://github.com/anomalyco/opencode/issues/27695

## Validation
- `bun validate`