### PR TITLE
feat(novita-ai): add reasoning options

### DIFF
--- a/providers/novita-ai/models/baidu/ernie-4.5-21B-a3b-thinking.toml
+++ b/providers/novita-ai/models/baidu/ernie-4.5-21B-a3b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-19"
 last_updated = "2025-09-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-03"
 tool_call = false

--- a/providers/novita-ai/models/baidu/ernie-4.5-vl-28b-a3b-thinking.toml
+++ b/providers/novita-ai/models/baidu/ernie-4.5-vl-28b-a3b-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-26"
 last_updated = "2025-11-26"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/baidu/ernie-4.5-vl-28b-a3b.toml
+++ b/providers/novita-ai/models/baidu/ernie-4.5-vl-28b-a3b.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-30"
 last_updated = "2025-06-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/novita-ai/models/baidu/ernie-4.5-vl-424b-a47b.toml
+++ b/providers/novita-ai/models/baidu/ernie-4.5-vl-424b-a47b.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-30"
 last_updated = "2025-06-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 open_weights = true

--- a/providers/novita-ai/models/deepseek/deepseek-r1-0528-qwen3-8b.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-r1-0528-qwen3-8b.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-29"
 last_updated = "2025-05-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 open_weights = true

--- a/providers/novita-ai/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-r1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-07"
 tool_call = true

--- a/providers/novita-ai/models/deepseek/deepseek-r1-distill-llama-70b.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-r1-distill-llama-70b.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-27"
 last_updated = "2025-01-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 structured_output = true

--- a/providers/novita-ai/models/deepseek/deepseek-r1-turbo.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-r1-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2025-03-05"
 last_updated = "2025-03-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/novita-ai/models/deepseek/deepseek-v3.1-terminus.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v3.1-terminus.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.27
 output = 1.0

--- a/providers/novita-ai/models/deepseek/deepseek-v3.1.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v3.1.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.27
 output = 1.0

--- a/providers/novita-ai/models/deepseek/deepseek-v3.2-exp.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v3.2-exp.toml
@@ -8,6 +8,9 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.27
 output = 0.41

--- a/providers/novita-ai/models/deepseek/deepseek-v3.2.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v3.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v4-flash.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/novita-ai/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/novita-ai/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v4-flash.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/novita-ai/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/novita-ai/models/google/gemma-4-26b-a4b-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/google/gemma-4-31b-it.toml
+++ b/providers/novita-ai/models/google/gemma-4-31b-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/novita-ai/models/inclusionai/ring-2.6-1t.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-08"
 last_updated = "2026-05-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/minimax/minimax-m2.5-highspeed.toml
+++ b/providers/novita-ai/models/minimax/minimax-m2.5-highspeed.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/minimax/minimax-m2.5.toml
+++ b/providers/novita-ai/models/minimax/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/novita-ai/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
 last_updated = "2026-05-27"
 structured_output = true
 

--- a/providers/novita-ai/models/minimax/minimax-m2.7.toml
+++ b/providers/novita-ai/models/minimax/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/minimax/minimax-m2.toml
+++ b/providers/novita-ai/models/minimax/minimax-m2.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-27"
 last_updated = "2025-10-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/novita-ai/models/minimaxai/minimax-m1-80k.toml
+++ b/providers/novita-ai/models/minimaxai/minimax-m1-80k.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/novita-ai/models/moonshotai/kimi-k2-instruct.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2-instruct.toml
@@ -5,7 +5,6 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-structured_output = true
 open_weights = true
 
 [cost]
@@ -14,7 +13,7 @@ output = 2.3
 
 [limit]
 context = 131_072
-output = 131_072
+output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/novita-ai/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-07"
 last_updated = "2025-11-07"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/moonshotai/kimi-k2.5.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/moonshotai/kimi-k2.6.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/novita-ai/models/openai/gpt-oss-120b.toml
+++ b/providers/novita-ai/models/openai/gpt-oss-120b.toml
@@ -3,7 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/openai/gpt-oss-120b.toml
+++ b/providers/novita-ai/models/openai/gpt-oss-120b.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/openai/gpt-oss-20b.toml
+++ b/providers/novita-ai/models/openai/gpt-oss-20b.toml
@@ -3,7 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = false
 structured_output = true

--- a/providers/novita-ai/models/openai/gpt-oss-20b.toml
+++ b/providers/novita-ai/models/openai/gpt-oss-20b.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 structured_output = true

--- a/providers/novita-ai/models/qwen/qwen3-235b-a22b-fp8.toml
+++ b/providers/novita-ai/models/qwen/qwen3-235b-a22b-fp8.toml
@@ -3,6 +3,7 @@ release_date = "2025-04-29"
 last_updated = "2025-04-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 open_weights = true

--- a/providers/novita-ai/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/novita-ai/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-25"
 last_updated = "2025-07-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-04"
 tool_call = true

--- a/providers/novita-ai/models/qwen/qwen3-30b-a3b-fp8.toml
+++ b/providers/novita-ai/models/qwen/qwen3-30b-a3b-fp8.toml
@@ -3,6 +3,7 @@ release_date = "2025-04-29"
 last_updated = "2025-04-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 open_weights = true

--- a/providers/novita-ai/models/qwen/qwen3-32b-fp8.toml
+++ b/providers/novita-ai/models/qwen/qwen3-32b-fp8.toml
@@ -3,6 +3,7 @@ release_date = "2025-04-29"
 last_updated = "2025-04-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 open_weights = true

--- a/providers/novita-ai/models/qwen/qwen3-4b-fp8.toml
+++ b/providers/novita-ai/models/qwen/qwen3-4b-fp8.toml
@@ -3,6 +3,7 @@ release_date = "2025-04-29"
 last_updated = "2025-04-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 open_weights = true

--- a/providers/novita-ai/models/qwen/qwen3-8b-fp8.toml
+++ b/providers/novita-ai/models/qwen/qwen3-8b-fp8.toml
@@ -3,6 +3,7 @@ release_date = "2025-04-29"
 last_updated = "2025-04-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 open_weights = true

--- a/providers/novita-ai/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/novita-ai/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-10"
 last_updated = "2025-09-10"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/qwen/qwen3-omni-30b-a3b-thinking.toml
+++ b/providers/novita-ai/models/qwen/qwen3-omni-30b-a3b-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-24"
 last_updated = "2025-09-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/qwen/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/novita-ai/models/qwen/qwen3-vl-235b-a22b-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-24"
 last_updated = "2025-09-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 open_weights = true

--- a/providers/novita-ai/models/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/novita-ai/models/qwen/qwen3.5-122b-a10b.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-26"
 last_updated = "2026-02-26"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/qwen/qwen3.5-27b.toml
+++ b/providers/novita-ai/models/qwen/qwen3.5-27b.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-26"
 last_updated = "2026-02-26"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/qwen/qwen3.5-35b-a3b.toml
+++ b/providers/novita-ai/models/qwen/qwen3.5-35b-a3b.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-26"
 last_updated = "2026-02-26"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/novita-ai/models/qwen/qwen3.5-397b-a17b.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/qwen/qwen3.7-max.toml
+++ b/providers/novita-ai/models/qwen/qwen3.7-max.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-21"
 last_updated = "2026-05-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/xiaomimimo/mimo-v2-flash.toml
+++ b/providers/novita-ai/models/xiaomimimo/mimo-v2-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-19"
 last_updated = "2025-12-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-12"
 tool_call = true

--- a/providers/novita-ai/models/xiaomimimo/mimo-v2-pro.toml
+++ b/providers/novita-ai/models/xiaomimimo/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+reasoning_options = []
 last_updated = "2026-05-27"
 structured_output = true
 

--- a/providers/novita-ai/models/xiaomimimo/mimo-v2.5-pro.toml
+++ b/providers/novita-ai/models/xiaomimimo/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
 last_updated = "2026-05-27"
 structured_output = true
 

--- a/providers/novita-ai/models/zai-org/glm-4.5-air.toml
+++ b/providers/novita-ai/models/zai-org/glm-4.5-air.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-13"
 last_updated = "2025-10-13"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true

--- a/providers/novita-ai/models/zai-org/glm-4.5.toml
+++ b/providers/novita-ai/models/zai-org/glm-4.5.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.6
 output = 2.2

--- a/providers/novita-ai/models/zai-org/glm-4.5v.toml
+++ b/providers/novita-ai/models/zai-org/glm-4.5v.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-11"
 last_updated = "2025-08-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true

--- a/providers/novita-ai/models/zai-org/glm-4.6.toml
+++ b/providers/novita-ai/models/zai-org/glm-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/zai-org/glm-4.6v.toml
+++ b/providers/novita-ai/models/zai-org/glm-4.6v.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true

--- a/providers/novita-ai/models/zai-org/glm-4.7-flash.toml
+++ b/providers/novita-ai/models/zai-org/glm-4.7-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/zai-org/glm-4.7.toml
+++ b/providers/novita-ai/models/zai-org/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/zai-org/glm-5.1.toml
+++ b/providers/novita-ai/models/zai-org/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/novita-ai/models/zai-org/glm-5.toml
+++ b/providers/novita-ai/models/zai-org/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- expose live reasoning toggles and effort controls for Novita models where supported
- add model-specific DeepSeek V4 active effort sets validated against Novita
- mark reasoning as fixed only where no caller-selectable control was confirmed
- correct Kimi K2 Instruct by removing unsupported structured output and setting its output limit to 32,768 tokens

## DeepSeek V4 validation
- V4 Pro active efforts: `low`, `medium`, `high`, `xhigh`
- V4 Flash active efforts: `minimal`, `low`, `medium`, `high`, `xhigh`
- `reasoning_effort=none` is intentionally omitted: live requests still emitted reasoning and did not behave as an off mode
- `enable_thinking=false` is the verified off switch for both V4 models; invalid non-boolean values return HTTP 400
- older V3 hybrid endpoints accept arbitrary `reasoning_effort` strings, so effort is not declared for them

## Other live validation
- GPT-OSS 20B and 120B accept `low`, `medium`, and `high`, while invalid effort values are rejected
- toggle declarations were retained only where response behavior changed with the provider control

## Verification
- `bun validate`
- `git diff --check`