### PR TITLE
feat(xai): add reasoning options

### DIFF
--- a/models/xai/grok-4.20-0309-non-reasoning.toml
+++ b/models/xai/grok-4.20-0309-non-reasoning.toml
@@ -6,10 +6,11 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]
-context = 2_000_000
+context = 1_000_000
 output = 30_000
 
 [modalities]

--- a/models/xai/grok-4.20-0309-reasoning.toml
+++ b/models/xai/grok-4.20-0309-reasoning.toml
@@ -6,10 +6,11 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]
-context = 2_000_000
+context = 1_000_000
 output = 30_000
 
 [modalities]

--- a/models/xai/grok-4.3.toml
+++ b/models/xai/grok-4.3.toml
@@ -6,6 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/packages/core/src/sync/providers/xai.ts
+++ b/packages/core/src/sync/providers/xai.ts
@@ -29,7 +29,7 @@ const XAIAPIKey = z.object({
   acls: z.array(z.string()),
 }).passthrough();
 
-type XAIModel = z.infer<typeof XAIModel>;
+export type XAIModel = z.infer<typeof XAIModel>;
 
 export const xai = {
   id: "xai",
@@ -87,7 +87,7 @@ export const xai = {
 
     return {
       id: model.id,
-      model: buildModel(model, existing),
+      model: buildXAIModel(model, existing),
     };
   },
 } satisfies SyncProvider<XAIModel>;
@@ -159,7 +159,7 @@ function cost(model: XAIModel, existing: ExistingModel) {
   };
 }
 
-function buildModel(model: XAIModel, existing: ExistingModel): SyncedModel {
+export function buildXAIModel(model: XAIModel, existing: ExistingModel): SyncedModel {
   const name = existing.name;
   const attachment = existing.attachment;
   const reasoning = existing.reasoning;
@@ -195,6 +195,7 @@ function buildModel(model: XAIModel, existing: ExistingModel): SyncedModel {
     last_updated: model.canonical_id === undefined ? created : lastUpdated!,
     attachment: input.some((value) => value !== "text"),
     reasoning,
+    reasoning_options: existing.reasoning_options,
     temperature: existing.temperature,
     tool_call: toolCall,
     structured_output: existing.structured_output,

--- a/packages/core/test/xai-sync.test.ts
+++ b/packages/core/test/xai-sync.test.ts
@@ -9,7 +9,6 @@ const model: XAIModel = {
   output_modalities: ["text"],
   prompt_text_token_price: 10_000,
   completion_text_token_price: 20_000,
-  max_prompt_length: 1_000_000,
 };
 
 test("xAI sync preserves reasoning options", () => {
@@ -27,5 +26,5 @@ test("xAI sync preserves reasoning options", () => {
   });
 
   expect(synced.reasoning_options).toEqual([{ type: "effort", values: ["none", "high"] }]);
-  expect(synced.limit?.context).toBe(1_000_000);
+  expect(synced.limit?.context).toBe(2_000_000);
 });

--- a/packages/core/test/xai-sync.test.ts
+++ b/packages/core/test/xai-sync.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+
+import { buildXAIModel, type XAIModel } from "../src/sync/providers/xai.js";
+
+const model: XAIModel = {
+  id: "grok-test",
+  created: 1_700_000_000,
+  input_modalities: ["text"],
+  output_modalities: ["text"],
+  prompt_text_token_price: 10_000,
+  completion_text_token_price: 20_000,
+  max_prompt_length: 1_000_000,
+};
+
+test("xAI sync preserves reasoning options", () => {
+  const synced = buildXAIModel(model, {
+    name: "Grok Test",
+    release_date: "2024-01-01",
+    last_updated: "2024-01-01",
+    attachment: false,
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["none", "high"] }],
+    tool_call: true,
+    open_weights: false,
+    limit: { context: 2_000_000, output: 30_000 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(synced.reasoning_options).toEqual([{ type: "effort", values: ["none", "high"] }]);
+  expect(synced.limit?.context).toBe(1_000_000);
+});

--- a/providers/xai/models/grok-4.20-0309-non-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-non-reasoning.toml
@@ -4,8 +4,10 @@ release_date = "2026-03-09"
 last_updated = "2026-03-09"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]
@@ -20,7 +22,7 @@ output = 5
 cache_read = 0.4
 
 [limit]
-context = 2_000_000
+context = 1_000_000
 output = 30_000
 
 [modalities]

--- a/providers/xai/models/grok-4.20-0309-reasoning.toml
+++ b/providers/xai/models/grok-4.20-0309-reasoning.toml
@@ -4,8 +4,10 @@ release_date = "2026-03-09"
 last_updated = "2026-03-09"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]
@@ -20,7 +22,7 @@ output = 5
 cache_read = 0.4
 
 [limit]
-context = 2_000_000
+context = 1_000_000
 output = 30_000
 
 [modalities]

--- a/providers/xai/models/grok-4.20-multi-agent-0309.toml
+++ b/providers/xai/models/grok-4.20-multi-agent-0309.toml
@@ -6,7 +6,12 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = false
+structured_output = true
 open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
 
 [cost]
 input = 1.25
@@ -20,7 +25,7 @@ output = 5
 cache_read = 0.4
 
 [limit]
-context = 2_000_000
+context = 1_000_000
 output = 30_000
 
 [modalities]

--- a/providers/xai/models/grok-4.3.toml
+++ b/providers/xai/models/grok-4.3.toml
@@ -6,7 +6,12 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
 
 [cost]
 input = 1.25

--- a/providers/xai/models/grok-build-0.1.toml
+++ b/providers/xai/models/grok-build-0.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- add endpoint-specific reasoning options for current xAI models
- correct Grok 4.20 context windows from the stale 2M value to the 1M value documented on xAI model pages
- add strict structured-output metadata confirmed through live requests
- preserve curated reasoning options during future xAI catalog syncs

## Verification
- live-tested every current xAI endpoint and declared reasoning option
- confirmed canonical IDs and aliases
- confirmed strict structured output and context metadata against xAI model documentation
- `bun test packages/core/test/xai-sync.test.ts`
- `bun validate`
- `git diff --check`

## Sync behavior
The xAI language-model catalog does not expose a context-window field (`max_prompt_length` is exposed for image-generation models), so hourly sync preserves the existing language-model context rather than correcting it. The Grok context corrections in this PR are therefore documentation-backed manual corrections. Provider-agnostic `models/xai` metadata is maintained separately and was corrected alongside the provider entries.