### PR TITLE
[zai-coding-plan] Complete reasoning options

### DIFF
--- a/providers/zai-coding-plan/models/glm-5v-turbo.toml
+++ b/providers/zai-coding-plan/models/glm-5v-turbo.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-5v-turbo"
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
## Summary
- add the documented GLM-5V Turbo `thinking.type` toggle
- omit unsupported effort levels
- make no unrelated changes

## Validation
- `bun validate`
- `git diff --check`
- complete Z.AI Coding Plan reasoning coverage