### PR TITLE
Venice: Add MiniMax M3 model

### DIFF
--- a/providers/venice/models/minimax-m3.toml
+++ b/providers/venice/models/minimax-m3.toml
@@ -1,0 +1,22 @@
+name = "MiniMax M3"
+family = "minimax-m3"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+open_weights = false
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+
+[limit]
+context = 500_000
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
- Add minimax-m3.toml with cost, limits, modalities
- Enable text/image input and text output support
- Set 500k context, 32k output, cache pricing