### PR TITLE
Add Step 3.7 Flash model to NVIDIA provider

### DIFF
--- a/providers/nvidia/models/stepfun-ai/step-3.7-flash.toml
+++ b/providers/nvidia/models/stepfun-ai/step-3.7-flash.toml
@@ -1,0 +1,20 @@
+name = "Step 3.7 Flash"
+release_date = "2026-05-28"
+last_updated = "2026-05-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 256_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Adds StepFun AI's Step 3.7 Flash model to the NVIDIA provider.

## Model Details
- **Name**: Step 3.7 Flash
- **Architecture**: Sparse Mixture-of-Experts (198B total, ~11B active per token)
- **Context Window**: 256K tokens
- **Input**: Text + Image
- **Output**: Text
- **License**: Apache 2.0

## Key Features
- Multimodal reasoning (text + image input)
- Tool calling support
- 256K context with 3:1 sliding window attention
- MTP-3 acceleration (100-300 tok/s)

## References
- [NVIDIA Build](https://build.nvidia.com/stepfun-ai/step-3.7-flash)
- [HuggingFace](https://huggingface.co/stepfun-ai/Step-3.7-Flash)
- [API Docs](https://docs.api.nvidia.com/nim/reference/stepfun-ai-step-3-7-flash)

## Changes
- Added `providers/nvidia/models/stepfun-ai/step-3.7-flash.toml`