### PR TITLE
feat(deepseek): add reasoning options

### DIFF
--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -10,6 +10,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -10,6 +10,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
## Summary
- add thinking toggle metadata for first-party DeepSeek V4 Flash and V4 Pro
- add the two distinct documented reasoning effort values: `high` and `max`
- leave deprecated mode-fixed `deepseek-chat` and `deepseek-reasoner` aliases unchanged

## Sources
- https://api-docs.deepseek.com/guides/thinking_mode
- https://api-docs.deepseek.com/quick_start/pricing

## Validation
- `bun validate`
- `git diff --check`