### PR TITLE
feat: add GitLab Agentic Chat Opus 4.8

### DIFF
--- a/providers/gitlab/models/duo-chat-opus-4-8.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-8.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (Claude Opus 4.8)"
+family = "claude-opus"
+release_date = "2026-05-28"
+last_updated = "2026-05-28"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2026-01-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
Adds the Claude Opus 4.8 model for GitLab Duo Agentic Chat.

Mirrors the existing `duo-chat-opus-4-7.toml` definition with:
- 1M context window
- 128k max output (matches GitLab AI Gateway models.yml for Opus 4.8)
- text/image/pdf input, text output
- tool calling + reasoning + attachments enabled