### PR TITLE
[moonshotai] Complete reasoning options

### DIFF
--- a/providers/moonshotai/models/kimi-k2-thinking-turbo.toml
+++ b/providers/moonshotai/models/kimi-k2-thinking-turbo.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-08"

--- a/providers/moonshotai/models/kimi-k2-thinking.toml
+++ b/providers/moonshotai/models/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-08"


### PR DESCRIPTION
## Summary
- declare Kimi K2 Thinking and Turbo aliases as fixed reasoning
- preserve existing K2.5 and K2.6 toggles
- shared model files cover global and CN providers

## Validation
- `bun validate`
- `git diff --check`