### PR TITLE
feat: add MiniMax-M3 model to all minimax providers

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2025-12-16"
+last_updated = "2025-12-16"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2025-12-16"
+last_updated = "2025-12-16"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2025-12-16"
+last_updated = "2025-12-16"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2025-12-16"
+last_updated = "2025-12-16"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Add MiniMax-M3 model definition to all four minimax providers.

### Model Specs
- **Context window**: 1,000,000 tokens
- **Output**: 131,072 tokens
- **Modalities**: text + image + video (per [MiniMax Anthropic API docs](https://platform.minimaxi.com/docs/api-reference/text-anthropic-api))
- **Reasoning**: true
- **Tool call**: true

### Providers Updated
| Provider | Type |
|---|---|
| `minimax-cn-coding-plan` | Token plan (minimaxi.com) |
| `minimax-cn` | Paid (minimaxi.com) |
| `minimax-coding-plan` | Token plan (minimax.io) |
| `minimax` | Paid (minimax.io) |

### Notes
- Costs set to 0 (need verification from official pricing)
- M3 supports multimodal input via the Anthropic-compatible API