### PR TITLE
[friendli] Add reasoning options

### DIFF
--- a/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -2,6 +2,7 @@ name = "MiniMax-M2.5"
 family = "minimax"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 temperature = true

--- a/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -2,7 +2,7 @@ name = "MiniMax-M2.5"
 family = "minimax"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 tool_call = true
 structured_output = true
 temperature = true

--- a/providers/friendli/models/zai-org/GLM-5.1.toml
+++ b/providers/friendli/models/zai-org/GLM-5.1.toml
@@ -2,6 +2,7 @@ name = "GLM-5.1"
 family = "glm"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 temperature = true

--- a/providers/friendli/models/zai-org/GLM-5.1.toml
+++ b/providers/friendli/models/zai-org/GLM-5.1.toml
@@ -2,7 +2,7 @@ name = "GLM-5.1"
 family = "glm"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 tool_call = true
 structured_output = true
 temperature = true

--- a/providers/friendli/models/zai-org/GLM-5.toml
+++ b/providers/friendli/models/zai-org/GLM-5.toml
@@ -2,6 +2,7 @@ name = "GLM-5"
 family = "glm"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 temperature = true

--- a/providers/friendli/models/zai-org/GLM-5.toml
+++ b/providers/friendli/models/zai-org/GLM-5.toml
@@ -2,7 +2,7 @@ name = "GLM-5"
 family = "glm"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 tool_call = true
 structured_output = true
 temperature = true


### PR DESCRIPTION
## Summary
- add explicit `reasoning_options = []` to the three existing Friendli reasoning models missing declarations
- do not advertise effort or toggle controls for MiniMax M2.5, GLM-5, or GLM-5.1
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`
- complete Friendli reasoning coverage