### PR TITLE
[moark] Add reasoning options

### DIFF
--- a/providers/moark/models/GLM-4.7.toml
+++ b/providers/moark/models/GLM-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/moark/models/MiniMax-M2.1.toml
+++ b/providers/moark/models/MiniMax-M2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- add explicit fixed reasoning declarations for GLM-4.7 and MiniMax M2.1
- avoid inferring upstream controls through Moark transport
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`