### PR TITLE
[wafer.ai] Add reasoning options

### DIFF
--- a/providers/wafer.ai/models/GLM-5.1.toml
+++ b/providers/wafer.ai/models/GLM-5.1.toml
@@ -5,6 +5,7 @@ last_updated = "2026-06-01"
 knowledge = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/wafer.ai/models/Kimi-K2.6.toml
+++ b/providers/wafer.ai/models/Kimi-K2.6.toml
@@ -5,6 +5,7 @@ last_updated = "2026-06-01"
 knowledge = "2025-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/wafer.ai/models/Qwen3.5-397B-A17B.toml
+++ b/providers/wafer.ai/models/Qwen3.5-397B-A17B.toml
@@ -5,6 +5,7 @@ last_updated = "2026-06-01"
 knowledge = "2025-04"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/wafer.ai/models/Qwen3.6-35B-A3B.toml
+++ b/providers/wafer.ai/models/Qwen3.6-35B-A3B.toml
@@ -5,6 +5,7 @@ last_updated = "2026-05-30"
 knowledge = "2025-04"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/wafer.ai/models/deepseek-v4-flash.toml
+++ b/providers/wafer.ai/models/deepseek-v4-flash.toml
@@ -5,7 +5,7 @@ last_updated = "2026-05-30"
 knowledge = "2025-05"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/wafer.ai/models/deepseek-v4-flash.toml
+++ b/providers/wafer.ai/models/deepseek-v4-flash.toml
@@ -5,6 +5,7 @@ last_updated = "2026-05-30"
 knowledge = "2025-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/wafer.ai/models/deepseek-v4-pro.toml
+++ b/providers/wafer.ai/models/deepseek-v4-pro.toml
@@ -5,7 +5,7 @@ last_updated = "2026-05-30"
 knowledge = "2025-05"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/wafer.ai/models/deepseek-v4-pro.toml
+++ b/providers/wafer.ai/models/deepseek-v4-pro.toml
@@ -5,6 +5,7 @@ last_updated = "2026-05-30"
 knowledge = "2025-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/wafer.ai/models/qwen3.7-max.toml
+++ b/providers/wafer.ai/models/qwen3.7-max.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-21"
 last_updated = "2026-05-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- add explicit reasoning controls to seven Wafer reasoning models
- add toggle plus effective `high|max` effort for DeepSeek V4 Flash and Pro
- retain toggle-only controls for the other hybrid models

## Evidence
- Wafer explicitly supports `thinking` and `reasoning_effort` across reasoning-capable routes and names DeepSeek V4 Pro as an example
- DeepSeek V4 has two distinct effective effort levels: `high` and `max`; compatibility values `low|medium` collapse to `high`

## Validation
- `bun validate`
- `git diff --check`