### PR TITLE
[kimi-for-coding] Complete reasoning options

### DIFF
--- a/providers/kimi-for-coding/models/kimi-k2-thinking.toml
+++ b/providers/kimi-for-coding/models/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11"
 last_updated = "2025-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 structured_output = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
## Summary
- declare Kimi K2 Thinking as fixed reasoning with `reasoning_options = []`
- preserve existing K2.5 and K2.6 toggles
- make no unrelated changes

## Validation
- `bun validate`
- `git diff --check`
- complete Kimi for Coding reasoning coverage