### PR TITLE
Add MiniMax-M3 model (#1933)

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 512_000
+output = 131072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 512_000
+output = 131072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 512_000
+output = 131072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -1,0 +1,23 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+cache_write = 0.375
+
+[limit]
+context = 512_000
+output = 131072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
Adds the MiniMax M3 model to the five providers where it should be available.

## What this PR does

MiniMax-M3 is MiniMax's new frontier multimodal coding model: 1M context window, native text/image/video input, tool calling, reasoning, and open weights.

Adds `MiniMax-M3.toml` (and `minimax-m3.toml` for ollama-cloud) to:

- `providers/minimax/` — pay-as-you-go, global
- `providers/minimax-cn/` — pay-as-you-go, China
- `providers/minimax-coding-plan/` — token plan subscription, global
- `providers/minimax-cn-coding-plan/` — token plan subscription, China
- `providers/ollama-cloud/` — ollama cloud, `minimax-m3:cloud`

## Source

- MiniMax M3 launch page: https://www.minimax.io/models/text/m3
- MiniMax M3 API reference: https://platform.minimax.io/docs/guides/models-intro
- ollama M3 model card: https://ollama.com/library/minimax-m3

Closes #1933.

## Notes for reviewers

- **Cost on `minimax` and `minimax-cn`** matches M2.7. MiniMax's own docs state the M3 pricing is unchanged from M2.7.
- **1M/512K context divergence on `ollama-cloud`** is intentional. ollama advertises M3 as having a 1M context window with a 512K minimum, so 512K is the safe floor — using 1M there would mean opencode users could hit silent mid-request rejections.
- **`output = 131072`** on the limit block is inherited from the existing M2.7 files in this repo. MiniMax's published M3 docs only advertise the 1M input context window, not a separate output cap. Worth verifying against the M3 changelog when reviewers have access.
- **`minimax-coding-plan` variant verified end-to-end** in opencode against the MiniMax token plan API (auth, streaming, tool calls, reasoning) by the author before opening this PR.

## Validation

`bun validate` errors on a pre-existing issue (`Unable to resolve extends.from: mistral/mistral-medium-latest`) that also occurs on a clean `dev` checkout — not introduced by this changeset. CI may need to be re-run once that's fixed upstream.

The five new TOML files parse cleanly and conform to the schema in `packages/core/src/schema.ts`.