### PR TITLE
feat(sarvam): add reasoning options

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -21,6 +21,14 @@ const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
   ]),
 );
 
+const ReasoningEffortValue = z.preprocess(
+  (value) => (value === "null" ? null : value),
+  z.union([
+    z.null(),
+    z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]),
+  ]),
+);
+
 const ReasoningOption = z
   .discriminatedUnion("type", [
     z
@@ -31,9 +39,7 @@ const ReasoningOption = z
     z
       .object({
         type: z.literal("effort"),
-        values: z.array(
-          z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]),
-        ),
+        values: z.array(ReasoningEffortValue),
       })
       .strict(),
     z

--- a/providers/sarvam/models/sarvam-105b.toml
+++ b/providers/sarvam/models/sarvam-105b.toml
@@ -9,11 +9,8 @@ tool_call = true
 open_weights = true
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
+values = ["null", "low", "medium", "high"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/sarvam/models/sarvam-105b.toml
+++ b/providers/sarvam/models/sarvam-105b.toml
@@ -8,6 +8,13 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/sarvam/models/sarvam-30b.toml
+++ b/providers/sarvam/models/sarvam-30b.toml
@@ -9,11 +9,8 @@ tool_call = true
 open_weights = true
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
+values = ["null", "low", "medium", "high"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/sarvam/models/sarvam-30b.toml
+++ b/providers/sarvam/models/sarvam-30b.toml
@@ -8,6 +8,13 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
## Summary
- add nullable reasoning effort metadata for Sarvam first-party `sarvam-30b` and `sarvam-105b` records
- represent Sarvam's documented `reasoning_effort` choices as one normalized effort option: `null`, `low`, `medium`, and `high`
- add schema parsing so authored TOML can use the string sentinel `"null"`, while the resolved catalog/API emits actual JSON `null`

## Official sources
- https://docs.sarvam.ai/api-reference-docs/chat/chat-completions
- https://docs.sarvam.ai/api-reference-docs/api-guides-tutorials/chat-completion/how-to/adjust-the-models-thinking-level

## Applicability and normalization
The official Chat Completion OpenAPI schema lists `sarvam-30b` and `sarvam-105b` as primary supported chat completion model IDs. The same request schema exposes `reasoning_effort`, permits `low`, `medium`, and `high`, defaults to `medium`, and documents explicit `null` / `None` as disabling reasoning.

Because `null` is one of the actual selectable wire values for `reasoning_effort`, this PR represents Sarvam as:

```toml
[[reasoning_options]]
type = "effort"
values = ["null", "low", "medium", "high"]
```

TOML has no null literal in arrays, so the authored `"null"` sentinel is parsed into actual JSON `null` in the resolved catalog:

```json
[{ "type": "effort", "values": [null, "low", "medium", "high"] }]
```

## Deliberate exclusions
- no other providers or models were changed; this audit is limited to Sarvam first-party endpoint records under `providers/sarvam`
- `sarvam-m` appears in the endpoint schema as a legacy accepted model, but there is no first-party `providers/sarvam` catalog record for it, so this PR intentionally does not add or modify one
- no control was inferred solely from intrinsic reasoning capability

## Validation
- `bun validate`
- `git diff --check`