### PR TITLE
[clarifai] Add reasoning options

### DIFF
--- a/providers/clarifai/models/arcee_ai/AFM/models/trinity-mini.toml
+++ b/providers/clarifai/models/arcee_ai/AFM/models/trinity-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-12"
 last_updated = "2026-02-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/clarifai/models/minimaxai/chat-completion/models/MiniMax-M2_5-high-throughput.toml
+++ b/providers/clarifai/models/minimaxai/chat-completion/models/MiniMax-M2_5-high-throughput.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/clarifai/models/mistralai/completion/models/Ministral-3-14B-Reasoning-2512.toml
+++ b/providers/clarifai/models/mistralai/completion/models/Ministral-3-14B-Reasoning-2512.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-12"

--- a/providers/clarifai/models/mistralai/completion/models/Ministral-3-3B-Reasoning-2512.toml
+++ b/providers/clarifai/models/mistralai/completion/models/Ministral-3-3B-Reasoning-2512.toml
@@ -4,6 +4,7 @@ release_date = "2025-12"
 last_updated = "2026-02-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/clarifai/models/moonshotai/chat-completion/models/Kimi-K2_6.toml
+++ b/providers/clarifai/models/moonshotai/chat-completion/models/Kimi-K2_6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/clarifai/models/openai/chat-completion/models/gpt-oss-120b-high-throughput.toml
+++ b/providers/clarifai/models/openai/chat-completion/models/gpt-oss-120b-high-throughput.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2026-02-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/clarifai/models/openai/chat-completion/models/gpt-oss-20b.toml
+++ b/providers/clarifai/models/openai/chat-completion/models/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-12-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/clarifai/models/qwen/qwenLM/models/Qwen3-30B-A3B-Thinking-2507.toml
+++ b/providers/clarifai/models/qwen/qwenLM/models/Qwen3-30B-A3B-Thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-31"
 last_updated = "2026-02-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- add GPT-OSS `low|medium|high` effort controls
- declare 6 fixed-thinking routes without selectable controls
- model-specific reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`