### PR TITLE
fix(github-copilot): preserve model-specific limits

### DIFF
--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "anthropic/claude-haiku-4-5"
+
+[limit]
+context = 200_000
+input = 136_000
+output = 64_000

--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "anthropic/claude-opus-4-5"
+
+[limit]
+context = 200_000
+input = 168_000
+output = 32_000

--- a/providers/github-copilot/models/claude-opus-4.7.toml
+++ b/providers/github-copilot/models/claude-opus-4.7.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "anthropic/claude-opus-4-7"
+
+[limit]
+context = 200_000
+input = 168_000
+output = 32_000

--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "anthropic/claude-sonnet-4-5"
+
+[limit]
+context = 200_000
+input = 168_000
+output = 32_000

--- a/providers/github-copilot/models/claude-sonnet-4.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "anthropic/claude-sonnet-4-0"
+
+[limit]
+context = 216_000
+input = 128_000
+output = 16_000

--- a/providers/github-copilot/models/gemini-2.5-pro.toml
+++ b/providers/github-copilot/models/gemini-2.5-pro.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "google/gemini-2.5-pro"
+
+[limit]
+context = 128_000
+input = 128_000
+output = 64_000

--- a/providers/github-copilot/models/gemini-3-flash-preview.toml
+++ b/providers/github-copilot/models/gemini-3-flash-preview.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "google/gemini-3-flash-preview"
+
+[limit]
+context = 128_000
+input = 128_000
+output = 64_000

--- a/providers/github-copilot/models/gpt-5-mini.toml
+++ b/providers/github-copilot/models/gpt-5-mini.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "openai/gpt-5-mini"
+
+[limit]
+context = 264_000
+input = 128_000
+output = 64_000

--- a/providers/github-copilot/models/gpt-5.2-codex.toml
+++ b/providers/github-copilot/models/gpt-5.2-codex.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "openai/gpt-5.2-codex"
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000

--- a/providers/github-copilot/models/gpt-5.2.toml
+++ b/providers/github-copilot/models/gpt-5.2.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "openai/gpt-5.2"
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000

--- a/providers/github-copilot/models/gpt-5.3-codex.toml
+++ b/providers/github-copilot/models/gpt-5.3-codex.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "openai/gpt-5.3-codex"
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000

--- a/providers/github-copilot/models/gpt-5.4-mini.toml
+++ b/providers/github-copilot/models/gpt-5.4-mini.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "openai/gpt-5.4-mini"
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000

--- a/providers/github-copilot/models/gpt-5.4-nano.toml
+++ b/providers/github-copilot/models/gpt-5.4-nano.toml
@@ -1,2 +1,7 @@
 [extends]
 from = "openai/gpt-5.4-nano"
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000


### PR DESCRIPTION
## Summary

- add explicit GitHub Copilot limit overrides to every remaining inherited model stub
- restore Copilot-specific context, input, and output limits that were lost when the manifests switched to `[extends]`
- pin currently equivalent GPT limits too, preventing future upstream metadata changes from silently changing Copilot limits

## Context

PR #1934 switched Copilot manifests to inherit upstream Anthropic, Google, and OpenAI definitions. GitHub Copilot enforces provider-specific limits, so inheriting upstream limits caused several models to over-report context windows and lose prompt caps. PR #1947 repaired the subset with live CAPI verification; this completes the remaining inherited manifests using their existing Copilot-specific limits from repository history.

Refs #1946

## Verification

- `bun validate`
- `bun run compare:migrations`
- `git diff --check`
- confirmed all 21 inherited GitHub Copilot manifests now have explicit `[limit]` overrides