### PR TITLE
Add CoderPlan provider

### DIFF
--- a/providers/coderplan/logo.svg
+++ b/providers/coderplan/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="2" y="2" width="20" height="20" rx="5" fill="currentColor" opacity="0.15"/>
+  <rect x="2" y="2" width="20" height="20" rx="5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+  <text x="12" y="16.5" font-family="monospace" font-size="13" font-weight="700" fill="currentColor" text-anchor="middle">$</text>
+</svg>

--- a/providers/coderplan/models/claude-haiku-4-5-20251001.toml
+++ b/providers/coderplan/models/claude-haiku-4-5-20251001.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 0.14
+output = 0.68
+cache_read = 0.01

--- a/providers/coderplan/models/claude-opus-4-6.toml
+++ b/providers/coderplan/models/claude-opus-4-6.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-opus-4-6"
+
+[cost]
+input = 0.68
+output = 3.42
+cache_read = 0.07

--- a/providers/coderplan/models/claude-opus-4-7.toml
+++ b/providers/coderplan/models/claude-opus-4-7.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[cost]
+input = 0.68
+output = 3.42
+cache_read = 0.07

--- a/providers/coderplan/models/claude-opus-4-8.toml
+++ b/providers/coderplan/models/claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[cost]
+input = 10.20
+output = 51.00

--- a/providers/coderplan/models/claude-sonnet-4-6.toml
+++ b/providers/coderplan/models/claude-sonnet-4-6.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 0.41
+output = 2.05
+cache_read = 0.04

--- a/providers/coderplan/models/deepseek-v4-flash.toml
+++ b/providers/coderplan/models/deepseek-v4-flash.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[cost]
+input = 0.01
+output = 0.02
+cache_read = 0.002

--- a/providers/coderplan/models/deepseek-v4-pro.toml
+++ b/providers/coderplan/models/deepseek-v4-pro.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 0.08
+output = 0.17
+cache_read = 0.007

--- a/providers/coderplan/models/gemini-2.5-flash-image.toml
+++ b/providers/coderplan/models/gemini-2.5-flash-image.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash-image"
+
+[cost]
+input = 0.29
+output = 28.56
+cache_read = 0.07

--- a/providers/coderplan/models/gemini-2.5-flash.toml
+++ b/providers/coderplan/models/gemini-2.5-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash"
+
+[cost]
+input = 0.09
+output = 0.68
+cache_read = 0.003

--- a/providers/coderplan/models/gemini-2.5-pro.toml
+++ b/providers/coderplan/models/gemini-2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-pro"
+
+[cost]
+input = 1.20
+output = 9.59
+cache_read = 0.12

--- a/providers/coderplan/models/gemini-3-flash-preview.toml
+++ b/providers/coderplan/models/gemini-3-flash-preview.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3-flash-preview"
+
+[cost]
+input = 0.07
+output = 0.41
+cache_read = 0.007

--- a/providers/coderplan/models/gemini-3-pro-preview.toml
+++ b/providers/coderplan/models/gemini-3-pro-preview.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3-pro-preview"
+
+[cost]
+input = 0.54
+output = 3.27
+cache_read = 0.05

--- a/providers/coderplan/models/gemini-3.1-flash-image-preview.toml
+++ b/providers/coderplan/models/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-flash-image-preview"
+
+[cost]
+input = 0.24
+output = 57.12

--- a/providers/coderplan/models/gemini-3.1-pro-preview.toml
+++ b/providers/coderplan/models/gemini-3.1-pro-preview.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[cost]
+input = 1.90
+output = 11.42
+cache_read = 0.19

--- a/providers/coderplan/models/glm-5.1.toml
+++ b/providers/coderplan/models/glm-5.1.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5.1"
+
+[cost]
+input = 0.15
+output = 0.48
+cache_read = 0.03

--- a/providers/coderplan/models/glm-5.toml
+++ b/providers/coderplan/models/glm-5.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5"
+
+[cost]
+input = 0.11
+output = 0.35
+cache_read = 0.02

--- a/providers/coderplan/models/gpt-5.4-mini.toml
+++ b/providers/coderplan/models/gpt-5.4-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4-mini"
+
+[cost]
+input = 0.05
+output = 0.31
+cache_read = 0.005

--- a/providers/coderplan/models/gpt-5.4.toml
+++ b/providers/coderplan/models/gpt-5.4.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4"
+
+[cost]
+input = 0.17
+output = 1.03
+cache_read = 0.02

--- a/providers/coderplan/models/gpt-5.5.toml
+++ b/providers/coderplan/models/gpt-5.5.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.5"
+
+[cost]
+input = 0.34
+output = 2.05
+cache_read = 0.03

--- a/providers/coderplan/models/hy3-preview.toml
+++ b/providers/coderplan/models/hy3-preview.toml
@@ -1,0 +1,6 @@
+base_model = "tencent/hy3-preview"
+
+[cost]
+input = 0.007
+output = 0.03
+cache_read = 0.003

--- a/providers/coderplan/models/kimi-k2.5.toml
+++ b/providers/coderplan/models/kimi-k2.5.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.5"
+
+[cost]
+input = 0.07
+output = 0.33
+cache_read = 0.01

--- a/providers/coderplan/models/kimi-k2.6.toml
+++ b/providers/coderplan/models/kimi-k2.6.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.10
+output = 0.44
+cache_read = 0.02

--- a/providers/coderplan/models/mimo-v2.5-pro.toml
+++ b/providers/coderplan/models/mimo-v2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 0.05
+output = 0.09
+cache_read = 0.0004

--- a/providers/coderplan/models/mimo-v2.5.toml
+++ b/providers/coderplan/models/mimo-v2.5.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5"
+
+[cost]
+input = 0.02
+output = 0.03
+cache_read = 0.0003

--- a/providers/coderplan/models/minimax-m2.5-highspeed.toml
+++ b/providers/coderplan/models/minimax-m2.5-highspeed.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.5-highspeed"
+
+[cost]
+input = 0.07
+output = 0.26
+cache_read = 0.007

--- a/providers/coderplan/models/minimax-m2.5.toml
+++ b/providers/coderplan/models/minimax-m2.5.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.5"
+
+[cost]
+input = 0.03
+output = 0.13
+cache_read = 0.003

--- a/providers/coderplan/models/minimax-m2.7-highspeed.toml
+++ b/providers/coderplan/models/minimax-m2.7-highspeed.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
+
+[cost]
+input = 0.07
+output = 0.26
+cache_read = 0.007

--- a/providers/coderplan/models/minimax-m2.7.toml
+++ b/providers/coderplan/models/minimax-m2.7.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.7"
+
+[cost]
+input = 0.03
+output = 0.13
+cache_read = 0.007

--- a/providers/coderplan/models/minimax-m3.toml
+++ b/providers/coderplan/models/minimax-m3.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M3"
+
+[cost]
+input = 0.03
+output = 0.13
+cache_read = 0.007

--- a/providers/coderplan/models/qwen3.6-plus.toml
+++ b/providers/coderplan/models/qwen3.6-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.6-plus"
+
+[cost]
+input = 0.03
+output = 0.18
+cache_read = 0.003

--- a/providers/coderplan/models/qwen3.7-max.toml
+++ b/providers/coderplan/models/qwen3.7-max.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-max"
+
+[cost]
+input = 0.14
+output = 0.14
+cache_read = 0.03

--- a/providers/coderplan/models/qwen3.7-plus.toml
+++ b/providers/coderplan/models/qwen3.7-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-plus"
+
+[cost]
+input = 0.03
+output = 0.14
+cache_read = 0.007

--- a/providers/coderplan/provider.toml
+++ b/providers/coderplan/provider.toml
@@ -1,0 +1,5 @@
+name = "CoderPlan"
+env = ["CODERPLAN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://coderplan.ai/docs/setup"
+api = "https://api.coderplan.ai/v1"


### PR DESCRIPTION
## Summary

Adds **CoderPlan** as a provider — an OpenAI-compatible LLM API relay for Chinese developers.

- **32 models**: Claude (Opus 4.6–4.8, Sonnet 4.6, Haiku 4.5), GPT (5.5, 5.4, 5.4-mini), Gemini (2.5 Flash/Pro, 3 Flash/Pro, 3.1 Flash/Pro), DeepSeek (V4 Flash/Pro), GLM (5, 5.1), Kimi (K2.5, K2.6), Qwen (3.6-plus, 3.7-max, 3.7-plus), MiniMax (M2.5, M2.7, M3 + highspeed), MiMo (V2.5, V2.5-Pro), HY3
- **Pricing**: pay-per-use at ~0.7x official rates, ¥10 minimum top-up, Alipay/WeChat
- **API endpoint**: `https://api.coderplan.ai/v1` (OpenAI-compatible)
- **Docs**: https://coderplan.ai/docs/setup

All model definitions use `base_model` to inherit capabilities from the canonical base providers, with CoderPlan-specific pricing overrides.

## Checklist

- [x] `provider.toml` follows existing schema
- [x] Model files use `base_model` from canonical base providers
- [x] Pricing data matches published rates at https://coderplan.ai/pricing
- [x] Logo SVG uses `currentColor` with no fixed dimensions