### PR TITLE
[bailing] Add reasoning options

### DIFF
--- a/providers/bailing/models/Ring-1T.toml
+++ b/providers/bailing/models/Ring-1T.toml
@@ -4,6 +4,7 @@ release_date = "2025-10"
 last_updated = "2025-10"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = false


### PR DESCRIPTION
## Summary
- declare Ring-1T as fixed reasoning with `reasoning_options = []`
- avoid unsupported effort controls; Bailing documents effort only for Ring-2.6
- make no unrelated changes

## Validation
- `bun validate`
- `git diff --check`
- complete Bailing reasoning coverage