### PR TITLE
feat(cloudflare-workers-ai): add reasoning options

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -223,7 +223,7 @@ const ModelBase = z.object({
       z.literal(true),
       z
         .object({
-          field: z.enum(["reasoning_content", "reasoning_details"]),
+          field: z.enum(["reasoning", "reasoning_content", "reasoning_details"]),
         })
         .strict(),
     ])

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -223,7 +223,7 @@ const ModelBase = z.object({
       z.literal(true),
       z
         .object({
-          field: z.enum(["reasoning", "reasoning_content", "reasoning_details"]),
+          field: z.enum(["reasoning_content", "reasoning_details"]),
         })
         .strict(),
     ])

--- a/providers/cloudflare-workers-ai/models/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b.toml
@@ -1,5 +1,6 @@
 base_model = "deepseek/deepseek-r1"
 name = "Deepseek R1 Distill Qwen 32B"
+reasoning_options = []
 tool_call = false
 structured_output = false
 

--- a/providers/cloudflare-workers-ai/models/@cf/google/gemma-4-26b-a4b-it.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/google/gemma-4-26b-a4b-it.toml
@@ -1,4 +1,8 @@
 base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning"
 
 [cost]
 input = 0.1

--- a/providers/cloudflare-workers-ai/models/@cf/google/gemma-4-26b-a4b-it.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/google/gemma-4-26b-a4b-it.toml
@@ -1,8 +1,6 @@
 base_model = "google/gemma-4-26b-a4b-it"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
-
-[interleaved]
-field = "reasoning"
+interleaved = true
 
 [cost]
 input = 0.1

--- a/providers/cloudflare-workers-ai/models/@cf/moonshotai/kimi-k2.6.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/moonshotai/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
@@ -1,9 +1,10 @@
 base_model = "nvidia/nemotron-3-super-120b-a12b"
 name = "Nemotron 3 Super 120B"
 structured_output = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
-field = "reasoning_content"
+field = "reasoning"
 
 [cost]
 input = 0.5

--- a/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
@@ -2,9 +2,7 @@ base_model = "nvidia/nemotron-3-super-120b-a12b"
 name = "Nemotron 3 Super 120B"
 structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
-
-[interleaved]
-field = "reasoning"
+interleaved = true
 
 [cost]
 input = 0.5

--- a/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-120b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-20b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/cloudflare-workers-ai/models/@cf/qwen/qwen3-30b-a3b-fp8.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/qwen/qwen3-30b-a3b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-30"
 last_updated = "2025-04-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/cloudflare-workers-ai/models/@cf/qwen/qwq-32b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/qwen/qwq-32b.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-05"
 last_updated = "2025-03-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
@@ -4,11 +4,15 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true
 knowledge = "2025-04"
 open_weights = true
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.0605


### PR DESCRIPTION
## Summary
- add live-verified reasoning option metadata for supported Cloudflare Workers AI models
- record explicit empty option sets for fixed-reasoning DeepSeek R1 Distill and QwQ endpoints
- mark Gemma and Nemotron as interleaved without adding a new shared response-field enum value

## Live verification
- live-tested the included Workers AI endpoints and retained only controls accepted by each endpoint
- verified toggle and low/medium/high effort controls where declared, and effort-only controls for GPT-OSS
- confirmed fixed-reasoning endpoints do not expose a functional caller-selectable control
- observed Cloudflare reasoning output for Gemma and Nemotron while preserving compatibility with strict models.dev consumers

## Verification
- `bun validate`
- `git diff --check`
- original branch test run: `bun test` reported 24 pass and 1 unrelated pre-existing NVIDIA weights-link assertion failure