### PR TITLE
[meganova] Add reasoning options

### DIFF
--- a/providers/meganova/models/MiniMaxAI/MiniMax-M2.1.toml
+++ b/providers/meganova/models/MiniMaxAI/MiniMax-M2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/meganova/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/meganova/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/meganova/models/Qwen/Qwen3.5-Plus.toml
+++ b/providers/meganova/models/Qwen/Qwen3.5-Plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-02"
 last_updated = "2026-02"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-04"
 tool_call = true

--- a/providers/meganova/models/XiaomiMiMo/MiMo-V2-Flash.toml
+++ b/providers/meganova/models/XiaomiMiMo/MiMo-V2-Flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 knowledge = "2024-12-01"
 tool_call = true

--- a/providers/meganova/models/deepseek-ai/DeepSeek-R1-0528.toml
+++ b/providers/meganova/models/deepseek-ai/DeepSeek-R1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-07"
 tool_call = false

--- a/providers/meganova/models/moonshotai/Kimi-K2-Thinking.toml
+++ b/providers/meganova/models/moonshotai/Kimi-K2-Thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-08"

--- a/providers/meganova/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/meganova/models/moonshotai/Kimi-K2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2026-01"

--- a/providers/meganova/models/zai-org/GLM-4.6.toml
+++ b/providers/meganova/models/zai-org/GLM-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/meganova/models/zai-org/GLM-4.7.toml
+++ b/providers/meganova/models/zai-org/GLM-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/meganova/models/zai-org/GLM-5.toml
+++ b/providers/meganova/models/zai-org/GLM-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- backfill 10 existing reasoning models
- add verified GLM-5 and MiMo toggles; use fixed declarations elsewhere
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`