### PR TITLE
feat(amazon-bedrock): add OpenAI Mantle models

### DIFF
--- a/providers/amazon-bedrock/models/openai.gpt-5.4.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.4.toml
@@ -1,0 +1,19 @@
+last_updated = "2026-06-01"
+
+[extends]
+from = "openai/gpt-5.4"
+omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
+
+[cost]
+input = 2.75
+output = 16.50
+cache_read = 0.275
+
+[limit]
+context = 272_000
+output = 128_000
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-5.5.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.5.toml
@@ -1,0 +1,19 @@
+last_updated = "2026-06-01"
+
+[extends]
+from = "openai/gpt-5.5"
+omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
+
+[cost]
+input = 5.50
+output = 33.00
+cache_read = 0.55
+
+[limit]
+context = 272_000
+output = 128_000
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b.toml
@@ -1,0 +1,7 @@
+[extends]
+from = "amazon-bedrock/openai.gpt-oss-120b-1:0"
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b.toml
@@ -1,0 +1,7 @@
+[extends]
+from = "amazon-bedrock/openai.gpt-oss-20b-1:0"
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/v1"
+shape = "responses"


### PR DESCRIPTION
## Summary
- add Amazon Bedrock Mantle entries for OpenAI GPT-5.4 and GPT-5.5
- add Mantle Responses entries for the unsuffixed gpt-oss-20b and gpt-oss-120b model IDs
- route GPT-5.x through the model-specific `/openai/v1` base path and gpt-oss through Mantle's standard `/v1` base path

## Validation
- `bun validate`
- `cd packages/web && bun run build`

Closes #1962