### PR TITLE
chore(sync): update Vercel model catalog

### DIFF
--- a/providers/vercel/models/alibaba/qwen-3-14b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-14b.toml
@@ -1,21 +1,21 @@
 name = "Qwen3-14B"
 family = "qwen"
-release_date = "2025-04"
+release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2025-04"
+open_weights = false
 
 [cost]
-input = 0.06
+input = 0.12
 output = 0.24
 
 [limit]
-context = 40960
-output = 16384
+context = 40_960
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/alibaba/qwen-3-235b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-235b.toml
@@ -1,21 +1,21 @@
 name = "Qwen3 235B A22B Instruct 2507"
 family = "qwen"
-release_date = "2025-04"
+release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2025-04"
+open_weights = false
 
 [cost]
-input = 0.13
-output = 0.6
+input = 0.22
+output = 0.88
 
 [limit]
-context = 40960
-output = 16384
+context = 262_144
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/alibaba/qwen-3-30b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-30b.toml
@@ -1,21 +1,21 @@
 name = "Qwen3-30B-A3B"
 family = "qwen"
-release_date = "2025-04"
+release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2025-04"
+open_weights = false
 
 [cost]
 input = 0.08
 output = 0.29
 
 [limit]
-context = 40960
-output = 16384
+context = 40_960
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/alibaba/qwen-3-32b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-32b.toml
@@ -1,21 +1,21 @@
 name = "Qwen 3.32B"
 family = "qwen"
-release_date = "2025-04"
+release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2025-04"
+open_weights = false
 
 [cost]
-input = 0.1
-output = 0.3
+input = 0.16
+output = 0.64
 
 [limit]
-context = 40960
-output = 16384
+context = 128_000
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/alibaba/qwen-3.6-max-preview.toml
+++ b/providers/vercel/models/alibaba/qwen-3.6-max-preview.toml
@@ -1,11 +1,11 @@
 name = "Qwen 3.6 Max Preview"
 family = "qwen"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-04-20"
 last_updated = "2026-04-24"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
 open_weights = true
 
 [cost]
@@ -19,5 +19,5 @@ context = 240_000
 output = 64_000
 
 [modalities]
-input = ["text", "image", "pdf"]
+input = ["text", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/alibaba/qwen3-235b-a22b-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-235b-a22b-thinking.toml
@@ -1,21 +1,21 @@
 name = "Qwen3 235B A22B Thinking 2507"
 family = "qwen"
-release_date = "2025-04"
+release_date = "2025-09-24"
 last_updated = "2025-04"
 attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2025-04"
+open_weights = false
 
 [cost]
-input = 0.3
-output = 2.9
+input = 0.4
+output = 4
 
 [limit]
-context = 262114
-output = 262114
+context = 131_072
+output = 32_768
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/alibaba/qwen3-coder-30b-a3b.toml
+++ b/providers/vercel/models/alibaba/qwen3-coder-30b-a3b.toml
@@ -1,21 +1,21 @@
 name = "Qwen 3 Coder 30B A3B Instruct"
 family = "qwen"
-release_date = "2025-04"
+release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2025-04"
+open_weights = false
 
 [cost]
-input = 0.07
-output = 0.27
+input = 0.15
+output = 0.6
 
 [limit]
-context = 160000
-output = 32768
+context = 262_144
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/alibaba/qwen3-coder-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3-coder-plus.toml
@@ -1,22 +1,11 @@
-name = "Qwen3 Coder Plus"
-family = "qwen"
-release_date = "2025-07-23"
-last_updated = "2025-07-23"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2025-04"
-tool_call = true
+base_model = "alibaba/qwen3-coder-plus"
 open_weights = true
 
 [cost]
-input = 1.0
-output = 5.0
+input = 1
+output = 5
+cache_read = 0.2
 
 [limit]
 context = 1_000_000
-output = 1_000_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 65_536

--- a/providers/vercel/models/alibaba/qwen3-coder.toml
+++ b/providers/vercel/models/alibaba/qwen3-coder.toml
@@ -1,21 +1,22 @@
 name = "Qwen3 Coder 480B A35B Instruct"
 family = "qwen"
-release_date = "2025-04"
+release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2025-04"
+open_weights = false
 
 [cost]
-input = 0.38
-output = 1.53
+input = 1.5
+output = 7.5
+cache_read = 0.3
 
 [limit]
-context = 262144
-output = 66536
+context = 262_144
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/alibaba/qwen3-embedding-0.6b.toml
+++ b/providers/vercel/models/alibaba/qwen3-embedding-0.6b.toml
@@ -4,17 +4,13 @@ release_date = "2025-11-14"
 last_updated = "2025-11-14"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.01
-output = 0
-
 [limit]
-context = 32768
-output = 32768
+context = 32_768
+output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/alibaba/qwen3-embedding-4b.toml
+++ b/providers/vercel/models/alibaba/qwen3-embedding-4b.toml
@@ -4,17 +4,13 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.02
-output = 0
-
 [limit]
-context = 32768
-output = 32768
+context = 32_768
+output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/alibaba/qwen3-embedding-8b.toml
+++ b/providers/vercel/models/alibaba/qwen3-embedding-8b.toml
@@ -4,17 +4,13 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.05
-output = 0
-
 [limit]
-context = 32768
-output = 32768
+context = 32_768
+output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/alibaba/qwen3-max.toml
+++ b/providers/vercel/models/alibaba/qwen3-max.toml
@@ -1,23 +1,10 @@
-name = "Qwen3 Max"
-family = "qwen"
-release_date = "2025-09-23"
-last_updated = "2025-09-23"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2025-04"
-tool_call = true
-open_weights = false
+base_model = "alibaba/qwen3-max"
 
 [cost]
 input = 1.2
-output = 6.0
-cached_input = 0.24
+output = 6
+cache_read = 0.24
 
 [limit]
 context = 262_144
 output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/alibaba/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/vercel/models/alibaba/qwen3-next-80b-a3b-instruct.toml
@@ -1,22 +1,7 @@
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
 name = "Qwen3 Next 80B A3B Instruct"
-family = "qwen"
 release_date = "2025-09-12"
-last_updated = "2025-09-12"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2025-04"
-tool_call = true
-open_weights = true
 
 [cost]
-input = 0.09
-output = 1.1
-
-[limit]
-context = 262144
-output = 32768
-
-[modalities]
-input = ["text"]
-output = ["text"]
+input = 0.15
+output = 1.2

--- a/providers/vercel/models/alibaba/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-next-80b-a3b-thinking.toml
@@ -1,22 +1,8 @@
+base_model = "alibaba/qwen3-next-80b-a3b-thinking"
 name = "Qwen3 Next 80B A3B Thinking"
-family = "qwen"
 release_date = "2025-09-12"
-last_updated = "2025-09-12"
-attachment = false
-reasoning = true
-temperature = true
 knowledge = "2025-09"
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0.15
-output = 1.5
-
-[limit]
-context = 131_072
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 1.2

--- a/providers/vercel/models/alibaba/qwen3-vl-235b-a22b-instruct.toml
+++ b/providers/vercel/models/alibaba/qwen3-vl-235b-a22b-instruct.toml
@@ -1,21 +1,21 @@
 name = "Qwen3 VL 235B A22B Instruct"
 family = "qwen"
-attachment = true
-reasoning = false
-tool_call = false
-temperature = true
 release_date = "2025-09-24"
 last_updated = "2026-05-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
 open_weights = false
 
 [cost]
-input = 0.39999999999999997
-output = 1.5999999999999999
+input = 0.4
+output = 1.6
 
 [limit]
 context = 131_072
 output = 129_024
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/alibaba/qwen3-vl-instruct.toml
+++ b/providers/vercel/models/alibaba/qwen3-vl-instruct.toml
@@ -5,18 +5,18 @@ last_updated = "2025-09-24"
 attachment = true
 reasoning = false
 temperature = true
-knowledge = "2025-04"
 tool_call = true
+knowledge = "2025-04"
 open_weights = true
 
 [cost]
-input = 0.7
-output = 2.8
+input = 0.4
+output = 1.6
 
 [limit]
 context = 131_072
 output = 129_024
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/alibaba/qwen3-vl-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-vl-thinking.toml
@@ -5,18 +5,18 @@ last_updated = "2025-09-24"
 attachment = true
 reasoning = true
 temperature = true
-knowledge = "2025-09"
 tool_call = true
+knowledge = "2025-09"
 open_weights = true
 
 [cost]
-input = 0.7
-output = 8.4
+input = 0.4
+output = 4
 
 [limit]
 context = 131_072
-output = 129_024
+output = 32_768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/alibaba/qwen3.5-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.5-plus.toml
@@ -1,12 +1,6 @@
+base_model = "alibaba/qwen3.5-plus"
 name = "Qwen 3.5 Plus"
-family = "qwen"
 attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-02-16"
-last_updated = "2026-02-19"
-open_weights = false
 
 [cost]
 input = 0.4

--- a/providers/vercel/models/alibaba/qwen3.6-27b.toml
+++ b/providers/vercel/models/alibaba/qwen3.6-27b.toml
@@ -1,16 +1,11 @@
+base_model = "alibaba/qwen3.6-27b"
 name = "Qwen 3.6 27B"
 family = "qwen3.6"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-04-22"
-last_updated = "2026-05-01"
 open_weights = false
 
 [cost]
 input = 0.6
-output = 3.5999999999999996
+output = 3.6
 
 [limit]
 context = 256_000

--- a/providers/vercel/models/alibaba/qwen3.6-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.6-plus.toml
@@ -1,17 +1,11 @@
+base_model = "alibaba/qwen3.6-plus"
 name = "Qwen 3.6 Plus"
-family = "qwen"
 attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-04-02"
-last_updated = "2026-04-03"
-open_weights = false
 
 [cost]
 input = 0.5
 output = 3
-cache_read = 0.09999999999999999
+cache_read = 0.1
 cache_write = 0.625
 
 [limit]

--- a/providers/vercel/models/alibaba/qwen3.7-max.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-max.toml
@@ -1,23 +1,17 @@
+base_model = "alibaba/qwen3.7-max"
 name = "Qwen 3.7 Max"
-family = "qwen"
 attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-05-21"
-last_updated = "2026-05-21"
-open_weights = false
 
 [cost]
-input = 2.5
-output = 7.5
-cache_read = 0.5
-cache_write = 3.125
+input = 1.25
+output = 3.75
+cache_read = 0.25
+cache_write = 1.5625
 
 [limit]
 context = 991_000
 output = 64_000
 
 [modalities]
-input = ["text", "image", "pdf"]
+input = ["text", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/alibaba/qwen3.7-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-plus.toml
@@ -1,0 +1,19 @@
+base_model = "alibaba/qwen3.7-plus"
+name = "Qwen 3.7 Plus"
+family = "qwen3.7-plus"
+release_date = "2026-06-01"
+attachment = true
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.08
+cache_write = 0.5
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/vercel/models/amazon/nova-2-lite.toml
+++ b/providers/vercel/models/amazon/nova-2-lite.toml
@@ -6,16 +6,17 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = false
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.3
 output = 2.5
+cache_read = 0.075
 
 [limit]
-context = 1000000
-output = 1000000
+context = 1_000_000
+output = 1_000_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/vercel/models/amazon/titan-embed-text-v2.toml
+++ b/providers/vercel/models/amazon/titan-embed-text-v2.toml
@@ -1,20 +1,16 @@
 name = "Titan Text Embeddings V2"
 family = "titan-embed"
-release_date = "2024-04"
+release_date = "2024-04-01"
 last_updated = "2024-04"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.02
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -1,26 +1,10 @@
+base_model = "anthropic/claude-haiku-4-5"
 name = "Claude Haiku 4.5"
-family = "claude-haiku"
-release_date = "2025-10-15"
-last_updated = "2025-10-15"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-02-28"
-open_weights = false
 
 interleaved = true
 
 [cost]
-input = 1.00
-output = 5.00
-cache_read = 0.10
+input = 1
+output = 5
+cache_read = 0.1
 cache_write = 1.25
-
-[limit]
-context = 200_000
-output = 64_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/anthropic/claude-opus-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.5.toml
@@ -1,26 +1,11 @@
+base_model = "anthropic/claude-opus-4-5"
 name = "Claude Opus 4.5"
-family = "claude-opus"
-release_date = "2025-11-24"
-last_updated = "2025-11-24"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-03-31"
-open_weights = false
+release_date = "2024-11-24"
 
 interleaved = true
 
 [cost]
-input = 5.00
-output = 25.00
+input = 5
+output = 25
 cache_read = 0.5
-cache_write = 18.75
-
-[limit]
-context = 200_000
-output = 64_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]
+cache_write = 6.25

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,26 +1,9 @@
-name = "Claude Opus 4.6"
-family = "claude-opus"
-release_date = "2026-02"
-last_updated = "2026-02"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-05-31"
-open_weights = false
+base_model = "anthropic/claude-opus-4-6"
 
 interleaved = true
 
 [cost]
-input = 5.00
-output = 25.00
-cache_read = 0.50
+input = 5
+output = 25
+cache_read = 0.5
 cache_write = 6.25
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/anthropic/claude-opus-4.7.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.7.toml
@@ -1,23 +1,8 @@
-name = "Claude Opus 4.7"
-family = "claude-opus"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = false
-release_date = "2026-04-16"
-last_updated = "2026-04-16"
-open_weights = false
+base_model = "anthropic/claude-opus-4-7"
+temperature = true
 
 [cost]
 input = 5
 output = 25
 cache_read = 0.5
 cache_write = 6.25
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/anthropic/claude-opus-4.8.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.8.toml
@@ -1,23 +1,8 @@
-name = "Claude Opus 4.8"
-family = "claude-opus"
-attachment = true
-reasoning = true
-tool_call = true
+base_model = "anthropic/claude-opus-4-8"
 temperature = true
-release_date = "2026-05-28"
-last_updated = "2026-05-28"
-open_weights = false
 
 [cost]
 input = 5
 output = 25
 cache_read = 0.5
 cache_write = 6.25
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,33 +1,20 @@
-name = "Claude Sonnet 4.6"
-family = "claude-sonnet"
-release_date = "2026-02-17"
-last_updated = "2026-02-17"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-08-31"
-open_weights = false
+base_model = "anthropic/claude-sonnet-4-6"
 
 interleaved = true
 
 [cost]
-input = 3.00
-output = 15.00
-cache_read = 0.30
+input = 3
+output = 15
+cache_read = 0.3
 cache_write = 3.75
 
 [[cost.tiers]]
-tier = { size = 200_000 }
-input = 6.00
-output = 22.50
-cache_read = 0.60
-cache_write = 7.50
+tier = { type = "context", size = 200_000 }
+input = 6
+output = 22.5
+cache_read = 0.6
+cache_write = 7.5
 
 [limit]
 context = 1_000_000
 output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/arcee-ai/trinity-large-preview.toml
+++ b/providers/vercel/models/arcee-ai/trinity-large-preview.toml
@@ -1,17 +1,17 @@
 name = "Trinity Large Preview"
 family = "trinity"
-release_date = "2025-01"
+release_date = "2025-01-01"
 last_updated = "2025-01"
 attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.25
-output = 1.00
+output = 1
 
 [limit]
 context = 131_000

--- a/providers/vercel/models/arcee-ai/trinity-mini.toml
+++ b/providers/vercel/models/arcee-ai/trinity-mini.toml
@@ -1,21 +1,21 @@
 name = "Trinity Mini"
 family = "trinity"
-release_date = "2025-12"
+release_date = "2025-12-01"
 last_updated = "2025-12"
 attachment = false
 reasoning = false
 temperature = true
 tool_call = false
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
-input = 0.05
+input = 0.045
 output = 0.15
 
 [limit]
-context = 131072
-output = 131072
+context = 131_072
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/bytedance/seed-1.6.toml
+++ b/providers/vercel/models/bytedance/seed-1.6.toml
@@ -1,13 +1,13 @@
 name = "Seed 1.6"
 family = "seed"
-release_date = "2025-09"
+release_date = "2025-09-01"
 last_updated = "2025-09"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.25
@@ -15,8 +15,8 @@ output = 2
 cache_read = 0.05
 
 [limit]
-context = 256000
-output = 32000
+context = 256_000
+output = 32_000
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/bytedance/seed-1.8.toml
+++ b/providers/vercel/models/bytedance/seed-1.8.toml
@@ -1,13 +1,13 @@
 name = "Seed 1.8"
 family = "seed"
-release_date = "2025-10"
+release_date = "2025-09-01"
 last_updated = "2025-10"
 attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.25
@@ -15,8 +15,8 @@ output = 2
 cache_read = 0.05
 
 [limit]
-context = 256000
-output = 64000
+context = 256_000
+output = 64_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/vercel/models/cohere/embed-v4.0.toml
+++ b/providers/vercel/models/cohere/embed-v4.0.toml
@@ -4,17 +4,13 @@ release_date = "2025-04-15"
 last_updated = "2025-04-15"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.12
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/deepseek/deepseek-v3.1-terminus.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.1-terminus.toml
@@ -5,17 +5,18 @@ last_updated = "2025-09-22"
 attachment = false
 reasoning = true
 temperature = true
-knowledge = "2025-07"
 tool_call = true
+knowledge = "2025-07"
 open_weights = true
 
 [cost]
 input = 0.27
-output = 1.00
+output = 1
+cache_read = 0.135
 
 [limit]
-context = 131072
-output = 65536
+context = 131_072
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/deepseek/deepseek-v3.1.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.1.toml
@@ -6,16 +6,17 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-07"
+open_weights = false
 
 [cost]
-input = 0.3
-output = 1
+input = 0.56
+output = 1.68
+cache_read = 0.28
 
 [limit]
-context = 163840
-output = 128000
+context = 163_840
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/deepseek/deepseek-v3.2-thinking.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.2-thinking.toml
@@ -6,20 +6,19 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-07"
+open_weights = false
 
 interleaved = true
 
 [cost]
-input = 0.28
-output = 0.42
-cache_read = 0.03
+input = 0.62
+output = 1.85
 
 [limit]
-context = 128000
-output = 64000
+context = 128_000
+output = 8_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/deepseek/deepseek-v3.2.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.2.toml
@@ -6,18 +6,18 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = false
-open_weights = false
 knowledge = "2024-07"
+open_weights = false
 
 [cost]
-input = 0.27
-output = 0.4
-cache_read = 0.22
+input = 0.28
+output = 0.42
+cache_read = 0.028
 
 [limit]
-context = 163842
-output = 8000
+context = 128_000
+output = 8_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/deepseek/deepseek-v3.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.toml
@@ -6,16 +6,17 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-07"
+open_weights = false
 
 [cost]
-input = 0.77
-output = 0.77
+input = 0.27
+output = 1.12
+cache_read = 0.135
 
 [limit]
-context = 163840
-output = 16384
+context = 163_840
+output = 163_840
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/vercel/models/deepseek/deepseek-v4-flash.toml
@@ -1,22 +1,12 @@
-name = "DeepSeek V4 Flash"
+base_model = "deepseek/deepseek-v4-flash"
 family = "deepseek"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-04-23"
-last_updated = "2026-04-24"
-open_weights = true
 
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.028
-
-[limit]
-context = 1_000_000
-output = 384_000
+cache_read = 0.0028
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/vercel/models/deepseek/deepseek-v4-pro.toml
@@ -1,22 +1,12 @@
-name = "DeepSeek V4 Pro"
+base_model = "deepseek/deepseek-v4-pro"
 family = "deepseek"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-04-23"
-last_updated = "2026-04-24"
-open_weights = true
 
 [cost]
-input = 1.74
-output = 3.48
-cache_read = 0.145
-
-[limit]
-context = 1_000_000
-output = 384_000
+input = 0.435
+output = 0.87
+cache_read = 0.0036
 
 [modalities]
-input = ["text"]
+input = ["text", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/google/gemini-2.5-flash-image.toml
+++ b/providers/vercel/models/google/gemini-2.5-flash-image.toml
@@ -1,21 +1,18 @@
+base_model = "google/gemini-2.5-flash-image"
 name = "Nano Banana (Gemini 2.5 Flash Image)"
-family = "gemini-flash"
 release_date = "2025-03-20"
-last_updated = "2025-03-20"
 attachment = false
 reasoning = false
-temperature = true
-tool_call = false
-open_weights = false
 knowledge = "2025-01"
 
 [cost]
 input = 0.3
 output = 2.5
+cache_read = 0.03
 
 [limit]
-context = 32768
-output = 32768
+context = 32_768
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/vercel/models/google/gemini-2.5-flash-lite.toml
@@ -1,23 +1,11 @@
+base_model = "google/gemini-2.5-flash-lite"
 name = "Gemini 2.5 Flash Lite"
-family = "gemini-flash-lite"
-release_date = "2025-06-17"
-last_updated = "2025-06-17"
-attachment = true
-reasoning = true
-temperature = true
-knowledge = "2025-01"
-tool_call = true
-open_weights = false
 
 [cost]
-input = 0.10
-output = 0.40
+input = 0.1
+output = 0.4
 cache_read = 0.01
 
-[limit]
-context = 1_048_576
-output = 65_536
-
 [modalities]
-input = ["text", "image", "audio", "video", "pdf"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/google/gemini-3-flash.toml
+++ b/providers/vercel/models/google/gemini-3-flash.toml
@@ -6,8 +6,8 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2025-03"
+open_weights = false
 
 [cost]
 input = 0.5
@@ -15,8 +15,8 @@ output = 3
 cache_read = 0.05
 
 [limit]
-context = 1000000
-output = 64000
+context = 1_000_000
+output = 65_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/google/gemini-3-pro-image.toml
+++ b/providers/vercel/models/google/gemini-3-pro-image.toml
@@ -1,21 +1,22 @@
 name = "Nano Banana Pro (Gemini 3 Pro Image)"
 family = "gemini-pro"
-release_date = "2025-09"
+release_date = "2025-09-01"
 last_updated = "2025-09"
 attachment = false
 reasoning = false
 temperature = true
 tool_call = false
-open_weights = false
 knowledge = "2025-03"
+open_weights = false
 
 [cost]
 input = 2
-output = 120
+output = 12
+cache_read = 0.2
 
 [limit]
-context = 65536
-output = 32768
+context = 65_536
+output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/google/gemini-3-pro-preview.toml
+++ b/providers/vercel/models/google/gemini-3-pro-preview.toml
@@ -1,29 +1,20 @@
-name = "Gemini 3 Pro Preview"
-family = "gemini-pro"
-release_date = "2025-11-18"
-last_updated = "2025-11-18"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-01"
-open_weights = false
+base_model = "google/gemini-3-pro-preview"
 
 [cost]
-input = 2.00
-output = 12.00
-cache_read = 0.20
+input = 2
+output = 12
+cache_read = 0.2
 
 [[cost.tiers]]
-tier = { size = 200_000 }
-input = 4.00
-output = 18.00
-cache_read = 0.40
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4
 
 [limit]
-context = 1000000
-output = 64000
+context = 1_000_000
+output = 64_000
 
 [modalities]
-input = ["text", "image", "video", "audio", "pdf"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/vercel/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,16 +1,11 @@
+base_model = "google/gemini-3.1-flash-image-preview"
 name = "Gemini 3.1 Flash Image Preview (Nano Banana 2)"
 family = "gemini"
-attachment = true
-reasoning = true
-tool_call = false
-temperature = true
-release_date = "2026-02-26"
-last_updated = "2026-03-06"
-open_weights = false
 
 [cost]
 input = 0.5
 output = 3
+cache_read = 0.05
 
 [limit]
 context = 131_072

--- a/providers/vercel/models/google/gemini-3.1-flash-image.toml
+++ b/providers/vercel/models/google/gemini-3.1-flash-image.toml
@@ -1,0 +1,22 @@
+name = "Gemini 3.1 Flash Image (Nano Banana 2)"
+family = "gemini"
+release_date = "2026-05-28"
+last_updated = "2026-05-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text", "image"]

--- a/providers/vercel/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/vercel/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,18 +1,10 @@
-name = "Gemini 3.1 Flash Lite Preview"
+base_model = "google/gemini-3.1-flash-lite-preview"
 family = "gemini"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-03-03"
-last_updated = "2026-03-06"
-open_weights = false
 
 [cost]
 input = 0.25
-output = 1.50
-cache_read = 0.025
-cache_write = 1.00
+output = 1.5
+cache_read = 0.03
 
 [limit]
 context = 1_000_000

--- a/providers/vercel/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/vercel/models/google/gemini-3.1-flash-lite.toml
@@ -1,12 +1,5 @@
-name = "Gemini 3.1 Flash Lite"
+base_model = "google/gemini-3.1-flash-lite"
 family = "gemini"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-05-07"
-last_updated = "2026-05-08"
-open_weights = false
 
 [cost]
 input = 0.25

--- a/providers/vercel/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/vercel/models/google/gemini-3.1-pro-preview.toml
@@ -1,12 +1,6 @@
-name = "Gemini 3.1 Pro Preview"
+base_model = "google/gemini-3.1-pro-preview"
 family = "gemini"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-02-19"
-last_updated = "2026-02-24"
-open_weights = false
+release_date = "2025-11-18"
 
 [cost]
 input = 2

--- a/providers/vercel/models/google/gemini-3.5-flash.toml
+++ b/providers/vercel/models/google/gemini-3.5-flash.toml
@@ -1,12 +1,5 @@
-name = "Gemini 3.5 Flash"
+base_model = "google/gemini-3.5-flash"
 family = "gemini"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-05-19"
-last_updated = "2026-05-21"
-open_weights = false
 
 [cost]
 input = 1.5

--- a/providers/vercel/models/google/gemini-embedding-001.toml
+++ b/providers/vercel/models/google/gemini-embedding-001.toml
@@ -1,21 +1,7 @@
-name = "Gemini Embedding 001"
+base_model = "google/gemini-embedding-001"
 family = "gemini-embedding"
-release_date = "2025-05-20"
-last_updated = "2025-05-20"
-attachment = false
-reasoning = false
-temperature = false
-tool_call = false
-open_weights = false
-
-[cost]
-input = 0.15
-output = 0
+temperature = true
 
 [limit]
-context = 8192
-output = 1536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 8_192
+output = 1_536

--- a/providers/vercel/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/vercel/models/google/gemma-4-26b-a4b-it.toml
@@ -1,16 +1,10 @@
-name = "Gemma 4 26B A4B IT"
-family = "gemma"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-04-02"
-last_updated = "2026-04-03"
+base_model = "google/gemma-4-26b-a4b-it"
 open_weights = false
 
 [cost]
-input = 0.13
-output = 0.39999999999999997
+input = 0.15
+output = 0.6
+cache_read = 0.015
 
 [limit]
 context = 262_144

--- a/providers/vercel/models/google/gemma-4-31b-it.toml
+++ b/providers/vercel/models/google/gemma-4-31b-it.toml
@@ -1,16 +1,9 @@
-name = "Gemma 4 31B IT"
-family = "gemma"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-04-02"
-last_updated = "2026-04-03"
+base_model = "google/gemma-4-31b-it"
 open_weights = false
 
 [cost]
 input = 0.14
-output = 0.39999999999999997
+output = 0.4
 
 [limit]
 context = 262_144

--- a/providers/vercel/models/google/text-embedding-005.toml
+++ b/providers/vercel/models/google/text-embedding-005.toml
@@ -1,20 +1,16 @@
 name = "Text Embedding 005"
 family = "text-embedding"
-release_date = "2024-08"
+release_date = "2024-08-01"
 last_updated = "2024-08"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.03
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/google/text-multilingual-embedding-002.toml
+++ b/providers/vercel/models/google/text-multilingual-embedding-002.toml
@@ -1,20 +1,16 @@
 name = "Text Multilingual Embedding 002"
 family = "text-embedding"
-release_date = "2024-03"
+release_date = "2024-03-01"
 last_updated = "2024-03"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.03
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/inception/mercury-coder-small.toml
+++ b/providers/vercel/models/inception/mercury-coder-small.toml
@@ -1,0 +1,21 @@
+name = "Mercury Coder Small Beta"
+family = "mercury"
+release_date = "2025-02-26"
+last_updated = "2025-02-26"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1
+
+[limit]
+context = 32_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vercel/models/kwaipilot/kat-coder-pro-v1.toml
+++ b/providers/vercel/models/kwaipilot/kat-coder-pro-v1.toml
@@ -6,12 +6,17 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = false
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
+
+[cost]
+input = 0.03
+output = 1.2
+cache_read = 0.06
 
 [limit]
-context = 256000
-output = 32000
+context = 256_000
+output = 32_000
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/meituan/longcat-flash-chat.toml
+++ b/providers/vercel/models/meituan/longcat-flash-chat.toml
@@ -6,12 +6,12 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [limit]
-context = 128000
-output = 8192
+context = 128_000
+output = 100_000
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/meta/llama-3.1-70b.toml
+++ b/providers/vercel/models/meta/llama-3.1-70b.toml
@@ -6,16 +6,16 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2023-12"
+open_weights = false
 
 [cost]
-input = 0.4
-output = 0.4
+input = 0.72
+output = 0.72
 
 [limit]
-context = 131072
-output = 16384
+context = 128_000
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/meta/llama-3.1-8b.toml
+++ b/providers/vercel/models/meta/llama-3.1-8b.toml
@@ -6,16 +6,16 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2023-12"
+open_weights = false
 
 [cost]
-input = 0.03
-output = 0.05
+input = 0.22
+output = 0.22
 
 [limit]
-context = 131072
-output = 16384
+context = 128_000
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/minimax/minimax-m2.1-lightning.toml
+++ b/providers/vercel/models/minimax/minimax-m2.1-lightning.toml
@@ -6,18 +6,18 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.3
 output = 2.4
 cache_read = 0.03
-cache_write = 0.38
+cache_write = 0.375
 
 [limit]
-context = 204800
-output = 131072
+context = 204_800
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/minimax/minimax-m2.1.toml
+++ b/providers/vercel/models/minimax/minimax-m2.1.toml
@@ -1,13 +1,8 @@
+base_model = "minimax/MiniMax-M2.1"
 name = "MiniMax M2.1"
-family = "minimax"
 release_date = "2025-10-27"
-last_updated = "2025-10-27"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 interleaved = true
 
@@ -15,12 +10,4 @@ interleaved = true
 input = 0.3
 output = 1.2
 cache_read = 0.03
-cache_write = 0.38
-
-[limit]
-context = 204800
-output = 131072
-
-[modalities]
-input = ["text"]
-output = ["text"]
+cache_write = 0.375

--- a/providers/vercel/models/minimax/minimax-m2.5-highspeed.toml
+++ b/providers/vercel/models/minimax/minimax-m2.5-highspeed.toml
@@ -1,11 +1,6 @@
+base_model = "minimax/MiniMax-M2.5-highspeed"
 name = "MiniMax M2.5 High Speed"
-family = "minimax"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-02-12"
-last_updated = "2026-03-13"
 open_weights = false
 
 [cost]
@@ -15,9 +10,5 @@ cache_read = 0.03
 cache_write = 0.375
 
 [limit]
-context = 0
-output = 0
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 204_800
+output = 131_000

--- a/providers/vercel/models/minimax/minimax-m2.5.toml
+++ b/providers/vercel/models/minimax/minimax-m2.5.toml
@@ -1,11 +1,5 @@
+base_model = "minimax/MiniMax-M2.5"
 name = "MiniMax M2.5"
-family = "minimax"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-02-12"
-last_updated = "2026-02-19"
 open_weights = false
 
 [cost]
@@ -17,7 +11,3 @@ cache_write = 0.375
 [limit]
 context = 204_800
 output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,12 +1,6 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
 name = "MiniMax M2.7 High Speed"
-family = "minimax"
 attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-open_weights = true
 
 [cost]
 input = 0.6
@@ -17,7 +11,3 @@ cache_write = 0.375
 [limit]
 context = 204_800
 output = 131_100
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/vercel/models/minimax/minimax-m2.7.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7.toml
@@ -1,12 +1,6 @@
+base_model = "minimax/MiniMax-M2.7"
 name = "Minimax M2.7"
-family = "minimax"
 attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-open_weights = true
 
 [cost]
 input = 0.3
@@ -17,7 +11,3 @@ cache_write = 0.375
 [limit]
 context = 204_800
 output = 131_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/minimax/minimax-m2.toml
+++ b/providers/vercel/models/minimax/minimax-m2.toml
@@ -1,26 +1,15 @@
+base_model = "minimax/MiniMax-M2"
 name = "MiniMax M2"
-family = "minimax"
-release_date = "2025-10-27"
-last_updated = "2025-10-27"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 knowledge = "2024-10"
-open_weights = true
 
 interleaved = true
 
 [cost]
-input = 0.27
-output = 1.15
+input = 0.3
+output = 1.2
 cache_read = 0.03
-cache_write = 0.38
+cache_write = 0.375
 
 [limit]
-context = 262114
-output = 262114
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 205_000
+output = 205_000

--- a/providers/vercel/models/minimax/minimax-m3.toml
+++ b/providers/vercel/models/minimax/minimax-m3.toml
@@ -1,0 +1,17 @@
+base_model = "minimax/MiniMax-M3"
+name = "MiniMax M3"
+family = "minimax-m3"
+release_date = "2026-05-31"
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+
+[limit]
+context = 1_000_000
+output = 1_000_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/vercel/models/mistral/codestral-embed.toml
+++ b/providers/vercel/models/mistral/codestral-embed.toml
@@ -4,17 +4,13 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.15
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/mistral/devstral-2.toml
+++ b/providers/vercel/models/mistral/devstral-2.toml
@@ -6,12 +6,16 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
+
+[cost]
+input = 0.4
+output = 2
 
 [limit]
-context = 256000
-output = 256000
+context = 256_000
+output = 256_000
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/mistral/devstral-small-2.toml
+++ b/providers/vercel/models/mistral/devstral-small-2.toml
@@ -6,12 +6,16 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
+
+[cost]
+input = 0.1
+output = 0.3
 
 [limit]
-context = 256000
-output = 256000
+context = 256_000
+output = 256_000
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/mistral/mistral-embed.toml
+++ b/providers/vercel/models/mistral/mistral-embed.toml
@@ -4,17 +4,13 @@ release_date = "2023-12-11"
 last_updated = "2023-12-11"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.1
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/mistral/mistral-nemo.toml
+++ b/providers/vercel/models/mistral/mistral-nemo.toml
@@ -6,16 +6,16 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-04"
+open_weights = false
 
 [cost]
-input = 0.04
-output = 0.17
+input = 0.02
+output = 0.04
 
 [limit]
-context = 60288
-output = 16000
+context = 131_072
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/moonshotai/kimi-k2-thinking-turbo.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2-thinking-turbo.toml
@@ -1,13 +1,5 @@
-name = "Kimi K2 Thinking Turbo"
-family = "kimi-thinking"
-release_date = "2025-11-06"
-last_updated = "2025-11-06"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
+base_model = "moonshotai/kimi-k2-thinking-turbo"
 open_weights = false
-knowledge = "2024-08"
 
 interleaved = true
 
@@ -17,9 +9,5 @@ output = 8
 cache_read = 0.15
 
 [limit]
-context = 262114
-output = 262114
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262_114
+output = 262_114

--- a/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
@@ -1,25 +1,13 @@
-name = "Kimi K2 Thinking"
-family = "kimi-thinking"
-release_date = "2025-11-06"
-last_updated = "2025-11-06"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
+base_model = "moonshotai/kimi-k2-thinking"
 open_weights = false
-knowledge = "2024-08"
 
 interleaved = true
 
 [cost]
-input = 0.47
-output = 2
-cache_read = 0.14
+input = 0.6
+output = 2.5
+cache_read = 0.15
 
 [limit]
-context = 216144
-output = 216144
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262_114
+output = 262_114

--- a/providers/vercel/models/moonshotai/kimi-k2-turbo.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2-turbo.toml
@@ -6,16 +6,17 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-08"
+open_weights = false
 
 [cost]
-input = 2.4
-output = 10
+input = 1.15
+output = 8
+cache_read = 0.15
 
 [limit]
-context = 256000
-output = 16384
+context = 256_000
+output = 16_384
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/moonshotai/kimi-k2.5.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.5.toml
@@ -1,24 +1,20 @@
-name = "Kimi K2.5"
+base_model = "moonshotai/kimi-k2.5"
 family = "kimi"
 release_date = "2026-01-26"
-last_updated = "2026-01-26"
 attachment = true
-reasoning = true
 temperature = true
-tool_call = true
-knowledge = "2025-01"
-open_weights = true
 
 interleaved = true
 
 [cost]
-input = 0.60
-output = 1.20
+input = 0.6
+output = 3
+cache_read = 0.1
 
 [limit]
-context = 262_144
-output = 262_144
+context = 262_114
+output = 262_114
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/vercel/models/moonshotai/kimi-k2.6.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.6.toml
@@ -1,12 +1,5 @@
-name = "Kimi K2.6"
-family = "kimi-k2.6"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
+base_model = "moonshotai/kimi-k2.6"
 release_date = "2026-04-20"
-last_updated = "2026-04-24"
-open_weights = true
 
 [cost]
 input = 0.95

--- a/providers/vercel/models/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/vercel/models/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -1,23 +1,9 @@
-name = "Nemotron 3 Nano 30B A3B"
 base_model = "nvidia/nemotron-3-nano-30b-a3b"
-family = "nemotron"
-release_date = "2024-12"
-last_updated = "2024-12"
-attachment = false
-reasoning = true
-temperature = true
+release_date = "2024-12-01"
 tool_call = false
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
-input = 0.06
+input = 0.05
 output = 0.24
-
-[limit]
-context = 262144
-output = 262144
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/vercel/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,12 +1,8 @@
-name = "NVIDIA Nemotron 3 Super 120B A12B"
 base_model = "nvidia/nemotron-3-super-120b-a12b"
-family = "nemotron"
-attachment = false
+name = "NVIDIA Nemotron 3 Super 120B A12B"
+release_date = "2026-03-18"
 reasoning = false
 tool_call = false
-temperature = true
-release_date = "2026-03-18"
-last_updated = "2026-03-30"
 open_weights = false
 
 [cost]
@@ -16,7 +12,3 @@ output = 0.65
 [limit]
 context = 256_000
 output = 32_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/vercel/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,12 @@
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+name = "Nemotron 3 Ultra"
+open_weights = false
+
+[cost]
+input = 0.6
+output = 2.4
+cache_read = 0.12
+
+[limit]
+context = 1_000_000
+output = 65_000

--- a/providers/vercel/models/nvidia/nemotron-nano-12b-v2-vl.toml
+++ b/providers/vercel/models/nvidia/nemotron-nano-12b-v2-vl.toml
@@ -1,22 +1,16 @@
-name = "Nvidia Nemotron Nano 12B V2 VL"
 base_model = "nvidia/nemotron-nano-12b-v2-vl"
-family = "nemotron"
-release_date = "2024-12"
-last_updated = "2024-12"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
+name = "Nvidia Nemotron Nano 12B V2 VL"
+release_date = "2024-12-01"
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.2
 output = 0.6
 
 [limit]
-context = 131072
-output = 131072
+context = 131_072
+output = 131_072
 
 [modalities]
 input = ["text", "image"]

--- a/providers/vercel/models/nvidia/nemotron-nano-9b-v2.toml
+++ b/providers/vercel/models/nvidia/nemotron-nano-9b-v2.toml
@@ -1,23 +1,8 @@
-name = "Nvidia Nemotron Nano 9B V2"
 base_model = "nvidia/nemotron-nano-9b-v2"
-family = "nemotron"
-release_date = "2025-08-18"
-last_updated = "2025-08-18"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
+name = "Nvidia Nemotron Nano 9B V2"
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
-input = 0.04
-output = 0.16
-
-[limit]
-context = 131072
-output = 131072
-
-[modalities]
-input = ["text"]
-output = ["text"]
+input = 0.06
+output = 0.23

--- a/providers/vercel/models/openai/gpt-3.5-turbo-instruct.toml
+++ b/providers/vercel/models/openai/gpt-3.5-turbo-instruct.toml
@@ -1,22 +1,22 @@
 name = "GPT-3.5 Turbo Instruct"
 family = "gpt"
-release_date = "2023-03-01"
+release_date = "2023-09-28"
 last_updated = "2023-03-01"
 attachment = false
 reasoning = false
 temperature = true
 tool_call = false
-open_weights = false
 knowledge = "2021-09"
+open_weights = false
 
 [cost]
 input = 1.5
 output = 2
 
 [limit]
-context = 8192
+context = 8_192
 input = 4_096
-output = 4096
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/openai/gpt-3.5-turbo.toml
+++ b/providers/vercel/models/openai/gpt-3.5-turbo.toml
@@ -1,12 +1,6 @@
+base_model = "openai/gpt-3.5-turbo"
 name = "GPT-3.5 Turbo"
-family = "gpt"
-release_date = "2023-03-01"
-last_updated = "2023-03-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = false
-open_weights = false
+release_date = "2023-05-28"
 knowledge = "2021-09"
 
 [cost]
@@ -14,10 +8,6 @@ input = 0.5
 output = 1.5
 
 [limit]
-context = 16385
+context = 16_385
 input = 12_289
-output = 4096
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 4_096

--- a/providers/vercel/models/openai/gpt-4o-mini-search-preview.toml
+++ b/providers/vercel/models/openai/gpt-4o-mini-search-preview.toml
@@ -1,18 +1,18 @@
 name = "GPT 4o Mini Search Preview"
 family = "gpt-mini"
-release_date = "2025-01"
+release_date = "2025-03-12"
 last_updated = "2025-01"
 attachment = false
 reasoning = false
 temperature = true
-knowledge = "2023-09"
 tool_call = false
 structured_output = false
+knowledge = "2023-09"
 open_weights = false
 
 [cost]
 input = 0.15
-output = 0.60
+output = 0.6
 
 [limit]
 context = 128_000

--- a/providers/vercel/models/openai/gpt-5-chat.toml
+++ b/providers/vercel/models/openai/gpt-5-chat.toml
@@ -6,18 +6,18 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 1.25
 output = 10
-cache_read = 0.13
+cache_read = 0.125
 
 [limit]
-context = 128000
+context = 128_000
 input = 111_616
-output = 16384
+output = 16_384
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5-pro.toml
+++ b/providers/vercel/models/openai/gpt-5-pro.toml
@@ -1,12 +1,8 @@
+base_model = "openai/gpt-5-pro"
 name = "GPT-5 pro"
 family = "gpt"
 release_date = "2025-08-07"
-last_updated = "2025-08-07"
-attachment = true
-reasoning = true
 temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
 
 [cost]
@@ -14,9 +10,9 @@ input = 15
 output = 120
 
 [limit]
-context = 400000
+context = 400_000
 input = 128_000
-output = 272000
+output = 272_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/vercel/models/openai/gpt-5.1-codex-max.toml
@@ -1,23 +1,14 @@
+base_model = "openai/gpt-5.1-codex-max"
 name = "GPT 5.1 Codex Max"
 family = "gpt"
-release_date = "2025-08-07"
-last_updated = "2025-08-07"
-attachment = true
-reasoning = true
+release_date = "2025-11-19"
 temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
 
 [cost]
 input = 1.25
 output = 10
-cache_read = 0.13
-
-[limit]
-context = 400000
-input = 272_000
-output = 128000
+cache_read = 0.125
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/vercel/models/openai/gpt-5.1-codex-mini.toml
@@ -1,23 +1,13 @@
-name = "GPT-5.1 Codex mini"
+base_model = "openai/gpt-5.1-codex-mini"
 family = "gpt"
-release_date = "2025-05-16"
-last_updated = "2025-05-16"
-attachment = true
-reasoning = true
+release_date = "2025-11-12"
 temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
 
 [cost]
 input = 0.25
 output = 2
-cache_read = 0.03
-
-[limit]
-context = 400000
-input = 272_000
-output = 128000
+cache_read = 0.025
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.1-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.1-codex.toml
@@ -1,23 +1,14 @@
+base_model = "openai/gpt-5.1-codex"
 name = "GPT-5.1-Codex"
 family = "gpt"
-release_date = "2025-08-07"
-last_updated = "2025-08-07"
-attachment = true
-reasoning = true
+release_date = "2025-11-12"
 temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
 
 [cost]
 input = 1.25
 output = 10
-cache_read = 0.13
-
-[limit]
-context = 400000
-input = 272_000
-output = 128000
+cache_read = 0.125
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.1-instant.toml
+++ b/providers/vercel/models/openai/gpt-5.1-instant.toml
@@ -1,24 +1,24 @@
 name = "GPT-5.1 Instant"
 family = "gpt"
-release_date = "2025-08-07"
+release_date = "2025-11-12"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 1.25
 output = 10
-cache_read = 0.13
+cache_read = 0.125
 
 [limit]
-context = 128000
+context = 128_000
 input = 111_616
-output = 16384
+output = 16_384
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text", "image"]
+output = ["text"]

--- a/providers/vercel/models/openai/gpt-5.1-thinking.toml
+++ b/providers/vercel/models/openai/gpt-5.1-thinking.toml
@@ -1,23 +1,23 @@
 name = "GPT 5.1 Thinking"
 family = "gpt"
-release_date = "2025-08-07"
+release_date = "2025-11-12"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-temperature = false
+temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 1.25
 output = 10
-cache_read = 0.13
+cache_read = 0.125
 
 [limit]
-context = 400000
+context = 400_000
 input = 272_000
-output = 128000
+output = 128_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.2-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.2-chat.toml
@@ -1,23 +1,23 @@
 name = "GPT-5.2 Chat"
 family = "gpt"
-release_date = "2025-08-07"
+release_date = "2025-12-11"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 1.75
 output = 14
-cache_read = 0.18
+cache_read = 0.175
 
 [limit]
-context = 128000
+context = 128_000
 input = 111_616
-output = 16384
+output = 16_384
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.2-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.2-codex.toml
@@ -1,24 +1,10 @@
+base_model = "openai/gpt-5.2-codex"
 name = "GPT-5.2-Codex"
-family = "gpt-codex"
-release_date = "2025-12"
-last_updated = "2025-12"
-attachment = true
-reasoning = true
+release_date = "2025-12-18"
 temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
 
 [cost]
 input = 1.75
 output = 14
 cache_read = 0.175
-
-[limit]
-context = 400000
-input = 272_000
-output = 128000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/openai/gpt-5.2-pro.toml
+++ b/providers/vercel/models/openai/gpt-5.2-pro.toml
@@ -1,22 +1,12 @@
+base_model = "openai/gpt-5.2-pro"
 name = "GPT 5.2 "
 family = "gpt"
-release_date = "2025-08-07"
-last_updated = "2025-08-07"
-attachment = true
-reasoning = true
 temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
 
 [cost]
 input = 21
 output = 168
-
-[limit]
-context = 400000
-input = 272_000
-output = 128000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.2.toml
+++ b/providers/vercel/models/openai/gpt-5.2.toml
@@ -1,23 +1,11 @@
-name = "GPT-5.2"
-family = "gpt"
-release_date = "2025-08-07"
-last_updated = "2025-08-07"
-attachment = true
-reasoning = true
+base_model = "openai/gpt-5.2"
 temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
 
 [cost]
 input = 1.75
 output = 14
-cache_read = 0.18
-
-[limit]
-context = 400000
-input = 272_000
-output = 128000
+cache_read = 0.175
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.3-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.3-codex.toml
@@ -1,23 +1,10 @@
+base_model = "openai/gpt-5.3-codex"
 name = "GPT 5.3 Codex"
 family = "gpt"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-02-24"
-last_updated = "2026-02-24"
-open_weights = false
+temperature = true
 
 [cost]
 input = 1.75
 output = 14
 cache_read = 0.175
-
-[limit]
-context = 400_000
-input = 272_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/openai/gpt-5.4-mini.toml
+++ b/providers/vercel/models/openai/gpt-5.4-mini.toml
@@ -1,22 +1,12 @@
+base_model = "openai/gpt-5.4-mini"
 name = "GPT 5.4 Mini"
 family = "gpt"
-attachment = true
-reasoning = true
-tool_call = true
 temperature = true
-release_date = "2026-03-17"
-last_updated = "2026-03-17"
-open_weights = false
 
 [cost]
 input = 0.75
 output = 4.5
 cache_read = 0.075
-
-[limit]
-context = 400_000
-input = 272_000
-output = 128_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.4-nano.toml
+++ b/providers/vercel/models/openai/gpt-5.4-nano.toml
@@ -1,22 +1,12 @@
+base_model = "openai/gpt-5.4-nano"
 name = "GPT 5.4 Nano"
 family = "gpt"
-attachment = true
-reasoning = true
-tool_call = true
 temperature = true
-release_date = "2026-03-17"
-last_updated = "2026-03-17"
-open_weights = false
 
 [cost]
-input = 0.19999999999999998
+input = 0.2
 output = 1.25
 cache_read = 0.02
-
-[limit]
-context = 400_000
-input = 272_000
-output = 128_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.4-pro.toml
+++ b/providers/vercel/models/openai/gpt-5.4-pro.toml
@@ -1,21 +1,11 @@
+base_model = "openai/gpt-5.4-pro"
 name = "GPT 5.4 Pro"
 family = "gpt"
-attachment = true
-reasoning = true
-tool_call = true
 temperature = true
-release_date = "2026-03-05"
-last_updated = "2026-03-06"
-open_weights = false
 
 [cost]
 input = 30
 output = 180
-
-[limit]
-context = 1_050_000
-input = 922_000
-output = 128_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/gpt-5.4.toml
+++ b/providers/vercel/models/openai/gpt-5.4.toml
@@ -1,23 +1,8 @@
+base_model = "openai/gpt-5.4"
 name = "GPT 5.4"
-family = "gpt"
-attachment = true
-reasoning = true
-tool_call = true
 temperature = true
-release_date = "2026-03-05"
-last_updated = "2026-03-06"
-open_weights = false
 
 [cost]
 input = 2.5
 output = 15
 cache_read = 0.25
-
-[limit]
-context = 1_050_000
-input = 922_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/openai/gpt-5.5-pro.toml
+++ b/providers/vercel/models/openai/gpt-5.5-pro.toml
@@ -1,12 +1,8 @@
+base_model = "openai/gpt-5.5-pro"
 name = "GPT 5.5 Pro"
 family = "gpt"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-04-24"
-last_updated = "2026-04-24"
-open_weights = false
+temperature = true
 
 [cost]
 input = 30
@@ -16,7 +12,3 @@ output = 180
 context = 1_000_000
 input = 872_000
 output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/openai/gpt-5.5.toml
+++ b/providers/vercel/models/openai/gpt-5.5.toml
@@ -1,12 +1,7 @@
+base_model = "openai/gpt-5.5"
 name = "GPT 5.5"
-family = "gpt"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-04-24"
-last_updated = "2026-04-24"
-open_weights = false
+temperature = true
 
 [cost]
 input = 5
@@ -17,7 +12,3 @@ cache_read = 0.5
 context = 1_000_000
 input = 872_000
 output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/openai/gpt-oss-120b.toml
+++ b/providers/vercel/models/openai/gpt-oss-120b.toml
@@ -6,16 +6,18 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = true
 knowledge = "2024-10"
+open_weights = true
 
 [cost]
-input = 0.10
-output = 0.50
+input = 0.35
+output = 0.75
+cache_read = 0.25
 
 [limit]
 context = 131_072
-output = 131072
+input = 72
+output = 131_000
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/openai/gpt-oss-20b.toml
+++ b/providers/vercel/models/openai/gpt-oss-20b.toml
@@ -6,17 +6,17 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = true
 knowledge = "2024-10"
+open_weights = true
 
 [cost]
-input = 0.07
-output = 0.30
+input = 0.05
+output = 0.2
 
 [limit]
 context = 131_072
-input = 98_304
-output = 32_768
+input = 122_880
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/vercel/models/openai/gpt-oss-safeguard-20b.toml
@@ -6,18 +6,18 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
-input = 0.08
+input = 0.075
 output = 0.3
-cache_read = 0.04
+cache_read = 0.037
 
 [limit]
-context = 131072
+context = 131_072
 input = 65_536
-output = 65536
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/openai/o3-deep-research.toml
+++ b/providers/vercel/models/openai/o3-deep-research.toml
@@ -1,12 +1,5 @@
-name = "o3-deep-research"
-family = "o"
-release_date = "2024-06-26"
-last_updated = "2024-06-26"
-attachment = true
-reasoning = true
-temperature = false
-tool_call = true
-open_weights = false
+base_model = "openai/o3-deep-research"
+temperature = true
 knowledge = "2024-10"
 
 [cost]
@@ -15,9 +8,9 @@ output = 40
 cache_read = 2.5
 
 [limit]
-context = 200000
+context = 200_000
 input = 100_000
-output = 100000
+output = 100_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/o3-pro.toml
+++ b/providers/vercel/models/openai/o3-pro.toml
@@ -1,12 +1,7 @@
+base_model = "openai/o3-pro"
 name = "o3 Pro"
-family = "o-pro"
 release_date = "2025-04-16"
-last_updated = "2025-04-16"
-attachment = true
-reasoning = true
-temperature = false
-tool_call = true
-open_weights = false
+temperature = true
 knowledge = "2024-10"
 
 [cost]
@@ -14,9 +9,9 @@ input = 20
 output = 80
 
 [limit]
-context = 200000
+context = 200_000
 input = 100_000
-output = 100000
+output = 100_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/openai/text-embedding-3-large.toml
+++ b/providers/vercel/models/openai/text-embedding-3-large.toml
@@ -4,18 +4,14 @@ release_date = "2024-01-25"
 last_updated = "2024-01-25"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.13
-output = 0
-
 [limit]
-context = 8192
+context = 8_192
 input = 6_656
-output = 1536
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/openai/text-embedding-3-small.toml
+++ b/providers/vercel/models/openai/text-embedding-3-small.toml
@@ -4,18 +4,14 @@ release_date = "2024-01-25"
 last_updated = "2024-01-25"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.02
-output = 0
-
 [limit]
-context = 8192
+context = 8_192
 input = 6_656
-output = 1536
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/openai/text-embedding-ada-002.toml
+++ b/providers/vercel/models/openai/text-embedding-ada-002.toml
@@ -4,18 +4,14 @@ release_date = "2022-12-15"
 last_updated = "2022-12-15"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.1
-output = 0
-
 [limit]
-context = 8192
+context = 8_192
 input = 6_656
-output = 1536
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/perplexity/sonar-pro.toml
+++ b/providers/vercel/models/perplexity/sonar-pro.toml
@@ -5,13 +5,9 @@ last_updated = "2025-02-19"
 attachment = true
 reasoning = false
 temperature = true
-knowledge = "2025-09"
 tool_call = true
+knowledge = "2025-09"
 open_weights = false
-
-[cost]
-input = 3.0
-output = 15.0
 
 [limit]
 context = 200_000

--- a/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
@@ -5,13 +5,9 @@ last_updated = "2025-02-19"
 attachment = false
 reasoning = true
 temperature = true
-knowledge = "2025-09"
 tool_call = false
+knowledge = "2025-09"
 open_weights = false
-
-[cost]
-input = 2.0
-output = 8.0
 
 [limit]
 context = 127_000

--- a/providers/vercel/models/perplexity/sonar.toml
+++ b/providers/vercel/models/perplexity/sonar.toml
@@ -5,13 +5,9 @@ last_updated = "2025-02-19"
 attachment = true
 reasoning = false
 temperature = true
-knowledge = "2025-02"
 tool_call = true
+knowledge = "2025-02"
 open_weights = false
-
-[cost]
-input = 1.0
-output = 1.0
 
 [limit]
 context = 127_000

--- a/providers/vercel/models/stepfun/step-3.5-flash.toml
+++ b/providers/vercel/models/stepfun/step-3.5-flash.toml
@@ -1,0 +1,14 @@
+base_model = "stepfun/step-3.5-flash"
+base_model_omit = ["limit.input"]
+name = "StepFun 3.5 Flash"
+family = "step"
+open_weights = false
+
+[cost]
+input = 0.09
+output = 0.3
+cache_write = 0.02
+
+[limit]
+context = 262_114
+output = 262_114

--- a/providers/vercel/models/stepfun/step-3.7-flash.toml
+++ b/providers/vercel/models/stepfun/step-3.7-flash.toml
@@ -1,0 +1,22 @@
+name = "Step 3.7 Flash"
+family = "step"
+release_date = "2026-05-28"
+last_updated = "2026-05-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 1.15
+cache_read = 0.04
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/vercel/models/voyage/voyage-3-large.toml
+++ b/providers/vercel/models/voyage/voyage-3-large.toml
@@ -1,20 +1,16 @@
 name = "voyage-3-large"
 family = "voyage"
-release_date = "2024-09"
+release_date = "2024-09-01"
 last_updated = "2024-09"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.18
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/voyage/voyage-3.5-lite.toml
+++ b/providers/vercel/models/voyage/voyage-3.5-lite.toml
@@ -4,17 +4,13 @@ release_date = "2025-05-20"
 last_updated = "2025-05-20"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.02
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/voyage/voyage-3.5.toml
+++ b/providers/vercel/models/voyage/voyage-3.5.toml
@@ -4,17 +4,13 @@ release_date = "2025-05-20"
 last_updated = "2025-05-20"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.06
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/voyage/voyage-code-2.toml
+++ b/providers/vercel/models/voyage/voyage-code-2.toml
@@ -1,20 +1,16 @@
 name = "voyage-code-2"
 family = "voyage"
-release_date = "2024-01"
+release_date = "2024-01-01"
 last_updated = "2024-01"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.12
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/voyage/voyage-code-3.toml
+++ b/providers/vercel/models/voyage/voyage-code-3.toml
@@ -1,20 +1,16 @@
 name = "voyage-code-3"
 family = "voyage"
-release_date = "2024-09"
+release_date = "2024-09-01"
 last_updated = "2024-09"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.18
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/voyage/voyage-finance-2.toml
+++ b/providers/vercel/models/voyage/voyage-finance-2.toml
@@ -1,20 +1,16 @@
 name = "voyage-finance-2"
 family = "voyage"
-release_date = "2024-03"
+release_date = "2024-03-01"
 last_updated = "2024-03"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.12
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/voyage/voyage-law-2.toml
+++ b/providers/vercel/models/voyage/voyage-law-2.toml
@@ -1,20 +1,16 @@
 name = "voyage-law-2"
 family = "voyage"
-release_date = "2024-03"
+release_date = "2024-03-01"
 last_updated = "2024-03"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
 
-[cost]
-input = 0.12
-output = 0
-
 [limit]
-context = 8192
-output = 1536
+context = 8_192
+output = 1_536
 
 [modalities]
 input = ["text"]

--- a/providers/vercel/models/xai/grok-4.1-fast-non-reasoning.toml
+++ b/providers/vercel/models/xai/grok-4.1-fast-non-reasoning.toml
@@ -6,8 +6,8 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.2
@@ -15,9 +15,9 @@ output = 0.5
 cache_read = 0.05
 
 [limit]
-context = 2000000
-output = 30000
+context = 1_000_000
+output = 1_000_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/xai/grok-4.1-fast-reasoning.toml
+++ b/providers/vercel/models/xai/grok-4.1-fast-reasoning.toml
@@ -6,8 +6,8 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.2
@@ -15,9 +15,9 @@ output = 0.5
 cache_read = 0.05
 
 [limit]
-context = 2000000
-output = 30000
+context = 1_000_000
+output = 1_000_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/xai/grok-4.20-multi-agent-beta.toml
+++ b/providers/vercel/models/xai/grok-4.20-multi-agent-beta.toml
@@ -1,22 +1,22 @@
 name = "Grok 4.20 Multi Agent Beta"
 family = "grok"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-03-11"
 last_updated = "2026-03-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
 open_weights = false
 
 [cost]
-input = 2
-output = 6
-cache_read = 0.19999999999999998
+input = 1.25
+output = 2.5
+cache_read = 0.2
 
 [limit]
 context = 2_000_000
 output = 2_000_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/xai/grok-4.20-multi-agent.toml
+++ b/providers/vercel/models/xai/grok-4.20-multi-agent.toml
@@ -1,22 +1,22 @@
 name = "Grok 4.20 Multi-Agent"
 family = "grok"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-03-09"
 last_updated = "2026-03-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
 open_weights = false
 
 [cost]
-input = 2
-output = 6
-cache_read = 0.19999999999999998
+input = 1.25
+output = 2.5
+cache_read = 0.2
 
 [limit]
 context = 2_000_000
 output = 2_000_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/xai/grok-4.20-non-reasoning-beta.toml
+++ b/providers/vercel/models/xai/grok-4.20-non-reasoning-beta.toml
@@ -1,17 +1,17 @@
 name = "Grok 4.20 Beta Non-Reasoning"
 family = "grok"
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
 release_date = "2026-03-11"
 last_updated = "2026-03-13"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
 open_weights = false
 
 [cost]
-input = 2
-output = 6
-cache_read = 0.19999999999999998
+input = 1.25
+output = 2.5
+cache_read = 0.4
 
 [limit]
 context = 2_000_000

--- a/providers/vercel/models/xai/grok-4.20-non-reasoning.toml
+++ b/providers/vercel/models/xai/grok-4.20-non-reasoning.toml
@@ -1,17 +1,17 @@
 name = "Grok 4.20 Non-Reasoning"
 family = "grok"
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
 release_date = "2026-03-09"
 last_updated = "2026-03-23"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
 open_weights = false
 
 [cost]
-input = 2
-output = 6
-cache_read = 0.19999999999999998
+input = 1.25
+output = 2.5
+cache_read = 0.2
 
 [limit]
 context = 2_000_000

--- a/providers/vercel/models/xai/grok-4.20-reasoning-beta.toml
+++ b/providers/vercel/models/xai/grok-4.20-reasoning-beta.toml
@@ -1,17 +1,17 @@
 name = "Grok 4.20 Beta Reasoning"
 family = "grok"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-03-11"
 last_updated = "2026-03-13"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
 open_weights = false
 
 [cost]
-input = 2
-output = 6
-cache_read = 0.19999999999999998
+input = 1.25
+output = 2.5
+cache_read = 0.2
 
 [limit]
 context = 2_000_000

--- a/providers/vercel/models/xai/grok-4.20-reasoning.toml
+++ b/providers/vercel/models/xai/grok-4.20-reasoning.toml
@@ -1,17 +1,17 @@
 name = "Grok 4.20 Reasoning"
 family = "grok"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-03-09"
 last_updated = "2026-03-23"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
 open_weights = false
 
 [cost]
-input = 2
-output = 6
-cache_read = 0.19999999999999998
+input = 1.25
+output = 2.5
+cache_read = 0.2
 
 [limit]
 context = 2_000_000

--- a/providers/vercel/models/xai/grok-4.3.toml
+++ b/providers/vercel/models/xai/grok-4.3.toml
@@ -1,22 +1,11 @@
-name = "Grok 4.3"
-family = "grok"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
+base_model = "xai/grok-4.3"
 release_date = "2026-04-30"
-last_updated = "2026-05-01"
-open_weights = false
 
 [cost]
 input = 1.25
 output = 2.5
-cache_read = 0.19999999999999998
+cache_read = 0.2
 
 [limit]
 context = 1_000_000
 output = 1_000_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/vercel/models/xai/grok-build-0.1.toml
+++ b/providers/vercel/models/xai/grok-build-0.1.toml
@@ -1,21 +1,10 @@
-name = "Grok Build 0.1"
-family = "grok-build"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
+base_model = "xai/grok-build-0.1"
 release_date = "2026-05-20"
-last_updated = "2026-05-21"
-open_weights = false
 
 [cost]
 input = 1
 output = 2
-cache_read = 0.19999999999999998
-
-[limit]
-context = 256_000
-output = 256_000
+cache_read = 0.2
 
 [modalities]
 input = ["text", "image"]

--- a/providers/vercel/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2-flash.toml
@@ -1,22 +1,14 @@
+base_model = "xiaomi/mimo-v2-flash"
 name = "MiMo V2 Flash"
-family = "mimo"
 release_date = "2025-12-17"
-last_updated = "2025-12-17"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.1
-output = 0.29
+output = 0.3
+cache_read = 0.01
 
 [limit]
-context = 262144
-output = 32000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262_144
+output = 32_000

--- a/providers/vercel/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2-pro.toml
@@ -1,22 +1,11 @@
+base_model = "xiaomi/mimo-v2-pro"
 name = "MiMo V2 Pro"
-family = "mimo"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-03-18"
-last_updated = "2026-03-20"
-open_weights = false
 
 [cost]
 input = 1
 output = 3
-cache_read = 0.19999999999999998
+cache_read = 0.2
 
 [limit]
 context = 1_000_000
 output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,22 +1,18 @@
+base_model = "xiaomi/mimo-v2.5-pro"
 name = "MiMo V2.5 Pro"
 family = "mimo-v2.5-pro"
 attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-04-22"
-last_updated = "2026-05-01"
 open_weights = false
 
 [cost]
-input = 1
-output = 3
-cache_read = 0.19999999999999998
+input = 0.435
+output = 0.87
+cache_read = 0.0036
 
 [limit]
 context = 1_050_000
 output = 131_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/xiaomi/mimo-v2.5.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2.5.toml
@@ -1,22 +1,17 @@
+base_model = "xiaomi/mimo-v2.5"
 name = "MiMo M2.5"
 family = "mimo-v2.5"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-04-22"
-last_updated = "2026-05-01"
 open_weights = false
 
 [cost]
-input = 0.39999999999999997
-output = 2
-cache_read = 0.08
+input = 0.14
+output = 0.28
+cache_read = 0.0028
 
 [limit]
 context = 1_050_000
 output = 131_100
 
 [modalities]
-input = ["text", "image", "audio", "video"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/vercel/models/zai/glm-4.5-air.toml
+++ b/providers/vercel/models/zai/glm-4.5-air.toml
@@ -1,22 +1,11 @@
+base_model = "zhipuai/glm-4.5-air"
 name = "GLM 4.5 Air"
-family = "glm-air"
-release_date = "2025-07-28"
-last_updated = "2025-07-28"
-attachment = false
-reasoning = true
-temperature = true
-knowledge = "2025-04"
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0.2
 output = 1.1
+cache_read = 0.03
 
 [limit]
 context = 128_000
 output = 96_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/zai/glm-4.5.toml
+++ b/providers/vercel/models/zai/glm-4.5.toml
@@ -1,24 +1,14 @@
+base_model = "zhipuai/glm-4.5"
 name = "GLM 4.5"
-family = "glm"
-release_date = "2025-07-28"
-last_updated = "2025-07-28"
-attachment = false
-reasoning = true
-temperature = true
 knowledge = "2025-07"
-tool_call = true
-open_weights = true
 
 interleaved = true
 
 [cost]
 input = 0.6
 output = 2.2
+cache_read = 0.11
 
 [limit]
-context = 131072
-output = 131072
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 128_000
+output = 96_000

--- a/providers/vercel/models/zai/glm-4.5v.toml
+++ b/providers/vercel/models/zai/glm-4.5v.toml
@@ -1,21 +1,15 @@
+base_model = "zhipuai/glm-4.5v"
 name = "GLM 4.5V"
-family = "glm"
-release_date = "2025-08-11"
-last_updated = "2025-08-11"
-attachment = true
-reasoning = true
-temperature = true
 knowledge = "2025-08"
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0.6
 output = 1.8
+cache_read = 0.11
 
 [limit]
 context = 66_000
-output = 66000
+output = 16_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/vercel/models/zai/glm-4.6.toml
+++ b/providers/vercel/models/zai/glm-4.6.toml
@@ -1,25 +1,13 @@
+base_model = "zhipuai/glm-4.6"
 name = "GLM 4.6"
-family = "glm"
-release_date = "2025-09-30"
-last_updated = "2025-09-30"
-attachment = false
-reasoning = true
-temperature = true
-knowledge = "2025-04"
-tool_call = true
-open_weights = true
 
 interleaved = true
 
 [cost]
-input = 0.45
-output = 1.8
-cached_input = 0.45
+input = 0.6
+output = 2.2
+cache_read = 0.11
 
 [limit]
 context = 200_000
-output = 96000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 96_000

--- a/providers/vercel/models/zai/glm-4.6v.toml
+++ b/providers/vercel/models/zai/glm-4.6v.toml
@@ -1,13 +1,7 @@
-name = "GLM-4.6V"
-family = "glm"
+base_model = "zhipuai/glm-4.6v"
 release_date = "2025-09-30"
-last_updated = "2025-09-30"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 [cost]
 input = 0.3
@@ -15,8 +9,8 @@ output = 0.9
 cache_read = 0.05
 
 [limit]
-context = 128000
-output = 24000
+context = 128_000
+output = 24_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/zai/glm-4.7-flash.toml
+++ b/providers/vercel/models/zai/glm-4.7-flash.toml
@@ -1,21 +1,13 @@
+base_model = "zhipuai/glm-4.7-flash"
 name = "GLM 4.7 Flash"
 family = "glm"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-03-13"
-last_updated = "2026-03-13"
 open_weights = false
 
 [cost]
 input = 0.07
-output = 0.39999999999999997
+output = 0.4
 
 [limit]
 context = 200_000
 output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/zai/glm-4.7-flashx.toml
+++ b/providers/vercel/models/zai/glm-4.7-flashx.toml
@@ -1,25 +1,15 @@
+base_model = "zhipuai/glm-4.7-flashx"
 name = "GLM 4.7 FlashX"
-family = "glm-flash"
-release_date = "2025-01"
-last_updated = "2025-01"
-attachment = false
-reasoning = true
-temperature = true
+release_date = "2025-01-01"
 knowledge = "2025-01"
-tool_call = true
-open_weights = true
 
 interleaved = true
 
 [cost]
 input = 0.06
-output = 0.40
+output = 0.4
 cache_read = 0.01
 
 [limit]
 context = 200_000
 output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/zai/glm-4.7.toml
+++ b/providers/vercel/models/zai/glm-4.7.toml
@@ -1,25 +1,15 @@
+base_model = "zhipuai/glm-4.7"
 name = "GLM 4.7"
-family = "glm"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
 
 interleaved = true
 
 [cost]
-input = 0.43
-output = 1.75
-cache_read = 0.08
+input = 2.25
+output = 2.75
+cache_read = 2.25
 
 [limit]
-context = 202752
-output = 120000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 131_000
+output = 40_000

--- a/providers/vercel/models/zai/glm-5-turbo.toml
+++ b/providers/vercel/models/zai/glm-5-turbo.toml
@@ -1,12 +1,6 @@
+base_model = "zhipuai/glm-5-turbo"
 name = "GLM 5 Turbo"
-family = "glm"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-03-15"
-last_updated = "2026-03-17"
-open_weights = false
 
 [cost]
 input = 1.2
@@ -16,7 +10,3 @@ cache_read = 0.24
 [limit]
 context = 202_800
 output = 131_100
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/zai/glm-5.1.toml
+++ b/providers/vercel/models/zai/glm-5.1.toml
@@ -1,11 +1,7 @@
+base_model = "zhipuai/glm-5.1"
 name = "GLM 5.1"
-family = "glm"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
 release_date = "2026-04-07"
-last_updated = "2026-04-16"
+attachment = true
 open_weights = false
 
 [cost]
@@ -14,8 +10,8 @@ output = 4.4
 cache_read = 0.26
 
 [limit]
-context = 202_752
-output = 202_752
+context = 202_800
+output = 64_000
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/vercel/models/zai/glm-5.toml
+++ b/providers/vercel/models/zai/glm-5.toml
@@ -1,22 +1,11 @@
-name = "GLM-5"
-family = "glm"
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
+base_model = "zhipuai/glm-5"
 release_date = "2026-02-12"
-last_updated = "2026-02-19"
-open_weights = true
 
 [cost]
 input = 1
-output = 3.20
-cache_read = 0.20
+output = 3.2
+cache_read = 0.2
 
 [limit]
 context = 202_800
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 131_100

--- a/providers/vercel/models/zai/glm-5v-turbo.toml
+++ b/providers/vercel/models/zai/glm-5v-turbo.toml
@@ -1,12 +1,5 @@
+base_model = "zhipuai/glm-5v-turbo"
 name = "GLM 5V Turbo"
-family = "glm"
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-release_date = "2026-04-01"
-last_updated = "2026-04-03"
-open_weights = false
 
 [cost]
 input = 1.2


### PR DESCRIPTION
## Summary
- sync the Vercel AI Gateway catalog against the live public models endpoint
- add 7 newly returned models and update 147 existing entries
- factor 72 matching provider records through canonical `base_model` metadata
- preserve all existing symlink aliases and retain API-missing local models

## New models
- `alibaba/qwen3.7-plus`
- `google/gemini-3.1-flash-image`
- `inception/mercury-coder-small`
- `minimax/minimax-m3`
- `nvidia/nemotron-3-ultra-550b-a55b`
- `stepfun/step-3.5-flash`
- `stepfun/step-3.7-flash`

## Validation
- `bun validate`
- second `bun models:sync vercel --dry-run`: 0 created, 0 updated, 0 deleted
- `git diff --check`

## Dependency
Stacked on #2041; only `providers/vercel/models/**` differs from that branch.