### PR TITLE
Add model logo endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,19 @@ Provider logos are available as SVG files:
 curl https://models.dev/logos/{provider}.svg
 ```
 
-Replace `{provider}` with the **Provider ID** (e.g., `anthropic`, `openai`, `google`). If we don't have a provider's logo, a default logo is served instead.
+Lab logos are also available:
+
+```bash
+curl https://models.dev/logos/labs/{lab}.svg
+```
+
+And model logos return the logo for the lab that created the model:
+
+```bash
+curl https://models.dev/logos/models/{model-id}.svg
+```
+
+Replace `{provider}` with the **Provider ID** (e.g., `anthropic`, `openai`, `google`), `{lab}` with the **Lab ID** (e.g., `anthropic`, `openai`, `google`), and `{model-id}` with the short model ID (e.g., `gpt-5`, `claude-opus-4-6`). If we don't have a matching logo, a default logo is served instead.
 
 ## Contributing
 

--- a/packages/web/script/build.ts
+++ b/packages/web/script/build.ts
@@ -63,6 +63,30 @@ try {
   }
 }
 
+// Copy lab logos to dist/logos/models/<model-id>.svg.
+await fs.mkdir("./dist/logos/models", { recursive: true });
+
+const modelLogoIds = new Set<string>();
+for (const canonicalModelId of Object.keys(Models)) {
+  const [lab, ...modelParts] = canonicalModelId.split("/");
+  const model = modelParts.join("/");
+  if (!lab || !model) continue;
+
+  if (modelLogoIds.has(model)) {
+    throw new Error(`Duplicate model logo id: ${model}`);
+  }
+  modelLogoIds.add(model);
+
+  const logoPath = path.join(labsDir, lab, "logo.svg");
+  const logoFile = Bun.file(logoPath);
+  const modelLogoPath = path.join("./dist/logos/models", `${model}.svg`);
+  await fs.mkdir(path.dirname(modelLogoPath), { recursive: true });
+  await Bun.write(
+    modelLogoPath,
+    (await logoFile.exists()) ? logoFile : defaultLogo,
+  );
+}
+
 const template = await Bun.file("./dist/index.html").text();
 
 for (const [route, rendered] of RenderedPages) {

--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -1332,13 +1332,31 @@ function HelpDialog() {
         <p>
           Provider logos are available at <code>/logos/{`{provider}`}.svg</code>{" "}
           where <code>{`{provider}`}</code> is the provider ID. Lab logos are
-          available at <code>/logos/labs/{`{lab}`}.svg</code>.
+          available at <code>/logos/labs/{`{lab}`}.svg</code>. Model logos are
+          available at <code>/logos/models/{`{model-id}`}.svg</code> and return
+          the logo for the lab that created the model.
         </p>
         <div class="code-block">
           <code>
             curl{" "}
             <a href="/logos/anthropic.svg">
               https://models.dev/logos/anthropic.svg
+            </a>
+          </code>
+        </div>
+        <div class="code-block">
+          <code>
+            curl{" "}
+            <a href="/logos/labs/anthropic.svg">
+              https://models.dev/logos/labs/anthropic.svg
+            </a>
+          </code>
+        </div>
+        <div class="code-block">
+          <code>
+            curl{" "}
+            <a href="/logos/models/gpt-5.svg">
+              https://models.dev/logos/models/gpt-5.svg
             </a>
           </code>
         </div>

--- a/packages/web/src/server.ts
+++ b/packages/web/src/server.ts
@@ -33,6 +33,48 @@ Bun.serve({
       );
       return new Response(file);
     },
+    "/logos/models/*": async (req) => {
+      const url = new URL(req.url);
+      const model = decodeURIComponent(
+        url.pathname.slice("/logos/models/".length).replace(/\.svg$/, ""),
+      );
+      const canonicalModel = Object.keys(Models).find((id) => {
+        const [, ...modelParts] = id.split("/");
+        return modelParts.join("/") === model;
+      });
+      const lab = canonicalModel?.split("/")[0];
+      const defaultLogoPath = path.join(
+        import.meta.dir,
+        "..",
+        "..",
+        "..",
+        "providers",
+        "logo.svg"
+      );
+      const logoPath = lab === undefined
+        ? defaultLogoPath
+        : path.join(
+            import.meta.dir,
+            "..",
+            "..",
+            "..",
+            "labs",
+            lab,
+            "logo.svg"
+          );
+
+      let file = Bun.file(logoPath);
+      if (!(await file.exists())) {
+        file = Bun.file(defaultLogoPath);
+      }
+
+      return new Response(file, {
+        headers: {
+          "Content-Type": "image/svg+xml",
+          "Cache-Control": "public, max-age=3600",
+        },
+      });
+    },
     "/logos/labs/*": async (req) => {
       const url = new URL(req.url);
       const lab = url.pathname.split("/")[3].replace(".svg", "");


### PR DESCRIPTION
## Summary
- Add `/logos/models/{model-id}.svg` support for short model IDs
- Generate model logo assets during the web build from each model's lab logo
- Document provider, lab, and model logo endpoints in the README and help dialog

## Testing
- `bun validate`
- `cd packages/web && bun run build`
- `git diff --check`