### PR TITLE
fix(sync): preserve Cloudflare base models

### DIFF
--- a/packages/core/script/compare-model-migrations.ts
+++ b/packages/core/script/compare-model-migrations.ts
@@ -71,6 +71,7 @@ try {
     if (!match) continue;
 
     const [, providerID, modelID] = match;
+    if (providerID === undefined || modelID === undefined) continue;
     const beforeModel = before[providerID]?.models[modelID];
     const afterModel = after[providerID]?.models[modelID];
     const beforeJson = sortedJson(beforeModel);
@@ -263,6 +264,9 @@ async function generateLegacyExtends(directory: string) {
   for (const pendingModel of pendingModels) {
     const [providerID, ...modelParts] = pendingModel.model.extends.from.split("/");
     const modelID = modelParts.join("/");
+    if (providerID === undefined) {
+      throw new Error(`Invalid legacy extends.from: ${pendingModel.model.extends.from}`);
+    }
     const baseModel = result[providerID]?.models[modelID];
     if (baseModel === undefined) {
       throw new Error(`Unable to resolve legacy extends.from: ${pendingModel.model.extends.from}`, {
@@ -363,7 +367,8 @@ function applyOmit(target: Record<string, unknown>, paths: string[]) {
 
     for (let index = parents.length - 1; index >= 0; index--) {
       const parent = parents[index];
-      const value = parent?.value[parent.key];
+      if (parent === undefined) continue;
+      const value = parent.value[parent.key];
       if (
         value === null ||
         value === undefined ||

--- a/packages/core/script/generate-chutes.ts
+++ b/packages/core/script/generate-chutes.ts
@@ -158,7 +158,7 @@ function formatNumber(n: number): string {
  */
 function humanizeModelName(modelId: string): string {
   const parts = modelId.split("/");
-  const modelPart = parts[parts.length - 1];
+  const modelPart = parts.at(-1) ?? modelId;
   return modelPart.replace(/-/g, " ");
 }
 

--- a/packages/core/script/generate-venice.ts
+++ b/packages/core/script/generate-venice.ts
@@ -509,10 +509,10 @@ async function main() {
   const apiKeyArgIndex = args.findIndex((arg) => arg.startsWith("--api-key"));
   if (apiKeyArgIndex !== -1) {
     const arg = args[apiKeyArgIndex];
-    if (arg.includes("=")) {
-      apiKey = arg.split("=")[1];
+    if (arg?.includes("=")) {
+      apiKey = arg.split("=")[1] ?? null;
     } else if (args[apiKeyArgIndex + 1]) {
-      apiKey = args[apiKeyArgIndex + 1];
+      apiKey = args[apiKeyArgIndex + 1] ?? null;
     }
   }
 

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -131,7 +131,7 @@ export async function syncProvider<SourceModel>(
 
     const parsed = SyncedAuthoredModel.safeParse(stripUndefined({
       id: translated.id,
-      ...translated.model,
+      ...preserveBaseModel(translated.model, existing.get(relativePath)?.authored),
     }));
     if (!parsed.success) {
       parsed.error.cause = { provider: provider.id, path: relativePath };
@@ -202,6 +202,15 @@ export async function syncProvider<SourceModel>(
     `${options.dryRun ? "Dry run: " : ""}${result.created} created, ${result.updated} updated, ${result.deleted} removed, ${result.unchanged} unchanged`,
   );
   return result;
+}
+
+export function preserveBaseModel(model: SyncedModel, existing: ExistingModel | undefined): SyncedModel {
+  if (existing?.base_model === undefined || "base_model" in model) return model;
+  return {
+    ...model,
+    base_model: existing.base_model,
+    base_model_omit: existing.base_model_omit,
+  };
 }
 
 export async function syncTargets(target: string, options: SyncOptions = {}) {

--- a/packages/core/src/sync/providers/cloudflare-workers-ai.ts
+++ b/packages/core/src/sync/providers/cloudflare-workers-ai.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
+import { readdirSync } from "node:fs";
+import path from "node:path";
 
-import type { ExistingModel, SyncProvider } from "../index.js";
+import type { ExistingModel, SyncedModel, SyncProvider } from "../index.js";
 import {
   buildOpenRouterModel,
   OpenRouterModel,
@@ -8,6 +10,19 @@ import {
 } from "./openrouter.js";
 
 const API_BASE = "https://api.cloudflare.com/client/v4/accounts";
+const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
+const metadataFilesByPublisher = new Map<string, string[]>();
+const METADATA_PUBLISHERS: Record<string, string> = {
+  "deepseek-ai": "deepseek",
+  google: "google",
+  meta: "meta",
+  mistralai: "mistral",
+  moonshotai: "moonshotai",
+  nvidia: "nvidia",
+  openai: "openai",
+  qwen: "alibaba",
+  "zai-org": "zhipuai",
+};
 
 const CloudflareOpenRouterResponse = z.object({
   result: z.union([OpenRouterResponse, z.array(OpenRouterModel)]).optional(),
@@ -81,8 +96,20 @@ export const cloudflareWorkersAi = {
   },
 } satisfies SyncProvider<CloudflareModel>;
 
-function buildWorkersAiModel(model: z.infer<typeof OpenRouterModel>, existing: ExistingModel | undefined) {
-  const synced = buildOpenRouterModel(model, existing);
+function buildWorkersAiModel(
+  model: z.infer<typeof OpenRouterModel>,
+  existing: ExistingModel | undefined,
+): SyncedModel {
+  const source = {
+    ...model,
+    name: existing?.name ?? model.name,
+    top_provider: {
+      ...model.top_provider,
+      max_completion_tokens: existing?.limit?.output ?? model.top_provider.max_completion_tokens,
+    },
+  };
+  const synced = buildOpenRouterModel(source, existing, resolveCloudflareBaseModel(model));
+  if ("base_model" in synced) return synced;
   return {
     ...synced,
     name: existing?.name ?? synced.name,
@@ -93,6 +120,34 @@ function buildWorkersAiModel(model: z.infer<typeof OpenRouterModel>, existing: E
       output: existing?.limit?.output ?? synced.limit.output,
     },
   };
+}
+
+export function resolveCloudflareBaseModel(model: z.infer<typeof OpenRouterModel>) {
+  const [, publisher] = model.id.replace(/^workers-ai\//, "").split("/");
+  if (publisher === undefined) return undefined;
+
+  const metadataPublisher = METADATA_PUBLISHERS[publisher];
+  if (metadataPublisher === undefined) return undefined;
+
+  let files = metadataFilesByPublisher.get(metadataPublisher);
+  if (files === undefined) {
+    try {
+      files = readdirSync(path.join(MODELS_DIR, metadataPublisher))
+        .filter((file) => file.endsWith(".toml"))
+        .map((file) => file.slice(0, -5));
+    } catch {
+      files = [];
+    }
+    metadataFilesByPublisher.set(metadataPublisher, files);
+  }
+
+  const identity = new Set(identityTokens(`${model.id} ${model.name}`));
+  const matches = files.filter((file) => identityTokens(file).every((token) => identity.has(token)));
+  return matches.length === 1 ? `${metadataPublisher}/${matches[0]}` : undefined;
+}
+
+function identityTokens(value: string) {
+  return value.toLowerCase().match(/[a-z]+|\d+(?:\.\d+)?/g) ?? [];
 }
 
 async function fetchPage(accountID: string, token: string, page: number) {
@@ -112,18 +167,19 @@ async function fetchPage(accountID: string, token: string, page: number) {
   return response.json();
 }
 
-function parseCloudflareModels(raw: unknown) {
+function parseCloudflareModels(raw: unknown): CloudflareModel[] {
   const cloudflare = CloudflareResponse.safeParse(raw);
   if (cloudflare.success) return cloudflare.data.data;
 
   const direct = OpenRouterResponse.safeParse(raw);
-  if (direct.success) return direct.data.data;
+  if (direct.success) return direct.data.data.map((model) => CloudflareModel.parse(model));
 
   const wrapped = CloudflareOpenRouterResponse.parse(raw);
   if (wrapped.result === undefined) {
     throw new Error("Cloudflare Workers AI response did not include model data");
   }
-  return Array.isArray(wrapped.result) ? wrapped.result : wrapped.result.data;
+  const models = Array.isArray(wrapped.result) ? wrapped.result : wrapped.result.data;
+  return models.map((model) => CloudflareModel.parse(model));
 }
 
 function normalizeModel(model: CloudflareModel) {

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -121,7 +121,11 @@ function inferFamily(model: OpenRouterModel, name: string) {
     });
 }
 
-export function buildOpenRouterModel(model: OpenRouterModel, existing: ExistingModel | undefined): SyncedModel {
+export function buildOpenRouterModel(
+  model: OpenRouterModel,
+  existing: ExistingModel | undefined,
+  baseModel?: string,
+): SyncedModel {
   const params = new Set(model.supported_parameters);
   const name = model.name.replace(/^[^:]+:\s+/, "");
   const input = modalities(model.architecture.input_modalities, ["text"]);
@@ -155,14 +159,14 @@ export function buildOpenRouterModel(model: OpenRouterModel, existing: ExistingM
     input: existing?.limit?.input,
     output: model.top_provider.max_completion_tokens ?? existing?.limit?.output ?? context,
   };
-  const canonical = resolveCanonicalModel(model.id);
+  const canonical = baseModel ?? resolveCanonicalModel(model.id)?.from;
 
   if (canonical !== undefined) {
     return {
-      base_model: canonical.from,
-      base_model_omit: baseModelOmit(canonical.from, limit),
-      ...baseModelOverrides(canonical.from, {
-        name: model.id.endsWith(":free") ? name : undefined,
+      base_model: canonical,
+      base_model_omit: baseModelOmit(canonical, limit),
+      ...baseModelOverrides(canonical, {
+        name: baseModel !== undefined || model.id.endsWith(":free") ? name : undefined,
         attachment,
         reasoning,
         temperature: params.has("temperature"),

--- a/packages/core/test/openrouter-sync.test.ts
+++ b/packages/core/test/openrouter-sync.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
 
+import { preserveBaseModel } from "../src/sync/index.js";
+import { resolveCloudflareBaseModel } from "../src/sync/providers/cloudflare-workers-ai.js";
 import { buildOpenRouterModel, type OpenRouterModel } from "../src/sync/providers/openrouter.js";
 
 test("OpenRouter z-ai models inherit from zhipuai metadata", () => {
@@ -28,4 +30,68 @@ test("OpenRouter z-ai models inherit from zhipuai metadata", () => {
   const synced = buildOpenRouterModel(model, undefined);
 
   expect("base_model" in synced ? synced.base_model : undefined).toBe("zhipuai/glm-5.1");
+});
+
+test("OpenRouter-derived syncs preserve existing base model links", () => {
+  const model: OpenRouterModel = {
+    id: "@cf/nvidia/nemotron-3-120b-a12b",
+    name: "Nemotron 3 Super 120B",
+    created: 1_773_187_200,
+    hugging_face_id: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+    knowledge_cutoff: null,
+    context_length: 256_000,
+    architecture: {
+      input_modalities: ["text"],
+      output_modalities: ["text"],
+    },
+    pricing: {
+      prompt: "0.0000005",
+      completion: "0.0000015",
+    },
+    top_provider: {
+      context_length: 256_000,
+      max_completion_tokens: 256_000,
+    },
+    supported_parameters: ["reasoning", "tools", "temperature", "structured_outputs"],
+  };
+
+  const synced = preserveBaseModel(buildOpenRouterModel(model, undefined), {
+    base_model: "nvidia/nemotron-3-super-120b-a12b",
+    base_model_omit: ["limit.input"],
+  });
+
+  expect("base_model" in synced ? synced.base_model : undefined)
+    .toBe("nvidia/nemotron-3-super-120b-a12b");
+  expect("base_model_omit" in synced ? synced.base_model_omit : undefined)
+    .toEqual(["limit.input"]);
+});
+
+test("existing links do not replace newly detected base models", () => {
+  const synced = preserveBaseModel({
+    base_model: "zhipuai/glm-5.1",
+  }, {
+    base_model: "zhipuai/glm-5",
+  });
+
+  expect("base_model" in synced ? synced.base_model : undefined).toBe("zhipuai/glm-5.1");
+});
+
+test("new Cloudflare models discover a unique metadata base model", () => {
+  const model: OpenRouterModel = {
+    id: "@cf/nvidia/nemotron-3-120b-a12b",
+    name: "Nemotron 3 Super 120B",
+    created: 1_773_187_200,
+    hugging_face_id: null,
+    knowledge_cutoff: null,
+    context_length: 256_000,
+    architecture: { input_modalities: ["text"], output_modalities: ["text"] },
+    pricing: { prompt: "0.0000005", completion: "0.0000015" },
+    top_provider: { context_length: 256_000, max_completion_tokens: 256_000 },
+    supported_parameters: ["reasoning"],
+  };
+
+  expect(resolveCloudflareBaseModel(model)).toBe("nvidia/nemotron-3-super-120b-a12b");
+  const synced = buildOpenRouterModel(model, undefined, resolveCloudflareBaseModel(model));
+  expect("base_model" in synced ? synced.base_model : undefined)
+    .toBe("nvidia/nemotron-3-super-120b-a12b");
 });

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/bun/tsconfig.json",
-  "compilerOptions": {}
+  "compilerOptions": {
+    "types": ["bun", "node"]
+  }
 }


### PR DESCRIPTION
## Summary
- preserve authored `base_model` and `base_model_omit` links across provider sync updates
- automatically link new Cloudflare Workers AI models to unique canonical metadata matches
- add explicit Bun/Node types and fix strict type errors so the core typecheck passes

## Validation
- `bun test packages/core/test/openrouter-sync.test.ts`
- `bunx tsc --noEmit -p packages/core/tsconfig.json`
- `bun validate`
- `git diff --check`