### PR TITLE
feat(minimax): add MiniMax-M3 to minimax and minimax-cn providers

### DIFF
--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -1,0 +1,22 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-05-21"
+last_updated = "2026-05-21"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 2.40
+cache_read = 0.12
+
+[limit]
+context = 512_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -1,0 +1,22 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-05-21"
+last_updated = "2026-05-21"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 2.40
+cache_read = 0.12
+
+[limit]
+context = 512_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary
Add the MiniMax **M3** flagship to the minimax and minimax-cn provider catalogs.

- New `MiniMax-M3.toml` in both `providers/minimax/models/` and `providers/minimax-cn/models/`.
- 512K context, 131,072 max output, **native multimodal** (`input = ["text", "image"]`, `attachment = true`), reasoning, tool_call.
- Pricing (USD per M tokens): input 0.60 / output 2.40 / cache_read 0.12 / cache_write 0.75.
- Fields mirror the existing M2.7 entry.

Supersedes #1907 (closed; its head commit was rewritten). Note vs the other open M3 PRs: this one correctly marks M3 as multimodal (attachment=true, image input) and covers both the global (minimax) and CN (minimax-cn) providers.

## Test
- `bun run validate` passes (M3 appears in both providers' validated catalog).