### PR TITLE
feat(snowflake-cortex): add missing but officially supported models

### DIFF
--- a/providers/snowflake-cortex/models/claude-fable-5.toml
+++ b/providers/snowflake-cortex/models/claude-fable-5.toml
@@ -1,0 +1,1 @@
+base_model = "anthropic/claude-fable-5"

--- a/providers/snowflake-cortex/models/claude-opus-4-8.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-8.toml
@@ -1,0 +1,1 @@
+base_model = "anthropic/claude-opus-4-8"

--- a/providers/snowflake-cortex/models/deepseek-r1.toml
+++ b/providers/snowflake-cortex/models/deepseek-r1.toml
@@ -1,0 +1,1 @@
+base_model = "deepseek/deepseek-r1"

--- a/providers/snowflake-cortex/models/gemini-3.1-pro.toml
+++ b/providers/snowflake-cortex/models/gemini-3.1-pro.toml
@@ -1,0 +1,1 @@
+base_model = "google/gemini-3.1-pro-preview"

--- a/providers/snowflake-cortex/models/mistral-large2.toml
+++ b/providers/snowflake-cortex/models/mistral-large2.toml
@@ -1,0 +1,1 @@
+base_model = "mistral/mistral-large-latest"

--- a/providers/snowflake-cortex/models/openai-gpt-5.5.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5.5.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.5"
+status = "beta"

--- a/providers/snowflake-cortex/models/snowflake-llama3.3-70b.toml
+++ b/providers/snowflake-cortex/models/snowflake-llama3.3-70b.toml
@@ -1,0 +1,1 @@
+base_model = "meta/llama-3.3-70b-instruct"


### PR DESCRIPTION
This PR adds officially supported models on Snowflake Cortex AI that were missing or recently published, bringing the Snowflake Cortex catalog up to date:
 
### Models Added:
- **Claude Fable 5** (`claude-fable-5.toml` - recently published)
- **Claude Opus 4.8** (`claude-opus-4-8.toml`)
- **OpenAI GPT-5.5** (`openai-gpt-5.5.toml`)
- **Snowflake Llama 3.3 70B** (`snowflake-llama3.3-70b.toml`)
- **DeepSeek-R1** (`deepseek-r1.toml`)
- **Mistral Large 2** (`mistral-large2.toml`)
- **Gemini 3.1 Pro** (`gemini-3.1-pro.toml`)
 
All configurations reuse existing global model metadata via `base_model` and have been validated locally using `bun validate`.