### PR TITLE
fix(llmgateway): update model pricing

### DIFF
--- a/providers/llmgateway/models/deepseek-r1-0528.toml
+++ b/providers/llmgateway/models/deepseek-r1-0528.toml
@@ -11,8 +11,8 @@ open_weights = true
 status = "beta"
 
 [cost]
-input = 0.80
-output = 2.40
+input = 0.55
+output = 2.19
 
 [limit]
 context = 64_000

--- a/providers/llmgateway/models/deepseek-v3.1.toml
+++ b/providers/llmgateway/models/deepseek-v3.1.toml
@@ -12,7 +12,7 @@ open_weights = true
 [cost]
 input = 0.56
 output = 1.68
-cache_read = 0.11
+cache_read = 0.112
 
 [limit]
 context = 128_000

--- a/providers/llmgateway/models/deepseek-v3.1.toml
+++ b/providers/llmgateway/models/deepseek-v3.1.toml
@@ -12,7 +12,7 @@ open_weights = true
 [cost]
 input = 0.56
 output = 1.68
-cache_read = 0.112
+cache_read = 0.07
 
 [limit]
 context = 128_000

--- a/providers/llmgateway/models/deepseek-v3.2.toml
+++ b/providers/llmgateway/models/deepseek-v3.2.toml
@@ -10,9 +10,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.28
-output = 0.42
-cache_read = 0.03
+input = 0.269
+output = 0.40
+cache_read = 0.1345
 
 [limit]
 context = 163_840

--- a/providers/llmgateway/models/deepseek-v3.2.toml
+++ b/providers/llmgateway/models/deepseek-v3.2.toml
@@ -10,9 +10,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.269
-output = 0.40
-cache_read = 0.1345
+input = 0.28
+output = 0.42
+cache_read = 0.056
 
 [limit]
 context = 163_840

--- a/providers/llmgateway/models/glm-4.6v-flashx.toml
+++ b/providers/llmgateway/models/glm-4.6v-flashx.toml
@@ -12,7 +12,7 @@ open_weights = false
 [cost]
 input = 0.04
 output = 0.40
-cache_read = 0.00
+cache_read = 0.004
 
 [limit]
 context = 128_000

--- a/providers/llmgateway/models/gpt-oss-120b.toml
+++ b/providers/llmgateway/models/gpt-oss-120b.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.15
-output = 0.75
+input = 0.05
+output = 0.25
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/gpt-oss-20b.toml
+++ b/providers/llmgateway/models/gpt-oss-20b.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.10
-output = 0.50
+input = 0.04
+output = 0.15
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/kimi-k2.toml
+++ b/providers/llmgateway/models/kimi-k2.toml
@@ -10,9 +10,9 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 1.00
-output = 3.00
-cache_read = 0.50
+input = 0.60
+output = 2.50
+cache_read = 0.12
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen-coder-plus.toml
+++ b/providers/llmgateway/models/qwen-coder-plus.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.50
-output = 1.00
+input = 0.502
+output = 1.004
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen-max-latest.toml
+++ b/providers/llmgateway/models/qwen-max-latest.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 1.60
-output = 6.40
+input = 0.345
+output = 1.377
 
 [limit]
 context = 32_768

--- a/providers/llmgateway/models/qwen-plus-latest.toml
+++ b/providers/llmgateway/models/qwen-plus-latest.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.30
-output = 0.90
+input = 0.115
+output = 0.287
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen2-5-vl-32b-instruct.toml
+++ b/providers/llmgateway/models/qwen2-5-vl-32b-instruct.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.30
-output = 0.30
+input = 1.40
+output = 4.20
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-235b-a22b-fp8.toml
+++ b/providers/llmgateway/models/qwen3-235b-a22b-fp8.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.50
-output = 2.50
+input = 0.20
+output = 0.80
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/llmgateway/models/qwen3-235b-a22b-instruct-2507.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.20
-output = 0.60
+input = 0.09
+output = 0.58
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/llmgateway/models/qwen3-235b-a22b-instruct-2507.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.80
-output = 2.40
+input = 0.20
+output = 0.60
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/llmgateway/models/qwen3-235b-a22b-thinking-2507.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.80
-output = 2.40
+input = 0.20
+output = 0.60
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-30b-a3b-instruct-2507.toml
+++ b/providers/llmgateway/models/qwen3-30b-a3b-instruct-2507.toml
@@ -11,7 +11,7 @@ open_weights = true
 
 [cost]
 input = 0.10
-output = 0.10
+output = 0.30
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-4b-fp8.toml
+++ b/providers/llmgateway/models/qwen3-4b-fp8.toml
@@ -11,7 +11,7 @@ open_weights = true
 
 [cost]
 input = 0.03
-output = 0.05
+output = 0.03
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-coder-next.toml
+++ b/providers/llmgateway/models/qwen3-coder-next.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.80
-output = 4.00
+input = 0.108
+output = 0.675
 
 [limit]
 context = 262_144

--- a/providers/llmgateway/models/qwen3-max-2026-01-23.toml
+++ b/providers/llmgateway/models/qwen3-max-2026-01-23.toml
@@ -10,9 +10,9 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 3.00
-output = 15.00
-cache_read = 0.60
+input = 0.359
+output = 1.434
+cache_read = 0.072
 
 [limit]
 context = 256_000

--- a/providers/llmgateway/models/qwen3-vl-235b-a22b-instruct.toml
+++ b/providers/llmgateway/models/qwen3-vl-235b-a22b-instruct.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.80
-output = 2.40
+input = 0.50
+output = 2.00
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-vl-235b-a22b-instruct.toml
+++ b/providers/llmgateway/models/qwen3-vl-235b-a22b-instruct.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.50
-output = 2.00
+input = 0.30
+output = 1.50
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/llmgateway/models/qwen3-vl-235b-a22b-thinking.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.80
-output = 2.40
+input = 0.50
+output = 2.00
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-vl-30b-a3b-instruct.toml
+++ b/providers/llmgateway/models/qwen3-vl-30b-a3b-instruct.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.10
-output = 0.10
+input = 0.20
+output = 0.70
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-vl-30b-a3b-thinking.toml
+++ b/providers/llmgateway/models/qwen3-vl-30b-a3b-thinking.toml
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.10
-output = 0.10
+input = 0.20
+output = 1.00
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-vl-8b-instruct.toml
+++ b/providers/llmgateway/models/qwen3-vl-8b-instruct.toml
@@ -10,8 +10,8 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.10
-output = 0.10
+input = 0.08
+output = 0.50
 
 [limit]
 context = 131_072

--- a/providers/llmgateway/models/qwen3-vl-flash.toml
+++ b/providers/llmgateway/models/qwen3-vl-flash.toml
@@ -10,9 +10,9 @@ structured_output = true
 open_weights = false
 
 [cost]
-input = 0.05
-output = 0.40
-cache_read = 0.01
+input = 0.022
+output = 0.215
+cache_read = 0.0044
 
 [limit]
 context = 1_000_000

--- a/providers/llmgateway/models/seed-1-6-flash-250715.toml
+++ b/providers/llmgateway/models/seed-1-6-flash-250715.toml
@@ -12,7 +12,7 @@ open_weights = true
 [cost]
 input = 0.07
 output = 0.30
-cache_read = 0.01
+cache_read = 0.015
 
 [limit]
 context = 256_000


### PR DESCRIPTION
## Summary

- update LLM Gateway pricing from `https://internal.llmgateway.io/internal/models`
- ignore deactivated internal mappings when selecting provider pricing
- select one provider per model using a realistic weighted single-request price metric
- fix DeepSeek V3.2 pricing now that the official DeepSeek provider mapping is deactivated

## Weighted Price Metric

For each active provider mapping, compute:

```text
weighted_price = 0.20 * uncached_input + 0.70 * cached_input + 0.10 * output
```

- `uncached_input`, `cached_input`, and `output` are all dollars per million tokens.
- If a provider has no cached-input price, cached input falls back to uncached input.
- The selected provider is the active mapping with the lowest weighted price.
- All catalog price fields for a model come from the selected provider; prices are not mixed across providers.

This favors realistic repeated-prefix/chat workloads while still accounting for fresh input and output cost.

## DeepSeek V3.2

- The official `deepseek` mapping is deactivated in the internal response.
- The weighted metric selects the active Bytedance mapping for DeepSeek V3.2.
- Updated price: input `0.28`, output `0.42`, cache read `0.056`.

## Validation

- `git diff --check`
- weighted-source consistency check reports zero remaining mismatches for the updated subset
- `bun validate` currently fails on an unrelated existing issue: `Unable to resolve extends.from: mistral/mistral-medium-latest`

Generated by GPT-5.5 with human oversight.
