### PR TITLE
[the-grid-ai] Add reasoning options

### DIFF
--- a/providers/the-grid-ai/models/agent-max.toml
+++ b/providers/the-grid-ai/models/agent-max.toml
@@ -4,6 +4,7 @@ last_updated = "2026-05-19"
 # reflects last update to contract specification: https://thegrid.ai/docs/instrument-specifications/current-instruments
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/agent-prime.toml
+++ b/providers/the-grid-ai/models/agent-prime.toml
@@ -4,6 +4,7 @@ last_updated = "2026-05-19"
 # reflects last update to contract specification: https://thegrid.ai/docs/instrument-specifications/current-instruments
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/agent-standard.toml
+++ b/providers/the-grid-ai/models/agent-standard.toml
@@ -4,6 +4,7 @@ last_updated = "2026-05-19"
 # reflects last update to contract specification: https://thegrid.ai/docs/instrument-specifications/current-instruments
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/code-max.toml
+++ b/providers/the-grid-ai/models/code-max.toml
@@ -4,6 +4,7 @@ last_updated = "2026-05-19"
 # reflects last update to contract specification: https://thegrid.ai/docs/instrument-specifications/current-instruments
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/code-prime.toml
+++ b/providers/the-grid-ai/models/code-prime.toml
@@ -4,6 +4,7 @@ last_updated = "2026-05-19"
 # reflects last update to contract specification: https://thegrid.ai/docs/instrument-specifications/current-instruments
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/code-standard.toml
+++ b/providers/the-grid-ai/models/code-standard.toml
@@ -4,6 +4,7 @@ last_updated = "2026-05-19"
 # reflects last update to contract specification: https://thegrid.ai/docs/instrument-specifications/current-instruments
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/text-max.toml
+++ b/providers/the-grid-ai/models/text-max.toml
@@ -4,6 +4,7 @@ last_updated = "2026-05-19"
 # reflects last update to contract specification: https://thegrid.ai/docs/instrument-specifications/current-instruments
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/text-prime.toml
+++ b/providers/the-grid-ai/models/text-prime.toml
@@ -4,6 +4,7 @@ last_updated = "2026-05-19"
 # reflects last update to contract specification: https://thegrid.ai/docs/instrument-specifications/current-instruments
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/text-standard.toml
+++ b/providers/the-grid-ai/models/text-standard.toml
@@ -4,6 +4,7 @@ last_updated = "2026-05-19"
 # reflects last update to contract specification: https://thegrid.ai/docs/instrument-specifications/current-instruments
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- add explicit fixed reasoning declarations for all 9 instruments
- The Grid handles reasoning internally without per-call controls

## Validation
- `bun validate`
- `git diff --check`