### PR TITLE
Add Claude Fable 5

### DIFF
--- a/models/anthropic/claude-fable-5.toml
+++ b/models/anthropic/claude-fable-5.toml
@@ -1,0 +1,17 @@
+name = "Claude Fable 5"
+family = "claude-fable"
+release_date = "2026-06-09"
+last_updated = "2026-06-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -26,6 +26,7 @@ export const ModelFamilyValues = [
   "claude-haiku",
   "claude-sonnet",
   "claude-opus",
+  "claude-fable",
 
   // Gemini style
   "gemini",

--- a/providers/anthropic/models/claude-fable-5.toml
+++ b/providers/anthropic/models/claude-fable-5.toml
@@ -1,0 +1,27 @@
+name = "Claude Fable 5"
+family = "claude-fable"
+release_date = "2026-06-09"
+last_updated = "2026-06-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10.00
+output = 50.00
+cache_read = 1.00
+cache_write = 12.50
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add provider-agnostic metadata for Claude Fable 5
- add the Anthropic API model with pricing and adaptive effort options
- register the new `claude-fable` model family

## Verification
- `bun validate`
- live Anthropic Models API metadata check
- live Messages API requests for `low`, `medium`, `high`, `xhigh`, and `max` effort