### PR TITLE
feat: add FreeModel.dev provider

### DIFF
--- a/providers/freemodel/logo.svg
+++ b/providers/freemodel/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm0 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16zm-1.5 10.5L7 11l1.5-1.5 2 2L16 6l1.5 1.5-7 7z"/></svg>

--- a/providers/freemodel/models/gpt-5.3-codex.toml
+++ b/providers/freemodel/models/gpt-5.3-codex.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.3 Codex (Free)"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-03"
+release_date = "2025-01-01"
+last_updated = "2025-03-01"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/freemodel/models/gpt-5.4-mini.toml
+++ b/providers/freemodel/models/gpt-5.4-mini.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.4 Mini (Free)"
+attachment = true
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-06"
+release_date = "2025-04-01"
+last_updated = "2025-06-01"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/freemodel/models/gpt-5.4.toml
+++ b/providers/freemodel/models/gpt-5.4.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.4 (Free)"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-06"
+release_date = "2025-04-01"
+last_updated = "2025-06-01"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/freemodel/models/gpt-5.5.toml
+++ b/providers/freemodel/models/gpt-5.5.toml
@@ -1,0 +1,23 @@
+name = "GPT-5.5 (Free)"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+knowledge = "2025-12"
+release_date = "2025-06-01"
+last_updated = "2025-12-01"
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 131072
+input = 131072
+output = 16384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/freemodel/provider.toml
+++ b/providers/freemodel/provider.toml
@@ -1,0 +1,5 @@
+name = "FreeModel"
+npm = "@ai-sdk/openai-compatible"
+env = ["FREEMODEL_API_KEY"]
+api = "https://api.freemodel.dev/v1"
+doc = "https://freemodel.dev"


### PR DESCRIPTION
Add FreeModel.dev (https://freemodel.dev) as a provider.

FreeModel.dev is a free API proxy that provides access to AI models through an OpenAI-compatible endpoint.

Provider details:
- npm: @ai-sdk/openai-compatible
- API: https://api.freemodel.dev/v1
- Env: FREEMODEL_API_KEY
- Models: gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex (all free)