### PR TITLE
feat(zhipuai-coding-plan): add glm-4.6v symlink from zai

### DIFF
--- a/providers/zhipuai-coding-plan/models/glm-4.6v.toml
+++ b/providers/zhipuai-coding-plan/models/glm-4.6v.toml
@@ -1,0 +1,1 @@
+../../zai/models/glm-4.6v.toml


### PR DESCRIPTION
This is the only multimodal model supported in the zhipuai-coding-plan, which is very useful for coding.