### PR TITLE
fix(together): DeepSeek-R1, DeepSeek-V3 name & release date

### DIFF
--- a/providers/togetherai/models/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/togetherai/models/deepseek-ai/DeepSeek-R1.toml
@@ -1,6 +1,6 @@
-name = "DeepSeek R1"
+name = "DeepSeek-R1"
 family = "deepseek-thinking"
-release_date = "2024-12-26"
+release_date = "2025-01-20"
 last_updated = "2025-03-24"
 attachment = false
 reasoning = true

--- a/providers/togetherai/models/deepseek-ai/DeepSeek-V3.toml
+++ b/providers/togetherai/models/deepseek-ai/DeepSeek-V3.toml
@@ -1,6 +1,6 @@
-name = "DeepSeek V3"
+name = "DeepSeek-V3"
 family = "deepseek"
-release_date = "2025-01-20"
+release_date = "2024-12-26"
 last_updated = "2025-05-29"
 attachment = false
 reasoning = true


### PR DESCRIPTION
The release dates for DeepSeek-R1 and DeepSeek-V3 were inverted on together.ai. Further, the models are missing dashes in the model names.

See timestamps on the initial release commits for these two models below:
* "Release DeepSeek-R1": https://github.com/deepseek-ai/DeepSeek-R1/commit/23807ced51627276434655dd9f27725354818974
* "Release DeepSeek-V3": https://github.com/deepseek-ai/DeepSeek-V3/commit/4c2fdb8f55e049553b9f4f1a3241f86d739c8cf8

We plan to start using models.dev as a reference for release dateson our project ForecastBench (www.forecastbench.org) so I may be making commits from time to time to ensure release dates are correct.