### PR TITLE
Add Claude Fable 5 for Amazon Bedrock

### DIFF
--- a/models/anthropic/claude-fable-5.toml
+++ b/models/anthropic/claude-fable-5.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = false
 tool_call = true
 open_weights = false
+knowledge = "2026-01-31"
 
 [limit]
 context = 1_000_000

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-fable-5.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-fable-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+name = "Claude Fable 5 (EU)"
+
+[modalities]
+input = ["text", "image"]
+
+[cost]
+input = 11
+output = 55
+cache_read = 1.1
+cache_write = 13.75

--- a/providers/amazon-bedrock/models/global.anthropic.claude-fable-5.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-fable-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+name = "Claude Fable 5 (Global)"
+
+[modalities]
+input = ["text", "image"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/amazon-bedrock/models/us.anthropic.claude-fable-5.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-fable-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+name = "Claude Fable 5 (US)"
+
+[modalities]
+input = ["text", "image"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5


### PR DESCRIPTION
Add us/eu/global cross-region inference profiles and set the knowledge cutoff on the shared base model.

Reference https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html