### PR TITLE
[mixlayer] Add reasoning options

### DIFF
--- a/providers/mixlayer/models/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/mixlayer/models/qwen/qwen3.5-122b-a10b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/mixlayer/models/qwen/qwen3.5-27b.toml
+++ b/providers/mixlayer/models/qwen/qwen3.5-27b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/mixlayer/models/qwen/qwen3.5-35b-a3b.toml
+++ b/providers/mixlayer/models/qwen/qwen3.5-35b-a3b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/mixlayer/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/mixlayer/models/qwen/qwen3.5-397b-a17b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/mixlayer/models/qwen/qwen3.5-9b.toml
+++ b/providers/mixlayer/models/qwen/qwen3.5-9b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- add reasoning toggles to 5 Qwen 3.5 models
- omit accepted effort aliases because all map to the same enabled state
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`