### PR TITLE
Add Claude Fable 5 for OpenRouter

### DIFF
--- a/providers/openrouter/models/anthropic/claude-fable-5.toml
+++ b/providers/openrouter/models/anthropic/claude-fable-5.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-fable-5"
+structured_output = true
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5


### PR DESCRIPTION
Adds the missing `anthropic/claude-fable-5` model to the OpenRouter provider. OpenRouter serves Claude Fable 5, but it wasn't in the catalog here.

```toml
base_model = "anthropic/claude-fable-5"
structured_output = true

[cost]
input = 10
output = 50
cache_read = 1
cache_write = 12.5
```

Pricing mirrors Anthropic-direct Fable 5 pricing (\$10 in / \$50 out / \$1 cache read / \$12.50 cache write), consistent with the other OpenRouter Claude entries.