### PR TITLE
Venice: Add Claude Opus 4.8 models

### DIFF
--- a/providers/venice/models/claude-opus-4-8-fast.toml
+++ b/providers/venice/models/claude-opus-4-8-fast.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.8 Fast"
+family = "claude-opus"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-05-28"
+last_updated = "2026-05-28"
+open_weights = false
+
+[cost]
+input = 12
+output = 60
+cache_read = 1.2
+cache_write = 15
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/venice/models/claude-opus-4-8.toml
+++ b/providers/venice/models/claude-opus-4-8.toml
@@ -1,0 +1,24 @@
+name = "Claude Opus 4.8"
+family = "claude-opus"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-05-28"
+last_updated = "2026-05-28"
+open_weights = false
+
+[cost]
+input = 6
+output = 30
+cache_read = 0.6
+cache_write = 7.5
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
- Add claude-opus-4-8.toml (standard pricing)
- Add claude-opus-4-8-fast.toml (fast variant)
- Both: 1M context, image input, Opus 4.8 family