### PR TITLE
fix(openrouter): inherit input limits when context matches

### DIFF
--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -246,12 +246,10 @@ function baseModelOmit(
   const omit: string[] = [];
   const baseLimit = metadata.limit;
   if (
-    baseLimit !== undefined &&
-    baseLimit !== null &&
-    typeof baseLimit === "object" &&
-    !Array.isArray(baseLimit) &&
-    (baseLimit as Record<string, unknown>).input !== undefined &&
-    limit.input === undefined
+    isPlainObject(baseLimit) &&
+    baseLimit.input !== undefined &&
+    limit.input === undefined &&
+    baseLimit.context !== limit.context
   ) {
     omit.push("limit.input");
   }

--- a/providers/openrouter/models/openai/gpt-5-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5-codex.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5-codex"
-base_model_omit = ["limit.input"]
 attachment = true
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-5-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5-mini.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5-mini"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 0.25

--- a/providers/openrouter/models/openai/gpt-5-nano.toml
+++ b/providers/openrouter/models/openai/gpt-5-nano.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5-nano"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 0.05

--- a/providers/openrouter/models/openai/gpt-5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5-pro.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5-pro"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 15

--- a/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex-max.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.1-codex-max"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex-mini.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.1-codex-mini"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 0.25

--- a/providers/openrouter/models/openai/gpt-5.1-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.1-codex.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.1-codex"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/openai/gpt-5.1.toml
+++ b/providers/openrouter/models/openai/gpt-5.1.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.1"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 1.25

--- a/providers/openrouter/models/openai/gpt-5.2-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.2-codex.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.2-codex"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 1.75

--- a/providers/openrouter/models/openai/gpt-5.2-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5.2-pro.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.2-pro"
-base_model_omit = ["limit.input"]
 structured_output = true
 
 [cost]

--- a/providers/openrouter/models/openai/gpt-5.2.toml
+++ b/providers/openrouter/models/openai/gpt-5.2.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.2"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 1.75

--- a/providers/openrouter/models/openai/gpt-5.3-codex.toml
+++ b/providers/openrouter/models/openai/gpt-5.3-codex.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.3-codex"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 1.75

--- a/providers/openrouter/models/openai/gpt-5.4-mini.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-mini.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.4-mini"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 0.75

--- a/providers/openrouter/models/openai/gpt-5.4-nano.toml
+++ b/providers/openrouter/models/openai/gpt-5.4-nano.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.4-nano"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 0.2

--- a/providers/openrouter/models/openai/gpt-5.4.toml
+++ b/providers/openrouter/models/openai/gpt-5.4.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.4"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 2.5

--- a/providers/openrouter/models/openai/gpt-5.5-pro.toml
+++ b/providers/openrouter/models/openai/gpt-5.5-pro.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.5-pro"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 30

--- a/providers/openrouter/models/openai/gpt-5.5.toml
+++ b/providers/openrouter/models/openai/gpt-5.5.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.5"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 5

--- a/providers/openrouter/models/openai/gpt-5.toml
+++ b/providers/openrouter/models/openai/gpt-5.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5"
-base_model_omit = ["limit.input"]
 
 [cost]
 input = 1.25


### PR DESCRIPTION
## Summary\n- only omit inherited OpenRouter `limit.input` when the OpenRouter context differs from base metadata\n- remove unnecessary `base_model_omit = ["limit.input"]` entries from GPT-5-family OpenRouter models\n- restores generated OpenRouter input limits for consumers that rely on them for compaction thresholds\n\n## Validation\n- `bun validate`\n- `bun ./packages/core/script/sync-models.ts openrouter --dry-run`\n- real `bun ./packages/core/script/sync-models.ts openrouter` in a temporary worktree\n- verified synced OpenRouter TOMLs do not reintroduce `base_model_omit = ["limit.input"]`\n- validated the synced temporary worktree with `bun validate`\n- verified generated limits include `input` for `openai/gpt-5`, `openai/gpt-5.5`, and `openai/gpt-5.1-codex`