### PR TITLE
feat(glm): add Zhipu and coding plan reasoning toggles

### DIFF
--- a/providers/zai-coding-plan/models/glm-4.5-air.toml
+++ b/providers/zai-coding-plan/models/glm-4.5-air.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0

--- a/providers/zai-coding-plan/models/glm-4.7.toml
+++ b/providers/zai-coding-plan/models/glm-4.7.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zai-coding-plan/models/glm-5-turbo.toml
+++ b/providers/zai-coding-plan/models/glm-5-turbo.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zai-coding-plan/models/glm-5.1.toml
+++ b/providers/zai-coding-plan/models/glm-5.1.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zhipuai-coding-plan/models/glm-5.1.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5.1.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zhipuai/models/glm-5.1.toml
+++ b/providers/zhipuai/models/glm-5.1.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zhipuai/models/glm-5.toml
+++ b/providers/zhipuai/models/glm-5.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/zhipuai/models/glm-5v-turbo.toml
+++ b/providers/zhipuai/models/glm-5v-turbo.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
## Summary
- add explicit reasoning toggle metadata to verified Z.AI Coding Plan GLM records
- add explicit reasoning toggle metadata to separately authored primary Zhipu AI GLM-5, GLM-5.1, and GLM-5V-Turbo records
- add the separately authored Zhipu AI Coding Plan GLM-5.1 declaration
- cover shared Zhipu AI records through existing symlinks
- leave plan-only vision records unchanged pending separate direct Coding Plan chat-endpoint verification

## Context
- primary Z.AI standard API records were already covered by the earlier Z.AI rollout
- older primary Zhipu AI standard records project those declarations through existing symlinks

## Sources
- https://docs.z.ai/devpack/overview
- https://docs.z.ai/devpack/tool/others
- https://docs.z.ai/guides/capabilities/thinking-mode
- https://docs.bigmodel.cn/cn/coding-plan/overview
- https://docs.bigmodel.cn/cn/coding-plan/tool/others
- https://docs.bigmodel.cn/cn/guide/capabilities/thinking-mode
- https://docs.bigmodel.cn/cn/guide/capabilities/thinking
- https://docs.bigmodel.cn/cn/guide/models/vlm/glm-5v-turbo

## Validation
- `bun validate`
- `git diff --check`