### PR TITLE
[modelscope] Add reasoning options

### DIFF
--- a/providers/modelscope/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
+++ b/providers/modelscope/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-25"
 last_updated = "2025-07-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/modelscope/models/Qwen/Qwen3-30B-A3B-Thinking-2507.toml
+++ b/providers/modelscope/models/Qwen/Qwen3-30B-A3B-Thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-30"
 last_updated = "2025-07-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/modelscope/models/ZhipuAI/GLM-4.5.toml
+++ b/providers/modelscope/models/ZhipuAI/GLM-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-28"
 last_updated = "2025-07-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/modelscope/models/ZhipuAI/GLM-4.6.toml
+++ b/providers/modelscope/models/ZhipuAI/GLM-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-07"


### PR DESCRIPTION
## Summary
- add toggles for GLM-4.5 and GLM-4.6
- declare Qwen Thinking checkpoints as fixed reasoning
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`