### PR TITLE
feat: add reasoning options schema

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -21,6 +21,28 @@ const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
   ]),
 );
 
+const ReasoningOption = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("effort"),
+      values: z.array(z.enum(["none", "low", "medium", "high", "xhigh", "max"])),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("budget_tokens"),
+      min: z.number().min(0, "Minimum reasoning budget cannot be negative").optional(),
+      max: z.number().min(0, "Maximum reasoning budget cannot be negative"),
+    })
+    .strict(),
+]).refine(
+  (data) => data.type !== "budget_tokens" || data.min === undefined || data.min <= data.max,
+  {
+    message: "Minimum reasoning budget cannot exceed maximum reasoning budget",
+    path: ["min"],
+  },
+);
+
 const Cost = z.object({
   input: z.number().min(0, "Input price cannot be negative"),
   output: z.number().min(0, "Output price cannot be negative"),
@@ -68,6 +90,7 @@ const ModelBase = z.object({
   family: ModelFamily.optional(),
   attachment: z.boolean(),
   reasoning: z.boolean(),
+  reasoning_options: z.array(ReasoningOption).optional(),
   tool_call: z.boolean(),
   interleaved: z
     .union([


### PR DESCRIPTION
## Summary
- add optional `reasoning_options` model metadata
- support typed `effort` and `budget_tokens` reasoning option variants
- validate reasoning budget ranges and known effort values

## Validation
- `bun validate`