### PR TITLE
feat(fireworks-ai): add reasoning options

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p1.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p1.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 1.40
 output = 4.40

--- a/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-120b.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-120b.toml
@@ -8,6 +8,10 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 0.15
 output = 0.60

--- a/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-20b.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-20b.toml
@@ -8,6 +8,10 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 0.07
 output = 0.30

--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
@@ -3,11 +3,14 @@ family = "kimi-thinking"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 knowledge = "2025-01"
-attachment = false
+attachment = true
 reasoning = true
 temperature = true
 tool_call = true
 open_weights = true
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 cache_read = 0.10

--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p6.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p6.toml
@@ -2,11 +2,14 @@ name = "Kimi K2.6"
 family = "kimi-thinking"
 release_date = "2026-04-17"
 last_updated = "2026-04-17"
-attachment = false
+attachment = true
 reasoning = true
 temperature = true
 tool_call = true
 open_weights = true
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 cache_read = 0.16

--- a/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p5.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p5.toml
@@ -8,6 +8,10 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 0.30
 output = 1.20

--- a/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p7.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m2p7.toml
@@ -8,6 +8,10 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 0.30
 output = 1.20

--- a/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p6-plus.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p6-plus.toml
@@ -8,6 +8,13 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 cache_read = 0.10
 input = 0.50

--- a/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p1-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p1-fast.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 2.80
 output = 8.80

--- a/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p6-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p6-fast.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 cache_read = 0.30
 input = 2.00

--- a/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p6-turbo.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p6-turbo.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 cache_read = 0.30
 input = 2.00


### PR DESCRIPTION
## Summary

- add Fireworks reasoning controls confirmed through live model and router verification for DeepSeek, GPT-OSS, Kimi, MiniMax, Qwen, and GLM entries
- correct Qwen 3.6 Plus to expose both its reasoning toggle and low/medium/high effort controls
- correct GLM 5.1 model and fast router to expose toggle-only reasoning, matching live behavior
- mark Kimi K2.5 and K2.6 attachment support observed during verification

## Validation

- `bun validate`
- `git diff --check`