### PR TITLE
feat: add cross-region inference entries for Bedrock for Opus 4.8

### DIFF
--- a/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+name = "Claude Opus 4.8 (AU)"
+
+[extends]
+from = "anthropic/claude-opus-4-8"
+omit = ["experimental.modes.fast"]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+name = "Claude Opus 4.8 (EU)"
+
+[extends]
+from = "anthropic/claude-opus-4-8"
+omit = ["experimental.modes.fast"]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+name = "Claude Opus 4.8 (Global)"
+
+[extends]
+from = "anthropic/claude-opus-4-8"
+omit = ["experimental.modes.fast"]

--- a/providers/amazon-bedrock/models/jp.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+name = "Claude Opus 4.8 (JP)"
+
+[extends]
+from = "anthropic/claude-opus-4-8"
+omit = ["experimental.modes.fast"]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+name = "Claude Opus 4.8 (US)"
+
+[extends]
+from = "anthropic/claude-opus-4-8"
+omit = ["experimental.modes.fast"]


### PR DESCRIPTION
Follows the patterns set by other Anthropic models. This is required to actually run inference with these.