### PR TITLE
feat(sync): sync FastRouter model catalog

### DIFF
--- a/providers/fastrouter/models/ace-step/prompt-to-audio.toml
+++ b/providers/fastrouter/models/ace-step/prompt-to-audio.toml
@@ -1,0 +1,16 @@
+name = "ACE-Step Prompt to Audio"
+release_date = "2025-04-01"
+last_updated = "2025-04-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[limit]
+context = 512
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/fastrouter/models/anthropic/claude-3-5-haiku-20241022.toml
+++ b/providers/fastrouter/models/anthropic/claude-3-5-haiku-20241022.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-3-5-haiku-20241022"
+
+[cost]
+input = 0.80
+output = 4

--- a/providers/fastrouter/models/anthropic/claude-4.5-sonnet.toml
+++ b/providers/fastrouter/models/anthropic/claude-4.5-sonnet.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-sonnet-4-5"
+
+[cost]
+input = 3
+output = 15

--- a/providers/fastrouter/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/fastrouter/models/anthropic/claude-haiku-4.5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 1
+output = 5

--- a/providers/fastrouter/models/anthropic/claude-opus-4-20250514.toml
+++ b/providers/fastrouter/models/anthropic/claude-opus-4-20250514.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-20250514"
+
+[cost]
+input = 15
+output = 75

--- a/providers/fastrouter/models/anthropic/claude-opus-4.5.toml
+++ b/providers/fastrouter/models/anthropic/claude-opus-4.5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-5"
+
+[cost]
+input = 5
+output = 25

--- a/providers/fastrouter/models/anthropic/claude-opus-4.6.toml
+++ b/providers/fastrouter/models/anthropic/claude-opus-4.6.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-6"
+
+[cost]
+input = 5
+output = 25

--- a/providers/fastrouter/models/anthropic/claude-opus-4.7.toml
+++ b/providers/fastrouter/models/anthropic/claude-opus-4.7.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[cost]
+input = 5
+output = 25

--- a/providers/fastrouter/models/anthropic/claude-opus-4.8.toml
+++ b/providers/fastrouter/models/anthropic/claude-opus-4.8.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[cost]
+input = 5
+output = 25

--- a/providers/fastrouter/models/anthropic/claude-sonnet-4-20250514.toml
+++ b/providers/fastrouter/models/anthropic/claude-sonnet-4-20250514.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-sonnet-4-20250514"
+
+[cost]
+input = 3
+output = 15

--- a/providers/fastrouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/fastrouter/models/anthropic/claude-sonnet-4.6.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3
+output = 15

--- a/providers/fastrouter/models/black-forest-labs/flux-dev.toml
+++ b/providers/fastrouter/models/black-forest-labs/flux-dev.toml
@@ -1,0 +1,17 @@
+name = "FLUX.1 Dev"
+family = "flux"
+release_date = "2024-08-01"
+last_updated = "2024-08-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/black-forest-labs/flux-kontext-pro.toml
+++ b/providers/fastrouter/models/black-forest-labs/flux-kontext-pro.toml
@@ -1,0 +1,17 @@
+name = "FLUX.1 Kontext Pro"
+family = "flux"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/black-forest-labs/flux-pro-2.0.toml
+++ b/providers/fastrouter/models/black-forest-labs/flux-pro-2.0.toml
@@ -1,0 +1,17 @@
+name = "FLUX.2 Pro"
+family = "flux"
+release_date = "2025-11-01"
+last_updated = "2025-11-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/bytedance/seedance-1.5-pro.toml
+++ b/providers/fastrouter/models/bytedance/seedance-1.5-pro.toml
@@ -1,0 +1,17 @@
+name = "Seedance 1.5 Pro"
+family = "seed"
+release_date = "2025-11-01"
+last_updated = "2025-11-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 400_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/bytedance/seedance-2-fast.toml
+++ b/providers/fastrouter/models/bytedance/seedance-2-fast.toml
@@ -1,0 +1,17 @@
+name = "Seedance 2 Fast"
+family = "seed"
+release_date = "2026-04-01"
+last_updated = "2026-04-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/bytedance/seedance-2.toml
+++ b/providers/fastrouter/models/bytedance/seedance-2.toml
@@ -1,0 +1,17 @@
+name = "Seedance 2"
+family = "seed"
+release_date = "2026-04-01"
+last_updated = "2026-04-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/bytedance/seedance-pro.toml
+++ b/providers/fastrouter/models/bytedance/seedance-pro.toml
@@ -1,0 +1,17 @@
+name = "Seedance 1.0 Pro"
+family = "seed"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/bytedance/seedance.toml
+++ b/providers/fastrouter/models/bytedance/seedance.toml
@@ -1,0 +1,17 @@
+name = "Seedance 1.0 Lite"
+family = "seed"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/bytedance/seedream-4.0.toml
+++ b/providers/fastrouter/models/bytedance/seedream-4.0.toml
@@ -1,0 +1,17 @@
+name = "Seedream 4.0"
+family = "seed"
+release_date = "2025-11-01"
+last_updated = "2025-11-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/bytedance/seedream-4.5.toml
+++ b/providers/fastrouter/models/bytedance/seedream-4.5.toml
@@ -1,0 +1,17 @@
+name = "Seedream 4.5"
+family = "seed"
+release_date = "2026-03-01"
+last_updated = "2026-03-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/deepinfra/intfloat-e5-base-v2.toml
+++ b/providers/fastrouter/models/deepinfra/intfloat-e5-base-v2.toml
@@ -1,0 +1,20 @@
+name = "E5 Base v2"
+release_date = "2023-01-01"
+last_updated = "2023-01-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0
+
+[limit]
+context = 512
+output = 768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/deepseek-ai/DeepSeek-Prover-V2-671B.toml
+++ b/providers/fastrouter/models/deepseek-ai/DeepSeek-Prover-V2-671B.toml
@@ -1,17 +1,16 @@
-name = "DeepSeek R1 Distill Llama 70B"
+name = "DeepSeek Prover V2 671B"
 family = "deepseek-thinking"
-release_date = "2025-01-23"
-last_updated = "2025-01-23"
+release_date = "2025-04-30"
+last_updated = "2025-04-30"
 attachment = false
 reasoning = true
 temperature = true
-knowledge = "2024-10"
 tool_call = false
 open_weights = true
 
 [cost]
-input = 0.70
-output = 0.80
+input = 0.20
+output = 0.77
 
 [limit]
 context = 131_072

--- a/providers/fastrouter/models/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B.toml
+++ b/providers/fastrouter/models/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B.toml
@@ -1,4 +1,4 @@
-name = "DeepSeek R1 Distill Llama 70B"
+name = "DeepSeek R1 Distill Qwen 32B"
 family = "deepseek-thinking"
 release_date = "2025-01-23"
 last_updated = "2025-01-23"

--- a/providers/fastrouter/models/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/fastrouter/models/deepseek-ai/DeepSeek-R1.toml
@@ -1,0 +1,5 @@
+base_model = "deepseek/deepseek-r1"
+
+[cost]
+input = 0.50
+output = 2.15

--- a/providers/fastrouter/models/deepseek/deepseek-v3.1.toml
+++ b/providers/fastrouter/models/deepseek/deepseek-v3.1.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek V3.1"
+family = "deepseek"
+release_date = "2025-05-01"
+last_updated = "2025-05-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.21
+output = 0.79
+
+[limit]
+context = 163_840
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/deepseek/deepseek-v3.2.toml
+++ b/providers/fastrouter/models/deepseek/deepseek-v3.2.toml
@@ -1,0 +1,21 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2025-08-01"
+last_updated = "2025-08-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.26
+output = 0.38
+
+[limit]
+context = 163_840
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/fastrouter/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,5 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 1.74
+output = 3.48

--- a/providers/fastrouter/models/google/gemini-2.5-flash-image.toml
+++ b/providers/fastrouter/models/google/gemini-2.5-flash-image.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-2.5-flash-image"
+
+[cost]
+input = 0.30
+output = 2.50

--- a/providers/fastrouter/models/google/gemini-3-flash-preview.toml
+++ b/providers/fastrouter/models/google/gemini-3-flash-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3-flash-preview"
+
+[cost]
+input = 0.50
+output = 3

--- a/providers/fastrouter/models/google/gemini-3-pro-image-preview.toml
+++ b/providers/fastrouter/models/google/gemini-3-pro-image-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3-pro-image-preview"
+
+[cost]
+input = 2
+output = 12

--- a/providers/fastrouter/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/fastrouter/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-flash-image-preview"
+
+[cost]
+input = 0.50
+output = 3

--- a/providers/fastrouter/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/fastrouter/models/google/gemini-3.1-pro-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[cost]
+input = 2
+output = 12

--- a/providers/fastrouter/models/google/gemini-3.5-flash.toml
+++ b/providers/fastrouter/models/google/gemini-3.5-flash.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.5-flash"
+
+[cost]
+input = 1.50
+output = 9

--- a/providers/fastrouter/models/google/gemini-embedding-001.toml
+++ b/providers/fastrouter/models/google/gemini-embedding-001.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-embedding-001"
+
+[cost]
+input = 0.15
+output = 0

--- a/providers/fastrouter/models/google/gemma-4-31b-it.toml
+++ b/providers/fastrouter/models/google/gemma-4-31b-it.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemma-4-31b-it"
+
+[cost]
+input = 0.13
+output = 0.38

--- a/providers/fastrouter/models/google/imagen-4.0-fast.toml
+++ b/providers/fastrouter/models/google/imagen-4.0-fast.toml
@@ -1,0 +1,17 @@
+name = "Imagen 4 Fast"
+family = "imagen"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 480
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/fastrouter/models/google/imagen-4.0-ultra.toml
+++ b/providers/fastrouter/models/google/imagen-4.0-ultra.toml
@@ -1,0 +1,17 @@
+name = "Imagen 4 Ultra"
+family = "imagen"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 480
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/fastrouter/models/google/imagen-4.0.toml
+++ b/providers/fastrouter/models/google/imagen-4.0.toml
@@ -1,0 +1,17 @@
+name = "Imagen 4"
+family = "imagen"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 480
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/fastrouter/models/google/veo2.toml
+++ b/providers/fastrouter/models/google/veo2.toml
@@ -1,0 +1,17 @@
+name = "Veo 2"
+family = "veo"
+release_date = "2025-01-01"
+last_updated = "2025-01-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/google/veo3-fast.toml
+++ b/providers/fastrouter/models/google/veo3-fast.toml
@@ -1,0 +1,17 @@
+name = "Veo 3 Fast"
+family = "veo"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/google/veo3.1-fast.toml
+++ b/providers/fastrouter/models/google/veo3.1-fast.toml
@@ -1,0 +1,17 @@
+name = "Veo 3.1 Fast"
+family = "veo"
+release_date = "2026-05-01"
+last_updated = "2026-05-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 400_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/google/veo3.1-lite.toml
+++ b/providers/fastrouter/models/google/veo3.1-lite.toml
@@ -1,0 +1,17 @@
+name = "Veo 3.1 Lite"
+family = "veo"
+release_date = "2026-05-01"
+last_updated = "2026-05-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 400_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/google/veo3.1.toml
+++ b/providers/fastrouter/models/google/veo3.1.toml
@@ -1,0 +1,17 @@
+name = "Veo 3.1"
+family = "veo"
+release_date = "2026-05-01"
+last_updated = "2026-05-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 400_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/google/veo3.toml
+++ b/providers/fastrouter/models/google/veo3.toml
@@ -1,0 +1,17 @@
+name = "Veo 3"
+family = "veo"
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/kling-ai/kling-v1-6.toml
+++ b/providers/fastrouter/models/kling-ai/kling-v1-6.toml
@@ -1,0 +1,16 @@
+name = "Kling V1.6"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/kling-ai/kling-v2-1-master.toml
+++ b/providers/fastrouter/models/kling-ai/kling-v2-1-master.toml
@@ -1,0 +1,16 @@
+name = "Kling V2.1 Master"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/kling-ai/kling-v2-1.toml
+++ b/providers/fastrouter/models/kling-ai/kling-v2-1.toml
@@ -1,0 +1,16 @@
+name = "Kling V2.1"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/kling-ai/kling-v2.toml
+++ b/providers/fastrouter/models/kling-ai/kling-v2.toml
@@ -1,0 +1,16 @@
+name = "Kling V2"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/kling-ai/kling-v3.toml
+++ b/providers/fastrouter/models/kling-ai/kling-v3.toml
@@ -1,0 +1,16 @@
+name = "Kling V3"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 400_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/kling-ai/kling-video-o1.toml
+++ b/providers/fastrouter/models/kling-ai/kling-video-o1.toml
@@ -1,0 +1,16 @@
+name = "Kling Video O1"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 400_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/leonardo-ai/lucid-origin.toml
+++ b/providers/fastrouter/models/leonardo-ai/lucid-origin.toml
@@ -1,0 +1,17 @@
+name = "Lucid Origin"
+family = "lucid"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/leonardo-ai/lucid-realism.toml
+++ b/providers/fastrouter/models/leonardo-ai/lucid-realism.toml
@@ -1,0 +1,17 @@
+name = "Lucid Realism"
+family = "lucid"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/leonardo-ai/phoenix.toml
+++ b/providers/fastrouter/models/leonardo-ai/phoenix.toml
@@ -1,0 +1,17 @@
+name = "Phoenix"
+family = "phoenix"
+release_date = "2024-11-01"
+last_updated = "2024-11-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 4_096
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/meta-llama/llama-3.1-8b-instant.toml
+++ b/providers/fastrouter/models/meta-llama/llama-3.1-8b-instant.toml
@@ -1,0 +1,22 @@
+name = "Llama 3.1 8B Instant"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2023-12"
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.08
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/meta-llama/llama-3.3-70b-versatile.toml
+++ b/providers/fastrouter/models/meta-llama/llama-3.3-70b-versatile.toml
@@ -1,0 +1,5 @@
+base_model = "meta/llama-3.3-70b-instruct"
+
+[cost]
+input = 0.59
+output = 0.79

--- a/providers/fastrouter/models/meta-llama/llama-4-scout-17b-16e-instruct.toml
+++ b/providers/fastrouter/models/meta-llama/llama-4-scout-17b-16e-instruct.toml
@@ -1,0 +1,5 @@
+base_model = "meta/llama-4-scout-17b-instruct"
+
+[cost]
+input = 0.11
+output = 0.34

--- a/providers/fastrouter/models/minimax/minimax-m2.1.toml
+++ b/providers/fastrouter/models/minimax/minimax-m2.1.toml
@@ -1,0 +1,5 @@
+base_model = "minimax/MiniMax-M2.1"
+
+[cost]
+input = 0.15
+output = 1.15

--- a/providers/fastrouter/models/minimax/minimax-m2.5-highspeed.toml
+++ b/providers/fastrouter/models/minimax/minimax-m2.5-highspeed.toml
@@ -1,0 +1,5 @@
+base_model = "minimax/MiniMax-M2.5-highspeed"
+
+[cost]
+input = 0.60
+output = 2.40

--- a/providers/fastrouter/models/minimax/minimax-m2.5.toml
+++ b/providers/fastrouter/models/minimax/minimax-m2.5.toml
@@ -1,0 +1,5 @@
+base_model = "minimax/MiniMax-M2.5"
+
+[cost]
+input = 0.15
+output = 1.15

--- a/providers/fastrouter/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/fastrouter/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,0 +1,5 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
+
+[cost]
+input = 0.60
+output = 2.40

--- a/providers/fastrouter/models/minimax/minimax-m2.7.toml
+++ b/providers/fastrouter/models/minimax/minimax-m2.7.toml
@@ -1,0 +1,5 @@
+base_model = "minimax/MiniMax-M2.7"
+
+[cost]
+input = 0.30
+output = 1.20

--- a/providers/fastrouter/models/mistralai/Mistral-7B-Instruct-v0.1.toml
+++ b/providers/fastrouter/models/mistralai/Mistral-7B-Instruct-v0.1.toml
@@ -1,0 +1,22 @@
+name = "Mistral 7B Instruct v0.1"
+family = "mistral"
+release_date = "2023-09-27"
+last_updated = "2023-09-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+knowledge = "2023-09"
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.20
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/mistralai/Mistral-7B-Instruct-v0.3.toml
+++ b/providers/fastrouter/models/mistralai/Mistral-7B-Instruct-v0.3.toml
@@ -1,0 +1,22 @@
+name = "Mistral 7B Instruct v0.3"
+family = "mistral"
+release_date = "2024-05-22"
+last_updated = "2024-05-22"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2023-09"
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.20
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/mistralai/Mistral-Nemo-Instruct-2407.toml
+++ b/providers/fastrouter/models/mistralai/Mistral-Nemo-Instruct-2407.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-nemo"
+
+[cost]
+input = 0.02
+output = 0.04

--- a/providers/fastrouter/models/mistralai/Mistral-Small-24B-Instruct-2501.toml
+++ b/providers/fastrouter/models/mistralai/Mistral-Small-24B-Instruct-2501.toml
@@ -1,0 +1,22 @@
+name = "Mistral Small 3"
+family = "mistral-small"
+release_date = "2025-01-15"
+last_updated = "2025-01-15"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-12"
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.08
+
+[limit]
+context = 28_000
+output = 28_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/mistralai/Mixtral-8x7B-Instruct-v0.1.toml
+++ b/providers/fastrouter/models/mistralai/Mixtral-8x7B-Instruct-v0.1.toml
@@ -1,0 +1,22 @@
+name = "Mixtral 8x7B Instruct"
+family = "mixtral"
+release_date = "2023-12-11"
+last_updated = "2023-12-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+knowledge = "2023-12"
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.08
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/fastrouter/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2.5"
+
+[cost]
+input = 0.45
+output = 2.25

--- a/providers/fastrouter/models/moonshotai/kimi-k2.6.toml
+++ b/providers/fastrouter/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.75
+output = 3.50

--- a/providers/fastrouter/models/openai/gpt-3.5-turbo-0125.toml
+++ b/providers/fastrouter/models/openai/gpt-3.5-turbo-0125.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-3.5-turbo"
+
+[cost]
+input = 0.50
+output = 1.50

--- a/providers/fastrouter/models/openai/gpt-3.5-turbo-1106.toml
+++ b/providers/fastrouter/models/openai/gpt-3.5-turbo-1106.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-3.5-turbo"
+
+[cost]
+input = 1
+output = 2

--- a/providers/fastrouter/models/openai/gpt-3.5-turbo-16k.toml
+++ b/providers/fastrouter/models/openai/gpt-3.5-turbo-16k.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-3.5-turbo"
+
+[cost]
+input = 3
+output = 4

--- a/providers/fastrouter/models/openai/gpt-3.5-turbo.toml
+++ b/providers/fastrouter/models/openai/gpt-3.5-turbo.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-3.5-turbo"
+
+[cost]
+input = 0.50
+output = 1.50

--- a/providers/fastrouter/models/openai/gpt-4-turbo.toml
+++ b/providers/fastrouter/models/openai/gpt-4-turbo.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4-turbo"
+
+[cost]
+input = 10
+output = 30

--- a/providers/fastrouter/models/openai/gpt-4.1-mini.toml
+++ b/providers/fastrouter/models/openai/gpt-4.1-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4.1-mini"
+
+[cost]
+input = 0.40
+output = 1.60

--- a/providers/fastrouter/models/openai/gpt-4.1-nano.toml
+++ b/providers/fastrouter/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4.1-nano"
+
+[cost]
+input = 0.10
+output = 0.40

--- a/providers/fastrouter/models/openai/gpt-4.toml
+++ b/providers/fastrouter/models/openai/gpt-4.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4"
+
+[cost]
+input = 30
+output = 60

--- a/providers/fastrouter/models/openai/gpt-4o-2024-05-13.toml
+++ b/providers/fastrouter/models/openai/gpt-4o-2024-05-13.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-2024-05-13"
+
+[cost]
+input = 5
+output = 15

--- a/providers/fastrouter/models/openai/gpt-4o-2024-08-06.toml
+++ b/providers/fastrouter/models/openai/gpt-4o-2024-08-06.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-2024-08-06"
+
+[cost]
+input = 2.50
+output = 10

--- a/providers/fastrouter/models/openai/gpt-4o-2024-11-20.toml
+++ b/providers/fastrouter/models/openai/gpt-4o-2024-11-20.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-2024-11-20"
+
+[cost]
+input = 2.50
+output = 10

--- a/providers/fastrouter/models/openai/gpt-4o-mini-2024-07-18.toml
+++ b/providers/fastrouter/models/openai/gpt-4o-mini-2024-07-18.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-mini"
+
+[cost]
+input = 0.15
+output = 0.60

--- a/providers/fastrouter/models/openai/gpt-4o-mini-search-preview.toml
+++ b/providers/fastrouter/models/openai/gpt-4o-mini-search-preview.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-mini"
+
+[cost]
+input = 0.15
+output = 0.60

--- a/providers/fastrouter/models/openai/gpt-4o-mini.toml
+++ b/providers/fastrouter/models/openai/gpt-4o-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-mini"
+
+[cost]
+input = 0.15
+output = 0.60

--- a/providers/fastrouter/models/openai/gpt-4o-search-preview.toml
+++ b/providers/fastrouter/models/openai/gpt-4o-search-preview.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o"
+
+[cost]
+input = 2.50
+output = 10

--- a/providers/fastrouter/models/openai/gpt-4o.toml
+++ b/providers/fastrouter/models/openai/gpt-4o.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o"
+
+[cost]
+input = 2.50
+output = 10

--- a/providers/fastrouter/models/openai/gpt-5.1.toml
+++ b/providers/fastrouter/models/openai/gpt-5.1.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.1"
+
+[cost]
+input = 1.25
+output = 10

--- a/providers/fastrouter/models/openai/gpt-5.2-chat.toml
+++ b/providers/fastrouter/models/openai/gpt-5.2-chat.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.2-chat-latest"
+
+[cost]
+input = 1.75
+output = 14

--- a/providers/fastrouter/models/openai/gpt-5.2-codex.toml
+++ b/providers/fastrouter/models/openai/gpt-5.2-codex.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.2-codex"
+
+[cost]
+input = 1.75
+output = 14

--- a/providers/fastrouter/models/openai/gpt-5.2-pro.toml
+++ b/providers/fastrouter/models/openai/gpt-5.2-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.2-pro"
+
+[cost]
+input = 21
+output = 168

--- a/providers/fastrouter/models/openai/gpt-5.2.toml
+++ b/providers/fastrouter/models/openai/gpt-5.2.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.2"
+
+[cost]
+input = 1.75
+output = 14

--- a/providers/fastrouter/models/openai/gpt-5.3-chat.toml
+++ b/providers/fastrouter/models/openai/gpt-5.3-chat.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.3-chat-latest"
+
+[cost]
+input = 1.75
+output = 14

--- a/providers/fastrouter/models/openai/gpt-5.3-codex.toml
+++ b/providers/fastrouter/models/openai/gpt-5.3-codex.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.3-codex"
+
+[cost]
+input = 1.75
+output = 14

--- a/providers/fastrouter/models/openai/gpt-5.4-mini.toml
+++ b/providers/fastrouter/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-mini"
+
+[cost]
+input = 0.75
+output = 4.50

--- a/providers/fastrouter/models/openai/gpt-5.4-nano.toml
+++ b/providers/fastrouter/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-nano"
+
+[cost]
+input = 0.20
+output = 1.25

--- a/providers/fastrouter/models/openai/gpt-5.4-pro.toml
+++ b/providers/fastrouter/models/openai/gpt-5.4-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-pro"
+
+[cost]
+input = 30
+output = 180

--- a/providers/fastrouter/models/openai/gpt-5.4.toml
+++ b/providers/fastrouter/models/openai/gpt-5.4.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4"
+
+[cost]
+input = 2.50
+output = 15

--- a/providers/fastrouter/models/openai/gpt-5.5-pro.toml
+++ b/providers/fastrouter/models/openai/gpt-5.5-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.5-pro"
+
+[cost]
+input = 30
+output = 180

--- a/providers/fastrouter/models/openai/gpt-5.5.toml
+++ b/providers/fastrouter/models/openai/gpt-5.5.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.5"
+
+[cost]
+input = 5
+output = 30

--- a/providers/fastrouter/models/openai/gpt-image-1-mini.toml
+++ b/providers/fastrouter/models/openai/gpt-image-1-mini.toml
@@ -1,0 +1,17 @@
+name = "GPT Image 1 Mini"
+family = "gpt-image"
+release_date = "2025-03-25"
+last_updated = "2025-03-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 128_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/openai/gpt-image-1.5.toml
+++ b/providers/fastrouter/models/openai/gpt-image-1.5.toml
@@ -1,0 +1,17 @@
+name = "GPT Image 1.5"
+family = "gpt-image"
+release_date = "2025-08-01"
+last_updated = "2025-08-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 128_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/openai/gpt-image-1.toml
+++ b/providers/fastrouter/models/openai/gpt-image-1.toml
@@ -1,0 +1,17 @@
+name = "GPT Image 1"
+family = "gpt-image"
+release_date = "2025-03-25"
+last_updated = "2025-03-25"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 128_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/openai/gpt-image-2.toml
+++ b/providers/fastrouter/models/openai/gpt-image-2.toml
@@ -1,0 +1,17 @@
+name = "GPT Image 2"
+family = "gpt-image"
+release_date = "2026-04-21"
+last_updated = "2026-04-21"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[limit]
+context = 128_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/fastrouter/models/openai/gpt-realtime-1.5.toml
+++ b/providers/fastrouter/models/openai/gpt-realtime-1.5.toml
@@ -1,0 +1,21 @@
+name = "GPT Realtime 1.5"
+family = "gpt"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 4
+output = 16
+
+[limit]
+context = 32_000
+output = 4_096
+
+[modalities]
+input = ["text", "audio", "image"]
+output = ["text", "audio"]

--- a/providers/fastrouter/models/openai/gpt-realtime-mini.toml
+++ b/providers/fastrouter/models/openai/gpt-realtime-mini.toml
@@ -1,0 +1,22 @@
+name = "GPT Realtime Mini"
+family = "gpt"
+release_date = "2024-10-01"
+last_updated = "2024-10-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+knowledge = "2023-10"
+
+[cost]
+input = 0.60
+output = 2.40
+
+[limit]
+context = 32_000
+output = 4_096
+
+[modalities]
+input = ["text", "audio", "image"]
+output = ["text", "audio"]

--- a/providers/fastrouter/models/openai/gpt-realtime.toml
+++ b/providers/fastrouter/models/openai/gpt-realtime.toml
@@ -1,0 +1,22 @@
+name = "GPT Realtime"
+family = "gpt"
+release_date = "2024-10-01"
+last_updated = "2024-10-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+knowledge = "2023-10"
+
+[cost]
+input = 4
+output = 16
+
+[limit]
+context = 32_000
+output = 4_096
+
+[modalities]
+input = ["text", "audio", "image"]
+output = ["text", "audio"]

--- a/providers/fastrouter/models/openai/o1.toml
+++ b/providers/fastrouter/models/openai/o1.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o1"
+
+[cost]
+input = 15
+output = 60

--- a/providers/fastrouter/models/openai/o3-mini-high.toml
+++ b/providers/fastrouter/models/openai/o3-mini-high.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o3-mini"
+
+[cost]
+input = 1.10
+output = 4.40

--- a/providers/fastrouter/models/openai/o3-mini.toml
+++ b/providers/fastrouter/models/openai/o3-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o3-mini"
+
+[cost]
+input = 1.10
+output = 4.40

--- a/providers/fastrouter/models/openai/o3.toml
+++ b/providers/fastrouter/models/openai/o3.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o3"
+
+[cost]
+input = 2
+output = 8

--- a/providers/fastrouter/models/openai/o4-mini-high.toml
+++ b/providers/fastrouter/models/openai/o4-mini-high.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o4-mini"
+
+[cost]
+input = 1.10
+output = 4.40

--- a/providers/fastrouter/models/openai/o4-mini.toml
+++ b/providers/fastrouter/models/openai/o4-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o4-mini"
+
+[cost]
+input = 1.10
+output = 4.40

--- a/providers/fastrouter/models/openai/sora-2-pro.toml
+++ b/providers/fastrouter/models/openai/sora-2-pro.toml
@@ -1,0 +1,17 @@
+name = "Sora 2 Pro"
+family = "sora"
+release_date = "2025-10-01"
+last_updated = "2025-10-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/openai/sora-2.toml
+++ b/providers/fastrouter/models/openai/sora-2.toml
@@ -1,0 +1,17 @@
+name = "Sora 2"
+family = "sora"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/openai/text-embedding-3-large.toml
+++ b/providers/fastrouter/models/openai/text-embedding-3-large.toml
@@ -1,0 +1,22 @@
+name = "text-embedding-3-large"
+family = "text-embedding"
+release_date = "2024-01-25"
+last_updated = "2024-01-25"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+knowledge = "2024-01"
+open_weights = false
+
+[cost]
+input = 0.13
+output = 0
+
+[limit]
+context = 8_191
+output = 3_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/openai/text-embedding-3-small.toml
+++ b/providers/fastrouter/models/openai/text-embedding-3-small.toml
@@ -1,0 +1,22 @@
+name = "text-embedding-3-small"
+family = "text-embedding"
+release_date = "2024-01-25"
+last_updated = "2024-01-25"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+knowledge = "2024-01"
+open_weights = false
+
+[cost]
+input = 0.02
+output = 0
+
+[limit]
+context = 8_191
+output = 1_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/openai/text-embedding-ada-002.toml
+++ b/providers/fastrouter/models/openai/text-embedding-ada-002.toml
@@ -1,0 +1,22 @@
+name = "text-embedding-ada-002"
+family = "text-embedding"
+release_date = "2022-12-15"
+last_updated = "2022-12-15"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+knowledge = "2021-09"
+open_weights = false
+
+[cost]
+input = 0.10
+output = 0
+
+[limit]
+context = 8_191
+output = 1_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/perplexity/sonar-deep-research.toml
+++ b/providers/fastrouter/models/perplexity/sonar-deep-research.toml
@@ -1,0 +1,21 @@
+name = "Sonar Deep Research"
+family = "sonar-deep-research"
+release_date = "2025-02-14"
+last_updated = "2025-02-14"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 2
+output = 8
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/perplexity/sonar-pro.toml
+++ b/providers/fastrouter/models/perplexity/sonar-pro.toml
@@ -1,0 +1,5 @@
+base_model = "perplexity/sonar-pro"
+
+[cost]
+input = 3
+output = 15

--- a/providers/fastrouter/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/fastrouter/models/perplexity/sonar-reasoning-pro.toml
@@ -1,0 +1,5 @@
+base_model = "perplexity/sonar-reasoning-pro"
+
+[cost]
+input = 2
+output = 8

--- a/providers/fastrouter/models/perplexity/sonar.toml
+++ b/providers/fastrouter/models/perplexity/sonar.toml
@@ -1,0 +1,5 @@
+base_model = "perplexity/sonar"
+
+[cost]
+input = 1
+output = 1

--- a/providers/fastrouter/models/pika/pika-v2-2.toml
+++ b/providers/fastrouter/models/pika/pika-v2-2.toml
@@ -1,0 +1,16 @@
+name = "Pika 2.2"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/pollo/pollo-v1-6.toml
+++ b/providers/fastrouter/models/pollo/pollo-v1-6.toml
@@ -1,0 +1,16 @@
+name = "Pollo 1.6"
+release_date = "2025-05-01"
+last_updated = "2025-05-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/qwen/Qwen2.5-72B-Instruct.toml
+++ b/providers/fastrouter/models/qwen/Qwen2.5-72B-Instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen2.5 72B Instruct"
+family = "qwen"
+release_date = "2024-09-19"
+last_updated = "2024-09-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-09"
+open_weights = true
+
+[cost]
+input = 0.36
+output = 0.40
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/qwen/Qwen2.5-7B-Instruct.toml
+++ b/providers/fastrouter/models/qwen/Qwen2.5-7B-Instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen2.5 7B Instruct"
+family = "qwen"
+release_date = "2024-09-19"
+last_updated = "2024-09-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-09"
+open_weights = true
+
+[cost]
+input = 0.12
+output = 0.24
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/qwen/Qwen2.5-Coder-32B-Instruct.toml
+++ b/providers/fastrouter/models/qwen/Qwen2.5-Coder-32B-Instruct.toml
@@ -1,0 +1,22 @@
+name = "Qwen2.5 Coder 32B Instruct"
+family = "qwen"
+release_date = "2024-11-12"
+last_updated = "2024-11-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-09"
+open_weights = true
+
+[cost]
+input = 0.08
+output = 0.28
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/qwen/Qwen3-14B.toml
+++ b/providers/fastrouter/models/qwen/Qwen3-14B.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 14B"
+family = "qwen"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.12
+output = 0.24
+
+[limit]
+context = 40_960
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/qwen/Qwen3-30B-A3B.toml
+++ b/providers/fastrouter/models/qwen/Qwen3-30B-A3B.toml
@@ -1,0 +1,22 @@
+name = "Qwen3 30B A3B"
+family = "qwen"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 0.09
+output = 0.45
+
+[limit]
+context = 40_960
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/qwen/qwen2.5-vl-32b-instruct.toml
+++ b/providers/fastrouter/models/qwen/qwen2.5-vl-32b-instruct.toml
@@ -1,0 +1,21 @@
+name = "Qwen2.5 VL 32B Instruct"
+family = "qwen"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 16_384
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/fastrouter/models/qwen/qwen3-235b-a22b.toml
+++ b/providers/fastrouter/models/qwen/qwen3-235b-a22b.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-235b-a22b"
+
+[cost]
+input = 0.07
+output = 0.10

--- a/providers/fastrouter/models/qwen/qwen3-32b.toml
+++ b/providers/fastrouter/models/qwen/qwen3-32b.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-32b"
+
+[cost]
+input = 0.08
+output = 0.28

--- a/providers/fastrouter/models/runway/runway-gen-3-turbo.toml
+++ b/providers/fastrouter/models/runway/runway-gen-3-turbo.toml
@@ -1,0 +1,17 @@
+name = "Runway Gen-3 Turbo"
+family = "runway"
+release_date = "2024-06-01"
+last_updated = "2024-06-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/runway/runway-gen-4-turbo.toml
+++ b/providers/fastrouter/models/runway/runway-gen-4-turbo.toml
@@ -1,0 +1,17 @@
+name = "Runway Gen-4 Turbo"
+family = "runway"
+release_date = "2025-03-01"
+last_updated = "2025-03-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/sarvam/bulbul:v2.toml
+++ b/providers/fastrouter/models/sarvam/bulbul:v2.toml
@@ -1,0 +1,21 @@
+name = "Bulbul v2"
+family = "sarvam"
+release_date = "2025-07-01"
+last_updated = "2025-07-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 15
+output = 0
+
+[limit]
+context = 1_500
+output = 1
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/fastrouter/models/sarvam/saaras:v3.toml
+++ b/providers/fastrouter/models/sarvam/saaras:v3.toml
@@ -1,0 +1,21 @@
+name = "Saaras v3"
+family = "sarvam"
+release_date = "2025-07-01"
+last_updated = "2025-07-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 2_046
+output = 1
+
+[modalities]
+input = ["audio"]
+output = ["text"]

--- a/providers/fastrouter/models/sarvam/sarvam-105b.toml
+++ b/providers/fastrouter/models/sarvam/sarvam-105b.toml
@@ -1,0 +1,21 @@
+name = "Sarvam 105B"
+family = "sarvam"
+release_date = "2025-09-01"
+last_updated = "2025-09-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.04
+output = 0.16
+
+[limit]
+context = 128_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/sarvam/sarvam-30b.toml
+++ b/providers/fastrouter/models/sarvam/sarvam-30b.toml
@@ -1,20 +1,20 @@
-name = "GLM 4.5"
-release_date = "2025-07-28"
-last_updated = "2025-07-28"
+name = "Sarvam 30B"
+family = "sarvam"
+release_date = "2026-02-18"
+last_updated = "2026-02-18"
 attachment = false
-reasoning = true
+reasoning = false
 temperature = true
 tool_call = true
-knowledge = "2025-04"
 open_weights = true
 
 [cost]
-input = 0.60
-output = 2.20
+input = 0.02
+output = 0.10
 
 [limit]
 context = 128_000
-output = 96_000
+output = 128_000
 
 [modalities]
 input = ["text"]

--- a/providers/fastrouter/models/vidu/vidu-q1.toml
+++ b/providers/fastrouter/models/vidu/vidu-q1.toml
@@ -1,0 +1,16 @@
+name = "Vidu Q1"
+release_date = "2025-06-01"
+last_updated = "2025-06-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/vidu/vidu-v2-0.toml
+++ b/providers/fastrouter/models/vidu/vidu-v2-0.toml
@@ -1,0 +1,16 @@
+name = "Vidu 2.0"
+release_date = "2024-07-01"
+last_updated = "2024-07-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/wanx/wan-v2-6.toml
+++ b/providers/fastrouter/models/wanx/wan-v2-6.toml
@@ -1,0 +1,16 @@
+name = "Wan 2.6"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[limit]
+context = 400_000
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["video"]

--- a/providers/fastrouter/models/x-ai/grok-2-1212.toml
+++ b/providers/fastrouter/models/x-ai/grok-2-1212.toml
@@ -1,17 +1,17 @@
-name = "Kimi K2"
-family = "kimi"
-release_date = "2025-07-11"
-last_updated = "2025-07-11"
+name = "Grok 2 1212"
+family = "grok"
+release_date = "2024-12-12"
+last_updated = "2024-12-12"
 attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-knowledge = "2024-10"
-open_weights = true
+open_weights = false
+knowledge = "2024-11"
 
 [cost]
-input = 0.55
-output = 2.20
+input = 2
+output = 10
 
 [limit]
 context = 131_072

--- a/providers/fastrouter/models/x-ai/grok-3-beta.toml
+++ b/providers/fastrouter/models/x-ai/grok-3-beta.toml
@@ -1,0 +1,21 @@
+name = "Grok 3 Beta"
+family = "grok-beta"
+release_date = "2025-02-19"
+last_updated = "2025-02-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 5
+output = 25
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/x-ai/grok-3-mini-beta.toml
+++ b/providers/fastrouter/models/x-ai/grok-3-mini-beta.toml
@@ -1,0 +1,21 @@
+name = "Grok 3 Mini Beta"
+family = "grok-beta"
+release_date = "2025-02-19"
+last_updated = "2025-02-19"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.60
+output = 4
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/x-ai/grok-4-fast.toml
+++ b/providers/fastrouter/models/x-ai/grok-4-fast.toml
@@ -1,0 +1,21 @@
+name = "Grok 4 Fast"
+family = "grok"
+release_date = "2025-07-09"
+last_updated = "2025-07-09"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.50
+
+[limit]
+context = 2_000_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/x-ai/grok-4.1-fast.toml
+++ b/providers/fastrouter/models/x-ai/grok-4.1-fast.toml
@@ -1,0 +1,21 @@
+name = "Grok 4.1 Fast"
+family = "grok"
+release_date = "2026-04-01"
+last_updated = "2026-04-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 0.50
+
+[limit]
+context = 2_000_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/x-ai/grok-4.20-beta.toml
+++ b/providers/fastrouter/models/x-ai/grok-4.20-beta.toml
@@ -1,0 +1,21 @@
+name = "Grok 4.20 Beta"
+family = "grok"
+release_date = "2026-03-09"
+last_updated = "2026-03-09"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 2
+output = 6
+
+[limit]
+context = 2_000_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/x-ai/grok-4.3.toml
+++ b/providers/fastrouter/models/x-ai/grok-4.3.toml
@@ -1,0 +1,5 @@
+base_model = "xai/grok-4.3"
+
+[cost]
+input = 1.25
+output = 2.50

--- a/providers/fastrouter/models/x-ai/grok-code-fast-1.toml
+++ b/providers/fastrouter/models/x-ai/grok-code-fast-1.toml
@@ -1,0 +1,21 @@
+name = "Grok Code Fast 1"
+family = "grok"
+release_date = "2026-05-01"
+last_updated = "2026-05-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.20
+output = 1.50
+
+[limit]
+context = 256_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/fastrouter/models/z-ai/glm-4.5-air.toml
+++ b/providers/fastrouter/models/z-ai/glm-4.5-air.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-4.5-air"
+
+[cost]
+input = 0.03
+output = 0.14

--- a/providers/fastrouter/models/z-ai/glm-4.5.toml
+++ b/providers/fastrouter/models/z-ai/glm-4.5.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-4.5"
+
+[cost]
+input = 0.43
+output = 1.74

--- a/providers/fastrouter/models/z-ai/glm-4.6.toml
+++ b/providers/fastrouter/models/z-ai/glm-4.6.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-4.6"
+
+[cost]
+input = 0.43
+output = 1.74

--- a/providers/fastrouter/models/z-ai/glm-4.7.toml
+++ b/providers/fastrouter/models/z-ai/glm-4.7.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-4.7"
+
+[cost]
+input = 0.40
+output = 1.75

--- a/providers/fastrouter/models/z-ai/glm-5.1.toml
+++ b/providers/fastrouter/models/z-ai/glm-5.1.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-5.1"
+
+[cost]
+input = 1.05
+output = 3.50

--- a/providers/fastrouter/models/z-ai/glm-5.toml
+++ b/providers/fastrouter/models/z-ai/glm-5.toml
@@ -12,8 +12,8 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 0.95
-output = 3.15
+input = 0.60
+output = 2.08
 
 [limit]
 context = 204800


### PR DESCRIPTION
Adds ~117 new model TOMLs, removes 1 stale entry, and updates 2 pricing files to match the current fastrouter.ai/models listing.

- Remove moonshotai/kimi-k2 (replaced by kimi-k2.5 and kimi-k2.6)
- Fix z-ai/glm-4.5 (missing .toml extension); convert to base_model ref
- Update pricing: deepseek-r1-distill-llama-70b, z-ai/glm-5
- Add Anthropic claude-opus-4.5 through claude-3-5-haiku-20241022
- Add OpenAI gpt-5.x/4.x/3.5, o-series, realtime, image, sora, embeddings
- Add Google gemini-3.x/gemma-4, imagen-4, veo2/veo3/veo3.1 families
- Add xAI grok-4.x/3.x/2, DeepSeek v3.x/v4-pro/R1 variants
- Add Qwen, MoonshotAI, MiniMax, Perplexity, Meta, Mistral, Z.AI, Sarvam
- Add FLUX, ByteDance seedream/seedance, Leonardo AI, Kling, Runway, Pika, Pollo, Vidu, Wanx video/image models and ace-step audio

Uses base_model inheritance where canonical models/ entries exist; self-contained TOMLs otherwise. bun validate exits 0.