### PR TITLE
[llmgateway] Add reasoning options

### DIFF
--- a/providers/llmgateway/models/claude-3-7-sonnet-20250219.toml
+++ b/providers/llmgateway/models/claude-3-7-sonnet-20250219.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-3-7-sonnet-20250219"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 3

--- a/providers/llmgateway/models/claude-3-7-sonnet.toml
+++ b/providers/llmgateway/models/claude-3-7-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-24"
 last_updated = "2025-02-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/llmgateway/models/claude-haiku-4-5-20251001.toml
+++ b/providers/llmgateway/models/claude-haiku-4-5-20251001.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5-20251001"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1

--- a/providers/llmgateway/models/claude-haiku-4-5.toml
+++ b/providers/llmgateway/models/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1

--- a/providers/llmgateway/models/claude-opus-4-1-20250805.toml
+++ b/providers/llmgateway/models/claude-opus-4-1-20250805.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 15

--- a/providers/llmgateway/models/claude-opus-4-20250514.toml
+++ b/providers/llmgateway/models/claude-opus-4-20250514.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-20250514"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 15

--- a/providers/llmgateway/models/claude-opus-4-5-20251101.toml
+++ b/providers/llmgateway/models/claude-opus-4-5-20251101.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5-20251101"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/llmgateway/models/claude-opus-4-6.toml
+++ b/providers/llmgateway/models/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/llmgateway/models/claude-opus-4-7.toml
+++ b/providers/llmgateway/models/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/llmgateway/models/claude-opus-4-8.toml
+++ b/providers/llmgateway/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/llmgateway/models/claude-sonnet-4-20250514.toml
+++ b/providers/llmgateway/models/claude-sonnet-4-20250514.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-20250514"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 3

--- a/providers/llmgateway/models/claude-sonnet-4-5-20250929.toml
+++ b/providers/llmgateway/models/claude-sonnet-4-5-20250929.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 3

--- a/providers/llmgateway/models/claude-sonnet-4-5.toml
+++ b/providers/llmgateway/models/claude-sonnet-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 3

--- a/providers/llmgateway/models/claude-sonnet-4-6.toml
+++ b/providers/llmgateway/models/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 3

--- a/providers/llmgateway/models/deepseek-r1-0528.toml
+++ b/providers/llmgateway/models/deepseek-r1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/llmgateway/models/deepseek-v3.1.toml
+++ b/providers/llmgateway/models/deepseek-v3.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-21"
 last_updated = "2025-08-21"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/deepseek-v3.2.toml
+++ b/providers/llmgateway/models/deepseek-v3.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/deepseek-v4-flash.toml
+++ b/providers/llmgateway/models/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/deepseek-v4-pro.toml
+++ b/providers/llmgateway/models/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/gemini-2.5-flash-lite.toml
+++ b/providers/llmgateway/models/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.1

--- a/providers/llmgateway/models/gemini-2.5-flash.toml
+++ b/providers/llmgateway/models/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/llmgateway/models/gemini-2.5-pro.toml
+++ b/providers/llmgateway/models/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/gemini-3-flash-preview.toml
+++ b/providers/llmgateway/models/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.5

--- a/providers/llmgateway/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/llmgateway/models/gemini-3.1-flash-lite-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/llmgateway/models/gemini-3.1-flash-lite.toml
+++ b/providers/llmgateway/models/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/llmgateway/models/gemini-3.1-pro-preview.toml
+++ b/providers/llmgateway/models/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/llmgateway/models/gemini-3.5-flash.toml
+++ b/providers/llmgateway/models/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.5

--- a/providers/llmgateway/models/gemini-pro-latest.toml
+++ b/providers/llmgateway/models/gemini-pro-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-27"
 last_updated = "2026-02-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.5-air.toml
+++ b/providers/llmgateway/models/glm-4.5-air.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.2

--- a/providers/llmgateway/models/glm-4.5-flash.toml
+++ b/providers/llmgateway/models/glm-4.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0

--- a/providers/llmgateway/models/glm-4.5-x.toml
+++ b/providers/llmgateway/models/glm-4.5-x.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-28"
 last_updated = "2025-07-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.5.toml
+++ b/providers/llmgateway/models/glm-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/glm-4.5v.toml
+++ b/providers/llmgateway/models/glm-4.5v.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5v"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/glm-4.6.toml
+++ b/providers/llmgateway/models/glm-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/glm-4.6v-flash.toml
+++ b/providers/llmgateway/models/glm-4.6v-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.6v-flashx.toml
+++ b/providers/llmgateway/models/glm-4.6v-flashx.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.6v.toml
+++ b/providers/llmgateway/models/glm-4.6v.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6v"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/llmgateway/models/glm-4.7-flash.toml
+++ b/providers/llmgateway/models/glm-4.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0

--- a/providers/llmgateway/models/glm-4.7-flashx.toml
+++ b/providers/llmgateway/models/glm-4.7-flashx.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flashx"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.07

--- a/providers/llmgateway/models/glm-4.7.toml
+++ b/providers/llmgateway/models/glm-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/glm-5.1.toml
+++ b/providers/llmgateway/models/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/glm-5.toml
+++ b/providers/llmgateway/models/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/gpt-5-chat-latest.toml
+++ b/providers/llmgateway/models/gpt-5-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-chat-latest"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/gpt-5-mini.toml
+++ b/providers/llmgateway/models/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/llmgateway/models/gpt-5-nano.toml
+++ b/providers/llmgateway/models/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/llmgateway/models/gpt-5-pro.toml
+++ b/providers/llmgateway/models/gpt-5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-pro"
+reasoning_options = [{ type = "effort", values = ["high"] }]
 
 [cost]
 input = 15

--- a/providers/llmgateway/models/gpt-5.1-codex-mini.toml
+++ b/providers/llmgateway/models/gpt-5.1-codex-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/llmgateway/models/gpt-5.1-codex.toml
+++ b/providers/llmgateway/models/gpt-5.1-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/gpt-5.1.toml
+++ b/providers/llmgateway/models/gpt-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/gpt-5.2-chat-latest.toml
+++ b/providers/llmgateway/models/gpt-5.2-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-chat-latest"
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 
 [cost]
 input = 1.75

--- a/providers/llmgateway/models/gpt-5.2-codex.toml
+++ b/providers/llmgateway/models/gpt-5.2-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/llmgateway/models/gpt-5.2-pro.toml
+++ b/providers/llmgateway/models/gpt-5.2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
 input = 21

--- a/providers/llmgateway/models/gpt-5.2.toml
+++ b/providers/llmgateway/models/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/llmgateway/models/gpt-5.3-codex.toml
+++ b/providers/llmgateway/models/gpt-5.3-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/llmgateway/models/gpt-5.4-mini.toml
+++ b/providers/llmgateway/models/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.75

--- a/providers/llmgateway/models/gpt-5.4-nano.toml
+++ b/providers/llmgateway/models/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.2

--- a/providers/llmgateway/models/gpt-5.4-pro.toml
+++ b/providers/llmgateway/models/gpt-5.4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
 input = 30

--- a/providers/llmgateway/models/gpt-5.4.toml
+++ b/providers/llmgateway/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/llmgateway/models/gpt-5.5-pro.toml
+++ b/providers/llmgateway/models/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
 input = 30

--- a/providers/llmgateway/models/gpt-5.5.toml
+++ b/providers/llmgateway/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/llmgateway/models/gpt-5.toml
+++ b/providers/llmgateway/models/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/gpt-oss-120b.toml
+++ b/providers/llmgateway/models/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/gpt-oss-20b.toml
+++ b/providers/llmgateway/models/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/grok-4-1-fast-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-19"
 last_updated = "2025-11-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/grok-4-20-beta-0309-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-20-beta-0309-reasoning.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/grok-4-20-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-20-reasoning.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/grok-4-3.toml
+++ b/providers/llmgateway/models/grok-4-3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/grok-4-fast-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/kimi-k2-thinking-turbo.toml
+++ b/providers/llmgateway/models/kimi-k2-thinking-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking-turbo"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2-thinking.toml
+++ b/providers/llmgateway/models/kimi-k2-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2.5.toml
+++ b/providers/llmgateway/models/kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2.6.toml
+++ b/providers/llmgateway/models/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/mimo-v2-flash.toml
+++ b/providers/llmgateway/models/mimo-v2-flash.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/mimo-v2-omni.toml
+++ b/providers/llmgateway/models/mimo-v2-omni.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-omni"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/mimo-v2-pro.toml
+++ b/providers/llmgateway/models/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/mimo-v2.5-pro.toml
+++ b/providers/llmgateway/models/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/mimo-v2.5.toml
+++ b/providers/llmgateway/models/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/minimax-m2.1-lightning.toml
+++ b/providers/llmgateway/models/minimax-m2.1-lightning.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/llmgateway/models/minimax-m2.1.toml
+++ b/providers/llmgateway/models/minimax-m2.1.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.1"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/llmgateway/models/minimax-m2.5-highspeed.toml
+++ b/providers/llmgateway/models/minimax-m2.5-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5-highspeed"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/minimax-m2.5.toml
+++ b/providers/llmgateway/models/minimax-m2.5.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/llmgateway/models/minimax-m2.7-highspeed.toml
+++ b/providers/llmgateway/models/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/minimax-m2.7.toml
+++ b/providers/llmgateway/models/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/llmgateway/models/minimax-m2.toml
+++ b/providers/llmgateway/models/minimax-m2.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/llmgateway/models/minimax-m3.toml
+++ b/providers/llmgateway/models/minimax-m3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/minimax-text-01.toml
+++ b/providers/llmgateway/models/minimax-text-01.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-15"
 last_updated = "2025-01-15"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/llmgateway/models/o1.toml
+++ b/providers/llmgateway/models/o1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o1"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 15

--- a/providers/llmgateway/models/o3-mini.toml
+++ b/providers/llmgateway/models/o3-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.1

--- a/providers/llmgateway/models/o3.toml
+++ b/providers/llmgateway/models/o3.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/llmgateway/models/o4-mini.toml
+++ b/providers/llmgateway/models/o4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.1

--- a/providers/llmgateway/models/qwen-flash.toml
+++ b/providers/llmgateway/models/qwen-flash.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/llmgateway/models/qwen-plus.toml
+++ b/providers/llmgateway/models/qwen-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen-plus"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.4

--- a/providers/llmgateway/models/qwen-turbo.toml
+++ b/providers/llmgateway/models/qwen-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen-turbo"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/llmgateway/models/qwen3-235b-a22b-fp8.toml
+++ b/providers/llmgateway/models/qwen3-235b-a22b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-28"
 last_updated = "2025-04-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/llmgateway/models/qwen3-235b-a22b-thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-08"
 last_updated = "2025-07-08"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-30b-a3b-fp8.toml
+++ b/providers/llmgateway/models/qwen3-30b-a3b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-28"
 last_updated = "2025-04-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-30b-a3b-thinking-2507.toml
+++ b/providers/llmgateway/models/qwen3-30b-a3b-thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-08"
 last_updated = "2025-07-08"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-32b-fp8.toml
+++ b/providers/llmgateway/models/qwen3-32b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-28"
 last_updated = "2025-04-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-32b.toml
+++ b/providers/llmgateway/models/qwen3-32b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-32b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.7

--- a/providers/llmgateway/models/qwen3-4b-fp8.toml
+++ b/providers/llmgateway/models/qwen3-4b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-28"
 last_updated = "2025-04-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-coder-next.toml
+++ b/providers/llmgateway/models/qwen3-coder-next.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-max-2026-01-23.toml
+++ b/providers/llmgateway/models/qwen3-max-2026-01-23.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-23"
 last_updated = "2026-01-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/llmgateway/models/qwen3-next-80b-a3b-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-next-80b-a3b-thinking"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.5

--- a/providers/llmgateway/models/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/llmgateway/models/qwen3-vl-235b-a22b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-vl-30b-a3b-thinking.toml
+++ b/providers/llmgateway/models/qwen3-vl-30b-a3b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-02"
 last_updated = "2025-10-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-vl-plus.toml
+++ b/providers/llmgateway/models/qwen3-vl-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-vl-plus"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.2

--- a/providers/llmgateway/models/qwen3.6-35b-a3b.toml
+++ b/providers/llmgateway/models/qwen3.6-35b-a3b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.248

--- a/providers/llmgateway/models/qwen3.6-max-preview.toml
+++ b/providers/llmgateway/models/qwen3.6-max-preview.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-max-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.3

--- a/providers/llmgateway/models/qwen3.6-plus.toml
+++ b/providers/llmgateway/models/qwen3.6-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-plus"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.5

--- a/providers/llmgateway/models/qwen3.7-max.toml
+++ b/providers/llmgateway/models/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2.5

--- a/providers/llmgateway/models/qwen3.7-plus.toml
+++ b/providers/llmgateway/models/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.4

--- a/providers/llmgateway/models/qwen35-397b-a17b.toml
+++ b/providers/llmgateway/models/qwen35-397b-a17b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-397b-a17b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/qwq-plus.toml
+++ b/providers/llmgateway/models/qwq-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwq-plus"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.8

--- a/providers/llmgateway/models/seed-1-6-250615.toml
+++ b/providers/llmgateway/models/seed-1-6-250615.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-25"
 last_updated = "2025-06-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-6-250915.toml
+++ b/providers/llmgateway/models/seed-1-6-250915.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-6-flash-250715.toml
+++ b/providers/llmgateway/models/seed-1-6-flash-250715.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-26"
 last_updated = "2025-07-26"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-8-251228.toml
+++ b/providers/llmgateway/models/seed-1-8-251228.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-18"
 last_updated = "2025-12-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/sonar-reasoning-pro.toml
+++ b/providers/llmgateway/models/sonar-reasoning-pro.toml
@@ -1,4 +1,5 @@
 base_model = "perplexity/sonar-reasoning-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2


### PR DESCRIPTION
## Summary
- add explicit `reasoning_options` to all 118 existing reasoning models
- use model-specific OpenAI effort sets where known and normalized `low|medium|high` for ordinary chat-completions reasoning routes
- make no catalog, base-model, test, or unrelated metadata changes

## Validation
- `bun validate`
- `git diff --check`
- 118/118 reasoning models covered; 0 options on non-reasoning models
- diff contains exactly 118 `reasoning_options` insertions