### PR TITLE
fix vercel claude opus 4.1 symlink

### DIFF
--- a/providers/vercel/models/anthropic/claude-opus-4.1.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.1.toml
@@ -1,1 +1,1 @@
-../../../anthropic/models/claude-opus-4-20250514.toml
+../../../anthropic/models/claude-opus-4-1-20250805.toml


### PR DESCRIPTION
## Summary

- repoint the Vercel `anthropic/claude-opus-4.1` symlink to the Claude Opus 4.1 canonical model
- prevent generated Vercel metadata from inheriting Claude Opus 4 data

## Validation

- `bun validate`

Fixes #1924