### PR TITLE
[zhipuai-coding-plan] Complete reasoning options

### DIFF
--- a/providers/zhipuai-coding-plan/models/glm-5v-turbo.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5v-turbo.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
## Summary
- add the documented GLM-5V Turbo `thinking.type` toggle
- omit unsupported effort levels
- make no unrelated changes

## Validation
- `bun validate`
- `git diff --check`
- complete ZhipuAI Coding Plan reasoning coverage