### PR TITLE
[cloudflare-ai-gateway] Add reasoning options

### DIFF
--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-fable-5.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-fable-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 10

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-1.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-5.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-7.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-8.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-07-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.1-codex.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.1.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.2-codex.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.2.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.3-codex.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.4.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.4.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.5.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/cloudflare-ai-gateway/models/openai/o1.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/o1.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-05"
 last_updated = "2024-12-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2023-09"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/o3-mini.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/o3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-20"
 last_updated = "2025-01-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/o3-pro.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/o3-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-10"
 last_updated = "2025-06-10"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/o3.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/o3.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/openai/o4-mini.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.5.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 structured_output = true
 temperature = true
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.6.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 structured_output = true
 temperature = true
 tool_call = true

--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/nvidia/nemotron-3-120b-a12b.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/nvidia/nemotron-3-120b-a12b.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/zai-org/glm-4.7-flash.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/zai-org/glm-4.7-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"


### PR DESCRIPTION
## Summary
- backfill `reasoning_options` for all 27 existing reasoning-capable Cloudflare AI Gateway models
- model the Unified OpenAI-compatible route using its effective normalized controls
- retain route-specific OpenAI effort subsets, native Anthropic handling for Claude Opus 4.7, and Workers AI toggle/effort controls

## Validation
- `bun validate`
- `git diff --check origin/dev...HEAD`