### PR TITLE
[minimax-cn] Complete reasoning options

### DIFF
--- a/providers/minimax-cn/models/MiniMax-M2.1.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/minimax-cn/models/MiniMax-M2.5-highspeed.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.5-highspeed.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-13"
 last_updated = "2026-02-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/minimax-cn/models/MiniMax-M2.5.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/minimax-cn/models/MiniMax-M2.7-highspeed.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.7-highspeed.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/minimax-cn/models/MiniMax-M2.7.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/minimax-cn/models/MiniMax-M2.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-27"
 last_updated = "2025-10-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 # knowledge = "2025-04" # Not listed on model page.


### PR DESCRIPTION
## Summary
- declare six MiniMax M2.x routes as fixed reasoning
- preserve existing M3 toggle
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`