### PR TITLE
feat(ovhcloud): Add new Qwen models and sync mode

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -6,6 +6,7 @@ import { AuthoredModel, AuthoredModelShape } from "../schema.js";
 import { cloudflareWorkersAi } from "./providers/cloudflare-workers-ai.js";
 import { google } from "./providers/google.js";
 import { openrouter } from "./providers/openrouter.js";
+import { ovhcloud } from "./providers/ovhcloud.js";
 import { xai } from "./providers/xai.js";
 
 const ExtendsConfig = z
@@ -73,18 +74,20 @@ export const providers: {
   "cloudflare-workers-ai": SyncProvider<any>;
   google: SyncProvider<any>;
   openrouter: SyncProvider<any>;
+  ovhcloud: SyncProvider<any>;
   xai: SyncProvider<any>;
 } = {
   "cloudflare-workers-ai": cloudflareWorkersAi,
   google,
   openrouter,
+  ovhcloud,
   xai,
 };
 
 export const groups = {
   aggregators: ["openrouter"],
   cloudflare: ["cloudflare-workers-ai"],
-  direct: ["google", "xai"],
+  direct: ["google", "ovhcloud", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;

--- a/packages/core/src/sync/providers/ovhcloud.ts
+++ b/packages/core/src/sync/providers/ovhcloud.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+
+import type { ExistingModel, SyncedFullModel, SyncProvider, SyncedModel } from "../index.js";
+
+const API_ENDPOINT = "https://catalog.endpoints.ai.ovh.net/rest/v2/openrouter";
+
+export const OvhcloudModel = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    created: z.number(),
+    hugging_face_id: z.string().nullable().optional(),
+    context_length: z.number(),
+    max_output_length: z.number().optional(),
+    input_modalities: z.array(z.string()).optional(),
+    output_modalities: z.array(z.string()).optional(),
+    pricing: z
+      .object({
+        prompt: z.string().optional(),
+        completion: z.string().optional(),
+        input_cache_reads: z.string().optional(),
+        input_cache_writes: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    supported_features: z.array(z.string()).optional(),
+    supported_sampling_parameters: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+export const OvhcloudResponse = z
+  .object({
+    data: z.array(OvhcloudModel),
+  })
+  .passthrough();
+
+export type OvhcloudModel = z.infer<typeof OvhcloudModel>;
+
+export const ovhcloud = {
+  id: "ovhcloud",
+  name: "OVHcloud AI Endpoints",
+  modelsDir: "providers/ovhcloud/models",
+  async fetchModels() {
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`OVHcloud request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return OvhcloudResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    return {
+      id: model.id.toLowerCase(),
+      model: buildOvhcloudModel(model, context.existing(model.id.toLowerCase())),
+    };
+  },
+} satisfies SyncProvider<OvhcloudModel>;
+
+function dateFromTimestamp(timestamp: number) {
+  return new Date(timestamp * 1000).toISOString().slice(0, 10);
+}
+
+function price(value: string | undefined) {
+  if (value === undefined) return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0
+    ? Math.round(number * 1_000_000_000_000) / 1_000_000
+    : undefined;
+}
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+function modalities(values: string[], fallback: Modality[]): Modality[] {
+  const allowed = new Set<Modality>(["text", "audio", "image", "video", "pdf"]);
+  const result = values
+    .map((value) => value.toLowerCase())
+    .map((value) => (value === "file" ? "pdf" : value))
+    .filter((value): value is Modality => allowed.has(value as Modality));
+  return [...new Set(result.length > 0 ? result : fallback)];
+}
+
+export function buildOvhcloudModel(
+  model: OvhcloudModel,
+  existing: ExistingModel | undefined,
+): SyncedModel {
+  const features = new Set(model.supported_features ?? []);
+  const samplingParameters = new Set(model.supported_sampling_parameters ?? []);
+  const input = modalities(model.input_modalities ?? ["text"], ["text"]);
+  const output = modalities(model.output_modalities ?? ["text"], ["text"]);
+  const attachment = input.some((value) => value !== "text");
+  const reasoning = features.has("reasoning");
+  const toolCall = features.has("tools");
+  const structuredOutput = features.has("structured_outputs");
+  const temperature = samplingParameters.has("temperature");
+  const openWeights = Boolean(model.hugging_face_id);
+  const releaseDate = existing?.release_date ?? dateFromTimestamp(model.created);
+  const lastUpdated = existing?.last_updated ?? releaseDate;
+
+  const inputCost = price(model.pricing?.prompt);
+  const outputCost = price(model.pricing?.completion);
+  const cacheRead = price(model.pricing?.input_cache_reads);
+  const cacheWrite = price(model.pricing?.input_cache_writes);
+  const cost =
+    (inputCost ?? 0) > 0 || (outputCost ?? 0) > 0
+      ? {
+          input: inputCost ?? 0,
+          output: outputCost ?? 0,
+          cache_read: cacheRead !== undefined && cacheRead > 0 ? cacheRead : undefined,
+          cache_write: cacheWrite !== undefined && cacheWrite > 0 ? cacheWrite : undefined,
+        }
+      : undefined;
+
+  return {
+    name: model.name,
+    family: existing?.family,
+    release_date: releaseDate,
+    last_updated: lastUpdated,
+    attachment,
+    reasoning,
+    temperature: temperature || undefined,
+    tool_call: toolCall,
+    structured_output: structuredOutput || undefined,
+    knowledge: existing?.knowledge,
+    open_weights: openWeights,
+    status: existing?.status,
+    interleaved: existing?.interleaved,
+    cost,
+    limit: {
+      context: model.context_length,
+      input: existing?.limit?.input,
+      output: model.max_output_length ?? existing?.limit?.output ?? model.context_length,
+    },
+    modalities: { input, output },
+  } satisfies SyncedFullModel;
+}

--- a/providers/ovhcloud/models/llama-3.1-8b-instruct.toml
+++ b/providers/ovhcloud/models/llama-3.1-8b-instruct.toml
@@ -3,9 +3,9 @@ release_date = "2025-06-11"
 last_updated = "2025-06-11"
 attachment = false
 reasoning = false
+temperature = true
 tool_call = true
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]

--- a/providers/ovhcloud/models/meta-llama-3_3-70b-instruct.toml
+++ b/providers/ovhcloud/models/meta-llama-3_3-70b-instruct.toml
@@ -3,9 +3,9 @@ release_date = "2025-04-01"
 last_updated = "2025-04-01"
 attachment = false
 reasoning = false
+temperature = true
 tool_call = true
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]

--- a/providers/ovhcloud/models/mistral-7b-instruct-v0.3.toml
+++ b/providers/ovhcloud/models/mistral-7b-instruct-v0.3.toml
@@ -3,9 +3,9 @@ release_date = "2025-04-01"
 last_updated = "2025-04-01"
 attachment = false
 reasoning = false
+temperature = true
 tool_call = true
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]

--- a/providers/ovhcloud/models/mistral-nemo-instruct-2407.toml
+++ b/providers/ovhcloud/models/mistral-nemo-instruct-2407.toml
@@ -3,9 +3,9 @@ release_date = "2024-11-20"
 last_updated = "2024-11-20"
 attachment = false
 reasoning = false
+temperature = true
 tool_call = true
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]

--- a/providers/ovhcloud/models/mistral-small-3.2-24b-instruct-2506.toml
+++ b/providers/ovhcloud/models/mistral-small-3.2-24b-instruct-2506.toml
@@ -3,13 +3,13 @@ release_date = "2025-07-16"
 last_updated = "2025-07-16"
 attachment = true
 reasoning = false
+temperature = true
 tool_call = true
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]
-input = 0.10
+input = 0.1
 output = 0.31
 
 [limit]

--- a/providers/ovhcloud/models/qwen2.5-vl-72b-instruct.toml
+++ b/providers/ovhcloud/models/qwen2.5-vl-72b-instruct.toml
@@ -3,9 +3,9 @@ release_date = "2025-03-31"
 last_updated = "2025-03-31"
 attachment = true
 reasoning = false
+temperature = true
 tool_call = false
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]

--- a/providers/ovhcloud/models/qwen3-32b.toml
+++ b/providers/ovhcloud/models/qwen3-32b.toml
@@ -3,9 +3,9 @@ release_date = "2025-07-16"
 last_updated = "2025-07-16"
 attachment = false
 reasoning = true
+temperature = true
 tool_call = true
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]

--- a/providers/ovhcloud/models/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/ovhcloud/models/qwen3-coder-30b-a3b-instruct.toml
@@ -3,9 +3,9 @@ release_date = "2025-10-28"
 last_updated = "2025-10-28"
 attachment = false
 reasoning = false
+temperature = true
 tool_call = true
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]

--- a/providers/ovhcloud/models/qwen3.5-397b-a17b.toml
+++ b/providers/ovhcloud/models/qwen3.5-397b-a17b.toml
@@ -3,9 +3,9 @@ release_date = "2026-05-18"
 last_updated = "2026-05-18"
 attachment = true
 reasoning = true
+temperature = true
 tool_call = true
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]

--- a/providers/ovhcloud/models/qwen3.5-397b-a17b.toml
+++ b/providers/ovhcloud/models/qwen3.5-397b-a17b.toml
@@ -1,6 +1,6 @@
-name = "Qwen3.5-9B"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
+name = "Qwen3.5-397B-A17B"
+release_date = "2026-05-18"
+last_updated = "2026-05-18"
 attachment = true
 reasoning = true
 tool_call = true
@@ -9,8 +9,8 @@ temperature = true
 open_weights = true
 
 [cost]
-input = 0.12
-output = 0.18
+input = 0.71
+output = 4.25
 
 [limit]
 context = 262_144

--- a/providers/ovhcloud/models/qwen3.5-9b.toml
+++ b/providers/ovhcloud/models/qwen3.5-9b.toml
@@ -3,9 +3,9 @@ release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = true
 reasoning = true
+temperature = true
 tool_call = true
 structured_output = true
-temperature = true
 open_weights = true
 
 [cost]

--- a/providers/ovhcloud/models/qwen3.6-27b.toml
+++ b/providers/ovhcloud/models/qwen3.6-27b.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.6-27B"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.47
+output = 3.19
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/ovhcloud/models/qwen3guard-gen-0.6b.toml
+++ b/providers/ovhcloud/models/qwen3guard-gen-0.6b.toml
@@ -3,8 +3,8 @@ release_date = "2026-01-22"
 last_updated = "2026-01-22"
 attachment = false
 reasoning = false
-tool_call = false
 temperature = true
+tool_call = false
 open_weights = true
 
 [limit]

--- a/providers/ovhcloud/models/qwen3guard-gen-0.6b.toml
+++ b/providers/ovhcloud/models/qwen3guard-gen-0.6b.toml
@@ -1,0 +1,16 @@
+name = "Qwen3Guard-Gen-0.6B"
+release_date = "2026-01-22"
+last_updated = "2026-01-22"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = true
+open_weights = true
+
+[limit]
+context = 32_768
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ovhcloud/models/qwen3guard-gen-8b.toml
+++ b/providers/ovhcloud/models/qwen3guard-gen-8b.toml
@@ -1,0 +1,16 @@
+name = "Qwen3Guard-Gen-8B"
+release_date = "2026-01-22"
+last_updated = "2026-01-22"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = true
+open_weights = true
+
+[limit]
+context = 32_768
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ovhcloud/models/qwen3guard-gen-8b.toml
+++ b/providers/ovhcloud/models/qwen3guard-gen-8b.toml
@@ -3,8 +3,8 @@ release_date = "2026-01-22"
 last_updated = "2026-01-22"
 attachment = false
 reasoning = false
-tool_call = false
 temperature = true
+tool_call = false
 open_weights = true
 
 [limit]

--- a/sync.md
+++ b/sync.md
@@ -150,6 +150,18 @@ xAI is implemented in `packages/core/src/sync/providers/xai.ts`.
 - Existing xAI models are updated from API-authoritative fields while local metadata is preserved for fields the API does not expose, especially output token limits and some feature/capability flags.
 - New xAI API models are reported in `.sync/model-sync-report.md` but not created automatically because the API does not provide enough authoritative metadata for complete catalog entries.
 
+## OVHcloud Notes
+
+OVHcloud AI Endpoints is implemented in `packages/core/src/sync/providers/ovhcloud.ts`.
+
+- Source endpoint: `https://catalog.endpoints.ai.ovh.net/rest/v2/openrouter`.
+- No auth required: the catalog is public.
+- Model IDs are lowercased from the catalog `id` to match the existing TOML paths under `providers/ovhcloud/models`.
+- API prices are per-token strings and are converted to per-1M-token numbers; free models (price `0`) get no `[cost]` section.
+- `reasoning`, `tool_call`, and `structured_output` come from `supported_features`; `temperature` comes from `supported_sampling_parameters`.
+- `attachment` is derived from non-text `input_modalities`, and `open_weights` from the presence of `hugging_face_id`.
+- `release_date`/`last_updated` default to the catalog `created` timestamp but preserve any existing hand-authored dates; `knowledge`, `family`, `status`, `interleaved`, and `limit.input` are preserved when present.
+
 ## Vercel Status
 
 Vercel is intentionally not wired into `bun models:sync` right now. Keep using the existing `vercel:generate` script until Vercel sync behavior is redesigned and reviewed separately.


### PR DESCRIPTION
This PR adds new Qwen models for OVHcloud.

It also implements OVHcloud in the sync mode, so we do not need to create manually PRs anymore.