### PR TITLE
[google-vertex] Add MaaS reasoning options

### DIFF
--- a/providers/google-vertex/models/deepseek-ai/deepseek-v3.1-maas.toml
+++ b/providers/google-vertex/models/deepseek-ai/deepseek-v3.1-maas.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-28"
 last_updated = "2025-08-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/google-vertex/models/deepseek-ai/deepseek-v3.2-maas.toml
+++ b/providers/google-vertex/models/deepseek-ai/deepseek-v3.2-maas.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2026-04-04"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/google-vertex/models/moonshotai/kimi-k2-thinking-maas.toml
+++ b/providers/google-vertex/models/moonshotai/kimi-k2-thinking-maas.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/google-vertex/models/openai/gpt-oss-120b-maas.toml
+++ b/providers/google-vertex/models/openai/gpt-oss-120b-maas.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/google-vertex/models/openai/gpt-oss-20b-maas.toml
+++ b/providers/google-vertex/models/openai/gpt-oss-20b-maas.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/google-vertex/models/qwen/qwen3-235b-a22b-instruct-2507-maas.toml
+++ b/providers/google-vertex/models/qwen/qwen3-235b-a22b-instruct-2507-maas.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-13"
 last_updated = "2025-08-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/google-vertex/models/zai-org/glm-4.7-maas.toml
+++ b/providers/google-vertex/models/zai-org/glm-4.7-maas.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-06"
 last_updated = "2026-01-06"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/google-vertex/models/zai-org/glm-5-maas.toml
+++ b/providers/google-vertex/models/zai-org/glm-5-maas.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- add low, medium, and high reasoning effort options for Vertex GPT-OSS MaaS models
- add reasoning toggles for Vertex GLM 4.7 and GLM 5 MaaS models
- mark remaining reasoning MaaS models as fixed-control

## Validation
- bun validate
- git diff --check