### PR TITLE
Add Claude Fable 5 (Vercel AI Gateway)

### DIFF
--- a/providers/vercel/models/anthropic/claude-fable-5.toml
+++ b/providers/vercel/models/anthropic/claude-fable-5.toml
@@ -1,0 +1,23 @@
+name = "Claude Fable 5"
+family = "claude"
+release_date = "2026-06-09"
+last_updated = "2026-06-09"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds the `claude-fable-5` model definition under the `vercel` provider, generated from the [Vercel AI Gateway API](https://ai-gateway.vercel.sh/v1/models) now that the model is live.

```
bun run vercel:generate --new-only
```

New file: `providers/vercel/models/anthropic/claude-fable-5.toml` (1 created, 0 updated, 0 deleted).