### PR TITLE
feat(minimax): add MiniMax-M3 to minimax and minimax-cn providers

### DIFF
--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-05-21"
+last_updated = "2026-05-21"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 512_000
+output = 196_608
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-05-21"
+last_updated = "2026-05-21"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 512_000
+output = 196_608
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## What

Adds the new flagship `MiniMax-M3` model entry to both `minimax` (international) and `minimax-cn` (China) providers.

## M3 spec

| field | value |
|---|---|
| context | 512_000 |
| output | 196_608 (server hard cap) |
| attachment / multimodal | **true** — text + image input |
| reasoning | true (Anthropic-style thinking blocks) |
| tool_call | true |
| API | Anthropic Messages + OpenAI chat compatible (same endpoints as M2.7) |

## Why this matters for downstream consumers

Tools that read this catalog (Hermes Agent, OpenClaw, opencode, kilo, vercel-ai-sdk wrappers, etc.) currently default to M2.x context windows and text-only modalities for any unknown minimax model. Without this entry, M3 users get silent image stripping and 204K-cap behavior in those tools.

## Files

```
providers/minimax/models/MiniMax-M3.toml      (new)
providers/minimax-cn/models/MiniMax-M3.toml   (new)
```

## Verified

- `bun ./packages/core/script/validate.ts` exits 0 with both new entries serialized correctly (attachment: true, modalities.input: ["text","image"], limit.context: 512000, limit.output: 196608).

## Notes

- Pricing fields placeholder = M2.7 prices. Will update once final M3 pricing is published.
- This PR only adds M3. M2.x `attachment` flag and other historical entries are intentionally untouched.