### PR TITLE
fix(vercel): declare claude-fable-5 reasoning as effort-only

### DIFF
--- a/providers/vercel/models/anthropic/claude-fable-5.toml
+++ b/providers/vercel/models/anthropic/claude-fable-5.toml
@@ -8,6 +8,10 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 10
 output = 50


### PR DESCRIPTION
## Summary

`claude-fable-5` was added (#2103) with `reasoning = true` but **no `reasoning_options`**. The model rejects the legacy `thinking.type = "enabled"` (`budget_tokens`) control:

> `thinking.type.enabled` is not supported for this model. use `thinking.type.adaptive` and `output_config.effort` to control thinking behavior

Consumers that pick a reasoning control from `reasoning_options` (e.g. OpenCode) fall back to `budget_tokens` when the array is absent, which triggers the error.

This declares fable-5 as **effort-only**, matching `claude-opus-4-8` (also effort-only, no `budget_tokens`):

```toml
[[reasoning_options]]
type = "effort"
values = ["low", "medium", "high", "xhigh", "max"]
```

## Test plan
- `bun run validate` passes