### PR TITLE
Ensure provider names are unique

### DIFF
--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -81,6 +81,19 @@ export async function generate(directory: string) {
     result[providerID] = provider.data;
   }
 
+  const nameToProviderID = new Map<string, string>();
+  for (const provider of Object.values(result)) {
+    const nameKey = provider.name.toLowerCase();
+    const existingID = nameToProviderID.get(nameKey);
+    if (existingID !== undefined) {
+      throw new Error(
+        `Duplicate provider name "${provider.name}" used by both "${existingID}" and "${provider.id}". Provider names must be unique.`,
+        { cause: { providerIDs: [existingID, provider.id], name: provider.name } },
+      );
+    }
+    nameToProviderID.set(nameKey, provider.id);
+  }
+
   for (const pendingModel of extendsModels) {
     const [providerID, modelID] = pendingModel.model.extends.from.split("/");
     const baseModel = result[providerID]?.models[modelID];

--- a/providers/stepfun/provider.toml
+++ b/providers/stepfun/provider.toml
@@ -1,4 +1,4 @@
-name = "StepFun"
+name = "StepFun (China)"
 env = ["STEPFUN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
 doc = "https://platform.stepfun.com/docs/zh/overview/concept"


### PR DESCRIPTION
## Summary

Fixes #1906 — provider names were unique in practice until a second provider with the name "StepFun" was added in #1814.

## Changes

- **Rename the China StepFun provider** to `"StepFun (China)"`, keeping the international platform as `"StepFun"`. This follows the existing `Alibaba` / `Alibaba (China)` convention.
  - `providers/stepfun/` uses the `.com` domain and Chinese (`docs/zh/`) docs → China variant.
  - `providers/stepfun-ai/` uses the `.ai` domain and English (`docs/en/`) docs → international.
- **Add validation** in `generate()` so that two providers sharing a (case-insensitive) name now fail validation, preventing this from happening again. The error reports both conflicting provider IDs:
  ```
  Duplicate provider name "StepFun" used by both "stepfun" and "stepfun-ai". Provider names must be unique.
  ```
  Case-insensitive matching mirrors the unique index used by the downstream [modelsdotdev-python](https://github.com/vercel-labs/modelsdotdev-python) library described in the issue.

## Verification

- `bun validate` passes with the rename in place.
- Temporarily reverting the name back to `"StepFun"` makes `bun validate` fail with the new duplicate-name error.
