### PR TITLE
[kilo] Add reasoning options

### DIFF
--- a/providers/kilo/models/aion-labs/aion-1.0-mini.toml
+++ b/providers/kilo/models/aion-labs/aion-1.0-mini.toml
@@ -2,6 +2,7 @@ name = "AionLabs: Aion-1.0-Mini"
 release_date = "2025-02-05"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/aion-labs/aion-1.0.toml
+++ b/providers/kilo/models/aion-labs/aion-1.0.toml
@@ -2,6 +2,7 @@ name = "AionLabs: Aion-1.0"
 release_date = "2025-02-05"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/aion-labs/aion-2.0.toml
+++ b/providers/kilo/models/aion-labs/aion-2.0.toml
@@ -2,6 +2,7 @@ name = "AionLabs: Aion-2.0"
 release_date = "2026-02-24"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/allenai/olmo-3-32b-think.toml
+++ b/providers/kilo/models/allenai/olmo-3-32b-think.toml
@@ -2,6 +2,7 @@ name = "AllenAI: Olmo 3 32B Think"
 release_date = "2025-11-22"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/amazon/nova-2-lite-v1.toml
+++ b/providers/kilo/models/amazon/nova-2-lite-v1.toml
@@ -2,6 +2,7 @@ name = "Amazon: Nova 2 Lite"
 release_date = "2024-12-01"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-haiku-4.5.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Haiku 4.5"
 release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.1.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.1.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.1"
 release_date = "2025-08-05"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.5.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.5"
 release_date = "2025-11-24"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.6-fast.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.6-fast.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.6 (Fast)"
 release_date = "2026-04-07"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.6.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.6.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.6"
 release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.7-fast.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.7-fast.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.7 (Fast)"
 release_date = "2026-05-12"
 last_updated = "2026-05-16"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/anthropic/claude-opus-4.7.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.7.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.7"
 release_date = "2026-04-16"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/anthropic/claude-opus-4.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4"
 release_date = "2025-05-22"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.5.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Sonnet 4.5"
 release_date = "2025-09-29"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.6.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Sonnet 4.6"
 release_date = "2026-02-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-sonnet-4.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Sonnet 4"
 release_date = "2025-05-22"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/arcee-ai/trinity-large-thinking.toml
+++ b/providers/kilo/models/arcee-ai/trinity-large-thinking.toml
@@ -2,6 +2,7 @@ name = "Arcee AI: Trinity Large Thinking"
 release_date = "2026-04-01"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/arcee-ai/trinity-mini.toml
+++ b/providers/kilo/models/arcee-ai/trinity-mini.toml
@@ -2,6 +2,7 @@ name = "Arcee AI: Trinity Mini"
 release_date = "2025-12"
 last_updated = "2026-01-28"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/baidu/cobuddy:free.toml
+++ b/providers/kilo/models/baidu/cobuddy:free.toml
@@ -2,6 +2,7 @@ name = "Baidu: CoBuddy (free)"
 release_date = "2026-05-06"
 last_updated = "2026-05-07"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/baidu/ernie-4.5-21b-a3b-thinking.toml
+++ b/providers/kilo/models/baidu/ernie-4.5-21b-a3b-thinking.toml
@@ -2,6 +2,7 @@ name = "Baidu: ERNIE 4.5 21B A3B Thinking"
 release_date = "2025-09-19"
 last_updated = "2025-09-19"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/baidu/ernie-4.5-vl-28b-a3b.toml
+++ b/providers/kilo/models/baidu/ernie-4.5-vl-28b-a3b.toml
@@ -2,6 +2,7 @@ name = "Baidu: ERNIE 4.5 VL 28B A3B"
 release_date = "2025-06-30"
 last_updated = "2025-06-30"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/baidu/ernie-4.5-vl-424b-a47b.toml
+++ b/providers/kilo/models/baidu/ernie-4.5-vl-424b-a47b.toml
@@ -2,6 +2,7 @@ name = "Baidu: ERNIE 4.5 VL 424B A47B "
 release_date = "2025-06-30"
 last_updated = "2026-01"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/baidu/qianfan-ocr-fast.toml
+++ b/providers/kilo/models/baidu/qianfan-ocr-fast.toml
@@ -2,6 +2,7 @@ name = "Baidu: Qianfan-OCR-Fast"
 release_date = "2026-04-20"
 last_updated = "2026-05-16"
 attachment = true
+reasoning_options = []
 reasoning = true
 tool_call = false
 temperature = true

--- a/providers/kilo/models/bytedance-seed/seed-1.6-flash.toml
+++ b/providers/kilo/models/bytedance-seed/seed-1.6-flash.toml
@@ -2,6 +2,7 @@ name = "ByteDance Seed: Seed 1.6 Flash"
 release_date = "2025-12-23"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-1.6.toml
+++ b/providers/kilo/models/bytedance-seed/seed-1.6.toml
@@ -2,6 +2,7 @@ name = "ByteDance Seed: Seed 1.6"
 release_date = "2025-09"
 last_updated = "2025-09"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-2.0-lite.toml
+++ b/providers/kilo/models/bytedance-seed/seed-2.0-lite.toml
@@ -2,6 +2,7 @@ name = "ByteDance Seed: Seed-2.0-Lite"
 release_date = "2026-03-10"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-2.0-mini.toml
+++ b/providers/kilo/models/bytedance-seed/seed-2.0-mini.toml
@@ -2,6 +2,7 @@ name = "ByteDance Seed: Seed-2.0-Mini"
 release_date = "2026-02-27"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/deepcogito/cogito-v2.1-671b.toml
+++ b/providers/kilo/models/deepcogito/cogito-v2.1-671b.toml
@@ -2,6 +2,7 @@ name = "Deep Cogito: Cogito v2.1 671B"
 release_date = "2025-11-14"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/deepseek/deepseek-chat-v3-0324.toml
+++ b/providers/kilo/models/deepseek/deepseek-chat-v3-0324.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: DeepSeek V3 0324"
 release_date = "2025-03-24"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/deepseek/deepseek-chat-v3.1.toml
+++ b/providers/kilo/models/deepseek/deepseek-chat-v3.1.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: DeepSeek V3.1"
 release_date = "2025-08-21"
 last_updated = "2025-08-21"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/kilo/models/deepseek/deepseek-r1-0528.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: R1 0528"
 release_date = "2025-05-28"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/deepseek/deepseek-r1-distill-llama-70b.toml
+++ b/providers/kilo/models/deepseek/deepseek-r1-distill-llama-70b.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: R1 Distill Llama 70B"
 release_date = "2025-01-23"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/deepseek/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/kilo/models/deepseek/deepseek-r1-distill-qwen-32b.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: R1 Distill Qwen 32B"
 release_date = "2025-01-01"
 last_updated = "2025-11-25"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/deepseek/deepseek-r1.toml
+++ b/providers/kilo/models/deepseek/deepseek-r1.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: R1"
 release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/deepseek/deepseek-v3.1-terminus.toml
+++ b/providers/kilo/models/deepseek/deepseek-v3.1-terminus.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: DeepSeek V3.1 Terminus"
 release_date = "2025-09-22"
 last_updated = "2025-09-22"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/deepseek/deepseek-v3.2-exp.toml
+++ b/providers/kilo/models/deepseek/deepseek-v3.2-exp.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: DeepSeek V3.2 Exp"
 release_date = "2025-01-01"
 last_updated = "2025-09-29"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/deepseek/deepseek-v3.2-speciale.toml
+++ b/providers/kilo/models/deepseek/deepseek-v3.2-speciale.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: DeepSeek V3.2 Speciale"
 release_date = "2025-12-01"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/deepseek/deepseek-v3.2.toml
+++ b/providers/kilo/models/deepseek/deepseek-v3.2.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: DeepSeek V3.2"
 release_date = "2025-12-01"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/kilo/models/deepseek/deepseek-v4-flash.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: DeepSeek V4 Flash"
 release_date = "2026-04-24"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/kilo/models/deepseek/deepseek-v4-pro.toml
@@ -2,6 +2,7 @@ name = "DeepSeek: DeepSeek V4 Pro"
 release_date = "2026-04-24"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Flash Lite Preview 09-2025"
 release_date = "2025-09-25"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash-lite.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Flash Lite"
 release_date = "2025-06-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-flash.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Flash"
 release_date = "2025-07-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro-preview-05-06.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Pro Preview 05-06"
 release_date = "2025-05-06"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-pro-preview.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Pro Preview 06-05"
 release_date = "2025-06-05"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-pro.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Pro"
 release_date = "2025-03-20"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3-flash-preview.toml
+++ b/providers/kilo/models/google/gemini-3-flash-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3 Flash Preview"
 release_date = "2025-12-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3-pro-image-preview.toml
+++ b/providers/kilo/models/google/gemini-3-pro-image-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Nano Banana Pro (Gemini 3 Pro Image Preview)"
 release_date = "2025-11-20"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/kilo/models/google/gemini-3.1-flash-image-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Nano Banana 2 (Gemini 3.1 Flash Image Preview)"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/kilo/models/google/gemini-3.1-flash-lite-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.1 Flash Lite Preview"
 release_date = "2026-03-03"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/kilo/models/google/gemini-3.1-flash-lite.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.1 Flash Lite"
 release_date = "2026-05-07"
 last_updated = "2026-05-16"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/kilo/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.1 Pro Preview Custom Tools"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/kilo/models/google/gemini-3.1-pro-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.1 Pro Preview"
 release_date = "2026-02-19"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3.5-flash.toml
+++ b/providers/kilo/models/google/gemini-3.5-flash.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.5 Flash"
 release_date = "2026-05-19"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/kilo/models/google/gemma-4-26b-a4b-it.toml
@@ -2,6 +2,7 @@ name = "Google: Gemma 4 26B A4B"
 release_date = "2026-04-03"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemma-4-31b-it.toml
+++ b/providers/kilo/models/google/gemma-4-31b-it.toml
@@ -2,6 +2,7 @@ name = "Google: Gemma 4 31B"
 release_date = "2026-04-02"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/inception/mercury-2.toml
+++ b/providers/kilo/models/inception/mercury-2.toml
@@ -2,6 +2,7 @@ name = "Inception: Mercury 2"
 release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/kilo/models/inclusionai/ring-2.6-1t.toml
@@ -2,6 +2,7 @@ name = "inclusionAI: Ring-2.6-1T"
 release_date = "2026-05-08"
 last_updated = "2026-05-16"
 attachment = false
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/kilo-auto/balanced.toml
+++ b/providers/kilo/models/kilo-auto/balanced.toml
@@ -2,6 +2,7 @@ name = "Kilo Auto Balanced"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/kilo-auto/free.toml
+++ b/providers/kilo/models/kilo-auto/free.toml
@@ -2,6 +2,7 @@ name = "Kilo Auto Free"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/kilo-auto/frontier.toml
+++ b/providers/kilo/models/kilo-auto/frontier.toml
@@ -2,6 +2,7 @@ name = "Kilo Auto Frontier"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/kilo-auto/small.toml
+++ b/providers/kilo/models/kilo-auto/small.toml
@@ -2,6 +2,7 @@ name = "Kilo Auto Small"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m1.toml
+++ b/providers/kilo/models/minimax/minimax-m1.toml
@@ -2,6 +2,7 @@ name = "MiniMax: MiniMax M1"
 release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.1.toml
+++ b/providers/kilo/models/minimax/minimax-m2.1.toml
@@ -2,6 +2,7 @@ name = "MiniMax: MiniMax M2.1"
 release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.5.toml
+++ b/providers/kilo/models/minimax/minimax-m2.5.toml
@@ -2,6 +2,7 @@ name = "MiniMax: MiniMax M2.5"
 release_date = "2026-02-12"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.7.toml
+++ b/providers/kilo/models/minimax/minimax-m2.7.toml
@@ -3,6 +3,7 @@ family = "minimax-m2.7"
 release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.toml
+++ b/providers/kilo/models/minimax/minimax-m2.toml
@@ -2,6 +2,7 @@ name = "MiniMax: MiniMax M2"
 release_date = "2025-10-23"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/mistralai/mistral-medium-3-5.toml
+++ b/providers/kilo/models/mistralai/mistral-medium-3-5.toml
@@ -2,6 +2,7 @@ name = "Mistral: Mistral Medium 3.5"
 release_date = "2026-04-30"
 last_updated = "2026-05-07"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/mistralai/mistral-small-2603.toml
+++ b/providers/kilo/models/mistralai/mistral-small-2603.toml
@@ -2,6 +2,7 @@ name = "Mistral: Mistral Small 4"
 release_date = "2026-03-16"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2-thinking.toml
@@ -2,6 +2,7 @@ name = "MoonshotAI: Kimi K2 Thinking"
 release_date = "2025-11-06"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/moonshotai/kimi-k2.5.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2.5.toml
@@ -2,6 +2,7 @@ name = "MoonshotAI: Kimi K2.5"
 release_date = "2026-01-27"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/moonshotai/kimi-k2.6.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-20"
 last_updated = "2026-05-12"
 
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nousresearch/hermes-4-405b.toml
+++ b/providers/kilo/models/nousresearch/hermes-4-405b.toml
@@ -2,6 +2,7 @@ name = "Nous: Hermes 4 405B"
 release_date = "2025-08-25"
 last_updated = "2025-08-25"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/nousresearch/hermes-4-70b.toml
+++ b/providers/kilo/models/nousresearch/hermes-4-70b.toml
@@ -2,6 +2,7 @@ name = "Nous: Hermes 4 70B"
 release_date = "2025-08-25"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
+++ b/providers/kilo/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/llama-3.3-nemotron-super-49b-v1.5"
 release_date = "2025-03-16"
 last_updated = "2025-03-16"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-3-nano-30b-a3b"
 release_date = "2024-12"
 last_updated = "2026-02-04"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 release_date = "2026-04-28"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-3-super-120b-a12b"
 release_date = "2026-03-11"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b:free.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b:free.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-3-super-120b-a12b"
 release_date = "2026-03-12"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-nano-9b-v2.toml
+++ b/providers/kilo/models/nvidia/nemotron-nano-9b-v2.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-nano-9b-v2"
 release_date = "2025-08-18"
 last_updated = "2025-08-18"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-codex.toml
+++ b/providers/kilo/models/openai/gpt-5-codex.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Codex"
 release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-image-mini.toml
+++ b/providers/kilo/models/openai/gpt-5-image-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Image Mini"
 release_date = "2025-10-16"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-image.toml
+++ b/providers/kilo/models/openai/gpt-5-image.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Image"
 release_date = "2025-10-14"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-mini.toml
+++ b/providers/kilo/models/openai/gpt-5-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Mini"
 release_date = "2025-08-07"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-nano.toml
+++ b/providers/kilo/models/openai/gpt-5-nano.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Nano"
 release_date = "2025-08-07"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-pro.toml
+++ b/providers/kilo/models/openai/gpt-5-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Pro"
 release_date = "2025-10-06"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex-max.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.1-Codex-Max"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.1-Codex-Mini"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1-codex.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.1-Codex"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1.toml
+++ b/providers/kilo/models/openai/gpt-5.1.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.1"
 release_date = "2025-11-13"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.2-codex.toml
+++ b/providers/kilo/models/openai/gpt-5.2-codex.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.2-Codex"
 release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.2-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.2-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.2 Pro"
 release_date = "2025-12-11"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.2.toml
+++ b/providers/kilo/models/openai/gpt-5.2.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.2"
 release_date = "2025-12-11"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.3-codex.toml
+++ b/providers/kilo/models/openai/gpt-5.3-codex.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.3-Codex"
 release_date = "2026-02-25"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/gpt-5.4-image-2.toml
+++ b/providers/kilo/models/openai/gpt-5.4-image-2.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4 Image 2"
 release_date = "2026-04-21"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = false
 temperature = false

--- a/providers/kilo/models/openai/gpt-5.4-mini.toml
+++ b/providers/kilo/models/openai/gpt-5.4-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4 Mini"
 release_date = "2026-03-17"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.4-nano.toml
+++ b/providers/kilo/models/openai/gpt-5.4-nano.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4 Nano"
 release_date = "2026-03-17"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.4-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.4-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4 Pro"
 release_date = "2026-03-06"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/gpt-5.4.toml
+++ b/providers/kilo/models/openai/gpt-5.4.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4"
 release_date = "2026-03-06"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/gpt-5.5-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.5-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.5 Pro"
 release_date = "2026-04-24"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/openai/gpt-5.5.toml
+++ b/providers/kilo/models/openai/gpt-5.5.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.5"
 release_date = "2026-04-24"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/openai/gpt-5.toml
+++ b/providers/kilo/models/openai/gpt-5.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5"
 release_date = "2025-08-07"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-chat-latest.toml
+++ b/providers/kilo/models/openai/gpt-chat-latest.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT Chat Latest"
 release_date = "2026-05-05"
 last_updated = "2026-05-07"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-oss-120b.toml
+++ b/providers/kilo/models/openai/gpt-oss-120b.toml
@@ -2,6 +2,7 @@ name = "OpenAI: gpt-oss-120b"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-oss-20b.toml
+++ b/providers/kilo/models/openai/gpt-oss-20b.toml
@@ -2,6 +2,7 @@ name = "OpenAI: gpt-oss-20b"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/kilo/models/openai/gpt-oss-safeguard-20b.toml
@@ -2,6 +2,7 @@ name = "OpenAI: gpt-oss-safeguard-20b"
 release_date = "2025-10-29"
 last_updated = "2025-10-29"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/o1-pro.toml
+++ b/providers/kilo/models/openai/o1-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o1-pro"
 release_date = "2025-03-19"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = false

--- a/providers/kilo/models/openai/o3-deep-research.toml
+++ b/providers/kilo/models/openai/o3-deep-research.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o3 Deep Research"
 release_date = "2024-06-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/o3-pro.toml
+++ b/providers/kilo/models/openai/o3-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o3 Pro"
 release_date = "2025-04-16"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/o3.toml
+++ b/providers/kilo/models/openai/o3.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o3"
 release_date = "2025-04-16"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/o4-mini-deep-research.toml
+++ b/providers/kilo/models/openai/o4-mini-deep-research.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o4 Mini Deep Research"
 release_date = "2024-06-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/o4-mini-high.toml
+++ b/providers/kilo/models/openai/o4-mini-high.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o4 Mini High"
 release_date = "2025-04-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/o4-mini.toml
+++ b/providers/kilo/models/openai/o4-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o4 Mini"
 release_date = "2025-04-16"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openrouter/auto.toml
+++ b/providers/kilo/models/openrouter/auto.toml
@@ -2,6 +2,7 @@ name = "Auto Router"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openrouter/free.toml
+++ b/providers/kilo/models/openrouter/free.toml
@@ -2,6 +2,7 @@ name = "Free Models Router"
 release_date = "2026-02-01"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openrouter/owl-alpha.toml
+++ b/providers/kilo/models/openrouter/owl-alpha.toml
@@ -2,6 +2,7 @@ name = "Owl Alpha"
 release_date = "2026-04-28"
 last_updated = "2026-04-30"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/perceptron/perceptron-mk1.toml
+++ b/providers/kilo/models/perceptron/perceptron-mk1.toml
@@ -2,6 +2,7 @@ name = "Perceptron: Perceptron Mk1"
 release_date = "2026-05-12"
 last_updated = "2026-05-16"
 attachment = true
+reasoning_options = []
 reasoning = true
 tool_call = false
 temperature = true

--- a/providers/kilo/models/perplexity/sonar-deep-research.toml
+++ b/providers/kilo/models/perplexity/sonar-deep-research.toml
@@ -2,6 +2,7 @@ name = "Perplexity: Sonar Deep Research"
 release_date = "2025-01-27"
 last_updated = "2025-01-27"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/perplexity/sonar-pro-search.toml
+++ b/providers/kilo/models/perplexity/sonar-pro-search.toml
@@ -2,6 +2,7 @@ name = "Perplexity: Sonar Pro Search"
 release_date = "2025-10-31"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/kilo/models/perplexity/sonar-reasoning-pro.toml
@@ -2,6 +2,7 @@ name = "Perplexity: Sonar Reasoning Pro"
 release_date = "2024-01-01"
 last_updated = "2025-09-01"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/poolside/laguna-m.1:free.toml
+++ b/providers/kilo/models/poolside/laguna-m.1:free.toml
@@ -2,6 +2,7 @@ name = "Poolside: Laguna M.1 (free)"
 release_date = "2026-04-28"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/poolside/laguna-xs.2:free.toml
+++ b/providers/kilo/models/poolside/laguna-xs.2:free.toml
@@ -2,6 +2,7 @@ name = "Poolside: Laguna XS.2 (free)"
 release_date = "2026-04-28"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/prime-intellect/intellect-3.toml
+++ b/providers/kilo/models/prime-intellect/intellect-3.toml
@@ -2,6 +2,7 @@ name = "Prime Intellect: INTELLECT-3"
 release_date = "2025-11-26"
 last_updated = "2026-02-04"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen-plus-2025-07-28:thinking.toml
+++ b/providers/kilo/models/qwen/qwen-plus-2025-07-28:thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen Plus 0728 (thinking)"
 release_date = "2025-09-09"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-14b.toml
+++ b/providers/kilo/models/qwen/qwen3-14b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 14B"
 release_date = "2025-04"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-235b-a22b-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b-2507.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 235B A22B Instruct 2507"
 release_date = "2025-04"
 last_updated = "2026-01"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 235B A22B Thinking 2507"
 release_date = "2025-07-25"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-235b-a22b.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 235B A22B"
 release_date = "2024-12-01"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-30b-a3b-thinking-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-30b-a3b-thinking-2507.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 30B A3B Thinking 2507"
 release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-30b-a3b.toml
+++ b/providers/kilo/models/qwen/qwen3-30b-a3b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 30B A3B"
 release_date = "2025-04"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-32b.toml
+++ b/providers/kilo/models/qwen/qwen3-32b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 32B"
 release_date = "2024-12-01"
 last_updated = "2026-02-04"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-8b.toml
+++ b/providers/kilo/models/qwen/qwen3-8b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 8B"
 release_date = "2025-04"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-max-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-max-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 Max Thinking"
 release_date = "2026-01-23"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 Next 80B A3B Thinking"
 release_date = "2025-09-11"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-235b-a22b-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 VL 235B A22B Thinking"
 release_date = "2025-09-24"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-vl-30b-a3b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-30b-a3b-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 VL 30B A3B Thinking"
 release_date = "2025-10-11"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-vl-8b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-8b-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 VL 8B Thinking"
 release_date = "2025-10-15"
 last_updated = "2025-11-25"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-122b-a10b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-122B-A10B"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-27b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-27b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-27B"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-35b-a3b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-35b-a3b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-35B-A3B"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-397b-a17b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5 397B A17B"
 release_date = "2026-02-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-9b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-9b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-9B"
 release_date = "2026-03-10"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-flash-02-23.toml
+++ b/providers/kilo/models/qwen/qwen3.5-flash-02-23.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-Flash"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-plus-02-15.toml
+++ b/providers/kilo/models/qwen/qwen3.5-plus-02-15.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5 Plus 2026-02-15"
 release_date = "2026-02-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-plus-20260420.toml
+++ b/providers/kilo/models/qwen/qwen3.5-plus-20260420.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5 Plus 2026-04-20"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-27b.toml
+++ b/providers/kilo/models/qwen/qwen3.6-27b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 27B"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-35b-a3b.toml
+++ b/providers/kilo/models/qwen/qwen3.6-35b-a3b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 35B A3B"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = false
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-flash.toml
+++ b/providers/kilo/models/qwen/qwen3.6-flash.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 Flash"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-max-preview.toml
+++ b/providers/kilo/models/qwen/qwen3.6-max-preview.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 Max Preview"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-plus.toml
+++ b/providers/kilo/models/qwen/qwen3.6-plus.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 Plus"
 release_date = "2025-08-26"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.7-max.toml
+++ b/providers/kilo/models/qwen/qwen3.7-max.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.7 Max"
 release_date = "2025-08-26"
 last_updated = "2026-05-27"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/rekaai/reka-flash-3.toml
+++ b/providers/kilo/models/rekaai/reka-flash-3.toml
@@ -2,6 +2,7 @@ name = "Reka Flash 3"
 release_date = "2025-03-12"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/stealth/claude-opus-4.6.toml
+++ b/providers/kilo/models/stealth/claude-opus-4.6.toml
@@ -2,6 +2,7 @@ name = "Stealth: Claude Opus 4.6 (20% off)"
 release_date = "2026-02-05"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/stealth/claude-opus-4.7.toml
+++ b/providers/kilo/models/stealth/claude-opus-4.7.toml
@@ -2,6 +2,7 @@ name = "Stealth: Claude Opus 4.7 (20% off)"
 release_date = "2026-04-16"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/stealth/claude-sonnet-4.6.toml
+++ b/providers/kilo/models/stealth/claude-sonnet-4.6.toml
@@ -2,6 +2,7 @@ name = "Stealth: Claude Sonnet 4.6 (20% off)"
 release_date = "2026-02-17"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/stepfun/step-3.5-flash.toml
+++ b/providers/kilo/models/stepfun/step-3.5-flash.toml
@@ -2,6 +2,7 @@ name = "StepFun: Step 3.5 Flash"
 release_date = "2026-01-29"
 last_updated = "2026-01-29"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/switchpoint/router.toml
+++ b/providers/kilo/models/switchpoint/router.toml
@@ -2,6 +2,7 @@ name = "Switchpoint Router"
 release_date = "2025-07-12"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/tencent/hunyuan-a13b-instruct.toml
+++ b/providers/kilo/models/tencent/hunyuan-a13b-instruct.toml
@@ -2,6 +2,7 @@ name = "Tencent: Hunyuan A13B Instruct"
 release_date = "2025-06-30"
 last_updated = "2025-11-25"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/tencent/hy3-preview.toml
+++ b/providers/kilo/models/tencent/hy3-preview.toml
@@ -2,6 +2,7 @@ name = "Tencent: Hy3 Preview"
 release_date = "2026-04-22"
 last_updated = "2026-05-16"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["none", "low", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/upstage/solar-pro-3.toml
+++ b/providers/kilo/models/upstage/solar-pro-3.toml
@@ -2,6 +2,7 @@ name = "Upstage: Solar Pro 3"
 release_date = "2026-01-27"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/x-ai/grok-4.20-multi-agent.toml
+++ b/providers/kilo/models/x-ai/grok-4.20-multi-agent.toml
@@ -2,6 +2,7 @@ name = "xAI: Grok 4.20 Multi-Agent"
 release_date = "2026-03-31"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/x-ai/grok-4.20.toml
+++ b/providers/kilo/models/x-ai/grok-4.20.toml
@@ -2,6 +2,7 @@ name = "xAI: Grok 4.20"
 release_date = "2026-03-31"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/x-ai/grok-4.3.toml
+++ b/providers/kilo/models/x-ai/grok-4.3.toml
@@ -2,6 +2,7 @@ name = "xAI: Grok 4.3"
 release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/x-ai/grok-build-0.1.toml
+++ b/providers/kilo/models/x-ai/grok-build-0.1.toml
@@ -2,6 +2,7 @@ name = "xAI: Grok Build 0.1"
 release_date = "2026-05-20"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-flash.toml
@@ -1,3 +1,4 @@
+reasoning_options = [{ type = "toggle" }]
 base_model = "xiaomi/mimo-v2-flash"
 name = "Xiaomi: MiMo-V2-Flash"
 

--- a/providers/kilo/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-omni.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "xiaomi/mimo-v2-omni"
 name = "Xiaomi: MiMo-V2-Omni"
 

--- a/providers/kilo/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-pro.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "xiaomi/mimo-v2-pro"
 name = "Xiaomi: MiMo-V2-Pro"
 

--- a/providers/kilo/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,3 +1,4 @@
+reasoning_options = [{ type = "toggle" }]
 base_model = "xiaomi/mimo-v2.5-pro"
 name = "Xiaomi: MiMo V2.5 Pro"
 

--- a/providers/kilo/models/xiaomi/mimo-v2.5.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2.5.toml
@@ -1,3 +1,4 @@
+reasoning_options = [{ type = "toggle" }]
 base_model = "xiaomi/mimo-v2.5"
 name = "Xiaomi: MiMo-V2.5"
 

--- a/providers/kilo/models/z-ai/glm-4.5-air.toml
+++ b/providers/kilo/models/z-ai/glm-4.5-air.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.5 Air"
 release_date = "2025-07-28"
 last_updated = "2025-07-28"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.5.toml
+++ b/providers/kilo/models/z-ai/glm-4.5.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.5"
 release_date = "2025-07-28"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.5v.toml
+++ b/providers/kilo/models/z-ai/glm-4.5v.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.5V"
 release_date = "2025-08-11"
 last_updated = "2025-08-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.6.toml
+++ b/providers/kilo/models/z-ai/glm-4.6.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.6"
 release_date = "2025-09-30"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.6v.toml
+++ b/providers/kilo/models/z-ai/glm-4.6v.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.6V"
 release_date = "2025-09-30"
 last_updated = "2026-01-10"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.7-flash.toml
+++ b/providers/kilo/models/z-ai/glm-4.7-flash.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.7 Flash"
 release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.7.toml
+++ b/providers/kilo/models/z-ai/glm-4.7.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.7"
 release_date = "2025-12-22"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5-turbo.toml
+++ b/providers/kilo/models/z-ai/glm-5-turbo.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 5 Turbo"
 release_date = "2026-03-15"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5.1.toml
+++ b/providers/kilo/models/z-ai/glm-5.1.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 5.1"
 release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5.toml
+++ b/providers/kilo/models/z-ai/glm-5.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 5"
 release_date = "2026-02-12"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5v-turbo.toml
+++ b/providers/kilo/models/z-ai/glm-5v-turbo.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 5V Turbo"
 release_date = "2026-04-01"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/~anthropic/claude-haiku-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-haiku-latest.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Haiku Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~anthropic/claude-opus-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-opus-latest.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus Latest"
 release_date = "2026-04-16"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/~anthropic/claude-sonnet-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-sonnet-latest.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Sonnet Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~google/gemini-flash-latest.toml
+++ b/providers/kilo/models/~google/gemini-flash-latest.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini Flash Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~google/gemini-pro-latest.toml
+++ b/providers/kilo/models/~google/gemini-pro-latest.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini Pro Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~moonshotai/kimi-latest.toml
+++ b/providers/kilo/models/~moonshotai/kimi-latest.toml
@@ -2,6 +2,7 @@ name = "MoonshotAI: Kimi Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~openai/gpt-latest.toml
+++ b/providers/kilo/models/~openai/gpt-latest.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/~openai/gpt-mini-latest.toml
+++ b/providers/kilo/models/~openai/gpt-mini-latest.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT Mini Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false


### PR DESCRIPTION
## Summary
- add explicit `reasoning_options` to all 188 existing reasoning models
- derive 125 controls from Kilo normalized variants and use conservative `[]` for fixed or unresolved routes
- make no catalog, base-model, test, or unrelated metadata changes

## Matrix
- 53 fixed/unresolved
- 58 toggle-only
- 23 effort-only
- 54 toggle plus effort

## Validation
- `bun validate`
- `git diff --check`
- 188/188 covered; 0 non-reasoning leaks; 0 token budgets