### PR TITLE
[abacus] Add reasoning options

### DIFF
--- a/providers/abacus/models/Qwen/QwQ-32B.toml
+++ b/providers/abacus/models/Qwen/QwQ-32B.toml
@@ -4,6 +4,7 @@ release_date = "2024-11-28"
 last_updated = "2024-11-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
+++ b/providers/abacus/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-01"
 last_updated = "2025-07-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/Qwen/Qwen3-32B.toml
+++ b/providers/abacus/models/Qwen/Qwen3-32B.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-29"
 last_updated = "2025-04-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/Qwen/qwen3-coder-480b-a35b-instruct.toml
+++ b/providers/abacus/models/Qwen/qwen3-coder-480b-a35b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-22"
 last_updated = "2025-07-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/claude-3-7-sonnet-20250219.toml
+++ b/providers/abacus/models/claude-3-7-sonnet-20250219.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10-31"

--- a/providers/abacus/models/claude-haiku-4-5-20251001.toml
+++ b/providers/abacus/models/claude-haiku-4-5-20251001.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/abacus/models/claude-opus-4-1-20250805.toml
+++ b/providers/abacus/models/claude-opus-4-1-20250805.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/abacus/models/claude-opus-4-20250514.toml
+++ b/providers/abacus/models/claude-opus-4-20250514.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-14"
 last_updated = "2025-05-14"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/abacus/models/claude-opus-4-5-20251101.toml
+++ b/providers/abacus/models/claude-opus-4-5-20251101.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/abacus/models/claude-opus-4-6.toml
+++ b/providers/abacus/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/abacus/models/claude-sonnet-4-20250514.toml
+++ b/providers/abacus/models/claude-sonnet-4-20250514.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-14"
 last_updated = "2025-05-14"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/abacus/models/claude-sonnet-4-5-20250929.toml
+++ b/providers/abacus/models/claude-sonnet-4-5-20250929.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-07-31"

--- a/providers/abacus/models/claude-sonnet-4-6.toml
+++ b/providers/abacus/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/abacus/models/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/abacus/models/deepseek-ai/DeepSeek-R1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/deepseek-ai/DeepSeek-V3.1-Terminus.toml
+++ b/providers/abacus/models/deepseek-ai/DeepSeek-V3.1-Terminus.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-01"
 last_updated = "2025-06-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/deepseek-ai/DeepSeek-V3.2.toml
+++ b/providers/abacus/models/deepseek-ai/DeepSeek-V3.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-15"
 last_updated = "2025-06-15"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/deepseek/deepseek-v3.1.toml
+++ b/providers/abacus/models/deepseek/deepseek-v3.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/gemini-2.5-flash.toml
+++ b/providers/abacus/models/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/abacus/models/gemini-2.5-pro.toml
+++ b/providers/abacus/models/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-25"
 last_updated = "2025-03-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/abacus/models/gemini-3-flash-preview.toml
+++ b/providers/abacus/models/gemini-3-flash-preview.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/abacus/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/abacus/models/gemini-3.1-flash-lite-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/abacus/models/gemini-3.1-pro-preview.toml
+++ b/providers/abacus/models/gemini-3.1-pro-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/abacus/models/gpt-5-codex.toml
+++ b/providers/abacus/models/gpt-5-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/abacus/models/gpt-5-mini.toml
+++ b/providers/abacus/models/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/abacus/models/gpt-5-nano.toml
+++ b/providers/abacus/models/gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/abacus/models/gpt-5.1-chat-latest.toml
+++ b/providers/abacus/models/gpt-5.1-chat-latest.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/abacus/models/gpt-5.1-codex-max.toml
+++ b/providers/abacus/models/gpt-5.1-codex-max.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/abacus/models/gpt-5.1-codex.toml
+++ b/providers/abacus/models/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/abacus/models/gpt-5.1.toml
+++ b/providers/abacus/models/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/abacus/models/gpt-5.2-chat-latest.toml
+++ b/providers/abacus/models/gpt-5.2-chat-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-01"
 last_updated = "2026-01-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/abacus/models/gpt-5.2-codex.toml
+++ b/providers/abacus/models/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/abacus/models/gpt-5.2.toml
+++ b/providers/abacus/models/gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/abacus/models/gpt-5.3-chat-latest.toml
+++ b/providers/abacus/models/gpt-5.3-chat-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/abacus/models/gpt-5.3-codex-xhigh.toml
+++ b/providers/abacus/models/gpt-5.3-codex-xhigh.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/abacus/models/gpt-5.3-codex.toml
+++ b/providers/abacus/models/gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/abacus/models/gpt-5.4.toml
+++ b/providers/abacus/models/gpt-5.4.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/abacus/models/gpt-5.toml
+++ b/providers/abacus/models/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/abacus/models/grok-4-0709.toml
+++ b/providers/abacus/models/grok-4-0709.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/abacus/models/kimi-k2.5.toml
+++ b/providers/abacus/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 structured_output = true
 temperature = true
 tool_call = true

--- a/providers/abacus/models/o3-mini.toml
+++ b/providers/abacus/models/o3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-20"
 last_updated = "2025-01-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/abacus/models/o3-pro.toml
+++ b/providers/abacus/models/o3-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-10"
 last_updated = "2025-06-10"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/abacus/models/o3.toml
+++ b/providers/abacus/models/o3.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/abacus/models/o4-mini.toml
+++ b/providers/abacus/models/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/abacus/models/openai/gpt-oss-120b.toml
+++ b/providers/abacus/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/qwen3-max.toml
+++ b/providers/abacus/models/qwen3-max.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/abacus/models/zai-org/glm-4.5.toml
+++ b/providers/abacus/models/zai-org/glm-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-28"
 last_updated = "2025-07-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/abacus/models/zai-org/glm-5.toml
+++ b/providers/abacus/models/zai-org/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- cover all 47 reasoning-capable Abacus models with explicit `reasoning_options`
- expose only GPT-OSS 120B's provider-advertised `low`, `medium`, and `high` effort levels
- mark the other 46 models as fixed reasoning with `reasoning_options = []`
- avoid inferred family aliases, toggles, and token budgets

## Provider evidence
- Abacus's live `https://routellm.abacus.ai/v1/models` catalog explicitly describes GPT-OSS 120B as supporting configurable reasoning effort levels
- the same catalog exposes only a boolean `thinking` route characteristic for other models and publishes fixed variants such as `gpt-5.3-codex-xhigh`; no distinct graded controls or exact finite budget bounds are advertised

## Validation
- `bun validate`
- `git diff --check`
- coverage audit: 47 reasoning models, 47 declarations, 46 fixed, 1 graded
- leak audit: 0 declarations on non-reasoning models; 0 toggles, budgets, or unsupported effort aliases
- diff audit: 47 files changed, 47 insertions, 0 deletions