### PR TITLE
fix(minimax): Increase M3 context size to 1 million

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -18,7 +18,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -17,7 +17,7 @@ output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -18,7 +18,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -17,7 +17,7 @@ output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
It's supposed to be 1 million, don't know why it was set to 512000 https://platform.minimax.io/docs/guides/text-generation#supported-models