### PR TITLE
[io-net] Add reasoning options

### DIFF
--- a/providers/io-net/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
+++ b/providers/io-net/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-01"
 last_updated = "2025-07-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/io-net/models/deepseek-ai/DeepSeek-R1-0528.toml
+++ b/providers/io-net/models/deepseek-ai/DeepSeek-R1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-07"

--- a/providers/io-net/models/moonshotai/Kimi-K2-Thinking.toml
+++ b/providers/io-net/models/moonshotai/Kimi-K2-Thinking.toml
@@ -4,6 +4,7 @@ release_date = "2024-11-01"
 last_updated = "2024-11-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-08"


### PR DESCRIPTION
## Summary
- backfill fixed reasoning metadata for three io.net thinking-only models
- mark the models as having no configurable reasoning controls

## Validation
- bun validate
- git diff --check