### PR TITLE
fix: correct evroc Qwen3-Embedding-8B limit.output to 4096

### DIFF
--- a/providers/evroc/models/Qwen/Qwen3-Embedding-8B.toml
+++ b/providers/evroc/models/Qwen/Qwen3-Embedding-8B.toml
@@ -13,7 +13,7 @@ output = 0.12
 
 [limit]
 context = 40_960
-output = 40_960
+output = 4_096
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
## Summary

`evroc` lists Qwen3-Embedding-8B with `limit.output = 40_960`, which duplicates the context window instead of the model's embedding dimension. The [HuggingFace model card](https://huggingface.co/Qwen/Qwen3-Embedding-8B) gives an embedding dimension of 4096, so this sets `limit.output = 4_096`. `bun run validate` passes; no other evroc model carries the same value.

Closes #1848
