### PR TITLE
feat(moonshot): add reasoning toggle options

### DIFF
--- a/providers/kimi-for-coding/models/k2p5.toml
+++ b/providers/kimi-for-coding/models/k2p5.toml
@@ -10,6 +10,9 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0
@@ -23,5 +26,4 @@ output = 32_768
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
-
 

--- a/providers/kimi-for-coding/models/k2p6.toml
+++ b/providers/kimi-for-coding/models/k2p6.toml
@@ -10,6 +10,9 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0

--- a/providers/kimi-for-coding/provider.toml
+++ b/providers/kimi-for-coding/provider.toml
@@ -1,5 +1,5 @@
 name = "Kimi For Coding"
 env = ["KIMI_API_KEY"]
 npm = "@ai-sdk/anthropic"
-doc = "https://www.kimi.com/coding/docs/en/third-party-agents.html"
+doc = "https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html"
 api = "https://api.kimi.com/coding/v1"

--- a/providers/moonshotai/models/kimi-k2.5.toml
+++ b/providers/moonshotai/models/kimi-k2.5.toml
@@ -13,6 +13,9 @@ open_weights = true
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.6
 output = 3.0

--- a/providers/moonshotai/models/kimi-k2.6.toml
+++ b/providers/moonshotai/models/kimi-k2.6.toml
@@ -13,6 +13,9 @@ open_weights = true
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.95
 output = 4.0


### PR DESCRIPTION
## Summary
- add normalized `toggle` reasoning options for Moonshot AI `kimi-k2.5` and `kimi-k2.6`
- add the same verified toggle metadata for Kimi For Coding `k2p5` and `k2p6`
- update the Kimi For Coding documentation URL to the current official integration page

Moonshot AI China is covered automatically because its model TOMLs are symlink projections of the Moonshot AI source records. Explicit `kimi-k2-thinking` variants remain unchanged because they are intrinsic-thinking models rather than verified caller-toggleable surfaces.

## Sources
- https://platform.kimi.ai/docs/api/chat
- https://platform.kimi.com/docs/api/chat
- https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/providers-and-models.html
- https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html

## Verification
- `bun validate`
- `git diff --check`