### PR TITLE
feat(stepfun): add reasoning effort options

### DIFF
--- a/providers/stepfun/models/step-3.5-flash-2603.toml
+++ b/providers/stepfun/models/step-3.5-flash-2603.toml
@@ -8,6 +8,10 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high"]
+
 [cost]
 input = 0.10
 output = 0.30


### PR DESCRIPTION
## Summary
- add normalized `reasoning_options` effort metadata for first-party `step-3.5-flash-2603`
- expose the officially supported `low` and `high` reasoning effort values
- keep the change scoped to the shared first-party authored record used by the audited StepFun endpoint surfaces

## Endpoint audit
- `providers/stepfun` targets the China standard OpenAI-compatible endpoint: `https://api.stepfun.com/v1`. The official China Chat Completions reference documents `reasoning_effort` and states that `step-3.5-flash-2603` supports the two values `low` and `high`.
- `providers/stepfun-ai` targets the international Step Plan OpenAI-compatible endpoint: `https://api.stepfun.ai/step_plan/v1`. Its checked-in model files symlink the first-party StepFun authored records. The official international Step Plan integration guide states that Step Plan endpoint parameters are exactly the same as the open-platform API, and the official international Chat Completions reference independently documents `step-3.5-flash-2603` as accepting `low` and `high` only.
- This PR normalizes those endpoint controls as `[[reasoning_options]] type = "effort"` with `values = ["low", "high"]`.

## Official sources
- China standard Chat Completions API: https://platform.stepfun.com/docs/zh/api-reference/chat/chat-completion-create
- China Step 3.5 Flash model guide: https://platform.stepfun.com/docs/zh/guides/models/step-3.5-flash
- International Step Plan reasoning integration: https://platform.stepfun.ai/docs/en/step-plan/integrations/reasoning-api
- International Chat Completions API: https://platform.stepfun.ai/docs/en/api-reference/chat/chat-completion-create
- International Step 3.5 Flash model guide: https://platform.stepfun.ai/docs/en/guides/models/step-3.5-flash

## Validation
- `bun validate`
- `git diff --check origin/dev...HEAD`
- generated catalog spot-check: `stepfun` and `stepfun-ai` expose `[{ type: "effort", values: ["low", "high"] }]`; `routing-run` remains unchanged

## Unchanged records
- `providers/stepfun/models/step-3.5-flash.toml`: unchanged because official docs document the two-tier `reasoning_effort` control specifically for `step-3.5-flash-2603`, not the base model.
- `providers/stepfun/models/step-1-32k.toml` and `providers/stepfun/models/step-2-16k.toml`: unchanged because no official endpoint-specific reasoning-option controls were verified for these legacy China standard records.
- `providers/stepfun-ai/models/step-3.5-flash.toml`: unchanged for the same model-specific reason; the Step Plan docs list the model but do not verify a normalized effort control for it.
- `providers/routing-run/models/route/step-3.5-flash-2603.toml`: unchanged because `routing-run` is a separate third-party endpoint surface and was not projected from first-party StepFun documentation.
- `models/stepfun/step-3.5-flash-2603.toml`: unchanged because `reasoning_options` is provider-specific metadata.