### PR TITLE
feat: add LLMTR provider

### DIFF
--- a/providers/llmtr/logo.svg
+++ b/providers/llmtr/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="14 6 38 24" role="img" aria-label="LLMTR">
+  <title>LLMTR</title>
+  <path
+    d="M 38 18 A 11 11 0 1 0 16 18 A 11 11 0 1 0 38 18 Z M 38 18 A 8 8 0 1 0 22 18 A 8 8 0 1 0 38 18 Z"
+    fill="currentColor"
+    fill-rule="evenodd"
+  />
+  <polygon
+    points="46,13 47.12,16.45 50.76,16.45 47.82,18.59 48.94,22.05 46,19.91 43.06,22.05 44.18,18.59 41.24,16.45 44.88,16.45"
+    fill="currentColor"
+  />
+</svg>

--- a/providers/llmtr/models/gemma-4.toml
+++ b/providers/llmtr/models/gemma-4.toml
@@ -1,0 +1,20 @@
+name = "Gemma 4"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 5.0
+output = 10.0
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llmtr/models/magibu-11b-v8.toml
+++ b/providers/llmtr/models/magibu-11b-v8.toml
@@ -1,0 +1,20 @@
+name = "Magibu 11B v8"
+release_date = "2026-06-05"
+last_updated = "2026-06-05"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 8_192
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llmtr/models/medgemma-4b.toml
+++ b/providers/llmtr/models/medgemma-4b.toml
@@ -1,0 +1,20 @@
+name = "MedGemma 4B"
+release_date = "2026-04-26"
+last_updated = "2026-04-26"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 3.0
+output = 5.0
+
+[limit]
+context = 8_192
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/llmtr/models/qwen3-6-35b.toml
+++ b/providers/llmtr/models/qwen3-6-35b.toml
@@ -1,12 +1,4 @@
-name = "Qwen 3.6 35B-A3B"
-family = "qwen"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = false
-open_weights = true
+base_model = "alibaba/qwen3.6-35b-a3b"
 
 [cost]
 input = 5.0
@@ -14,8 +6,3 @@ output = 10.0
 
 [limit]
 context = 16_384
-output = 8_192
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/llmtr/models/qwen3-6-35b.toml
+++ b/providers/llmtr/models/qwen3-6-35b.toml
@@ -1,0 +1,21 @@
+name = "Qwen 3.6 35B-A3B"
+family = "qwen"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 5.0
+output = 10.0
+
+[limit]
+context = 16_384
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llmtr/models/sincap.toml
+++ b/providers/llmtr/models/sincap.toml
@@ -1,0 +1,20 @@
+name = "Sincap"
+release_date = "2026-05-05"
+last_updated = "2026-05-05"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llmtr/models/trendyol-7b.toml
+++ b/providers/llmtr/models/trendyol-7b.toml
@@ -1,0 +1,21 @@
+name = "Trendyol 7B"
+family = "qwen"
+release_date = "2026-06-06"
+last_updated = "2026-06-06"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/llmtr/provider.toml
+++ b/providers/llmtr/provider.toml
@@ -1,0 +1,5 @@
+name = "LLMTR"
+env = ["LLMTR_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://llmtr.com/docs"
+api = "https://llmtr.com/v1"


### PR DESCRIPTION
Adds [LLMTR](https://llmtr.com), an OpenAI-compatible AI gateway hosted in Turkey, with its six first-party models (Gemma 4, Qwen 3.6 35B-A3B, MedGemma 4B, Trendyol 7B, Magibu 11B v8, Sincap).

Passthrough models (OpenAI/Anthropic/etc.) are reachable via user config and can be added later.

- `bun validate` passes.
- Pricing/limits/capabilities taken from the per-model pages on llmtr.com.
- `release_date`/`last_updated` derived from the API `created` timestamps; `output` limits are conservative defaults where the model page doesn't state one.

Verified with opencode: built an augmented catalog and confirmed it lists all six `llmtr/*` models and completes a chat with `llmtr/gemma-4`.

Related opencode issue: anomalyco/opencode#31315
