### PR TITLE
fix(google): compact sync and add Vertex TTS

### DIFF
--- a/models/google/gemini-2.5-pro-tts.toml
+++ b/models/google/gemini-2.5-pro-tts.toml
@@ -1,0 +1,18 @@
+name = "Gemini 2.5 Pro TTS"
+family = "gemini-pro"
+release_date = "2025-09-30"
+last_updated = "2025-12-10"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+knowledge = "2025-01"
+open_weights = false
+
+[limit]
+context = 32_768
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/packages/core/src/sync/providers/google.ts
+++ b/packages/core/src/sync/providers/google.ts
@@ -33,10 +33,6 @@ export const google = {
   name: "Google",
   modelsDir: "providers/google/models",
   skipCreates: true,
-  deleteMissing: false,
-  missingNotice(paths) {
-    return paths.map((model) => `Google model is not currently returned by the Models API and was retained: ${model}`);
-  },
   sourceID(model) {
     return model.name.replace(/^models\//, "");
   },

--- a/packages/core/src/sync/providers/google.ts
+++ b/packages/core/src/sync/providers/google.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-import type { ExistingModel, SyncProvider, SyncedModel } from "../index.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models";
 
@@ -32,6 +33,10 @@ export const google = {
   name: "Google",
   modelsDir: "providers/google/models",
   skipCreates: true,
+  deleteMissing: false,
+  missingNotice(paths) {
+    return paths.map((model) => `Google model is not currently returned by the Models API and was retained: ${model}`);
+  },
   sourceID(model) {
     return model.name.replace(/^models\//, "");
   },
@@ -81,12 +86,12 @@ export const google = {
 
     return {
       id,
-      model: buildModel(model, existing),
+      model: buildGoogleModel(model, existing),
     };
   },
 } satisfies SyncProvider<GoogleModel>;
 
-function buildModel(model: GoogleModel, existing: ExistingModel): SyncedModel {
+export function buildGoogleModel(model: GoogleModel, existing: ExistingModel): SyncedModel {
   const name = existing.name;
   const releaseDate = existing.release_date;
   const lastUpdated = existing.last_updated;
@@ -111,9 +116,7 @@ function buildModel(model: GoogleModel, existing: ExistingModel): SyncedModel {
     throw new Error(`Google model ${model.name} has incomplete local TOML metadata required for sync`);
   }
 
-  return {
-    base_model: existing.base_model,
-    base_model_omit: existing.base_model_omit,
+  const synced: SyncedFullModel = {
     name: model.displayName ?? name,
     family: existing.family,
     release_date: releaseDate,
@@ -138,4 +141,8 @@ function buildModel(model: GoogleModel, existing: ExistingModel): SyncedModel {
     },
     modalities,
   };
+
+  return existing.base_model === undefined
+    ? synced
+    : factorBaseModel(existing.base_model, synced, synced.limit, existing.base_model_omit);
 }

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -286,6 +286,14 @@ function baseModelOverrides(
 function inheritedOverride(value: unknown, inherited: unknown): unknown {
   if (value === undefined) return undefined;
   if (sameInheritedValue(value, inherited)) return undefined;
+  if (isPlainObject(value) && isPlainObject(inherited)) {
+    const overrides = Object.fromEntries(
+      Object.entries(value)
+        .map(([key, item]) => [key, inheritedOverride(item, inherited[key])])
+        .filter(([, item]) => item !== undefined),
+    );
+    return Object.keys(overrides).length > 0 ? overrides : undefined;
+  }
   return stripUndefined(value);
 }
 

--- a/packages/core/test/google-sync.test.ts
+++ b/packages/core/test/google-sync.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+
+import { buildGoogleModel } from "../src/sync/providers/google.js";
+
+test("Google sync keeps base models compact", () => {
+  const synced = buildGoogleModel({
+    name: "models/gemini-3-pro-image-preview",
+    displayName: "Nano Banana Pro",
+    inputTokenLimit: 131_072,
+    outputTokenLimit: 32_768,
+    temperature: 1,
+    thinking: true,
+  }, {
+    base_model: "google/gemini-3-pro-image-preview",
+    name: "Nano Banana Pro",
+    family: "gemini-pro",
+    release_date: "2025-11-20",
+    last_updated: "2025-11-20",
+    attachment: true,
+    reasoning: true,
+    temperature: true,
+    tool_call: false,
+    knowledge: "2025-01",
+    open_weights: false,
+    cost: { input: 2, output: 120 },
+    limit: { context: 65_536, output: 32_768 },
+    modalities: { input: ["text", "image"], output: ["text", "image"] },
+  });
+
+  expect(synced).toEqual({
+    base_model: "google/gemini-3-pro-image-preview",
+    cost: { input: 2, output: 120 },
+    limit: { context: 131_072 },
+  });
+});

--- a/providers/google-vertex/models/gemini-2.5-flash-tts.toml
+++ b/providers/google-vertex/models/gemini-2.5-flash-tts.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash-tts"
+temperature = false
+
+[cost]
+input = 0.5
+output = 10

--- a/providers/google-vertex/models/gemini-2.5-pro-tts.toml
+++ b/providers/google-vertex/models/gemini-2.5-pro-tts.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-2.5-pro-tts"
+
+[cost]
+input = 1
+output = 20

--- a/providers/google/models/gemini-2.5-flash-tts.toml
+++ b/providers/google/models/gemini-2.5-flash-tts.toml
@@ -1,5 +1,0 @@
-base_model = "google/gemini-2.5-flash-tts"
-
-[cost]
-input = 0.5
-output = 10

--- a/providers/google/models/gemini-3-pro-image-preview.toml
+++ b/providers/google/models/gemini-3-pro-image-preview.toml
@@ -3,3 +3,6 @@ base_model = "google/gemini-3-pro-image-preview"
 [cost]
 input = 2
 output = 120
+
+[limit]
+context = 131_072


### PR DESCRIPTION
## Summary
- compact Google API updates against canonical `base_model` metadata instead of expanding inherited fields
- compare nested inherited objects field-by-field so only changed limit fields are emitted
- remove the unsupported Gemini API ID `gemini-2.5-flash-tts` while retaining the supported preview TTS entries
- add the GA Flash and Pro TTS IDs to the correct `google-vertex` provider
- apply the current Gemini 3 Pro Image context override in compact form

## TTS provider split
**Gemini API (`google`)**
- `gemini-2.5-flash-preview-tts` is retained; direct API lookup returned HTTP 200
- `gemini-2.5-pro-preview-tts` is retained
- `gemini-2.5-flash-tts` is removed from this provider; direct API lookup returned HTTP 404

**Vertex AI (`google-vertex`)**
- adds `gemini-2.5-flash-tts` using `base_model = "google/gemini-2.5-flash-tts"`
- adds `gemini-2.5-pro-tts` using new canonical metadata
- official GA release date: September 30, 2025
- official pricing: Flash $0.50/$10 and Pro $1/$20 per million input/output tokens
- modalities: text input, audio output
- Vertex documentation explicitly lists both IDs and states temperature controls are ignored

## Google sync result
The image model remains compact:

```toml
base_model = "google/gemini-3-pro-image-preview"

[cost]
input = 2
output = 120

[limit]
context = 131_072
```

## Live verification
- first Google sync: 0 created, 0 updated, 1 unsupported ID deleted
- second Google sync: 0 created, 0 updated, 0 deleted

## Validation
- 13 focused sync tests passed
- core TypeScript typecheck passed
- `bun validate` passed
- `git diff --check` passed