### PR TITLE
feat(cloudflare-ai-gateway): add opus 4.8

### DIFF
--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-8.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-8.toml
@@ -1,0 +1,3 @@
+[extends]
+from = "anthropic/claude-opus-4-8"
+omit = ["experimental.modes.fast"]


### PR DESCRIPTION
Cloudflare's AI Gateway supports Opus 4.8 now