### PR TITLE
Add Step 3.7 Flash model to NVIDIA provider

### DIFF
--- a/providers/nvidia/models/stepfun-ai/step-3.7-flash.toml
+++ b/providers/nvidia/models/stepfun-ai/step-3.7-flash.toml
@@ -1,0 +1,20 @@
+name = "Step 3.7 Flash"
+release_date = "2026-05-28"
+last_updated = "2026-05-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 256_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceClone"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "audio"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceDesign"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi-token-plan-ams/models/mimo-v2.5-tts.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2-pro"
-omit = ["cost.context_over_200k", "cost.tiers"]
+omit = ["cost.tiers"]
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5-pro"
-omit = ["cost.context_over_200k", "cost.tiers"]
+omit = ["cost.tiers"]
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5-pro"
-omit = ["cost.tiers"]
+
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceClone"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "audio"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceDesign"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5"
-omit = ["cost.context_over_200k", "cost.tiers"]
+omit = ["cost.tiers"]
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
@@ -1,6 +1,6 @@
 [extends]
 from = "xiaomi/mimo-v2.5"
-omit = ["cost.tiers"]
+
 
 [cost]
 input = 0

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceClone"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "audio"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceDesign"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi-token-plan-sgp/models/mimo-v2.5-tts.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -10,15 +10,9 @@ knowledge = "2024-12"
 open_weights = true
 
 [cost]
-input = 1
-output = 3
-cache_read = 0.2
-
-[[cost.tiers]]
-tier = { size = 256_000 }
-input = 2.00
-output = 6.00
-cache_read = 0.40
+input = 0.435
+output = 0.87
+cache_read = 0.0036
 
 [limit]
 context = 1_048_576

--- a/providers/xiaomi/models/mimo-v2.5-tts-voiceclone.toml
+++ b/providers/xiaomi/models/mimo-v2.5-tts-voiceclone.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceClone"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text", "audio"]
+output = ["audio"]

--- a/providers/xiaomi/models/mimo-v2.5-tts-voicedesign.toml
+++ b/providers/xiaomi/models/mimo-v2.5-tts-voicedesign.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS-VoiceDesign"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi/models/mimo-v2.5-tts.toml
+++ b/providers/xiaomi/models/mimo-v2.5-tts.toml
@@ -1,0 +1,21 @@
+name = "MiMo-V2.5-TTS"
+family = "mimo"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/xiaomi/models/mimo-v2.5.toml
+++ b/providers/xiaomi/models/mimo-v2.5.toml
@@ -10,15 +10,9 @@ knowledge = "2024-12"
 open_weights = true
 
 [cost]
-input = 0.4
-output = 2
-cache_read = 0.08
-
-[[cost.tiers]]
-tier = { size = 256_000 }
-input = 0.80
-output = 4.00
-cache_read = 0.16
+input = 0.14
+output = 0.28
+cache_read = 0.0028
 
 [limit]
 context = 1_048_576


### PR DESCRIPTION
## Summary
Adds StepFun AI's Step 3.7 Flash model to the NVIDIA provider in models.dev.

## Model Details
- **Name**: Step 3.7 Flash
- **Architecture**: Sparse Mixture-of-Experts (198B total params, ~11B active per token)
- **Context Window**: 256K tokens
- **Modalities**: Text and image input, text output
- **License**: Apache 2.0

## Key Features
- Multimodal reasoning (text + image)
- Tool calling support
- Attachment support
- Reasoning capabilities
- 256K context window with sliding window attention

## Source
- [NVIDIA Build](https://build.nvidia.com/stepfun-ai/step-3.7-flash)
- [HuggingFace](https://huggingface.co/stepfun-ai/Step-3.7-Flash)
- [NVIDIA API Documentation](https://docs.api.nvidia.com/nim/reference/stepfun-ai-step-3-7-flash)

## Changes
- Added 