### PR TITLE
feat(xiaomi): add TTS models and update V2.5 pricing

### DIFF
--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceClone"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "audio"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceDesign"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2-pro"
-omit = ["cost.context_over_200k", "cost.tiers"]
+omit = ["cost.tiers"]
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5-pro"
-omit = ["cost.context_over_200k", "cost.tiers"]
+omit = ["cost.tiers"]
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5-pro"
-omit = ["cost.tiers"]
+
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceClone"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "audio"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceDesign"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5"
-omit = ["cost.context_over_200k", "cost.tiers"]
+omit = ["cost.tiers"]
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5"
-omit = ["cost.tiers"]
+
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceClone"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "audio"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceDesign"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -10,15 +10,9 @@ knowledge = "2024-12"
 open_weights = true
 
 [cost]
-input = 1
-output = 3
-cache_read = 0.2
-
-[[cost.tiers]]
-tier = { size = 256_000 }
-input = 2.00
-output = 6.00
-cache_read = 0.40
+input = 0.435
+output = 0.87
+cache_read = 0.0036
 
 [limit]
 context = 1_048_576

--- a/providers/xiaomi/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceClone"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "audio"]
+output = ["audio"]

--- a/providers/xiaomi/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceDesign"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi/models/mimo-v2.5-tts.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi/models/mimo-v2.5.toml
+++ b/providers/xiaomi/models/mimo-v2.5.toml
@@ -10,15 +10,9 @@ knowledge = "2024-12"
 open_weights = true
 
 [cost]
-input = 0.4
-output = 2
-cache_read = 0.08
-
-[[cost.tiers]]
-tier = { size = 256_000 }
-input = 0.80
-output = 4.00
-cache_read = 0.16
+input = 0.14
+output = 0.28
+cache_read = 0.0028
 
 [limit]
 context = 1_048_576


### PR DESCRIPTION
## Changes

### Added TTS Models
- `mimo-v2.5-tts` - Standard TTS
- `mimo-v2.5-tts-voiceclone` - Voice cloning TTS
- `mimo-v2.5-tts-voicedesign` - Voice design TTS
- Added to all providers: xiaomi, xiaomi-token-plan-cn, xiaomi-token-plan-sgp, xiaomi-token-plan-ams
- TTS models are currently free (limited time promotion)

### Updated V2.5 Pricing (effective May 27, 2026)
| Model | Input (was) | Input (now) | Output (was) | Output (now) |
|-------|-------------|-------------|--------------|--------------|
| mimo-v2.5-pro | $1.00 | $0.435 | $3.00 | $0.87 |
| mimo-v2.5 | $0.40 | $0.14 | $2.00 | $0.28 |

### References
- [Xiaomi MiMo Pricing](https://platform.xiaomimimo.com/docs/en-US/price/pay-as-you-go)
- [Xiaomi MiMo Models](https://platform.xiaomimimo.com/docs/en-US/quick-start/model)