### PR TITLE
[poolside] Add reasoning options

### DIFF
--- a/providers/poolside/models/poolside/laguna-m.1.toml
+++ b/providers/poolside/models/poolside/laguna-m.1.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/poolside/models/poolside/laguna-xs.2.toml
+++ b/providers/poolside/models/poolside/laguna-xs.2.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- add documented effort controls to both Laguna reasoning models
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`
- no token budgets