### PR TITLE
[azure] Backfill DeepSeek V4 reasoning options

### DIFF
--- a/providers/azure/models/deepseek-v4-flash.toml
+++ b/providers/azure/models/deepseek-v4-flash.toml
@@ -2,6 +2,8 @@ base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek-V4-Flash"
 tool_call = false
 
+reasoning_options = []
+
 [cost]
 input = 1.74
 output = 3.48

--- a/providers/azure/models/deepseek-v4-pro.toml
+++ b/providers/azure/models/deepseek-v4-pro.toml
@@ -2,6 +2,8 @@ base_model = "deepseek/deepseek-v4-pro"
 name = "DeepSeek-V4-Pro"
 tool_call = false
 
+reasoning_options = []
+
 [cost]
 input = 0.19
 output = 0.51


### PR DESCRIPTION
## Summary
- mark DeepSeek V4 Flash reasoning controls as fixed on Azure
- mark DeepSeek V4 Pro reasoning controls as fixed on Azure

Azure Foundry route evidence exposes reasoning for both models without configurable effort controls, represented by `reasoning_options = []`.

## Validation
- `bun validate`