### PR TITLE
feat(mistral): add reasoning effort options

### DIFF
--- a/models/mistral/mistral-medium-latest.toml
+++ b/models/mistral/mistral-medium-latest.toml
@@ -1,13 +1,15 @@
+# Mistral's live API currently maps this alias to Mistral Medium 3.1,
+# even though Mistral Medium 3.5 is newer and exposed as mistral-medium-2604.
 name = "Mistral Medium (latest)"
 family = "mistral-medium"
-release_date = "2026-04-29"
-last_updated = "2026-04-29"
+release_date = "2025-08-12"
+last_updated = "2025-08-12"
 attachment = true
-reasoning = true
+reasoning = false
 temperature = true
+knowledge = "2025-05"
 tool_call = true
-structured_output = true
-open_weights = true
+open_weights = false
 
 [limit]
 context = 262_144

--- a/providers/merge-gateway/models/mistral/mistral-medium-latest.toml
+++ b/providers/merge-gateway/models/mistral/mistral-medium-latest.toml
@@ -1,5 +1,5 @@
 base_model = "mistral/mistral-medium-latest"
 
 [cost]
-input = 1.5
-output = 7.5
+input = 0.4
+output = 2.0

--- a/providers/mistral/models/mistral-medium-2604.toml
+++ b/providers/mistral/models/mistral-medium-2604.toml
@@ -9,6 +9,10 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
 [cost]
 input = 1.50
 output = 7.50

--- a/providers/mistral/models/mistral-medium-latest.toml
+++ b/providers/mistral/models/mistral-medium-latest.toml
@@ -1,6 +1,8 @@
-base_model = "mistral/mistral-medium-2604"
+# Mistral's live API currently maps this alias to mistral-medium-2508,
+# even though Mistral Medium 3.5 is newer and exposed as mistral-medium-2604.
+base_model = "mistral/mistral-medium-latest"
 name = "Mistral Medium (latest)"
 
 [cost]
-input = 1.5
-output = 7.5
+input = 0.40
+output = 2.00

--- a/providers/mistral/models/mistral-small-2603.toml
+++ b/providers/mistral/models/mistral-small-2603.toml
@@ -9,6 +9,10 @@ knowledge = "2025-06"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
 [cost]
 input = 0.15
 output = 0.60

--- a/providers/mistral/models/mistral-small-latest.toml
+++ b/providers/mistral/models/mistral-small-latest.toml
@@ -9,6 +9,10 @@ knowledge = "2025-06"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
 [cost]
 input = 0.15
 output = 0.60


### PR DESCRIPTION
## Summary
- add normalized `reasoning_options` metadata for live-verified first-party Mistral chat-completion IDs present in this repo
- expose the supported `reasoning_effort` values as normalized effort options: `none` and `high`
- correct `mistral-medium-latest` metadata to match the live Mistral API alias target (`mistral-medium-2508`), not the newer `mistral-medium-2604` / Medium 3.5 endpoint

## Changed records
- `providers/mistral/models/mistral-small-latest.toml`
- `providers/mistral/models/mistral-small-2603.toml`
- `providers/mistral/models/mistral-medium-2604.toml`
- `providers/mistral/models/mistral-medium-latest.toml`
- `models/mistral/mistral-medium-latest.toml`
- `providers/merge-gateway/models/mistral/mistral-medium-latest.toml`

## Wire parameter
Mistral Chat Completions accepts `reasoning_effort` on the verified endpoints. The normalized metadata added here represents its supported values as:

```toml
[[reasoning_options]]
type = "effort"
values = ["none", "high"]
```

## Live verification
I probed Mistral `/v1/models`, `/v1/models/{model_id}`, and `/v1/chat/completions` directly. For each tested model, requests used a small chat completion payload with `reasoning_effort` set to candidate values.

Accepted `none` and `high`:

```text
magistral-small-latest
mistral-medium-2604
mistral-medium-3
mistral-medium-3-5
mistral-medium-3.5
mistral-medium-c21211-r0-75
mistral-small-2603
mistral-small-latest
mistral-vibe-cli-fast
mistral-vibe-cli-latest
```

Rejected `minimal`, `low`, `medium`, `xhigh`, and `max` with unsupported-value errors; supported values were reported as `high` and `none`.

Rejected `none` and `high` with `reasoning_effort is not enabled for this model`:

```text
codestral-2508
codestral-latest
devstral-2512
devstral-latest
devstral-medium-latest
magistral-medium-2509
magistral-medium-latest
magistral-small-2509
ministral-14b-2512
ministral-14b-latest
ministral-3b-2512
ministral-3b-latest
ministral-8b-2512
ministral-8b-latest
mistral-code-agent-latest
mistral-code-fim-latest
mistral-code-latest
mistral-large-2512
mistral-large-latest
mistral-medium
mistral-medium-2505
mistral-medium-2508
mistral-medium-latest
mistral-small-2506
mistral-tiny-2407
mistral-tiny-latest
mistral-vibe-cli-with-tools
open-mistral-nemo
open-mistral-nemo-2407
voxtral-mini-2507
voxtral-small-2507
voxtral-small-latest
```

`labs-leanstral-2603` was not classified because the test organization did not have Labs models enabled; the endpoint returned 403 before effort validation.

## `mistral-medium-latest` alias correction
Live `GET /v1/models/mistral-medium-latest` returns:

```text
id: mistral-medium-latest
name: mistral-medium-2508
aliases: ["mistral-medium-2508", "mistral-medium", "mistral-vibe-cli-with-tools"]
reasoning: false
```

Live `GET /v1/models/mistral-medium-2604` returns Medium 3.5 aliases, but does not list `mistral-medium-latest`:

```text
aliases: ["mistral-medium-3-5-0", "mistral-medium-3-5", "mistral-medium-3.5", "mistral-medium-3", "mistral-medium-c21211-r0-75", "mistral-vibe-cli-latest"]
reasoning: true
```

So this PR corrects `mistral-medium-latest` to 2508 metadata and leaves a TOML comment documenting that Mistral Medium 3.5 is newer but exposed separately as `mistral-medium-2604`.

## Scope notes
- `mistral-medium-latest` intentionally has no `reasoning_options`: live chat completions reject `reasoning_effort`.
- `mistral-medium-2604` is changed: live chat completions accept `reasoning_effort = "none" | "high"`.
- Mistral API exposes additional aliases such as `mistral-medium-3-5`, `mistral-medium-3.5`, and `mistral-vibe-cli-latest`, but this repo currently has `mistral-medium-2604` as the corresponding authored first-party record.
- `magistral-medium-*` and `magistral-small-2509` are native reasoning models but do not accept this caller-selectable `reasoning_effort` control.

## Official sources
- https://docs.mistral.ai/studio-api/conversations/reasoning
- https://docs.mistral.ai/api/endpoint/chat
- https://docs.mistral.ai/api/endpoint/models
- https://docs.mistral.ai/resources/deprecated/native-reasoning

## Validation
- `bun validate`
- `git diff --check`
- resolved output check for `mistral/mistral-medium-latest` and `merge-gateway/mistral/mistral-medium-latest`