### PR TITLE
feat(minimax-coding-plan): add MiniMax-M3 token plan models

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -1,0 +1,25 @@
+name = "MiniMax-M3"
+family = "minimax-m3"
+release_date = "2026-05-31"
+last_updated = "2026-05-31"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 512_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -1,0 +1,25 @@
+name = "MiniMax-M3"
+family = "minimax-m3"
+release_date = "2026-05-31"
+last_updated = "2026-05-31"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 512_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+


### PR DESCRIPTION
## Summary

Adds `MiniMax-M3` to the MiniMax token-plan providers:

- `providers/minimax-coding-plan/models/MiniMax-M3.toml`
- `providers/minimax-cn-coding-plan/models/MiniMax-M3.toml`

This keeps the token-plan provider catalogs in parity with the M3 model metadata already present for OpenCode-specific MiniMax M3 routes, while preserving token-plan zero-cost catalog entries.

## Why

MiniMax M3 is available to token-plan users, but `minimax-coding-plan` currently only lists M2.x models. Downstream tools that read Models.dev, including OpenCode, therefore cannot select `minimax-coding-plan/MiniMax-M3` without a local registry override.

Local OpenCode smoke with an ephemeral Models.dev override containing this entry:

```bash
OPENCODE_MODELS_PATH=/tmp/opencode-models-minimax-m3.json \
  opencode run -m minimax-coding-plan/MiniMax-M3 \
  "Reply with exactly: MINIMAX_CODING_PLAN_M3_DIRECT_SMOKE_OK"
```

Output:

```text
> build · MiniMax-M3
MINIMAX_CODING_PLAN_M3_DIRECT_SMOKE_OK
```

## Verification

```bash
bun validate
bun ./packages/core/script/validate.ts > /tmp/models-dev-minimax-m3-final-validate.json
jq -r '.["minimax-coding-plan"].models["MiniMax-M3"].id, .["minimax-cn-coding-plan"].models["MiniMax-M3"].id' /tmp/models-dev-minimax-m3-final-validate.json
git diff --check
```

The generated catalog includes `MiniMax-M3` for both token-plan providers.
