### PR TITLE
[deepseek] Complete reasoning options

### DIFF
--- a/providers/deepseek/models/deepseek-reasoner.toml
+++ b/providers/deepseek/models/deepseek-reasoner.toml
@@ -9,9 +9,7 @@ knowledge = "2025-09"
 tool_call = true
 open_weights = true
 
-[[reasoning_options]]
-type = "effort"
-values = ["high", "max"]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/deepseek/models/deepseek-reasoner.toml
+++ b/providers/deepseek/models/deepseek-reasoner.toml
@@ -9,6 +9,10 @@ knowledge = "2025-09"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
## Summary
- declare the legacy `deepseek-reasoner` alias as fixed thinking with `reasoning_options = []`
- do not inherit `high|max` effort controls from the newer `deepseek-v4-*` IDs without exact alias evidence
- make no unrelated changes

## Evidence
- DeepSeek documents `deepseek-reasoner` as a compatibility alias pinned to the thinking mode of `deepseek-v4-flash`
- current effort examples explicitly use the new V4 model IDs, while the alias-specific guide documents no selectable reasoning control

## Validation
- `bun validate`
- `git diff --check`
- complete DeepSeek reasoning coverage