### PR TITLE
[xiaomi-token-plan] Add reasoning toggles

### DIFF
--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-omni.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-omni.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-omni"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Summary
- add reasoning toggles to the four canonical Xiaomi Token Plan language models
- cover `xiaomi-token-plan-cn`, `xiaomi-token-plan-ams`, and `xiaomi-token-plan-sgp` through the AMS/SGP model symlinks to the CN canonical files
- keep regional provider files unchanged and avoid duplicate regional PRs

## Validation
- `bun validate`
- confirmed all four models resolve with `reasoning_options = [{ type = "toggle" }]` under the CN, AMS, and SGP provider-visible catalogs