### PR TITLE
fix(alibaba/qwen3.7-plus): correct max output to 64K and tier size to 256K

### DIFF
--- a/providers/alibaba/models/qwen3.7-plus.toml
+++ b/providers/alibaba/models/qwen3.7-plus.toml
@@ -16,7 +16,7 @@ cache_read = 0.05
 cache_write = 0.625
 
 [[cost.tiers]]
-tier = { size = 128_000 }
+tier = { size = 256_000 }
 input = 2.00
 output = 6.00
 cache_read = 0.20
@@ -24,7 +24,7 @@ cache_write = 2.50
 
 [limit]
 context = 1_000_000
-output = 16_384
+output = 65_536
 
 [modalities]
 input = ["text", "image", "video"]


### PR DESCRIPTION
## Summary

Fix two remaining incorrect parameters for `alibaba/qwen3.7-plus` that are still wrong on dev (context and modalities were already fixed by 977e2f0).

## Changes

| Field | Before | After | Official Source |
|-------|--------|-------|-----------------|
| `limit.output` | 16,384 (16K) | 65,536 (64K) | [百炼控制台](https://bailian.console.aliyun.com/cn-beijing/?tab=model#/model-market/detail/qwen3.7-plus): 最大输出长度 64K |
| `cost.tiers[0].tier.size` | 128,000 | 256,000 | Matches `qwen3.6-plus` tier threshold |

## Why this matters

OpenCode reads models.dev for model capabilities. When `output` is set to 16K instead of 64K, it causes:
- Premature context auto-compaction in agent sessions
- Incorrect token budget allocation for long-generation tasks

## Verification

After this fix, `qwen3.7-plus` is structurally identical to `qwen3.6-plus` (excluding name/dates/knowledge), confirming they share the same Plus-tier architecture.

**Note: This PR only modifies `providers/alibaba/` — no opencode-go changes.**