### PR TITLE
[llmtr] Complete reasoning options

### DIFF
--- a/providers/llmtr/models/qwen3-6-35b.toml
+++ b/providers/llmtr/models/qwen3-6-35b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 5.0


### PR DESCRIPTION
## Summary
- add the model-specific `reasoning_toggle` capability for Qwen3.6 35B
- avoid unconfirmed effort levels
- make no unrelated changes

## Validation
- `bun validate`
- `git diff --check`
- complete LLMTR reasoning coverage