### PR TITLE
fix gpt-5.4 cortecs

### DIFF
--- a/providers/cortecs/models/gpt-5.4.toml
+++ b/providers/cortecs/models/gpt-5.4.toml
@@ -1,11 +1,24 @@
-base_model = "openai/gpt-5.4"
-base_model_omit = ["limit.input"]
+name = "GPT-5.4"
+family = "gpt"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2025-08-31"
+open_weights = false
 
 [cost]
-input = 3
+input = 3.00
 output = 16.13
 cache_read = 0.25
 
 [limit]
 context = 1_050_000
 output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Opencode seems to be inserting a bunch of openai-specific parameters, breaking cortecs. I have a vague hope that not pulling in the openai model as a base will make it work. GPT 4.1 is currently working, so I based the updated file on that.