### PR TITLE
[regolo-ai] Add reasoning options

### DIFF
--- a/providers/regolo-ai/models/gpt-oss-120b.toml
+++ b/providers/regolo-ai/models/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/regolo-ai/models/gpt-oss-20b.toml
+++ b/providers/regolo-ai/models/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/regolo-ai/models/minimax-m2.5.toml
+++ b/providers/regolo-ai/models/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-10"
 last_updated = "2026-03-10"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/regolo-ai/models/mistral-small-4-119b.toml
+++ b/providers/regolo-ai/models/mistral-small-4-119b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/regolo-ai/models/mistral-small3.2.toml
+++ b/providers/regolo-ai/models/mistral-small3.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/regolo-ai/models/qwen3-coder-next.toml
+++ b/providers/regolo-ai/models/qwen3-coder-next.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/regolo-ai/models/qwen3.5-122b.toml
+++ b/providers/regolo-ai/models/qwen3.5-122b.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-01"
 last_updated = "2026-02-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/regolo-ai/models/qwen3.5-9b.toml
+++ b/providers/regolo-ai/models/qwen3.5-9b.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-01"
 last_updated = "2026-02-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- add GPT-OSS `low|medium|high` effort controls
- conservatively declare 6 other routes fixed or unresolved
- model-specific effective controls only

## Validation
- `bun validate`
- `git diff --check`