### PR TITLE
fix: update HPC-AI model pricing

### DIFF
--- a/providers/hpc-ai/models/minimax/minimax-m2.5.toml
+++ b/providers/hpc-ai/models/minimax/minimax-m2.5.toml
@@ -1,7 +1,7 @@
 name = "MiniMax M2.5"
 family = "minimax-m2.5"
 release_date = "2026-02-12"
-last_updated = "2026-03-25"
+last_updated = "2026-06-01"
 attachment = false
 reasoning = true
 temperature = true
@@ -10,9 +10,9 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.14
-output = 0.56
-cache_read = 0.014
+input = 0.30
+output = 1.20
+cache_read = 0.03
 
 [limit]
 context = 1_000_000

--- a/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
+++ b/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
@@ -1,7 +1,7 @@
 name = "Kimi K2.5"
 family = "kimi"
 release_date = "2026-01-01"
-last_updated = "2026-03-25"
+last_updated = "2026-06-01"
 attachment = false
 reasoning = true
 structured_output = true
@@ -14,9 +14,9 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 0.21
-output = 1.00
-cache_read = 0.03
+input = 0.30
+output = 1.50
+cache_read = 0.05
 
 [limit]
 context = 262_144

--- a/providers/hpc-ai/models/zai-org/glm-5.1.toml
+++ b/providers/hpc-ai/models/zai-org/glm-5.1.toml
@@ -1,7 +1,7 @@
 name = "GLM 5.1"
 family = "glm"
 release_date = "2026-04-08"
-last_updated = "2026-04-08"
+last_updated = "2026-06-01"
 attachment = false
 reasoning = true
 temperature = true
@@ -13,9 +13,9 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 0.66
-output = 2.00
-cache_read = 0.12
+input = 0.615
+output = 2.46
+cache_read = 0.133
 
 [limit]
 context = 202_000


### PR DESCRIPTION
## Summary

- update HPC-AI pricing for MiniMax M2.5
- update HPC-AI pricing for MoonshotAI Kimi K2.5
- update HPC-AI pricing for Z.ai GLM 5.1 using the lower end of the current published range

## Notes

HPC-AI's current pricing table shows some old values as struck-through discounts. This PR uses the current non-struck values rather than the old struck-through values.

For GLM 5.1, the current published price is still a range:

- input: `0.615-0.819`
- output: `2.46-2.87`
- cache read: `0.133-0.205`

This PR uses the lower end of that range because the repo schema does not have enough provider-specific context to represent the range without inventing an undocumented cutoff.

## Validation

- `bun validate` was run locally after `bun install`, but it currently fails on `dev` with a pre-existing unrelated issue:

```text
error: Unable to resolve extends.from: mistral/mistral-medium-latest
      at generate (/tmp/models.dev/packages/core/src/generate.ts:101:17)
```

The failure points to the existing `merge-gateway` Mistral model inheritance chain and is not caused by these HPC-AI data changes. This PR may need to be rebased or updated once upstream fixes that validation blocker.

Generated by GPT-5.5 with human oversight.
