### PR TITLE
Rename Xpersona Frieren display name

### DIFF
--- a/providers/xpersona/models/xpersona-frieren-coder.toml
+++ b/providers/xpersona/models/xpersona-frieren-coder.toml
@@ -1,4 +1,4 @@
-name = "Xpersona Frieren Coder"
+name = "Xpersona Frieren 1"
 release_date = "2026-05-01"
 last_updated = "2026-05-25"
 attachment = false


### PR DESCRIPTION
## Summary
- update Xpersona's public model display name from "Xpersona Frieren Coder" to "Xpersona Frieren 1"
- keep the model id `xpersona-frieren-coder` unchanged for compatibility

## Testing
- not run; metadata-only TOML change
