### PR TITLE
feat(llmgateway): add Claude Opus 4.8

### DIFF
--- a/providers/llmgateway/models/claude-opus-4-8.toml
+++ b/providers/llmgateway/models/claude-opus-4-8.toml
@@ -1,0 +1,3 @@
+[extends]
+from = "anthropic/claude-opus-4-8"
+omit = ["experimental.modes.fast"]


### PR DESCRIPTION
Adds **Claude Opus 4.8** to the LLM Gateway provider.

It extends `anthropic/claude-opus-4-8` and omits `experimental.modes.fast`, since LLM Gateway does not expose Anthropic's fast mode — consistent with the existing `claude-opus-4-7` and `claude-opus-4-6` entries.

```toml
[extends]
from = "anthropic/claude-opus-4-8"
omit = ["experimental.modes.fast"]
```

`bun run validate` passes and the model resolves correctly (1M context, 128k output, $5/$25 pricing, fast mode omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)