### PR TITLE
Venice: Add claude-fable-5 model

### DIFF
--- a/providers/venice/models/claude-fable-5.toml
+++ b/providers/venice/models/claude-fable-5.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-fable-5"
+structured_output = true
+last_updated = "2026-06-10"
+
+[cost]
+input = 12
+output = 60
+cache_read = 1.2
+cache_write = 15
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
- Add new provider model configuration inheriting from anthropic base
- Enable structured_output and define cost/modalities
- New file: providers/venice/models/claude-fable-5.toml