### PR TITLE
fix(minimax): correct MiniMax-M3 context window to 1M tokens

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -18,7 +18,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -17,7 +17,7 @@ output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -18,7 +18,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -17,7 +17,7 @@ output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
## Problem

`MiniMax-M3` (released 2026-06-01) has its context window set to `512_000` in the four provider files under the official `minimax*` provider dirs. The MiniMax documentation states the correct value is **1,000,000 tokens**:

> **MiniMax-M3** | Frontier multimodal coding model **with 1M context window** | • Multimodal • **1M context window** • Frontier coding

Source: https://platform.minimax.io/docs/guides/models-intro

## Evidence the value should be 1M

1. **Official MiniMax docs** explicitly list "1M context window" for M3.
2. **Cross-provider check**: `providers/vercel/models/minimax/minimax-m3.toml` already has `context = 1_000_000`. OpenRouter's `524_288` is clearly derived from the same wrong 512k base value (524288 = 512 × 1024), reinforcing that 512k is a placeholder that was never corrected in the upstream `minimax*` files.
3. **API behavior**: live `/v1/messages` calls to M3 do not get rate-limited or rejected at 512k boundary in any way that suggests the model actually caps there.

## Fix

Change `context = 512_000` → `context = 1_000_000` in all four files:
- `providers/minimax/models/MiniMax-M3.toml`
- `providers/minimax-cn/models/MiniMax-M3.toml`
- `providers/minimax-coding-plan/models/MiniMax-M3.toml`
- `providers/minimax-cn-coding-plan/models/MiniMax-M3.toml`

`output = 128_000` is left as-is (not in the bug report and the official docs don't list a separate M3 max-output value).

## Validation

Ran `bun validate` locally — passes with rc=0. The validated JSON dump confirms all four `MiniMax-M3` entries now emit `"context": 1000000`.

## Out of scope

Several third-party providers (openrouter, nvidia, opencode-go, nano-gpt, venice, etc.) also have wrong M3 context values. These are not part of this PR — only the official `minimax*` provider files, which are the source of truth for the MiniMax direct API. Third-party providers should be addressed in separate PRs per provider to keep the diff focused and reviewable.

## Impact

Affects any consumer of models.dev (Hermes Agent, OpenCode, etc.) that displays or budgets based on the context window. With the correct 1M value, compression thresholds and prompt-budget hints will stop triggering prematurely when prompts grow past the false 512k ceiling.
