### PR TITLE
fix(github-copilot): correct limits for 8 models with verified CAPI data (partial, refs #1946)

### DIFF
--- a/providers/github-copilot/models/claude-opus-4.6.toml
+++ b/providers/github-copilot/models/claude-opus-4.6.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "anthropic/claude-opus-4-6"
+
+[limit]
+context = 200_000
+input = 168_000
+output = 32_000

--- a/providers/github-copilot/models/claude-opus-4.8.toml
+++ b/providers/github-copilot/models/claude-opus-4.8.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "anthropic/claude-opus-4-8"
+
+[limit]
+context = 200_000
+input = 168_000
+output = 64_000

--- a/providers/github-copilot/models/claude-sonnet-4.6.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.6.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "anthropic/claude-sonnet-4-6"
+
+[limit]
+context = 200_000
+input = 168_000
+output = 32_000

--- a/providers/github-copilot/models/gemini-3.1-pro-preview.toml
+++ b/providers/github-copilot/models/gemini-3.1-pro-preview.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "google/gemini-3.1-pro-preview"
+
+[limit]
+context = 200_000
+input = 136_000
+output = 64_000

--- a/providers/github-copilot/models/gemini-3.5-flash.toml
+++ b/providers/github-copilot/models/gemini-3.5-flash.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "google/gemini-3.5-flash"
+
+[limit]
+context = 200_000
+input = 128_000
+output = 64_000

--- a/providers/github-copilot/models/gpt-4.1.toml
+++ b/providers/github-copilot/models/gpt-4.1.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "openai/gpt-4.1"
+
+[limit]
+context = 128_000
+input = 128_000
+output = 16_384

--- a/providers/github-copilot/models/gpt-5.4.toml
+++ b/providers/github-copilot/models/gpt-5.4.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "openai/gpt-5.4"
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000

--- a/providers/github-copilot/models/gpt-5.5.toml
+++ b/providers/github-copilot/models/gpt-5.5.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "openai/gpt-5.5"
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000


### PR DESCRIPTION
## What

Corrects the `limit` (context / input / output) fields for **8** `github-copilot` models whose values were verified first-hand against the live Copilot API (`GET https://api.githubcopilot.com/models`).

Related to #1946 — this is a **partial** fix and intentionally does **not** close the issue (see "Scope / limitation" below).

## Why

The `github-copilot` model files are thin `[extends]` stubs that inherit the **upstream base model's** limits (~1M context for OpenAI / Anthropic / Google). GitHub Copilot enforces its **own**, much smaller, per-model limits via CAPI (`max_context_window_tokens`, `max_prompt_tokens`, `max_output_tokens`). The inherited values are therefore wrong and cause consumers (e.g. OpenCode) to over-size context and mis-tune compaction.

This PR keeps the `[extends]` inheritance (cost, modalities, capabilities, dates stay shared) and only overrides the three `limit` fields, which `mergeDeep(base, overrides)` in `generate.ts` applies field-by-field.

## Changes (live CAPI vs previous inherited value)

| Model | context (was → now) | input (was → now) | output (was → now) |
|---|---|---|---|
| claude-opus-4.6 | 1,000,000 → **200,000** | — → **168,000** | 128,000 → **32,000** |
| claude-opus-4.8 | 1,000,000 → **200,000** | — → **168,000** | 128,000 → **64,000** |
| claude-sonnet-4.6 | 1,000,000 → **200,000** | — → **168,000** | 64,000 → **32,000** |
| gemini-3.1-pro-preview | 1,048,576 → **200,000** | — → **136,000** | 65,536 → **64,000** |
| gemini-3.5-flash | 1,048,576 → **200,000** | — → **128,000** | 65,536 → **64,000** |
| gpt-4.1 | 1,047,576 → **128,000** | — → **128,000** | 32,768 → **16,384** |
| gpt-5.4 | 1,050,000 → **400,000** | 922,000 → **272,000** | 128,000 (unchanged) |
| gpt-5.5 | 1,050,000 → **400,000** | 922,000 → **272,000** | 128,000 (unchanged) |

`input` = CAPI `max_prompt_tokens`, `context` = `max_context_window_tokens`, `output` = `max_output_tokens`.

## Scope / limitation (why this is partial)

The CAPI `/models` response only returns the models **enabled for the authenticated account's plan**. On the account used to verify this, only the 8 models above were exposed, so those are the only ones with first-hand ground-truth data.

The remaining `github-copilot` models still in the registry (e.g. `claude-opus-4.5`, `claude-opus-4.7`, `claude-sonnet-4`, `claude-sonnet-4.5`, `claude-haiku-4.5`, `gemini-2.5-pro`, `gemini-3-flash-preview`, `gpt-5-mini`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.4-nano`, `raptor-mini`) were **not** enabled on the test account, so I could not fetch authoritative CAPI limits for them. They are **left untouched** in this PR rather than guessed at. Because of that, **#1946 should stay open** until the rest can be verified with an account that has those models enabled.

## Verification

- `bun run validate` → passes (exit 0)
- `bun run compare:migrations` → confirms the generated JSON changes are limited to the `limit` fields of these 8 models; no other fields drift.
