### PR TITLE
chore: mark retired models as deprecated

### DIFF
--- a/providers/anthropic/models/claude-3-5-haiku-20241022.toml
+++ b/providers/anthropic/models/claude-3-5-haiku-20241022.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2024-07-31"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.80

--- a/providers/anthropic/models/claude-3-5-sonnet-20240620.toml
+++ b/providers/anthropic/models/claude-3-5-sonnet-20240620.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2024-04-30"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 3.00

--- a/providers/anthropic/models/claude-3-5-sonnet-20241022.toml
+++ b/providers/anthropic/models/claude-3-5-sonnet-20241022.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2024-04-30"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 3.00

--- a/providers/anthropic/models/claude-3-7-sonnet-20250219.toml
+++ b/providers/anthropic/models/claude-3-7-sonnet-20250219.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2024-10-31"
 open_weights = false
+status = "deprecated"
 
 [[reasoning_options]]
 type = "budget_tokens"

--- a/providers/anthropic/models/claude-3-haiku-20240307.toml
+++ b/providers/anthropic/models/claude-3-haiku-20240307.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2023-08-31"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.25

--- a/providers/anthropic/models/claude-3-opus-20240229.toml
+++ b/providers/anthropic/models/claude-3-opus-20240229.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2023-08-31"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 15.00

--- a/providers/anthropic/models/claude-3-sonnet-20240229.toml
+++ b/providers/anthropic/models/claude-3-sonnet-20240229.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2023-08-31"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 3.00

--- a/providers/google/models/gemini-2.0-flash-lite.toml
+++ b/providers/google/models/gemini-2.0-flash-lite.toml
@@ -9,6 +9,7 @@ tool_call = true
 structured_output = true
 knowledge = "2024-06"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.075

--- a/providers/google/models/gemini-2.0-flash.toml
+++ b/providers/google/models/gemini-2.0-flash.toml
@@ -9,6 +9,7 @@ knowledge = "2024-06"
 tool_call = true
 structured_output = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.10

--- a/providers/google/models/gemini-3-pro-preview.toml
+++ b/providers/google/models/gemini-3-pro-preview.toml
@@ -9,6 +9,7 @@ tool_call = true
 structured_output = true
 knowledge = "2025-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 2

--- a/providers/google/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/google/models/gemini-3.1-flash-lite-preview.toml
@@ -9,6 +9,7 @@ tool_call = true
 structured_output = true
 knowledge = "2025-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.25

--- a/providers/openai/models/o1-mini.toml
+++ b/providers/openai/models/o1-mini.toml
@@ -9,6 +9,7 @@ knowledge = "2023-09"
 tool_call = false
 structured_output = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 1.10

--- a/providers/openai/models/o1-preview.toml
+++ b/providers/openai/models/o1-preview.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2023-09"
 tool_call = false
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 15.00


### PR DESCRIPTION
Adds `status = "deprecated"` to models that are **past their provider's published shutdown/retirement date** (i.e. no longer served by the public API), matching the repo's definition of `deprecated`.

### Models marked (13)

**Google Gemini (4)**
| Model | Shutdown |
|---|---|
| `gemini-2.0-flash` | 2026-06-01 |
| `gemini-2.0-flash-lite` | 2026-06-01 |
| `gemini-3-pro-preview` | 2026-03-09 |
| `gemini-3.1-flash-lite-preview` | 2026-05-25 |

**Anthropic Claude (7)** — all in Anthropic's "Retired" state
| Model | Retired |
|---|---|
| `claude-3-sonnet-20240229` | 2025-07-21 |
| `claude-3-5-sonnet-20240620` | 2025-10-28 |
| `claude-3-5-sonnet-20241022` | 2025-10-28 |
| `claude-3-opus-20240229` | 2026-01-05 |
| `claude-3-7-sonnet-20250219` | 2026-02-19 |
| `claude-3-5-haiku-20241022` | 2026-02-19 |
| `claude-3-haiku-20240307` | 2026-04-20 |

**OpenAI (2)**
| Model | Shutdown |
|---|---|
| `o1-preview` | 2025-07-28 |
| `o1-mini` | 2025-10-27 |

### Scope notes
- Models still within an **announced but future** shutdown window were left unchanged (e.g. OpenAI's 2026-07-23/10-23 batches, Anthropic's deprecated Opus 4 / Sonnet 4 retiring 2026-06-15, several still-served Gemini 2.5 models).
- **Bedrock / Vertex mirrors** were not touched — those platforms set their own retirement schedules.

### Sources
- Gemini: https://ai.google.dev/gemini-api/docs/deprecations
- Anthropic: https://platform.claude.com/docs/en/about-claude/model-deprecations
- OpenAI: https://developers.openai.com/api/docs/deprecations

Validated with `bun validate` (passes).