### PR TITLE
feat(fireworks-ai): add kimi-k2p6-fast model

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p6-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p6-fast.toml
@@ -1,0 +1,25 @@
+name = "Kimi K2.6 Fast"
+family = "kimi-thinking"
+release_date = "2026-04-17"
+last_updated = "2026-06-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+cache_read = 0.30
+input = 2.00
+output = 8.00
+
+[limit]
+context = 262_000
+output = 262_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
Fireworks AI is standardizing their naming convention to just "Fast" for Fast/Turbo offerings (e.g., GLM 5.1 Fast). This PR adds the `kimi-k2p6-fast` model to match this new pattern.

The existing `kimi-k2p6-turbo` variant is retained for now to maintain backward compatibility with existing user workflows.