### PR TITLE
[inceptron] Add reasoning options

### DIFF
--- a/providers/inceptron/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/inceptron/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "minimax/MiniMax-M2.5"
 name = "MiniMax M2.5"
 structured_output = true

--- a/providers/inceptron/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/inceptron/models/moonshotai/Kimi-K2.6.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "moonshotai/kimi-k2.6"
 
 [interleaved]

--- a/providers/inceptron/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/inceptron/models/zai-org/GLM-5.1-FP8.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "zhipuai/glm-5.1"
 name = "GLM 5.1"
 


### PR DESCRIPTION
## Summary
- declare the 3 authoritative reasoning models as fixed reasoning
- leave the non-reasoning Llama model unchanged
- reasoning-options-only scope

## Validation
- `bun validate`
- `git diff --check`