### PR TITLE
feat(models): add coding benchmarks and weights

### DIFF
--- a/models/alibaba/qwen-max.toml
+++ b/models/alibaba/qwen-max.toml
@@ -16,3 +16,10 @@ output = 8_192
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 21.8
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-01-28"

--- a/models/alibaba/qwen2-5-vl-72b-instruct.toml
+++ b/models/alibaba/qwen2-5-vl-72b-instruct.toml
@@ -16,3 +16,7 @@ output = 8_192
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen2.5-VL-72B-Instruct"

--- a/models/alibaba/qwen3-235b-a22b.toml
+++ b/models/alibaba/qwen3-235b-a22b.toml
@@ -16,3 +16,14 @@ output = 16_384
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3-235B-A22B"
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 59.6
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-05-09"

--- a/models/alibaba/qwen3-235b-a22b.toml
+++ b/models/alibaba/qwen3-235b-a22b.toml
@@ -27,3 +27,9 @@ score = 59.6
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2025-05-09"
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 21.41
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/alibaba/qwen3-235b-a22b.toml
+++ b/models/alibaba/qwen3-235b-a22b.toml
@@ -29,7 +29,8 @@ source = "https://aider.chat/docs/leaderboards/"
 date = "2025-05-09"
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 21.41
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/alibaba/qwen3-32b.toml
+++ b/models/alibaba/qwen3-32b.toml
@@ -16,3 +16,14 @@ output = 16_384
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3-32B"
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 40.0
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-05-08"

--- a/models/alibaba/qwen3-coder-30b-a3b-instruct.toml
+++ b/models/alibaba/qwen3-coder-30b-a3b-instruct.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 19.4
+metric = "index"
+source = "https://openrouter.ai/qwen/qwen3-coder-30b-a3b-instruct/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "SciCode"
+score = 27.8
+metric = "percent correct"
+source = "https://openrouter.ai/qwen/qwen3-coder-30b-a3b-instruct/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 15.2
+metric = "success rate"
+source = "https://openrouter.ai/qwen/qwen3-coder-30b-a3b-instruct/benchmarks"
+date = "2026-06-02"

--- a/models/alibaba/qwen3-coder-30b-a3b-instruct.toml
+++ b/models/alibaba/qwen3-coder-30b-a3b-instruct.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct"

--- a/models/alibaba/qwen3-coder-480b-a35b-instruct.toml
+++ b/models/alibaba/qwen3-coder-480b-a35b-instruct.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct"

--- a/models/alibaba/qwen3-coder-480b-a35b-instruct.toml
+++ b/models/alibaba/qwen3-coder-480b-a35b-instruct.toml
@@ -20,3 +20,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct"
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 38.7
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/alibaba/qwen3-coder-480b-a35b-instruct.toml
+++ b/models/alibaba/qwen3-coder-480b-a35b-instruct.toml
@@ -22,7 +22,8 @@ label = "Hugging Face"
 url = "https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct"
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 38.7
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/alibaba/qwen3-coder-plus.toml
+++ b/models/alibaba/qwen3-coder-plus.toml
@@ -7,7 +7,7 @@ reasoning = false
 temperature = true
 tool_call = true
 knowledge = "2025-04"
-open_weights = true
+open_weights = false
 
 [limit]
 context = 1_048_576

--- a/models/alibaba/qwen3-max.toml
+++ b/models/alibaba/qwen3-max.toml
@@ -16,3 +16,24 @@ output = 65_536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 26.4
+metric = "index"
+source = "https://openrouter.ai/qwen/qwen3-max/benchmarks"
+date = "2026-05-30"
+
+[[benchmarks]]
+name = "SciCode"
+score = 38.3
+metric = "percent correct"
+source = "https://openrouter.ai/qwen/qwen3-max/benchmarks"
+date = "2026-05-30"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 20.5
+metric = "success rate"
+source = "https://openrouter.ai/qwen/qwen3-max/benchmarks"
+date = "2026-05-30"

--- a/models/alibaba/qwen3-next-80b-a3b-instruct.toml
+++ b/models/alibaba/qwen3-next-80b-a3b-instruct.toml
@@ -16,3 +16,7 @@ output = 32_768
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct"

--- a/models/alibaba/qwen3-next-80b-a3b-thinking.toml
+++ b/models/alibaba/qwen3-next-80b-a3b-thinking.toml
@@ -16,3 +16,7 @@ output = 32_768
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Thinking"

--- a/models/alibaba/qwen3.5-122b-a10b.toml
+++ b/models/alibaba/qwen3.5-122b-a10b.toml
@@ -20,3 +20,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/Qwen/Qwen3.5-122B-A10B"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 72
+metric = "resolved"
+source = "https://huggingface.co/Qwen/Qwen3.5-122B-A10B"

--- a/models/alibaba/qwen3.5-122b-a10b.toml
+++ b/models/alibaba/qwen3.5-122b-a10b.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3.5-122B-A10B"

--- a/models/alibaba/qwen3.5-27b.toml
+++ b/models/alibaba/qwen3.5-27b.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3.5-27B"

--- a/models/alibaba/qwen3.5-27b.toml
+++ b/models/alibaba/qwen3.5-27b.toml
@@ -20,3 +20,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/Qwen/Qwen3.5-27B"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 72.4
+metric = "resolved"
+source = "https://huggingface.co/Qwen/Qwen3.5-27B"

--- a/models/alibaba/qwen3.5-35b-a3b.toml
+++ b/models/alibaba/qwen3.5-35b-a3b.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3.5-35B-A3B"

--- a/models/alibaba/qwen3.5-397b-a17b.toml
+++ b/models/alibaba/qwen3.5-397b-a17b.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3.5-397B-A17B"

--- a/models/alibaba/qwen3.5-397b-a17b.toml
+++ b/models/alibaba/qwen3.5-397b-a17b.toml
@@ -20,3 +20,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/Qwen/Qwen3.5-397B-A17B"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 76.4
+metric = "resolved"
+source = "https://huggingface.co/Qwen/Qwen3.5-397B-A17B"

--- a/models/alibaba/qwen3.6-27b.toml
+++ b/models/alibaba/qwen3.6-27b.toml
@@ -20,3 +20,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/Qwen/Qwen3.6-27B"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 77.2
+metric = "resolved"
+source = "https://huggingface.co/Qwen/Qwen3.6-27B"

--- a/models/alibaba/qwen3.6-27b.toml
+++ b/models/alibaba/qwen3.6-27b.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3.6-27B"

--- a/models/alibaba/qwen3.6-35b-a3b.toml
+++ b/models/alibaba/qwen3.6-35b-a3b.toml
@@ -20,3 +20,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 73.4
+metric = "resolved"
+source = "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"

--- a/models/alibaba/qwen3.6-35b-a3b.toml
+++ b/models/alibaba/qwen3.6-35b-a3b.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"

--- a/models/anthropic/claude-3-5-haiku-20241022.toml
+++ b/models/anthropic/claude-3-5-haiku-20241022.toml
@@ -16,3 +16,10 @@ output = 8_192
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 28.0
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2024-12-21"

--- a/models/anthropic/claude-3-5-sonnet-20241022.toml
+++ b/models/anthropic/claude-3-5-sonnet-20241022.toml
@@ -16,3 +16,10 @@ output = 8_192
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 51.6
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-01-17"

--- a/models/anthropic/claude-3-7-sonnet-20250219.toml
+++ b/models/anthropic/claude-3-7-sonnet-20250219.toml
@@ -16,3 +16,10 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 64.9
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-02-24"

--- a/models/anthropic/claude-haiku-4-5.toml
+++ b/models/anthropic/claude-haiku-4-5.toml
@@ -16,3 +16,9 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 39.45
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/anthropic/claude-haiku-4-5.toml
+++ b/models/anthropic/claude-haiku-4-5.toml
@@ -18,7 +18,8 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 39.45
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/anthropic/claude-opus-4-0.toml
+++ b/models/anthropic/claude-opus-4-0.toml
@@ -16,3 +16,10 @@ output = 32_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 72.0
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-05-25"

--- a/models/anthropic/claude-opus-4-20250514.toml
+++ b/models/anthropic/claude-opus-4-20250514.toml
@@ -16,3 +16,10 @@ output = 32_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 72.0
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-05-25"

--- a/models/anthropic/claude-opus-4-5-20251101.toml
+++ b/models/anthropic/claude-opus-4-5-20251101.toml
@@ -16,3 +16,9 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 45.89
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/anthropic/claude-opus-4-5-20251101.toml
+++ b/models/anthropic/claude-opus-4-5-20251101.toml
@@ -18,7 +18,8 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 45.89
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/anthropic/claude-opus-4-6.toml
+++ b/models/anthropic/claude-opus-4-6.toml
@@ -16,3 +16,63 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 51.9
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Claude Code)"
+score = 33.3
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+score = 30
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Claude Code)"
+score = 35.58
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Claude Code)"
+score = 36.67
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+score = 36.08
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Claude Code, medium)"
+score = 51.3
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, medium)"
+score = 71.9
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Claude Code, medium)"
+score = 11.8
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, medium)"
+score = 70.2
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/anthropic/claude-opus-4-6.toml
+++ b/models/anthropic/claude-opus-4-6.toml
@@ -18,61 +18,77 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 51.9
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Claude Code)"
+name = "SWE-Atlas Codebase QnA"
 score = 33.3
 metric = "score"
+harness = "Claude Code"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+name = "SWE-Atlas Codebase QnA"
 score = 30
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Claude Code)"
+name = "SWE-Atlas Refactoring"
 score = 35.58
 metric = "score"
+harness = "Claude Code"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Claude Code)"
+name = "SWE-Atlas Test Writing"
 score = 36.67
 metric = "score"
+harness = "Claude Code"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+name = "SWE-Atlas Test Writing"
 score = 36.08
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Claude Code, medium)"
+name = "Artificial Analysis Coding Agent Index"
 score = 51.3
 metric = "average pass@1"
+harness = "Claude Code"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, medium)"
+name = "SWE-Atlas Codebase QnA"
 score = 71.9
 metric = "pass@1"
+harness = "Claude Code"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Claude Code, medium)"
+name = "SWE-Bench Pro"
 score = 11.8
 metric = "pass@1"
+harness = "Claude Code"
+variant = "medium"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, medium)"
+name = "Terminal-Bench"
 score = 70.2
 metric = "pass@1"
+harness = "Claude Code"
+variant = "medium"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/anthropic/claude-opus-4-7.toml
+++ b/models/anthropic/claude-opus-4-7.toml
@@ -16,3 +16,95 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Anthropic launch table)"
+score = 64.3
+metric = "resolve rate"
+source = "https://www.anthropic.com/news/claude-opus-4-8"
+date = "2026-05-28"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1 (Terminus-2)"
+score = 66.1
+metric = "success rate"
+source = "https://www.anthropic.com/news/claude-opus-4-8"
+date = "2026-05-28"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Claude Code)"
+score = 48.57
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Claude Code, max)"
+score = 66.6
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, max)"
+score = 81
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Claude Code, max)"
+score = 44.9
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, max)"
+score = 73.8
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Cursor CLI, medium)"
+score = 61.2
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Cursor CLI, medium)"
+score = 78.4
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Cursor CLI, medium)"
+score = 34.4
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Cursor CLI, medium)"
+score = 70.6
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Claude Code, medium)"
+score = 59.9
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, medium)"
+score = 71.7
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Claude Code, medium)"
+score = 36.4
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, medium)"
+score = 71.4
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/anthropic/claude-opus-4-7.toml
+++ b/models/anthropic/claude-opus-4-7.toml
@@ -18,93 +18,126 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Anthropic launch table)"
+name = "SWE-Bench Pro"
 score = 64.3
 metric = "resolve rate"
 source = "https://www.anthropic.com/news/claude-opus-4-8"
 date = "2026-05-28"
 
 [[benchmarks]]
-name = "Terminal-Bench 2.1 (Terminus-2)"
+name = "Terminal-Bench"
 score = 66.1
 metric = "success rate"
+harness = "Terminus-2"
+version = "2.1"
 source = "https://www.anthropic.com/news/claude-opus-4-8"
 date = "2026-05-28"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Claude Code)"
+name = "SWE-Atlas Refactoring"
 score = 48.57
 metric = "score"
+harness = "Claude Code"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Claude Code, max)"
+name = "Artificial Analysis Coding Agent Index"
 score = 66.6
 metric = "average pass@1"
+harness = "Claude Code"
+variant = "max"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, max)"
+name = "SWE-Atlas Codebase QnA"
 score = 81
 metric = "pass@1"
+harness = "Claude Code"
+variant = "max"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Claude Code, max)"
+name = "SWE-Bench Pro"
 score = 44.9
 metric = "pass@1"
+harness = "Claude Code"
+variant = "max"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, max)"
+name = "Terminal-Bench"
 score = 73.8
 metric = "pass@1"
+harness = "Claude Code"
+variant = "max"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Cursor CLI, medium)"
+name = "Artificial Analysis Coding Agent Index"
 score = 61.2
 metric = "average pass@1"
+harness = "Cursor CLI"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Cursor CLI, medium)"
+name = "SWE-Atlas Codebase QnA"
 score = 78.4
 metric = "pass@1"
+harness = "Cursor CLI"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Cursor CLI, medium)"
+name = "SWE-Bench Pro"
 score = 34.4
 metric = "pass@1"
+harness = "Cursor CLI"
+variant = "medium"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Cursor CLI, medium)"
+name = "Terminal-Bench"
 score = 70.6
 metric = "pass@1"
+harness = "Cursor CLI"
+variant = "medium"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Claude Code, medium)"
+name = "Artificial Analysis Coding Agent Index"
 score = 59.9
 metric = "average pass@1"
+harness = "Claude Code"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, medium)"
+name = "SWE-Atlas Codebase QnA"
 score = 71.7
 metric = "pass@1"
+harness = "Claude Code"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Claude Code, medium)"
+name = "SWE-Bench Pro"
 score = 36.4
 metric = "pass@1"
+harness = "Claude Code"
+variant = "medium"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, medium)"
+name = "Terminal-Bench"
 score = 71.4
 metric = "pass@1"
+harness = "Claude Code"
+variant = "medium"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/anthropic/claude-opus-4-8.toml
+++ b/models/anthropic/claude-opus-4-8.toml
@@ -15,3 +15,17 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Anthropic launch table)"
+score = 69.2
+metric = "resolve rate"
+source = "https://www.anthropic.com/news/claude-opus-4-8"
+date = "2026-05-28"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1 (Terminus-2)"
+score = 74.6
+metric = "success rate"
+source = "https://www.anthropic.com/news/claude-opus-4-8"
+date = "2026-05-28"

--- a/models/anthropic/claude-opus-4-8.toml
+++ b/models/anthropic/claude-opus-4-8.toml
@@ -17,15 +17,17 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Anthropic launch table)"
+name = "SWE-Bench Pro"
 score = 69.2
 metric = "resolve rate"
 source = "https://www.anthropic.com/news/claude-opus-4-8"
 date = "2026-05-28"
 
 [[benchmarks]]
-name = "Terminal-Bench 2.1 (Terminus-2)"
+name = "Terminal-Bench"
 score = 74.6
 metric = "success rate"
+harness = "Terminus-2"
+version = "2.1"
 source = "https://www.anthropic.com/news/claude-opus-4-8"
 date = "2026-05-28"

--- a/models/anthropic/claude-sonnet-4-0.toml
+++ b/models/anthropic/claude-sonnet-4-0.toml
@@ -23,3 +23,9 @@ score = 61.3
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2025-05-24"
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 42.7
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/anthropic/claude-sonnet-4-0.toml
+++ b/models/anthropic/claude-sonnet-4-0.toml
@@ -16,3 +16,10 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 61.3
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-05-24"

--- a/models/anthropic/claude-sonnet-4-0.toml
+++ b/models/anthropic/claude-sonnet-4-0.toml
@@ -25,7 +25,8 @@ source = "https://aider.chat/docs/leaderboards/"
 date = "2025-05-24"
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 42.7
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/anthropic/claude-sonnet-4-20250514.toml
+++ b/models/anthropic/claude-sonnet-4-20250514.toml
@@ -16,3 +16,10 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 61.3
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-05-24"

--- a/models/anthropic/claude-sonnet-4-5.toml
+++ b/models/anthropic/claude-sonnet-4-5.toml
@@ -16,3 +16,9 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 43.6
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/anthropic/claude-sonnet-4-5.toml
+++ b/models/anthropic/claude-sonnet-4-5.toml
@@ -18,7 +18,8 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 43.6
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/anthropic/claude-sonnet-4-6.toml
+++ b/models/anthropic/claude-sonnet-4-6.toml
@@ -16,3 +16,45 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Claude Code)"
+score = 31.2
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Claude Code)"
+score = 32.21
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Claude Code)"
+score = 31.76
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Claude Code, medium)"
+score = 49.4
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, medium)"
+score = 70.3
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Claude Code, medium)"
+score = 14.9
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, medium)"
+score = 63.1
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/anthropic/claude-sonnet-4-6.toml
+++ b/models/anthropic/claude-sonnet-4-6.toml
@@ -18,43 +18,56 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Claude Code)"
+name = "SWE-Atlas Codebase QnA"
 score = 31.2
 metric = "score"
+harness = "Claude Code"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Claude Code)"
+name = "SWE-Atlas Refactoring"
 score = 32.21
 metric = "score"
+harness = "Claude Code"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Claude Code)"
+name = "SWE-Atlas Test Writing"
 score = 31.76
 metric = "score"
+harness = "Claude Code"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Claude Code, medium)"
+name = "Artificial Analysis Coding Agent Index"
 score = 49.4
 metric = "average pass@1"
+harness = "Claude Code"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, medium)"
+name = "SWE-Atlas Codebase QnA"
 score = 70.3
 metric = "pass@1"
+harness = "Claude Code"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Claude Code, medium)"
+name = "SWE-Bench Pro"
 score = 14.9
 metric = "pass@1"
+harness = "Claude Code"
+variant = "medium"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, medium)"
+name = "Terminal-Bench"
 score = 63.1
 metric = "pass@1"
+harness = "Claude Code"
+variant = "medium"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/cohere/command-a-03-2025.toml
+++ b/models/cohere/command-a-03-2025.toml
@@ -16,3 +16,14 @@ output = 8_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/c4ai-command-a-03-2025"
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 12.0
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-03-14"

--- a/models/cohere/command-r-08-2024.toml
+++ b/models/cohere/command-r-08-2024.toml
@@ -16,3 +16,7 @@ output = 4_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/c4ai-command-r-08-2024"

--- a/models/cohere/command-r-plus-08-2024.toml
+++ b/models/cohere/command-r-plus-08-2024.toml
@@ -16,3 +16,7 @@ output = 4_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/c4ai-command-r-plus-08-2024"

--- a/models/cohere/command-r7b-12-2024.toml
+++ b/models/cohere/command-r7b-12-2024.toml
@@ -16,3 +16,7 @@ output = 4_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/c4ai-command-r7b-12-2024"

--- a/models/deepseek/deepseek-chat.toml
+++ b/models/deepseek/deepseek-chat.toml
@@ -16,3 +16,14 @@ output = 384_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 70.2
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-10-03"

--- a/models/deepseek/deepseek-r1.toml
+++ b/models/deepseek/deepseek-r1.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 knowledge = "2024-07"
-open_weights = false
+open_weights = true
 
 [limit]
 context = 128_000
@@ -16,3 +16,14 @@ output = 32_768
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepseek-ai/DeepSeek-R1"
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 56.9
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-01-20"

--- a/models/deepseek/deepseek-r1.toml
+++ b/models/deepseek/deepseek-r1.toml
@@ -27,3 +27,24 @@ score = 56.9
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2025-01-20"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 15.9
+metric = "index"
+source = "https://openrouter.ai/deepseek/deepseek-r1/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "SciCode"
+score = 35.7
+metric = "percent correct"
+source = "https://openrouter.ai/deepseek/deepseek-r1/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 6.1
+metric = "success rate"
+source = "https://openrouter.ai/deepseek/deepseek-r1/benchmarks"
+date = "2026-03-11"

--- a/models/deepseek/deepseek-reasoner.toml
+++ b/models/deepseek/deepseek-reasoner.toml
@@ -16,3 +16,14 @@ output = 384_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 74.2
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-10-03"

--- a/models/deepseek/deepseek-v4-flash.toml
+++ b/models/deepseek/deepseek-v4-flash.toml
@@ -17,3 +17,7 @@ output = 384_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash"

--- a/models/deepseek/deepseek-v4-flash.toml
+++ b/models/deepseek/deepseek-v4-flash.toml
@@ -21,3 +21,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 79
+metric = "resolved"
+source = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash"

--- a/models/deepseek/deepseek-v4-pro.toml
+++ b/models/deepseek/deepseek-v4-pro.toml
@@ -27,3 +27,27 @@ name = "SWE-Bench Verified"
 score = 80.6
 metric = "resolved"
 source = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Claude Code, high)"
+score = 50.1
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, high)"
+score = 67.8
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Claude Code, high)"
+score = 18
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, high)"
+score = 64.7
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/deepseek/deepseek-v4-pro.toml
+++ b/models/deepseek/deepseek-v4-pro.toml
@@ -17,3 +17,7 @@ output = 384_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro"

--- a/models/deepseek/deepseek-v4-pro.toml
+++ b/models/deepseek/deepseek-v4-pro.toml
@@ -21,3 +21,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 80.6
+metric = "resolved"
+source = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro"

--- a/models/deepseek/deepseek-v4-pro.toml
+++ b/models/deepseek/deepseek-v4-pro.toml
@@ -29,25 +29,35 @@ metric = "resolved"
 source = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Claude Code, high)"
+name = "Artificial Analysis Coding Agent Index"
 score = 50.1
 metric = "average pass@1"
+harness = "Claude Code"
+variant = "high"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code, high)"
+name = "SWE-Atlas Codebase QnA"
 score = 67.8
 metric = "pass@1"
+harness = "Claude Code"
+variant = "high"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Claude Code, high)"
+name = "SWE-Bench Pro"
 score = 18
 metric = "pass@1"
+harness = "Claude Code"
+variant = "high"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Claude Code, high)"
+name = "Terminal-Bench"
 score = 64.7
 metric = "pass@1"
+harness = "Claude Code"
+variant = "high"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/google/gemini-2.5-flash-lite.toml
+++ b/models/google/gemini-2.5-flash-lite.toml
@@ -17,3 +17,24 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 9.5
+metric = "index"
+source = "https://openrouter.ai/google/gemini-2.5-flash-lite/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "SciCode"
+score = 19.3
+metric = "percent correct"
+source = "https://openrouter.ai/google/gemini-2.5-flash-lite/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 4.5
+metric = "success rate"
+source = "https://openrouter.ai/google/gemini-2.5-flash-lite/benchmarks"
+date = "2026-03-11"

--- a/models/google/gemini-2.5-flash.toml
+++ b/models/google/gemini-2.5-flash.toml
@@ -24,3 +24,24 @@ score = 55.1
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2025-05-25"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 22.2
+metric = "index"
+source = "https://openrouter.ai/google/gemini-2.5-flash/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "SciCode"
+score = 39.4
+metric = "percent correct"
+source = "https://openrouter.ai/google/gemini-2.5-flash/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 13.6
+metric = "success rate"
+source = "https://openrouter.ai/google/gemini-2.5-flash/benchmarks"
+date = "2026-06-02"

--- a/models/google/gemini-2.5-flash.toml
+++ b/models/google/gemini-2.5-flash.toml
@@ -17,3 +17,10 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 55.1
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-05-25"

--- a/models/google/gemini-2.5-pro.toml
+++ b/models/google/gemini-2.5-pro.toml
@@ -17,3 +17,10 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 83.1
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-06-06"

--- a/models/google/gemini-2.5-pro.toml
+++ b/models/google/gemini-2.5-pro.toml
@@ -24,3 +24,24 @@ score = 83.1
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2025-06-06"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 32
+metric = "index"
+source = "https://openrouter.ai/google/gemini-2.5-pro/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "SciCode"
+score = 42.8
+metric = "percent correct"
+source = "https://openrouter.ai/google/gemini-2.5-pro/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 26.5
+metric = "success rate"
+source = "https://openrouter.ai/google/gemini-2.5-pro/benchmarks"
+date = "2026-06-02"

--- a/models/google/gemini-3-flash-preview.toml
+++ b/models/google/gemini-3-flash-preview.toml
@@ -17,3 +17,27 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 34.63
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+score = 8.2
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Mini-SWE-Agent)"
+score = 10
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+score = 30.3
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/google/gemini-3-flash-preview.toml
+++ b/models/google/gemini-3-flash-preview.toml
@@ -19,25 +19,29 @@ input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 34.63
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+name = "SWE-Atlas Codebase QnA"
 score = 8.2
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Mini-SWE-Agent)"
+name = "SWE-Atlas Refactoring"
 score = 10
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+name = "SWE-Atlas Test Writing"
 score = 30.3
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/google/gemini-3-pro-preview.toml
+++ b/models/google/gemini-3-pro-preview.toml
@@ -17,3 +17,9 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 43.3
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/google/gemini-3-pro-preview.toml
+++ b/models/google/gemini-3-pro-preview.toml
@@ -19,7 +19,8 @@ input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 43.3
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/google/gemini-3.1-pro-preview.toml
+++ b/models/google/gemini-3.1-pro-preview.toml
@@ -17,3 +17,65 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Anthropic launch table)"
+score = 54.2
+metric = "resolve rate"
+source = "https://www.anthropic.com/news/claude-opus-4-8"
+date = "2026-05-28"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1 (Terminus-2)"
+score = 70.3
+metric = "success rate"
+source = "https://www.anthropic.com/news/claude-opus-4-8"
+date = "2026-05-28"
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 46.1
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+score = 13.5
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Gemini CLI)"
+score = 33.81
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+score = 29.84
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Gemini CLI, high)"
+score = 43
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Gemini CLI, high)"
+score = 45.6
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Gemini CLI, high)"
+score = 15.1
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Gemini CLI, high)"
+score = 68.3
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/google/gemini-3.1-pro-preview.toml
+++ b/models/google/gemini-3.1-pro-preview.toml
@@ -19,63 +19,79 @@ input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Anthropic launch table)"
+name = "SWE-Bench Pro"
 score = 54.2
 metric = "resolve rate"
 source = "https://www.anthropic.com/news/claude-opus-4-8"
 date = "2026-05-28"
 
 [[benchmarks]]
-name = "Terminal-Bench 2.1 (Terminus-2)"
+name = "Terminal-Bench"
 score = 70.3
 metric = "success rate"
+harness = "Terminus-2"
+version = "2.1"
 source = "https://www.anthropic.com/news/claude-opus-4-8"
 date = "2026-05-28"
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 46.1
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+name = "SWE-Atlas Codebase QnA"
 score = 13.5
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Gemini CLI)"
+name = "SWE-Atlas Refactoring"
 score = 33.81
 metric = "score"
+harness = "Gemini CLI"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+name = "SWE-Atlas Test Writing"
 score = 29.84
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Gemini CLI, high)"
+name = "Artificial Analysis Coding Agent Index"
 score = 43
 metric = "average pass@1"
+harness = "Gemini CLI"
+variant = "high"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Gemini CLI, high)"
+name = "SWE-Atlas Codebase QnA"
 score = 45.6
 metric = "pass@1"
+harness = "Gemini CLI"
+variant = "high"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Gemini CLI, high)"
+name = "SWE-Bench Pro"
 score = 15.1
 metric = "pass@1"
+harness = "Gemini CLI"
+variant = "high"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Gemini CLI, high)"
+name = "Terminal-Bench"
 score = 68.3
 metric = "pass@1"
+harness = "Gemini CLI"
+variant = "high"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/google/gemma-4-26b-a4b-it.toml
+++ b/models/google/gemma-4-26b-a4b-it.toml
@@ -16,3 +16,7 @@ output = 32_768
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/google/gemma-4-26B-A4B-it"

--- a/models/google/gemma-4-31b-it.toml
+++ b/models/google/gemma-4-31b-it.toml
@@ -16,3 +16,7 @@ output = 32_768
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/google/gemma-4-31B-it"

--- a/models/meta/llama-3.3-70b-instruct.toml
+++ b/models/meta/llama-3.3-70b-instruct.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 10.7
+metric = "index"
+source = "https://openrouter.ai/meta-llama/llama-3.3-70b-instruct/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "SciCode"
+score = 26
+metric = "percent correct"
+source = "https://openrouter.ai/meta-llama/llama-3.3-70b-instruct/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 3
+metric = "success rate"
+source = "https://openrouter.ai/meta-llama/llama-3.3-70b-instruct/benchmarks"
+date = "2026-03-11"

--- a/models/meta/llama-3.3-70b-instruct.toml
+++ b/models/meta/llama-3.3-70b-instruct.toml
@@ -16,3 +16,7 @@ output = 4_096
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct"

--- a/models/meta/llama-4-maverick-17b-instruct.toml
+++ b/models/meta/llama-4-maverick-17b-instruct.toml
@@ -16,3 +16,14 @@ output = 16_384
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct"
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 15.6
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-04-06"

--- a/models/meta/llama-4-maverick-17b-instruct.toml
+++ b/models/meta/llama-4-maverick-17b-instruct.toml
@@ -27,3 +27,9 @@ score = 15.6
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2025-04-06"
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 5.24
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/meta/llama-4-maverick-17b-instruct.toml
+++ b/models/meta/llama-4-maverick-17b-instruct.toml
@@ -29,7 +29,8 @@ source = "https://aider.chat/docs/leaderboards/"
 date = "2025-04-06"
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 5.24
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/meta/llama-4-scout-17b-instruct.toml
+++ b/models/meta/llama-4-scout-17b-instruct.toml
@@ -16,3 +16,7 @@ output = 16_384
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct"

--- a/models/minimax/MiniMax-M2.1.toml
+++ b/models/minimax/MiniMax-M2.1.toml
@@ -15,3 +15,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/MiniMaxAI/MiniMax-M2.1"

--- a/models/minimax/MiniMax-M2.1.toml
+++ b/models/minimax/MiniMax-M2.1.toml
@@ -25,3 +25,9 @@ name = "SWE-Bench Verified"
 score = 74
 metric = "resolved"
 source = "https://huggingface.co/MiniMaxAI/MiniMax-M2.1"
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 36.81
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/minimax/MiniMax-M2.1.toml
+++ b/models/minimax/MiniMax-M2.1.toml
@@ -19,3 +19,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/MiniMaxAI/MiniMax-M2.1"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 74
+metric = "resolved"
+source = "https://huggingface.co/MiniMaxAI/MiniMax-M2.1"

--- a/models/minimax/MiniMax-M2.1.toml
+++ b/models/minimax/MiniMax-M2.1.toml
@@ -27,7 +27,8 @@ metric = "resolved"
 source = "https://huggingface.co/MiniMaxAI/MiniMax-M2.1"
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 36.81
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/minimax/MiniMax-M2.5-highspeed.toml
+++ b/models/minimax/MiniMax-M2.5-highspeed.toml
@@ -15,3 +15,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/MiniMaxAI/MiniMax-M2.5"

--- a/models/minimax/MiniMax-M2.5.toml
+++ b/models/minimax/MiniMax-M2.5.toml
@@ -19,3 +19,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/MiniMaxAI/MiniMax-M2.5"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 75.8
+metric = "resolved"
+source = "https://www.swebench.com/"

--- a/models/minimax/MiniMax-M2.5.toml
+++ b/models/minimax/MiniMax-M2.5.toml
@@ -25,3 +25,21 @@ name = "SWE-Bench Verified"
 score = 75.8
 metric = "resolved"
 source = "https://www.swebench.com/"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+score = 10.3
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Mini-SWE-Agent)"
+score = 19.52
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+score = 18.6
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/minimax/MiniMax-M2.5.toml
+++ b/models/minimax/MiniMax-M2.5.toml
@@ -15,3 +15,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/MiniMaxAI/MiniMax-M2.5"

--- a/models/minimax/MiniMax-M2.5.toml
+++ b/models/minimax/MiniMax-M2.5.toml
@@ -27,19 +27,22 @@ metric = "resolved"
 source = "https://www.swebench.com/"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+name = "SWE-Atlas Codebase QnA"
 score = 10.3
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Mini-SWE-Agent)"
+name = "SWE-Atlas Refactoring"
 score = 19.52
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+name = "SWE-Atlas Test Writing"
 score = 18.6
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/minimax/MiniMax-M2.7-highspeed.toml
+++ b/models/minimax/MiniMax-M2.7-highspeed.toml
@@ -15,3 +15,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/MiniMaxAI/MiniMax-M2.7"

--- a/models/minimax/MiniMax-M2.7.toml
+++ b/models/minimax/MiniMax-M2.7.toml
@@ -15,3 +15,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/MiniMaxAI/MiniMax-M2.7"

--- a/models/minimax/MiniMax-M2.toml
+++ b/models/minimax/MiniMax-M2.toml
@@ -19,3 +19,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/MiniMaxAI/MiniMax-M2"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 69.4
+metric = "resolved"
+source = "https://huggingface.co/MiniMaxAI/MiniMax-M2"

--- a/models/minimax/MiniMax-M2.toml
+++ b/models/minimax/MiniMax-M2.toml
@@ -15,3 +15,7 @@ output = 128_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/MiniMaxAI/MiniMax-M2"

--- a/models/minimax/MiniMax-M3.toml
+++ b/models/minimax/MiniMax-M3.toml
@@ -6,7 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = true
+open_weights = false
 
 [limit]
 context = 512_000

--- a/models/mistral/codestral-latest.toml
+++ b/models/mistral/codestral-latest.toml
@@ -16,3 +16,14 @@ output = 4_096
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Codestral-22B-v0.1"
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 11.1
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-01-13"

--- a/models/mistral/devstral-2512.toml
+++ b/models/mistral/devstral-2512.toml
@@ -16,3 +16,7 @@ output = 262_144
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Devstral-2-123B-Instruct-2512"

--- a/models/mistral/devstral-2512.toml
+++ b/models/mistral/devstral-2512.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/mistralai/Devstral-2-123B-Instruct-2512"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 23.7
+metric = "index"
+source = "https://openrouter.ai/mistralai/devstral-2512/benchmarks"
+date = "2026-05-31"
+
+[[benchmarks]]
+name = "SciCode"
+score = 33.1
+metric = "percent correct"
+source = "https://openrouter.ai/mistralai/devstral-2512/benchmarks"
+date = "2026-05-31"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 18.9
+metric = "success rate"
+source = "https://openrouter.ai/mistralai/devstral-2512/benchmarks"
+date = "2026-05-31"

--- a/models/mistral/devstral-medium-2507.toml
+++ b/models/mistral/devstral-medium-2507.toml
@@ -7,7 +7,7 @@ reasoning = false
 temperature = true
 tool_call = true
 knowledge = "2025-05"
-open_weights = true
+open_weights = false
 
 [limit]
 context = 128_000
@@ -16,3 +16,10 @@ output = 128_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 61.6
+metric = "resolved"
+source = "https://mistral.ai/news/devstral-2507"
+date = "2025-07-10"

--- a/models/mistral/devstral-medium-latest.toml
+++ b/models/mistral/devstral-medium-latest.toml
@@ -16,3 +16,7 @@ output = 262_144
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Devstral-2-123B-Instruct-2512"

--- a/models/mistral/devstral-small-2507.toml
+++ b/models/mistral/devstral-small-2507.toml
@@ -16,3 +16,14 @@ output = 128_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Devstral-Small-2507"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 53.6
+metric = "resolved"
+source = "https://mistral.ai/news/devstral-2507"
+date = "2025-07-10"

--- a/models/mistral/magistral-medium-latest.toml
+++ b/models/mistral/magistral-medium-latest.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 knowledge = "2025-06"
-open_weights = true
+open_weights = false
 
 [limit]
 context = 128_000

--- a/models/mistral/mistral-large-2411.toml
+++ b/models/mistral/mistral-large-2411.toml
@@ -16,3 +16,7 @@ output = 16_384
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-Large-Instruct-2411"

--- a/models/mistral/mistral-large-2411.toml
+++ b/models/mistral/mistral-large-2411.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/mistralai/Mistral-Large-Instruct-2411"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 13.8
+metric = "index"
+source = "https://openrouter.ai/mistralai/mistral-large-2407/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "SciCode"
+score = 29.2
+metric = "percent correct"
+source = "https://openrouter.ai/mistralai/mistral-large-2407/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 6.1
+metric = "success rate"
+source = "https://openrouter.ai/mistralai/mistral-large-2407/benchmarks"
+date = "2026-03-11"

--- a/models/mistral/mistral-large-2512.toml
+++ b/models/mistral/mistral-large-2512.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 22.7
+metric = "index"
+source = "https://openrouter.ai/mistralai/mistral-large-2512/benchmarks"
+date = "2026-06-04"
+
+[[benchmarks]]
+name = "SciCode"
+score = 36.2
+metric = "percent correct"
+source = "https://openrouter.ai/mistralai/mistral-large-2512/benchmarks"
+date = "2026-06-04"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 15.9
+metric = "success rate"
+source = "https://openrouter.ai/mistralai/mistral-large-2512/benchmarks"
+date = "2026-06-04"

--- a/models/mistral/mistral-large-2512.toml
+++ b/models/mistral/mistral-large-2512.toml
@@ -16,3 +16,7 @@ output = 262_144
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512"

--- a/models/mistral/mistral-large-latest.toml
+++ b/models/mistral/mistral-large-latest.toml
@@ -16,3 +16,7 @@ output = 262_144
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512"

--- a/models/mistral/mistral-medium-2505.toml
+++ b/models/mistral/mistral-medium-2505.toml
@@ -16,3 +16,24 @@ output = 131_072
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 13.6
+metric = "index"
+source = "https://openrouter.ai/mistralai/mistral-medium-3/benchmarks"
+date = "2026-05-30"
+
+[[benchmarks]]
+name = "SciCode"
+score = 33.1
+metric = "percent correct"
+source = "https://openrouter.ai/mistralai/mistral-medium-3/benchmarks"
+date = "2026-05-30"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 3.8
+metric = "success rate"
+source = "https://openrouter.ai/mistralai/mistral-medium-3/benchmarks"
+date = "2026-05-30"

--- a/models/mistral/mistral-medium-2604.toml
+++ b/models/mistral/mistral-medium-2604.toml
@@ -16,3 +16,13 @@ output = 262_144
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 77.6
+metric = "resolved"
+source = "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B"

--- a/models/mistral/mistral-medium-latest.toml
+++ b/models/mistral/mistral-medium-latest.toml
@@ -16,3 +16,13 @@ output = 262_144
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 77.6
+metric = "resolved"
+source = "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B"

--- a/models/mistral/mistral-nemo.toml
+++ b/models/mistral/mistral-nemo.toml
@@ -16,3 +16,7 @@ output = 128_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407"

--- a/models/mistral/mistral-small-2506.toml
+++ b/models/mistral/mistral-small-2506.toml
@@ -16,3 +16,7 @@ output = 16_384
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-Small-3.2-24B-Instruct-2506"

--- a/models/mistral/mistral-small-2603.toml
+++ b/models/mistral/mistral-small-2603.toml
@@ -16,3 +16,7 @@ output = 256_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-Small-4-119B-2603"

--- a/models/mistral/mistral-small-2603.toml
+++ b/models/mistral/mistral-small-2603.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/mistralai/Mistral-Small-4-119B-2603"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 24.3
+metric = "index"
+source = "https://openrouter.ai/mistralai/mistral-small-2603/benchmarks"
+date = "2026-06-01"
+
+[[benchmarks]]
+name = "SciCode"
+score = 38
+metric = "percent correct"
+source = "https://openrouter.ai/mistralai/mistral-small-2603/benchmarks"
+date = "2026-06-01"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 17.4
+metric = "success rate"
+source = "https://openrouter.ai/mistralai/mistral-small-2603/benchmarks"
+date = "2026-06-01"

--- a/models/mistral/mistral-small-latest.toml
+++ b/models/mistral/mistral-small-latest.toml
@@ -16,3 +16,7 @@ output = 256_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-Small-4-119B-2603"

--- a/models/mistral/pixtral-12b.toml
+++ b/models/mistral/pixtral-12b.toml
@@ -16,3 +16,7 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Pixtral-12B-2409"

--- a/models/mistral/pixtral-large-latest.toml
+++ b/models/mistral/pixtral-large-latest.toml
@@ -16,3 +16,7 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Pixtral-Large-Instruct-2411"

--- a/models/moonshotai/kimi-k2-thinking-turbo.toml
+++ b/models/moonshotai/kimi-k2-thinking-turbo.toml
@@ -16,3 +16,7 @@ output = 262_144
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/moonshotai/Kimi-K2-Thinking"

--- a/models/moonshotai/kimi-k2-thinking.toml
+++ b/models/moonshotai/kimi-k2-thinking.toml
@@ -16,3 +16,7 @@ output = 262_144
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/moonshotai/Kimi-K2-Thinking"

--- a/models/moonshotai/kimi-k2-thinking.toml
+++ b/models/moonshotai/kimi-k2-thinking.toml
@@ -20,3 +20,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/moonshotai/Kimi-K2-Thinking"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 71.3
+metric = "resolved"
+source = "https://huggingface.co/moonshotai/Kimi-K2-Thinking"

--- a/models/moonshotai/kimi-k2.5.toml
+++ b/models/moonshotai/kimi-k2.5.toml
@@ -17,3 +17,7 @@ output = 262_144
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/moonshotai/Kimi-K2.5"

--- a/models/moonshotai/kimi-k2.5.toml
+++ b/models/moonshotai/kimi-k2.5.toml
@@ -21,3 +21,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/moonshotai/Kimi-K2.5"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 70.8
+metric = "resolved"
+source = "https://www.swebench.com/"

--- a/models/moonshotai/kimi-k2.5.toml
+++ b/models/moonshotai/kimi-k2.5.toml
@@ -27,3 +27,21 @@ name = "SWE-Bench Verified"
 score = 70.8
 metric = "resolved"
 source = "https://www.swebench.com/"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+score = 13.1
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Mini-SWE-Agent)"
+score = 20.95
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+score = 25.77
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/moonshotai/kimi-k2.5.toml
+++ b/models/moonshotai/kimi-k2.5.toml
@@ -29,19 +29,22 @@ metric = "resolved"
 source = "https://www.swebench.com/"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+name = "SWE-Atlas Codebase QnA"
 score = 13.1
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Mini-SWE-Agent)"
+name = "SWE-Atlas Refactoring"
 score = 20.95
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+name = "SWE-Atlas Test Writing"
 score = 25.77
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/moonshotai/kimi-k2.6.toml
+++ b/models/moonshotai/kimi-k2.6.toml
@@ -21,3 +21,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/moonshotai/Kimi-K2.6"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 80.2
+metric = "resolved"
+source = "https://huggingface.co/moonshotai/Kimi-K2.6"

--- a/models/moonshotai/kimi-k2.6.toml
+++ b/models/moonshotai/kimi-k2.6.toml
@@ -17,3 +17,7 @@ output = 262_144
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/moonshotai/Kimi-K2.6"

--- a/models/moonshotai/kimi-k2.6.toml
+++ b/models/moonshotai/kimi-k2.6.toml
@@ -27,3 +27,27 @@ name = "SWE-Bench Verified"
 score = 80.2
 metric = "resolved"
 source = "https://huggingface.co/moonshotai/Kimi-K2.6"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Claude Code)"
+score = 50.5
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code)"
+score = 59.8
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Claude Code)"
+score = 27.3
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Claude Code)"
+score = 64.3
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/moonshotai/kimi-k2.6.toml
+++ b/models/moonshotai/kimi-k2.6.toml
@@ -29,25 +29,31 @@ metric = "resolved"
 source = "https://huggingface.co/moonshotai/Kimi-K2.6"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Claude Code)"
+name = "Artificial Analysis Coding Agent Index"
 score = 50.5
 metric = "average pass@1"
+harness = "Claude Code"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code)"
+name = "SWE-Atlas Codebase QnA"
 score = 59.8
 metric = "pass@1"
+harness = "Claude Code"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Claude Code)"
+name = "SWE-Bench Pro"
 score = 27.3
 metric = "pass@1"
+harness = "Claude Code"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Claude Code)"
+name = "Terminal-Bench"
 score = 64.3
 metric = "pass@1"
+harness = "Claude Code"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/openai/gpt-3.5-turbo.toml
+++ b/models/openai/gpt-3.5-turbo.toml
@@ -17,3 +17,10 @@ output = 4_096
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 10.7
+metric = "index"
+source = "https://openrouter.ai/openai/gpt-3.5-turbo/benchmarks"
+date = "2026-03-11"

--- a/models/openai/gpt-4-turbo.toml
+++ b/models/openai/gpt-4-turbo.toml
@@ -17,3 +17,17 @@ output = 4_096
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 21.5
+metric = "index"
+source = "https://openrouter.ai/openai/gpt-4-turbo/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "SciCode"
+score = 31.9
+metric = "percent correct"
+source = "https://openrouter.ai/openai/gpt-4-turbo/benchmarks"
+date = "2026-03-11"

--- a/models/openai/gpt-4.1-mini.toml
+++ b/models/openai/gpt-4.1-mini.toml
@@ -17,3 +17,10 @@ output = 32_768
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 32.4
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-04-14"

--- a/models/openai/gpt-4.1-nano.toml
+++ b/models/openai/gpt-4.1-nano.toml
@@ -17,3 +17,10 @@ output = 32_768
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 8.9
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-04-14"

--- a/models/openai/gpt-4.1.toml
+++ b/models/openai/gpt-4.1.toml
@@ -17,3 +17,10 @@ output = 32_768
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 52.4
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-04-14"

--- a/models/openai/gpt-4.toml
+++ b/models/openai/gpt-4.toml
@@ -17,3 +17,10 @@ output = 8_192
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 13.1
+metric = "index"
+source = "https://openrouter.ai/openai/gpt-4/benchmarks"
+date = "2026-03-11"

--- a/models/openai/gpt-4o-2024-05-13.toml
+++ b/models/openai/gpt-4o-2024-05-13.toml
@@ -17,3 +17,17 @@ output = 4_096
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 24.2
+metric = "index"
+source = "https://openrouter.ai/openai/gpt-4o-2024-05-13/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "SciCode"
+score = 30.9
+metric = "percent correct"
+source = "https://openrouter.ai/openai/gpt-4o-2024-05-13/benchmarks"
+date = "2026-03-11"

--- a/models/openai/gpt-4o-2024-08-06.toml
+++ b/models/openai/gpt-4o-2024-08-06.toml
@@ -17,3 +17,10 @@ output = 16_384
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 23.1
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2024-12-30"

--- a/models/openai/gpt-4o-2024-08-06.toml
+++ b/models/openai/gpt-4o-2024-08-06.toml
@@ -24,3 +24,24 @@ score = 23.1
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2024-12-30"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 16.6
+metric = "index"
+source = "https://openrouter.ai/openai/gpt-4o-2024-08-06/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "SciCode"
+score = 33.1
+metric = "percent correct"
+source = "https://openrouter.ai/openai/gpt-4o-2024-08-06/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 8.3
+metric = "success rate"
+source = "https://openrouter.ai/openai/gpt-4o-2024-08-06/benchmarks"
+date = "2026-03-11"

--- a/models/openai/gpt-4o-2024-11-20.toml
+++ b/models/openai/gpt-4o-2024-11-20.toml
@@ -24,3 +24,24 @@ score = 18.2
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2024-12-30"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 16.7
+metric = "index"
+source = "https://openrouter.ai/openai/gpt-4o-2024-11-20/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "SciCode"
+score = 33.3
+metric = "percent correct"
+source = "https://openrouter.ai/openai/gpt-4o-2024-11-20/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 8.3
+metric = "success rate"
+source = "https://openrouter.ai/openai/gpt-4o-2024-11-20/benchmarks"
+date = "2026-03-11"

--- a/models/openai/gpt-4o-2024-11-20.toml
+++ b/models/openai/gpt-4o-2024-11-20.toml
@@ -17,3 +17,10 @@ output = 16_384
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 18.2
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2024-12-30"

--- a/models/openai/gpt-4o-mini.toml
+++ b/models/openai/gpt-4o-mini.toml
@@ -17,3 +17,10 @@ output = 16_384
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 3.6
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2024-12-21"

--- a/models/openai/gpt-4o-mini.toml
+++ b/models/openai/gpt-4o-mini.toml
@@ -24,3 +24,10 @@ score = 3.6
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2024-12-21"
+
+[[benchmarks]]
+name = "SciCode"
+score = 22.9
+metric = "percent correct"
+source = "https://openrouter.ai/openai/gpt-4o-mini/benchmarks"
+date = "2026-03-11"

--- a/models/openai/gpt-4o.toml
+++ b/models/openai/gpt-4o.toml
@@ -17,3 +17,10 @@ output = 16_384
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 23.1
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2024-12-30"

--- a/models/openai/gpt-5-codex.toml
+++ b/models/openai/gpt-5-codex.toml
@@ -18,3 +18,24 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 38.9
+metric = "index"
+source = "https://openrouter.ai/openai/gpt-5-codex/benchmarks"
+date = "2026-06-01"
+
+[[benchmarks]]
+name = "SciCode"
+score = 40.9
+metric = "percent correct"
+source = "https://openrouter.ai/openai/gpt-5-codex/benchmarks"
+date = "2026-06-01"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 37.9
+metric = "success rate"
+source = "https://openrouter.ai/openai/gpt-5-codex/benchmarks"
+date = "2026-06-01"

--- a/models/openai/gpt-5.2-codex.toml
+++ b/models/openai/gpt-5.2-codex.toml
@@ -18,3 +18,9 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 41.04
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/openai/gpt-5.2-codex.toml
+++ b/models/openai/gpt-5.2-codex.toml
@@ -20,7 +20,8 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 41.04
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/openai/gpt-5.2.toml
+++ b/models/openai/gpt-5.2.toml
@@ -18,3 +18,9 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 29.94
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/openai/gpt-5.2.toml
+++ b/models/openai/gpt-5.2.toml
@@ -20,7 +20,8 @@ input = ["text", "image"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 29.94
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/openai/gpt-5.3-codex.toml
+++ b/models/openai/gpt-5.3-codex.toml
@@ -18,3 +18,21 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Codex)"
+score = 32.6
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Codex)"
+score = 42.38
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Codex)"
+score = 38.98
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/openai/gpt-5.3-codex.toml
+++ b/models/openai/gpt-5.3-codex.toml
@@ -20,19 +20,22 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Codex)"
+name = "SWE-Atlas Codebase QnA"
 score = 32.6
 metric = "score"
+harness = "Codex"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Codex)"
+name = "SWE-Atlas Refactoring"
 score = 42.38
 metric = "score"
+harness = "Codex"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Codex)"
+name = "SWE-Atlas Test Writing"
 score = 38.98
 metric = "score"
+harness = "Codex"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/openai/gpt-5.4.toml
+++ b/models/openai/gpt-5.4.toml
@@ -18,3 +18,87 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 59.1
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Codex)"
+score = 40.8
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+score = 36.3
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Codex)"
+score = 44.29
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Codex CLI)"
+score = 44.36
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+score = 40
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Codex, medium)"
+score = 53.6
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Codex, medium)"
+score = 72.4
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Codex, medium)"
+score = 18.4
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Codex, medium)"
+score = 69.8
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Cursor CLI, medium)"
+score = 52.2
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Cursor CLI, medium)"
+score = 72.9
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Cursor CLI, medium)"
+score = 18.9
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Cursor CLI, medium)"
+score = 64.7
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/openai/gpt-5.4.toml
+++ b/models/openai/gpt-5.4.toml
@@ -20,85 +20,111 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 59.1
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Codex)"
+name = "SWE-Atlas Codebase QnA"
 score = 40.8
 metric = "score"
+harness = "Codex"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+name = "SWE-Atlas Codebase QnA"
 score = 36.3
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Codex)"
+name = "SWE-Atlas Refactoring"
 score = 44.29
 metric = "score"
+harness = "Codex"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Codex CLI)"
+name = "SWE-Atlas Test Writing"
 score = 44.36
 metric = "score"
+harness = "Codex CLI"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+name = "SWE-Atlas Test Writing"
 score = 40
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Codex, medium)"
+name = "Artificial Analysis Coding Agent Index"
 score = 53.6
 metric = "average pass@1"
+harness = "Codex"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Codex, medium)"
+name = "SWE-Atlas Codebase QnA"
 score = 72.4
 metric = "pass@1"
+harness = "Codex"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Codex, medium)"
+name = "SWE-Bench Pro"
 score = 18.4
 metric = "pass@1"
+harness = "Codex"
+variant = "medium"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Codex, medium)"
+name = "Terminal-Bench"
 score = 69.8
 metric = "pass@1"
+harness = "Codex"
+variant = "medium"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Cursor CLI, medium)"
+name = "Artificial Analysis Coding Agent Index"
 score = 52.2
 metric = "average pass@1"
+harness = "Cursor CLI"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Cursor CLI, medium)"
+name = "SWE-Atlas Codebase QnA"
 score = 72.9
 metric = "pass@1"
+harness = "Cursor CLI"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Cursor CLI, medium)"
+name = "SWE-Bench Pro"
 score = 18.9
 metric = "pass@1"
+harness = "Cursor CLI"
+variant = "medium"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Cursor CLI, medium)"
+name = "Terminal-Bench"
 score = 64.7
 metric = "pass@1"
+harness = "Cursor CLI"
+variant = "medium"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/openai/gpt-5.5.toml
+++ b/models/openai/gpt-5.5.toml
@@ -18,3 +18,107 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Anthropic launch table)"
+score = 58.6
+metric = "resolve rate"
+source = "https://www.anthropic.com/news/claude-opus-4-8"
+date = "2026-05-28"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1 (Terminus-2)"
+score = 78.2
+metric = "success rate"
+source = "https://www.anthropic.com/news/claude-opus-4-8"
+date = "2026-05-28"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Codex)"
+score = 45.43
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Codex)"
+score = 44.79
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Codex)"
+score = 42.59
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Codex, xhigh)"
+score = 65.3
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Codex, xhigh)"
+score = 80.8
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Codex, xhigh)"
+score = 30.9
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Codex, xhigh)"
+score = 84.1
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Codex, medium)"
+score = 60.4
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Codex, medium)"
+score = 79.1
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Codex, medium)"
+score = 26.2
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Codex, medium)"
+score = 75.8
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Cursor CLI, medium)"
+score = 57.8
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Cursor CLI, medium)"
+score = 75
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Cursor CLI, medium)"
+score = 24.9
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Cursor CLI, medium)"
+score = 73.4
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/openai/gpt-5.5.toml
+++ b/models/openai/gpt-5.5.toml
@@ -20,105 +20,140 @@ input = ["text", "image", "pdf"]
 output = ["text"]
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Anthropic launch table)"
+name = "SWE-Bench Pro"
 score = 58.6
 metric = "resolve rate"
 source = "https://www.anthropic.com/news/claude-opus-4-8"
 date = "2026-05-28"
 
 [[benchmarks]]
-name = "Terminal-Bench 2.1 (Terminus-2)"
+name = "Terminal-Bench"
 score = 78.2
 metric = "success rate"
+harness = "Terminus-2"
+version = "2.1"
 source = "https://www.anthropic.com/news/claude-opus-4-8"
 date = "2026-05-28"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Codex)"
+name = "SWE-Atlas Codebase QnA"
 score = 45.43
 metric = "score"
+harness = "Codex"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Codex)"
+name = "SWE-Atlas Refactoring"
 score = 44.79
 metric = "score"
+harness = "Codex"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Codex)"
+name = "SWE-Atlas Test Writing"
 score = 42.59
 metric = "score"
+harness = "Codex"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Codex, xhigh)"
+name = "Artificial Analysis Coding Agent Index"
 score = 65.3
 metric = "average pass@1"
+harness = "Codex"
+variant = "xhigh"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Codex, xhigh)"
+name = "SWE-Atlas Codebase QnA"
 score = 80.8
 metric = "pass@1"
+harness = "Codex"
+variant = "xhigh"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Codex, xhigh)"
+name = "SWE-Bench Pro"
 score = 30.9
 metric = "pass@1"
+harness = "Codex"
+variant = "xhigh"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Codex, xhigh)"
+name = "Terminal-Bench"
 score = 84.1
 metric = "pass@1"
+harness = "Codex"
+variant = "xhigh"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Codex, medium)"
+name = "Artificial Analysis Coding Agent Index"
 score = 60.4
 metric = "average pass@1"
+harness = "Codex"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Codex, medium)"
+name = "SWE-Atlas Codebase QnA"
 score = 79.1
 metric = "pass@1"
+harness = "Codex"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Codex, medium)"
+name = "SWE-Bench Pro"
 score = 26.2
 metric = "pass@1"
+harness = "Codex"
+variant = "medium"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Codex, medium)"
+name = "Terminal-Bench"
 score = 75.8
 metric = "pass@1"
+harness = "Codex"
+variant = "medium"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Cursor CLI, medium)"
+name = "Artificial Analysis Coding Agent Index"
 score = 57.8
 metric = "average pass@1"
+harness = "Cursor CLI"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Cursor CLI, medium)"
+name = "SWE-Atlas Codebase QnA"
 score = 75
 metric = "pass@1"
+harness = "Cursor CLI"
+variant = "medium"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Cursor CLI, medium)"
+name = "SWE-Bench Pro"
 score = 24.9
 metric = "pass@1"
+harness = "Cursor CLI"
+variant = "medium"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Cursor CLI, medium)"
+name = "Terminal-Bench"
 score = 73.4
 metric = "pass@1"
+harness = "Cursor CLI"
+variant = "medium"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/openai/gpt-5.toml
+++ b/models/openai/gpt-5.toml
@@ -25,3 +25,9 @@ score = 88.0
 metric = "percent correct"
 source = "https://aider.chat/docs/leaderboards/"
 date = "2025-08-23"
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 41.78
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/openai/gpt-5.toml
+++ b/models/openai/gpt-5.toml
@@ -18,3 +18,10 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 88.0
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-08-23"

--- a/models/openai/gpt-5.toml
+++ b/models/openai/gpt-5.toml
@@ -27,7 +27,8 @@ source = "https://aider.chat/docs/leaderboards/"
 date = "2025-08-23"
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 41.78
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/openai/o1.toml
+++ b/models/openai/o1.toml
@@ -17,3 +17,10 @@ output = 100_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 61.7
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2024-12-21"

--- a/models/openai/o3-mini.toml
+++ b/models/openai/o3-mini.toml
@@ -17,3 +17,10 @@ output = 100_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 60.4
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-01-31"

--- a/models/openai/o3-pro.toml
+++ b/models/openai/o3-pro.toml
@@ -17,3 +17,10 @@ output = 100_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 84.9
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-06-28"

--- a/models/openai/o3.toml
+++ b/models/openai/o3.toml
@@ -17,3 +17,10 @@ output = 100_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 81.3
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-06-25"

--- a/models/openai/o4-mini.toml
+++ b/models/openai/o4-mini.toml
@@ -17,3 +17,10 @@ output = 100_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Aider Polyglot"
+score = 72.0
+metric = "percent correct"
+source = "https://aider.chat/docs/leaderboards/"
+date = "2025-04-16"

--- a/models/perplexity/sonar-pro.toml
+++ b/models/perplexity/sonar-pro.toml
@@ -16,3 +16,10 @@ output = 8_192
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SciCode"
+score = 22.6
+metric = "percent correct"
+source = "https://openrouter.ai/perplexity/sonar-pro/benchmarks"
+date = "2026-03-11"

--- a/models/perplexity/sonar.toml
+++ b/models/perplexity/sonar.toml
@@ -16,3 +16,10 @@ output = 4_096
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[benchmarks]]
+name = "SciCode"
+score = 22.9
+metric = "percent correct"
+source = "https://openrouter.ai/perplexity/sonar/benchmarks"
+date = "2026-03-11"

--- a/models/stepfun/step-3.5-flash-2603.toml
+++ b/models/stepfun/step-3.5-flash-2603.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/stepfun-ai/Step-3.5-Flash"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 34.6
+metric = "index"
+source = "https://openrouter.ai/stepfun/step-3.5-flash/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "SciCode"
+score = 38.5
+metric = "percent correct"
+source = "https://openrouter.ai/stepfun/step-3.5-flash/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 32.6
+metric = "success rate"
+source = "https://openrouter.ai/stepfun/step-3.5-flash/benchmarks"
+date = "2026-06-02"

--- a/models/stepfun/step-3.5-flash-2603.toml
+++ b/models/stepfun/step-3.5-flash-2603.toml
@@ -16,3 +16,7 @@ output = 256_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/stepfun-ai/Step-3.5-Flash"

--- a/models/stepfun/step-3.5-flash.toml
+++ b/models/stepfun/step-3.5-flash.toml
@@ -16,3 +16,7 @@ output = 256_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/stepfun-ai/Step-3.5-Flash"

--- a/models/stepfun/step-3.5-flash.toml
+++ b/models/stepfun/step-3.5-flash.toml
@@ -20,3 +20,30 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/stepfun-ai/Step-3.5-Flash"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 31.6
+metric = "index"
+source = "https://openrouter.ai/stepfun/step-3.5-flash/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "SciCode"
+score = 40.4
+metric = "percent correct"
+source = "https://openrouter.ai/stepfun/step-3.5-flash/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 27.3
+metric = "success rate"
+source = "https://openrouter.ai/stepfun/step-3.5-flash/benchmarks"
+date = "2026-06-02"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 74.4
+metric = "resolved"
+source = "https://arxiv.org/abs/2602.10604"

--- a/models/tencent/hy3-preview.toml
+++ b/models/tencent/hy3-preview.toml
@@ -19,3 +19,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/tencent/Hy3-preview"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 74.4
+metric = "resolved"
+source = "https://huggingface.co/tencent/Hy3-preview"

--- a/models/tencent/hy3-preview.toml
+++ b/models/tencent/hy3-preview.toml
@@ -15,3 +15,7 @@ output = 64_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/tencent/Hy3-preview"

--- a/models/xiaomi/mimo-v2-flash.toml
+++ b/models/xiaomi/mimo-v2-flash.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash"

--- a/models/xiaomi/mimo-v2.5-pro.toml
+++ b/models/xiaomi/mimo-v2.5-pro.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro"

--- a/models/xiaomi/mimo-v2.5-pro.toml
+++ b/models/xiaomi/mimo-v2.5-pro.toml
@@ -20,3 +20,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 78.9
+metric = "resolved"
+source = "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro"

--- a/models/xiaomi/mimo-v2.5.toml
+++ b/models/xiaomi/mimo-v2.5.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text", "image", "audio", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/XiaomiMiMo/MiMo-V2.5"

--- a/models/zai/glm-4.5-air.toml
+++ b/models/zai/glm-4.5-air.toml
@@ -16,3 +16,7 @@ output = 98_304
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.5-Air"

--- a/models/zai/glm-4.5-air.toml
+++ b/models/zai/glm-4.5-air.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/zai-org/GLM-4.5-Air"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 23.8
+metric = "index"
+source = "https://openrouter.ai/z-ai/glm-4.5-air/benchmarks"
+date = "2026-05-30"
+
+[[benchmarks]]
+name = "SciCode"
+score = 30.6
+metric = "percent correct"
+source = "https://openrouter.ai/z-ai/glm-4.5-air/benchmarks"
+date = "2026-05-30"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 20.5
+metric = "success rate"
+source = "https://openrouter.ai/z-ai/glm-4.5-air/benchmarks"
+date = "2026-05-30"

--- a/models/zai/glm-4.5.toml
+++ b/models/zai/glm-4.5.toml
@@ -16,3 +16,7 @@ output = 98_304
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.5"

--- a/models/zai/glm-4.5.toml
+++ b/models/zai/glm-4.5.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/zai-org/GLM-4.5"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 26.3
+metric = "index"
+source = "https://openrouter.ai/z-ai/glm-4.5/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "SciCode"
+score = 34.8
+metric = "percent correct"
+source = "https://openrouter.ai/z-ai/glm-4.5/benchmarks"
+date = "2026-03-11"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 22
+metric = "success rate"
+source = "https://openrouter.ai/z-ai/glm-4.5/benchmarks"
+date = "2026-03-11"

--- a/models/zai/glm-4.5v.toml
+++ b/models/zai/glm-4.5v.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/zai-org/GLM-4.5V"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 10.9
+metric = "index"
+source = "https://openrouter.ai/z-ai/glm-4.5v/benchmarks"
+date = "2026-04-29"
+
+[[benchmarks]]
+name = "SciCode"
+score = 22.1
+metric = "percent correct"
+source = "https://openrouter.ai/z-ai/glm-4.5v/benchmarks"
+date = "2026-04-29"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 5.3
+metric = "success rate"
+source = "https://openrouter.ai/z-ai/glm-4.5v/benchmarks"
+date = "2026-04-29"

--- a/models/zai/glm-4.5v.toml
+++ b/models/zai/glm-4.5v.toml
@@ -16,3 +16,7 @@ output = 16_384
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.5V"

--- a/models/zai/glm-4.6.toml
+++ b/models/zai/glm-4.6.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.6"

--- a/models/zai/glm-4.6.toml
+++ b/models/zai/glm-4.6.toml
@@ -20,3 +20,24 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/zai-org/GLM-4.6"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Index"
+score = 29.5
+metric = "index"
+source = "https://openrouter.ai/z-ai/glm-4.6/benchmarks"
+date = "2026-05-22"
+
+[[benchmarks]]
+name = "SciCode"
+score = 38.4
+metric = "percent correct"
+source = "https://openrouter.ai/z-ai/glm-4.6/benchmarks"
+date = "2026-05-22"
+
+[[benchmarks]]
+name = "Terminal-Bench Hard"
+score = 25
+metric = "success rate"
+source = "https://openrouter.ai/z-ai/glm-4.6/benchmarks"
+date = "2026-05-22"

--- a/models/zai/glm-4.6.toml
+++ b/models/zai/glm-4.6.toml
@@ -41,3 +41,9 @@ score = 25
 metric = "success rate"
 source = "https://openrouter.ai/z-ai/glm-4.6/benchmarks"
 date = "2026-05-22"
+
+[[benchmarks]]
+name = "SWE-Bench Pro (Scale Public)"
+score = 9.67
+metric = "resolve rate"
+source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/zai/glm-4.6.toml
+++ b/models/zai/glm-4.6.toml
@@ -43,7 +43,8 @@ source = "https://openrouter.ai/z-ai/glm-4.6/benchmarks"
 date = "2026-05-22"
 
 [[benchmarks]]
-name = "SWE-Bench Pro (Scale Public)"
+name = "SWE-Bench Pro"
 score = 9.67
 metric = "resolve rate"
+dataset = "public"
 source = "https://labs.scale.com/leaderboard/swe_bench_pro_public"

--- a/models/zai/glm-4.6v.toml
+++ b/models/zai/glm-4.6v.toml
@@ -16,3 +16,7 @@ output = 32_768
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.6V"

--- a/models/zai/glm-4.7-flash.toml
+++ b/models/zai/glm-4.7-flash.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.7-Flash"

--- a/models/zai/glm-4.7-flash.toml
+++ b/models/zai/glm-4.7-flash.toml
@@ -20,3 +20,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/zai-org/GLM-4.7-Flash"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 59.2
+metric = "resolved"
+source = "https://huggingface.co/zai-org/GLM-4.7-Flash"

--- a/models/zai/glm-4.7-flashx.toml
+++ b/models/zai/glm-4.7-flashx.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.7-Flash"

--- a/models/zai/glm-4.7.toml
+++ b/models/zai/glm-4.7.toml
@@ -16,3 +16,19 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.7"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 73.8
+metric = "resolved"
+source = "https://huggingface.co/zai-org/GLM-4.7"
+
+[[benchmarks]]
+name = "Terminal Bench 2.0"
+score = 33.4
+metric = "score"
+source = "https://huggingface.co/zai-org/GLM-4.7"

--- a/models/zai/glm-5.1.toml
+++ b/models/zai/glm-5.1.toml
@@ -20,3 +20,27 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/zai-org/GLM-5.1"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index (Claude Code)"
+score = 52.7
+metric = "average pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code)"
+score = 73.2
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "SWE-Bench-Pro-Hard-AA (Claude Code)"
+score = 19.8
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"
+
+[[benchmarks]]
+name = "Terminal-Bench v2 (Artificial Analysis, Claude Code)"
+score = 65.1
+metric = "pass@1"
+source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/zai/glm-5.1.toml
+++ b/models/zai/glm-5.1.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [limit]
 context = 200_000
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-5.1"

--- a/models/zai/glm-5.1.toml
+++ b/models/zai/glm-5.1.toml
@@ -22,25 +22,31 @@ label = "Hugging Face"
 url = "https://huggingface.co/zai-org/GLM-5.1"
 
 [[benchmarks]]
-name = "Artificial Analysis Coding Agent Index (Claude Code)"
+name = "Artificial Analysis Coding Agent Index"
 score = 52.7
 metric = "average pass@1"
+harness = "Claude Code"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Atlas-QnA (Artificial Analysis, Claude Code)"
+name = "SWE-Atlas Codebase QnA"
 score = 73.2
 metric = "pass@1"
+harness = "Claude Code"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "SWE-Bench-Pro-Hard-AA (Claude Code)"
+name = "SWE-Bench Pro"
 score = 19.8
 metric = "pass@1"
+harness = "Claude Code"
+dataset = "hard-aa"
 source = "https://artificialanalysis.ai/agents/coding-agents"
 
 [[benchmarks]]
-name = "Terminal-Bench v2 (Artificial Analysis, Claude Code)"
+name = "Terminal-Bench"
 score = 65.1
 metric = "pass@1"
+harness = "Claude Code"
+version = "2.1"
 source = "https://artificialanalysis.ai/agents/coding-agents"

--- a/models/zai/glm-5.toml
+++ b/models/zai/glm-5.toml
@@ -15,3 +15,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-5"

--- a/models/zai/glm-5.toml
+++ b/models/zai/glm-5.toml
@@ -19,3 +19,9 @@ output = ["text"]
 [[weights]]
 label = "Hugging Face"
 url = "https://huggingface.co/zai-org/GLM-5"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 72.8
+metric = "resolved"
+source = "https://www.swebench.com/"

--- a/models/zai/glm-5.toml
+++ b/models/zai/glm-5.toml
@@ -25,3 +25,21 @@ name = "SWE-Bench Verified"
 score = 72.8
 metric = "resolved"
 source = "https://www.swebench.com/"
+
+[[benchmarks]]
+name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+score = 20.5
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-qna"
+
+[[benchmarks]]
+name = "SWE-Atlas Refactoring (Mini-SWE-Agent)"
+score = 24.24
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
+
+[[benchmarks]]
+name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+score = 28.74
+metric = "score"
+source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/zai/glm-5.toml
+++ b/models/zai/glm-5.toml
@@ -27,19 +27,22 @@ metric = "resolved"
 source = "https://www.swebench.com/"
 
 [[benchmarks]]
-name = "SWE-Atlas Codebase QnA (Mini-SWE-Agent)"
+name = "SWE-Atlas Codebase QnA"
 score = 20.5
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-qna"
 
 [[benchmarks]]
-name = "SWE-Atlas Refactoring (Mini-SWE-Agent)"
+name = "SWE-Atlas Refactoring"
 score = 24.24
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-refactoring"
 
 [[benchmarks]]
-name = "SWE-Atlas Test Writing (Mini-SWE-Agent)"
+name = "SWE-Atlas Test Writing"
 score = 28.74
 metric = "score"
+harness = "Mini-SWE-Agent"
 source = "https://labs.scale.com/leaderboard/sweatlas-tw"

--- a/models/zhipuai/glm-4.5-air.toml
+++ b/models/zhipuai/glm-4.5-air.toml
@@ -16,3 +16,7 @@ output = 98_304
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.5-Air"

--- a/models/zhipuai/glm-4.5-flash.toml
+++ b/models/zhipuai/glm-4.5-flash.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 knowledge = "2025-04"
-open_weights = true
+open_weights = false
 
 [limit]
 context = 131_072

--- a/models/zhipuai/glm-4.5.toml
+++ b/models/zhipuai/glm-4.5.toml
@@ -16,3 +16,7 @@ output = 98_304
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.5"

--- a/models/zhipuai/glm-4.5v.toml
+++ b/models/zhipuai/glm-4.5v.toml
@@ -16,3 +16,7 @@ output = 16_384
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.5V"

--- a/models/zhipuai/glm-4.6.toml
+++ b/models/zhipuai/glm-4.6.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.6"

--- a/models/zhipuai/glm-4.6v.toml
+++ b/models/zhipuai/glm-4.6v.toml
@@ -16,3 +16,7 @@ output = 32_768
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.6V"

--- a/models/zhipuai/glm-4.7-flash.toml
+++ b/models/zhipuai/glm-4.7-flash.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.7-Flash"

--- a/models/zhipuai/glm-4.7-flashx.toml
+++ b/models/zhipuai/glm-4.7-flashx.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.7-Flash"

--- a/models/zhipuai/glm-4.7.toml
+++ b/models/zhipuai/glm-4.7.toml
@@ -16,3 +16,19 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.7"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 73.8
+metric = "resolved"
+source = "https://huggingface.co/zai-org/GLM-4.7"
+
+[[benchmarks]]
+name = "Terminal Bench 2.0"
+score = 33.4
+metric = "score"
+source = "https://huggingface.co/zai-org/GLM-4.7"

--- a/models/zhipuai/glm-5.1.toml
+++ b/models/zhipuai/glm-5.1.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [limit]
 context = 200_000
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-5.1"

--- a/models/zhipuai/glm-5.toml
+++ b/models/zhipuai/glm-5.toml
@@ -15,3 +15,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-5"

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -170,6 +170,10 @@ export const BenchmarkResult = z
     name: z.string().min(1, "Benchmark name cannot be empty"),
     score: z.union([z.number(), z.string().min(1)]),
     metric: z.string().min(1, "Benchmark metric cannot be empty").optional(),
+    harness: z.string().min(1, "Benchmark harness cannot be empty").optional(),
+    variant: z.string().min(1, "Benchmark variant cannot be empty").optional(),
+    dataset: z.string().min(1, "Benchmark dataset cannot be empty").optional(),
+    version: z.string().min(1, "Benchmark version cannot be empty").optional(),
     source: UrlString.optional(),
     date: DateString.optional(),
   })

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -155,6 +155,24 @@ output = 32_000
     expect(leaked).toEqual([]);
   });
 
+  test("repository provider JSON excludes model-only metadata", async () => {
+    const root = path.join(import.meta.dirname, "..", "..", "..");
+    const providers = await generate(path.join(root, "providers"));
+    const modelOnlyFields = ["benchmarks", "license", "links", "weights"];
+    const leaked: string[] = [];
+
+    for (const [providerID, provider] of Object.entries(providers)) {
+      for (const [modelID, model] of Object.entries(provider.models)) {
+        const leakedFields = modelOnlyFields.filter((field) => field in model);
+        if (leakedFields.length > 0) {
+          leaked.push(`${providerID}/${modelID}: ${leakedFields.join(", ")}`);
+        }
+      }
+    }
+
+    expect(leaked).toEqual([]);
+  });
+
   test("repository model metadata avoids provider-only namespaces", async () => {
     const root = path.join(import.meta.dirname, "..", "..", "..");
     const providerNamespaces = [
@@ -180,6 +198,42 @@ output = 32_000
 
     expect(namespaceDirs).toEqual([]);
     expect(baseModelRefs).toEqual([]);
+  });
+
+  test("repository open-weight model metadata includes weights links", async () => {
+    const root = path.join(import.meta.dirname, "..", "..", "..");
+    const catalog = await generateCatalog(root);
+    const missingWeights: string[] = [];
+    const closedWithWeights: string[] = [];
+
+    for (const [modelID, model] of Object.entries(catalog.models)) {
+      const hasWeights = (model.weights?.length ?? 0) > 0;
+      if (model.open_weights === true && !hasWeights) {
+        missingWeights.push(modelID);
+      }
+      if (model.open_weights !== true && hasWeights) {
+        closedWithWeights.push(modelID);
+      }
+    }
+
+    expect(missingWeights).toEqual([]);
+    expect(closedWithWeights).toEqual([]);
+  });
+
+  test("repository benchmark metadata is sourced", async () => {
+    const root = path.join(import.meta.dirname, "..", "..", "..");
+    const catalog = await generateCatalog(root);
+    const unsourced: string[] = [];
+
+    for (const [modelID, model] of Object.entries(catalog.models)) {
+      for (const benchmark of model.benchmarks ?? []) {
+        if (benchmark.source === undefined) {
+          unsourced.push(`${modelID}: ${benchmark.name}`);
+        }
+      }
+    }
+
+    expect(unsourced).toEqual([]);
   });
 });
 

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -70,6 +70,10 @@ cache_read = 0.125
           name: "SWE-Bench Verified",
           score: 71.2,
           metric: "resolved",
+          harness: "Example Harness",
+          variant: "high",
+          dataset: "verified",
+          version: "1",
           source: "https://example.com/benchmarks",
         },
       ]);
@@ -235,6 +239,22 @@ output = 32_000
 
     expect(unsourced).toEqual([]);
   });
+
+  test("repository benchmark names are normalized", async () => {
+    const root = path.join(import.meta.dirname, "..", "..", "..");
+    const catalog = await generateCatalog(root);
+    const qualifiedNames: string[] = [];
+
+    for (const [modelID, model] of Object.entries(catalog.models)) {
+      for (const benchmark of model.benchmarks ?? []) {
+        if (/\s\([^)]+\)$/.test(benchmark.name)) {
+          qualifiedNames.push(`${modelID}: ${benchmark.name}`);
+        }
+      }
+    }
+
+    expect(qualifiedNames).toEqual([]);
+  });
 });
 
 function providerToml(name: string) {
@@ -282,6 +302,10 @@ format = "safetensors"
 name = "SWE-Bench Verified"
 score = 71.2
 metric = "resolved"
+harness = "Example Harness"
+variant = "high"
+dataset = "verified"
+version = "1"
 source = "https://example.com/benchmarks"
 `;
 }


### PR DESCRIPTION
## Summary
- add sourced programming benchmark metadata to model-only TOMLs
- add Hugging Face weights links for open-weight models
- add regression tests for model-only metadata and open-weight link coverage

## Verification
- bun test
- bun validate
- cd packages/web && bun run build