### PR TITLE
feat(zenmux): add 11 new model definitions

### DIFF
--- a/models/alibaba/qwen3.7-plus.toml
+++ b/models/alibaba/qwen3.7-plus.toml
@@ -10,9 +10,9 @@ knowledge = "2025-04"
 open_weights = false
 
 [limit]
-context = 131_072
-output = 16_384
+context = 1_000_000
+output = 64_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]

--- a/models/openai/gpt-5.5-instant.toml
+++ b/models/openai/gpt-5.5-instant.toml
@@ -1,0 +1,19 @@
+name = "GPT-5.5 Instant"
+release_date = "2026-05-05"
+last_updated = "2026-05-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-12-01"
+open_weights = false
+
+[limit]
+context = 400_000
+input = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/models/stepfun/step-3.7-flash.toml
+++ b/models/stepfun/step-3.7-flash.toml
@@ -1,0 +1,22 @@
+name = "Step 3.7 Flash"
+release_date = "2026-05-29"
+last_updated = "2026-05-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2026-01-01"
+open_weights = true
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/stepfun-ai/Step-3.7-Flash"

--- a/providers/zenmux/models/anthropic/claude-opus-4.8.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.8.toml
@@ -1,0 +1,28 @@
+name = "Claude Opus 4.8"
+release_date = "2026-05-22"
+last_updated = "2026-05-22"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2026-03-31"
+open_weights = false
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"

--- a/providers/zenmux/models/anthropic/claude-opus-4.8.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.8.toml
@@ -1,4 +1,4 @@
-base_model = "anthropic/claude-opus-4.8"
+base_model = "anthropic/claude-opus-4-8"
 
 [cost]
 input = 5.00

--- a/providers/zenmux/models/anthropic/claude-opus-4.8.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.8.toml
@@ -1,27 +1,10 @@
-name = "Claude Opus 4.8"
-release_date = "2026-05-22"
-last_updated = "2026-05-22"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2026-03-31"
-open_weights = false
+base_model = "anthropic/claude-opus-4.8"
 
 [cost]
 input = 5.00
 output = 25.00
 cache_read = 0.50
 cache_write = 6.25
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]
-
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/zenmux/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/zenmux/models/google/gemini-3.1-flash-lite.toml
@@ -1,21 +1,6 @@
-name = "Gemini 3.1 Flash Lite"
-release_date = "2025-03-20"
-last_updated = "2025-03-20"
-attachment = true
-reasoning = false
-temperature = true
-tool_call = true
-open_weights = false
+base_model = "google/gemini-3.1-flash-lite"
 
 [cost]
 input = 0.25
 output = 1.50
 cache_read = 0.025
-
-[limit]
-context = 1_050_000
-output = 65_530
-
-[modalities]
-input = ["text", "image", "audio"]
-output = ["text"]

--- a/providers/zenmux/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/zenmux/models/google/gemini-3.1-flash-lite.toml
@@ -1,0 +1,21 @@
+name = "Gemini 3.1 Flash Lite"
+release_date = "2025-03-20"
+last_updated = "2025-03-20"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.25
+output = 1.50
+cache_read = 0.025
+
+[limit]
+context = 1_050_000
+output = 65_530
+
+[modalities]
+input = ["text", "image", "audio"]
+output = ["text"]

--- a/providers/zenmux/models/google/gemini-3.5-flash.toml
+++ b/providers/zenmux/models/google/gemini-3.5-flash.toml
@@ -1,22 +1,6 @@
-name = "Gemini 3.5 Flash"
-release_date = "2026-05-19"
-last_updated = "2026-05-19"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-01-31"
-open_weights = false
+base_model = "google/gemini-3.5-flash"
 
 [cost]
 input = 1.50
 output = 9.00
 cache_read = 0.15
-
-[limit]
-context = 1048_000
-output = 65_000
-
-[modalities]
-input = ["text", "image", "pdf", "audio", "video"]
-output = ["text"]

--- a/providers/zenmux/models/google/gemini-3.5-flash.toml
+++ b/providers/zenmux/models/google/gemini-3.5-flash.toml
@@ -1,0 +1,22 @@
+name = "Gemini 3.5 Flash"
+release_date = "2026-05-19"
+last_updated = "2026-05-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-01-31"
+open_weights = false
+
+[cost]
+input = 1.50
+output = 9.00
+cache_read = 0.15
+
+[limit]
+context = 1048_000
+output = 65_000
+
+[modalities]
+input = ["text", "image", "pdf", "audio", "video"]
+output = ["text"]

--- a/providers/zenmux/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/zenmux/models/inclusionai/ring-2.6-1t.toml
@@ -1,0 +1,22 @@
+name = "inclusionAI: Ring-2.6-1T"
+release_date = "2026-05-07"
+last_updated = "2026-05-14"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-12-31"
+open_weights = true
+
+[cost]
+input = 0.30
+output = 2.50
+cache_read = 0.06
+
+[limit]
+context = 262_000
+output = 65_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/minimax/minimax-m3.toml
+++ b/providers/zenmux/models/minimax/minimax-m3.toml
@@ -1,23 +1,8 @@
-name = "MiniMax M3"
-release_date = "2026-06-01"
-last_updated = "2026-06-01"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
+base_model = "minimax/MiniMax-M3"
 
 [cost]
 input = 0.60
 output = 2.40
-
-[limit]
-context = 512_800
-output = 512_800
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/zenmux/models/minimax/minimax-m3.toml
+++ b/providers/zenmux/models/minimax/minimax-m3.toml
@@ -1,0 +1,24 @@
+name = "MiniMax M3"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.60
+output = 2.40
+
+[limit]
+context = 512_800
+output = 512_800
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"

--- a/providers/zenmux/models/openai/gpt-5.5-instant.toml
+++ b/providers/zenmux/models/openai/gpt-5.5-instant.toml
@@ -1,0 +1,22 @@
+name = "GPT-5.5 Instant"
+release_date = "2026-05-05"
+last_updated = "2026-05-28"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[limit]
+context = 400_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zenmux/models/openai/gpt-5.5-instant.toml
+++ b/providers/zenmux/models/openai/gpt-5.5-instant.toml
@@ -1,22 +1,6 @@
-name = "GPT-5.5 Instant"
-release_date = "2026-05-05"
-last_updated = "2026-05-28"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-08-31"
-open_weights = false
+base_model = "openai/gpt-5.5-instant"
 
 [cost]
 input = 5
 output = 30
 cache_read = 0.5
-
-[limit]
-context = 400_000
-output = 128_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/zenmux/models/qwen/qwen3.7-max.toml
+++ b/providers/zenmux/models/qwen/qwen3.7-max.toml
@@ -1,23 +1,7 @@
-name = "Qwen: Qwen3.7-Max"
-release_date = "2026-05-19"
-last_updated = "2026-05-19"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2026-03-31"
-open_weights = false
+base_model = "alibaba/qwen3.7-max"
 
 [cost]
 input = 2.50
 output = 7.50
 cache_read = 0.50
 cache_write = 3.125
-
-[limit]
-context = 1_000_000
-output = 64_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/zenmux/models/qwen/qwen3.7-max.toml
+++ b/providers/zenmux/models/qwen/qwen3.7-max.toml
@@ -1,0 +1,23 @@
+name = "Qwen: Qwen3.7-Max"
+release_date = "2026-05-19"
+last_updated = "2026-05-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2026-03-31"
+open_weights = false
+
+[cost]
+input = 2.50
+output = 7.50
+cache_read = 0.50
+cache_write = 3.125
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zenmux/models/qwen/qwen3.7-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.7-plus.toml
@@ -1,11 +1,4 @@
-name = "Qwen3.7-Plus"
-release_date = "2026-06-02"
-last_updated = "2026-06-02"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
+base_model = "alibaba/qwen3.7-plus"
 
 [cost]
 input = 0.40
@@ -17,13 +10,5 @@ cache_write = 0.50
 tier = { size = 256_000 }
 input = 1.20
 output = 4.80
-cache_read = 0
+cache_read = 0.24
 cache_write = 1.50
-
-[limit]
-context = 1_000_000
-output = 64_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/zenmux/models/qwen/qwen3.7-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.7-plus.toml
@@ -1,0 +1,29 @@
+name = "Qwen3.7-Plus"
+release_date = "2026-06-02"
+last_updated = "2026-06-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.40
+output = 1.60
+cache_read = 0.08
+cache_write = 0.50
+
+[[cost.tiers]]
+tier = { size = 256_000 }
+input = 1.20
+output = 4.80
+cache_read = 0
+cache_write = 1.50
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zenmux/models/stepfun/step-3.7-flash.toml
+++ b/providers/zenmux/models/stepfun/step-3.7-flash.toml
@@ -1,0 +1,21 @@
+name = "Step 3.7 Flash"
+release_date = "2026-05-29"
+last_updated = "2026-05-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2026-01-01"
+open_weights = true
+
+[cost]
+input = 0.20
+output = 1.15
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zenmux/models/stepfun/step-3.7-flash.toml
+++ b/providers/zenmux/models/stepfun/step-3.7-flash.toml
@@ -1,21 +1,5 @@
-name = "Step 3.7 Flash"
-release_date = "2026-05-29"
-last_updated = "2026-05-29"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2026-01-01"
-open_weights = true
+base_model = "stepfun/step-3.7-flash"
 
 [cost]
 input = 0.20
 output = 1.15
-
-[limit]
-context = 256_000
-output = 256_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/zenmux/models/x-ai/grok-4.3.toml
+++ b/providers/zenmux/models/x-ai/grok-4.3.toml
@@ -1,0 +1,30 @@
+name = "Grok 4.3"
+release_date = "2026-04-17"
+last_updated = "2026-05-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-12-31"
+open_weights = false
+
+[cost]
+input = 1.25
+output = 2.50
+cache_read = 0.20
+cache_write = 0
+
+[[cost.tiers]]
+tier = { size = 200_000 }
+input = 2.50
+output = 5.00
+cache_read = 0.40
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 1_000_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zenmux/models/x-ai/grok-4.3.toml
+++ b/providers/zenmux/models/x-ai/grok-4.3.toml
@@ -1,12 +1,4 @@
-name = "Grok 4.3"
-release_date = "2026-04-17"
-last_updated = "2026-05-01"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2025-12-31"
-open_weights = false
+base_model = "xai/grok-4.3"
 
 [cost]
 input = 1.25
@@ -24,7 +16,3 @@ cache_write = 0
 [limit]
 context = 1_000_000
 output = 1_000_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/zenmux/models/x-ai/grok-build-0.1.toml
+++ b/providers/zenmux/models/x-ai/grok-build-0.1.toml
@@ -1,22 +1,6 @@
-name = "Grok Build 0.1"
-release_date = "2026-05-20"
-last_updated = "2026-05-29"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-knowledge = "2024-11-30"
-open_weights = false
+base_model = "xai/grok-build-0.1"
 
 [cost]
 input = 1.00
 output = 2.00
 cache_read = 0.20
-
-[limit]
-context = 256_000
-output = 256_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/zenmux/models/x-ai/grok-build-0.1.toml
+++ b/providers/zenmux/models/x-ai/grok-build-0.1.toml
@@ -1,0 +1,22 @@
+name = "Grok Build 0.1"
+release_date = "2026-05-20"
+last_updated = "2026-05-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-11-30"
+open_weights = false
+
+[cost]
+input = 1.00
+output = 2.00
+cache_read = 0.20
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Add 11 new model configuration files for ZenMux provider.

## New Models

- anthropic/claude-opus-4.8
- google/gemini-3.1-flash-lite  
- google/gemini-3.5-flash
- inclusionai/ring-2.6-1t
- minimax/minimax-m3
- openai/gpt-5.5-instant
- qwen/qwen3.7-max
- qwen/qwen3.7-plus
- stepfun/step-3.7-flash
- x-ai/grok-4.3
- x-ai/grok-build-0.1

## Validation

All models pass `bun validate` successfully.