### PR TITLE
feat(gitlab): add Claude Fable 5 model

### DIFF
--- a/providers/gitlab/models/duo-chat-fable-5.toml
+++ b/providers/gitlab/models/duo-chat-fable-5.toml
@@ -1,0 +1,24 @@
+name = "Agentic Chat (Claude Fable 5)"
+family = "claude-fable"
+release_date = "2026-06-09"
+last_updated = "2026-06-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2026-01-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## What

Adds the **Claude Fable 5** model to the GitLab Duo provider (`providers/gitlab/models/duo-chat-fable-5.toml`).

GitLab Duo exposes this model through the AI Gateway via the `gitlab-ai-provider` mapping `duo-chat-fable-5` → `claude-fable-5`.

## Details

| Field | Value |
| --- | --- |
| id | `duo-chat-fable-5` |
| name | Agentic Chat (Claude Fable 5) |
| family | `claude-fable` |
| context | 1,000,000 |
| output | 128,000 |
| modalities | input: text/image/pdf, output: text |
| reasoning / tool_call / attachment | yes |
| cost | 0 (GitLab Duo billing is seat-based, consistent with other `gitlab` provider entries) |

Limits and modalities match the underlying Anthropic `claude-fable-5` entry; cost is set to 0 following the existing convention for the `gitlab` provider (e.g. `duo-chat-opus-4-8.toml`).

## Verification

- `bun run validate` passes against the current `dev` base.