### PR TITLE
[nano-gpt] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-Cognitive-Unshackled.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Cognitive-Unshackled.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-DarkIdol.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-DarkIdol.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-GarnetV2.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-GarnetV2.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-Gemopus.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Gemopus.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-Musica-v1.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Musica-v1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-Queen.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Queen.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-it.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-09"
 last_updated = "2026-04-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/MiniMax-M2.toml
+++ b/providers/nano-gpt/models/MiniMax-M2.toml
@@ -3,6 +3,7 @@ release_date = "2025-10-25"
 last_updated = "2025-10-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Anko.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Anko.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Infracelestial.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Infracelestial.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Musica-v1.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Musica-v1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-NaNovel-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-NaNovel-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-NaNovel-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-NaNovel-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Omega-Evolution-v2.0-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Omega-Evolution-v2.2-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Queen-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Queen-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Queen-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Queen-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-RpRMax-v1.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-RpRMax-v1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Vivid-Durian.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Vivid-Durian.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Writer-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Writer-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Writer-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Writer-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Writer-V2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Writer-V2-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Writer-V2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Writer-V2-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-earica-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-earica-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-earica-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-earica-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/TEE/deepseek-v4-pro.toml
+++ b/providers/nano-gpt/models/TEE/deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/deepseek-v4-pro:thinking.toml
+++ b/providers/nano-gpt/models/TEE/deepseek-v4-pro:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-29"
 last_updated = "2026-04-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/gemma-4-31b-it.toml
+++ b/providers/nano-gpt/models/TEE/gemma-4-31b-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-26"
 last_updated = "2026-05-26"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/TEE/gemma4-31b:thinking.toml
+++ b/providers/nano-gpt/models/TEE/gemma4-31b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/glm-5.1-thinking.toml
+++ b/providers/nano-gpt/models/TEE/glm-5.1-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/kimi-k2.5-thinking.toml
+++ b/providers/nano-gpt/models/TEE/kimi-k2.5-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-29"
 last_updated = "2026-01-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/TEE/minimax-m2.5.toml
+++ b/providers/nano-gpt/models/TEE/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/qwen3.5-122b-a10b.toml
+++ b/providers/nano-gpt/models/TEE/qwen3.5-122b-a10b.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-26"
 last_updated = "2026-05-26"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/TEE/qwen3.6-35b-a3b-uncensored.toml
+++ b/providers/nano-gpt/models/TEE/qwen3.6-35b-a3b-uncensored.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-23"
 last_updated = "2026-05-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/alibaba/qwen3.6-27b:thinking.toml
+++ b/providers/nano-gpt/models/alibaba/qwen3.6-27b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-23"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/allenai/olmo-3-32b-think.toml
+++ b/providers/nano-gpt/models/allenai/olmo-3-32b-think.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-haiku-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-haiku-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:low.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:low.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:max.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:max.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:medium.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:medium.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.7.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.7:thinking.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.7:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.8.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.8.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-28"
 last_updated = "2026-05-28"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.8:thinking.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.8:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-28"
 last_updated = "2026-05-28"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-sonnet-4.6:thinking.toml
+++ b/providers/nano-gpt/models/anthropic/claude-sonnet-4.6:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 knowledge = "2025-08-31"

--- a/providers/nano-gpt/models/anthropic/claude-sonnet-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-sonnet-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/arcee-ai/trinity-large-thinking.toml
+++ b/providers/nano-gpt/models/arcee-ai/trinity-large-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-01"
 last_updated = "2026-04-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/claude-haiku-4-5-20251001-thinking.toml
+++ b/providers/nano-gpt/models/claude-haiku-4-5-20251001-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-1-thinking.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-1-thinking:1024.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking:1024.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-1-thinking:32000.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking:32000.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-1-thinking:32768.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking:32768.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-1-thinking:8192.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking:8192.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-5-20251101.toml
+++ b/providers/nano-gpt/models/claude-opus-4-5-20251101.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-5-20251101:thinking.toml
+++ b/providers/nano-gpt/models/claude-opus-4-5-20251101:thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-15"
 last_updated = "2025-07-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking:1024.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking:1024.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking:32000.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking:32000.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking:32768.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking:32768.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking:8192.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking:8192.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-5-20250929-thinking.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-5-20250929-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-02-24"
 last_updated = "2025-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:1024.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:1024.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:32768.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:32768.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:64000.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:64000.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:8192.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:8192.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claw-high.toml
+++ b/providers/nano-gpt/models/claw-high.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claw-low.toml
+++ b/providers/nano-gpt/models/claw-low.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claw-medium.toml
+++ b/providers/nano-gpt/models/claw-medium.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/command-a-plus-05-2026.toml
+++ b/providers/nano-gpt/models/command-a-plus-05-2026.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-22"
 last_updated = "2026-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek-ai/DeepSeek-R1-0528.toml
+++ b/providers/nano-gpt/models/deepseek-ai/DeepSeek-R1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/deepseek-ai/deepseek-v3.2-exp-thinking.toml
+++ b/providers/nano-gpt/models/deepseek-ai/deepseek-v3.2-exp-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/deepseek-r1.toml
+++ b/providers/nano-gpt/models/deepseek-r1.toml
@@ -3,6 +3,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-latest.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v3.2-speciale.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v3.2-speciale.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-02"
 last_updated = "2025-12-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v3.2:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v3.2:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-flash:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-flash:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/ernie-5.0-thinking-preview.toml
+++ b/providers/nano-gpt/models/ernie-5.0-thinking-preview.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/ernie-5.1:thinking.toml
+++ b/providers/nano-gpt/models/ernie-5.1:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-10"
 last_updated = "2026-05-10"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.0-flash-thinking-exp-01-21.toml
+++ b/providers/nano-gpt/models/gemini-2.0-flash-thinking-exp-01-21.toml
@@ -3,6 +3,7 @@ release_date = "2025-01-21"
 last_updated = "2025-01-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025-thinking.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
@@ -3,6 +3,7 @@ release_date = "2025-04-17"
 last_updated = "2025-04-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17:thinking.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17:thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-04-17"
 last_updated = "2025-04-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-05-20:thinking.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-05-20:thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-20"
 last_updated = "2025-05-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025-thinking.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-exp-03-25.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-exp-03-25.toml
@@ -3,6 +3,7 @@ release_date = "2025-03-25"
 last_updated = "2025-03-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-03-25.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-03-25.toml
@@ -3,6 +3,7 @@ release_date = "2025-03-25"
 last_updated = "2025-03-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-05-06.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-06"
 last_updated = "2025-05-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-06-05.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-Fabled.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-Fabled.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-Garnet.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-Garnet.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-K1-v5.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-K1-v5.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-Larkspur-v0.5.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-Larkspur-v0.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-MeroMero.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-MeroMero.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3-flash-preview-thinking.toml
+++ b/providers/nano-gpt/models/google/gemini-3-flash-preview-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3-flash-preview.toml
+++ b/providers/nano-gpt/models/google/gemini-3-flash-preview.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-flash-lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-03"
 last_updated = "2026-03-03"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-27"
 last_updated = "2026-02-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-pro-preview-high.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-pro-preview-high.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-21"
 last_updated = "2026-02-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-pro-preview-low.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-pro-preview-low.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-21"
 last_updated = "2026-02-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-pro-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.5-flash-thinking.toml
+++ b/providers/nano-gpt/models/google/gemini-3.5-flash-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-19"
 last_updated = "2026-05-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.5-flash.toml
+++ b/providers/nano-gpt/models/google/gemini-3.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-19"
 last_updated = "2026-05-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-flash-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-flash-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-flash-lite-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-flash-lite-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-pro-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-pro-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/nano-gpt/models/google/gemma-4-26b-a4b-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemma-4-26b-a4b-it:thinking.toml
+++ b/providers/nano-gpt/models/google/gemma-4-26b-a4b-it:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemma-4-31b-it.toml
+++ b/providers/nano-gpt/models/google/gemma-4-31b-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemma-4-31b-it:thinking.toml
+++ b/providers/nano-gpt/models/google/gemma-4-31b-it:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/hermes-high.toml
+++ b/providers/nano-gpt/models/hermes-high.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/hermes-low.toml
+++ b/providers/nano-gpt/models/hermes-low.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/hermes-medium.toml
+++ b/providers/nano-gpt/models/hermes-medium.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/holo3-35b-a3b.toml
+++ b/providers/nano-gpt/models/holo3-35b-a3b.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/holo3-35b-a3b:thinking.toml
+++ b/providers/nano-gpt/models/holo3-35b-a3b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Llama-70B-abliterated.toml
+++ b/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Llama-70B-abliterated.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated.toml
+++ b/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/nano-gpt/models/inclusionai/ring-2.6-1t.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-08"
 last_updated = "2026-05-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mercury-2.toml
+++ b/providers/nano-gpt/models/mercury-2.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-latest.toml
+++ b/providers/nano-gpt/models/minimax/minimax-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m2.1.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-19"
 last_updated = "2025-12-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m2.5.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m2.7-turbo.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.7-turbo.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m2.7.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m3:thinking.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m3:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-01"
 last_updated = "2026-06-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mirothinker-1-7-deepresearch-mini.toml
+++ b/providers/nano-gpt/models/mirothinker-1-7-deepresearch-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/mirothinker-1-7-deepresearch.toml
+++ b/providers/nano-gpt/models/mirothinker-1-7-deepresearch.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/mistral/mistral-medium-3.5.toml
+++ b/providers/nano-gpt/models/mistral/mistral-medium-3.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-29"
 last_updated = "2026-04-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mistral/mistral-medium-3.5:thinking.toml
+++ b/providers/nano-gpt/models/mistral/mistral-medium-3.5:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603.toml
+++ b/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603:thinking.toml
+++ b/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2-thinking-original.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2-thinking-original.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2-thinking-turbo-original.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2-thinking-turbo-original.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5:thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-26"
 last_updated = "2026-01-26"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.6:thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.6:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = true

--- a/providers/nano-gpt/models/moonshotai/kimi-latest.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router:high.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router:high.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router:low.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router:low.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router:max.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router:max.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router:medium.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router:medium.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/providers/nano-gpt/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -5,6 +5,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b:thinking.toml
+++ b/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b:thinking.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5-mini.toml
+++ b/providers/nano-gpt/models/openai/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5-nano.toml
+++ b/providers/nano-gpt/models/openai/gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5-pro.toml
+++ b/providers/nano-gpt/models/openai/gpt-5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.1-codex-max.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.1-codex.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.1.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.2-codex.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.2-pro.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.2-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-01"
 last_updated = "2026-01-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.2.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-01"
 last_updated = "2026-01-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.3-codex.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.4-mini.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.4-nano.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.4-nano.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.4-pro.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.4.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.4.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.5.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-latest.toml
+++ b/providers/nano-gpt/models/openai/gpt-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-oss-120b.toml
+++ b/providers/nano-gpt/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-oss-20b.toml
+++ b/providers/nano-gpt/models/openai/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/nano-gpt/models/openai/gpt-oss-safeguard-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-29"
 last_updated = "2025-10-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o1-preview.toml
+++ b/providers/nano-gpt/models/openai/o1-preview.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-09-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o1.toml
+++ b/providers/nano-gpt/models/openai/o1.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-17"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-deep-research.toml
+++ b/providers/nano-gpt/models/openai/o3-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-mini-high.toml
+++ b/providers/nano-gpt/models/openai/o3-mini-high.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-mini-low.toml
+++ b/providers/nano-gpt/models/openai/o3-mini-low.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-mini.toml
+++ b/providers/nano-gpt/models/openai/o3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-pro-2025-06-10.toml
+++ b/providers/nano-gpt/models/openai/o3-pro-2025-06-10.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-10"
 last_updated = "2025-06-10"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/o4-mini-deep-research.toml
+++ b/providers/nano-gpt/models/openai/o4-mini-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o4-mini-high.toml
+++ b/providers/nano-gpt/models/openai/o4-mini-high.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/o4-mini.toml
+++ b/providers/nano-gpt/models/openai/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/pamanseau/OpenReasoning-Nemotron-32B.toml
+++ b/providers/nano-gpt/models/pamanseau/OpenReasoning-Nemotron-32B.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-21"
 last_updated = "2025-08-21"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/perceptron/perceptron-mk1.toml
+++ b/providers/nano-gpt/models/perceptron/perceptron-mk1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/qwen-plus.toml
+++ b/providers/nano-gpt/models/qwen-plus.toml
@@ -3,6 +3,7 @@ release_date = "2024-01-25"
 last_updated = "2024-01-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
+++ b/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-19"
 last_updated = "2026-04-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b-thinking.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/qwen3.5-9b.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-9b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-10"
 last_updated = "2026-03-10"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/qwen3.5-plus-thinking.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-plus-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/nano-gpt/models/qwen3-vl-235b-a22b-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-26"
 last_updated = "2025-08-26"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-122b-a10b:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-122b-a10b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-27b:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-27b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-35b-a3b:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-35b-a3b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-flash:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-flash:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.7-max:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.7-max:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-21"
 last_updated = "2026-05-21"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.7-plus:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.7-plus:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-01"
 last_updated = "2026-06-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/sarvam-105b.toml
+++ b/providers/nano-gpt/models/sarvam-105b.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/sarvam-30b.toml
+++ b/providers/nano-gpt/models/sarvam-30b.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/sonar-reasoning-pro.toml
+++ b/providers/nano-gpt/models/sonar-reasoning-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/stepfun-ai/step-3.5-flash-2603.toml
+++ b/providers/nano-gpt/models/stepfun-ai/step-3.5-flash-2603.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-14"
 last_updated = "2026-04-14"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/stepfun-ai/step-3.5-flash.toml
+++ b/providers/nano-gpt/models/stepfun-ai/step-3.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-02"
 last_updated = "2026-02-02"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/stepfun/step-3.7-flash:thinking.toml
+++ b/providers/nano-gpt/models/stepfun/step-3.7-flash:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-29"
 last_updated = "2026-05-29"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/x-ai/grok-4.20-multi-agent.toml
+++ b/providers/nano-gpt/models/x-ai/grok-4.20-multi-agent.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-31"
 last_updated = "2026-03-31"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/x-ai/grok-4.20.toml
+++ b/providers/nano-gpt/models/x-ai/grok-4.20.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-31"
 last_updated = "2026-03-31"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/x-ai/grok-4.3.toml
+++ b/providers/nano-gpt/models/x-ai/grok-4.3.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/x-ai/grok-build-0.1.toml
+++ b/providers/nano-gpt/models/x-ai/grok-build-0.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-20"
 last_updated = "2026-05-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/x-ai/grok-latest.toml
+++ b/providers/nano-gpt/models/x-ai/grok-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2.5.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/z-ai/glm-4.5v.toml
+++ b/providers/nano-gpt/models/z-ai/glm-4.5v.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-22"
 last_updated = "2025-11-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/z-ai/glm-4.5v:thinking.toml
+++ b/providers/nano-gpt/models/z-ai/glm-4.5v:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-22"
 last_updated = "2025-11-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/z-ai/glm-4.6.toml
+++ b/providers/nano-gpt/models/z-ai/glm-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/z-ai/glm-4.6:thinking.toml
+++ b/providers/nano-gpt/models/z-ai/glm-4.6:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/z-ai/glm-5v-turbo:thinking.toml
+++ b/providers/nano-gpt/models/z-ai/glm-5v-turbo:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/GLM-4.5-Air:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/GLM-4.5-Air:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/GLM-4.5:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/GLM-4.5:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/GLM-4.6-turbo:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/GLM-4.6-turbo:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-02"
 last_updated = "2025-10-02"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.6-original.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.6-original.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-flash-original.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-flash-original.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-flash-original:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-flash-original:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-flash.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-4.7-flash:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-flash:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-original.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-original.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-original:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-original:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-29"
 last_updated = "2026-01-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-4.7:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-5-original.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5-original.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-5-original:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5-original:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-5.1.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-5.1:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.1:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-5.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-5:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-latest.toml
+++ b/providers/nano-gpt/models/zai-org/glm-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
## Summary
- add explicit `reasoning_options` to all 255 existing reasoning models
- classify 124 fixed/preset models as `[]`, 69 hybrid models with toggles, and 62 models with effort controls
- make no catalog, base-model, test, or unrelated metadata changes

## Validation
- `bun validate`
- `git diff --check`
- 255/255 reasoning models covered; 0 options on non-reasoning models
- diff contains exactly 255 `reasoning_options` insertions