### PR TITLE
feat: add Trillionir AI provider

### DIFF
--- a/providers/thetrillioniar/logo.svg
+++ b/providers/thetrillioniar/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="1" y="1" width="22" height="22" rx="4.4" stroke="currentColor" stroke-width="1.5"/>
+  <text x="12" y="16.5" font-family="system-ui" font-weight="900" font-size="13" fill="currentColor" text-anchor="middle">T</text>
+</svg>

--- a/providers/thetrillioniar/models/anthropic/claude-opus-4.toml
+++ b/providers/thetrillioniar/models/anthropic/claude-opus-4.toml
@@ -1,11 +1,6 @@
+base_model = "anthropic/claude-opus-4-0"
+
 name = "Trillionir AI: Claude Opus 4 (Gemma 4 31B)"
-release_date = "2026-01-01"
-last_updated = "2026-01-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0

--- a/providers/thetrillioniar/models/anthropic/claude-opus-4.toml
+++ b/providers/thetrillioniar/models/anthropic/claude-opus-4.toml
@@ -1,0 +1,20 @@
+name = "Trillionir AI: Claude Opus 4 (Gemma 4 31B)"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/thetrillioniar/models/anthropic/claude-sonnet-4.toml
+++ b/providers/thetrillioniar/models/anthropic/claude-sonnet-4.toml
@@ -1,0 +1,20 @@
+name = "Trillionir AI: Claude Sonnet 4 (Devstral 24B)"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/thetrillioniar/models/anthropic/claude-sonnet-4.toml
+++ b/providers/thetrillioniar/models/anthropic/claude-sonnet-4.toml
@@ -1,11 +1,6 @@
+base_model = "anthropic/claude-sonnet-4-0"
+
 name = "Trillionir AI: Claude Sonnet 4 (Devstral 24B)"
-release_date = "2026-01-01"
-last_updated = "2026-01-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0

--- a/providers/thetrillioniar/models/auto.toml
+++ b/providers/thetrillioniar/models/auto.toml
@@ -1,0 +1,20 @@
+name = "Trillionir Auto Router"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/thetrillioniar/models/auto.toml
+++ b/providers/thetrillioniar/models/auto.toml
@@ -7,6 +7,9 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0

--- a/providers/thetrillioniar/models/google/gemini-2.0-flash.toml
+++ b/providers/thetrillioniar/models/google/gemini-2.0-flash.toml
@@ -1,0 +1,20 @@
+name = "Trillionir AI: Gemini 2.0 Flash (RNJ-1 8B)"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/thetrillioniar/models/google/gemini-2.0-flash.toml
+++ b/providers/thetrillioniar/models/google/gemini-2.0-flash.toml
@@ -1,11 +1,6 @@
+base_model = "google/gemini-2.0-flash"
+
 name = "Trillionir AI: Gemini 2.0 Flash (RNJ-1 8B)"
-release_date = "2026-01-01"
-last_updated = "2026-01-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0

--- a/providers/thetrillioniar/models/google/gemini-2.5-pro.toml
+++ b/providers/thetrillioniar/models/google/gemini-2.5-pro.toml
@@ -1,11 +1,6 @@
+base_model = "google/gemini-2.5-pro"
+
 name = "Trillionir AI: Gemini 2.5 Pro (Gemma 4 31B)"
-release_date = "2026-01-01"
-last_updated = "2026-01-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0

--- a/providers/thetrillioniar/models/google/gemini-2.5-pro.toml
+++ b/providers/thetrillioniar/models/google/gemini-2.5-pro.toml
@@ -1,0 +1,20 @@
+name = "Trillionir AI: Gemini 2.5 Pro (Gemma 4 31B)"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/thetrillioniar/models/openai/gpt-4o.toml
+++ b/providers/thetrillioniar/models/openai/gpt-4o.toml
@@ -1,0 +1,20 @@
+name = "Trillionir AI: GPT-4o (Gemma 4 31B)"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/thetrillioniar/models/openai/gpt-4o.toml
+++ b/providers/thetrillioniar/models/openai/gpt-4o.toml
@@ -1,11 +1,6 @@
+base_model = "openai/gpt-4o"
+
 name = "Trillionir AI: GPT-4o (Gemma 4 31B)"
-release_date = "2026-01-01"
-last_updated = "2026-01-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0

--- a/providers/thetrillioniar/models/openai/gpt-5.5.toml
+++ b/providers/thetrillioniar/models/openai/gpt-5.5.toml
@@ -1,0 +1,20 @@
+name = "Trillionir AI: GPT-5.5 (Gemma 4 31B)"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/thetrillioniar/models/openai/gpt-5.5.toml
+++ b/providers/thetrillioniar/models/openai/gpt-5.5.toml
@@ -1,11 +1,6 @@
+base_model = "openai/gpt-5.5"
+
 name = "Trillionir AI: GPT-5.5 (Gemma 4 31B)"
-release_date = "2026-01-01"
-last_updated = "2026-01-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0

--- a/providers/thetrillioniar/provider.toml
+++ b/providers/thetrillioniar/provider.toml
@@ -1,0 +1,5 @@
+name = "Trillionir AI"
+env = ["TRILLIONIAR_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://thetrillioniar.me/openai/v1"
+doc = "https://thetrillioniar.me"


### PR DESCRIPTION
Adds [Trillionir AI](https://thetrillioniar.me) — an OpenAI-compatible inference platform running open-source models (Gemma 4 31B, Devstral 24B, RNJ-1 8B).

- Provider ID: `thetrillioniar`
- Base URL: `https://thetrillioniar.me/openai/v1`
- Flat $5/mo pricing — costs set to 0 as there are no per-token charges
- Models include a smart `auto` router that picks the best model per task type
- Branded model names (gpt-4o, claude-sonnet-4, etc.) are routing aliases to benchmarked OSS models, documented transparently on the site