### PR TITLE
feat(amazon-bedrock): add reasoning options

### DIFF
--- a/providers/amazon-bedrock/models/amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-2-lite-v1:0.toml
@@ -3,7 +3,8 @@ family = "nova"
 release_date = "2024-12-01"
 last_updated = "2024-12-01"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/amazon-bedrock/models/anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true
@@ -23,4 +24,3 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-

--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-1-20250805-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-1-20250805-v1:0.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 15

--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-08-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-6-v1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true
@@ -23,4 +24,3 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-

--- a/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/au.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5-20251001"
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 name = "Claude Haiku 4.5 (AU)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-6-v1.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 name = "Claude Opus 4.8 (AU)"
 
 [cost]

--- a/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 name = "Claude Sonnet 4.5 (AU)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/deepseek.r1-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.r1-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-05-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-07"
 tool_call = true

--- a/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-18"
 last_updated = "2025-09-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-07"
 tool_call = true

--- a/providers/amazon-bedrock/models/deepseek.v3.2.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3.2.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-06"
 last_updated = "2026-02-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-07"
 tool_call = true

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-08-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-6-v1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 name = "Claude Opus 4.6 (EU)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 name = "Claude Opus 4.8 (EU)"
 
 [cost]

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 name = "Claude Sonnet 4.6 (EU)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/global.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-08-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-6-v1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 name = "Claude Opus 4.6 (Global)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 name = "Claude Opus 4.8 (Global)"
 
 [cost]

--- a/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 name = "Claude Sonnet 4.6 (Global)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/jp.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 name = "Claude Opus 4.7 (JP)"
 
 [cost]

--- a/providers/amazon-bedrock/models/jp.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 name = "Claude Opus 4.8 (JP)"
 
 [cost]

--- a/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 name = "Claude Sonnet 4.5 (JP)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 name = "Claude Sonnet 4.6 (JP)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-27"
 last_updated = "2025-10-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/amazon-bedrock/models/mistral.magistral-small-2509.toml
+++ b/providers/amazon-bedrock/models/mistral.magistral-small-2509.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-02"
 last_updated = "2025-12-02"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -5,6 +5,7 @@ family = "kimi-thinking"
 last_updated = "2025-12-02"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
+++ b/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
@@ -5,6 +5,7 @@ release_date = "2026-02-06"
 last_updated = "2026-02-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
@@ -5,6 +5,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/openai.gpt-5.4.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
 last_updated = "2026-06-01"
 

--- a/providers/amazon-bedrock/models/openai.gpt-5.5.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
 last_updated = "2026-06-01"
 

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
@@ -3,7 +3,8 @@ family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b.toml
@@ -3,7 +3,8 @@ family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
@@ -3,7 +3,8 @@ family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b.toml
@@ -3,7 +3,8 @@ family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-18"
 last_updated = "2025-09-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-next.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-next.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-06"
 last_updated = "2026-02-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/us.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-1-20250805-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-1-20250805-v1:0.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 name = "Claude Opus 4.1 (US)"
 
 [cost]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-08-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-6-v1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 name = "Claude Opus 4.6 (US)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-8.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 name = "Claude Opus 4.8 (US)"
 
 [cost]

--- a/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-6.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 name = "Claude Sonnet 4.6 (US)"
 structured_output = true
 

--- a/providers/amazon-bedrock/models/us.deepseek.r1-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.deepseek.r1-v1:0.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-r1"
+reasoning_options = []
 name = "DeepSeek-R1 (US)"
 
 [cost]

--- a/providers/amazon-bedrock/models/writer.palmyra-x4-v1:0.toml
+++ b/providers/amazon-bedrock/models/writer.palmyra-x4-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-28"
 last_updated = "2025-04-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/amazon-bedrock/models/writer.palmyra-x5-v1:0.toml
+++ b/providers/amazon-bedrock/models/writer.palmyra-x5-v1:0.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-28"
 last_updated = "2025-04-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/zai.glm-4.7.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/amazon-bedrock/models/zai.glm-5.toml
+++ b/providers/amazon-bedrock/models/zai.glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- add endpoint-specific reasoning options across Amazon Bedrock models
- add explicit empty option sets where Bedrock exposes fixed reasoning without a functional control
- correct reasoning capability metadata for Nova 2 Lite and GPT-OSS Runtime/Mantle endpoints

## Live verification
- tested all declared controls and fixed-reasoning groups through Bedrock in `us-east-2`
- confirmed GPT-5.4/5.5 effort controls through Bedrock Mantle
- confirmed GPT-OSS effort controls through both Runtime and Mantle
- confirmed Claude budget and adaptive effort controls across reachable US/global inference profiles
- confirmed Nova 2 Lite toggle and effort controls through US/global inference profiles
- verified provider-native Kimi, Qwen, GLM, Nemotron, and Writer controls are ignored or unsupported through Bedrock, so those remain explicit empty sets
- retained Nova Lite, Nova Pro, and Qwen3 235B Instruct-2507 as non-reasoning after live tests disproved broader capability labels

## Verification
- `bun validate`
- `git diff --check`