### PR TITLE
Add Xpersona A_BETTER_YOU

### DIFF
--- a/providers/xpersona/models/xpersona-a-better-you.toml
+++ b/providers/xpersona/models/xpersona-a-better-you.toml
@@ -1,0 +1,25 @@
+name = "Xpersona A_BETTER_YOU"
+release_date = "2026-05-29"
+last_updated = "2026-05-29"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-12-30"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 18.00
+reasoning = 18.00
+cache_read = 0.30
+
+[limit]
+context = 1_000_000
+input = 872_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/xpersona/models/xpersona-frieren-coder.toml
+++ b/providers/xpersona/models/xpersona-frieren-coder.toml
@@ -1,4 +1,4 @@
-name = "Xpersona Frieren Coder"
+name = "Xpersona Frieren 1"
 release_date = "2026-05-01"
 last_updated = "2026-05-25"
 attachment = false


### PR DESCRIPTION
## Summary
- add xpersona-a-better-you to the Xpersona provider catalog
- list GPT-5.5-style capabilities, including reasoning, tool calling, structured output, attachments, image/PDF input, and premium pricing
- rename the existing Frieren display label to Xpersona Frieren 1

## Notes
- Xpersona API base remains https://www.xpersona.co/v1
- Public model id: xpersona-a-better-you
