### PR TITLE
[cortecs] Add reasoning options

### DIFF
--- a/providers/cortecs/models/claude-4-5-sonnet.toml
+++ b/providers/cortecs/models/claude-4-5-sonnet.toml
@@ -5,6 +5,7 @@ last_updated = "2025-09-29"
 knowledge = "2025-07-31"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 tool_call = true
 temperature = true
 open_weights = false

--- a/providers/cortecs/models/claude-4-6-sonnet.toml
+++ b/providers/cortecs/models/claude-4-6-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/cortecs/models/claude-haiku-4-5.toml
+++ b/providers/cortecs/models/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/cortecs/models/claude-opus4-5.toml
+++ b/providers/cortecs/models/claude-opus4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cortecs/models/claude-opus4-6.toml
+++ b/providers/cortecs/models/claude-opus4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/cortecs/models/claude-opus4-7.toml
+++ b/providers/cortecs/models/claude-opus4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/cortecs/models/claude-opus4-8.toml
+++ b/providers/cortecs/models/claude-opus4-8.toml
@@ -1,8 +1,8 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5.64
 output = 28.198
 cache_read = 0.563
 cache_write = 7.049
-

--- a/providers/cortecs/models/deepseek-r1-0528.toml
+++ b/providers/cortecs/models/deepseek-r1-0528.toml
@@ -5,6 +5,7 @@ last_updated = "2025-05-28"
 knowledge = "2024-07"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/deepseek-v3.2.toml
+++ b/providers/cortecs/models/deepseek-v3.2.toml
@@ -5,6 +5,7 @@ last_updated = "2025-12-01"
 knowledge = "2024-07"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/deepseek-v4-flash.toml
+++ b/providers/cortecs/models/deepseek-v4-flash.toml
@@ -1,5 +1,6 @@
 base_model = "deepseek/deepseek-v4-flash"
 base_model_omit = ["structured_output"]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/cortecs/models/deepseek-v4-pro.toml
+++ b/providers/cortecs/models/deepseek-v4-pro.toml
@@ -1,5 +1,6 @@
 base_model = "deepseek/deepseek-v4-pro"
 base_model_omit = ["structured_output"]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/cortecs/models/glm-4.5-air.toml
+++ b/providers/cortecs/models/glm-4.5-air.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-01"
 last_updated = "2025-08-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-4.5.toml
+++ b/providers/cortecs/models/glm-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-4.7-flash.toml
+++ b/providers/cortecs/models/glm-4.7-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-4.7.toml
+++ b/providers/cortecs/models/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-5.1.toml
+++ b/providers/cortecs/models/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-14"
 last_updated = "2026-04-14"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
 temperature = true
 tool_call = true

--- a/providers/cortecs/models/glm-5.toml
+++ b/providers/cortecs/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/gpt-5.4.toml
+++ b/providers/cortecs/models/gpt-5.4.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.4"
 base_model_omit = ["limit.input"]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 3

--- a/providers/cortecs/models/gpt-oss-120b.toml
+++ b/providers/cortecs/models/gpt-oss-120b.toml
@@ -5,6 +5,7 @@ last_updated = "2025-08-05"
 knowledge = "2024-01"
 attachment = false
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/hermes-4-70b.toml
+++ b/providers/cortecs/models/hermes-4-70b.toml
@@ -4,6 +4,7 @@ last_updated = "2025-08-26"
 knowledge = "2023-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/intellect-3.toml
+++ b/providers/cortecs/models/intellect-3.toml
@@ -4,6 +4,7 @@ last_updated = "2025-11-26"
 knowledge = "2025-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/kimi-k2-thinking.toml
+++ b/providers/cortecs/models/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ last_updated = "2025-12-08"
 knowledge = "2025-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/kimi-k2.5.toml
+++ b/providers/cortecs/models/kimi-k2.5.toml
@@ -5,6 +5,7 @@ last_updated = "2026-01-27"
 knowledge = "2025-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/kimi-k2.6.toml
+++ b/providers/cortecs/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-17"
 last_updated = "2026-04-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/llama-3.3-70b-instruct.toml
+++ b/providers/cortecs/models/llama-3.3-70b-instruct.toml
@@ -2,6 +2,7 @@ base_model = "meta/llama-3.3-70b-instruct"
 name = "Llama 3.3 70B Instruct"
 attachment = false
 reasoning = true
+reasoning_options = []
 
 [cost]
 input = 0.089

--- a/providers/cortecs/models/minimax-m2.1.toml
+++ b/providers/cortecs/models/minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/minimax-m2.5.toml
+++ b/providers/cortecs/models/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/minimax-m2.7.toml
+++ b/providers/cortecs/models/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/cortecs/models/minimax-m2.toml
+++ b/providers/cortecs/models/minimax-m2.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-27"
 last_updated = "2025-10-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-11"
 tool_call = true

--- a/providers/cortecs/models/mixtral-8x7B-instruct-v0.1.toml
+++ b/providers/cortecs/models/mixtral-8x7B-instruct-v0.1.toml
@@ -4,6 +4,7 @@ last_updated = "2023-12-11"
 knowledge = "2023-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/nemotron-3-super-120b-a12b.toml
+++ b/providers/cortecs/models/nemotron-3-super-120b-a12b.toml
@@ -5,6 +5,7 @@ last_updated = "2026-03-11"
 knowledge = "2025-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/cortecs/models/qwen3-235b-a22b-instruct-2507.toml
@@ -5,6 +5,7 @@ last_updated = "2025-07-23"
 knowledge = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/cortecs/models/qwen3-coder-30b-a3b-instruct.toml
@@ -3,6 +3,7 @@ name = "Qwen3 Coder 30B A3B Instruct"
 release_date = "2025-07-31"
 last_updated = "2025-07-31"
 reasoning = true
+reasoning_options = []
 
 [cost]
 input = 0.053

--- a/providers/cortecs/models/qwen3-coder-next.toml
+++ b/providers/cortecs/models/qwen3-coder-next.toml
@@ -5,6 +5,7 @@ last_updated = "2026-02-04"
 knowledge = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/cortecs/models/qwen3-next-80b-a3b-thinking.toml
@@ -4,6 +4,7 @@ last_updated = "2025-09-11"
 knowledge = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/qwen3.5-122b-a10b.toml
+++ b/providers/cortecs/models/qwen3.5-122b-a10b.toml
@@ -1,5 +1,6 @@
 base_model = "alibaba/qwen3.5-122b-a10b"
 base_model_omit = ["structured_output"]
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen3.5 122B A10B"
 release_date = "2026-02-24"
 last_updated = "2026-02-24"

--- a/providers/cortecs/models/qwen3.5-397b-a17b.toml
+++ b/providers/cortecs/models/qwen3.5-397b-a17b.toml
@@ -1,5 +1,6 @@
 base_model = "alibaba/qwen3.5-397b-a17b"
 base_model_omit = ["structured_output"]
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen3.5 397B A17B"
 release_date = "2026-02-16"
 last_updated = "2026-02-16"


### PR DESCRIPTION
## Summary
- add explicit `reasoning_options` to 37 existing Cortecs model entries
- cover the newly added `gpt-5.4` route with Cortecs-supported `low`, `medium`, and `high` effort
- keep MiniMax and fixed/unresolved reasoning models non-configurable with `[]`
- expose only documented model-specific GLM, Kimi, and Qwen toggles
- expose Cortecs-supported `low`, `medium`, and `high` effort for GPT-OSS and Anthropic routes
- bound all Anthropic token budgets with finite model-specific minima and maxima
- leave DeepSeek V4 controls unresolved because Cortecs documents `low|medium|high`, while the upstream model supports only meaningful `high|max` and Cortecs does not document forwarding `max`

## Validation
- rebased onto latest `dev`
- `bun validate`
- `git diff --check origin/dev...HEAD`
- effective generated-catalog reasoning coverage invariant: 0 Cortecs reasoning models missing options
- scope invariant: only existing `providers/cortecs/models/*.toml` entries and `reasoning_options` changed

## Sources
- Cortecs reasoning controls: https://docs.cortecs.ai/usage/reasoning
- Cortecs chat completions/pass-through behavior: https://docs.cortecs.ai/api-overview/chat-completions
- Cortecs live model routes/providers: https://api.cortecs.ai/v1/models
- MiniMax M2.x fixed thinking: https://platform.minimax.io/docs/api-reference/text-openai-api
- GLM thinking modes: https://docs.z.ai/guides/capabilities/thinking-mode
- Kimi thinking controls: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
- Qwen thinking controls: https://qwen.readthedocs.io/en/latest/deployment/vllm.html
- Qwen3-Coder-Next fixed non-thinking mode: https://huggingface.co/Qwen/Qwen3-Coder-Next
- DeepSeek V4 effort semantics: https://api-docs.deepseek.com/guides/thinking_mode
- GPT-OSS effort levels: https://developers.openai.com/cookbook/articles/openai-harmony