### PR TITLE
[vercel] Complete reasoning options

### DIFF
--- a/providers/vercel/models/alibaba/qwen-3-14b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-14b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen-3-30b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-30b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen-3-32b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-32b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen-3.6-max-preview.toml
+++ b/providers/vercel/models/alibaba/qwen-3.6-max-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/vercel/models/alibaba/qwen3-235b-a22b-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-235b-a22b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-24"
 last_updated = "2025-04"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen3-coder-30b-a3b.toml
+++ b/providers/vercel/models/alibaba/qwen3-coder-30b-a3b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen3-coder-next.toml
+++ b/providers/vercel/models/alibaba/qwen3-coder-next.toml
@@ -2,6 +2,7 @@ name = "Qwen3 Coder Next"
 family = "qwen"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 temperature = true
 release_date = "2025-07-22"

--- a/providers/vercel/models/alibaba/qwen3-max-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-max-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-01"
 last_updated = "2025-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/vercel/models/alibaba/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-next-80b-a3b-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-next-80b-a3b-thinking"
+reasoning_options = []
 name = "Qwen3 Next 80B A3B Thinking"
 release_date = "2025-09-12"
 knowledge = "2025-09"

--- a/providers/vercel/models/alibaba/qwen3-vl-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-vl-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-24"
 last_updated = "2025-09-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-09"

--- a/providers/vercel/models/alibaba/qwen3.5-flash.toml
+++ b/providers/vercel/models/alibaba/qwen3.5-flash.toml
@@ -2,6 +2,7 @@ name = "Qwen 3.5 Flash"
 family = "qwen"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 temperature = true
 release_date = "2026-02-24"

--- a/providers/vercel/models/alibaba/qwen3.5-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.5-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-plus"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.5 Plus"
 attachment = true
 

--- a/providers/vercel/models/alibaba/qwen3.6-27b.toml
+++ b/providers/vercel/models/alibaba/qwen3.6-27b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-27b"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.6 27B"
 family = "qwen3.6"
 open_weights = false

--- a/providers/vercel/models/alibaba/qwen3.6-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.6-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-plus"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.6 Plus"
 attachment = true
 

--- a/providers/vercel/models/alibaba/qwen3.7-max.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.7 Max"
 attachment = true
 

--- a/providers/vercel/models/alibaba/qwen3.7-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.7 Plus"
 family = "qwen3.7-plus"
 release_date = "2026-06-01"

--- a/providers/vercel/models/amazon/nova-2-lite.toml
+++ b/providers/vercel/models/amazon/nova-2-lite.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-01"
 last_updated = "2024-12-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = false
 knowledge = "2024-10"

--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
 name = "Claude Haiku 4.5"
 
 interleaved = true

--- a/providers/vercel/models/anthropic/claude-opus-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
+reasoning_options = []
 name = "Claude Opus 4.5"
 release_date = "2024-11-24"
 

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-opus-4.7.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.8.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 interleaved = true
 

--- a/providers/vercel/models/arcee-ai/trinity-large-thinking.toml
+++ b/providers/vercel/models/arcee-ai/trinity-large-thinking.toml
@@ -2,6 +2,7 @@ name = "Trinity Large Thinking"
 family = "trinity"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2026-04-01"

--- a/providers/vercel/models/bytedance/seed-1.6.toml
+++ b/providers/vercel/models/bytedance/seed-1.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-01"
 last_updated = "2025-09"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/bytedance/seed-1.8.toml
+++ b/providers/vercel/models/bytedance/seed-1.8.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-01"
 last_updated = "2025-10"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/deepseek/deepseek-v3.1-terminus.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.1-terminus.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-22"
 last_updated = "2025-09-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-07"

--- a/providers/vercel/models/deepseek/deepseek-v3.1.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-21"
 last_updated = "2025-08-21"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-07"

--- a/providers/vercel/models/deepseek/deepseek-v3.2-thinking.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.2-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-07"

--- a/providers/vercel/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/vercel/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 family = "deepseek"
 release_date = "2026-04-23"
 

--- a/providers/vercel/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/vercel/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 family = "deepseek"
 release_date = "2026-04-23"
 

--- a/providers/vercel/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/vercel/models/google/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 512, max = 24_576 }]
 name = "Gemini 2.5 Flash Lite"
 
 [cost]

--- a/providers/vercel/models/google/gemini-3-flash.toml
+++ b/providers/vercel/models/google/gemini-3-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03"

--- a/providers/vercel/models/google/gemini-3-pro-preview.toml
+++ b/providers/vercel/models/google/gemini-3-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "high"] }]
 
 [cost]
 input = 2

--- a/providers/vercel/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/vercel/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-image-preview"
+reasoning_options = [{ type = "effort", values = ["minimal", "high"] }]
 name = "Gemini 3.1 Flash Image Preview (Nano Banana 2)"
 family = "gemini"
 

--- a/providers/vercel/models/google/gemini-3.1-flash-image.toml
+++ b/providers/vercel/models/google/gemini-3.1-flash-image.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-28"
 last_updated = "2026-05-28"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "high"] }]
 temperature = true
 tool_call = false
 open_weights = false

--- a/providers/vercel/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/vercel/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 family = "gemini"
 
 [cost]

--- a/providers/vercel/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/vercel/models/google/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 family = "gemini"
 
 [cost]

--- a/providers/vercel/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/vercel/models/google/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 family = "gemini"
 release_date = "2025-11-18"
 

--- a/providers/vercel/models/google/gemini-3.5-flash.toml
+++ b/providers/vercel/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 family = "gemini"
 
 [cost]

--- a/providers/vercel/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/vercel/models/google/gemma-4-26b-a4b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = [{ type = "toggle" }]
 open_weights = false
 
 [cost]

--- a/providers/vercel/models/google/gemma-4-31b-it.toml
+++ b/providers/vercel/models/google/gemma-4-31b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = [{ type = "toggle" }]
 open_weights = false
 
 [cost]

--- a/providers/vercel/models/inception/mercury-2.toml
+++ b/providers/vercel/models/inception/mercury-2.toml
@@ -2,6 +2,7 @@ name = "Mercury 2"
 family = "mercury"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 release_date = "2026-02-24"

--- a/providers/vercel/models/interfaze/interfaze-beta.toml
+++ b/providers/vercel/models/interfaze/interfaze-beta.toml
@@ -1,6 +1,7 @@
 name = "Interfaze Beta"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 temperature = true
 release_date = "2025-10-07"

--- a/providers/vercel/models/kwaipilot/kat-coder-pro-v1.toml
+++ b/providers/vercel/models/kwaipilot/kat-coder-pro-v1.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-24"
 last_updated = "2025-10-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 knowledge = "2024-10"

--- a/providers/vercel/models/kwaipilot/kat-coder-pro-v2.toml
+++ b/providers/vercel/models/kwaipilot/kat-coder-pro-v2.toml
@@ -2,6 +2,7 @@ name = "Kat Coder Pro V2"
 family = "kat-coder"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2026-03-27"

--- a/providers/vercel/models/meituan/longcat-flash-thinking-2601.toml
+++ b/providers/vercel/models/meituan/longcat-flash-thinking-2601.toml
@@ -2,6 +2,7 @@ name = "LongCat Flash Thinking 2601"
 family = "longcat"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 temperature = true
 release_date = "2026-03-13"

--- a/providers/vercel/models/minimax/minimax-m2.1-lightning.toml
+++ b/providers/vercel/models/minimax/minimax-m2.1-lightning.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-27"
 last_updated = "2025-10-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/minimax/minimax-m2.1.toml
+++ b/providers/vercel/models/minimax/minimax-m2.1.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.1"
+reasoning_options = []
 name = "MiniMax M2.1"
 release_date = "2025-10-27"
 knowledge = "2024-10"

--- a/providers/vercel/models/minimax/minimax-m2.5-highspeed.toml
+++ b/providers/vercel/models/minimax/minimax-m2.5-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5-highspeed"
+reasoning_options = []
 name = "MiniMax M2.5 High Speed"
 release_date = "2026-02-12"
 open_weights = false

--- a/providers/vercel/models/minimax/minimax-m2.5.toml
+++ b/providers/vercel/models/minimax/minimax-m2.5.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
 name = "MiniMax M2.5"
 open_weights = false
 

--- a/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
 name = "MiniMax M2.7 High Speed"
 attachment = true
 

--- a/providers/vercel/models/minimax/minimax-m2.7.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
 name = "Minimax M2.7"
 attachment = true
 

--- a/providers/vercel/models/minimax/minimax-m2.toml
+++ b/providers/vercel/models/minimax/minimax-m2.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2"
+reasoning_options = []
 name = "MiniMax M2"
 knowledge = "2024-10"
 

--- a/providers/vercel/models/minimax/minimax-m3.toml
+++ b/providers/vercel/models/minimax/minimax-m3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = []
 name = "MiniMax M3"
 family = "minimax-m3"
 release_date = "2026-05-31"

--- a/providers/vercel/models/mistral/mistral-medium-3.5.toml
+++ b/providers/vercel/models/mistral/mistral-medium-3.5.toml
@@ -2,6 +2,7 @@ name = "Mistral Medium Latest"
 family = "mistral-medium"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 release_date = "2026-05-21"

--- a/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking"
+reasoning_options = []
 open_weights = false
 
 interleaved = true

--- a/providers/vercel/models/moonshotai/kimi-k2.5.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+reasoning_options = [{ type = "toggle" }]
 family = "kimi"
 release_date = "2026-01-26"
 attachment = true

--- a/providers/vercel/models/moonshotai/kimi-k2.6.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2026-04-20"
 
 [cost]

--- a/providers/vercel/models/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/vercel/models/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-nano-30b-a3b"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2024-12-01"
 tool_call = false
 knowledge = "2024-10"

--- a/providers/vercel/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/vercel/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+reasoning_options = [{ type = "toggle" }]
 name = "Nemotron 3 Ultra"
 open_weights = false
 

--- a/providers/vercel/models/nvidia/nemotron-nano-12b-v2-vl.toml
+++ b/providers/vercel/models/nvidia/nemotron-nano-12b-v2-vl.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-nano-12b-v2-vl"
+reasoning_options = [{ type = "toggle" }]
 name = "Nvidia Nemotron Nano 12B V2 VL"
 release_date = "2024-12-01"
 knowledge = "2024-10"

--- a/providers/vercel/models/nvidia/nemotron-nano-9b-v2.toml
+++ b/providers/vercel/models/nvidia/nemotron-nano-9b-v2.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-nano-9b-v2"
+reasoning_options = [{ type = "toggle" }]
 name = "Nvidia Nemotron Nano 9B V2"
 knowledge = "2024-10"
 open_weights = false

--- a/providers/vercel/models/openai/gpt-5-chat.toml
+++ b/providers/vercel/models/openai/gpt-5-chat.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5-pro.toml
+++ b/providers/vercel/models/openai/gpt-5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-pro"
+reasoning_options = [{ type = "effort", values = ["high"] }]
 name = "GPT-5 pro"
 family = "gpt"
 release_date = "2025-08-07"

--- a/providers/vercel/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/vercel/models/openai/gpt-5.1-codex-max.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex-max"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "GPT 5.1 Codex Max"
 family = "gpt"
 release_date = "2025-11-19"

--- a/providers/vercel/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/vercel/models/openai/gpt-5.1-codex-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 family = "gpt"
 release_date = "2025-11-12"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.1-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.1-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 name = "GPT-5.1-Codex"
 family = "gpt"
 release_date = "2025-11-12"

--- a/providers/vercel/models/openai/gpt-5.1-instant.toml
+++ b/providers/vercel/models/openai/gpt-5.1-instant.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.1-thinking.toml
+++ b/providers/vercel/models/openai/gpt-5.1-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.2-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.2-chat.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.2-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.2-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "GPT-5.2-Codex"
 release_date = "2025-12-18"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.2-pro.toml
+++ b/providers/vercel/models/openai/gpt-5.2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 name = "GPT 5.2 "
 family = "gpt"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.2.toml
+++ b/providers/vercel/models/openai/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = true
 knowledge = "2024-10"
 

--- a/providers/vercel/models/openai/gpt-5.3-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.3-chat.toml
@@ -2,6 +2,7 @@ name = "GPT-5.3 Chat"
 family = "gpt"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2026-03-03"

--- a/providers/vercel/models/openai/gpt-5.3-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.3-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "GPT 5.3 Codex"
 family = "gpt"
 release_date = "2026-02-24"

--- a/providers/vercel/models/openai/gpt-5.4-mini.toml
+++ b/providers/vercel/models/openai/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.4 Mini"
 family = "gpt"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.4-nano.toml
+++ b/providers/vercel/models/openai/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.4 Nano"
 family = "gpt"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.4-pro.toml
+++ b/providers/vercel/models/openai/gpt-5.4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 name = "GPT 5.4 Pro"
 family = "gpt"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.4.toml
+++ b/providers/vercel/models/openai/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.4"
 temperature = true
 

--- a/providers/vercel/models/openai/gpt-5.5-pro.toml
+++ b/providers/vercel/models/openai/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 name = "GPT 5.5 Pro"
 family = "gpt"
 release_date = "2026-04-24"

--- a/providers/vercel/models/openai/gpt-5.5.toml
+++ b/providers/vercel/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.5"
 release_date = "2026-04-24"
 temperature = true

--- a/providers/vercel/models/openai/gpt-oss-120b.toml
+++ b/providers/vercel/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-oss-20b.toml
+++ b/providers/vercel/models/openai/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/vercel/models/openai/gpt-oss-safeguard-20b.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-01"
 last_updated = "2024-12-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/o3-deep-research.toml
+++ b/providers/vercel/models/openai/o3-deep-research.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-deep-research"
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 temperature = true
 knowledge = "2024-10"
 

--- a/providers/vercel/models/openai/o3-pro.toml
+++ b/providers/vercel/models/openai/o3-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 name = "o3 Pro"
 release_date = "2025-04-16"
 temperature = true

--- a/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 knowledge = "2025-09"

--- a/providers/vercel/models/stepfun/step-3.5-flash.toml
+++ b/providers/vercel/models/stepfun/step-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.5-flash"
+reasoning_options = []
 base_model_omit = ["limit.input"]
 name = "StepFun 3.5 Flash"
 family = "step"

--- a/providers/vercel/models/stepfun/step-3.7-flash.toml
+++ b/providers/vercel/models/stepfun/step-3.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 family = "step"
 release_date = "2026-05-28"
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.1-fast-reasoning.toml
+++ b/providers/vercel/models/xai/grok-4.1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/xai/grok-4.20-multi-agent-beta.toml
+++ b/providers/vercel/models/xai/grok-4.20-multi-agent-beta.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-13"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.20-multi-agent.toml
+++ b/providers/vercel/models/xai/grok-4.20-multi-agent.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-09"
 last_updated = "2026-03-23"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.20-reasoning-beta.toml
+++ b/providers/vercel/models/xai/grok-4.20-reasoning-beta.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.20-reasoning.toml
+++ b/providers/vercel/models/xai/grok-4.20-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-09"
 last_updated = "2026-03-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.3.toml
+++ b/providers/vercel/models/xai/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 release_date = "2026-04-30"
 
 [cost]

--- a/providers/vercel/models/xai/grok-build-0.1.toml
+++ b/providers/vercel/models/xai/grok-build-0.1.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-build-0.1"
+reasoning_options = []
 release_date = "2026-05-20"
 
 [cost]

--- a/providers/vercel/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2-flash.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-flash"
+reasoning_options = [{ type = "toggle" }]
 name = "MiMo V2 Flash"
 release_date = "2025-12-17"
 knowledge = "2024-10"

--- a/providers/vercel/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+reasoning_options = []
 name = "MiMo V2 Pro"
 
 [cost]

--- a/providers/vercel/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "MiMo V2.5 Pro"
 family = "mimo-v2.5-pro"
 attachment = true

--- a/providers/vercel/models/xiaomi/mimo-v2.5.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 name = "MiMo M2.5"
 family = "mimo-v2.5"
 open_weights = false

--- a/providers/vercel/models/zai/glm-4.5-air.toml
+++ b/providers/vercel/models/zai/glm-4.5-air.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.5 Air"
 
 [cost]

--- a/providers/vercel/models/zai/glm-4.5.toml
+++ b/providers/vercel/models/zai/glm-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.5"
 knowledge = "2025-07"
 

--- a/providers/vercel/models/zai/glm-4.5v.toml
+++ b/providers/vercel/models/zai/glm-4.5v.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5v"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.5V"
 knowledge = "2025-08"
 

--- a/providers/vercel/models/zai/glm-4.6.toml
+++ b/providers/vercel/models/zai/glm-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.6"
 
 interleaved = true

--- a/providers/vercel/models/zai/glm-4.6v-flash.toml
+++ b/providers/vercel/models/zai/glm-4.6v-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/zai/glm-4.6v.toml
+++ b/providers/vercel/models/zai/glm-4.6v.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6v"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2025-09-30"
 knowledge = "2024-10"
 open_weights = false

--- a/providers/vercel/models/zai/glm-4.7-flash.toml
+++ b/providers/vercel/models/zai/glm-4.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.7 Flash"
 family = "glm"
 release_date = "2026-03-13"

--- a/providers/vercel/models/zai/glm-4.7-flashx.toml
+++ b/providers/vercel/models/zai/glm-4.7-flashx.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flashx"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.7 FlashX"
 release_date = "2025-01-01"
 knowledge = "2025-01"

--- a/providers/vercel/models/zai/glm-4.7.toml
+++ b/providers/vercel/models/zai/glm-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.7"
 knowledge = "2024-10"
 open_weights = false

--- a/providers/vercel/models/zai/glm-5-turbo.toml
+++ b/providers/vercel/models/zai/glm-5-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5-turbo"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 5 Turbo"
 release_date = "2026-03-15"
 

--- a/providers/vercel/models/zai/glm-5.1.toml
+++ b/providers/vercel/models/zai/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 5.1"
 release_date = "2026-04-07"
 attachment = true

--- a/providers/vercel/models/zai/glm-5.toml
+++ b/providers/vercel/models/zai/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2026-02-12"
 
 [cost]

--- a/providers/vercel/models/zai/glm-5v-turbo.toml
+++ b/providers/vercel/models/zai/glm-5v-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5v-turbo"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 5V Turbo"
 
 [cost]


### PR DESCRIPTION
## Summary
- backfill explicit `reasoning_options` for 114 existing Vercel AI Gateway models
- preserve the existing Claude Fable declaration and complete 115/115 reasoning-model coverage
- retain only one verified finite token budget: Gemini 2.5 Flash-Lite at 512..24,576
- make no catalog, base-model, test, or unrelated metadata changes

## Validation
- `bun validate`
- `git diff --check`
- 115/115 covered; 0 non-reasoning leaks; 0 unbounded budgets