### PR TITLE
SiliconFlow: migrate existing models to base_model

### DIFF
--- a/providers/siliconflow-cn/models/Pro/MiniMaxAI/MiniMax-M2.1.toml
+++ b/providers/siliconflow-cn/models/Pro/MiniMaxAI/MiniMax-M2.1.toml
@@ -1,11 +1,6 @@
+base_model = "minimax/MiniMax-M2.1"
 name = "Pro/MiniMaxAI/MiniMax-M2.1"
-family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +9,5 @@ input = 0.3
 output = 1.2
 
 [limit]
-context = 197_000
-output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 197000
+output = 131000

--- a/providers/siliconflow-cn/models/Pro/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/siliconflow-cn/models/Pro/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,11 +1,8 @@
+base_model = "minimax/MiniMax-M2.5"
 name = "Pro/MiniMaxAI/MiniMax-M2.5"
-family = "minimax"
 release_date = "2026-02-13"
 last_updated = "2026-02-13"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -17,9 +14,5 @@ input = 0.3
 output = 1.22
 
 [limit]
-context = 192_000
-output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 192000
+output = 131000

--- a/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-R1.toml
@@ -1,5 +1,4 @@
 base_model = "deepseek/deepseek-r1"
-base_model_omit = ["knowledge"]
 name = "Pro/deepseek-ai/DeepSeek-R1"
 release_date = "2025-05-28"
 last_updated = "2025-11-25"

--- a/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/siliconflow-cn/models/Pro/deepseek-ai/DeepSeek-R1.toml
@@ -1,11 +1,8 @@
+base_model = "deepseek/deepseek-r1"
+base_model_omit = ["knowledge"]
 name = "Pro/deepseek-ai/DeepSeek-R1"
-family = "deepseek-thinking"
 release_date = "2025-05-28"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +11,5 @@ input = 0.5
 output = 2.18
 
 [limit]
-context = 164_000
-output = 164_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 164000
+output = 164000

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Thinking.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Thinking.toml
@@ -1,22 +1,15 @@
+base_model = "moonshotai/kimi-k2-thinking"
+base_model_omit = ["knowledge"]
 name = "Pro/moonshotai/Kimi-K2-Thinking"
-family = "kimi-thinking"
 release_date = "2025-11-07"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
 [cost]
 input = 0.55
-output = 2.50
+output = 2.5
 
 [limit]
-context = 262_000
-output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262000
+output = 262000

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Thinking.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Thinking.toml
@@ -1,5 +1,4 @@
 base_model = "moonshotai/kimi-k2-thinking"
-base_model_omit = ["knowledge"]
 name = "Pro/moonshotai/Kimi-K2-Thinking"
 release_date = "2025-11-07"
 last_updated = "2025-11-25"

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.5.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.5.toml
@@ -1,13 +1,10 @@
+base_model = "moonshotai/kimi-k2.5"
+base_model_omit = ["knowledge"]
 name = "Pro/moonshotai/Kimi-K2.5"
 family = "kimi"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
-attachment = false
-reasoning = true
 temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -18,9 +15,8 @@ output = 2.25
 cache_input = 0.07
 
 [limit]
-context = 262_000
-output = 262_000
+context = 262000
+output = 262000
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.5.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,4 @@
 base_model = "moonshotai/kimi-k2.5"
-base_model_omit = ["knowledge"]
 name = "Pro/moonshotai/Kimi-K2.5"
 family = "kimi"
 release_date = "2026-01-27"

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.6.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.6.toml
@@ -1,26 +1,20 @@
+base_model = "moonshotai/kimi-k2.6"
+base_model_omit = ["knowledge"]
 name = "Pro/moonshotai/Kimi-K2.6"
 family = "kimi"
-release_date = "2026-04-21"
-last_updated = "2026-04-21"
 attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
 input = 0.95
-output = 4.0
+output = 4
 cache_read = 0.16
 
 [limit]
-context = 262_000
-output = 262_000
+context = 262000
+output = 262000
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.6.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,4 @@
 base_model = "moonshotai/kimi-k2.6"
-base_model_omit = ["knowledge"]
 name = "Pro/moonshotai/Kimi-K2.6"
 family = "kimi"
 attachment = false

--- a/providers/siliconflow-cn/models/Pro/zai-org/GLM-4.7.toml
+++ b/providers/siliconflow-cn/models/Pro/zai-org/GLM-4.7.toml
@@ -1,11 +1,6 @@
+base_model = "zhipuai/glm-4.7"
+base_model_omit = ["knowledge"]
 name = "Pro/zai-org/GLM-4.7"
-family = "glm"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -13,13 +8,9 @@ open_weights = false
 field = "reasoning_content"
 
 [cost]
-input = 0.60
-output = 2.20
+input = 0.6
+output = 2.2
 
 [limit]
-context = 205_000
-output = 205_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 205000
+output = 205000

--- a/providers/siliconflow-cn/models/Pro/zai-org/GLM-4.7.toml
+++ b/providers/siliconflow-cn/models/Pro/zai-org/GLM-4.7.toml
@@ -1,5 +1,4 @@
 base_model = "zhipuai/glm-4.7"
-base_model_omit = ["knowledge"]
 name = "Pro/zai-org/GLM-4.7"
 structured_output = true
 open_weights = false

--- a/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.1.toml
+++ b/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.1.toml
@@ -1,13 +1,7 @@
+base_model = "zhipuai/glm-5.1"
 name = "Pro/zai-org/GLM-5.1"
-family = "glm"
 release_date = "2026-04-08"
 last_updated = "2026-04-08"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -19,9 +13,5 @@ cache_input = 0.26
 cache_write = 0
 
 [limit]
-context = 205_000
-output = 205_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 205000
+output = 205000

--- a/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.toml
+++ b/providers/siliconflow-cn/models/Pro/zai-org/GLM-5.toml
@@ -1,25 +1,16 @@
+base_model = "zhipuai/glm-5"
 name = "Pro/zai-org/GLM-5"
-family = "glm"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
 input = 1
-output = 3.20
+output = 3.2
 
 [limit]
-context = 205_000
-output = 205_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 205000
+output = 205000

--- a/providers/siliconflow-cn/models/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/siliconflow-cn/models/Qwen/Qwen3.5-122B-A10B.toml
@@ -1,22 +1,14 @@
+base_model = "alibaba/qwen3.5-122b-a10b"
+base_model_omit = ["structured_output"]
 name = "Qwen/Qwen3.5-122B-A10B"
-family = "qwen"
 release_date = "2026-02-26"
 last_updated = "2026-02-26"
 attachment = false
-reasoning = true
-temperature = true
 knowledge = "2025-04"
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0.29
 output = 2.32
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/siliconflow-cn/models/Qwen/Qwen3.5-27B.toml
+++ b/providers/siliconflow-cn/models/Qwen/Qwen3.5-27B.toml
@@ -1,22 +1,14 @@
+base_model = "alibaba/qwen3.5-27b"
+base_model_omit = ["structured_output"]
 name = "Qwen/Qwen3.5-27B"
-family = "qwen"
 release_date = "2026-02-25"
 last_updated = "2026-02-25"
 attachment = false
-reasoning = true
-temperature = true
 knowledge = "2025-04"
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0.26
 output = 2.09
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/siliconflow-cn/models/Qwen/Qwen3.5-35B-A3B.toml
+++ b/providers/siliconflow-cn/models/Qwen/Qwen3.5-35B-A3B.toml
@@ -1,22 +1,14 @@
+base_model = "alibaba/qwen3.5-35b-a3b"
+base_model_omit = ["structured_output"]
 name = "Qwen/Qwen3.5-35B-A3B"
-family = "qwen"
 release_date = "2026-02-25"
 last_updated = "2026-02-25"
 attachment = false
-reasoning = true
-temperature = true
 knowledge = "2025-04"
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0.23
 output = 1.86
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/siliconflow-cn/models/Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/siliconflow-cn/models/Qwen/Qwen3.5-397B-A17B.toml
@@ -1,22 +1,14 @@
+base_model = "alibaba/qwen3.5-397b-a17b"
+base_model_omit = ["structured_output"]
 name = "Qwen/Qwen3.5-397B-A17B"
-family = "qwen"
 release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = false
-reasoning = true
-temperature = true
 knowledge = "2025-04"
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0.29
 output = 1.74
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/siliconflow-cn/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/siliconflow-cn/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,22 +1,12 @@
+base_model = "alibaba/qwen3.6-35b-a3b"
+base_model_omit = ["structured_output"]
 name = "Qwen/Qwen3.6-35B-A3B"
-family = "qwen"
-release_date = "2026-04-17"
-last_updated = "2026-04-17"
 attachment = false
-reasoning = true
-temperature = true
 knowledge = "2025-04"
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0.23
 output = 1.86
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -1,13 +1,7 @@
+base_model = "deepseek/deepseek-v4-pro"
+base_model_omit = ["knowledge"]
 name = "deepseek-ai/DeepSeek-V4-Pro"
-family = "deepseek-thinking"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = false
-open_weights = true
 
 [cost]
 input = 1.74
@@ -15,9 +9,5 @@ output = 3.48
 cache_read = 0.145
 
 [limit]
-context = 1_049_000
-output = 393_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 1049000
+output = 393000

--- a/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -1,5 +1,4 @@
 base_model = "deepseek/deepseek-v4-pro"
-base_model_omit = ["knowledge"]
 name = "deepseek-ai/DeepSeek-V4-Pro"
 structured_output = false
 

--- a/providers/siliconflow-cn/models/stepfun-ai/Step-3.5-Flash.toml
+++ b/providers/siliconflow-cn/models/stepfun-ai/Step-3.5-Flash.toml
@@ -1,11 +1,9 @@
+base_model = "stepfun/step-3.5-flash"
+base_model_omit = ["knowledge", "limit.input"]
 name = "stepfun-ai/Step-3.5-Flash"
 family = "step"
 release_date = "2026-02-11"
 last_updated = "2026-02-11"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +12,5 @@ input = 0.1
 output = 0.3
 
 [limit]
-context = 262_000
-output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262000
+output = 262000

--- a/providers/siliconflow-cn/models/stepfun-ai/Step-3.5-Flash.toml
+++ b/providers/siliconflow-cn/models/stepfun-ai/Step-3.5-Flash.toml
@@ -1,5 +1,5 @@
 base_model = "stepfun/step-3.5-flash"
-base_model_omit = ["knowledge", "limit.input"]
+base_model_omit = ["limit.input"]
 name = "stepfun-ai/Step-3.5-Flash"
 family = "step"
 release_date = "2026-02-11"

--- a/providers/siliconflow/models/MiniMaxAI/MiniMax-M2.1.toml
+++ b/providers/siliconflow/models/MiniMaxAI/MiniMax-M2.1.toml
@@ -1,11 +1,6 @@
+base_model = "minimax/MiniMax-M2.1"
 name = "MiniMaxAI/MiniMax-M2.1"
-family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +9,5 @@ input = 0.3
 output = 1.2
 
 [limit]
-context = 197_000
-output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 197000
+output = 131000

--- a/providers/siliconflow/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/siliconflow/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,11 +1,8 @@
+base_model = "minimax/MiniMax-M2.5"
 name = "MiniMaxAI/MiniMax-M2.5"
-family = "minimax"
 release_date = "2026-02-15"
 last_updated = "2026-02-15"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = false
 open_weights = false
 
@@ -14,9 +11,5 @@ input = 0.3
 output = 1.2
 
 [limit]
-context = 197_000
-output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 197000
+output = 131000

--- a/providers/siliconflow/models/Qwen/Qwen2.5-VL-72B-Instruct.toml
+++ b/providers/siliconflow/models/Qwen/Qwen2.5-VL-72B-Instruct.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen2-5-vl-72b-instruct"
-base_model_omit = ["knowledge"]
 name = "Qwen/Qwen2.5-VL-72B-Instruct"
 release_date = "2025-01-28"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/Qwen/Qwen2.5-VL-72B-Instruct.toml
+++ b/providers/siliconflow/models/Qwen/Qwen2.5-VL-72B-Instruct.toml
@@ -1,11 +1,9 @@
+base_model = "alibaba/qwen2-5-vl-72b-instruct"
+base_model_omit = ["knowledge"]
 name = "Qwen/Qwen2.5-VL-72B-Instruct"
-family = "qwen"
 release_date = "2025-01-28"
 last_updated = "2025-11-25"
 attachment = true
-reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +12,5 @@ input = 0.59
 output = 0.59
 
 [limit]
-context = 131_000
-output = 4_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+context = 131000
+output = 4000

--- a/providers/siliconflow/models/Qwen/Qwen3-235B-A22B.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-235B-A22B.toml
@@ -1,11 +1,9 @@
+base_model = "alibaba/qwen3-235b-a22b"
+base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-235B-A22B"
-family = "qwen"
 release_date = "2025-04-30"
 last_updated = "2025-11-25"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +12,5 @@ input = 0.35
 output = 1.42
 
 [limit]
-context = 131_000
-output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 131000
+output = 131000

--- a/providers/siliconflow/models/Qwen/Qwen3-235B-A22B.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-235B-A22B.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen3-235b-a22b"
-base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-235B-A22B"
 release_date = "2025-04-30"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/Qwen/Qwen3-32B.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-32B.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen3-32b"
-base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-32B"
 release_date = "2025-04-30"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/Qwen/Qwen3-32B.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-32B.toml
@@ -1,11 +1,9 @@
+base_model = "alibaba/qwen3-32b"
+base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-32B"
-family = "qwen"
 release_date = "2025-04-30"
 last_updated = "2025-11-25"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +12,5 @@ input = 0.14
 output = 0.57
 
 [limit]
-context = 131_000
-output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 131000
+output = 131000

--- a/providers/siliconflow/models/Qwen/Qwen3-Coder-30B-A3B-Instruct.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-Coder-30B-A3B-Instruct.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
-base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-Coder-30B-A3B-Instruct"
 release_date = "2025-08-01"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/Qwen/Qwen3-Coder-30B-A3B-Instruct.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-Coder-30B-A3B-Instruct.toml
@@ -1,11 +1,8 @@
+base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
+base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-Coder-30B-A3B-Instruct"
-family = "qwen"
 release_date = "2025-08-01"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +11,5 @@ input = 0.07
 output = 0.28
 
 [limit]
-context = 262_000
-output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262000
+output = 262000

--- a/providers/siliconflow/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
@@ -1,22 +1,15 @@
+base_model = "alibaba/qwen3-coder-480b-a35b-instruct"
+base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-Coder-480B-A35B-Instruct"
-family = "qwen"
 release_date = "2025-07-31"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
 [cost]
 input = 0.25
-output = 1.0
+output = 1
 
 [limit]
-context = 262_000
-output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262000
+output = 262000

--- a/providers/siliconflow/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen3-coder-480b-a35b-instruct"
-base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-Coder-480B-A35B-Instruct"
 release_date = "2025-07-31"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen3-next-80b-a3b-instruct"
-base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 release_date = "2025-09-18"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
@@ -1,11 +1,8 @@
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-Next-80B-A3B-Instruct"
-family = "qwen"
 release_date = "2025-09-18"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +11,5 @@ input = 0.14
 output = 1.4
 
 [limit]
-context = 262_000
-output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262000
+output = 262000

--- a/providers/siliconflow/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
@@ -1,11 +1,8 @@
+base_model = "alibaba/qwen3-next-80b-a3b-thinking"
+base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-Next-80B-A3B-Thinking"
-family = "qwen"
 release_date = "2025-09-25"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +11,5 @@ input = 0.14
 output = 0.57
 
 [limit]
-context = 262_000
-output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262000
+output = 262000

--- a/providers/siliconflow/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
+++ b/providers/siliconflow/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen3-next-80b-a3b-thinking"
-base_model_omit = ["knowledge"]
 name = "Qwen/Qwen3-Next-80B-A3B-Thinking"
 release_date = "2025-09-25"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/siliconflow/models/deepseek-ai/DeepSeek-R1.toml
@@ -1,11 +1,8 @@
+base_model = "deepseek/deepseek-r1"
+base_model_omit = ["knowledge"]
 name = "deepseek-ai/DeepSeek-R1"
-family = "deepseek-thinking"
 release_date = "2025-05-28"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +11,5 @@ input = 0.5
 output = 2.18
 
 [limit]
-context = 164_000
-output = 164_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 164000
+output = 164000

--- a/providers/siliconflow/models/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/siliconflow/models/deepseek-ai/DeepSeek-R1.toml
@@ -1,5 +1,4 @@
 base_model = "deepseek/deepseek-r1"
-base_model_omit = ["knowledge"]
 name = "deepseek-ai/DeepSeek-R1"
 release_date = "2025-05-28"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/moonshotai/Kimi-K2-Thinking.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2-Thinking.toml
@@ -1,5 +1,4 @@
 base_model = "moonshotai/kimi-k2-thinking"
-base_model_omit = ["knowledge"]
 name = "moonshotai/Kimi-K2-Thinking"
 release_date = "2025-11-07"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/moonshotai/Kimi-K2-Thinking.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2-Thinking.toml
@@ -1,22 +1,15 @@
+base_model = "moonshotai/kimi-k2-thinking"
+base_model_omit = ["knowledge"]
 name = "moonshotai/Kimi-K2-Thinking"
-family = "kimi-thinking"
 release_date = "2025-11-07"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
 [cost]
 input = 0.55
-output = 2.50
+output = 2.5
 
 [limit]
-context = 262_000
-output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262000
+output = 262000

--- a/providers/siliconflow/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,4 @@
 base_model = "moonshotai/kimi-k2.5"
-base_model_omit = ["knowledge"]
 name = "moonshotai/Kimi-K2.5"
 family = "kimi"
 release_date = "2026-01-27"

--- a/providers/siliconflow/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2.5.toml
@@ -1,13 +1,10 @@
+base_model = "moonshotai/kimi-k2.5"
+base_model_omit = ["knowledge"]
 name = "moonshotai/Kimi-K2.5"
 family = "kimi"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
-attachment = false
-reasoning = true
 temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -18,9 +15,8 @@ output = 2.25
 cache_input = 0.07
 
 [limit]
-context = 262_000
-output = 262_000
+context = 262000
+output = 262000
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/siliconflow/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,4 @@
 base_model = "moonshotai/kimi-k2.6"
-base_model_omit = ["knowledge"]
 name = "moonshotai/Kimi-K2.6"
 family = "kimi"
 attachment = false

--- a/providers/siliconflow/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2.6.toml
@@ -1,26 +1,20 @@
+base_model = "moonshotai/kimi-k2.6"
+base_model_omit = ["knowledge"]
 name = "moonshotai/Kimi-K2.6"
 family = "kimi"
-release_date = "2026-04-21"
-last_updated = "2026-04-21"
 attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
 input = 0.95
-output = 4.0
+output = 4
 cache_read = 0.16
 
 [limit]
-context = 262_000
-output = 262_000
+context = 262000
+output = 262000
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/siliconflow/models/stepfun-ai/Step-3.5-Flash.toml
+++ b/providers/siliconflow/models/stepfun-ai/Step-3.5-Flash.toml
@@ -1,11 +1,9 @@
+base_model = "stepfun/step-3.5-flash"
+base_model_omit = ["knowledge", "limit.input"]
 name = "stepfun-ai/Step-3.5-Flash"
 family = "step"
 release_date = "2026-02-11"
 last_updated = "2026-02-11"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +12,5 @@ input = 0.1
 output = 0.3
 
 [limit]
-context = 262_000
-output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262000
+output = 262000

--- a/providers/siliconflow/models/stepfun-ai/Step-3.5-Flash.toml
+++ b/providers/siliconflow/models/stepfun-ai/Step-3.5-Flash.toml
@@ -1,5 +1,5 @@
 base_model = "stepfun/step-3.5-flash"
-base_model_omit = ["knowledge", "limit.input"]
+base_model_omit = ["limit.input"]
 name = "stepfun-ai/Step-3.5-Flash"
 family = "step"
 release_date = "2026-02-11"

--- a/providers/siliconflow/models/zai-org/GLM-4.5-Air.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.5-Air.toml
@@ -1,11 +1,8 @@
+base_model = "zhipuai/glm-4.5-air"
+base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.5-Air"
-family = "glm-air"
-release_date = "2025-07-28"
 last_updated = "2025-11-25"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +11,5 @@ input = 0.14
 output = 0.86
 
 [limit]
-context = 131_000
-output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 131000
+output = 131000

--- a/providers/siliconflow/models/zai-org/GLM-4.5-Air.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.5-Air.toml
@@ -1,5 +1,4 @@
 base_model = "zhipuai/glm-4.5-air"
-base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.5-Air"
 last_updated = "2025-11-25"
 reasoning = false

--- a/providers/siliconflow/models/zai-org/GLM-4.5.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.5.toml
@@ -1,22 +1,15 @@
+base_model = "zhipuai/glm-4.5"
+base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.5"
-family = "glm"
-release_date = "2025-07-28"
 last_updated = "2025-11-25"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
 [cost]
 input = 0.4
-output = 2.0
+output = 2
 
 [limit]
-context = 131_000
-output = 131_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 131000
+output = 131000

--- a/providers/siliconflow/models/zai-org/GLM-4.5.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.5.toml
@@ -1,5 +1,4 @@
 base_model = "zhipuai/glm-4.5"
-base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.5"
 last_updated = "2025-11-25"
 reasoning = false

--- a/providers/siliconflow/models/zai-org/GLM-4.5V.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.5V.toml
@@ -1,11 +1,9 @@
+base_model = "zhipuai/glm-4.5v"
+base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.5V"
-family = "glm"
 release_date = "2025-08-13"
 last_updated = "2025-11-25"
-attachment = true
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +12,8 @@ input = 0.14
 output = 0.86
 
 [limit]
-context = 66_000
-output = 66_000
+context = 66000
+output = 66000
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/siliconflow/models/zai-org/GLM-4.5V.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.5V.toml
@@ -1,5 +1,4 @@
 base_model = "zhipuai/glm-4.5v"
-base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.5V"
 release_date = "2025-08-13"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/zai-org/GLM-4.6.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.6.toml
@@ -1,11 +1,9 @@
+base_model = "zhipuai/glm-4.6"
+base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.6"
-family = "glm"
 release_date = "2025-10-04"
 last_updated = "2025-11-25"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -14,9 +12,5 @@ input = 0.5
 output = 1.9
 
 [limit]
-context = 205_000
-output = 205_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 205000
+output = 205000

--- a/providers/siliconflow/models/zai-org/GLM-4.6.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.6.toml
@@ -1,5 +1,4 @@
 base_model = "zhipuai/glm-4.6"
-base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.6"
 release_date = "2025-10-04"
 last_updated = "2025-11-25"

--- a/providers/siliconflow/models/zai-org/GLM-4.6V.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.6V.toml
@@ -1,22 +1,18 @@
+base_model = "zhipuai/glm-4.6v"
+base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.6V"
-family = "glm"
 release_date = "2025-12-07"
 last_updated = "2025-12-07"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = false
 open_weights = false
 
 [cost]
-input = 0.30
-output = 0.90
+input = 0.3
+output = 0.9
 
 [limit]
-context = 131_000
-output = 131_000
+context = 131000
+output = 131000
 
 [modalities]
-input = ["text","image"]
-output = ["text"]
+input = ["text", "image"]

--- a/providers/siliconflow/models/zai-org/GLM-4.6V.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.6V.toml
@@ -1,5 +1,4 @@
 base_model = "zhipuai/glm-4.6v"
-base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.6V"
 release_date = "2025-12-07"
 last_updated = "2025-12-07"

--- a/providers/siliconflow/models/zai-org/GLM-4.7.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.7.toml
@@ -1,5 +1,4 @@
 base_model = "zhipuai/glm-4.7"
-base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.7"
 structured_output = true
 open_weights = false

--- a/providers/siliconflow/models/zai-org/GLM-4.7.toml
+++ b/providers/siliconflow/models/zai-org/GLM-4.7.toml
@@ -1,11 +1,6 @@
+base_model = "zhipuai/glm-4.7"
+base_model_omit = ["knowledge"]
 name = "zai-org/GLM-4.7"
-family = "glm"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
 open_weights = false
 
@@ -13,13 +8,9 @@ open_weights = false
 field = "reasoning_content"
 
 [cost]
-input = 0.60
-output = 2.20
+input = 0.6
+output = 2.2
 
 [limit]
-context = 205_000
-output = 205_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 205000
+output = 205000

--- a/providers/siliconflow/models/zai-org/GLM-5.1.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.1.toml
@@ -1,13 +1,7 @@
+base_model = "zhipuai/glm-5.1"
 name = "zai-org/GLM-5.1"
-family = "glm"
 release_date = "2026-04-08"
 last_updated = "2026-04-08"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -19,9 +13,5 @@ cache_input = 0.26
 cache_write = 0
 
 [limit]
-context = 205_000
-output = 205_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 205000
+output = 205000

--- a/providers/siliconflow/models/zai-org/GLM-5.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.toml
@@ -1,25 +1,16 @@
+base_model = "zhipuai/glm-5"
 name = "zai-org/GLM-5"
-family = "glm"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
 input = 1
-output = 3.20
+output = 3.2
 
 [limit]
-context = 205_000
-output = 205_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 205000
+output = 205000

--- a/providers/siliconflow/models/zai-org/GLM-5V-Turbo.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5V-Turbo.toml
@@ -1,12 +1,5 @@
+base_model = "zhipuai/glm-5v-turbo"
 name = "zai-org/GLM-5V-Turbo"
-family = "glm"
-release_date = "2026-04-01"
-last_updated = "2026-04-01"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = false
 
 [interleaved]
 field = "reasoning_content"
@@ -17,10 +10,5 @@ output = 4
 cache_input = 0.24
 cache_write = 0
 
-[limit]
-context = 200_000
-output = 131_072
-
 [modalities]
 input = ["text", "image"]
-output = ["text"]


### PR DESCRIPTION
## Summary

- migrate 39 duplicated SiliconFlow global/China model TOMLs to canonical `base_model` metadata
- retain provider overrides and necessary `base_model_omit` paths while inheriting canonical core facts
- leave 62 full TOMLs without canonical metadata unchanged
- leave 55 regional/catalog symlinks and 2 pre-existing `base_model` TOMLs unchanged

This is a prerequisite for #2136 and contains none of that PR's catalog or reasoning audit changes. The authored TOMLs are compressed by removing duplicated fields, while resolved generated models continue to contain their evidenced core metadata. The only intentional generated-data change is adding canonical `knowledge` to 25 migrated models whose original provider TOMLs lacked it.

## Audit

- retained model paths audited: 158
- authored regular TOMLs: 103
- migrated: 39
- ineligible because canonical metadata is absent: 62
- already using `base_model`: 2
- symlinks retained unchanged: 55
- test paths changed: 0
- `provider.toml` files changed/added: 0
- resolved `family` coverage: 39/39, no gaps
- resolved `release_date` coverage: 39/39, no gaps
- resolved `last_updated` coverage: 39/39, no gaps
- resolved `knowledge` coverage: 30/39 (5 retained provider values and 25 inherited canonical values)
- forbidden core facts in `base_model_omit`: 0

The 9 resolved `knowledge` gaps have no value in either the original provider TOML or canonical metadata:

```text
siliconflow-cn/Pro/MiniMaxAI/MiniMax-M2.1
siliconflow-cn/Pro/MiniMaxAI/MiniMax-M2.5
siliconflow-cn/Pro/zai-org/GLM-5.1
siliconflow-cn/Pro/zai-org/GLM-5
siliconflow/MiniMaxAI/MiniMax-M2.1
siliconflow/MiniMaxAI/MiniMax-M2.5
siliconflow/zai-org/GLM-5.1
siliconflow/zai-org/GLM-5
siliconflow/zai-org/GLM-5V-Turbo
```

<details>
<summary>25 models receiving inherited canonical knowledge</summary>

```text
siliconflow-cn/Pro/deepseek-ai/DeepSeek-R1: 2024-07
siliconflow-cn/Pro/moonshotai/Kimi-K2-Thinking: 2024-08
siliconflow-cn/Pro/moonshotai/Kimi-K2.5: 2025-01
siliconflow-cn/Pro/moonshotai/Kimi-K2.6: 2025-01
siliconflow-cn/Pro/zai-org/GLM-4.7: 2025-04
siliconflow-cn/deepseek-ai/DeepSeek-V4-Pro: 2025-05
siliconflow-cn/stepfun-ai/Step-3.5-Flash: 2025-01
siliconflow/Qwen/Qwen2.5-VL-72B-Instruct: 2024-04
siliconflow/Qwen/Qwen3-235B-A22B: 2025-04
siliconflow/Qwen/Qwen3-32B: 2025-04
siliconflow/Qwen/Qwen3-Coder-30B-A3B-Instruct: 2025-04
siliconflow/Qwen/Qwen3-Coder-480B-A35B-Instruct: 2025-04
siliconflow/Qwen/Qwen3-Next-80B-A3B-Instruct: 2025-04
siliconflow/Qwen/Qwen3-Next-80B-A3B-Thinking: 2025-04
siliconflow/deepseek-ai/DeepSeek-R1: 2024-07
siliconflow/moonshotai/Kimi-K2-Thinking: 2024-08
siliconflow/moonshotai/Kimi-K2.5: 2025-01
siliconflow/moonshotai/Kimi-K2.6: 2025-01
siliconflow/stepfun-ai/Step-3.5-Flash: 2025-01
siliconflow/zai-org/GLM-4.5-Air: 2025-04
siliconflow/zai-org/GLM-4.5: 2025-04
siliconflow/zai-org/GLM-4.5V: 2025-04
siliconflow/zai-org/GLM-4.6: 2025-04
siliconflow/zai-org/GLM-4.6V: 2025-04
siliconflow/zai-org/GLM-4.7: 2025-04
```

</details>

<details>
<summary>62 intentionally retained full TOMLs</summary>

```text
siliconflow/openai/gpt-oss-120b.toml
siliconflow/openai/gpt-oss-20b.toml
siliconflow/meta-llama/Meta-Llama-3.1-8B-Instruct.toml
siliconflow/nex-agi/DeepSeek-V3.1-Nex-N1.toml
siliconflow/tencent/Hunyuan-MT-7B.toml
siliconflow/tencent/Hunyuan-A13B-Instruct.toml
siliconflow/inclusionAI/Ling-flash-2.0.toml
siliconflow/inclusionAI/Ring-flash-2.0.toml
siliconflow/inclusionAI/Ling-mini-2.0.toml
siliconflow/Qwen/Qwen2.5-72B-Instruct-128K.toml
siliconflow/Qwen/Qwen2.5-14B-Instruct.toml
siliconflow/Qwen/Qwen2.5-Coder-32B-Instruct.toml
siliconflow/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
siliconflow/Qwen/Qwen3-VL-235B-A22B-Instruct.toml
siliconflow/Qwen/Qwen3-Omni-30B-A3B-Captioner.toml
siliconflow/Qwen/Qwen3-VL-235B-A22B-Thinking.toml
siliconflow/Qwen/Qwen3-30B-A3B-Instruct-2507.toml
siliconflow/Qwen/Qwen3-14B.toml
siliconflow/Qwen/Qwen2.5-72B-Instruct.toml
siliconflow/Qwen/Qwen2.5-7B-Instruct.toml
siliconflow/Qwen/Qwen2.5-VL-7B-Instruct.toml
siliconflow/Qwen/Qwen3-VL-30B-A3B-Thinking.toml
siliconflow/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
siliconflow/Qwen/Qwen2.5-VL-32B-Instruct.toml
siliconflow/Qwen/Qwen3-8B.toml
siliconflow/Qwen/Qwen3-30B-A3B-Thinking-2507.toml
siliconflow/Qwen/QwQ-32B.toml
siliconflow/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
siliconflow/Qwen/Qwen3-VL-32B-Thinking.toml
siliconflow/Qwen/Qwen3-VL-8B-Thinking.toml
siliconflow/Qwen/Qwen3-Omni-30B-A3B-Instruct.toml
siliconflow/Qwen/Qwen3-VL-32B-Instruct.toml
siliconflow/Qwen/Qwen2.5-32B-Instruct.toml
siliconflow/Qwen/Qwen3-VL-8B-Instruct.toml
siliconflow/Qwen/Qwen3-Omni-30B-A3B-Thinking.toml
siliconflow/deepseek-ai/DeepSeek-V3.2-Exp.toml
siliconflow/deepseek-ai/DeepSeek-V3.1.toml
siliconflow/deepseek-ai/DeepSeek-V3.toml
siliconflow/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B.toml
siliconflow/deepseek-ai/DeepSeek-V3.2.toml
siliconflow/deepseek-ai/deepseek-vl2.toml
siliconflow/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B.toml
siliconflow/deepseek-ai/DeepSeek-V3.1-Terminus.toml
siliconflow/THUDM/GLM-4-32B-0414.toml
siliconflow/THUDM/GLM-4-9B-0414.toml
siliconflow/THUDM/GLM-Z1-32B-0414.toml
siliconflow/THUDM/GLM-Z1-9B-0414.toml
siliconflow/baidu/ERNIE-4.5-300B-A47B.toml
siliconflow/moonshotai/Kimi-K2-Instruct-0905.toml
siliconflow/moonshotai/Kimi-K2-Instruct.toml
siliconflow/ByteDance-Seed/Seed-OSS-36B-Instruct.toml
siliconflow-cn/Qwen/Qwen3.5-9B.toml
siliconflow-cn/Qwen/Qwen3.5-4B.toml
siliconflow-cn/deepseek-ai/DeepSeek-OCR.toml
siliconflow-cn/ascend-tribe/pangu-pro-moe.toml
siliconflow-cn/Pro/deepseek-ai/DeepSeek-V3.toml
siliconflow-cn/Pro/deepseek-ai/DeepSeek-V3.2.toml
siliconflow-cn/Pro/deepseek-ai/DeepSeek-V3.1-Terminus.toml
siliconflow-cn/Pro/moonshotai/Kimi-K2-Instruct-0905.toml
siliconflow-cn/Kwaipilot/KAT-Dev.toml
siliconflow-cn/PaddlePaddle/PaddleOCR-VL-1.5.toml
siliconflow-cn/PaddlePaddle/PaddleOCR-VL.toml
```

</details>

## Validation

- `bun compare:migrations` (reports only the 25 approved canonical `knowledge` additions)
- `bun validate`
- `git diff --check`
- local before/after semantic audit across all 39 resolved models: no removed fields, no changed pre-existing values, and no additions except the 25 canonical `knowledge` fields listed above
- explicit core-fact audit against original provider and canonical metadata: all evidenced `family`, `release_date`, `last_updated`, and `knowledge` values resolve correctly
