### PR TITLE
feat(alibaba-token-plan): add qwen3.7-plus

### DIFF
--- a/providers/alibaba-token-plan/models/qwen3.7-plus.toml
+++ b/providers/alibaba-token-plan/models/qwen3.7-plus.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.7-plus"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
## Summary
- Add `qwen3.7-plus` to the Alibaba Token Plan provider. It is listed on the official Token Plan model page but was the only one of the 16 listed models missing from this provider (which had 15).
- Thin record inheriting from `alibaba/qwen3.7-plus`; Token Plan is a subscription / credit plan, so per-token `[cost]` is zeroed, matching the sibling `qwen3.6-plus` record.

## Verified record
| Provider | Model | base_model | cost |
| --- | --- | --- | --- |
| `alibaba-token-plan` | `qwen3.7-plus` | `alibaba/qwen3.7-plus` | 0 (subscription billing) |

## Official sources
- Token Plan models (EN): https://www.alibabacloud.com/help/en/model-studio/token-plan-overview
- Token Plan models (ZH): https://www.alibabacloud.com/help/zh/model-studio/token-plan-overview

## Validation
- `bun install --frozen-lockfile`
- `bun validate`
- `git diff --check`
