### PR TITLE
fix(bedrock): correct EU cross-region pricing for Claude Opus and Sonnet models

### DIFF
--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
@@ -4,3 +4,9 @@ structured_output = true
 [extends]
 from = "anthropic/claude-opus-4-6"
 omit = ["experimental.modes.fast"]
+
+[cost]
+input = 5.50
+output = 27.50
+cache_read = 0.55
+cache_write = 6.875

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-7.toml
@@ -10,10 +10,10 @@ knowledge = "2026-01-31"
 open_weights = false
 
 [cost]
-input = 5.00
-output = 25.00
-cache_read = 0.50
-cache_write = 6.25
+input = 5.50
+output = 27.50
+cache_read = 0.55
+cache_write = 6.875
 
 [limit]
 context = 1_000_000

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-8.toml
@@ -3,3 +3,9 @@ name = "Claude Opus 4.8 (EU)"
 [extends]
 from = "anthropic/claude-opus-4-8"
 omit = ["experimental.modes.fast"]
+
+[cost]
+input = 5.50
+output = 27.50
+cache_read = 0.55
+cache_write = 6.875

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -11,10 +11,10 @@ knowledge = "2025-07-31"
 open_weights = false
 
 [cost]
-input = 3.00
-output = 15.00
-cache_read = 0.30
-cache_write = 3.75
+input = 3.30
+output = 16.50
+cache_read = 0.33
+cache_write = 4.125
 
 [limit]
 context = 200_000

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
@@ -3,3 +3,9 @@ structured_output = true
 
 [extends]
 from = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3.30
+output = 16.50
+cache_read = 0.33
+cache_write = 4.125


### PR DESCRIPTION
## Summary

AWS Bedrock EU (Europe/London) cross-region inference has a 10% premium over the base Anthropic pricing. The EU models were incorrectly using the same pricing as the US/base models.

## Affected models

- `eu.anthropic.claude-opus-4-6-v1`
- `eu.anthropic.claude-opus-4-7`
- `eu.anthropic.claude-opus-4-8`
- `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`
- `eu.anthropic.claude-sonnet-4-6`

## Corrected pricing (per 1M tokens)

### Opus models

| Field | Before | After |
|-------|--------|-------|
| Input | $5.00 | $5.50 |
| Output | $25.00 | $27.50 |
| Cache read | $0.50 | $0.55 |
| Cache write | $6.25 | $6.875 |

### Sonnet models

| Field | Before | After |
|-------|--------|-------|
| Input | $3.00 | $3.30 |
| Output | $15.00 | $16.50 |
| Cache read | $0.30 | $0.33 |
| Cache write | $3.75 | $4.125 |

## Source

[AWS Bedrock pricing page](https://aws.amazon.com/bedrock/pricing/) - Europe (London) region, Geo and In-region Cross-region Inference section.