### PR TITLE
feat(alibaba-token-plan-cn): add Alibaba Token Plan (China) provider

### DIFF
--- a/providers/alibaba-token-plan-cn/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-token-plan-cn/models/MiniMax-M2.5.toml
@@ -1,0 +1,15 @@
+base_model = "minimax/MiniMax-M2.5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 196_608
+input = 196_601
+output = 24_576

--- a/providers/alibaba-token-plan-cn/models/deepseek-v3.2.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v3.2.toml
@@ -1,0 +1,23 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2025-12-03"
+last_updated = "2025-12-05"
+attachment = false
+reasoning = true
+structured_output = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131_072
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-flash.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-flash.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-pro.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-pro.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/alibaba-token-plan-cn/models/glm-5.1.toml
+++ b/providers/alibaba-token-plan-cn/models/glm-5.1.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.1"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 202_752
+output = 128_000

--- a/providers/alibaba-token-plan-cn/models/glm-5.toml
+++ b/providers/alibaba-token-plan-cn/models/glm-5.toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5"
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 202_752
+output = 16_384

--- a/providers/alibaba-token-plan-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.5.toml
@@ -1,0 +1,17 @@
+base_model = "moonshotai/kimi-k2.5"
+base_model_omit = ["structured_output"]
+family = "kimi"
+attachment = true
+temperature = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+output = 32_768

--- a/providers/alibaba-token-plan-cn/models/kimi-k2.6.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.6.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k2.6"
+base_model_omit = ["structured_output"]
+family = "kimi"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+output = 16_384

--- a/providers/alibaba-token-plan-cn/models/qwen-image-2.0-pro.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen-image-2.0-pro.toml
@@ -1,0 +1,21 @@
+name = "Qwen Image 2.0 Pro"
+family = "qwen"
+release_date = "2026-03-03"
+last_updated = "2026-03-03"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/alibaba-token-plan-cn/models/qwen-image-2.0.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen-image-2.0.toml
@@ -1,0 +1,21 @@
+name = "Qwen Image 2.0"
+family = "qwen"
+release_date = "2026-03-03"
+last_updated = "2026-03-03"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/alibaba-token-plan-cn/models/qwen3.6-flash.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.6-flash.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.6-flash"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan-cn/models/qwen3.6-plus.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.6-plus.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.6-plus"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan-cn/models/qwen3.7-max.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.7-max.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.7-max"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan-cn/models/qwen3.7-plus.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.7-plus.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.7-plus"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan-cn/models/wan2.7-image-pro.toml
+++ b/providers/alibaba-token-plan-cn/models/wan2.7-image-pro.toml
@@ -1,0 +1,20 @@
+name = "Wan2.7 Image Pro"
+release_date = "2026-05-29"
+last_updated = "2026-05-29"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/alibaba-token-plan-cn/models/wan2.7-image.toml
+++ b/providers/alibaba-token-plan-cn/models/wan2.7-image.toml
@@ -1,0 +1,20 @@
+name = "Wan2.7 Image"
+release_date = "2026-05-29"
+last_updated = "2026-05-29"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/alibaba-token-plan-cn/provider.toml
+++ b/providers/alibaba-token-plan-cn/provider.toml
@@ -1,0 +1,5 @@
+name = "Alibaba Token Plan (China)"
+env = ["ALIBABA_TOKEN_PLAN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://www.alibabacloud.com/help/zh/model-studio/token-plan-overview"
+api = "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"


### PR DESCRIPTION
## Summary
- Add a new provider `alibaba-token-plan-cn` for the China-region (Beijing) Alibaba Cloud Model Studio / Bailian Token Plan (Token套餐, Team Edition).
- The Token Plan exposes the same model set in both regions; only the Base URL differs. The international sibling already exists as `alibaba-token-plan` (Singapore, `ap-southeast-1`). China endpoint: `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`.
- Includes all 16 listed models. Records mirror the international provider (subscription billing, so per-token `[cost]` is zeroed; reasoning / limit / interleaved fields inherited or copied identically).

## Provider
| field | value |
| --- | --- |
| name | Alibaba Token Plan (China) |
| api | `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` |
| env | `ALIBABA_TOKEN_PLAN_API_KEY` |
| npm | `@ai-sdk/openai-compatible` |

## Models (16, identical to the international provider)
`qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-plus`, `qwen3.6-flash`, `qwen-image-2.0`, `qwen-image-2.0-pro`, `wan2.7-image`, `wan2.7-image-pro`, `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-v3.2`, `kimi-k2.6`, `kimi-k2.5`, `glm-5.1`, `glm-5`, `MiniMax-M2.5`.

## Official sources
- Token Plan overview (ZH): https://www.alibabacloud.com/help/zh/model-studio/token-plan-overview
- Token Plan overview (EN): https://www.alibabacloud.com/help/en/model-studio/token-plan-overview

## Notes
- Model records copied from `alibaba-token-plan` because the catalogue is identical across regions. `base_model` references use the shared provider-agnostic `models/<vendor>/` tree, identical to the international provider.

## Validation
- `bun install --frozen-lockfile`
- `bun validate`
- `git diff --check`
