### PR TITLE
feat(xiaomi): add reasoning toggles

### DIFF
--- a/providers/xiaomi/models/mimo-v2-flash.toml
+++ b/providers/xiaomi/models/mimo-v2-flash.toml
@@ -9,6 +9,9 @@ knowledge = "2024-12-01"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.10
 output = 0.30

--- a/providers/xiaomi/models/mimo-v2-omni.toml
+++ b/providers/xiaomi/models/mimo-v2-omni.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2024-12"
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/xiaomi/models/mimo-v2-pro.toml
+++ b/providers/xiaomi/models/mimo-v2-pro.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2024-12"
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2024-12"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 1
 output = 3

--- a/providers/xiaomi/models/mimo-v2.5.toml
+++ b/providers/xiaomi/models/mimo-v2.5.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2024-12"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.4
 output = 2


### PR DESCRIPTION
## Summary
- add normalized `reasoning_options = [{ type = "toggle" }]` metadata to Xiaomi first-party pay-as-you-go text-generation models: `mimo-v2.5-pro`, `mimo-v2.5`, `mimo-v2-pro`, `mimo-v2-omni`, and `mimo-v2-flash`
- leave Xiaomi Token Plan records unchanged because its dedicated endpoint documentation does not establish the same `thinking` request control

## Official Sources
- Pay-as-you-go OpenAI endpoint request schema: https://platform.xiaomimimo.com/docs/zh-CN/api/chat/openai-api
- Pay-as-you-go OpenAI endpoint example: https://platform.xiaomimimo.com/docs/en-US/api/chat/openai-api
- First-party model capability list: https://platform.xiaomimimo.com/docs/en-US/quick-start/model
- Token Plan dedicated endpoint and credential documentation: https://platform.xiaomimimo.com/docs/en-US/tokenplan/quick-access

## Wire Parameter
The Xiaomi OpenAI-compatible pay-as-you-go request schema documents `thinking.type` as an optional chain-of-thought switch. Its allowed values are `enabled` and `disabled`. The schema lists `mimo-v2.5-pro`, `mimo-v2.5`, `mimo-v2-pro`, `mimo-v2-omni`, and `mimo-v2-flash`, and excludes the TTS models. This is represented in models.dev as the normalized `toggle` reasoning option.

## Token Plan Exclusion
Xiaomi Token Plan uses dedicated `tp-xxxxx` credentials and separate `token-plan-*.xiaomimimo.com` base URLs. Its quick-access direct-call examples do not document `thinking`, so this PR does not infer pay-as-you-go parity and does not modify Token Plan records.

## Validation
- `bun validate`
- `git diff --check`