### PR TITLE
feat(sync): add Baseten model sync

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Sync model catalogs
         run: bun models:sync ${{ matrix.provider }}
         env:
+          BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "bun test",
     "validate": "bun ./packages/core/script/validate.ts",
     "compare:migrations": "bun ./packages/core/script/compare-model-migrations.ts",
+    "baseten:sync": "bun ./packages/core/script/sync-models.ts baseten",
     "cloudflare:sync": "bun ./packages/core/script/sync-models.ts cloudflare-workers-ai",
     "chutes:generate": "bun ./packages/core/script/generate-chutes.ts",
     "databricks:generate": "bun ./packages/core/script/generate-databricks.ts",

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -4,6 +4,7 @@ import { mergeDeep } from "remeda";
 import { z } from "zod";
 
 import { AuthoredModel, AuthoredModelShape } from "../schema.js";
+import { baseten } from "./providers/baseten.js";
 import { cloudflareWorkersAi } from "./providers/cloudflare-workers-ai.js";
 import { google } from "./providers/google.js";
 import { openrouter } from "./providers/openrouter.js";
@@ -72,6 +73,7 @@ export interface SyncResult {
 }
 
 export const providers: {
+  baseten: SyncProvider<any>;
   "cloudflare-workers-ai": SyncProvider<any>;
   google: SyncProvider<any>;
   openrouter: SyncProvider<any>;
@@ -79,6 +81,7 @@ export const providers: {
   vercel: SyncProvider<any>;
   xai: SyncProvider<any>;
 } = {
+  baseten,
   "cloudflare-workers-ai": cloudflareWorkersAi,
   google,
   openrouter,
@@ -90,7 +93,7 @@ export const providers: {
 export const groups = {
   aggregators: ["openrouter", "vercel"],
   cloudflare: ["cloudflare-workers-ai"],
-  direct: ["google", "ovhcloud", "xai"],
+  direct: ["baseten", "google", "ovhcloud", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;
@@ -122,7 +125,7 @@ export async function syncProvider<SourceModel>(
       },
     });
     if (translated === undefined) {
-      if (provider.skipCreates) skippedRemote.push(provider.sourceID?.(sourceModel) ?? "unknown");
+      if (provider.sourceID !== undefined) skippedRemote.push(provider.sourceID(sourceModel));
       continue;
     }
 

--- a/packages/core/src/sync/providers/baseten.ts
+++ b/packages/core/src/sync/providers/baseten.ts
@@ -1,0 +1,188 @@
+import { z } from "zod";
+
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://inference.baseten.co/v1/models";
+
+const Price = z.union([z.string(), z.number()]);
+
+export const BasetenModel = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  context_length: z.number().int().positive(),
+  max_completion_tokens: z.number().int().positive(),
+  input_modalities: z.array(z.string()),
+  output_modalities: z.array(z.string()),
+  pricing: z.object({
+    prompt: Price,
+    completion: Price,
+  }).passthrough(),
+  supported_features: z.array(z.string()),
+  supported_sampling_parameters: z.array(z.string()),
+}).passthrough();
+
+export const BasetenResponse = z.object({
+  data: z.array(BasetenModel),
+}).passthrough();
+
+export type BasetenModel = z.infer<typeof BasetenModel>;
+
+export const baseten = {
+  id: "baseten",
+  name: "Baseten",
+  modelsDir: "providers/baseten/models",
+  deleteMissing: false,
+  sourceID(model) {
+    return model.id;
+  },
+  skippedNotice(ids) {
+    if (ids.length === 0) return [];
+    return [
+      `${ids.length} Baseten models were not created because their slugs could not be mapped exactly to provider-agnostic metadata.`,
+      `Skipped remote IDs: ${ids.map((id) => `\`${id}\``).join(", ")}`,
+    ];
+  },
+  missingNotice(paths) {
+    if (paths.length === 0) return [];
+    return [
+      `${paths.length} local Baseten models were absent from the catalog and were retained for manual lifecycle review.`,
+      `Retained local paths: ${paths.map((item) => `\`${item}\``).join(", ")}`,
+    ];
+  },
+  async fetchModels() {
+    const key = process.env.BASETEN_API_KEY;
+    if (key === undefined) throw new Error("Baseten sync requires BASETEN_API_KEY");
+    return fetchBasetenModels(key);
+  },
+  parseModels(raw) {
+    return BasetenResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    const existing = context.existing(model.id);
+    const baseModel = existing === undefined
+      ? resolveBasetenBaseModel(model.id)
+      : existing.base_model;
+    if (existing === undefined && baseModel === undefined) return undefined;
+    if (
+      existing === undefined
+      && (price(model.pricing.prompt) === undefined || price(model.pricing.completion) === undefined)
+    ) return undefined;
+
+    return {
+      id: model.id,
+      model: buildBasetenModel(model, existing, baseModel),
+    };
+  },
+} satisfies SyncProvider<BasetenModel>;
+
+export async function fetchBasetenModels(
+  key: string,
+  fetcher: typeof fetch = fetch,
+) {
+  const response = await fetcher(API_ENDPOINT, {
+    headers: { Authorization: `Api-Key ${key}` },
+  });
+  if (!response.ok) {
+    throw new Error(`Baseten models request failed: ${response.status} ${response.statusText}`);
+  }
+  return BasetenResponse.parse(await response.json());
+}
+
+function price(value: string | number | undefined) {
+  if (value === undefined || value === "") return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0
+    ? Math.round(number * 1_000_000_000_000) / 1_000_000
+    : undefined;
+}
+
+export function buildBasetenModel(
+  model: BasetenModel,
+  existing: ExistingModel | undefined,
+  baseModel = existing === undefined ? resolveBasetenBaseModel(model.id) : existing.base_model,
+): SyncedModel {
+  const features = new Set(model.supported_features);
+  const samplingParameters = new Set(model.supported_sampling_parameters);
+  const input = modalities(model.input_modalities, existing?.modalities?.input ?? ["text"]);
+  const output = modalities(model.output_modalities, existing?.modalities?.output ?? ["text"]);
+  const inputCost = price(model.pricing.prompt);
+  const outputCost = price(model.pricing.completion);
+  const cost = inputCost !== undefined && outputCost !== undefined
+    ? {
+        input: inputCost,
+        output: outputCost,
+        reasoning: existing?.cost?.reasoning,
+        cache_read: existing?.cost?.cache_read,
+        cache_write: existing?.cost?.cache_write,
+        tiers: existing?.cost?.tiers,
+      }
+    : existing?.cost;
+  const limit = {
+    context: model.context_length,
+    input: existing?.limit?.input,
+    output: model.max_completion_tokens,
+  };
+  const values: Partial<SyncedFullModel> = {
+    name: model.name ?? existing?.name,
+    family: existing?.family,
+    release_date: existing?.release_date,
+    last_updated: existing?.last_updated,
+    attachment: input.some((value) => value !== "text"),
+    reasoning: features.has("reasoning") || existing?.reasoning,
+    reasoning_options: existing?.reasoning_options,
+    temperature: samplingParameters.has("temperature"),
+    tool_call: features.has("tools") || existing?.tool_call,
+    structured_output: features.has("structured_outputs") || existing?.structured_output,
+    knowledge: existing?.knowledge,
+    open_weights: existing?.open_weights,
+    status: existing?.status,
+    interleaved: existing?.interleaved,
+    cost,
+    limit,
+    modalities: { input, output },
+  };
+
+  if (baseModel !== undefined) {
+    if (limit.context === undefined || limit.output === undefined) {
+      throw new Error(`Baseten model ${model.id} has incomplete token limits required for sync`);
+    }
+    return factorBaseModel(baseModel, values, limit, existing?.base_model_omit);
+  }
+
+  const required = z.object({
+    name: z.string(),
+    release_date: z.string(),
+    last_updated: z.string(),
+    open_weights: z.boolean(),
+    cost: z.object({ input: z.number(), output: z.number() }),
+  }).safeParse(values);
+  if (!required.success) {
+    throw new Error(`Baseten model ${model.id} has incomplete local metadata required for sync`);
+  }
+  return values as SyncedFullModel;
+}
+
+export function resolveBasetenBaseModel(id: string) {
+  const [prefix, ...parts] = id.split("/");
+  if (prefix === undefined || parts.length === 0) return undefined;
+  const canonicalPrefix = {
+    "deepseek-ai": "deepseek",
+    MiniMaxAI: "minimax",
+    moonshotai: "moonshotai",
+    nvidia: "nvidia",
+    "zai-org": "zai",
+  }[prefix];
+  if (canonicalPrefix === undefined) return resolveCanonicalBaseModel(id);
+  return resolveCanonicalBaseModel(`${canonicalPrefix}/${parts.join("/").toLowerCase()}`);
+}
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+function modalities(values: string[], fallback: Modality[]): Modality[] {
+  const allowed = new Set<Modality>(["text", "audio", "image", "video", "pdf"]);
+  const result = values
+    .map((value) => value.toLowerCase())
+    .filter((value): value is Modality => allowed.has(value as Modality));
+  return [...new Set(result.length > 0 ? result : fallback)];
+}

--- a/packages/core/test/baseten-sync.test.ts
+++ b/packages/core/test/baseten-sync.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, expect, test } from "bun:test";
+import path from "node:path";
+import { mkdir, mkdtemp } from "node:fs/promises";
+import os from "node:os";
+
+import { syncProvider } from "../src/sync/index.js";
+import {
+  BasetenResponse,
+  baseten,
+  buildBasetenModel,
+  fetchBasetenModels,
+  type BasetenModel,
+} from "../src/sync/providers/baseten.js";
+
+const catalogModel: BasetenModel = {
+  id: "zai-org/GLM-5.1",
+  name: "GLM 5.1",
+  context_length: 128_000,
+  max_completion_tokens: 32_000,
+  input_modalities: ["text"],
+  output_modalities: ["text"],
+  pricing: {
+    prompt: "0.00000012",
+    completion: "0.0000005",
+  },
+  supported_features: ["reasoning", "reasoning_effort", "tools", "structured_outputs"],
+  supported_sampling_parameters: ["temperature", "top_p"],
+};
+
+const newCatalogModel: BasetenModel = {
+  ...catalogModel,
+};
+
+afterEach(() => {
+  baseten.modelsDir = "providers/baseten/models";
+  baseten.fetchModels = async () => {
+    const key = process.env.BASETEN_API_KEY;
+    if (key === undefined) throw new Error("Baseten sync requires BASETEN_API_KEY");
+    return fetchBasetenModels(key);
+  };
+});
+
+test("Baseten maps authoritative fields and preserves curated metadata", () => {
+  const synced = buildBasetenModel(catalogModel, {
+    name: "Old name",
+    release_date: "2025-08-05",
+    last_updated: "2025-09-01",
+    attachment: false,
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+    tool_call: true,
+    open_weights: true,
+    status: "deprecated",
+    interleaved: { field: "reasoning_content" },
+    base_model: "zhipuai/glm-5.1",
+    base_model_omit: ["limit.input"],
+    cost: { input: 0.1, output: 0.4, cache_write: 0.2 },
+    limit: { context: 64_000, output: 16_000 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(synced).toMatchObject({
+    base_model: "zhipuai/glm-5.1",
+    base_model_omit: ["limit.input"],
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+    status: "deprecated",
+    interleaved: { field: "reasoning_content" },
+    cost: { input: 0.12, output: 0.5, cache_write: 0.2 },
+    limit: { context: 128_000, output: 32_000 },
+  });
+});
+
+test("Baseten preserves curated reasoning when an opt-in capability is omitted", () => {
+  const synced = buildBasetenModel({
+    ...catalogModel,
+    supported_features: ["tools", "structured_outputs"],
+  }, {
+    name: "GLM 5.1",
+    release_date: "2026-05-20",
+    last_updated: "2026-05-20",
+    attachment: false,
+    reasoning: true,
+    reasoning_options: [{ type: "toggle" }],
+    tool_call: true,
+    open_weights: true,
+    cost: { input: 1, output: 4 },
+    limit: { context: 100_000, output: 50_000 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(synced).toMatchObject({
+    reasoning: true,
+    reasoning_options: [{ type: "toggle" }],
+  });
+});
+
+test("Baseten sync adds exact base models, retains missing entries, and is idempotent", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "models-dev-baseten-"));
+  const modelsDir = path.join(root, "providers", "baseten", "models");
+  const metadataDir = path.join(root, "models", "zhipuai");
+  await mkdir(path.join(modelsDir, "stale"), { recursive: true });
+  await mkdir(metadataDir, { recursive: true });
+  await Bun.write(
+    path.join(metadataDir, "glm-5.1.toml"),
+    Bun.file(path.join(import.meta.dirname, "../../../models/zhipuai/glm-5.1.toml")),
+  );
+  await Bun.write(path.join(modelsDir, "stale", "model.toml"), [
+    'name = "Retained"',
+    'release_date = "2025-01-01"',
+    'last_updated = "2025-01-01"',
+    "attachment = false",
+    "reasoning = false",
+    "tool_call = false",
+    "open_weights = false",
+    "[cost]",
+    "input = 1",
+    "output = 1",
+    "[limit]",
+    "context = 1000",
+    "output = 100",
+    "[modalities]",
+    'input = ["text"]',
+    'output = ["text"]',
+    "",
+  ].join("\n"));
+  baseten.modelsDir = modelsDir;
+  baseten.fetchModels = async () => ({ data: [newCatalogModel] });
+
+  const first = await syncProvider(baseten);
+  const second = await syncProvider(baseten);
+
+  expect(first.created).toBe(1);
+  expect(first.deleted).toBe(0);
+  expect(first.notices.join(" ")).toContain("stale/model.toml");
+  expect(second).toMatchObject({ created: 0, updated: 0, deleted: 0 });
+});
+
+test("Baseten rejects malformed catalog responses", () => {
+  expect(() => BasetenResponse.parse({ data: "broken" })).toThrow();
+});
+
+test("Baseten rejects non-success API responses", async () => {
+  const fetcher = async () => new Response("unauthorized", {
+    status: 401,
+    statusText: "Unauthorized",
+  });
+
+  expect(fetchBasetenModels("fixture-key", fetcher as typeof fetch))
+    .rejects.toThrow("Baseten models request failed: 401 Unauthorized");
+});

--- a/providers/baseten/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/baseten/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -1,5 +1,9 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+name = "Deepseek V4 Pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/baseten/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.5.toml
@@ -4,24 +4,27 @@ release_date = "2026-01-30"
 last_updated = "2026-02-12"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = true
-knowledge = "2025-12"
 tool_call = true
+structured_output = true
+knowledge = "2025-12"
 open_weights = true
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"
+
+[cost]
+input = 0.6
+output = 3
+cache_read = 0.12
 
 [limit]
 context = 262_000
 output = 262_000
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image"]
 output = ["text"]
-
-[cost]
-input = 0.60
-output = 3.00
-cache_read = 0.12

--- a/providers/baseten/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.6.toml
@@ -4,19 +4,21 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
-structured_output = true
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-01"
 open_weights = true
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
 input = 0.95
-output = 4.0
+output = 4
 cache_read = 0.16
 
 [limit]
@@ -24,5 +26,5 @@ context = 262_000
 output = 262_000
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/baseten/models/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B.toml
+++ b/providers/baseten/models/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B.toml
@@ -1,12 +1,16 @@
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
-reasoning_options = [{ type = "toggle" }]
+name = "Nemotron Ultra"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.60
-output = 2.40
+input = 0.6
+output = 2.4
 cache_read = 0.12
 
 [limit]

--- a/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
+++ b/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
@@ -1,28 +1,19 @@
-name = "Nemotron 3 Super"
 base_model = "nvidia/nemotron-3-super-120b-a12b"
-family = "nemotron"
-release_date = "2026-03-11"
-last_updated = "2026-03-11"
-attachment = false
-reasoning = true
-reasoning_options = [{ type = "toggle" }]
-temperature = true
-tool_call = true
+name = "Nemotron Super"
+structured_output = true
 knowledge = "2026-02"
-open_weights = true
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.30
+input = 0.06
 output = 0.75
 cache_read = 0.06
 
 [limit]
 context = 202_800
 output = 202_800
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/baseten/models/openai/gpt-oss-120b.toml
+++ b/providers/baseten/models/openai/gpt-oss-120b.toml
@@ -1,14 +1,22 @@
-name = "GPT OSS 120B"
+name = "OpenAI GPT 120B"
 family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
-knowledge = "2025-08"
 tool_call = true
+structured_output = true
+knowledge = "2025-08"
 open_weights = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.1
+output = 0.5
 
 [limit]
 context = 128_072
@@ -17,7 +25,3 @@ output = 128_072
 [modalities]
 input = ["text"]
 output = ["text"]
-
-[cost]
-input = 0.10
-output = 0.50

--- a/providers/baseten/models/zai-org/GLM-4.7.toml
+++ b/providers/baseten/models/zai-org/GLM-4.7.toml
@@ -1,21 +1,24 @@
-name = "GLM-4.7"
+name = "GLM 4.7"
 family = "glm"
 release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2025-04"
 open_weights = true
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.60
-output = 2.20
+input = 0.12
+output = 2.2
 cache_read = 0.12
 
 [limit]

--- a/providers/baseten/models/zai-org/GLM-5.1.toml
+++ b/providers/baseten/models/zai-org/GLM-5.1.toml
@@ -1,12 +1,15 @@
 base_model = "zhipuai/glm-5.1"
-reasoning_options = [{ type = "toggle" }]
+name = "GLM 5.1"
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 1.30
-output = 4.30
+input = 1.3
+output = 4.3
 cache_read = 0.26
 
 [limit]

--- a/providers/baseten/models/zai-org/GLM-5.toml
+++ b/providers/baseten/models/zai-org/GLM-5.toml
@@ -1,14 +1,17 @@
-name = "GLM-5"
+name = "GLM 5"
 family = "glm"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
+structured_output = true
 knowledge = "2026-01"
 open_weights = true
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"
@@ -16,7 +19,7 @@ field = "reasoning_content"
 [cost]
 input = 0.95
 output = 3.15
-cache_read = 0.20
+cache_read = 0.2
 
 [limit]
 context = 202_800

--- a/providers/baseten/provider.toml
+++ b/providers/baseten/provider.toml
@@ -1,5 +1,5 @@
 name = "Baseten"
 npm = "@ai-sdk/openai-compatible"
-doc = "https://docs.baseten.co/development/model-apis/overview"
+doc = "https://docs.baseten.co/inference/model-apis/overview"
 api = "https://inference.baseten.co/v1"
 env = ["BASETEN_API_KEY"]


### PR DESCRIPTION
## Summary
- add Baseten to the shared model sync registry and scheduled workflow
- sync live model identity, pricing, limits, modalities, and advertised capabilities while preserving curated metadata
- retain catalog-missing models for manual lifecycle review instead of deleting them
- update the Baseten documentation URL and add `baseten:sync`

## Live validation
- authenticated `GET https://inference.baseten.co/v1/models` returned 9 models in a single `data` envelope with no pagination fields
- confirmed prompt/completion pricing strings, context/output limits, modalities, feature flags, and sampling parameters
- the endpoint exposes no cache-pricing field, so curated cache prices are preserved
- a second live sync completed with 0 created, 0 updated, and 0 deleted; two catalog-missing scheduled-deprecation entries were retained

## Tests
- `bun test packages/core/test/baseten-sync.test.ts`
- `bun test packages/core/test/*sync.test.ts`
- `bun validate`
- `git diff --check`