### PR TITLE
Sync NovitaAI models

### DIFF
--- a/providers/novita-ai/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/novita-ai/models/inclusionai/ring-2.6-1t.toml
@@ -1,0 +1,23 @@
+name = "Ring-2.6-1T"
+family = "ring"
+release_date = "2026-05-08"
+last_updated = "2026-05-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.06
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/novita-ai/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/novita-ai/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,0 +1,23 @@
+last_updated = "2026-05-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+
+[extends]
+from = "minimax/MiniMax-M2.7-highspeed"
+
+[cost]
+input = 0.6
+output = 2.4
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/novita-ai/models/qwen/qwen3.7-max.toml
+++ b/providers/novita-ai/models/qwen/qwen3.7-max.toml
@@ -1,0 +1,24 @@
+name = "Qwen3.7-Max"
+family = "qwen"
+release_date = "2026-05-21"
+last_updated = "2026-05-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.25
+output = 3.75
+cache_read = 0.125
+cache_write = 1.5625
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/novita-ai/models/xiaomimimo/mimo-v2-pro.toml
+++ b/providers/novita-ai/models/xiaomimimo/mimo-v2-pro.toml
@@ -1,0 +1,22 @@
+last_updated = "2026-05-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+
+[extends]
+from = "xiaomi/mimo-v2-pro"
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.4
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/novita-ai/models/xiaomimimo/mimo-v2.5-pro.toml
+++ b/providers/novita-ai/models/xiaomimimo/mimo-v2.5-pro.toml
@@ -1,0 +1,22 @@
+last_updated = "2026-05-27"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+
+[extends]
+from = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.4
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add only the selected new NovitaAI models
- no changes to existing NovitaAI model files
- no sync pipeline changes

## Added models
- inclusionai/ring-2.6-1t
- minimax/minimax-m2.7-highspeed
- xiaomimimo/mimo-v2-pro
- xiaomimimo/mimo-v2.5-pro
- qwen/qwen3.7-max

## Inheritance check
- MiniMax M2.7 highspeed extends `minimax/MiniMax-M2.7-highspeed`
- MiMo V2 Pro extends `xiaomi/mimo-v2-pro`
- MiMo V2.5 Pro extends `xiaomi/mimo-v2.5-pro`
- Ring 2.6 1T and Qwen3.7 Max stay full TOMLs because this repo does not have matching canonical providers/models for them