### PR TITLE
fix(sync): preserve reasoning options

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -141,7 +141,10 @@ export async function syncProvider<SourceModel>(
 
     const parsed = SyncedAuthoredModel.safeParse(stripUndefined({
       id: translated.id,
-      ...preserveBaseModel(translated.model, existing.get(relativePath)?.authored),
+      ...preserveReasoningOptions(
+        preserveBaseModel(translated.model, existing.get(relativePath)?.authored),
+        existing.get(relativePath)?.authored,
+      ),
     }));
     if (!parsed.success) {
       parsed.error.cause = { provider: provider.id, path: relativePath };
@@ -242,6 +245,17 @@ export function preserveBaseModel(model: SyncedModel, existing: ExistingModel | 
     ...model,
     base_model: existing.base_model,
     base_model_omit: existing.base_model_omit,
+  };
+}
+
+export function preserveReasoningOptions(
+  model: SyncedModel,
+  existing: ExistingModel | undefined,
+): SyncedModel {
+  if (model.reasoning_options !== undefined || existing?.reasoning_options === undefined) return model;
+  return {
+    ...model,
+    reasoning_options: existing.reasoning_options,
   };
 }
 

--- a/packages/core/src/sync/providers/cloudflare-workers-ai.ts
+++ b/packages/core/src/sync/providers/cloudflare-workers-ai.ts
@@ -96,7 +96,7 @@ export const cloudflareWorkersAi = {
   },
 } satisfies SyncProvider<CloudflareModel>;
 
-function buildWorkersAiModel(
+export function buildWorkersAiModel(
   model: z.infer<typeof OpenRouterModel>,
   existing: ExistingModel | undefined,
 ): SyncedModel {
@@ -108,11 +108,14 @@ function buildWorkersAiModel(
       max_completion_tokens: existing?.limit?.output ?? model.top_provider.max_completion_tokens,
     },
   };
-  const synced = buildOpenRouterModel(
-    source,
-    existing,
-    existing?.base_model ?? resolveCloudflareBaseModel(model),
-  );
+  const synced = {
+    ...buildOpenRouterModel(
+      source,
+      existing,
+      existing?.base_model ?? resolveCloudflareBaseModel(model),
+    ),
+    reasoning_options: existing?.reasoning_options,
+  };
   if ("base_model" in synced) return synced;
   return {
     ...synced,

--- a/packages/core/src/sync/providers/vercel.ts
+++ b/packages/core/src/sync/providers/vercel.ts
@@ -176,6 +176,7 @@ function sameVercelModel(current: ExistingModel, desired: SyncedModel) {
     [current.family, desiredModel.family],
     [current.attachment, desiredModel.attachment],
     [current.reasoning, desiredModel.reasoning],
+    [current.reasoning_options, desiredModel.reasoning_options],
     [current.tool_call, desiredModel.tool_call],
     [current.structured_output, desiredModel.structured_output],
     [current.open_weights, desiredModel.open_weights],

--- a/packages/core/test/cloudflare-workers-ai-sync.test.ts
+++ b/packages/core/test/cloudflare-workers-ai-sync.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+
+import { buildWorkersAiModel } from "../src/sync/providers/cloudflare-workers-ai.js";
+import type { OpenRouterModel } from "../src/sync/providers/openrouter.js";
+
+test("Cloudflare Workers AI sync preserves reasoning options", () => {
+  const model: OpenRouterModel = {
+    id: "@cf/nvidia/nemotron-3-120b-a12b",
+    name: "Nemotron 3 Super 120B",
+    created: 1_773_187_200,
+    hugging_face_id: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+    knowledge_cutoff: null,
+    context_length: 256_000,
+    architecture: {
+      input_modalities: ["text"],
+      output_modalities: ["text"],
+    },
+    pricing: {
+      prompt: "0.0000005",
+      completion: "0.0000015",
+    },
+    top_provider: {
+      context_length: 256_000,
+      max_completion_tokens: 256_000,
+    },
+    supported_parameters: ["reasoning", "tools", "temperature"],
+  };
+
+  const synced = buildWorkersAiModel(model, {
+    base_model: "nvidia/nemotron-3-super-120b-a12b",
+    reasoning_options: [{ type: "toggle" }],
+  });
+
+  expect(synced.reasoning_options).toEqual([{ type: "toggle" }]);
+});

--- a/packages/core/test/sync-runner.test.ts
+++ b/packages/core/test/sync-runner.test.ts
@@ -97,3 +97,47 @@ test("non-deleting sync reports missing broken symlinks", async () => {
   expect(result.notices).toEqual(["missing: model.toml"]);
   expect(await readlink(filePath)).toBe("missing.toml");
 });
+
+test("sync preserves authored reasoning options omitted by a translator", async () => {
+  const { modelsDir } = await fixture();
+  const filePath = path.join(modelsDir, "model.toml");
+  await Bun.write(filePath, `name = "Old name"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = true
+tool_call = false
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high"]
+
+[cost]
+input = 1
+output = 2
+
+[limit]
+context = 1000
+output = 100
+
+[modalities]
+input = ["text"]
+output = ["text"]
+`);
+  const sync = provider(modelsDir, ["model"]);
+  sync.translateModel = (id) => ({
+    id,
+    model: { ...model, reasoning: true },
+  });
+
+  const first = await syncProvider(sync);
+  const content = await Bun.file(filePath).text();
+  const second = await syncProvider(sync);
+
+  expect(first.updated).toBe(1);
+  expect(content).toContain("[[reasoning_options]]");
+  expect(content).toContain('values = ["low", "high"]');
+  expect(second.updated).toBe(0);
+  expect(second.unchanged).toBe(1);
+});


### PR DESCRIPTION
## Summary
- preserve explicitly authored `reasoning_options` at the shared sync boundary when a translator omits them
- retain Cloudflare Workers AI options through its OpenRouter-derived translator, including factored `base_model` models
- include `reasoning_options` in Vercel's custom model comparison
- add runner-level update and idempotence coverage plus Cloudflare regression coverage

## Audit
All seven registered sync providers were traced end to end. Baseten, Cloudflare Workers AI, Google, Vercel, and xAI already preserve options in their translators. OpenRouter and OVHcloud omitted them and could remove curated options during any unrelated update. Shared runner preservation fixes those current omissions and protects future providers from the same regression.

## Validation
- `bun validate`
- `bun test packages/core/test/sync-runner.test.ts packages/core/test/cloudflare-workers-ai-sync.test.ts packages/core/test/openrouter-sync.test.ts packages/core/test/vercel-sync.test.ts` (16 passed)
- `git diff --check`

The complete `bun test packages/core/test` run is 32 passed, 1 unrelated existing failure: newly listed NVIDIA/Cohere open-weight models are missing weights links.