### PR TITLE
Add Subconscious provider and TIM-Qwen3.6 27B

### DIFF
--- a/providers/subconscious/models/subconscious/tim-qwen3.6-27b.toml
+++ b/providers/subconscious/models/subconscious/tim-qwen3.6-27b.toml
@@ -1,0 +1,21 @@
+name = "TIM-Qwen3.6 27B"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-05-11"
+last_updated = "2026-05-11"
+open_weights = false
+
+[cost]
+input = 0.5
+output = 3.5
+
+[limit]
+context = 262144
+output = 262144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/subconscious/provider.toml
+++ b/providers/subconscious/provider.toml
@@ -1,0 +1,5 @@
+name = "Subconscious"
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.subconscious.dev/v1"
+env = ["SUBCONSCIOUS_API_KEY"]
+doc = "https://docs.subconscious.dev"


### PR DESCRIPTION
Adds the Subconscious provider (OpenAI-compatible API at `https://api.subconscious.dev/v1`) and its `TIM-Qwen3.6 27B` model — a post-trained Qwen3.6-27B served on the TIMRUN runtime. The model supports tool calling, reasoning, structured outputs, and image input, with a 262K-token context window (and up to 262K output tokens); pricing is $0.50/1M input and $3.50/1M output. The model id is namespaced `subconscious/tim-qwen3.6-27b` (the federated-gateway slug the API requires), stored via a nested folder per the README's slash convention, so the auto-injected id matches exactly what `/v1/chat/completions` accepts. Validated locally with `bun validate` (passes, model appears correctly in the generated catalog).