### PR TITLE
Update Poolside Laguna series models to new context length (OpenRouter)

### DIFF
--- a/providers/openrouter/models/poolside/laguna-m.1:free.toml
+++ b/providers/openrouter/models/poolside/laguna-m.1:free.toml
@@ -1,6 +1,6 @@
 name = "Laguna M.1 (free)"
 release_date = "2026-04-28"
-last_updated = "2026-04-28"
+last_updated = "2026-05-26"
 attachment = false
 reasoning = true
 temperature = true
@@ -16,8 +16,8 @@ input = 0
 output = 0
 
 [limit]
-context = 131_072
-output = 8_192
+context = 262_144
+output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/openrouter/models/poolside/laguna-xs.2:free.toml
+++ b/providers/openrouter/models/poolside/laguna-xs.2:free.toml
@@ -1,6 +1,6 @@
 name = "Laguna XS.2 (free)"
 release_date = "2026-04-28"
-last_updated = "2026-04-28"
+last_updated = "2026-05-26"
 attachment = false
 reasoning = true
 temperature = true
@@ -16,8 +16,8 @@ input = 0
 output = 0
 
 [limit]
-context = 131_072
-output = 8_192
+context = 262_144
+output = 32_768
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Updates `poolside/laguna-m.1:free` and `poolside/laguna-xs.2:free` to 256K context length and 32K max output in line with serving update.

Disclaimer: I work at Poolside

Announcement post: https://poolside.ai/blog/long-context-update-laguna-xs-2-and-m-1