### PR TITLE
[chutes] Add reasoning options

### DIFF
--- a/providers/chutes/models/MiniMaxAI/MiniMax-M2.5-TEE.toml
+++ b/providers/chutes/models/MiniMaxAI/MiniMax-M2.5-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "minimax/MiniMax-M2.5"
 name = "MiniMax M2.5 TEE"
+reasoning_options = []
 structured_output = true
 
 [interleaved]

--- a/providers/chutes/models/NousResearch/Hermes-4-14B.toml
+++ b/providers/chutes/models/NousResearch/Hermes-4-14B.toml
@@ -6,6 +6,7 @@ release_date = "2025-12-29"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
+++ b/providers/chutes/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
@@ -6,6 +6,7 @@ release_date = "2025-12-29"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/Qwen/Qwen3-30B-A3B.toml
+++ b/providers/chutes/models/Qwen/Qwen3-30B-A3B.toml
@@ -6,6 +6,7 @@ release_date = "2025-12-29"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/Qwen/Qwen3-32B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3-32B-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "alibaba/qwen3-32b"
 name = "Qwen3 32B TEE"
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
 
 [cost]

--- a/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "alibaba/qwen3.5-397b-a17b"
 name = "Qwen3.5 397B A17B TEE"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "alibaba/qwen3.6-27b"
 name = "Qwen3.6 27B TEE"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.195

--- a/providers/chutes/models/deepseek-ai/DeepSeek-R1-0528-TEE.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-R1-0528-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "deepseek/deepseek-r1"
 name = "DeepSeek R1 0528 TEE"
+reasoning_options = []
 structured_output = true
 
 [interleaved]

--- a/providers/chutes/models/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-R1-Distill-Llama-70B.toml
@@ -6,6 +6,7 @@ release_date = "2025-12-29"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/deepseek-ai/DeepSeek-V3.1-TEE.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V3.1-TEE.toml
@@ -6,6 +6,7 @@ release_date = "2025-12-29"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/deepseek-ai/DeepSeek-V3.2-TEE.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V3.2-TEE.toml
@@ -6,6 +6,7 @@ release_date = "2025-12-29"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
+++ b/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "google/gemma-4-31b-it"
 name = "gemma 4 31B turbo TEE"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.13

--- a/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K2.5-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "moonshotai/kimi-k2.5"
 name = "Kimi K2.5 TEE"
+reasoning_options = [{ type = "toggle" }]
 attachment = true
 temperature = true
 knowledge = "2024-10"

--- a/providers/chutes/models/moonshotai/Kimi-K2.6-TEE.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K2.6-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "moonshotai/kimi-k2.6"
 name = "Kimi K2.6 TEE"
+reasoning_options = [{ type = "toggle" }]
 knowledge = "2025-12"
 
 [interleaved]

--- a/providers/chutes/models/openai/gpt-oss-120b-TEE.toml
+++ b/providers/chutes/models/openai/gpt-oss-120b-TEE.toml
@@ -6,6 +6,7 @@ release_date = "2025-12-29"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/tngtech/DeepSeek-TNG-R1T2-Chimera-TEE.toml
+++ b/providers/chutes/models/tngtech/DeepSeek-TNG-R1T2-Chimera-TEE.toml
@@ -6,6 +6,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/zai-org/GLM-4.6V.toml
+++ b/providers/chutes/models/zai-org/GLM-4.6V.toml
@@ -6,6 +6,7 @@ release_date = "2025-12-29"
 last_updated = "2026-04-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/zai-org/GLM-4.7-FP8.toml
+++ b/providers/chutes/models/zai-org/GLM-4.7-FP8.toml
@@ -6,6 +6,7 @@ release_date = "2026-01-27"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/zai-org/GLM-4.7-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-4.7-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "zhipuai/glm-4.7"
 name = "GLM 4.7 TEE"
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
 
 [interleaved]

--- a/providers/chutes/models/zai-org/GLM-5-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-5-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "zhipuai/glm-5"
 name = "GLM 5 TEE"
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
 
 [interleaved]

--- a/providers/chutes/models/zai-org/GLM-5-Turbo.toml
+++ b/providers/chutes/models/zai-org/GLM-5-Turbo.toml
@@ -6,6 +6,7 @@ release_date = "2026-03-11"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/chutes/models/zai-org/GLM-5.1-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-5.1-TEE.toml
@@ -2,6 +2,7 @@
 # Manual overrides preserved on re-run: name, family, knowledge, interleaved, status
 base_model = "zhipuai/glm-5.1"
 name = "GLM 5.1 TEE"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Summary
- record binary thinking controls for Chutes hybrid model templates
- mark fixed-thinking models with no configurable controls
- expose GPT-OSS low, medium, and high reasoning effort
- omit token budgets because Chutes publishes no finite bounds

## Validation
- `bun validate`
- resolved provider audit: 22 reasoning models, 0 missing, 0 leaked
- `git diff --check`