### PR TITLE
[firepass] Add reasoning options

### DIFF
--- a/providers/firepass/models/accounts/fireworks/routers/kimi-k2p6-turbo.toml
+++ b/providers/firepass/models/accounts/fireworks/routers/kimi-k2p6-turbo.toml
@@ -8,6 +8,9 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0


### PR DESCRIPTION
## Summary
- add a verified reasoning toggle for the Kimi K2.6 Turbo Fireworks router
- avoid unverified effort values
- make no unrelated changes

## Validation
- `bun validate`
- `git diff --check`
- complete Firepass reasoning coverage