### PR TITLE
[ambient] Add reasoning options

### DIFF
--- a/providers/ambient/models/moonshotai/kimi-k2.6.toml
+++ b/providers/ambient/models/moonshotai/kimi-k2.6.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "moonshotai/kimi-k2.6"
 
 [interleaved]

--- a/providers/ambient/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/ambient/models/zai-org/GLM-5.1-FP8.toml
@@ -1,3 +1,4 @@
+reasoning_options = []
 base_model = "zhipuai/glm-5.1"
 
 [interleaved]


### PR DESCRIPTION
## Summary
- add explicit fixed reasoning declarations for Ambient's two existing reasoning models
- avoid advertising selectable controls not documented by Ambient
- reasoning-options-only scope

## Evidence
- Ambient's catalog contains exactly GLM-5.1 FP8 and Kimi K2.6
- both inherited model records are reasoning-capable; Ambient's OpenAI-compatible contract documents no selectable reasoning control

## Validation
- `bun validate`
- `git diff --check`
- 2/2 reasoning models covered; 0 non-reasoning leaks; 0 unbounded budgets