### PR TITLE
feat(anthropic): add reasoning options

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -32,11 +32,15 @@ const ReasoningOption = z.discriminatedUnion("type", [
     .object({
       type: z.literal("budget_tokens"),
       min: z.number().min(0, "Minimum reasoning budget cannot be negative").optional(),
-      max: z.number().min(0, "Maximum reasoning budget cannot be negative"),
+      max: z.number().min(0, "Maximum reasoning budget cannot be negative").optional(),
     })
     .strict(),
 ]).refine(
-  (data) => data.type !== "budget_tokens" || data.min === undefined || data.min <= data.max,
+  (data) =>
+    data.type !== "budget_tokens" ||
+    data.min === undefined ||
+    data.max === undefined ||
+    data.min <= data.max,
   {
     message: "Minimum reasoning budget cannot exceed maximum reasoning budget",
     path: ["min"],

--- a/providers/anthropic/models/claude-3-7-sonnet-20250219.toml
+++ b/providers/anthropic/models/claude-3-7-sonnet-20250219.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2024-10-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/anthropic/models/claude-haiku-4-5-20251001.toml
+++ b/providers/anthropic/models/claude-haiku-4-5-20251001.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-02-28"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 1.00
 output = 5.00

--- a/providers/anthropic/models/claude-haiku-4-5.toml
+++ b/providers/anthropic/models/claude-haiku-4-5.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-02-28"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 1.00
 output = 5.00

--- a/providers/anthropic/models/claude-opus-4-0.toml
+++ b/providers/anthropic/models/claude-opus-4-0.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 15.00
 output = 75.00

--- a/providers/anthropic/models/claude-opus-4-1-20250805.toml
+++ b/providers/anthropic/models/claude-opus-4-1-20250805.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 15.00
 output = 75.00

--- a/providers/anthropic/models/claude-opus-4-1.toml
+++ b/providers/anthropic/models/claude-opus-4-1.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 15.00
 output = 75.00

--- a/providers/anthropic/models/claude-opus-4-20250514.toml
+++ b/providers/anthropic/models/claude-opus-4-20250514.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 15.00
 output = 75.00

--- a/providers/anthropic/models/claude-opus-4-5-20251101.toml
+++ b/providers/anthropic/models/claude-opus-4-5-20251101.toml
@@ -9,6 +9,14 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 5.00
 output = 25.00

--- a/providers/anthropic/models/claude-opus-4-5.toml
+++ b/providers/anthropic/models/claude-opus-4-5.toml
@@ -9,6 +9,14 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 5.00
 output = 25.00

--- a/providers/anthropic/models/claude-opus-4-6.toml
+++ b/providers/anthropic/models/claude-opus-4-6.toml
@@ -9,6 +9,14 @@ tool_call = true
 knowledge = "2025-05-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 5.00
 output = 25.00

--- a/providers/anthropic/models/claude-opus-4-7.toml
+++ b/providers/anthropic/models/claude-opus-4-7.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2026-01-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 5.00
 output = 25.00

--- a/providers/anthropic/models/claude-opus-4-8.toml
+++ b/providers/anthropic/models/claude-opus-4-8.toml
@@ -8,6 +8,10 @@ temperature = false
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 5.00
 output = 25.00

--- a/providers/anthropic/models/claude-sonnet-4-0.toml
+++ b/providers/anthropic/models/claude-sonnet-4-0.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/anthropic/models/claude-sonnet-4-20250514.toml
+++ b/providers/anthropic/models/claude-sonnet-4-20250514.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/anthropic/models/claude-sonnet-4-5-20250929.toml
+++ b/providers/anthropic/models/claude-sonnet-4-5-20250929.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-07-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/anthropic/models/claude-sonnet-4-5.toml
+++ b/providers/anthropic/models/claude-sonnet-4-5.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-07-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/anthropic/models/claude-sonnet-4-6.toml
+++ b/providers/anthropic/models/claude-sonnet-4-6.toml
@@ -9,6 +9,14 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [cost]
 input = 3.00
 output = 15.00


### PR DESCRIPTION
## Summary
- add reasoning option metadata for supported Anthropic Claude models
- track effort support for newer Claude models and manual budget token support where accepted
- make `budget_tokens.max` optional because Anthropic budgets are constrained by each request's `max_tokens` value

## Validation
- `bun validate`
- `git diff --check`