### PR TITLE
fix(sync): restore model catalog workflow

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: List sync providers
         id: providers
-        run: echo "matrix=$(bun models:sync --list-providers)" >> "$GITHUB_OUTPUT"
+        run: |
+          matrix="$(bun models:sync --list-providers)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   sync:
     needs: providers

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -235,7 +235,7 @@ function canonicalModelExists(provider: string, modelID: string) {
 }
 
 function modelMetadataExists(provider: string, modelID: string) {
-  return existsSync(path.join(MODELS_DIR, provider, `${modelID}.toml"));
+  return existsSync(path.join(MODELS_DIR, provider, `${modelID}.toml`));
 }
 
 function baseModelOmit(


### PR DESCRIPTION
## Summary
- close the unterminated OpenRouter metadata path template literal so sync provider imports succeed
- preserve provider-list command failures in the workflow instead of writing an empty matrix and failing later in `fromJSON`

## Investigation
- verified all five provider sync targets complete dry runs successfully
- verified the `cloudflare:sync` package alias and the grouped `direct` target complete dry runs successfully

## Verification
- `bun models:sync --list-providers`
- `bun models:sync openrouter --dry-run`
- `bun models:sync ovhcloud --dry-run`
- `bun models:sync cloudflare-workers-ai --dry-run`
- `bun models:sync google --dry-run`
- `bun models:sync xai --dry-run`
- `bun cloudflare:sync --dry-run`
- `bun models:sync direct --dry-run`
- `bun validate`
- `git diff --check`