### PR TITLE
fix(alibaba): qwen3.7-plus GA adds vision (image+video) and 1M context

### DIFF
--- a/providers/alibaba/models/qwen3.7-plus.toml
+++ b/providers/alibaba/models/qwen3.7-plus.toml
@@ -1,7 +1,7 @@
 name = "Qwen3.7 Plus"
 family = "qwen"
 release_date = "2026-06-02"
-last_updated = "2026-06-02"
+last_updated = "2026-06-04"
 attachment = false
 reasoning = true
 temperature = true
@@ -23,9 +23,9 @@ cache_read = 0.20
 cache_write = 2.50
 
 [limit]
-context = 131_072
+context = 1_000_000
 output = 16_384
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "video"]
 output = ["text"]


### PR DESCRIPTION
## What

Correct the capability metadata for **`qwen3.7-plus`** (base model, inherited by `alibaba-cn`):

| Field | Before | After |
| --- | --- | --- |
| `modalities.input` | `["text"]` | `["text", "image", "video"]` |
| `limit.context` | `131_072` | `1_000_000` |
| `last_updated` | `2026-06-02` | `2026-06-04` |

`attachment`, `cost`, and `output` are left unchanged (consistent with the other Alibaba VL entries, e.g. `qwen3.6-plus`/`qwen-vl-*`, which also keep `attachment = false` while declaring image modalities).

## Why

The current entry still reflects the **May 14 preview** spec (text-only, 131K context). Alibaba shipped **qwen3.7-plus GA on 2026-06-02**, which added full multimodal input (image + video) and a 1M-token context window shared across modalities.

Because the catalog declares `input = ["text"]`, downstream consumers (e.g. OpenCode) treat the model as text-only and refuse to send image parts, so users get "this model does not support image input" even though the DashScope API accepts images fine.

### Verification (direct DashScope call, qwen3.7-plus)

A real `/compatible-mode/v1/chat/completions` request with an `image_url` part returned a correct visual reading of a test image (red square, green circle, exact yellow text string) — confirming the model is multimodal at the API level. The only thing blocking it in tooling is this metadata.

This matches the sibling entry `qwen3.6-plus` which already declares `input = ["text", "image", "video"]` and `context = 1_000_000`.

### Sources

- Alibaba Cloud Model Studio — Qwen vision (image/video understanding): https://www.alibabacloud.com/help/en/model-studio/vision
- Qwen3.7-Plus GA (multimodal, 1M context): https://qwen3lm.com/qwen3.7-plus/
