### PR TITLE
[hpc-ai] Add reasoning options

### DIFF
--- a/providers/hpc-ai/models/minimax/minimax-m2.5.toml
+++ b/providers/hpc-ai/models/minimax/minimax-m2.5.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-06-01"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/hpc-ai/models/minimax/minimax-m2.5.toml
+++ b/providers/hpc-ai/models/minimax/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-06-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
+++ b/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
@@ -4,7 +4,7 @@ release_date = "2026-01-01"
 last_updated = "2026-06-01"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
 temperature = false
 tool_call = true

--- a/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
+++ b/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-01"
 last_updated = "2026-06-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 structured_output = true
 temperature = false
 tool_call = true

--- a/providers/hpc-ai/models/zai-org/glm-5.1.toml
+++ b/providers/hpc-ai/models/zai-org/glm-5.1.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-08"
 last_updated = "2026-06-01"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/hpc-ai/models/zai-org/glm-5.1.toml
+++ b/providers/hpc-ai/models/zai-org/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-08"
 last_updated = "2026-06-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- add binary reasoning toggles for GLM-5.1 and Kimi K2.5
- declare MiniMax M2.5 as fixed reasoning with `reasoning_options = []`
- do not advertise unsupported graded effort controls
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`
- complete HPC-AI reasoning coverage