### PR TITLE
[perplexity] Add reasoning options

### DIFF
--- a/providers/perplexity/models/sonar-deep-research.toml
+++ b/providers/perplexity/models/sonar-deep-research.toml
@@ -3,6 +3,7 @@ release_date = "2025-02-01"
 last_updated = "2025-09-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 tool_call = false
 knowledge = "2025-01"

--- a/providers/perplexity/models/sonar-reasoning-pro.toml
+++ b/providers/perplexity/models/sonar-reasoning-pro.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2025-09-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = false
 knowledge = "2025-09-01"


### PR DESCRIPTION
## Summary
- add documented effort controls to Sonar Deep Research and Sonar Reasoning Pro
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`
- no token budgets