### PR TITLE
feat: add qwen3.7-plus to alibaba-coding-plan-cn provider

### DIFF
--- a/providers/alibaba-coding-plan-cn/models/qwen3.7-plus.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3.7-plus.toml
@@ -1,24 +1,7 @@
-name = "Qwen3.7 Plus"
-family = "qwen"
-release_date = "2026-06-02"
-last_updated = "2026-06-02"
-attachment = false
-reasoning = true
-temperature = true
-knowledge = "2025-04"
-tool_call = true
-open_weights = false
+base_model = "alibaba/qwen3.7-plus"
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 cache_write = 0
-
-[limit]
-context = 1_000_000
-output = 65_536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/alibaba-coding-plan-cn/models/qwen3.7-plus.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3.7-plus.toml
@@ -1,0 +1,24 @@
+name = "Qwen3.7 Plus"
+family = "qwen"
+release_date = "2026-06-02"
+last_updated = "2026-06-02"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Add `qwen3.7-plus` to `alibaba-coding-plan-cn` provider
- Qwen3.7 Plus is now available on Alibaba Cloud Coding Plan (China)

## References

- [Alibaba Cloud Coding Plan docs](https://help.aliyun.com/zh/model-studio/coding-plan)
- [DashScope text generation models](https://help.aliyun.com/zh/model-studio/text-generation-model/)