### PR TITLE
feat: add MiniMax-M3 and MiniMax-M3-highspeed models

### DIFF
--- a/providers/minimax/models/MiniMax-M3-highspeed.toml
+++ b/providers/minimax/models/MiniMax-M3-highspeed.toml
@@ -1,0 +1,24 @@
+name = "MiniMax-M3-highspeed"
+family = "minimax"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 2.40
+cache_read = 0.12
+cache_write = 0.75
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -1,0 +1,24 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add MiniMax M3 models released on 2026-06-01.

## Changes
- Add `MiniMax-M3` and `MiniMax-M3-highspeed` models to the minimax provider
- Context window: 1M tokens (1,048,576)
- Multimodal support: text, image, video
- Tool calling and reasoning support

## Model Details
- **MiniMax-M3**: Standard version with 1M context window
- **MiniMax-M3-highspeed**: High-speed version with same capabilities

Both models support:
- Attachment (multimodal input)
- Reasoning
- Tool calling
- Structured output
- Open weights