### PR TITLE
feat(sap-ai-core): add GPT-5.5

### DIFF
--- a/providers/sap-ai-core/models/gpt-5.4.toml
+++ b/providers/sap-ai-core/models/gpt-5.4.toml
@@ -1,7 +1,7 @@
 name = "gpt-5.4"
 family = "gpt"
-release_date = "2026-04-27"
-last_updated = "2026-04-27"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
 attachment = true
 reasoning = true
 temperature = false

--- a/providers/sap-ai-core/models/gpt-5.5.toml
+++ b/providers/sap-ai-core/models/gpt-5.5.toml
@@ -1,0 +1,25 @@
+name = "gpt-5.5"
+family = "gpt"
+release_date = "2026-04-23"
+last_updated = "2026-04-23"
+attachment = true
+reasoning = true
+temperature = false
+knowledge = "2025-12-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
**Add** `gpt-5.5` ([OpenAI release 2026-04-23](https://help.openai.com/en/articles/9624314-model-release-notes)).

SAP AI Core routes to OpenAI's `gpt-5.5` (Azure-OpenAI executable); specs mirror the canonical [`openai/gpt-5.5`](../blob/dev/providers/openai/models/gpt-5.5.toml) with the established `sap-ai-core` wrapper adjustments: lowercase `name`, no `[[cost.tiers]]`, no `[experimental.modes.fast]`.

**Sync:**
- `gpt-5.4`: `release_date` / `last_updated` 2026-04-27 → 2026-03-05 (align with [OpenAI release date](https://help.openai.com/en/articles/9624314-model-release-notes); SAP routes to OpenAI, the model release date is the relevant date).