### PR TITLE
feat(minimax): add M3 reasoning toggle

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.60
 output = 2.40

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.60
 output = 2.40


### PR DESCRIPTION
## Summary
- add `reasoning_options.type = "toggle"` to MiniMax-M3
- cover international, China, and both token-plan Anthropic-compatible surfaces
- leave M2.x unchanged because MiniMax documents configurable `thinking` as an M3-only feature

## Why
MiniMax confirmed that MiniMax-M3 exposes an on/off reasoning capability rather than caller-selectable effort tiers. The Anthropic-compatible API represents the enabled state as `thinking.type = "adaptive"` and the disabled state as `thinking.type = "disabled"`; normalized catalog metadata is therefore `type = "toggle"`.

MiniMax documents `thinking` as a new M3 feature and describes the request field as: `Controls deep thinking for MiniMax-M3.` The M2.x models remain reasoning-capable, but their documented API surfaces do not expose a caller-selectable on/off control.

Sources:
- https://platform.minimax.io/docs/api-reference/text-chat-anthropic
- https://platform.minimax.io/docs/api-reference/text-openai-api
- https://platform.minimaxi.com/docs/api-reference/text-chat-anthropic
- https://platform.minimaxi.com/docs/api-reference/text-openai-api

## Validation
- `bun validate`
- `git diff --check`
- generated catalog check confirms all four M3 surfaces emit `[{ "type": "toggle" }]`