### PR TITLE
[upstage] Add reasoning options

### DIFF
--- a/providers/upstage/models/solar-pro2.toml
+++ b/providers/upstage/models/solar-pro2.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-20"
 last_updated = "2025-05-20"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "high"] }]
 temperature = true
 knowledge = "2025-03"
 tool_call = true

--- a/providers/upstage/models/solar-pro3.toml
+++ b/providers/upstage/models/solar-pro3.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 knowledge = "2025-03"
 tool_call = true


### PR DESCRIPTION
## Summary
- record distinct effective effort controls for Solar Pro 2 and Solar Pro 3
- omit compatibility aliases that collapse to identical behavior
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`
- no token budgets