### PR TITLE
fix(azure-cognitive-services): remove broken symlinks for retired xAI models

### DIFF
--- a/providers/azure-cognitive-services/models/grok-3-mini.toml
+++ b/providers/azure-cognitive-services/models/grok-3-mini.toml
@@ -1,1 +1,0 @@
-../../azure/models/grok-3-mini.toml

--- a/providers/azure-cognitive-services/models/grok-3.toml
+++ b/providers/azure-cognitive-services/models/grok-3.toml
@@ -1,1 +1,0 @@
-../../azure/models/grok-3.toml

--- a/providers/azure-cognitive-services/models/grok-4-fast-non-reasoning.toml
+++ b/providers/azure-cognitive-services/models/grok-4-fast-non-reasoning.toml
@@ -1,1 +1,0 @@
-../../azure/models/grok-4-fast-non-reasoning.toml

--- a/providers/azure-cognitive-services/models/grok-4.toml
+++ b/providers/azure-cognitive-services/models/grok-4.toml
@@ -1,1 +1,0 @@
-../../azure/models/grok-4.toml

--- a/providers/azure-cognitive-services/models/grok-code-fast-1.toml
+++ b/providers/azure-cognitive-services/models/grok-code-fast-1.toml
@@ -1,1 +1,0 @@
-../../azure/models/grok-code-fast-1.toml


### PR DESCRIPTION
## Summary

Removes 5 dangling symlinks in `providers/azure-cognitive-services/models/` that were left behind after their target files in `providers/azure/models/` were deleted.

## Background

[PR #1788](https://github.com/anomalyco/models.dev/pull/1788) ("xai: drop models retired May 15, 2026") deleted the corresponding model files from `providers/azure/models/` because the xAI base models they referenced via `[extends]` had been retired. However, the symlinks in `providers/azure-cognitive-services/models/` pointing to those deleted files were overlooked and not cleaned up.

## Removed

- `grok-3.toml` → `../../azure/models/grok-3.toml` (broken)
- `grok-3-mini.toml` → `../../azure/models/grok-3-mini.toml` (broken)
- `grok-4.toml` → `../../azure/models/grok-4.toml` (broken)
- `grok-4-fast-non-reasoning.toml` → `../../azure/models/grok-4-fast-non-reasoning.toml` (broken)
- `grok-code-fast-1.toml` → `../../azure/models/grok-code-fast-1.toml` (broken)

Note: `grok-4-fast-reasoning` was also added in the original PR but was **not** deleted in the retirement PR, so its symlink remains valid and is kept.

## Verification

- `bun install && bun validate` passes locally.