### PR TITLE
Add Neon provider

### DIFF
--- a/providers/neon/logo.svg
+++ b/providers/neon/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor" fill-rule="evenodd">
+  <path d="M63 0.0177909V63.5526L38.4178 42.2501V63.5526H0V0L63 0.0177909ZM7.72251 55.8389H30.6953V25.3238L55.2779 47.0476V7.72922L7.72251 7.71559V55.8389Z"/>
+</svg>

--- a/providers/neon/models/claude-haiku-4-5.toml
+++ b/providers/neon/models/claude-haiku-4-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25

--- a/providers/neon/models/claude-opus-4-1.toml
+++ b/providers/neon/models/claude-opus-4-1.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-1"
+
+[cost]
+input = 15
+output = 75
+cache_read = 1.5
+cache_write = 18.75

--- a/providers/neon/models/claude-opus-4-5.toml
+++ b/providers/neon/models/claude-opus-4-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-5"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/neon/models/claude-opus-4-6.toml
+++ b/providers/neon/models/claude-opus-4-6.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-6"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[experimental.modes.fast]
+cost = { input = 30, output = 150, cache_read = 3, cache_write = 37.5 }
+provider = { body = { speed = "fast" }, headers = { anthropic-beta = "fast-mode-2026-02-01" } }

--- a/providers/neon/models/claude-opus-4-7.toml
+++ b/providers/neon/models/claude-opus-4-7.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[experimental.modes.fast]
+cost = { input = 30, output = 150, cache_read = 3, cache_write = 37.5 }
+provider = { body = { speed = "fast" }, headers = { anthropic-beta = "fast-mode-2026-02-01" } }

--- a/providers/neon/models/claude-sonnet-4-5.toml
+++ b/providers/neon/models/claude-sonnet-4-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-sonnet-4-5"
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/neon/models/claude-sonnet-4-6.toml
+++ b/providers/neon/models/claude-sonnet-4-6.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/neon/models/claude-sonnet-4.toml
+++ b/providers/neon/models/claude-sonnet-4.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-sonnet-4-5-20250929"
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/neon/models/gemini-2-5-flash.toml
+++ b/providers/neon/models/gemini-2-5-flash.toml
@@ -1,0 +1,7 @@
+base_model = "google/gemini-2.5-flash"
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03
+input_audio = 1

--- a/providers/neon/models/gemini-2-5-pro.toml
+++ b/providers/neon/models/gemini-2-5-pro.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-2.5-pro"
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 15
+cache_read = 0.25

--- a/providers/neon/models/gemini-3-1-flash-lite.toml
+++ b/providers/neon/models/gemini-3-1-flash-lite.toml
@@ -1,0 +1,7 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+input_audio = 0.5

--- a/providers/neon/models/gemini-3-1-pro.toml
+++ b/providers/neon/models/gemini-3-1-pro.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-3.1-pro-preview-customtools"
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4

--- a/providers/neon/models/gemini-3-flash.toml
+++ b/providers/neon/models/gemini-3-flash.toml
@@ -1,0 +1,7 @@
+base_model = "google/gemini-3-flash-preview"
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+input_audio = 1

--- a/providers/neon/models/gemini-3-pro.toml
+++ b/providers/neon/models/gemini-3-pro.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-3-pro-preview"
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4

--- a/providers/neon/models/gpt-5-1.toml
+++ b/providers/neon/models/gpt-5-1.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.1"
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125

--- a/providers/neon/models/gpt-5-2.toml
+++ b/providers/neon/models/gpt-5-2.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.2"
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175

--- a/providers/neon/models/gpt-5-4-mini.toml
+++ b/providers/neon/models/gpt-5-4-mini.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-5.4-mini"
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+
+[experimental.modes.fast]
+cost = { input = 1.5, output = 9, cache_read = 0.15 }
+provider = { body = { service_tier = "priority" } }

--- a/providers/neon/models/gpt-5-4-nano.toml
+++ b/providers/neon/models/gpt-5-4-nano.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4-nano"
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02

--- a/providers/neon/models/gpt-5-4.toml
+++ b/providers/neon/models/gpt-5-4.toml
@@ -1,0 +1,16 @@
+base_model = "openai/gpt-5.4"
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5
+
+[experimental.modes.fast]
+cost = { input = 5, output = 30, cache_read = 0.5 }
+provider = { body = { service_tier = "priority" } }

--- a/providers/neon/models/gpt-5-5.toml
+++ b/providers/neon/models/gpt-5-5.toml
@@ -1,0 +1,16 @@
+base_model = "openai/gpt-5.5"
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+
+[experimental.modes.fast]
+cost = { input = 12.5, output = 75, cache_read = 1.25 }
+provider = { body = { service_tier = "priority" } }

--- a/providers/neon/models/gpt-5-mini.toml
+++ b/providers/neon/models/gpt-5-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5-mini"
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025

--- a/providers/neon/models/gpt-5-nano.toml
+++ b/providers/neon/models/gpt-5-nano.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5-nano"
+
+[cost]
+input = 0.05
+output = 0.4
+cache_read = 0.005

--- a/providers/neon/models/gpt-5.toml
+++ b/providers/neon/models/gpt-5.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5"
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125

--- a/providers/neon/models/gpt-oss-120b.toml
+++ b/providers/neon/models/gpt-oss-120b.toml
@@ -1,0 +1,22 @@
+name = "GPT OSS 120B"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.072
+output = 0.28
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/neon/models/gpt-oss-20b.toml
+++ b/providers/neon/models/gpt-oss-20b.toml
@@ -1,0 +1,22 @@
+name = "GPT OSS 20B"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.05
+output = 0.20
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/neon/provider.toml
+++ b/providers/neon/provider.toml
@@ -1,0 +1,5 @@
+name = "Neon"
+npm = "@ai-sdk/openai-compatible"
+api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1"
+env = ["NEON_AI_GATEWAY_BASE_URL", "NEON_AI_GATEWAY_TOKEN"]
+doc = "https://neon.com/docs"


### PR DESCRIPTION
## Summary

Adds the **Neon** provider. Neon's branch-scoped [AI Gateway](https://neon.com) serves the same Databricks-backed model catalog through an OpenAI-compatible endpoint, so this mirrors the existing `databricks` provider's models.

`provider.toml`:

```toml
name = "Neon"
npm = "@ai-sdk/openai-compatible"
api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/mlflow/v1"
env = ["NEON_AI_GATEWAY_BASE_URL", "NEON_AI_GATEWAY_TOKEN"]
doc = "https://neon.com/docs"
```

- **Branch-scoped base URL via env template.** The Neon AI Gateway host is per-branch, so the base URL is templated from `NEON_AI_GATEWAY_BASE_URL` (which already includes the scheme) + the unified MLflow OpenAI-compatible route — the same route the `databricks` provider uses. `NEON_AI_GATEWAY_TOKEN` is the bearer key. Both vars are emitted by `neonctl env pull`.
- **Clean model ids.** The gateway accepts the bare model ids (no `databricks-` prefix), so models resolve as `neon/claude-haiku-4-5`, `neon/gpt-5-nano`, `neon/gemini-2-5-flash`, etc. Model pricing/metadata is cloned from the `databricks` provider (same underlying models), reusing the shared `base_model` metadata where it exists.
- 25 models across Anthropic, OpenAI (incl. gpt-oss), and Google families.
- Includes a `currentColor` logo.

## Test plan

- [x] `provider.toml` + all 25 model TOMLs parse and carry the required fields
- [ ] CI schema validation (GitHub Action)