### PR TITLE
[auriko] Add reasoning options

### DIFF
--- a/providers/auriko/models/claude-opus-4-6.toml
+++ b/providers/auriko/models/claude-opus-4-6.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-opus-4-6"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+
 [cost]
 input = 5
 output = 25

--- a/providers/auriko/models/claude-opus-4-7.toml
+++ b/providers/auriko/models/claude-opus-4-7.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-opus-4-7"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 5
 output = 25

--- a/providers/auriko/models/claude-sonnet-4-6.toml
+++ b/providers/auriko/models/claude-sonnet-4-6.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-sonnet-4-6"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+
 [cost]
 input = 3
 output = 15

--- a/providers/auriko/models/deepseek-v4-flash.toml
+++ b/providers/auriko/models/deepseek-v4-flash.toml
@@ -1,5 +1,7 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/auriko/models/deepseek-v4-pro.toml
+++ b/providers/auriko/models/deepseek-v4-pro.toml
@@ -1,5 +1,7 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/auriko/models/gemini-2.5-flash.toml
+++ b/providers/auriko/models/gemini-2.5-flash.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-2.5-flash"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 0.3
 output = 2.5

--- a/providers/auriko/models/gemini-2.5-pro.toml
+++ b/providers/auriko/models/gemini-2.5-pro.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-2.5-pro"
 
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 1.25
 output = 10

--- a/providers/auriko/models/gemini-3.1-pro-preview.toml
+++ b/providers/auriko/models/gemini-3.1-pro-preview.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-3.1-pro-preview"
 
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
 [cost]
 input = 2
 output = 12

--- a/providers/auriko/models/glm-5.1.toml
+++ b/providers/auriko/models/glm-5.1.toml
@@ -1,5 +1,7 @@
 base_model = "zhipuai/glm-5.1"
 
+reasoning_options = []
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/auriko/models/grok-4.3.toml
+++ b/providers/auriko/models/grok-4.3.toml
@@ -1,5 +1,7 @@
 base_model = "xai/grok-4.3"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+
 [cost]
 input = 1.25
 output = 2.5

--- a/providers/auriko/models/kimi-k2.5.toml
+++ b/providers/auriko/models/kimi-k2.5.toml
@@ -1,5 +1,7 @@
 base_model = "moonshotai/kimi-k2.5"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/auriko/models/kimi-k2.6.toml
+++ b/providers/auriko/models/kimi-k2.6.toml
@@ -1,5 +1,7 @@
 base_model = "moonshotai/kimi-k2.6"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/auriko/models/minimax-m2-7-highspeed.toml
+++ b/providers/auriko/models/minimax-m2-7-highspeed.toml
@@ -1,5 +1,7 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
 
+reasoning_options = []
+
 [cost]
 input = 0.6
 output = 2.4

--- a/providers/auriko/models/minimax-m2-7.toml
+++ b/providers/auriko/models/minimax-m2-7.toml
@@ -1,5 +1,7 @@
 base_model = "minimax/MiniMax-M2.7"
 
+reasoning_options = []
+
 [cost]
 input = 0.3
 output = 1.2

--- a/providers/auriko/models/qwen-3.6-plus.toml
+++ b/providers/auriko/models/qwen-3.6-plus.toml
@@ -1,5 +1,7 @@
 base_model = "alibaba/qwen3.6-plus"
 
+reasoning_options = []
+
 [cost]
 input = 0.5
 output = 3


### PR DESCRIPTION
## Summary
- add Auriko-specific reasoning controls to all 15 existing model definitions
- model Auriko normalization ceilings and explicit disable support without exposing upstream token budgets
- override unsupported MiniMax, Qwen, and GLM controls with empty options

## Validation
- `bun validate`
- resolved all Auriko models with explicit `reasoning_options`

## Sources
- https://docs.auriko.ai/guides/extensions-and-thinking
- https://docs.auriko.ai/changelog.md
- https://docs.auriko.ai/errors/thinking_disable_not_supported.md