### PR TITLE
fix(sync): preserve reasoning options

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -494,6 +494,10 @@ function formatNumber(n: number) {
   return Number.isInteger(n) ? formatInteger(n) : String(n);
 }
 
+function formatReasoningValue(value: string | null) {
+  return value === null ? quote("null") : quote(value);
+}
+
 function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
   const lines: string[] = [];
 
@@ -515,6 +519,18 @@ function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
   if (model.knowledge !== undefined) lines.push(`knowledge = ${quote(model.knowledge)}`);
   if (model.open_weights !== undefined) lines.push(`open_weights = ${model.open_weights}`);
   if (model.status !== undefined) lines.push(`status = ${quote(model.status)}`);
+
+  for (const option of model.reasoning_options ?? []) {
+    lines.push("", "[[reasoning_options]]");
+    lines.push(`type = ${quote(option.type)}`);
+    if (option.type === "effort") {
+      lines.push(`values = [${option.values.map(formatReasoningValue).join(", ")}]`);
+    }
+    if (option.type === "budget_tokens") {
+      if (option.min !== undefined) lines.push(`min = ${formatInteger(option.min)}`);
+      if (option.max !== undefined) lines.push(`max = ${formatInteger(option.max)}`);
+    }
+  }
 
   if (model.interleaved !== undefined) {
     lines.push("");

--- a/packages/core/src/sync/providers/google.ts
+++ b/packages/core/src/sync/providers/google.ts
@@ -123,6 +123,7 @@ function buildModel(model: GoogleModel, existing: ExistingModel): SyncedModel {
     temperature: model.temperature !== undefined || model.maxTemperature !== undefined
       ? true
       : existing.temperature,
+    reasoning_options: existing.reasoning_options,
     tool_call: toolCall,
     structured_output: existing.structured_output,
     knowledge: existing.knowledge,


### PR DESCRIPTION
## Summary
- preserve existing `reasoning_options` when Google sync rewrites model TOMLs
- teach the generic sync TOML formatter to serialize `[[reasoning_options]]` blocks
- encode resolved JSON `null` effort values back to authored TOML `"null"` sentinel

## Why
Automation PR #1994 shows Google sync deleting Gemini reasoning metadata because the sync path did not carry or write `reasoning_options`. The Google Models API only exposes a boolean `thinking` field, not thinking budget ranges or supported thinking levels, so authored `reasoning_options` must be preserved.

## Validation
- `bun validate`
- `bun models:sync google --dry-run`
- `git diff --check`

Google dry-run result after this fix:

```text
Dry run: 0 created, 0 updated, 0 removed, 21 unchanged
```