### PR TITLE
feat(alibaba): add complete reasoning options

### DIFF
--- a/providers/alibaba-cn/models/deepseek-v4-flash.toml
+++ b/providers/alibaba-cn/models/deepseek-v4-flash.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/deepseek-v4-pro.toml
+++ b/providers/alibaba-cn/models/deepseek-v4-pro.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/glm-5.1.toml
+++ b/providers/alibaba-cn/models/glm-5.1.toml
@@ -9,6 +9,13 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/glm-5.toml
+++ b/providers/alibaba-cn/models/glm-5.toml
@@ -8,6 +8,13 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 32_768
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-cn/models/kimi-k2.5.toml
@@ -10,6 +10,13 @@ open_weights = true
 knowledge = "2025-01"
 structured_output = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/kimi-k2.6.toml
+++ b/providers/alibaba-cn/models/kimi-k2.6.toml
@@ -10,6 +10,13 @@ open_weights = true
 knowledge = "2025-01"
 structured_output = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/kimi/kimi-k2.5.toml
+++ b/providers/alibaba-cn/models/kimi/kimi-k2.5.toml
@@ -10,6 +10,13 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/qwen-flash.toml
+++ b/providers/alibaba-cn/models/qwen-flash.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.022
 output = 0.216

--- a/providers/alibaba-cn/models/qwen-plus.toml
+++ b/providers/alibaba-cn/models/qwen-plus.toml
@@ -9,6 +9,12 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.115
 output = 0.287

--- a/providers/alibaba-cn/models/qwen-plus.toml
+++ b/providers/alibaba-cn/models/qwen-plus.toml
@@ -14,6 +14,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
+max = 81_920
 
 [cost]
 input = 0.115

--- a/providers/alibaba-cn/models/qwen-turbo.toml
+++ b/providers/alibaba-cn/models/qwen-turbo.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.044
 output = 0.087

--- a/providers/alibaba-cn/models/qwen3-14b.toml
+++ b/providers/alibaba-cn/models/qwen3-14b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.144
 output = 0.574

--- a/providers/alibaba-cn/models/qwen3-235b-a22b.toml
+++ b/providers/alibaba-cn/models/qwen3-235b-a22b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.287
 output = 1.147

--- a/providers/alibaba-cn/models/qwen3-32b.toml
+++ b/providers/alibaba-cn/models/qwen3-32b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.287
 output = 1.147

--- a/providers/alibaba-cn/models/qwen3-8b.toml
+++ b/providers/alibaba-cn/models/qwen3-8b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.072
 output = 0.287

--- a/providers/alibaba-cn/models/qwen3-omni-flash.toml
+++ b/providers/alibaba-cn/models/qwen3-omni-flash.toml
@@ -9,6 +9,9 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.058
 output = 0.230

--- a/providers/alibaba-cn/models/qwen3-vl-plus.toml
+++ b/providers/alibaba-cn/models/qwen3-vl-plus.toml
@@ -9,12 +9,6 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
-[[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
-
 [cost]
 input = 0.143353
 output = 1.433525

--- a/providers/alibaba-cn/models/qwen3-vl-plus.toml
+++ b/providers/alibaba-cn/models/qwen3-vl-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.143353
 output = 1.433525

--- a/providers/alibaba-cn/models/qwen3-vl-plus.toml
+++ b/providers/alibaba-cn/models/qwen3-vl-plus.toml
@@ -9,6 +9,12 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.143353
 output = 1.433525

--- a/providers/alibaba-cn/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba-cn/models/qwen3.5-397b-a17b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.430
 output = 2.58

--- a/providers/alibaba-cn/models/qwen3.5-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.5-flash.toml
@@ -10,6 +10,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.172
 output = 1.72

--- a/providers/alibaba-cn/models/qwen3.5-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.5-plus.toml
@@ -9,6 +9,12 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.573
 output = 3.44

--- a/providers/alibaba-cn/models/qwen3.5-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.5-plus.toml
@@ -14,6 +14,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
+max = 81_920
 
 [cost]
 input = 0.573

--- a/providers/alibaba-cn/models/qwen3.6-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.6-flash.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.6-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 0.1875
 output = 1.125

--- a/providers/alibaba-cn/models/qwen3.6-max-preview.toml
+++ b/providers/alibaba-cn/models/qwen3.6-max-preview.toml
@@ -9,6 +9,13 @@ tool_call = true
 open_weights = false
 structured_output = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 1.32
 cache_read = 0.132

--- a/providers/alibaba-cn/models/qwen3.6-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.6-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.50
 output = 3.00

--- a/providers/alibaba-cn/models/qwen3.7-max.toml
+++ b/providers/alibaba-cn/models/qwen3.7-max.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.7-max"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 2.5
 output = 7.5

--- a/providers/alibaba-cn/models/qwen3.7-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.7-plus.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.7-plus"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 0.5
 output = 3

--- a/providers/alibaba-cn/models/siliconflow/deepseek-v3.1-terminus.toml
+++ b/providers/alibaba-cn/models/siliconflow/deepseek-v3.1-terminus.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.27
 output = 1.0

--- a/providers/alibaba-cn/models/siliconflow/deepseek-v3.2.toml
+++ b/providers/alibaba-cn/models/siliconflow/deepseek-v3.2.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.27
 output = 0.42

--- a/providers/alibaba/models/qwen-flash.toml
+++ b/providers/alibaba/models/qwen-flash.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.05
 output = 0.4

--- a/providers/alibaba/models/qwen-plus.toml
+++ b/providers/alibaba/models/qwen-plus.toml
@@ -14,6 +14,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
+max = 81_920
 
 [cost]
 input = 0.4

--- a/providers/alibaba/models/qwen-plus.toml
+++ b/providers/alibaba/models/qwen-plus.toml
@@ -9,6 +9,12 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.4
 output = 1.2

--- a/providers/alibaba/models/qwen-turbo.toml
+++ b/providers/alibaba/models/qwen-turbo.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.05
 output = 0.2

--- a/providers/alibaba/models/qwen3-14b.toml
+++ b/providers/alibaba/models/qwen3-14b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.35
 output = 1.4

--- a/providers/alibaba/models/qwen3-235b-a22b.toml
+++ b/providers/alibaba/models/qwen3-235b-a22b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.7
 output = 2.8

--- a/providers/alibaba/models/qwen3-32b.toml
+++ b/providers/alibaba/models/qwen3-32b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.7
 output = 2.8

--- a/providers/alibaba/models/qwen3-8b.toml
+++ b/providers/alibaba/models/qwen3-8b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.18
 output = 0.7

--- a/providers/alibaba/models/qwen3-omni-flash.toml
+++ b/providers/alibaba/models/qwen3-omni-flash.toml
@@ -9,6 +9,9 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.43
 output = 1.66

--- a/providers/alibaba/models/qwen3-vl-plus.toml
+++ b/providers/alibaba/models/qwen3-vl-plus.toml
@@ -9,6 +9,12 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.2
 output = 1.6

--- a/providers/alibaba/models/qwen3-vl-plus.toml
+++ b/providers/alibaba/models/qwen3-vl-plus.toml
@@ -9,12 +9,6 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
-[[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
-
 [cost]
 input = 0.2
 output = 1.6

--- a/providers/alibaba/models/qwen3-vl-plus.toml
+++ b/providers/alibaba/models/qwen3-vl-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.2
 output = 1.6

--- a/providers/alibaba/models/qwen3.5-122b-a10b.toml
+++ b/providers/alibaba/models/qwen3.5-122b-a10b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.4
 output = 3.2

--- a/providers/alibaba/models/qwen3.5-27b.toml
+++ b/providers/alibaba/models/qwen3.5-27b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.3
 output = 2.4

--- a/providers/alibaba/models/qwen3.5-35b-a3b.toml
+++ b/providers/alibaba/models/qwen3.5-35b-a3b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.25
 output = 2

--- a/providers/alibaba/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba/models/qwen3.5-397b-a17b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.6
 output = 3.6

--- a/providers/alibaba/models/qwen3.5-plus.toml
+++ b/providers/alibaba/models/qwen3.5-plus.toml
@@ -14,6 +14,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
+max = 81_920
 
 [cost]
 input = 0.4

--- a/providers/alibaba/models/qwen3.5-plus.toml
+++ b/providers/alibaba/models/qwen3.5-plus.toml
@@ -9,6 +9,12 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.4
 output = 2.4

--- a/providers/alibaba/models/qwen3.6-27b.toml
+++ b/providers/alibaba/models/qwen3.6-27b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 0.6
 output = 3.6

--- a/providers/alibaba/models/qwen3.6-35b-a3b.toml
+++ b/providers/alibaba/models/qwen3.6-35b-a3b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 0.248
 output = 1.485

--- a/providers/alibaba/models/qwen3.6-flash.toml
+++ b/providers/alibaba/models/qwen3.6-flash.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 0.1875
 output = 1.125

--- a/providers/alibaba/models/qwen3.6-max-preview.toml
+++ b/providers/alibaba/models/qwen3.6-max-preview.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 1.3
 output = 7.8

--- a/providers/alibaba/models/qwen3.6-plus.toml
+++ b/providers/alibaba/models/qwen3.6-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.50
 output = 3.00

--- a/providers/alibaba/models/qwen3.7-max.toml
+++ b/providers/alibaba/models/qwen3.7-max.toml
@@ -8,6 +8,13 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 2.50
 output = 7.50

--- a/providers/alibaba/models/qwen3.7-plus.toml
+++ b/providers/alibaba/models/qwen3.7-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 0.50
 output = 3.00


### PR DESCRIPTION
## Summary
- complete the caller-selectable `reasoning_options` matrix for both `alibaba` (international DashScope) and `alibaba-cn` (Chinese mainland DashScope)
- preserve the previously audited `qwen-plus` and `qwen3.5-plus` choices while covering all current documented hybrid-thinking gaps
- add only `reasoning_options`; no model capability, pricing, limit, endpoint, or identity fields change

## Effective control matrix

### `alibaba`
- `toggle` + `budget_tokens` (81,920): `qwen-plus`, `qwen-flash`, `qwen3.5-plus`, `qwen3.5-397b-a17b`, `qwen3.5-122b-a10b`, `qwen3.5-27b`, `qwen3.5-35b-a3b`, `qwen3-vl-plus`, `qwen3.6-plus`
- `toggle` + `budget_tokens` (38,912): `qwen-turbo`, `qwen3-235b-a22b`, `qwen3-32b`, `qwen3-14b`, `qwen3-8b`
- `toggle` + `budget_tokens` (131,072): `qwen3.6-max-preview`, `qwen3.6-flash`, `qwen3.6-27b`, `qwen3.6-35b-a3b`
- `toggle` + `budget_tokens` (262,144): `qwen3.7-max`, `qwen3.7-plus`
- `toggle` only: `qwen3-omni-flash`

### `alibaba-cn`
- `toggle` + `budget_tokens` (81,920): `qwen-plus`, `qwen-flash`, `qwen3.5-plus`, `qwen3.5-flash`, `qwen3.5-397b-a17b`, `qwen3-vl-plus`, `qwen3.6-plus`, `kimi-k2.5`, `kimi-k2.6`, `kimi/kimi-k2.5`
- `toggle` + `budget_tokens` (38,912): `qwen-turbo`, `qwen3-235b-a22b`, `qwen3-32b`, `qwen3-14b`, `qwen3-8b`
- `toggle` + `budget_tokens` (131,072): `qwen3.6-max-preview`, `qwen3.6-flash`, `glm-5.1`
- `toggle` + `budget_tokens` (262,144): `qwen3.7-max`, `qwen3.7-plus`
- `toggle` + `budget_tokens` (32,768): `glm-5`
- `toggle` only: `qwen3-omni-flash`, `siliconflow/deepseek-v3.2`, `siliconflow/deepseek-v3.1-terminus`
- `toggle` + `effort` (`high`, `max`): `deepseek-v4-pro`, `deepseek-v4-flash`

## Wire mapping
- `toggle` maps to DashScope Chat Completions `enable_thinking`.
- `budget_tokens` maps to `thinking_budget`, with each maximum taken from the applicable regional model specification.
- DeepSeek V4 `effort` maps to Chat Completions `reasoning_effort`; only distinct effective values are advertised. DashScope maps `low`/`medium` to `high` and `xhigh` to `max`, so the normalized values are exactly `high` and `max`.
- Responses-only Qwen `reasoning.effort` is not advertised on these Chat Completions provider surfaces.

## Thinking-only exclusions
Dedicated QwQ, QVQ, Qwen/Qwen-VL thinking variants, DeepSeek R1 and distill variants, Kimi K2 Thinking, and MiniMax M2.x records remain without caller-selectable options because their reasoning cannot be disabled. Non-reasoning records are unchanged.

## Official sources
- International deep thinking and regional endpoints: https://www.alibabacloud.com/help/en/model-studio/deep-thinking
- International model modes and Max CoT values: https://www.alibabacloud.com/help/en/model-studio/models
- International Qwen visual controls: https://www.alibabacloud.com/help/en/model-studio/vision
- Qwen-Omni regional hybrid control: https://www.alibabacloud.com/help/en/model-studio/qwen-omni
- Chinese mainland deep thinking controls and supported matrix: https://help.aliyun.com/zh/model-studio/deep-thinking
- Chinese mainland Qwen3.6/Qwen3.7 budgets: https://help.aliyun.com/zh/model-studio/text-generation-model/
- Chinese mainland visual controls: https://help.aliyun.com/zh/model-studio/vision
- DeepSeek controls and effective effort mapping: https://help.aliyun.com/zh/model-studio/deepseek-api
- SiliconFlow DeepSeek controls: https://help.aliyun.com/zh/model-studio/siliconflow-deepseek-api
- Kimi controls: https://help.aliyun.com/zh/model-studio/kimi-api
- GLM controls: https://help.aliyun.com/zh/model-studio/glm

## Validation
- `bun install --frozen-lockfile`
- `bun validate`
- targeted resolved-catalog inspection for provider IDs `alibaba` and `alibaba-cn`
- `git diff --check`
- additions-only diff check (47 model TOMLs, zero removed lines)