### PR TITLE
Add Forge provider (OpenAI-compatible embeddings)

### DIFF
--- a/providers/forge/models/forge-pro.toml
+++ b/providers/forge/models/forge-pro.toml
@@ -1,0 +1,21 @@
+name = "Forge Pro"
+family = "text-embedding"
+release_date = "2026-06-02"
+last_updated = "2026-06-02"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.30
+output = 0.00
+
+[limit]
+context = 512
+output = 2_560
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/forge/models/forge-turbo.toml
+++ b/providers/forge/models/forge-turbo.toml
@@ -1,0 +1,21 @@
+name = "Forge Turbo"
+family = "text-embedding"
+release_date = "2026-06-02"
+last_updated = "2026-06-02"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.00
+
+[limit]
+context = 512
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/forge/models/forge-ultra-4k.toml
+++ b/providers/forge/models/forge-ultra-4k.toml
@@ -1,0 +1,21 @@
+name = "Forge Ultra 4K"
+family = "text-embedding"
+release_date = "2026-06-02"
+last_updated = "2026-06-02"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.40
+output = 0.00
+
+[limit]
+context = 512
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/forge/provider.toml
+++ b/providers/forge/provider.toml
@@ -1,0 +1,5 @@
+name = "Forge"
+env = ["FORGE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.voxell.ai/v1"
+doc = "https://voxell.ai"


### PR DESCRIPTION
Adds the Forge embeddings provider.

Forge exposes an OpenAI-compatible embeddings API at `https://api.voxell.ai/v1`, consumed via `@ai-sdk/openai-compatible`. Auth via `FORGE_API_KEY`.

Three text-embedding models:

| id | dimensions | $/1M input tokens |
|----|-----------|-------------------|
| `forge-turbo` | 1024 | 0.20 |
| `forge-pro` | 2560 | 0.30 |
| `forge-ultra-4k` | 4096 | 0.40 |

The provider TOML mirrors `providers/fastrouter/provider.toml`; the model TOMLs mirror the `providers/openai` `text-embedding-*` shape (`family = "text-embedding"`, `cost.input` per 1M tokens, `limit.output` = embedding dimension, `modalities` text/text). `limit.context = 512` reflects the served max sequence length.

`bun run validate` passes with the new provider present in the generated output.