### PR TITLE
feat: add Qwen3.7 Plus model for alibaba-cn provider

### DIFF
--- a/providers/alibaba-cn/models/qwen3.7-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.7-plus.toml
@@ -1,0 +1,2 @@
+[extends]
+from = "alibaba/qwen3.7-plus"

--- a/providers/alibaba/models/qwen3.7-plus.toml
+++ b/providers/alibaba/models/qwen3.7-plus.toml
@@ -1,0 +1,31 @@
+name = "Qwen3.7 Plus"
+family = "qwen"
+release_date = "2026-06-02"
+last_updated = "2026-06-02"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.50
+output = 3.00
+cache_read = 0.05
+cache_write = 0.625
+
+[[cost.tiers]]
+tier = { size = 128_000 }
+input = 2.00
+output = 6.00
+cache_read = 0.20
+cache_write = 2.50
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Add Qwen3.7 Plus model definition for the alibaba-cn provider.

**Qwen3.7 Plus** was released on Alibaba Cloud DashScope on June 2, 2026. It is a cost-effective reasoning model in the Qwen 3.7 family.

## Changes

- Added base definition: `providers/alibaba/models/qwen3.7-plus.toml`
- Added extends reference: `providers/alibaba-cn/models/qwen3.7-plus.toml`

## Model Specifications

| Property | Value |
|----------|-------|
| Context Window | 131,072 tokens (128K) |
| Max Output | 16,384 tokens (16K) |
| Reasoning | ✅ |
| Tool Calling | ✅ |
| Input Modalities | text |
| Output Modalities | text |

## Pricing (per 1M tokens)

| Tier | Input | Output | Cache Read | Cache Write |
|------|-------|--------|------------|-------------|
| ≤128K | $0.50 | $3.00 | $0.05 | $0.625 |
| >128K | $2.00 | $6.00 | $0.20 | $2.50 |

> Pricing reference: [Alibaba Cloud DashScope](https://help.aliyun.com/zh/model-studio/getting-started/models)

## Checklist

- [x] Model definition follows existing patterns (qwen3.6-plus, qwen3.7-max)
- [x] Uses extends pattern for alibaba-cn provider
- [x] Pricing based on official Alibaba Cloud documentation