### PR TITLE
feat(google): add Gemini reasoning options

### DIFF
--- a/providers/google/models/gemini-2.5-flash-lite.toml
+++ b/providers/google/models/gemini-2.5-flash-lite.toml
@@ -10,6 +10,14 @@ structured_output = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 512
+max = 24_576
+
 [cost]
 input = 0.1
 output = 0.4

--- a/providers/google/models/gemini-2.5-flash.toml
+++ b/providers/google/models/gemini-2.5-flash.toml
@@ -10,6 +10,14 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 24_576
+
 [cost]
 input = 0.30
 output = 2.50

--- a/providers/google/models/gemini-2.5-pro.toml
+++ b/providers/google/models/gemini-2.5-pro.toml
@@ -10,6 +10,11 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 128
+max = 32_768
+
 [cost]
 input = 1.25
 output = 10.00

--- a/providers/google/models/gemini-3-flash-preview.toml
+++ b/providers/google/models/gemini-3-flash-preview.toml
@@ -10,6 +10,10 @@ structured_output = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 0.50
 output = 3.00

--- a/providers/google/models/gemini-3-pro-preview.toml
+++ b/providers/google/models/gemini-3-pro-preview.toml
@@ -11,10 +11,6 @@ knowledge = "2025-01"
 open_weights = false
 status = "deprecated"
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "high"]
-
 [cost]
 input = 2
 output = 12

--- a/providers/google/models/gemini-3-pro-preview.toml
+++ b/providers/google/models/gemini-3-pro-preview.toml
@@ -11,6 +11,10 @@ knowledge = "2025-01"
 open_weights = false
 status = "deprecated"
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high"]
+
 [cost]
 input = 2
 output = 12

--- a/providers/google/models/gemini-3.1-flash-lite.toml
+++ b/providers/google/models/gemini-3.1-flash-lite.toml
@@ -10,6 +10,10 @@ structured_output = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 0.25
 output = 1.50

--- a/providers/google/models/gemini-3.1-pro-preview.toml
+++ b/providers/google/models/gemini-3.1-pro-preview.toml
@@ -10,6 +10,10 @@ structured_output = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 2.00
 output = 12.00

--- a/providers/google/models/gemini-3.5-flash.toml
+++ b/providers/google/models/gemini-3.5-flash.toml
@@ -10,6 +10,10 @@ structured_output = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 1.50
 output = 9.00


### PR DESCRIPTION
## Summary

Add normalized reasoning controls for directly documented first-party Gemini API model records under `providers/google`. Active records are backed by official Gemini API documentation and live `generateContent` probes. The retired Gemini 3 Pro Preview record retains its known historical capability metadata from Google's official Interactions API matrix.

## Model matrix

| Google Gemini API model | Official wire control | Normalized `reasoning_options` | Notes |
| --- | --- | --- | --- |
| `gemini-2.5-pro` | `thinkingConfig.thinkingBudget` | `budget_tokens` `128..32768` | Thinking cannot be disabled. |
| `gemini-2.5-flash` | `thinkingConfig.thinkingBudget` | `toggle`; `budget_tokens` `0..24576` | Budget `0` fully disables thinking. |
| `gemini-2.5-flash-lite` | `thinkingConfig.thinkingBudget` | `toggle`; `budget_tokens` `512..24576` | Budget `0` fully disables thinking; positive documented range starts at `512`. |
| `gemini-3-pro-preview` | `thinking_level` | `effort` `low`, `high` | Retired model. Google's official Interactions API thinking matrix documents these historical supported levels. |
| `gemini-3-flash-preview` | `thinkingConfig.thinkingLevel` | `effort` `minimal`, `low`, `medium`, `high` | `minimal` is not guaranteed to disable thinking. |
| `gemini-3.1-pro-preview` | `thinkingConfig.thinkingLevel` | `effort` `low`, `medium`, `high` | `minimal` is not supported; thinking cannot be disabled. |
| `gemini-3.1-flash-lite` | `thinkingConfig.thinkingLevel` | `effort` `minimal`, `low`, `medium`, `high` | `minimal` is not guaranteed to disable thinking. |
| `gemini-3.5-flash` | `thinkingConfig.thinkingLevel` | `effort` `minimal`, `low`, `medium`, `high` | `minimal` is not guaranteed to disable thinking. |

## Wire-to-normalized mapping

- Gemini 3.x documented `thinkingLevel` / `thinking_level` enums map to normalized `effort` values.
- Gemini 2.5 documented `thinkingBudget` numeric ranges map to normalized `budget_tokens` bounds.
- `toggle` is included only where the docs explicitly support full caller disable with `thinkingBudget = 0`.
- Dynamic `thinkingBudget = -1` is an internal request sentinel, not a normalized catalog minimum.
- No Gemini 3.x `toggle` is added: the docs state that `minimal` may still think and does not guarantee thinking-off.

## Live verification

- The seven active changed records were probed against the represented Gemini API `generateContent` endpoint and matched the documented controls.
- `models/gemini-3-pro-preview:generateContent` currently returns HTTP `404 NOT_FOUND` even for a baseline request because the model is retired. Live probing therefore cannot reconfirm its historical accepted values.

## Retirement note

- Google's official Interactions API thinking matrix documents the retired `gemini-3-pro-preview` model's supported thinking levels as `low` and `high`.
- The catalog record already carries `status = "deprecated"`. That lifecycle metadata does not imply known capability metadata should be removed.

## Exclusions

- `providers/google-vertex` was not audited or modified.
- `gemma-*` records were not changed because Gemini controls were not inferred for Gemma.
- `gemini-flash-latest` and `gemini-flash-lite-latest` were not changed because official docs describe `*-latest` aliases as hot-swapped targets; stable exact per-alias controls were not established.
- `gemini-3.1-pro-preview-customtools`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-flash-image-preview`, `gemini-2.5-flash-image`, and TTS records were left unchanged because the audited docs did not directly establish exact controls for those record IDs.
- Gemini 2.0 and embedding records were left unchanged because the audited thinking matrix does not document these controls for them.

## Official sources

- Gemini thinking, generateContent API: https://ai.google.dev/gemini-api/docs/thinking
- Gemini 3 Developer Guide, generateContent API: https://ai.google.dev/gemini-api/docs/gemini-3
- Gemini thinking, Interactions API: https://ai.google.dev/gemini-api/docs/interactions/thinking
- Gemini model naming and `*-latest` alias behavior: https://ai.google.dev/gemini-api/docs/models.md.txt

## Validation

- `bun validate`
- `git diff --check origin/dev...HEAD`