### PR TITLE
[drun] Add reasoning options

### DIFF
--- a/providers/drun/models/public/deepseek-r1.toml
+++ b/providers/drun/models/public/deepseek-r1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-12"
 tool_call = true

--- a/providers/drun/models/public/minimax-m25.toml
+++ b/providers/drun/models/public/minimax-m25.toml
@@ -2,6 +2,7 @@ name = "MiniMax M2.5"
 family = "minimax"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2025-03-01"


### PR DESCRIPTION
## Summary
- declare DeepSeek R1 and MiniMax M2.5 as fixed reasoning
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`
- complete coverage