### PR TITLE
[aihubmix] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/alicloud-deepseek-v4-flash.toml
+++ b/providers/aihubmix/models/alicloud-deepseek-v4-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/alicloud-deepseek-v4-pro.toml
+++ b/providers/aihubmix/models/alicloud-deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/alicloud-glm-5.1.toml
+++ b/providers/aihubmix/models/alicloud-glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-6-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-6-think.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-6.toml
+++ b/providers/aihubmix/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-7-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-7-think.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-7.toml
+++ b/providers/aihubmix/models/claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-sonnet-4-6-think.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6-think.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-sonnet-4-6.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-glm-5.1-free.toml
+++ b/providers/aihubmix/models/coding-glm-5.1-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-11"
 last_updated = "2026-04-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-glm-5.1.toml
+++ b/providers/aihubmix/models/coding-glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-11"
 last_updated = "2026-04-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-minimax-m2.7-free.toml
+++ b/providers/aihubmix/models/coding-minimax-m2.7-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-minimax-m2.7-highspeed.toml
+++ b/providers/aihubmix/models/coding-minimax-m2.7-highspeed.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-minimax-m2.7.toml
+++ b/providers/aihubmix/models/coding-minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-xiaomi-mimo-v2.5-pro.toml
+++ b/providers/aihubmix/models/coding-xiaomi-mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "Coding Xiaomi MiMo-V2.5-Pro"
 family = "mimo-v2.5-pro"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/coding-xiaomi-mimo-v2.5.toml
+++ b/providers/aihubmix/models/coding-xiaomi-mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 name = "Coding Xiaomi MiMo-V2.5"
 family = "mimo-v2.5"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/deep-deepseek-v4-flash.toml
+++ b/providers/aihubmix/models/deep-deepseek-v4-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/deep-deepseek-v4-pro.toml
+++ b/providers/aihubmix/models/deep-deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-code-preview.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-code-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-lite-260428.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-mini-260428.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-pro.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-2.5-flash.toml
+++ b/providers/aihubmix/models/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-2.5-pro.toml
+++ b/providers/aihubmix/models/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-3-flash-preview.toml
+++ b/providers/aihubmix/models/gemini-3-flash-preview.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-3.1-flash-lite.toml
+++ b/providers/aihubmix/models/gemini-3.1-flash-lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-07"
 last_updated = "2026-05-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/aihubmix/models/gemini-3.1-pro-preview-customtools.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-3.1-pro-preview.toml
+++ b/providers/aihubmix/models/gemini-3.1-pro-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/glm-5v-turbo.toml
+++ b/providers/aihubmix/models/glm-5v-turbo.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gpt-5.1-codex-mini.toml
+++ b/providers/aihubmix/models/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.1-codex.toml
+++ b/providers/aihubmix/models/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.1.toml
+++ b/providers/aihubmix/models/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.2-codex.toml
+++ b/providers/aihubmix/models/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.2.toml
+++ b/providers/aihubmix/models/gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.3-codex.toml
+++ b/providers/aihubmix/models/gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.4-mini.toml
+++ b/providers/aihubmix/models/gpt-5.4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.4.toml
+++ b/providers/aihubmix/models/gpt-5.4.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.5.toml
+++ b/providers/aihubmix/models/gpt-5.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-12-01"
 tool_call = true

--- a/providers/aihubmix/models/grok-4.3.toml
+++ b/providers/aihubmix/models/grok-4.3.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/kimi-k2.5.toml
+++ b/providers/aihubmix/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/kimi-k2.6.toml
+++ b/providers/aihubmix/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/minimax-m2.7.toml
+++ b/providers/aihubmix/models/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/qwen3.6-flash.toml
+++ b/providers/aihubmix/models/qwen3.6-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/qwen3.6-max-preview.toml
+++ b/providers/aihubmix/models/qwen3.6-max-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/qwen3.6-plus.toml
+++ b/providers/aihubmix/models/qwen3.6-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/xiaomi-mimo-v2.5-free.toml
+++ b/providers/aihubmix/models/xiaomi-mimo-v2.5-free.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 name = "Xiaomi MiMo-V2.5 (free)"
 family = "mimo-v2.5"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/xiaomi-mimo-v2.5-pro-free.toml
+++ b/providers/aihubmix/models/xiaomi-mimo-v2.5-pro-free.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "Xiaomi MiMo-V2.5-Pro (free)"
 family = "mimo-v2.5-pro"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/xiaomi-mimo-v2.5-pro.toml
+++ b/providers/aihubmix/models/xiaomi-mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "Xiaomi MiMo-V2.5-Pro"
 family = "mimo-v2.5-pro"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/xiaomi-mimo-v2.5.toml
+++ b/providers/aihubmix/models/xiaomi-mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 name = "Xiaomi MiMo-V2.5"
 family = "mimo-v2.5"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/zai-glm-5.1.toml
+++ b/providers/aihubmix/models/zai-glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- backfill `reasoning_options` for all 50 effective AIHubMix reasoning models
- reflect the npm provider router: Claude Messages, native Gemini GenerateContent, and OpenAI-compatible Chat Completions for other models
- cover 6 inherited Xiaomi MiMo V2.5/Pro aliases with their binary thinking toggle
- keep binary and fixed-reasoning models from advertising ineffective effort levels
- bound Claude thinking budgets to finite values below route output limits

## Coverage
- 50 reasoning-capable models
- 50 explicit provider-local declarations
- 6 current effective gaps added after merging latest `dev`
- 0 missing declarations, 0 non-reasoning leaks, 0 invalid budgets

## Validation
- `bun validate`
- resolved AIHubMix coverage audit
- `git diff --check`
- 50 existing files changed, 50 `reasoning_options` insertions, no other provider-model metadata changes