### PR TITLE
feat(xiaomi): add mimo-v2.5-pro-ultraspeed

### DIFF
--- a/models/xiaomi/mimo-v2.5-pro-ultraspeed.toml
+++ b/models/xiaomi/mimo-v2.5-pro-ultraspeed.toml
@@ -1,0 +1,22 @@
+name = "MiMo-V2.5-Pro-UltraSpeed"
+family = "mimo"
+release_date = "2026-06-08"
+last_updated = "2026-06-09"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-12"
+open_weights = true
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash"

--- a/providers/xiaomi/models/mimo-v2.5-pro-ultraspeed.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro-ultraspeed.toml
@@ -1,0 +1,30 @@
+name = "MiMo-V2.5-Pro-UltraSpeed"
+family = "mimo"
+release_date = "2026-06-08"
+last_updated = "2026-06-09"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2024-12"
+open_weights = true
+status = "beta"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 1.305
+output = 2.61
+cache_read = 0.0108
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
## Summary

Add Xiaomi `mimo-v2.5-pro-ultraspeed` support to models.dev.

`MiMo-V2.5-Pro-UltraSpeed` is a newly released high-speed serving SKU of MiMo-V2.5-Pro. Xiaomi exposes it as a separate API model ID, `mimo-v2.5-pro-ultraspeed`, on the official API platform. Access is currently available through an application-based public beta.

This is similar to the existing MiniMax highspeed entries in models.dev: the high-speed variant is represented as its own model/SKU because it has a distinct API-facing model ID and pricing, even though it is closely related to the base model family.

This PR:

* Adds canonical model metadata under `models/xiaomi`
* Adds the Xiaomi provider entry with beta status, pricing, reasoning toggle, and `reasoning_content` interleaving
* Uses the existing MiMo V2.5 Pro metadata pattern for context window, output limit, modalities, and knowledge cutoff where UltraSpeed-specific values are not separately documented
* Uses the UTC release date for consistency with existing MiMo release-date conventions in models.dev

## Model details

* **Model ID:** `mimo-v2.5-pro-ultraspeed`
* **Model family:** MiMo / MiMo-V2.5-Pro
* **Status:** public beta, application required
* **Context window:** 1,048,576 tokens
* **Max output:** 131,072 tokens
* **Modalities:** text input, text output
* **Reasoning:** supported, with toggle metadata on the Xiaomi provider entry
* **Weights:** XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash

## References

* **Official Xiaomi MiMo model page:** documents `MiMo-V2.5-Pro-UltraSpeed`, the API-facing `mimo-v2.5-pro-ultraspeed` model ID, and public beta access
  https://platform.xiaomimimo.com/docs/en-US/model-intro/mimo-v2.5-pro-ultraspeed

* **Hugging Face weights:** official XiaomiMiMo FP4-DFlash weights associated with the UltraSpeed release
  https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash

## Validation

* `bun validate`
* `git diff --check`
