### PR TITLE
[scaleway] Add reasoning options

### DIFF
--- a/providers/scaleway/models/gemma-3-27b-it.toml
+++ b/providers/scaleway/models/gemma-3-27b-it.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-01"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-12"
 tool_call = true

--- a/providers/scaleway/models/gemma-4-26b-a4b-it.toml
+++ b/providers/scaleway/models/gemma-4-26b-a4b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 release_date = "2026-04-01"
 last_updated = "2026-05-22"
 knowledge = "2025-04"

--- a/providers/scaleway/models/gpt-oss-120b.toml
+++ b/providers/scaleway/models/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/scaleway/models/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/scaleway/models/qwen3-235b-a22b-instruct-2507.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-235b-a22b"
+reasoning_options = []
 name = "Qwen3 235B A22B Instruct 2507"
 release_date = "2025-07-01"
 last_updated = "2026-03-17"

--- a/providers/scaleway/models/qwen3.5-397b-a17b.toml
+++ b/providers/scaleway/models/qwen3.5-397b-a17b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-397b-a17b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 name = "Qwen3.5 397B A17B"
 release_date = "2026-03-17"
 last_updated = "2026-03-17"

--- a/providers/scaleway/models/qwen3.6-35b-a3b.toml
+++ b/providers/scaleway/models/qwen3.6-35b-a3b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 name = "Qwen3.6 35B A3B"
 release_date = "2026-05-01"
 last_updated = "2026-05-22"


### PR DESCRIPTION
## Summary
- backfill 6 existing reasoning models from Scaleway supported-model metadata
- add documented effort enums to 4 models and fixed declarations to 2

## Validation
- `bun validate`
- `git diff --check`
- complete coverage; no budgets