### PR TITLE
fix: update Wafer.ai pricing

### DIFF
--- a/providers/wafer.ai/models/GLM-5.1.toml
+++ b/providers/wafer.ai/models/GLM-5.1.toml
@@ -1,7 +1,7 @@
 name = "GLM-5.1"
 family = "glm"
 release_date = "2026-04-07"
-last_updated = "2026-05-30"
+last_updated = "2026-06-01"
 knowledge = "2025-04"
 attachment = false
 reasoning = true
@@ -11,9 +11,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 1.20
-output = 3.60
-cache_read = 0.12
+input = 1.00
+output = 3.20
+cache_read = 0.10
 cache_write = 0
 
 [limit]

--- a/providers/wafer.ai/models/Kimi-K2.6.toml
+++ b/providers/wafer.ai/models/Kimi-K2.6.toml
@@ -1,7 +1,7 @@
 name = "Kimi-K2.6"
 family = "kimi"
 release_date = "2026-05-13"
-last_updated = "2026-05-30"
+last_updated = "2026-06-01"
 knowledge = "2025-01"
 attachment = true
 reasoning = true
@@ -11,9 +11,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.88
-output = 3.84
-cache_read = 0.09
+input = 0.68
+output = 3.15
+cache_read = 0.07
 cache_write = 0
 
 [limit]

--- a/providers/wafer.ai/models/Qwen3.5-397B-A17B.toml
+++ b/providers/wafer.ai/models/Qwen3.5-397B-A17B.toml
@@ -1,7 +1,7 @@
 name = "Qwen3.5-397B-A17B"
 family = "qwen"
 release_date = "2026-02-16"
-last_updated = "2026-05-30"
+last_updated = "2026-06-01"
 knowledge = "2025-04"
 attachment = true
 reasoning = true
@@ -11,9 +11,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.48
-output = 2.88
-cache_read = 0.05
+input = 0.43
+output = 2.60
+cache_read = 0.04
 cache_write = 0
 
 [limit]


### PR DESCRIPTION
## What changed

Wafer.ai just updated their pricing for three models:

- `Kimi-K2.6`: $0.68 input / $3.15 output / $0.07 cache read per 1M tokens
- `GLM-5.1`: $1.00 input / $3.20 output / $0.10 cache read per 1M tokens
- `Qwen3.5-397B-A17B`: $0.43 input / $2.60 output / $0.04 cache read per 1M tokens


