### PR TITLE
feat(zai): add reasoning toggle options

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -25,6 +25,11 @@ const ReasoningOption = z
   .discriminatedUnion("type", [
     z
       .object({
+        type: z.literal("toggle"),
+      })
+      .strict(),
+    z
+      .object({
         type: z.literal("effort"),
         values: z.array(
           z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]),

--- a/providers/zai/models/glm-4.5-air.toml
+++ b/providers/zai/models/glm-4.5-air.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.2
 output = 1.1

--- a/providers/zai/models/glm-4.5-flash.toml
+++ b/providers/zai/models/glm-4.5-flash.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0

--- a/providers/zai/models/glm-4.5.toml
+++ b/providers/zai/models/glm-4.5.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.6
 output = 2.2

--- a/providers/zai/models/glm-4.5v.toml
+++ b/providers/zai/models/glm-4.5v.toml
@@ -9,6 +9,9 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.6
 output = 1.8

--- a/providers/zai/models/glm-4.6.toml
+++ b/providers/zai/models/glm-4.6.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.6
 output = 2.2

--- a/providers/zai/models/glm-4.6v.toml
+++ b/providers/zai/models/glm-4.6v.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.3
 output = 0.9

--- a/providers/zai/models/glm-4.7-flash.toml
+++ b/providers/zai/models/glm-4.7-flash.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0

--- a/providers/zai/models/glm-4.7-flashx.toml
+++ b/providers/zai/models/glm-4.7-flashx.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.07
 output = 0.40

--- a/providers/zai/models/glm-4.7.toml
+++ b/providers/zai/models/glm-4.7.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zai/models/glm-5-turbo.toml
+++ b/providers/zai/models/glm-5-turbo.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zai/models/glm-5.1.toml
+++ b/providers/zai/models/glm-5.1.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zai/models/glm-5.toml
+++ b/providers/zai/models/glm-5.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zai/models/glm-5v-turbo.toml
+++ b/providers/zai/models/glm-5v-turbo.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
## Summary
- add a normalized `reasoning_options.type = "toggle"` schema variant
- declare reasoning toggle support for 13 direct Z.AI GLM models
- keep endpoint-specific metadata scoped so `[extends]` wrappers do not inherit it

## Why
Z.AI documents a caller-selectable on/off reasoning control for GLM-4.5 and newer models:

```json
{
  "thinking": {
    "type": "enabled"
  }
}
```

The documented values are `enabled` and `disabled`. This is not an effort scale and not a reasoning-token budget, so it needs a dedicated normalized `toggle` option.

Source: https://docs.z.ai/api-reference/llm/chat-completion

## Validation
- `bun validate`
- `git diff --check`
- generated catalog check confirms normal `[extends]` wrappers do not inherit toggle metadata