### PR TITLE
feat: update Wafer provider models

### DIFF
--- a/providers/wafer.ai/models/Kimi-K2.6.toml
+++ b/providers/wafer.ai/models/Kimi-K2.6.toml
@@ -1,7 +1,7 @@
-name = "Kimi K2.6"
+name = "Kimi-K2.6"
 family = "kimi"
 release_date = "2026-05-13"
-last_updated = "2026-05-13"
+last_updated = "2026-05-30"
 knowledge = "2025-01"
 attachment = true
 reasoning = true
@@ -11,9 +11,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 1.10
-output = 4.80
-cache_read = 0.11
+input = 0.88
+output = 3.84
+cache_read = 0.09
 cache_write = 0
 
 [limit]
@@ -21,5 +21,5 @@ context = 262_144
 output = 65_536
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video"]
 output = ["text"]

--- a/providers/wafer.ai/models/Qwen3.5-397B-A17B.toml
+++ b/providers/wafer.ai/models/Qwen3.5-397B-A17B.toml
@@ -1,7 +1,7 @@
-name = "Qwen3.5 397B A17B"
+name = "Qwen3.5-397B-A17B"
 family = "qwen"
 release_date = "2026-02-16"
-last_updated = "2026-02-16"
+last_updated = "2026-05-30"
 knowledge = "2025-04"
 attachment = true
 reasoning = true
@@ -11,9 +11,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0
-output = 0
-cache_read = 0
+input = 0.48
+output = 2.88
+cache_read = 0.05
 cache_write = 0
 
 [limit]

--- a/providers/wafer.ai/models/Qwen3.6-35B-A3B.toml
+++ b/providers/wafer.ai/models/Qwen3.6-35B-A3B.toml
@@ -1,7 +1,7 @@
-name = "Qwen3.6 35B A3B"
+name = "Qwen3.6-35B-A3B"
 family = "qwen"
 release_date = "2026-05-11"
-last_updated = "2026-05-11"
+last_updated = "2026-05-30"
 knowledge = "2025-04"
 attachment = true
 reasoning = true
@@ -11,14 +11,15 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.19
-output = 1.25
+input = 0.15
+output = 1.00
 cache_read = 0.02
 cache_write = 0
 
 [limit]
-context = 32_768
-output = 16_384
+context = 256_000
+input = 229_376
+output = 65_536
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/wafer.ai/models/deepseek-v4-flash.toml
+++ b/providers/wafer.ai/models/deepseek-v4-flash.toml
@@ -1,0 +1,28 @@
+name = "DeepSeek V4 Flash"
+family = "deepseek-flash"
+release_date = "2026-04-24"
+last_updated = "2026-05-30"
+knowledge = "2025-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.01
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/wafer.ai/models/deepseek-v4-pro.toml
+++ b/providers/wafer.ai/models/deepseek-v4-pro.toml
@@ -1,0 +1,28 @@
+name = "DeepSeek V4 Pro"
+family = "deepseek-thinking"
+release_date = "2026-04-24"
+last_updated = "2026-05-30"
+knowledge = "2025-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.02
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/wafer.ai/models/qwen3.7-max.toml
+++ b/providers/wafer.ai/models/qwen3.7-max.toml
@@ -1,24 +1,23 @@
-name = "GLM-5.1"
-family = "glm"
-release_date = "2026-04-07"
+name = "Qwen3.7-Max"
+family = "qwen3.7-max"
+release_date = "2026-05-21"
 last_updated = "2026-05-30"
-knowledge = "2025-04"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = true
+open_weights = false
 
 [cost]
-input = 1.20
-output = 3.60
-cache_read = 0.12
+input = 5.00
+output = 15.00
+cache_read = 0.50
 cache_write = 0
 
 [limit]
-context = 202_752
-output = 131_072
+context = 256_000
+output = 65_536
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
## What changed

Updates the Wafer provider from the current `https://pass.wafer.ai/v1/models` response and follow-up live API checks.

- Adds `deepseek-v4-flash`, `deepseek-v4-pro`, and `qwen3.7-max`
- Updates pricing, cache-read pricing, context/input/output limits, and `last_updated` values
- Uses live `/v1/chat/completions` behavior for fields where `/v1/models` disagreed with runtime behavior

## How I checked it

I fetched `/v1/models` with a Wafer Serverless API key, then tested the affected models through `/v1/chat/completions`.

The runtime checks covered text completion, tool calling, reasoning output, image input, video input, and large text prompts.

Findings that changed the model files:

- Qwen models returned `reasoning_content` even when `/v1/models` reported `reasoning: false`.
- Kimi and Qwen accepted image and video inputs. The video check used a small MP4 with a known code in the frame.
- DeepSeek V4 returned no reasoning by default, but did return `reasoning_content` when the request included `reasoning_effort`. Streaming responses exposed it as `delta.reasoning_content`.
- `Qwen3.6-35B-A3B` reports `256000` context in `/v1/models`. A full-context streaming probe with `enable_thinking=false` returned `190464` prompt tokens, `65536` completion tokens, and `256000` total tokens with `finish_reason: "length"`.
- Default reasoning-mode large prompts for `Qwen3.6-35B-A3B` rejected with `Range of input length should be [1, 229376]`, so the model file keeps `context = 256_000`, adds `input = 229_376`, and keeps `output = 65_536`.

## Validation

- `bun validate`
