### PR TITLE
[tencent-coding-plan] Add reasoning options

### DIFF
--- a/providers/tencent-coding-plan/models/glm-5.toml
+++ b/providers/tencent-coding-plan/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/tencent-coding-plan/models/hunyuan-2.0-thinking.toml
+++ b/providers/tencent-coding-plan/models/hunyuan-2.0-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-08"
 last_updated = "2026-03-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/tencent-coding-plan/models/hunyuan-t1.toml
+++ b/providers/tencent-coding-plan/models/hunyuan-t1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-08"
 last_updated = "2026-03-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/tencent-coding-plan/models/kimi-k2.5.toml
+++ b/providers/tencent-coding-plan/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/tencent-coding-plan/models/minimax-m2.5.toml
+++ b/providers/tencent-coding-plan/models/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- backfill 5 existing reasoning models
- use toggles for Kimi K2.5 and GLM-5; fixed declarations for MiniMax and Hunyuan thinking models
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`