### PR TITLE
fix: do not inherit reasoning options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@
 - Merge semantics:
   - Plain objects (`[cost]`, `[limit]`, `[modalities]`, `[provider]`, `[experimental]`, …) are **deep-merged**
   - Arrays (e.g. `modalities.input`) and primitives are **replaced** wholesale by the child
-  - Any field the child omits is inherited verbatim from the base
+  - Any field the child omits is inherited verbatim from the base, except `reasoning_options`
+  - `reasoning_options` describes the endpoint interface and is never inherited; each derived provider must declare the controls its API exposes explicitly
 - `omit` runs **after** the merge and deletes each dot-path from the result (used when the child needs to *remove* something the base defines, e.g. a provider-specific experimental mode). Every listed path must exist in the merged model, else an error is thrown. Ancestor tables that become empty as a result are also pruned, so `omit = ["experimental.modes.fast"]` yields no `experimental` key in the final JSON when `fast` was the only mode.
 - Chains are allowed (A extends B extends C); cycles throw
 - The base model must exist; `[extends.from]` pointing at a missing provider/model is an error

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -104,8 +104,11 @@ export async function generate(directory: string) {
     }
 
     const { extends: extendsConfig, ...overrides } = pendingModel.model;
+    // Reasoning controls describe the endpoint interface, not just the model.
+    // Derived providers must declare the controls their API exposes explicitly.
+    const { reasoning_options: _reasoningOptions, ...inherited } = baseModel;
     const merged: Record<string, unknown> = structuredClone(
-      mergeDeep(baseModel, overrides),
+      mergeDeep(inherited, overrides),
     );
 
     for (const omit of extendsConfig.omit ?? []) {


### PR DESCRIPTION
## Summary
- stop `reasoning_options` from inheriting through `[extends]`
- require derived providers to declare endpoint-specific reasoning controls explicitly
- document the inheritance exception

## Why
`reasoning_options` describes an endpoint interface rather than an intrinsic model capability. Inheriting Anthropic `budget_tokens` metadata caused OpenAI-compatible wrappers and other derived providers to advertise controls their APIs may not support.

## Audit
- fixes accidental inheritance for 128 derived Anthropic model configs across 20 providers
- leaves direct Anthropic declarations unchanged
- does not change five Vercel AI Gateway symlinks into Anthropic TOMLs; those bypass `[extends]` and should be reviewed separately against Gateway behavior

## Validation
- `bun validate`
- `git diff --check`