### PR TITLE
[replicate] Add verified model metadata

### DIFF
--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -215,6 +215,39 @@ input = ["text"]
     expect(leaked).toEqual([]);
   });
 
+  test("repository Replicate provider resolves its discovery inventory", async () => {
+    const root = path.join(import.meta.dirname, "..", "..", "..");
+    const providers = await generate(path.join(root, "providers"));
+    const models = providers.replicate?.models;
+
+    expect(Object.keys(models ?? {}).sort()).toEqual([
+      "deepseek-ai/deepseek-r1",
+      "meta/meta-llama-3-70b-instruct",
+      "meta/meta-llama-3-8b-instruct",
+    ]);
+    expect(models?.["meta/meta-llama-3.1-405b-instruct"]).toBeUndefined();
+
+    expect(models?.["deepseek-ai/deepseek-r1"]).toMatchObject({
+      reasoning: true,
+      reasoning_options: [],
+      tool_call: false,
+    });
+
+    for (const modelID of [
+      "meta/meta-llama-3-8b-instruct",
+      "meta/meta-llama-3-70b-instruct",
+    ]) {
+      const model = models?.[modelID];
+      expect(model).toMatchObject({ reasoning: false, tool_call: false });
+      expect(model).not.toHaveProperty("reasoning_options");
+    }
+
+    for (const model of Object.values(models ?? {})) {
+      expect(model).not.toHaveProperty("base_model");
+      expect(model).not.toHaveProperty("base_model_omit");
+    }
+  });
+
   test("repository model metadata avoids provider-only namespaces", async () => {
     const root = path.join(import.meta.dirname, "..", "..", "..");
     const providerNamespaces = [

--- a/providers/replicate/models/deepseek-ai/deepseek-r1.toml
+++ b/providers/replicate/models/deepseek-ai/deepseek-r1.toml
@@ -1,0 +1,13 @@
+# https://replicate.com/deepseek-ai/deepseek-r1/llms.txt
+
+base_model = "deepseek/deepseek-r1"
+
+reasoning_options = []
+
+[cost]
+input = 10
+output = 10
+
+[limit]
+context = 128_000
+output = 20_480

--- a/providers/replicate/models/deepseek-ai/deepseek-r1.toml
+++ b/providers/replicate/models/deepseek-ai/deepseek-r1.toml
@@ -2,6 +2,7 @@
 
 base_model = "deepseek/deepseek-r1"
 
+tool_call = false
 reasoning_options = []
 
 [cost]

--- a/providers/replicate/models/meta/meta-llama-3-70b-instruct.toml
+++ b/providers/replicate/models/meta/meta-llama-3-70b-instruct.toml
@@ -1,0 +1,24 @@
+# https://replicate.com/meta/meta-llama-3-70b-instruct/llms.txt
+
+name = "Llama 3 70B Instruct"
+family = "llama"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+knowledge = "2023-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.65
+output = 2.75
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/replicate/models/meta/meta-llama-3-8b-instruct.toml
+++ b/providers/replicate/models/meta/meta-llama-3-8b-instruct.toml
@@ -1,0 +1,24 @@
+# https://replicate.com/meta/meta-llama-3-8b-instruct/llms.txt
+
+name = "Llama 3 8B Instruct"
+family = "llama"
+release_date = "2024-04-18"
+last_updated = "2024-04-18"
+knowledge = "2023-03"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.25
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/replicate/provider.toml
+++ b/providers/replicate/provider.toml
@@ -1,0 +1,4 @@
+name = "Replicate"
+env = ["REPLICATE_API_TOKEN"]
+npm = "replicate"
+doc = "https://replicate.com/docs"


### PR DESCRIPTION
## Scope
- coverage is complete only for the repository's checked-in four-model Replicate discovery inventory
- this is not a comprehensive audit of Replicate's 100+ official model catalog
- three inventory models currently resolve and are included; `meta/meta-llama-3.1-405b-instruct` returns 404 and is excluded

## Reasoning and tools
- `deepseek-ai/deepseek-r1`: fixed reasoning, `reasoning_options = []`, and `tool_call = false` because Replicate's current deployment schema exposes no tools interface
- `meta/meta-llama-3-8b-instruct`: non-reasoning; reasoning options omitted
- `meta/meta-llama-3-70b-instruct`: non-reasoning; reasoning options omitted

## Regression coverage
- generated provider-matrix test asserts the exact three retained IDs and explicit 405B absence
- asserts DeepSeek and both Llama reasoning/tool fields and reasoning-option presence/absence
- asserts resolved output contains no `base_model` or `base_model_omit` pointers

## Evidence
- current Replicate model-specific `llms.txt` input schemas for all three included deployments
- checked-in Cloudflare AI Gateway Replicate discovery snapshot for the four-model repository inventory and pricing
- current Replicate model URL checks, including the unavailable 405B ID
- generated provider output confirms DeepSeek R1 resolves with `tool_call: false`

## Validation
- `bun validate`: passed
- `bun test packages/core/test/generate.test.ts --test-name-pattern "repository Replicate provider"`: 1 passed, 13 assertions
- `bun test packages/core/test/generate.test.ts --test-name-pattern "base_model can factor metadata"`: 1 passed
- `git diff --check`: passed

The full suite was previously 43 passed with one unrelated baseline open-weight metadata failure reproduced on untouched `origin/dev`; focused tests covering this update pass.