### PR TITLE
fix(google): add missing Gemini models

### DIFF
--- a/models/google/gemini-2.5-flash-tts.toml
+++ b/models/google/gemini-2.5-flash-tts.toml
@@ -1,0 +1,18 @@
+name = "Gemini 2.5 Flash TTS"
+family = "gemini-flash"
+release_date = "2025-09-30"
+last_updated = "2025-12-10"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+knowledge = "2025-01"
+open_weights = false
+
+[limit]
+context = 32_768
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/models/google/gemini-3-pro-image-preview.toml
+++ b/models/google/gemini-3-pro-image-preview.toml
@@ -1,0 +1,18 @@
+name = "Nano Banana Pro"
+family = "gemini-pro"
+release_date = "2025-11-20"
+last_updated = "2025-11-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = false
+knowledge = "2025-01"
+open_weights = false
+
+[limit]
+context = 65_536
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]

--- a/providers/google/models/gemini-2.5-flash-tts.toml
+++ b/providers/google/models/gemini-2.5-flash-tts.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-2.5-flash-tts"
+
+[cost]
+input = 0.5
+output = 10

--- a/providers/google/models/gemini-3-pro-image-preview.toml
+++ b/providers/google/models/gemini-3-pro-image-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3-pro-image-preview"
+
+[cost]
+input = 2
+output = 120


### PR DESCRIPTION
## Summary
- add provider-agnostic metadata for gemini-2.5-flash-tts and gemini-3-pro-image-preview
- expose both models in the Google provider catalog with pricing

## Validation
- bun validate

Fixes #2018