### PR TITLE
fix(models.dev): correct deepseek-chat/reasoner cache_read pricing

### DIFF
--- a/providers/deepseek/models/deepseek-chat.toml
+++ b/providers/deepseek/models/deepseek-chat.toml
@@ -12,7 +12,7 @@ open_weights = true
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.028
+cache_read = 0.0028
 
 [limit]
 context = 1_000_000

--- a/providers/deepseek/models/deepseek-reasoner.toml
+++ b/providers/deepseek/models/deepseek-reasoner.toml
@@ -15,7 +15,7 @@ field = "reasoning_content"
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.028
+cache_read = 0.0028
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
## Summary

Fixes cache_read pricing for deepseek-chat and deepseek-reasoner from .028 to .0028 to match DeepSeek V4 Flash pricing.

## Background

These two model IDs (deepseek-chat, deepseek-reasoner) are **deprecated aliases** that will be removed on 2026/07/24. Per [DeepSeek's official docs](https://api-docs.deepseek.com/quick_start/pricing):

> *deepseek-chat ? deepseek-reasoner ??????????? 2026/07/24 23:59 ?????????,?????? deepseek-v4-flash ??????????*

Since they are aliases for deepseek-v4-flash, their pricing should match.

## Changes

| File | Field | Old Value | New Value |
|------|-------|-----------|-----------|
| providers/deepseek/models/deepseek-chat.toml | cache_read | .028 | .0028 |
| providers/deepseek/models/deepseek-reasoner.toml | cache_read | .028 | .0028 |

## Note on V4 Models

The source TOML files for deepseek-v4-pro and deepseek-v4-flash already have correct pricing. However, the **deployed API (https://models.dev/api.json) appears to be serving stale data** - the V4 pro pricing shows input: 1.74, output: 3.48, cache_read: 0.145 (4x wrong) instead of the correct input: 0.435, output: 0.87, cache_read: 0.003625. A rebuild/deploy should fix this.

Related issue: https://github.com/anomalyco/opencode/issues/31150