### PR TITLE
feat: add MiniMax-M3 model with 1M token context window

### DIFF
--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.35
+output = 1.40
+cache_read = 0.07
+cache_write = 0.40
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Add MiniMax-M3 model to the models.dev catalog.

## Model Details

| Field | Value |
|-------|-------|
| **Name** | MiniMax-M3 |
| **API ID** | minimax-m3 |
| **Context Window** | 1,000,000 tokens |
| **Release Date** | June 2026 |

## Capabilities

- Agentic reasoning
- Tool use / function calling
- Coding
- Long-context tasks (1M token context)

## References

- MiniMax API Docs: https://platform.minimax.io/docs/api-reference/api-overview
- Community example with minimax-m3: https://github.com/MiniMax-AI/MiniMax-01/issues/69

## Notes

-  - MiniMax-M3 appears to be API-only (no public weights repo yet, unlike M2/M2.1)
- Pricing is estimated based on M2.7 structure; please verify with official MiniMax pricing before merge
- Uses the existing MiniMax provider configuration (minimax.io API endpoint)