### PR TITLE
[zenmux] Add reasoning options

### DIFF
--- a/providers/zenmux/models/anthropic/claude-3.7-sonnet.toml
+++ b/providers/zenmux/models/anthropic/claude-3.7-sonnet.toml
@@ -3,6 +3,7 @@ release_date = "2025-02-24"
 last_updated = "2025-02-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-fable-5.toml
+++ b/providers/zenmux/models/anthropic/claude-fable-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 10.00

--- a/providers/zenmux/models/anthropic/claude-opus-4.1.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.1.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-opus-4.5.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.5.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-opus-4.6.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-06"
 last_updated = "2026-02-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/zenmux/models/anthropic/claude-opus-4.7.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.7.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/zenmux/models/anthropic/claude-opus-4.8.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5.00

--- a/providers/zenmux/models/anthropic/claude-opus-4.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/zenmux/models/anthropic/claude-sonnet-4.5.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/zenmux/models/anthropic/claude-sonnet-4.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-18"
 last_updated = "2026-02-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/anthropic/claude-sonnet-4.toml
+++ b/providers/zenmux/models/anthropic/claude-sonnet-4.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/baidu/ernie-5.0-thinking-preview.toml
+++ b/providers/zenmux/models/baidu/ernie-5.0-thinking-preview.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-22"
 last_updated = "2026-01-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/deepseek/deepseek-v3.2-exp.toml
+++ b/providers/zenmux/models/deepseek/deepseek-v3.2-exp.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/deepseek/deepseek-v3.2.toml
+++ b/providers/zenmux/models/deepseek/deepseek-v3.2.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-05"
 last_updated = "2025-12-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/zenmux/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zenmux/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/zenmux/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zenmux/models/google/gemini-2.5-flash.toml
+++ b/providers/zenmux/models/google/gemini-2.5-flash.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/google/gemini-2.5-pro.toml
+++ b/providers/zenmux/models/google/gemini-2.5-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/google/gemini-3-flash-preview.toml
+++ b/providers/zenmux/models/google/gemini-3-flash-preview.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/zenmux/models/google/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/zenmux/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/zenmux/models/google/gemini-3.1-pro-preview.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02-19"

--- a/providers/zenmux/models/google/gemini-3.5-flash.toml
+++ b/providers/zenmux/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.50

--- a/providers/zenmux/models/inclusionai/ring-1t.toml
+++ b/providers/zenmux/models/inclusionai/ring-1t.toml
@@ -3,6 +3,7 @@ release_date = "2025-10-12"
 last_updated = "2025-10-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/zenmux/models/inclusionai/ring-2.6-1t.toml
@@ -3,6 +3,7 @@ release_date = "2026-05-07"
 last_updated = "2026-05-14"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-12-31"

--- a/providers/zenmux/models/minimax/minimax-m2.1.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.1.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.5-lightning.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.5-lightning.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-13"
 last_updated = "2026-02-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.5.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.5.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-13"
 last_updated = "2026-02-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.7-highspeed.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.7.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.7.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.toml
@@ -3,6 +3,7 @@ release_date = "2025-10-27"
 last_updated = "2025-10-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m3.toml
+++ b/providers/zenmux/models/minimax/minimax-m3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = []
 
 [cost]
 input = 0.60

--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/moonshotai/kimi-k2.5.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2.5.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/moonshotai/kimi-k2.6.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5-codex.toml
+++ b/providers/zenmux/models/openai/gpt-5-codex.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-23"
 last_updated = "2025-09-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/zenmux/models/openai/gpt-5.1-codex-mini.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.1-codex.toml
+++ b/providers/zenmux/models/openai/gpt-5.1-codex.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.1.toml
+++ b/providers/zenmux/models/openai/gpt-5.1.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.2-codex.toml
+++ b/providers/zenmux/models/openai/gpt-5.2-codex.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-15"
 last_updated = "2026-01-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.2-pro.toml
+++ b/providers/zenmux/models/openai/gpt-5.2-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/openai/gpt-5.2.toml
+++ b/providers/zenmux/models/openai/gpt-5.2.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.3-codex.toml
+++ b/providers/zenmux/models/openai/gpt-5.3-codex.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/openai/gpt-5.4-pro.toml
+++ b/providers/zenmux/models/openai/gpt-5.4-pro.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/openai/gpt-5.4.toml
+++ b/providers/zenmux/models/openai/gpt-5.4.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/openai/gpt-5.5-instant.toml
+++ b/providers/zenmux/models/openai/gpt-5.5-instant.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-instant"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/zenmux/models/openai/gpt-5.5-pro.toml
+++ b/providers/zenmux/models/openai/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
 input = 30

--- a/providers/zenmux/models/openai/gpt-5.5.toml
+++ b/providers/zenmux/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/zenmux/models/openai/gpt-5.toml
+++ b/providers/zenmux/models/openai/gpt-5.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/qwen/qwen3-max.toml
+++ b/providers/zenmux/models/qwen/qwen3-max.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-23"
 last_updated = "2026-01-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/qwen/qwen3.5-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.5-plus.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/qwen/qwen3.6-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.6-plus.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-30"
 last_updated = "2026-03-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/zenmux/models/qwen/qwen3.7-max.toml
+++ b/providers/zenmux/models/qwen/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 2.50

--- a/providers/zenmux/models/qwen/qwen3.7-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.40

--- a/providers/zenmux/models/sapiens-ai/agnes-1.5-pro.toml
+++ b/providers/zenmux/models/sapiens-ai/agnes-1.5-pro.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-21"
 last_updated = "2026-03-21"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/zenmux/models/stepfun/step-3.7-flash-free.toml
+++ b/providers/zenmux/models/stepfun/step-3.7-flash-free.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 name = "Step 3.7 Flash (Free)"
 
 [cost]

--- a/providers/zenmux/models/stepfun/step-3.7-flash.toml
+++ b/providers/zenmux/models/stepfun/step-3.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.20

--- a/providers/zenmux/models/stepfun/step-3.toml
+++ b/providers/zenmux/models/stepfun/step-3.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-31"
 last_updated = "2025-07-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/tencent/hy3-preview.toml
+++ b/providers/zenmux/models/tencent/hy3-preview.toml
@@ -1,4 +1,5 @@
 base_model = "tencent/hy3-preview"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high"] }]
 
 [cost]
 input = 0.172

--- a/providers/zenmux/models/volcengine/doubao-seed-1.8.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-1.8.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-18"
 last_updated = "2025-12-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/volcengine/doubao-seed-2.0-lite.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-2.0-lite.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02-14"

--- a/providers/zenmux/models/volcengine/doubao-seed-2.0-mini.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-2.0-mini.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02-14"

--- a/providers/zenmux/models/volcengine/doubao-seed-2.0-pro.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-2.0-pro.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02-14"

--- a/providers/zenmux/models/volcengine/doubao-seed-code.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-code.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-11"
 last_updated = "2025-11-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-4-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4-fast.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-19"
 last_updated = "2025-09-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-4.1-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4.1-fast.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-20"
 last_updated = "2025-11-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-4.2-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4.2-fast.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/x-ai/grok-4.3.toml
+++ b/providers/zenmux/models/x-ai/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/zenmux/models/x-ai/grok-4.toml
+++ b/providers/zenmux/models/x-ai/grok-4.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-build-0.1.toml
+++ b/providers/zenmux/models/x-ai/grok-build-0.1.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-build-0.1"
+reasoning_options = []
 
 [cost]
 input = 1.00

--- a/providers/zenmux/models/x-ai/grok-code-fast-1.toml
+++ b/providers/zenmux/models/x-ai/grok-code-fast-1.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-26"
 last_updated = "2025-08-26"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-flash"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.1

--- a/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-omni"
+reasoning_options = []
 name = "MiMo V2 Omni"
 
 [cost]

--- a/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+reasoning_options = []
 name = "MiMo V2 Pro"
 
 [cost]

--- a/providers/zenmux/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zenmux/models/xiaomi/mimo-v2.5.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zenmux/models/z-ai/glm-4.5-air.toml
+++ b/providers/zenmux/models/z-ai/glm-4.5-air.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-25"
 last_updated = "2025-07-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.5.toml
+++ b/providers/zenmux/models/z-ai/glm-4.5.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-25"
 last_updated = "2025-07-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.6.toml
+++ b/providers/zenmux/models/z-ai/glm-4.6.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.6v-flash-free.toml
+++ b/providers/zenmux/models/z-ai/glm-4.6v-flash-free.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.6v-flash.toml
+++ b/providers/zenmux/models/z-ai/glm-4.6v-flash.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.6v.toml
+++ b/providers/zenmux/models/z-ai/glm-4.6v.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.7-flash-free.toml
+++ b/providers/zenmux/models/z-ai/glm-4.7-flash-free.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.7-flashx.toml
+++ b/providers/zenmux/models/z-ai/glm-4.7-flashx.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.7.toml
+++ b/providers/zenmux/models/z-ai/glm-4.7.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-5-turbo.toml
+++ b/providers/zenmux/models/z-ai/glm-5-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-5.1.toml
+++ b/providers/zenmux/models/z-ai/glm-5.1.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-03"
 last_updated = "2026-04-03"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/zenmux/models/z-ai/glm-5.toml
+++ b/providers/zenmux/models/z-ai/glm-5.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-5v-turbo.toml
+++ b/providers/zenmux/models/z-ai/glm-5v-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-01"
 last_updated = "2026-04-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
## Summary
- add explicit `reasoning_options` to all 89 existing reasoning models
- map ZenMux normalized effort and verified hybrid-thinking toggles
- use conservative `[]` for fixed or unresolved controls
- make no catalog, base-model, test, or unrelated metadata changes

## Matrix
- 46 effort-only
- 11 toggle-only
- 2 toggle plus effort
- 30 fixed/unresolved

## Validation
- `bun validate`
- `git diff --check`
- 89/89 covered; 0 leaks; 0 unbounded budgets