### PR TITLE
[poe] Add reasoning options

### DIFF
--- a/providers/poe/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/poe/models/anthropic/claude-haiku-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-opus-4.1.toml
+++ b/providers/poe/models/anthropic/claude-opus-4.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-opus-4.5.toml
+++ b/providers/poe/models/anthropic/claude-opus-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-21"
 last_updated = "2025-11-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-opus-4.6.toml
+++ b/providers/poe/models/anthropic/claude-opus-4.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-04"
 last_updated = "2026-02-04"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-opus-4.7.toml
+++ b/providers/poe/models/anthropic/claude-opus-4.7.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-15"
 last_updated = "2026-04-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-opus-4.8.toml
+++ b/providers/poe/models/anthropic/claude-opus-4.8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = []
 name = "Claude-Opus-4.8"
 
 [cost]

--- a/providers/poe/models/anthropic/claude-opus-4.toml
+++ b/providers/poe/models/anthropic/claude-opus-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-21"
 last_updated = "2025-05-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-sonnet-3.7.toml
+++ b/providers/poe/models/anthropic/claude-sonnet-3.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/poe/models/anthropic/claude-sonnet-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-26"
 last_updated = "2025-09-26"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/poe/models/anthropic/claude-sonnet-4.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-sonnet-4.toml
+++ b/providers/poe/models/anthropic/claude-sonnet-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-21"
 last_updated = "2025-05-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/cerebras/gpt-oss-120b-cs.toml
+++ b/providers/poe/models/cerebras/gpt-oss-120b-cs.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/cerebras/qwen3-235b-2507-cs.toml
+++ b/providers/poe/models/cerebras/qwen3-235b-2507-cs.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/cerebras/qwen3-32b-cs.toml
+++ b/providers/poe/models/cerebras/qwen3-32b-cs.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-15"
 last_updated = "2025-05-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/empiriolabs/deepseek-v4-flash-el.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-flash-el.toml
@@ -1,6 +1,7 @@
 name = "DeepSeek-V4-Flash-EL"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 release_date = "2026-04-24"
 last_updated = "2026-05-02"

--- a/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
@@ -1,6 +1,7 @@
 name = "DeepSeek-V4-Pro-EL"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 release_date = "2026-04-24"
 last_updated = "2026-05-02"

--- a/providers/poe/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/poe/models/google/gemini-2.5-flash-lite.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-19"
 last_updated = "2025-06-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/google/gemini-2.5-flash.toml
+++ b/providers/poe/models/google/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-26"
 last_updated = "2025-04-26"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/google/gemini-2.5-pro.toml
+++ b/providers/poe/models/google/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-05"
 last_updated = "2025-02-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/google/gemini-3-flash.toml
+++ b/providers/poe/models/google/gemini-3-flash.toml
@@ -3,6 +3,7 @@ release_date = "2025-10-07"
 last_updated = "2025-10-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/google/gemini-3-pro.toml
+++ b/providers/poe/models/google/gemini-3-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-22"
 last_updated = "2025-10-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/poe/models/google/gemini-3.1-flash-lite.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-18"
 last_updated = "2026-02-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/google/gemini-3.1-pro.toml
+++ b/providers/poe/models/google/gemini-3.1-pro.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/google/gemini-3.5-flash.toml
+++ b/providers/poe/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 name = "Gemini-3.5-Flash"
 temperature = false
 

--- a/providers/poe/models/google/gemini-deep-research.toml
+++ b/providers/poe/models/google/gemini-deep-research.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/deepseek-v3.2.toml
+++ b/providers/poe/models/novita/deepseek-v3.2.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 open_weights = true
 tool_call = true

--- a/providers/poe/models/novita/glm-4.6v.toml
+++ b/providers/poe/models/novita/glm-4.6v.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-09"
 last_updated = "2025-12-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-4.7-flash.toml
+++ b/providers/poe/models/novita/glm-4.7-flash.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-4.7-n.toml
+++ b/providers/poe/models/novita/glm-4.7-n.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-4.7.toml
+++ b/providers/poe/models/novita/glm-4.7.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-5.toml
+++ b/providers/poe/models/novita/glm-5.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-15"
 last_updated = "2026-02-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/kimi-k2-thinking.toml
+++ b/providers/poe/models/novita/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-07"
 last_updated = "2025-11-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/kimi-k2.5.toml
+++ b/providers/poe/models/novita/kimi-k2.5.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/kimi-k2.6.toml
+++ b/providers/poe/models/novita/kimi-k2.6.toml
@@ -1,6 +1,7 @@
 name = "Kimi-K2.6"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 temperature = true
 knowledge = "2025-04"

--- a/providers/poe/models/novita/minimax-m2.1.toml
+++ b/providers/poe/models/novita/minimax-m2.1.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-26"
 last_updated = "2025-12-26"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5-codex.toml
+++ b/providers/poe/models/openai/gpt-5-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-23"
 last_updated = "2025-09-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5-mini.toml
+++ b/providers/poe/models/openai/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-25"
 last_updated = "2025-06-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5-nano.toml
+++ b/providers/poe/models/openai/gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5-pro.toml
+++ b/providers/poe/models/openai/gpt-5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-06"
 last_updated = "2025-10-06"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/poe/models/openai/gpt-5.1-codex-max.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/poe/models/openai/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-codex.toml
+++ b/providers/poe/models/openai/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-instant.toml
+++ b/providers/poe/models/openai/gpt-5.1-instant.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1.toml
+++ b/providers/poe/models/openai/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.2-codex.toml
+++ b/providers/poe/models/openai/gpt-5.2-codex.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.2-pro.toml
+++ b/providers/poe/models/openai/gpt-5.2-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.2.toml
+++ b/providers/poe/models/openai/gpt-5.2.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.3-codex-spark.toml
+++ b/providers/poe/models/openai/gpt-5.3-codex-spark.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-04"
 last_updated = "2026-03-04"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.3-codex.toml
+++ b/providers/poe/models/openai/gpt-5.3-codex.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-10"
 last_updated = "2026-02-10"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4-mini.toml
+++ b/providers/poe/models/openai/gpt-5.4-mini.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-12"
 last_updated = "2026-03-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4-nano.toml
+++ b/providers/poe/models/openai/gpt-5.4-nano.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4-pro.toml
+++ b/providers/poe/models/openai/gpt-5.4-pro.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4.toml
+++ b/providers/poe/models/openai/gpt-5.4.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-26"
 last_updated = "2026-02-26"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.5-pro.toml
+++ b/providers/poe/models/openai/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high"] }]
 base_model_omit = ["limit.input"]
 name = "GPT-5.5-Pro"
 release_date = "2026-04-08"

--- a/providers/poe/models/openai/gpt-5.5.toml
+++ b/providers/poe/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 base_model_omit = ["limit.input"]
 release_date = "2026-04-08"
 last_updated = "2026-04-08"

--- a/providers/poe/models/openai/gpt-5.toml
+++ b/providers/poe/models/openai/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o1-pro.toml
+++ b/providers/poe/models/openai/o1-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-19"
 last_updated = "2025-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o1.toml
+++ b/providers/poe/models/openai/o1.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-18"
 last_updated = "2024-12-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3-deep-research.toml
+++ b/providers/poe/models/openai/o3-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-27"
 last_updated = "2025-06-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3-mini-high.toml
+++ b/providers/poe/models/openai/o3-mini-high.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3-mini.toml
+++ b/providers/poe/models/openai/o3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3-pro.toml
+++ b/providers/poe/models/openai/o3-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-10"
 last_updated = "2025-06-10"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3.toml
+++ b/providers/poe/models/openai/o3.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o4-mini-deep-research.toml
+++ b/providers/poe/models/openai/o4-mini-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-27"
 last_updated = "2025-06-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o4-mini.toml
+++ b/providers/poe/models/openai/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/poetools/claude-code.toml
+++ b/providers/poe/models/poetools/claude-code.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-27"
 last_updated = "2025-11-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-3-mini.toml
+++ b/providers/poe/models/xai/grok-3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-11"
 last_updated = "2025-04-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-4-fast-reasoning.toml
+++ b/providers/poe/models/xai/grok-4-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-16"
 last_updated = "2025-09-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-4.1-fast-reasoning.toml
+++ b/providers/poe/models/xai/grok-4.1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-19"
 last_updated = "2025-11-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-4.toml
+++ b/providers/poe/models/xai/grok-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-10"
 last_updated = "2025-07-10"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-code-fast-1.toml
+++ b/providers/poe/models/xai/grok-code-fast-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-22"
 last_updated = "2025-08-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true


### PR DESCRIPTION
## Summary
- add explicit `reasoning_options` to all 71 existing reasoning models
- classify 35 effort controls, 8 toggles, and 28 fixed/no-selectable-control entries
- omit token budgets because Poe does not document both finite bounds for affected routes
- make no catalog, base-model, test, or unrelated metadata changes

## Validation
- `bun validate`
- `git diff --check`
- 71/71 covered; 0 non-reasoning leaks; 0 unbounded budgets