### PR TITLE
feat(siliconflow-cn): add deepseek-ai/DeepSeek-V4-Pro

### DIFF
--- a/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -1,0 +1,23 @@
+name = "deepseek-ai/DeepSeek-V4-Pro"
+family = "deepseek-thinking"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.145
+
+[limit]
+context = 1_049_000
+output = 393_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds support for `siliconflow-cn/deepseek-ai/DeepSeek-V4-Pro`.

Closes anomalyco/opencode#29494

## Specs
Sourced from [SiliconFlow's model page](https://www.siliconflow.com/models/deepseek-v4-pro) and [DeepSeek API docs](https://api-docs.deepseek.com/quick_start/pricing):

- **Context / output**: 1,049,000 / 393,000 tokens (1M-token context window)
- **Cost (per 1M tokens)**: $1.74 input, $3.48 output, $0.145 cache read
- **Capabilities**: reasoning (thinking modes), tool calls, text in/out
- **Open weights**: true (MIT, 1.6T MoE / 49B activated)
- **Released**: 2026-04-24

## Notes
- `structured_output = false` per SiliconFlow's spec page (lists "Structured Outputs: Not supported"), though sibling DeepSeek entries set it `true`.
- `bun validate` passes.