### PR TITLE
[lilac] Add reasoning options

### DIFF
--- a/providers/lilac/models/google/gemma-4-31b-it.toml
+++ b/providers/lilac/models/google/gemma-4-31b-it.toml
@@ -1,3 +1,4 @@
+reasoning_options = [{ type = "toggle" }]
 base_model = "google/gemma-4-31b-it"
 knowledge = "2025-01"
 

--- a/providers/lilac/models/minimaxai/minimax-m2.7.toml
+++ b/providers/lilac/models/minimaxai/minimax-m2.7.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "minimax/MiniMax-M2.7"
 name = "MiniMax M2.7"
 structured_output = true

--- a/providers/lilac/models/moonshotai/kimi-k2.6.toml
+++ b/providers/lilac/models/moonshotai/kimi-k2.6.toml
@@ -1,3 +1,4 @@
+reasoning_options = [{ type = "toggle" }]
 base_model = "moonshotai/kimi-k2.6"
 
 [interleaved]

--- a/providers/lilac/models/zai-org/glm-5.1.toml
+++ b/providers/lilac/models/zai-org/glm-5.1.toml
@@ -1,3 +1,4 @@
+reasoning_options = [{ type = "toggle" }]
 base_model = "zhipuai/glm-5.1"
 name = "GLM 5.1"
 knowledge = "2025-04"


### PR DESCRIPTION
## Summary
- expose reasoning toggles for Gemma 4, Kimi K2.6, and GLM 5.1
- mark MiniMax M2.7 reasoning controls as fixed

## Validation
- `bun validate`
- exact four-file, reasoning-options-only diff check
- `git diff --check origin/dev...HEAD`