### PR TITLE
feat(stepfun): restructure into 4 providers with symlinks and step-3.7-flash

### DIFF
--- a/providers/stepfun-ai-step-plan/models/step-3.5-flash-2603.toml
+++ b/providers/stepfun-ai-step-plan/models/step-3.5-flash-2603.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-3.5-flash-2603.toml

--- a/providers/stepfun-ai-step-plan/models/step-3.5-flash.toml
+++ b/providers/stepfun-ai-step-plan/models/step-3.5-flash.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-3.5-flash.toml

--- a/providers/stepfun-ai-step-plan/models/step-3.7-flash.toml
+++ b/providers/stepfun-ai-step-plan/models/step-3.7-flash.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-3.7-flash.toml

--- a/providers/stepfun-ai-step-plan/provider.toml
+++ b/providers/stepfun-ai-step-plan/provider.toml
@@ -1,0 +1,5 @@
+name = "StepFun AI Step Plan"
+env = ["STEPFUN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://platform.stepfun.ai/docs/en/step-plan/integrations/open-code"
+api = "https://api.stepfun.ai/step_plan/v1"

--- a/providers/stepfun-ai/models/step-3.7-flash.toml
+++ b/providers/stepfun-ai/models/step-3.7-flash.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-3.7-flash.toml

--- a/providers/stepfun-ai/provider.toml
+++ b/providers/stepfun-ai/provider.toml
@@ -1,5 +1,5 @@
 name = "StepFun AI"
 env = ["STEPFUN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-doc = "https://platform.stepfun.ai/docs/en/step-plan/integrations/open-code"
-api = "https://api.stepfun.ai/step_plan/v1"
+doc = "https://platform.stepfun.ai/docs/en/overview/quick-start"
+api = "https://api.stepfun.ai/v1"

--- a/providers/stepfun-step-plan/models/step-3.5-flash-2603.toml
+++ b/providers/stepfun-step-plan/models/step-3.5-flash-2603.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-3.5-flash-2603.toml

--- a/providers/stepfun-step-plan/models/step-3.5-flash.toml
+++ b/providers/stepfun-step-plan/models/step-3.5-flash.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-3.5-flash.toml

--- a/providers/stepfun-step-plan/models/step-3.7-flash.toml
+++ b/providers/stepfun-step-plan/models/step-3.7-flash.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-3.7-flash.toml

--- a/providers/stepfun-step-plan/provider.toml
+++ b/providers/stepfun-step-plan/provider.toml
@@ -1,0 +1,5 @@
+name = "StepFun Step Plan"
+env = ["STEPFUN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://platform.stepfun.com/docs/zh/overview/concept"
+api = "https://api.stepfun.com/step_plan/v1"

--- a/providers/stepfun/models/step-3.7-flash.toml
+++ b/providers/stepfun/models/step-3.7-flash.toml
@@ -5,10 +5,6 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high"]
 knowledge = "2026-01-01"
 open_weights = true
 
@@ -21,6 +17,6 @@ output = 256_000
 input = ["text", "image"]
 output = ["text"]
 
-[[weights]]
-label = "Hugging Face"
-url = "https://huggingface.co/stepfun-ai/Step-3.7-Flash"
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/stepfun/models/step-3.7-flash.toml
+++ b/providers/stepfun/models/step-3.7-flash.toml
@@ -1,0 +1,26 @@
+name = "Step 3.7 Flash"
+release_date = "2026-05-29"
+last_updated = "2026-05-29"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+knowledge = "2026-01-01"
+open_weights = true
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/stepfun-ai/Step-3.7-Flash"


### PR DESCRIPTION
feat(stepfun): restructure into 4 providers with symlinks and step-3.7-flash

- Split stepfun-ai into StepFun AI (global, api.stepfun.ai/v1) and StepFun AI Step Plan (api.stepfun.ai/step_plan/v1)
- Add StepFun Step Plan (api.stepfun.com/step_plan/v1) for CN coding plan
- Use symlinks so model definitions live only in providers/stepfun/models/
- Add step-3.7-flash with effort-based reasoning options (low/medium/high)