### PR TITLE
fix(sync): retain curated base model links

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -205,7 +205,13 @@ export async function syncProvider<SourceModel>(
 }
 
 export function preserveBaseModel(model: SyncedModel, existing: ExistingModel | undefined): SyncedModel {
-  if (existing?.base_model === undefined || "base_model" in model) return model;
+  if (existing?.base_model === undefined) return model;
+  const translatedBase = "base_model" in model ? model.base_model : undefined;
+  if (translatedBase !== undefined) {
+    const translatedOmit = "base_model_omit" in model ? model.base_model_omit : undefined;
+    if (translatedBase !== existing.base_model || translatedOmit !== undefined) return model;
+    return { ...model, base_model_omit: existing.base_model_omit };
+  }
   return {
     ...model,
     base_model: existing.base_model,

--- a/packages/core/src/sync/providers/cloudflare-workers-ai.ts
+++ b/packages/core/src/sync/providers/cloudflare-workers-ai.ts
@@ -108,7 +108,11 @@ function buildWorkersAiModel(
       max_completion_tokens: existing?.limit?.output ?? model.top_provider.max_completion_tokens,
     },
   };
-  const synced = buildOpenRouterModel(source, existing, resolveCloudflareBaseModel(model));
+  const synced = buildOpenRouterModel(
+    source,
+    existing,
+    existing?.base_model ?? resolveCloudflareBaseModel(model),
+  );
   if ("base_model" in synced) return synced;
   return {
     ...synced,

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -1,14 +1,12 @@
 import { z } from "zod";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import { ModelFamilyValues } from "../../family.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
 
 const API_ENDPOINT = "https://openrouter.ai/api/v1/models";
-const PROVIDERS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "providers");
 const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
-const modelFilesByProvider = new Map<string, Set<string>>();
 const modelMetadataByID = new Map<string, Record<string, unknown>>();
 
 const CANONICAL_PROVIDER_PREFIXES = {
@@ -22,6 +20,10 @@ const CANONICAL_PROVIDER_PREFIXES = {
   mistralai: { provider: "mistral", metadata: "mistral" },
   moonshotai: { provider: "moonshotai", metadata: "moonshotai" },
   openai: { provider: "openai", metadata: "openai" },
+  nvidia: { provider: "nvidia", metadata: "nvidia" },
+  qwen: { provider: "alibaba", metadata: "alibaba" },
+  stepfun: { provider: "stepfun", metadata: "stepfun" },
+  tencent: { provider: "tencent", metadata: "tencent" },
   "x-ai": { provider: "xai", metadata: "xai" },
   xai: { provider: "xai", metadata: "xai" },
   xiaomi: { provider: "xiaomi", metadata: "xiaomi" },
@@ -159,12 +161,14 @@ export function buildOpenRouterModel(
     input: existing?.limit?.input,
     output: model.top_provider.max_completion_tokens ?? existing?.limit?.output ?? context,
   };
-  const canonical = baseModel ?? resolveCanonicalModel(model.id)?.from;
+  const canonical = existing?.base_model ?? baseModel ?? resolveCanonicalModel(model.id)?.from;
 
   if (canonical !== undefined) {
     return {
       base_model: canonical,
-      base_model_omit: baseModelOmit(canonical, limit),
+      base_model_omit: existing?.base_model === canonical
+        ? existing.base_model_omit ?? baseModelOmit(canonical, limit)
+        : baseModelOmit(canonical, limit),
       ...baseModelOverrides(canonical, {
         name: baseModel !== undefined || model.id.endsWith(":free") ? name : undefined,
         attachment,
@@ -212,8 +216,7 @@ function resolveCanonicalModel(openrouterID: string) {
   const modelID = modelParts.join("/").replace(/:free$/, "");
   const candidates = canonicalCandidates(canonical.provider, modelID);
   const match = candidates.find((candidate) => {
-    return canonicalModelExists(canonical.provider, candidate) &&
-      modelMetadataExists(canonical.metadata, candidate);
+    return modelMetadataExists(canonical.metadata, candidate);
   });
 
   return match === undefined
@@ -223,19 +226,6 @@ function resolveCanonicalModel(openrouterID: string) {
         provider: canonical.provider,
         modelID: match,
       };
-}
-
-function canonicalModelExists(provider: string, modelID: string) {
-  let files = modelFilesByProvider.get(provider);
-  if (files === undefined) {
-    try {
-      files = new Set(readdirSync(path.join(PROVIDERS_DIR, provider, "models")));
-    } catch {
-      files = new Set();
-    }
-    modelFilesByProvider.set(provider, files);
-  }
-  return files.has(`${modelID}.toml`);
 }
 
 function modelMetadataExists(provider: string, modelID: string) {

--- a/packages/core/test/openrouter-sync.test.ts
+++ b/packages/core/test/openrouter-sync.test.ts
@@ -66,14 +66,38 @@ test("OpenRouter-derived syncs preserve existing base model links", () => {
     .toEqual(["limit.input"]);
 });
 
-test("existing links do not replace newly detected base models", () => {
-  const synced = preserveBaseModel({
-    base_model: "zhipuai/glm-5.1",
-  }, {
+test("newly detected base models do not replace existing links", () => {
+  const model: OpenRouterModel = {
+    id: "z-ai/glm-5.1",
+    name: "Z.AI: GLM-5.1",
+    created: 1_777_680_000,
+    hugging_face_id: null,
+    knowledge_cutoff: null,
+    context_length: 200_000,
+    architecture: { input_modalities: ["text"], output_modalities: ["text"] },
+    pricing: { prompt: "0.0000014", completion: "0.0000044" },
+    top_provider: { context_length: 200_000, max_completion_tokens: 131_072 },
+    supported_parameters: ["tools"],
+  };
+  const synced = buildOpenRouterModel(model, {
     base_model: "zhipuai/glm-5",
   });
 
-  expect("base_model" in synced ? synced.base_model : undefined).toBe("zhipuai/glm-5.1");
+  expect("base_model" in synced ? synced.base_model : undefined).toBe("zhipuai/glm-5");
+});
+
+test("undefined translated links preserve existing base model fields", () => {
+  const synced = preserveBaseModel({
+    base_model: undefined,
+  } as never, {
+    base_model: "nvidia/nemotron-3-super-120b-a12b",
+    base_model_omit: ["limit.input"],
+  });
+
+  expect("base_model" in synced ? synced.base_model : undefined)
+    .toBe("nvidia/nemotron-3-super-120b-a12b");
+  expect("base_model_omit" in synced ? synced.base_model_omit : undefined)
+    .toEqual(["limit.input"]);
 });
 
 test("new Cloudflare models discover a unique metadata base model", () => {


### PR DESCRIPTION
## Summary
- prefer existing authored base-model links over automatic discovery during sync updates
- preserve existing omit lists and treat `base_model: undefined` as an omitted translation field
- expand OpenRouter canonical metadata discovery without requiring a direct-provider TOML

## Validation
- `bun test packages/core/test/openrouter-sync.test.ts`
- `bunx tsc --noEmit -p packages/core/tsconfig.json`
- `bun validate`
- `git diff --check origin/dev...HEAD`