### PR TITLE
feat(opencode-go): update Qwen Plus pricing and limits

### DIFF
--- a/providers/opencode-go/models/qwen3.6-plus.toml
+++ b/providers/opencode-go/models/qwen3.6-plus.toml
@@ -15,8 +15,15 @@ output = 3.00
 cache_read = 0.05
 cache_write = 0.625
 
+[[cost.tiers]]
+tier = { size = 256_000 }
+input = 2.00
+output = 6.00
+cache_read = 0.2
+cache_write = 2.50
+
 [limit]
-context = 262_144
+context = 1_000_000
 output = 65_536
 
 [modalities]

--- a/providers/opencode-go/models/qwen3.7-plus.toml
+++ b/providers/opencode-go/models/qwen3.7-plus.toml
@@ -14,8 +14,15 @@ output = 1.60
 cache_read = 0.04
 cache_write = 0.5
 
+[[cost.tiers]]
+tier = { size = 256_000 }
+input = 1.20
+output = 4.80
+cache_read = 0.12
+cache_write = 1.50
+
 [limit]
-context = 262_144
+context = 1_000_000
 output = 65_536
 
 [modalities]


### PR DESCRIPTION
## Summary
- increase Qwen3.6 Plus and Qwen3.7 Plus context limits to 1M tokens
- add higher pricing tiers starting at 256k context tokens

## Validation
- bun validate
- git diff --check origin/dev...HEAD