### PR TITLE
fix: mark MiMo-V2.5-Pro as multimodal (image, audio, video)

### DIFF
--- a/models/xiaomi/mimo-v2.5-pro.toml
+++ b/models/xiaomi/mimo-v2.5-pro.toml
@@ -2,7 +2,7 @@ name = "MiMo-V2.5-Pro"
 family = "mimo"
 release_date = "2026-04-22"
 last_updated = "2026-04-22"
-attachment = false
+attachment = true
 reasoning = true
 temperature = true
 tool_call = true
@@ -14,5 +14,5 @@ context = 1_048_576
 output = 131_072
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "audio", "video"]
 output = ["text"]

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -2,7 +2,7 @@ name = "MiMo-V2.5-Pro"
 family = "mimo"
 release_date = "2026-04-22"
 last_updated = "2026-04-22"
-attachment = false
+attachment = true
 reasoning = true
 temperature = true
 tool_call = true
@@ -25,7 +25,7 @@ context = 1_048_576
 output = 131_072
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "audio", "video"]
 output = ["text"]
 
 [interleaved]


### PR DESCRIPTION
## Summary

MiMo-V2.5-Pro is incorrectly listed as text-only. It's a native omnimodal model with dedicated vision and audio encoders — same architecture as MiMo-V2.5, which is already correctly tagged.

## Changes

- `models/xiaomi/mimo-v2.5-pro.toml`: set `attachment = true`, add image/audio/video to input modalities
- `providers/xiaomi/models/mimo-v2.5-pro.toml`: same fix (this provider duplicates metadata instead of using base_model)

All other providers (openrouter, kilo, zenmux, xiaomi-token-plan-*) inherit via `base_model` and will pick up the fix automatically.

## Evidence

- **Xiaomi official** ([mimo.mi.com](https://mimo.mi.com)): 'Native Omni-Modal Perception + 1M Context — Natively understands images, video, audio, and text'
- **HuggingFace** ([model card](https://huggingface.co/XiaomiMiMo/MiMo-V2.5)): Architecture includes Vision Encoder and Audio Encoder sections; Multimodal Benchmarks section
- **Same family/release date** as mimo-v2.5 (2026-04-22) which has `attachment = true` and full modalities
- OpenRouter description: 'native omnimodal model by Xiaomi'

## Comparison

| Model | attachment | input modalities |
|---|---|---|
| mimo-v2.5 | ✅ true | text, image, audio, video |
| mimo-v2.5-pro | ❌ false | text only |
| mimo-v2.5-pro (after fix) | ✅ true | text, image, audio, video |