### PR TITLE
CI Scheduled fork upstream ensurance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   deploy:
+    if: github.repository == 'anomalyco/models.dev'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,6 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   deploy:
-    if: github.repository == 'anomalyco/models.dev'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -14,6 +14,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   providers:
+    if: github.repository == 'anomalyco/models.dev'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.providers.outputs.matrix }}
@@ -37,6 +38,7 @@ jobs:
 
   sync:
     needs: providers
+    if: github.repository == 'anomalyco/models.dev'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Problem

Forks of this repository inherit the same GitHub Actions workflows, including the **hourly cron schedule** on `sync-models.yml`. Every hour, each fork (currently 1k forks available) spins up runners and attempts to run the full model sync pipeline: A massive and unnecessary waste of CI resources, with missing CI secrets. It currently generates a ton of failing pipelines for every fork.

Every person who forked the repository will start to get hourly failing CI notification and mail as well, due to missing repository secrets.

People *could* go into their fork's Settings → Actions and disable them, but nobody does.

## Changes

Added `if: github.repository == 'anomalyco/models.dev'` to:

- **`.github/workflows/sync-models.yml`** — both `providers` and `sync` jobs (scheduled cron, the main offender)
- **`.github/workflows/deploy.yml`** — the `deploy` job (push-triggered, but also runs on rebases/force-pushes to `dev` in forks, wasting runners)

This ensures these workflows only execute on the upstream repository.

## Reasoning

- Prevent recurring Action runs on every fork
- Reduce wasted GitHub Actions minutes across the ecosystem
- Eliminate hourly failing CI notifications for fork maintainers
- More polite to the community members who fork the repo
