### PR TITLE
[berget] Add reasoning options

### DIFF
--- a/providers/berget/models/google/gemma-4-31B-it.toml
+++ b/providers/berget/models/google/gemma-4-31B-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 knowledge = "2025-12"
 tool_call = true

--- a/providers/berget/models/google/gemma-4-31B-it.toml
+++ b/providers/berget/models/google/gemma-4-31B-it.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 knowledge = "2025-12"
 tool_call = true

--- a/providers/berget/models/meta-llama/Llama-3.3-70B-Instruct.toml
+++ b/providers/berget/models/meta-llama/Llama-3.3-70B-Instruct.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-27"
 last_updated = "2025-04-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/berget/models/meta-llama/Llama-3.3-70B-Instruct.toml
+++ b/providers/berget/models/meta-llama/Llama-3.3-70B-Instruct.toml
@@ -4,7 +4,7 @@ release_date = "2025-04-27"
 last_updated = "2025-04-27"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/berget/models/mistralai/Mistral-Medium-3.5-128B.toml
+++ b/providers/berget/models/mistralai/Mistral-Medium-3.5-128B.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-29"
 last_updated = "2026-04-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 knowledge = "2026-04"
 tool_call = true

--- a/providers/berget/models/mistralai/Mistral-Medium-3.5-128B.toml
+++ b/providers/berget/models/mistralai/Mistral-Medium-3.5-128B.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-29"
 last_updated = "2026-04-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
 temperature = true
 knowledge = "2026-04"
 tool_call = true

--- a/providers/berget/models/mistralai/Mistral-Small-3.2-24B-Instruct-2506.toml
+++ b/providers/berget/models/mistralai/Mistral-Small-3.2-24B-Instruct-2506.toml
@@ -4,7 +4,7 @@ release_date = "2025-10-01"
 last_updated = "2025-10-01"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 knowledge = "2025-09"
 tool_call = true

--- a/providers/berget/models/mistralai/Mistral-Small-3.2-24B-Instruct-2506.toml
+++ b/providers/berget/models/mistralai/Mistral-Small-3.2-24B-Instruct-2506.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-01"
 last_updated = "2025-10-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 knowledge = "2025-09"
 tool_call = true

--- a/providers/berget/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/berget/models/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 release_date = "2026-05-07"
 last_updated = "2026-05-07"
 

--- a/providers/berget/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/berget/models/moonshotai/Kimi-K2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 release_date = "2026-05-07"
 last_updated = "2026-05-07"
 

--- a/providers/berget/models/openai/gpt-oss-120b.toml
+++ b/providers/berget/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 knowledge = "2025-08"
 tool_call = true

--- a/providers/berget/models/openai/gpt-oss-120b.toml
+++ b/providers/berget/models/openai/gpt-oss-120b.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 knowledge = "2025-08"
 tool_call = true

--- a/providers/berget/models/zai-org/GLM-4.7.toml
+++ b/providers/berget/models/zai-org/GLM-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 knowledge = "2025-12"
 tool_call = true

--- a/providers/berget/models/zai-org/GLM-4.7.toml
+++ b/providers/berget/models/zai-org/GLM-4.7.toml
@@ -4,7 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 knowledge = "2025-12"
 tool_call = true


### PR DESCRIPTION
## Summary
- add Berget normalized effort controls to 7 reasoning models
- follow the provider OpenAPI enum and translation contract

## Validation
- `bun validate`
- `git diff --check`
- no token budgets