### PR TITLE
feat(stackit): refresh catalogue (add GPT-OSS 20B + Qwen3.6 27B, reprice, deprecate retired)

### DIFF
--- a/providers/stackit/models/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8.toml
+++ b/providers/stackit/models/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8.toml
@@ -10,12 +10,12 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 1.64
-output = 1.91
+input = 1.76
+output = 2.05
 
 [limit]
 context = 218_000
-output = 8_192
+output = 16_384
 
 [modalities]
 input = ["text", "image"]

--- a/providers/stackit/models/Qwen/Qwen3.6-27B.toml
+++ b/providers/stackit/models/Qwen/Qwen3.6-27B.toml
@@ -1,20 +1,13 @@
-name = "Qwen3.6 27B"
-family = "qwen"
-release_date = "2026-06-08"
-last_updated = "2026-06-08"
+base_model = "alibaba/qwen3.6-27b"
 attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = false
-open_weights = true
 
 [cost]
-input = 0.49
-output = 0.71
+input = 0.53
+output = 0.76
 
 [limit]
-context = 262_000
 output = 16_384
 
 [modalities]

--- a/providers/stackit/models/Qwen/Qwen3.6-27B.toml
+++ b/providers/stackit/models/Qwen/Qwen3.6-27B.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.6 27B"
+family = "qwen"
+release_date = "2026-06-08"
+last_updated = "2026-06-08"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.49
+output = 0.71
+
+[limit]
+context = 262_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/stackit/models/cortecs/Llama-3.3-70B-Instruct-FP8-Dynamic.toml
+++ b/providers/stackit/models/cortecs/Llama-3.3-70B-Instruct-FP8-Dynamic.toml
@@ -10,12 +10,12 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.49
-output = 0.71
+input = 0.53
+output = 0.76
 
 [limit]
 context = 128_000
-output = 8_192
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/stackit/models/google/gemma-3-27b-it.toml
+++ b/providers/stackit/models/google/gemma-3-27b-it.toml
@@ -10,12 +10,12 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.49
-output = 0.71
+input = 0.53
+output = 0.76
 
 [limit]
 context = 37_000
-output = 8_192
+output = 4_096
 
 [modalities]
 input = ["text", "image"]

--- a/providers/stackit/models/neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8.toml
+++ b/providers/stackit/models/neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8.toml
@@ -8,14 +8,15 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
+status = "deprecated"
 
 [cost]
-input = 0.16
-output = 0.27
+input = 0.18
+output = 0.29
 
 [limit]
 context = 128_000
-output = 8_192
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/stackit/models/neuralmagic/Mistral-Nemo-Instruct-2407-FP8.toml
+++ b/providers/stackit/models/neuralmagic/Mistral-Nemo-Instruct-2407-FP8.toml
@@ -8,14 +8,15 @@ temperature = true
 tool_call = true
 structured_output = false
 open_weights = true
+status = "deprecated"
 
 [cost]
-input = 0.49
-output = 0.71
+input = 0.53
+output = 0.76
 
 [limit]
 context = 128_000
-output = 8_192
+output = 4_096
 
 [modalities]
 input = ["text"]

--- a/providers/stackit/models/openai/gpt-oss-120b.toml
+++ b/providers/stackit/models/openai/gpt-oss-120b.toml
@@ -10,8 +10,8 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.49
-output = 0.71
+input = 0.53
+output = 0.76
 
 [limit]
 context = 131_000

--- a/providers/stackit/models/openai/gpt-oss-20b.toml
+++ b/providers/stackit/models/openai/gpt-oss-20b.toml
@@ -1,7 +1,7 @@
 name = "GPT-OSS 20B"
 family = "gpt"
-release_date = "2026-06-08"
-last_updated = "2026-06-08"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
 attachment = false
 reasoning = true
 temperature = true
@@ -10,8 +10,8 @@ structured_output = false
 open_weights = true
 
 [cost]
-input = 0.16
-output = 0.27
+input = 0.18
+output = 0.29
 
 [limit]
 context = 131_000

--- a/providers/stackit/models/openai/gpt-oss-20b.toml
+++ b/providers/stackit/models/openai/gpt-oss-20b.toml
@@ -1,0 +1,22 @@
+name = "GPT-OSS 20B"
+family = "gpt"
+release_date = "2026-06-08"
+last_updated = "2026-06-08"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = true
+
+[cost]
+input = 0.16
+output = 0.27
+
+[limit]
+context = 131_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Refreshes the full STACKIT shared-models catalogue against the official
[Available Shared Models](https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models)
docs. Prices converted EUR→USD at the ECB 6-month average rate of 1.17.

### New models
- **`openai/gpt-oss-20b`** — 131K context, 8192 max output, tool calling + reasoning, $0.18/$0.29 per 1M
- **`Qwen/Qwen3.6-27B`** — linked via `base_model = "alibaba/qwen3.6-27b"` with STACKIT overrides
  (text-only input, reasoning/structured_output disabled on this deployment, 16384 max output, $0.53/$0.76)

### Catalogue updates
- Repriced all live models to the 1.17 rate (gpt-oss-120b, Llama-3.3-70B, Gemma 3 27B, Qwen3-VL 235B)
- Corrected max-output limits from the docs: Qwen3-VL 235B → 16384; Llama-3.3-70B and Gemma 3 27B → 4096
- Marked **Mistral-Nemo** and **Llama 3.1 8B** as `status = "deprecated"` (docs flag them
  "Deprecated - migrate to gpt-oss-20b") rather than deleting them, since they are still billable and listed
- Fixed `gpt-oss-20b` release date to 2025-08-05

### Test plan
- [x] Specs/prices verified against STACKIT docs (per-model Facts tables)
- [x] `bun run validate` passes
- [x] `base_model` resolution confirmed (Qwen3.6 inherits canonical, overrides applied)
