### PR TITLE
fix(minimax): correct MiniMax-M3 pricing and max output

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -16,7 +16,7 @@ cache_write = 0
 
 [limit]
 context = 512_000
-output = 131072
+output = 128_000
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -9,14 +9,13 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.30
-output = 1.20
-cache_read = 0.06
-cache_write = 0.375
+input = 0.60
+output = 2.40
+cache_read = 0.12
 
 [limit]
 context = 512_000
-output = 131072
+output = 128_000
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -16,7 +16,7 @@ cache_write = 0
 
 [limit]
 context = 512_000
-output = 131072
+output = 128_000
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -9,14 +9,13 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.30
-output = 1.20
-cache_read = 0.06
-cache_write = 0.375
+input = 0.60
+output = 2.40
+cache_read = 0.12
 
 [limit]
 context = 512_000
-output = 131072
+output = 128_000
 
 [modalities]
 input = ["text", "image", "video"]


### PR DESCRIPTION
## What

The `MiniMax-M3` entries added in #1940 copied M2.7's `[cost]` values, so M3 is currently listed at the wrong (cheaper) prices. This corrects them to the official M3 pricing.

I'm from MiniMax — these are the official numbers.

### `minimax` and `minimax-cn` (pay-as-you-go)
| field | before (#1940) | after |
|---|---|---|
| input | 0.30 | **0.60** |
| output | 1.20 | **2.40** |
| cache_read | 0.06 | **0.12** |
| cache_write | 0.375 | **removed** (M3 has no active prompt-cache-write tier) |

### All four providers
- `limit.output` 131072 → **128000**

### coding-plan variants
- Keep their subscription-plan zero pricing (matching their M2.7 entries); only `limit.output` is corrected.

Context (512K), modalities, and other flags are unchanged. `bun run validate` passes.

> Note: I intentionally did **not** remove the older M2.x models — they're inherited via `extends.from` by ~15 third-party providers (openrouter, llmgateway, merge-gateway, etc.), so removing them would break the catalog.