### PR TITLE
Add DeepSeek R1 32B for opencode tool support via Ollama

### DIFF
--- a/providers/ollama/models/r1-32b-opencode.toml
+++ b/providers/ollama/models/r1-32b-opencode.toml
@@ -1,0 +1,13 @@
+name = "DeepSeek R1 32B (Opencode optimized)"
+tool_call = true
+reasoning = true
+release_date = "2025-01-20"
+last_updated = "2025-06-11"
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 32768
+output = 8192


### PR DESCRIPTION
Adds model entry for ollama/r1-32b-opencode:latest with tool_call=true so opencode can use it with local Ollama.