### PR TITLE
feat(cohere): add reasoning options

### DIFF
--- a/providers/cohere/models/command-a-reasoning-08-2025.toml
+++ b/providers/cohere/models/command-a-reasoning-08-2025.toml
@@ -9,6 +9,13 @@ knowledge = "2024-06-01"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+
 [cost]
 input = 2.50
 output = 10.00


### PR DESCRIPTION
## Summary
- add normalized reasoning controls for Cohere first-party `command-a-reasoning-08-2025`
- represent Cohere Chat API `thinking.type` as `[[reasoning_options]] type = "toggle"`
- represent Cohere Chat API `thinking.token_budget` as `[[reasoning_options]] type = "budget_tokens"` with `min = 1`

## Official Sources
- https://docs.cohere.com/docs/reasoning
- https://docs.cohere.com/reference/chat
- https://docs.cohere.com/changelog/2025-08-21-command-a-reasoning

## Wire Parameters And Normalization
Cohere documents `thinking.type` with `enabled` and `disabled` values for reasoning-capable models, so the catalog exposes the normalized `toggle` control. Cohere also documents `thinking.token_budget` as the maximum number of thinking tokens and requires a positive integer, so the catalog exposes `budget_tokens` with `min = 1`. No `max` is encoded: Cohere recommends 31K when reasoning up to the 32K output limit while leaving response space, but does not document 31K as an API maximum.

## Intentionally Unchanged Records
All other `providers/cohere/models/*.toml` records remain unchanged. The official model overview describes `command-a-reasoning-08-2025` as Cohere's first reasoning model, and this PR does not infer endpoint controls from general model capability or from controls available on the shared Chat API schema.

## Validation
- `bun validate`
- `git diff --check`
- `git diff --check origin/dev...HEAD`