### PR TITLE
[dinference] Mark reasoning controls fixed

### DIFF
--- a/providers/dinference/models/glm-4.7.toml
+++ b/providers/dinference/models/glm-4.7.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "zhipuai/glm-4.7"
 
 [interleaved]

--- a/providers/dinference/models/glm-5.1.toml
+++ b/providers/dinference/models/glm-5.1.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "zhipuai/glm-5.1"
 
 [interleaved]

--- a/providers/dinference/models/glm-5.toml
+++ b/providers/dinference/models/glm-5.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "zhipuai/glm-5"
 
 [interleaved]

--- a/providers/dinference/models/minimax-m2.5.toml
+++ b/providers/dinference/models/minimax-m2.5.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "minimax/MiniMax-M2.5"
 
 [cost]


### PR DESCRIPTION
## Summary
- mark four dinference reasoning models as having fixed reasoning controls
- set `reasoning_options = []` only

## Validation
- `bun validate`