### PR TITLE
[privatemode-ai] Add reasoning options

### DIFF
--- a/providers/privatemode-ai/models/gpt-oss-120b.toml
+++ b/providers/privatemode-ai/models/gpt-oss-120b.toml
@@ -2,6 +2,7 @@ name = "gpt-oss-120b"
 family = "gpt-oss"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 structured_output = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
## Summary
- add GPT-OSS `low|medium|high` reasoning effort controls
- follow PrivateMode vLLM deployment and GPT-OSS semantics
- make no unrelated metadata changes

## Validation
- `bun validate`
- `git diff --check`
- complete PrivateMode reasoning coverage