### PR TITLE
Add Tuning Engines provider catalog

### DIFF
--- a/providers/tuning-engines/logo.svg
+++ b/providers/tuning-engines/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 2.5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 12 2.5Zm0 3a6.5 6.5 0 1 1-6.5 6.5A6.51 6.51 0 0 1 12 5.5Zm0 2.25a4.25 4.25 0 1 0 4.25 4.25A4.26 4.26 0 0 0 12 7.75Z"/>
+  <path d="M11 9h2v6h-2zM9 11h6v2H9z"/>
+</svg>

--- a/providers/tuning-engines/models/auto.toml
+++ b/providers/tuning-engines/models/auto.toml
@@ -1,0 +1,22 @@
+name = "Tuning Engines Auto"
+family = "auto"
+release_date = "2026-01-01"
+last_updated = "2026-05-30"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/tuning-engines/models/auto.toml
+++ b/providers/tuning-engines/models/auto.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-01"
 last_updated = "2026-05-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/tuning-engines/models/claude-sonnet-4-5.toml
+++ b/providers/tuning-engines/models/claude-sonnet-4-5.toml
@@ -1,6 +1,6 @@
 temperature = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 
-[extends]
-from = "anthropic/claude-sonnet-4-5"
+base_model = "anthropic/claude-sonnet-4-5"

--- a/providers/tuning-engines/models/claude-sonnet-4-5.toml
+++ b/providers/tuning-engines/models/claude-sonnet-4-5.toml
@@ -1,0 +1,6 @@
+temperature = true
+tool_call = true
+structured_output = true
+
+[extends]
+from = "anthropic/claude-sonnet-4-5"

--- a/providers/tuning-engines/models/gemini-2.5-flash.toml
+++ b/providers/tuning-engines/models/gemini-2.5-flash.toml
@@ -1,6 +1,6 @@
 temperature = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 
-[extends]
-from = "google/gemini-2.5-flash"
+base_model = "google/gemini-2.5-flash"

--- a/providers/tuning-engines/models/gemini-2.5-flash.toml
+++ b/providers/tuning-engines/models/gemini-2.5-flash.toml
@@ -1,0 +1,6 @@
+temperature = true
+tool_call = true
+structured_output = true
+
+[extends]
+from = "google/gemini-2.5-flash"

--- a/providers/tuning-engines/models/gpt-4o.toml
+++ b/providers/tuning-engines/models/gpt-4o.toml
@@ -2,5 +2,4 @@ temperature = true
 tool_call = true
 structured_output = true
 
-[extends]
-from = "openai/gpt-4o"
+base_model = "openai/gpt-4o"

--- a/providers/tuning-engines/models/gpt-4o.toml
+++ b/providers/tuning-engines/models/gpt-4o.toml
@@ -1,0 +1,6 @@
+temperature = true
+tool_call = true
+structured_output = true
+
+[extends]
+from = "openai/gpt-4o"

--- a/providers/tuning-engines/models/gpt-5.2.toml
+++ b/providers/tuning-engines/models/gpt-5.2.toml
@@ -1,0 +1,6 @@
+temperature = false
+tool_call = true
+structured_output = true
+
+[extends]
+from = "openai/gpt-5.2"

--- a/providers/tuning-engines/models/gpt-5.2.toml
+++ b/providers/tuning-engines/models/gpt-5.2.toml
@@ -1,6 +1,6 @@
 temperature = false
+reasoning_options = []
 tool_call = true
 structured_output = true
 
-[extends]
-from = "openai/gpt-5.2"
+base_model = "openai/gpt-5.2"

--- a/providers/tuning-engines/models/kimi-k2.6.toml
+++ b/providers/tuning-engines/models/kimi-k2.6.toml
@@ -1,6 +1,6 @@
 temperature = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 
-[extends]
-from = "moonshotai/kimi-k2.6"
+base_model = "moonshotai/kimi-k2.6"

--- a/providers/tuning-engines/models/kimi-k2.6.toml
+++ b/providers/tuning-engines/models/kimi-k2.6.toml
@@ -1,0 +1,6 @@
+temperature = true
+tool_call = true
+structured_output = true
+
+[extends]
+from = "moonshotai/kimi-k2.6"

--- a/providers/tuning-engines/provider.toml
+++ b/providers/tuning-engines/provider.toml
@@ -1,0 +1,5 @@
+name = "Tuning Engines"
+env = ["TUNING_ENGINES_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.tuningengines.com/v1"
+doc = "https://app.tuningengines.com/docs/inference-api"


### PR DESCRIPTION
## Summary

Adds Tuning Engines as an OpenAI-compatible provider in the Models.dev catalog.

## Why this belongs here

Tuning Engines is a governed AI control plane for teams that already use OpenAI-compatible clients, coding agents, and workflow frameworks. The runtime endpoint is OpenAI-compatible, so tools that consume Models.dev can configure it with:

- provider: Tuning Engines
- base URL: `https://api.tuningengines.com/v1`
- API key env: `TUNING_ENGINES_API_KEY`

The useful distinction for Models.dev users is that Tuning Engines is not trying to replace the model/client framework. It sits between the app and the selected model so teams can centralize tenant keys, model routing, RBAC, guardrails, audit logs, traces, approvals, and usage/cost controls.

I kept the model list small and representative:

- `auto` for tenant-configured routing
- common OpenAI/Anthropic/Google/Kimi aliases that a tenant may enable in their catalog

Actual model availability remains controlled by the tenant's Tuning Engines catalog and role permissions.

## Validation

- `bun install`
- `bun run validate`
