### PR TITLE
chore(fireworks): update qwen3p6-plus limits to 262K context / 65K output

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p6-plus.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p6-plus.toml
@@ -14,8 +14,8 @@ input = 0.50
 output = 3.00
 
 [limit]
-context = 128_000
-output = 8_192
+context = 262_144
+output = 65_536
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
Updates Fireworks `qwen3p6-plus` limits to match the latest API specs:

- `limit.context`: 128K → 262K
- `limit.output`: 8K → 65K