### PR TITLE
chore: normalize base-model inheritance across provider TOMLs

### DIFF
--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -12,7 +12,7 @@ import {
 } from "./schema.js";
 
 const BaseModel = AuthoredModelShape
-  .partial()
+  .deepPartial()
   .extend({
     id: z.string(),
     base_model: z.string().min(1, "Base model cannot be empty"),
@@ -211,7 +211,8 @@ function applyOmit(target: Record<string, unknown>, paths: string[]) {
 
     for (let index = parents.length - 1; index >= 0; index--) {
       const parent = parents[index];
-      const value = parent?.value[parent.key];
+      if (parent === undefined) continue;
+      const value = parent.value[parent.key];
       if (
         value === null ||
         value === undefined ||

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -10,14 +10,21 @@ import { openrouter } from "./providers/openrouter.js";
 import { ovhcloud } from "./providers/ovhcloud.js";
 import { xai } from "./providers/xai.js";
 
-const ExistingModel = AuthoredModelShape.partial()
+const ExistingModelType = AuthoredModelShape.partial()
   .extend({
     base_model: z.string().optional(),
     base_model_omit: z.array(z.string()).optional(),
   })
   .strict();
 
-const SyncedBaseModel = AuthoredModelShape.partial()
+const ExistingModel = AuthoredModelShape.deepPartial()
+  .extend({
+    base_model: z.string().optional(),
+    base_model_omit: z.array(z.string()).optional(),
+  })
+  .strict();
+
+const SyncedBaseModel = AuthoredModelShape.deepPartial()
   .extend({
     id: z.string(),
     base_model: z.string(),
@@ -27,7 +34,7 @@ const SyncedBaseModel = AuthoredModelShape.partial()
 
 const SyncedAuthoredModel = z.union([AuthoredModel, SyncedBaseModel]);
 
-export type ExistingModel = z.infer<typeof ExistingModel>;
+export type ExistingModel = z.infer<typeof ExistingModelType>;
 export type SyncedFullModel = Omit<z.infer<typeof AuthoredModelShape>, "id">;
 export type SyncedBaseModel = Omit<z.infer<typeof SyncedBaseModel>, "id">;
 export type SyncedModel = SyncedFullModel | SyncedBaseModel;
@@ -240,7 +247,7 @@ async function readExisting(modelsDir: string) {
       throw parsed.error;
     }
 
-    const authored = parsed.data;
+    const authored = parsed.data as ExistingModel;
     if (authored.base_model !== undefined && modelMetadata === undefined) {
       modelMetadata = await readModelMetadata(modelsDir);
     }
@@ -304,7 +311,7 @@ function resolveBaseModel(
     parsed.error.cause = { modelPath, toml: merged };
     throw parsed.error;
   }
-  return parsed.data;
+  return parsed.data as ExistingModel;
 }
 
 function inheritableModelMetadata(model: Record<string, unknown>) {

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -128,6 +128,44 @@ output = 32_000
     });
   });
 
+  test("base_model can inherit sibling fields from partial object overrides", async () => {
+    await withFixture(async (root) => {
+      await write(root, "providers/provider/provider.toml", providerToml("Provider"));
+      await write(root, "models/lab/model.toml", modelMetadataToml());
+      await write(
+        root,
+        "providers/provider/models/model.toml",
+        `base_model = "lab/model"
+open_weights = true
+
+[cost]
+input = 1.25
+output = 2.50
+
+[limit]
+context = 200_000
+
+[modalities]
+input = ["text"]
+`,
+      );
+
+      const providers = await generate(path.join(root, "providers"));
+      const model = providers.provider?.models.model;
+
+      expect(model?.open_weights).toBe(true);
+      expect(model?.limit).toEqual({
+        context: 200_000,
+        input: 272_000,
+        output: 128_000,
+      });
+      expect(model?.modalities).toEqual({
+        input: ["text"],
+        output: ["text"],
+      });
+    });
+  });
+
   test("repository provider TOMLs do not use legacy extends tables", async () => {
     const root = path.join(import.meta.dirname, "..", "..", "..");
     const matches: string[] = [];

--- a/providers/alibaba-token-plan/models/kimi-k2.5.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.5.toml
@@ -14,5 +14,4 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 262_144
 output = 32_768

--- a/providers/alibaba-token-plan/models/kimi-k2.6.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.6.toml
@@ -12,5 +12,4 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 262_144
 output = 16_384

--- a/providers/ambient/models/moonshotai/kimi-k2.6.toml
+++ b/providers/ambient/models/moonshotai/kimi-k2.6.toml
@@ -11,4 +11,3 @@ cache_write = 0
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/ambient/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/ambient/models/zai-org/GLM-5.1-FP8.toml
@@ -11,4 +11,3 @@ cache_write = 0
 
 [limit]
 context = 202_752
-output = 131_072

--- a/providers/azure-cognitive-services/models/gpt-5.4-mini.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.4-mini.toml
@@ -8,4 +8,3 @@ cache_read = 0.075
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/azure-cognitive-services/models/gpt-5.4-nano.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.4-nano.toml
@@ -8,4 +8,3 @@ cache_read = 0.02
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/azure/models/gpt-4.1-mini.toml
+++ b/providers/azure/models/gpt-4.1-mini.toml
@@ -8,4 +8,3 @@ cache_read = 0.1
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/azure/models/gpt-4.1.toml
+++ b/providers/azure/models/gpt-4.1.toml
@@ -8,4 +8,3 @@ cache_read = 0.5
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/azure/models/gpt-4o-mini.toml
+++ b/providers/azure/models/gpt-4o-mini.toml
@@ -8,4 +8,3 @@ cache_read = 0.075
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/azure/models/gpt-4o.toml
+++ b/providers/azure/models/gpt-4o.toml
@@ -8,4 +8,3 @@ cache_read = 1.25
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/azure/models/gpt-5-pro.toml
+++ b/providers/azure/models/gpt-5-pro.toml
@@ -4,7 +4,3 @@ base_model_omit = ["limit.input"]
 [cost]
 input = 15
 output = 120
-
-[limit]
-context = 400_000
-output = 272_000

--- a/providers/azure/models/gpt-5.1-codex-max.toml
+++ b/providers/azure/models/gpt-5.1-codex-max.toml
@@ -5,7 +5,3 @@ base_model_omit = ["limit.input"]
 input = 1.25
 output = 10
 cache_read = 0.125
-
-[limit]
-context = 400_000
-output = 128_000

--- a/providers/azure/models/gpt-5.4-mini.toml
+++ b/providers/azure/models/gpt-5.4-mini.toml
@@ -8,4 +8,3 @@ cache_read = 0.075
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/azure/models/gpt-5.4-nano.toml
+++ b/providers/azure/models/gpt-5.4-nano.toml
@@ -8,4 +8,3 @@ cache_read = 0.02
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/azure/models/o3.toml
+++ b/providers/azure/models/o3.toml
@@ -8,4 +8,3 @@ cache_read = 0.5
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
@@ -11,10 +11,5 @@ input = 0.39
 output = 2.34
 cache_read = 0.195
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
@@ -8,10 +8,5 @@ input = 0.195
 output = 1.56
 cache_read = 0.0975
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/chutes/models/XiaomiMiMo/MiMo-V2-Flash-TEE.toml
+++ b/providers/chutes/models/XiaomiMiMo/MiMo-V2-Flash-TEE.toml
@@ -9,7 +9,3 @@ structured_output = true
 input = 0.09
 output = 0.29
 cache_read = 0.045
-
-[limit]
-context = 262_144
-output = 65_536

--- a/providers/chutes/models/deepseek-ai/DeepSeek-R1-0528-TEE.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-R1-0528-TEE.toml
@@ -3,7 +3,6 @@
 base_model = "deepseek/deepseek-r1"
 name = "DeepSeek R1 0528 TEE"
 structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
@@ -15,5 +15,4 @@ output = 2
 cache_read = 0.22
 
 [limit]
-context = 262_144
 output = 65_535

--- a/providers/chutes/models/moonshotai/Kimi-K2.6-TEE.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K2.6-TEE.toml
@@ -13,5 +13,4 @@ output = 4
 cache_read = 0.475
 
 [limit]
-context = 262_144
 output = 65_535

--- a/providers/chutes/models/zai-org/GLM-5.1-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-5.1-TEE.toml
@@ -2,7 +2,6 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "zai/glm-5.1"
 name = "GLM 5.1 TEE"
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/clarifai/models/moonshotai/chat-completion/models/Kimi-K2_6.toml
+++ b/providers/clarifai/models/moonshotai/chat-completion/models/Kimi-K2_6.toml
@@ -9,4 +9,3 @@ output = 4
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/cortecs/models/deepseek-v4-flash.toml
+++ b/providers/cortecs/models/deepseek-v4-flash.toml
@@ -11,4 +11,3 @@ cache_read = 0.0028
 
 [limit]
 context = 1_048_576
-output = 384_000

--- a/providers/cortecs/models/deepseek-v4-pro.toml
+++ b/providers/cortecs/models/deepseek-v4-pro.toml
@@ -11,4 +11,3 @@ cache_read = 0.003625
 
 [limit]
 context = 1_048_576
-output = 384_000

--- a/providers/cortecs/models/qwen3.5-122b-a10b.toml
+++ b/providers/cortecs/models/qwen3.5-122b-a10b.toml
@@ -11,9 +11,7 @@ input = 0.444
 output = 3.106
 
 [limit]
-context = 262_144
 output = 262_144
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/cortecs/models/qwen3.5-397b-a17b.toml
+++ b/providers/cortecs/models/qwen3.5-397b-a17b.toml
@@ -16,4 +16,3 @@ output = 250_000
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/crof/models/deepseek-v4-flash.toml
+++ b/providers/crof/models/deepseek-v4-flash.toml
@@ -9,7 +9,6 @@ output = 0.21
 cache_read = 0.003
 
 [limit]
-context = 1_000_000
 output = 131_072
 
 [provider]

--- a/providers/crof/models/deepseek-v4-pro-lightning.toml
+++ b/providers/crof/models/deepseek-v4-pro-lightning.toml
@@ -9,7 +9,6 @@ output = 1.6
 cache_read = 0.02
 
 [limit]
-context = 1_000_000
 output = 131_072
 
 [provider]

--- a/providers/crof/models/deepseek-v4-pro.toml
+++ b/providers/crof/models/deepseek-v4-pro.toml
@@ -9,7 +9,6 @@ output = 0.8
 cache_read = 0.003
 
 [limit]
-context = 1_000_000
 output = 131_072
 
 [provider]

--- a/providers/crof/models/gemma-4-31b-it.toml
+++ b/providers/crof/models/gemma-4-31b-it.toml
@@ -6,7 +6,6 @@ output = 0.3
 cache_read = 0.02
 
 [limit]
-context = 262_144
 output = 262_144
 
 [provider]

--- a/providers/crof/models/glm-4.7-flash.toml
+++ b/providers/crof/models/glm-4.7-flash.toml
@@ -8,7 +8,6 @@ cache_write = 0
 
 [limit]
 context = 202_752
-output = 131_072
 
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/qwen3.5-397b-a17b.toml
+++ b/providers/crof/models/qwen3.5-397b-a17b.toml
@@ -6,7 +6,6 @@ output = 1.75
 cache_read = 0.07
 
 [limit]
-context = 262_144
 output = 262_144
 
 [provider]

--- a/providers/crof/models/qwen3.6-27b.toml
+++ b/providers/crof/models/qwen3.6-27b.toml
@@ -6,7 +6,6 @@ output = 1.5
 cache_read = 0.04
 
 [limit]
-context = 262_144
 output = 262_144
 
 [provider]

--- a/providers/deepinfra/models/XiaomiMiMo/MiMo-V2.5-Pro.toml
+++ b/providers/deepinfra/models/XiaomiMiMo/MiMo-V2.5-Pro.toml
@@ -15,5 +15,4 @@ output = 6
 cache_read = 0.4
 
 [limit]
-context = 1_048_576
 output = 16_384

--- a/providers/dinference/models/glm-5.1.toml
+++ b/providers/dinference/models/glm-5.1.toml
@@ -8,5 +8,4 @@ input = 1.25
 output = 3.89
 
 [limit]
-context = 200_000
 output = 128_000

--- a/providers/fastrouter/models/openai/gpt-4.1.toml
+++ b/providers/fastrouter/models/openai/gpt-4.1.toml
@@ -8,4 +8,3 @@ cache_read = 0.5
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -7,6 +7,4 @@ cache_read = 0.1
 cache_write = 1.25
 
 [limit]
-context = 200_000
 input = 136_000
-output = 64_000

--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -7,6 +7,5 @@ cache_read = 0.5
 cache_write = 6.25
 
 [limit]
-context = 200_000
 input = 168_000
 output = 32_000

--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -7,6 +7,5 @@ cache_read = 0.3
 cache_write = 3.75
 
 [limit]
-context = 200_000
 input = 168_000
 output = 32_000

--- a/providers/github-copilot/models/gpt-5.4.toml
+++ b/providers/github-copilot/models/gpt-5.4.toml
@@ -14,7 +14,6 @@ cache_read = 0.5
 [limit]
 context = 400_000
 input = 272_000
-output = 128_000
 
 [experimental.modes.fast]
 cost = { input = 5, output = 30, cache_read = 0.5 }

--- a/providers/github-copilot/models/gpt-5.5.toml
+++ b/providers/github-copilot/models/gpt-5.5.toml
@@ -14,7 +14,6 @@ cache_read = 1
 [limit]
 context = 400_000
 input = 272_000
-output = 128_000
 
 [experimental.modes.fast]
 cost = { input = 12.5, output = 75, cache_read = 1.25 }

--- a/providers/gmicloud/models/anthropic/claude-opus-4.6.toml
+++ b/providers/gmicloud/models/anthropic/claude-opus-4.6.toml
@@ -7,8 +7,6 @@ cache_read = 0.5
 
 [limit]
 context = 409_600
-output = 128_000
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/gmicloud/models/anthropic/claude-opus-4.7.toml
+++ b/providers/gmicloud/models/anthropic/claude-opus-4.7.toml
@@ -7,11 +7,9 @@ cache_read = 0.45
 
 [limit]
 context = 409_600
-output = 128_000
 
 [modalities]
 input = ["text"]
-output = ["text"]
 
 [experimental.modes.fast]
 cost = { input = 30, output = 150, cache_read = 3, cache_write = 37.5 }

--- a/providers/gmicloud/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/gmicloud/models/anthropic/claude-sonnet-4.6.toml
@@ -7,8 +7,6 @@ cache_read = 0.3
 
 [limit]
 context = 409_600
-output = 64_000
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/gmicloud/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/gmicloud/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -10,4 +10,3 @@ cache_read = 0.022
 
 [limit]
 context = 1_048_575
-output = 384_000

--- a/providers/gmicloud/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/gmicloud/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -10,4 +10,3 @@ cache_read = 0.116
 
 [limit]
 context = 1_048_576
-output = 384_000

--- a/providers/gmicloud/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/gmicloud/models/moonshotai/Kimi-K2.6.toml
@@ -14,4 +14,3 @@ output = 65_536
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/gmicloud/models/zai-org/GLM-5-FP8.toml
+++ b/providers/gmicloud/models/zai-org/GLM-5-FP8.toml
@@ -10,4 +10,3 @@ cache_read = 0.12
 
 [limit]
 context = 202_752
-output = 131_072

--- a/providers/gmicloud/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/gmicloud/models/zai-org/GLM-5.1-FP8.toml
@@ -10,4 +10,3 @@ cache_read = 0.182
 
 [limit]
 context = 202_752
-output = 131_072

--- a/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-sonnet-4-6@default.toml
@@ -14,5 +14,4 @@ cache_read = 0.6
 cache_write = 7.5
 
 [limit]
-context = 1_000_000
 output = 128_000

--- a/providers/google-vertex/models/claude-sonnet-4-6@default.toml
+++ b/providers/google-vertex/models/claude-sonnet-4-6@default.toml
@@ -14,7 +14,6 @@ cache_read = 0.6
 cache_write = 7.5
 
 [limit]
-context = 1_000_000
 output = 128_000
 
 [provider]

--- a/providers/inceptron/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/inceptron/models/moonshotai/Kimi-K2.6.toml
@@ -11,4 +11,3 @@ cache_write = 0
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/kilo/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-omni.toml
@@ -7,5 +7,4 @@ output = 2
 cache_read = 0.08
 
 [limit]
-context = 262_144
 output = 65_536

--- a/providers/lilac/models/google/gemma-4-31b-it.toml
+++ b/providers/lilac/models/google/gemma-4-31b-it.toml
@@ -14,4 +14,3 @@ output = 262_100
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/lilac/models/minimaxai/minimax-m2.7.toml
+++ b/providers/lilac/models/minimaxai/minimax-m2.7.toml
@@ -12,5 +12,4 @@ output = 1.2
 cache_read = 0.055
 
 [limit]
-context = 204_800
 output = 204_800

--- a/providers/lilac/models/moonshotai/kimi-k2.6.toml
+++ b/providers/lilac/models/moonshotai/kimi-k2.6.toml
@@ -10,4 +10,3 @@ cache_read = 0.2
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/lilac/models/zai-org/glm-5.1.toml
+++ b/providers/lilac/models/zai-org/glm-5.1.toml
@@ -1,7 +1,6 @@
 base_model = "zai/glm-5.1"
 name = "GLM 5.1"
 knowledge = "2025-04"
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -13,4 +12,3 @@ cache_read = 0.27
 
 [limit]
 context = 202_800
-output = 131_072

--- a/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
@@ -10,4 +10,3 @@ output = 32_768
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
+++ b/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
@@ -7,9 +7,7 @@ output = 1.1
 cache_read = 0.056
 
 [limit]
-context = 262_144
 output = 32_768
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/nearai/models/anthropic/claude-opus-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-6.toml
@@ -8,4 +8,3 @@ cache_write = 6.25
 
 [limit]
 context = 200_000
-output = 128_000

--- a/providers/nearai/models/google/gemma-4-31B-it.toml
+++ b/providers/nearai/models/google/gemma-4-31B-it.toml
@@ -7,4 +7,3 @@ cache_read = 0.026
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.5.toml
@@ -16,4 +16,3 @@ cache_write = 7.5
 
 [limit]
 context = 1_000_000
-output = 64_000

--- a/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/openrouter/models/anthropic/claude-sonnet-4.6.toml
@@ -15,5 +15,4 @@ cache_read = 0.6
 cache_write = 7.5
 
 [limit]
-context = 1_000_000
 output = 128_000

--- a/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-pro.toml
@@ -10,4 +10,3 @@ cache_read = 0.003625
 
 [limit]
 context = 1_048_576
-output = 384_000

--- a/providers/openrouter/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash-lite.toml
@@ -8,5 +8,4 @@ cache_read = 0.01
 cache_write = 0.083333
 
 [limit]
-context = 1_048_576
 output = 65_535

--- a/providers/openrouter/models/google/gemini-2.5-flash.toml
+++ b/providers/openrouter/models/google/gemini-2.5-flash.toml
@@ -8,5 +8,4 @@ cache_read = 0.03
 cache_write = 0.083333
 
 [limit]
-context = 1_048_576
 output = 65_535

--- a/providers/openrouter/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/openrouter/models/google/gemma-4-26b-a4b-it.toml
@@ -5,9 +5,7 @@ input = 0.06
 output = 0.33
 
 [limit]
-context = 262_144
 output = 262_144
 
 [modalities]
 input = ["image", "text", "video"]
-output = ["text"]

--- a/providers/openrouter/models/google/gemma-4-26b-a4b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-4-26b-a4b-it:free.toml
@@ -8,4 +8,3 @@ output = 0
 
 [modalities]
 input = ["image", "text", "video"]
-output = ["text"]

--- a/providers/openrouter/models/google/gemma-4-31b-it.toml
+++ b/providers/openrouter/models/google/gemma-4-31b-it.toml
@@ -5,9 +5,7 @@ input = 0.12
 output = 0.37
 
 [limit]
-context = 262_144
 output = 16_384
 
 [modalities]
 input = ["image", "text", "video"]
-output = ["text"]

--- a/providers/openrouter/models/google/gemma-4-31b-it:free.toml
+++ b/providers/openrouter/models/google/gemma-4-31b-it:free.toml
@@ -8,4 +8,3 @@ output = 0
 
 [modalities]
 input = ["image", "text", "video"]
-output = ["text"]

--- a/providers/openrouter/models/minimax/minimax-m2.7.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.7.toml
@@ -7,4 +7,3 @@ output = 1.2
 
 [limit]
 context = 196_608
-output = 131_072

--- a/providers/openrouter/models/minimax/minimax-m2.toml
+++ b/providers/openrouter/models/minimax/minimax-m2.toml
@@ -10,5 +10,4 @@ output = 1
 cache_read = 0.03
 
 [limit]
-context = 196_608
 output = 196_608

--- a/providers/openrouter/models/mistralai/devstral-2512.toml
+++ b/providers/openrouter/models/mistralai/devstral-2512.toml
@@ -10,4 +10,3 @@ cache_read = 0.04
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/mistralai/mistral-large-2512.toml
+++ b/providers/openrouter/models/mistralai/mistral-large-2512.toml
@@ -8,4 +8,3 @@ cache_read = 0.05
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.5.toml
@@ -12,4 +12,3 @@ cache_read = 0.09
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/openrouter/models/moonshotai/kimi-k2.6.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.6.toml
@@ -10,4 +10,3 @@ cache_read = 0.144
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/openrouter/models/moonshotai/kimi-k2.6:free.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.6:free.toml
@@ -12,4 +12,3 @@ output = 0
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4.1-nano.toml
+++ b/providers/openrouter/models/openai/gpt-4.1-nano.toml
@@ -7,4 +7,3 @@ cache_read = 0.025
 
 [modalities]
 input = ["image", "text", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-2024-05-13.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-05-13.toml
@@ -6,4 +6,3 @@ output = 15
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-2024-08-06.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-08-06.toml
@@ -7,4 +7,3 @@ cache_read = 1.25
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-4o-2024-11-20.toml
+++ b/providers/openrouter/models/openai/gpt-4o-2024-11-20.toml
@@ -7,4 +7,3 @@ cache_read = 1.25
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5-codex.toml
@@ -6,7 +6,3 @@ attachment = true
 input = 1.25
 output = 10
 cache_read = 0.125
-
-[limit]
-context = 400_000
-output = 128_000

--- a/providers/openrouter/models/openai/gpt-5-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5-mini.toml
@@ -6,10 +6,5 @@ input = 0.25
 output = 2
 cache_read = 0.025
 
-[limit]
-context = 400_000
-output = 128_000
-
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5-nano.toml
+++ b/providers/openrouter/models/openai/gpt-5-nano.toml
@@ -6,10 +6,5 @@ input = 0.05
 output = 0.4
 cache_read = 0.01
 
-[limit]
-context = 400_000
-output = 128_000
-
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5-pro.toml
@@ -6,9 +6,7 @@ input = 15
 output = 120
 
 [limit]
-context = 400_000
 output = 128_000
 
 [modalities]
 input = ["image", "text", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
@@ -5,7 +5,3 @@ base_model_omit = ["limit.input"]
 input = 1.25
 output = 10
 cache_read = 0.125
-
-[limit]
-context = 400_000
-output = 128_000

--- a/providers/openrouter/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex-mini.toml
@@ -7,5 +7,4 @@ output = 2
 cache_read = 0.025
 
 [limit]
-context = 400_000
 output = 100_000

--- a/providers/openrouter/models/openai/gpt-5.1-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex.toml
@@ -5,7 +5,3 @@ base_model_omit = ["limit.input"]
 input = 1.25
 output = 10
 cache_read = 0.13
-
-[limit]
-context = 400_000
-output = 128_000

--- a/providers/openrouter/models/openai/gpt-5.1.toml
+++ b/providers/openrouter/models/openai/gpt-5.1.toml
@@ -6,10 +6,5 @@ input = 1.25
 output = 10
 cache_read = 0.13
 
-[limit]
-context = 400_000
-output = 128_000
-
 [modalities]
 input = ["image", "text", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.2-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.2-codex.toml
@@ -6,10 +6,5 @@ input = 1.75
 output = 14
 cache_read = 0.175
 
-[limit]
-context = 400_000
-output = 128_000
-
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.2-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5.2-pro.toml
@@ -6,10 +6,5 @@ structured_output = true
 input = 21
 output = 168
 
-[limit]
-context = 400_000
-output = 128_000
-
 [modalities]
 input = ["image", "text", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.2.toml
+++ b/providers/openrouter/models/openai/gpt-5.2.toml
@@ -6,10 +6,5 @@ input = 1.75
 output = 14
 cache_read = 0.175
 
-[limit]
-context = 400_000
-output = 128_000
-
 [modalities]
 input = ["pdf", "image", "text"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.3-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.3-codex.toml
@@ -5,7 +5,3 @@ base_model_omit = ["limit.input"]
 input = 1.75
 output = 14
 cache_read = 0.175
-
-[limit]
-context = 400_000
-output = 128_000

--- a/providers/openrouter/models/openai/gpt-5.4-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-mini.toml
@@ -6,10 +6,5 @@ input = 0.75
 output = 4.5
 cache_read = 0.075
 
-[limit]
-context = 400_000
-output = 128_000
-
 [modalities]
 input = ["pdf", "image", "text"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.4-nano.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-nano.toml
@@ -6,10 +6,5 @@ input = 0.2
 output = 1.25
 cache_read = 0.02
 
-[limit]
-context = 400_000
-output = 128_000
-
 [modalities]
 input = ["pdf", "image", "text"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.4-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-pro.toml
@@ -7,4 +7,3 @@ output = 180
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/gpt-5.4.toml
+++ b/providers/openrouter/models/openai/gpt-5.4.toml
@@ -5,7 +5,3 @@ base_model_omit = ["limit.input"]
 input = 2.5
 output = 15
 cache_read = 0.25
-
-[limit]
-context = 1_050_000
-output = 128_000

--- a/providers/openrouter/models/openai/gpt-5.5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5.5-pro.toml
@@ -4,7 +4,3 @@ base_model_omit = ["limit.input"]
 [cost]
 input = 30
 output = 180
-
-[limit]
-context = 1_050_000
-output = 128_000

--- a/providers/openrouter/models/openai/gpt-5.5.toml
+++ b/providers/openrouter/models/openai/gpt-5.5.toml
@@ -5,7 +5,3 @@ base_model_omit = ["limit.input"]
 input = 5
 output = 30
 cache_read = 0.5
-
-[limit]
-context = 1_050_000
-output = 128_000

--- a/providers/openrouter/models/openai/gpt-5.toml
+++ b/providers/openrouter/models/openai/gpt-5.toml
@@ -6,10 +6,5 @@ input = 1.25
 output = 10
 cache_read = 0.125
 
-[limit]
-context = 400_000
-output = 128_000
-
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/o1-pro.toml
+++ b/providers/openrouter/models/openai/o1-pro.toml
@@ -7,4 +7,3 @@ output = 600
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/o3-deep-research.toml
+++ b/providers/openrouter/models/openai/o3-deep-research.toml
@@ -9,4 +9,3 @@ cache_read = 2.5
 
 [modalities]
 input = ["image", "text", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/o3-mini.toml
+++ b/providers/openrouter/models/openai/o3-mini.toml
@@ -8,4 +8,3 @@ cache_read = 0.55
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/openai/o3-pro.toml
+++ b/providers/openrouter/models/openai/o3-pro.toml
@@ -6,4 +6,3 @@ output = 80
 
 [modalities]
 input = ["text", "pdf", "image"]
-output = ["text"]

--- a/providers/openrouter/models/openai/o4-mini-deep-research.toml
+++ b/providers/openrouter/models/openai/o4-mini-deep-research.toml
@@ -9,4 +9,3 @@ cache_read = 0.5
 
 [modalities]
 input = ["pdf", "image", "text"]
-output = ["text"]

--- a/providers/openrouter/models/openai/o4-mini.toml
+++ b/providers/openrouter/models/openai/o4-mini.toml
@@ -7,4 +7,3 @@ cache_read = 0.275
 
 [modalities]
 input = ["image", "text", "pdf"]
-output = ["text"]

--- a/providers/openrouter/models/x-ai/grok-4.3.toml
+++ b/providers/openrouter/models/x-ai/grok-4.3.toml
@@ -13,9 +13,7 @@ output = 5
 cache_read = 0.4
 
 [limit]
-context = 1_000_000
 output = 1_000_000
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/openrouter/models/x-ai/grok-build-0.1.toml
+++ b/providers/openrouter/models/x-ai/grok-build-0.1.toml
@@ -7,4 +7,3 @@ cache_read = 0.2
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/openrouter/models/z-ai/glm-4.5-air:free.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5-air:free.toml
@@ -7,5 +7,4 @@ input = 0
 output = 0
 
 [limit]
-context = 131_072
 output = 96_000

--- a/providers/openrouter/models/z-ai/glm-4.5v.toml
+++ b/providers/openrouter/models/z-ai/glm-4.5v.toml
@@ -8,8 +8,6 @@ cache_read = 0.11
 
 [limit]
 context = 65_536
-output = 16_384
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/openrouter/models/z-ai/glm-4.6.toml
+++ b/providers/openrouter/models/z-ai/glm-4.6.toml
@@ -8,4 +8,3 @@ cache_read = 0.08
 
 [limit]
 context = 202_752
-output = 131_072

--- a/providers/openrouter/models/z-ai/glm-4.7.toml
+++ b/providers/openrouter/models/z-ai/glm-4.7.toml
@@ -11,4 +11,3 @@ cache_read = 0.08
 
 [limit]
 context = 202_752
-output = 131_072

--- a/providers/openrouter/models/z-ai/glm-5-turbo.toml
+++ b/providers/openrouter/models/z-ai/glm-5-turbo.toml
@@ -11,4 +11,3 @@ cache_read = 0.24
 
 [limit]
 context = 202_752
-output = 131_072

--- a/providers/openrouter/models/z-ai/glm-5.1.toml
+++ b/providers/openrouter/models/z-ai/glm-5.1.toml
@@ -10,4 +10,3 @@ cache_read = 0.182
 
 [limit]
 context = 202_752
-output = 131_072

--- a/providers/openrouter/models/z-ai/glm-5v-turbo.toml
+++ b/providers/openrouter/models/z-ai/glm-5v-turbo.toml
@@ -11,8 +11,6 @@ cache_read = 0.24
 
 [limit]
 context = 202_752
-output = 131_072
 
 [modalities]
 input = ["image", "text", "video"]
-output = ["text"]

--- a/providers/poe/models/anthropic/claude-opus-4.8.toml
+++ b/providers/poe/models/anthropic/claude-opus-4.8.toml
@@ -7,4 +7,3 @@ output = 21.4646
 
 [limit]
 context = 1_048_576
-output = 128_000

--- a/providers/poe/models/google/gemini-3.5-flash.toml
+++ b/providers/poe/models/google/gemini-3.5-flash.toml
@@ -9,4 +9,3 @@ cache_read = 0.1515
 
 [modalities]
 input = ["text", "image", "audio"]
-output = ["text"]

--- a/providers/poe/models/openai/gpt-5.5-pro.toml
+++ b/providers/poe/models/openai/gpt-5.5-pro.toml
@@ -11,7 +11,6 @@ output = 163.6364
 
 [limit]
 context = 400_000
-output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/poe/models/openai/gpt-5.5.toml
+++ b/providers/poe/models/openai/gpt-5.5.toml
@@ -10,7 +10,6 @@ cache_read = 0.4545
 
 [limit]
 context = 400_000
-output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/requesty/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4-5.toml
@@ -8,4 +8,3 @@ cache_write = 3.75
 
 [limit]
 context = 1_000_000
-output = 64_000

--- a/providers/requesty/models/openai/gpt-4.1.toml
+++ b/providers/requesty/models/openai/gpt-4.1.toml
@@ -8,4 +8,3 @@ cache_read = 0.5
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/requesty/models/openai/gpt-5-pro.toml
+++ b/providers/requesty/models/openai/gpt-5-pro.toml
@@ -4,7 +4,3 @@ base_model_omit = ["limit.input"]
 [cost]
 input = 15
 output = 120
-
-[limit]
-context = 400_000
-output = 272_000

--- a/providers/requesty/models/openai/gpt-5.2.toml
+++ b/providers/requesty/models/openai/gpt-5.2.toml
@@ -5,7 +5,3 @@ base_model_omit = ["limit.input"]
 input = 1.75
 output = 14
 cache_read = 0.175
-
-[limit]
-context = 400_000
-output = 128_000

--- a/providers/routing-run/models/route/deepseek-v4-flash-6bit.toml
+++ b/providers/routing-run/models/route/deepseek-v4-flash-6bit.toml
@@ -10,5 +10,4 @@ output = 0.7392
 cache_read = 0.0028
 
 [limit]
-context = 1_000_000
 output = 131_072

--- a/providers/routing-run/models/route/deepseek-v4-flash.toml
+++ b/providers/routing-run/models/route/deepseek-v4-flash.toml
@@ -9,5 +9,4 @@ output = 0.7392
 cache_read = 0.0028
 
 [limit]
-context = 1_000_000
 output = 131_072

--- a/providers/routing-run/models/route/deepseek-v4-pro-6bit.toml
+++ b/providers/routing-run/models/route/deepseek-v4-pro-6bit.toml
@@ -10,5 +10,4 @@ output = 0.7392
 cache_read = 0.003625
 
 [limit]
-context = 1_000_000
 output = 131_072

--- a/providers/routing-run/models/route/deepseek-v4-pro.toml
+++ b/providers/routing-run/models/route/deepseek-v4-pro.toml
@@ -9,5 +9,4 @@ output = 0.7392
 cache_read = 0.003625
 
 [limit]
-context = 1_000_000
 output = 131_072

--- a/providers/routing-run/models/route/gemma-4-31b-it.toml
+++ b/providers/routing-run/models/route/gemma-4-31b-it.toml
@@ -11,4 +11,3 @@ output = 65_536
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/routing-run/models/route/mimo-v2.5-pro-6bit.toml
+++ b/providers/routing-run/models/route/mimo-v2.5-pro-6bit.toml
@@ -22,4 +22,3 @@ output = 262_144
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/routing-run/models/route/mimo-v2.5-pro.toml
+++ b/providers/routing-run/models/route/mimo-v2.5-pro.toml
@@ -22,4 +22,3 @@ output = 262_144
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/routing-run/models/route/mimo-v2.5.toml
+++ b/providers/routing-run/models/route/mimo-v2.5.toml
@@ -22,4 +22,3 @@ output = 262_144
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/routing-run/models/route/minimax-m2.5-highspeed.toml
+++ b/providers/routing-run/models/route/minimax-m2.5-highspeed.toml
@@ -10,4 +10,3 @@ cache_write = 0.375
 
 [limit]
 context = 100_000
-output = 131_072

--- a/providers/routing-run/models/route/minimax-m2.5.toml
+++ b/providers/routing-run/models/route/minimax-m2.5.toml
@@ -10,4 +10,3 @@ cache_write = 0.375
 
 [limit]
 context = 100_000
-output = 131_072

--- a/providers/routing-run/models/route/minimax-m2.7-highspeed.toml
+++ b/providers/routing-run/models/route/minimax-m2.7-highspeed.toml
@@ -12,4 +12,3 @@ cache_write = 0.375
 
 [limit]
 context = 100_000
-output = 131_072

--- a/providers/routing-run/models/route/minimax-m2.7.toml
+++ b/providers/routing-run/models/route/minimax-m2.7.toml
@@ -12,4 +12,3 @@ cache_write = 0.375
 
 [limit]
 context = 100_000
-output = 131_072

--- a/providers/routing-run/models/route/mistral-large-3.toml
+++ b/providers/routing-run/models/route/mistral-large-3.toml
@@ -11,4 +11,3 @@ output = 32_768
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/routing-run/models/route/mistral-medium-2505.toml
+++ b/providers/routing-run/models/route/mistral-medium-2505.toml
@@ -11,4 +11,3 @@ output = 32_768
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/routing-run/models/route/mistral-small-2503.toml
+++ b/providers/routing-run/models/route/mistral-small-2503.toml
@@ -12,4 +12,3 @@ output = 32_768
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/routing-run/models/route/qwen3.6-27b-202k.toml
+++ b/providers/routing-run/models/route/qwen3.6-27b-202k.toml
@@ -13,4 +13,3 @@ output = 32_768
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/routing-run/models/route/qwen3.6-27b.toml
+++ b/providers/routing-run/models/route/qwen3.6-27b.toml
@@ -12,4 +12,3 @@ output = 32_768
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/routing-run/models/route/step-3.5-flash-2603.toml
+++ b/providers/routing-run/models/route/step-3.5-flash-2603.toml
@@ -10,5 +10,4 @@ cache_read = 0.02
 
 [limit]
 context = 262_144
-input = 256_000
 output = 65_536

--- a/providers/routing-run/models/route/step-3.5-flash.toml
+++ b/providers/routing-run/models/route/step-3.5-flash.toml
@@ -10,5 +10,4 @@ cache_read = 0.019
 
 [limit]
 context = 262_144
-input = 256_000
 output = 65_536

--- a/providers/routing-run/models/route/stepfun-3.5-flash.toml
+++ b/providers/routing-run/models/route/stepfun-3.5-flash.toml
@@ -11,5 +11,4 @@ cache_read = 0.019
 
 [limit]
 context = 262_144
-input = 256_000
 output = 65_536

--- a/providers/scaleway/models/mistral-small-3.2-24b-instruct-2506.toml
+++ b/providers/scaleway/models/mistral-small-3.2-24b-instruct-2506.toml
@@ -7,5 +7,4 @@ input = 0.15
 output = 0.35
 
 [limit]
-context = 128_000
 output = 32_768

--- a/providers/scaleway/models/pixtral-12b-2409.toml
+++ b/providers/scaleway/models/pixtral-12b-2409.toml
@@ -8,5 +8,4 @@ input = 0.2
 output = 0.2
 
 [limit]
-context = 128_000
 output = 4_096

--- a/providers/scaleway/models/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/scaleway/models/qwen3-235b-a22b-instruct-2507.toml
@@ -10,4 +10,3 @@ reasoning = 8.4
 
 [limit]
 context = 260_000
-output = 16_384

--- a/providers/scaleway/models/qwen3.5-397b-a17b.toml
+++ b/providers/scaleway/models/qwen3.5-397b-a17b.toml
@@ -14,4 +14,3 @@ output = 16_384
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/scaleway/models/qwen3.6-35b-a3b.toml
+++ b/providers/scaleway/models/qwen3.6-35b-a3b.toml
@@ -15,4 +15,3 @@ output = 16_384
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/snowflake-cortex/models/claude-haiku-4-5.toml
+++ b/providers/snowflake-cortex/models/claude-haiku-4-5.toml
@@ -1,5 +1,4 @@
 base_model = "anthropic/claude-haiku-4-5"
 
 [limit]
-context = 200_000
 output = 16_384

--- a/providers/snowflake-cortex/models/claude-sonnet-4-5.toml
+++ b/providers/snowflake-cortex/models/claude-sonnet-4-5.toml
@@ -1,5 +1,4 @@
 base_model = "anthropic/claude-sonnet-4-5"
 
 [limit]
-context = 200_000
 output = 16_384

--- a/providers/snowflake-cortex/models/claude-sonnet-4-6.toml
+++ b/providers/snowflake-cortex/models/claude-sonnet-4-6.toml
@@ -1,5 +1,4 @@
 base_model = "anthropic/claude-sonnet-4-6"
 
 [limit]
-context = 1_000_000
 output = 16_384

--- a/providers/snowflake-cortex/models/openai-gpt-5-mini.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5-mini.toml
@@ -3,5 +3,4 @@ status = "beta"
 
 [limit]
 context = 272_000
-input = 272_000
 output = 8_192

--- a/providers/synthetic/models/hf:moonshotai/Kimi-K2.6.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K2.6.toml
@@ -9,9 +9,7 @@ output = 4
 cache_read = 0.95
 
 [limit]
-context = 262_144
 output = 65_536
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/umans-ai-coding-plan/models/umans-coder.toml
+++ b/providers/umans-ai-coding-plan/models/umans-coder.toml
@@ -13,4 +13,3 @@ cache_write = 0
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/umans-ai-coding-plan/models/umans-flash.toml
+++ b/providers/umans-ai-coding-plan/models/umans-flash.toml
@@ -9,9 +9,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 262_144
 output = 262_144
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/umans-ai-coding-plan/models/umans-glm-5.1.toml
+++ b/providers/umans-ai-coding-plan/models/umans-glm-5.1.toml
@@ -12,4 +12,3 @@ cache_write = 0
 
 [limit]
 context = 204_800
-output = 131_072

--- a/providers/umans-ai-coding-plan/models/umans-kimi-k2.6.toml
+++ b/providers/umans-ai-coding-plan/models/umans-kimi-k2.6.toml
@@ -12,4 +12,3 @@ cache_write = 0
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/umans-ai-coding-plan/models/umans-qwen3.6-35b-a3b.toml
+++ b/providers/umans-ai-coding-plan/models/umans-qwen3.6-35b-a3b.toml
@@ -9,9 +9,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 262_144
 output = 262_144
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/vultr/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/vultr/models/moonshotai/Kimi-K2.6.toml
@@ -8,9 +8,7 @@ input = 0.15
 output = 0.6
 
 [limit]
-context = 262_144
 output = 131_072
 
 [modalities]
 input = ["text"]
-output = ["text"]


### PR DESCRIPTION
## Summary
- Removed redundant provider overrides that matched inherited `base_model` values across 160 provider TOMLs
- Updated base-model parsing to accept deep-partial object overrides so inherited `limit` and `modalities` tables can be normalized without changing output
- Added regression coverage for partial object inheritance and preserved output parity

## Testing
- `bun test`
- `bun validate` with before/after JSON comparison: unchanged
- `cd packages/web && bun run build`
- `git diff --check`