### PR TITLE
[togetherai] Require reasoning options metadata

### DIFF
--- a/providers/togetherai/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/togetherai/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 status = "deprecated"
 temperature = true
 tool_call = true

--- a/providers/togetherai/models/google/gemma-4-31B-it.toml
+++ b/providers/togetherai/models/google/gemma-4-31B-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-07"
 last_updated = "2026-04-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 structured_output = true
 temperature = true
 knowledge = "2025-01"

--- a/providers/togetherai/models/pearl-ai/gemma-4-31b-it.toml
+++ b/providers/togetherai/models/pearl-ai/gemma-4-31b-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-07"
 last_updated = "2026-04-07"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 open_weights = false


### PR DESCRIPTION
## Summary
- add `reasoning_options = []` to the three Together AI reasoning models that lacked the mandatory field
- cover Google Gemma 4, Pearl Gemma 4, and deprecated MiniMax M2.5
- preserve all verified non-empty controls and existing fixed arrays; reasoning-disabled models continue to omit options

An empty array means reasoning capability is known, but the exact provider controls remain unspecified under the mandatory-field policy.

## Validation
- `bun validate`
- generated Together invariant scan: 18 reasoning models, 5 empty arrays, 13 non-empty controls, 0 missing options, 0 reasoning-disabled models with options
- `git diff --check`
- diff scope: 3 Together TOMLs, 0 test paths