### PR TITLE
Update routing.run API base URL

### DIFF
--- a/providers/routing-run/provider.toml
+++ b/providers/routing-run/provider.toml
@@ -1,5 +1,5 @@
 name = "routing.run"
 env = ["ROUTING_RUN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-api = "https://api.routing.run/v1"
+api = "https://ai.routing.sh/v1"
 doc = "https://docs.routing.run/api-reference/models"


### PR DESCRIPTION
Update the routing.run provider API base URL to `https://ai.routing.sh/v1`.

Validated with `bun run validate >/dev/null`.