### PR TITLE
Add CoderPlan provider

### DIFF
--- a/providers/coderplan/models/claude-haiku-4-5.toml
+++ b/providers/coderplan/models/claude-haiku-4-5.toml
@@ -1,0 +1,6 @@
+[extends]
+from = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 0.30
+output = 1.50

--- a/providers/coderplan/models/claude-opus-4-7.toml
+++ b/providers/coderplan/models/claude-opus-4-7.toml
@@ -1,0 +1,6 @@
+[extends]
+from = "anthropic/claude-opus-4-7"
+
+[cost]
+input = 1.48
+output = 7.39

--- a/providers/coderplan/models/claude-sonnet-4-6.toml
+++ b/providers/coderplan/models/claude-sonnet-4-6.toml
@@ -1,0 +1,6 @@
+[extends]
+from = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 0.89
+output = 4.43

--- a/providers/coderplan/models/deepseek-chat.toml
+++ b/providers/coderplan/models/deepseek-chat.toml
@@ -1,0 +1,6 @@
+[extends]
+from = "deepseek/deepseek-chat"
+
+[cost]
+input = 0.07
+output = 0.14

--- a/providers/coderplan/models/deepseek-reasoner.toml
+++ b/providers/coderplan/models/deepseek-reasoner.toml
@@ -1,0 +1,6 @@
+[extends]
+from = "deepseek/deepseek-reasoner"
+
+[cost]
+input = 0.07
+output = 0.14

--- a/providers/coderplan/models/gemini-2.5-pro.toml
+++ b/providers/coderplan/models/gemini-2.5-pro.toml
@@ -1,0 +1,6 @@
+[extends]
+from = "google/gemini-2.5-pro"
+
+[cost]
+input = 1.29
+output = 10.35

--- a/providers/coderplan/models/gpt-4.1.toml
+++ b/providers/coderplan/models/gpt-4.1.toml
@@ -1,0 +1,6 @@
+[extends]
+from = "openai/gpt-4.1"
+
+[cost]
+input = 0.14
+output = 0.56

--- a/providers/coderplan/models/gpt-5.4.toml
+++ b/providers/coderplan/models/gpt-5.4.toml
@@ -1,0 +1,6 @@
+[extends]
+from = "openai/gpt-5.4"
+
+[cost]
+input = 0.18
+output = 1.11

--- a/providers/coderplan/models/gpt-5.5.toml
+++ b/providers/coderplan/models/gpt-5.5.toml
@@ -1,0 +1,6 @@
+[extends]
+from = "openai/gpt-5.5"
+
+[cost]
+input = 0.37
+output = 2.22

--- a/providers/coderplan/provider.toml
+++ b/providers/coderplan/provider.toml
@@ -1,0 +1,5 @@
+name = "CoderPlan"
+env = ["CODERPLAN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.coderplan.ai/v1"
+doc = "https://coderplan.ai/docs/setup"


### PR DESCRIPTION
## Summary

Adds **CoderPlan** as a provider — an OpenAI-compatible LLM API relay for Chinese developers.

- **9 models**: Claude (Opus 4.7, Sonnet 4.6, Haiku 4.5), GPT (5.5, 5.4, 4.1), Gemini 2.5 Pro, DeepSeek (Chat, Reasoner)
- **Pricing**: pay-per-use at ~0.7x official rates, ¥10 minimum top-up, Alipay/WeChat
- **API endpoint**: `https://api.coderplan.ai/v1` (OpenAI-compatible)
- **Docs**: https://coderplan.ai/docs/setup

All model definitions use `[extends]` to inherit capabilities from the canonical base providers, with CoderPlan-specific pricing overrides.

## Checklist

- [x] `provider.toml` follows existing schema
- [x] Model files use `[extends]` from canonical base providers
- [x] Pricing data matches published rates at https://coderplan.ai/pricing
- [x] `bun validate` passes