### PR TITLE
[cloudferro-sherlock] Add reasoning options

### DIFF
--- a/providers/cloudferro-sherlock/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/cloudferro-sherlock/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 structured_output = true
 temperature = true
 tool_call = true

--- a/providers/cloudferro-sherlock/models/openai/gpt-oss-120b.toml
+++ b/providers/cloudferro-sherlock/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-28"
 last_updated = "2025-08-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 structured_output = true
 tool_call = true


### PR DESCRIPTION
## Summary
- backfill reasoning options for 2 existing models
- GPT-OSS uses `low|medium|high`; MiniMax M2.5 is fixed reasoning
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`
- complete coverage; no unbounded budgets