### PR TITLE
[kuae-cloud-coding-plan] Add reasoning options

### DIFF
--- a/providers/kuae-cloud-coding-plan/models/GLM-4.7.toml
+++ b/providers/kuae-cloud-coding-plan/models/GLM-4.7.toml
@@ -9,6 +9,9 @@ tool_call = true
 knowledge = "2025-04"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
## Summary
- add the documented GLM-4.7 `thinking.type` toggle
- omit unsupported effort levels
- make no unrelated changes

## Validation
- `bun validate`
- `git diff --check`
- complete KUAE Coding Plan reasoning coverage