### PR TITLE
[302ai] Add reasoning options

### DIFF
--- a/providers/302ai/models/claude-haiku-4-5-20251001.toml
+++ b/providers/302ai/models/claude-haiku-4-5-20251001.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-16"
 last_updated = "2025-10-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-haiku-4-5.toml
+++ b/providers/302ai/models/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-16"
 last_updated = "2025-10-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-1-20250805-thinking.toml
+++ b/providers/302ai/models/claude-opus-4-1-20250805-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-27"
 last_updated = "2025-05-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-1-20250805.toml
+++ b/providers/302ai/models/claude-opus-4-1-20250805.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 31999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-20250514.toml
+++ b/providers/302ai/models/claude-opus-4-20250514.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 31999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-5-20251101-thinking.toml
+++ b/providers/302ai/models/claude-opus-4-5-20251101-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-5-20251101.toml
+++ b/providers/302ai/models/claude-opus-4-5-20251101.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-5.toml
+++ b/providers/302ai/models/claude-opus-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-6-thinking.toml
+++ b/providers/302ai/models/claude-opus-4-6-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-06"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-6.toml
+++ b/providers/302ai/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-06"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 127999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-7.toml
+++ b/providers/302ai/models/claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-17"
 last_updated = "2026-04-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-20250514.toml
+++ b/providers/302ai/models/claude-sonnet-4-20250514.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-5-20250929-thinking.toml
+++ b/providers/302ai/models/claude-sonnet-4-5-20250929-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-5-20250929.toml
+++ b/providers/302ai/models/claude-sonnet-4-5-20250929.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-5.toml
+++ b/providers/302ai/models/claude-sonnet-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-6-thinking.toml
+++ b/providers/302ai/models/claude-sonnet-4-6-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-18"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-6.toml
+++ b/providers/302ai/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-18"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/deepseek-reasoner.toml
+++ b/providers/302ai/models/deepseek-reasoner.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/deepseek-v3.2-thinking.toml
+++ b/providers/302ai/models/deepseek-v3.2-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/doubao-seed-1-6-thinking-250715.toml
+++ b/providers/302ai/models/doubao-seed-1-6-thinking-250715.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-15"
 last_updated = "2025-07-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/glm-4.5-air.toml
+++ b/providers/302ai/models/glm-4.5-air.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.5.toml
+++ b/providers/302ai/models/glm-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.5v.toml
+++ b/providers/302ai/models/glm-4.5v.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-12"
 last_updated = "2025-08-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.6.toml
+++ b/providers/302ai/models/glm-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.6v.toml
+++ b/providers/302ai/models/glm-4.6v.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.7-flashx.toml
+++ b/providers/302ai/models/glm-4.7-flashx.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-20"
 last_updated = "2026-01-20"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.7.toml
+++ b/providers/302ai/models/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-5-turbo.toml
+++ b/providers/302ai/models/glm-5-turbo.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/glm-5.1.toml
+++ b/providers/302ai/models/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-10"
 last_updated = "2026-04-10"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/glm-5.toml
+++ b/providers/302ai/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-5v-turbo.toml
+++ b/providers/302ai/models/glm-5v-turbo.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/glm-for-coding.toml
+++ b/providers/302ai/models/glm-for-coding.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/gpt-5-mini.toml
+++ b/providers/302ai/models/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5-pro.toml
+++ b/providers/302ai/models/gpt-5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-08"
 last_updated = "2025-10-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5-thinking.toml
+++ b/providers/302ai/models/gpt-5-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/gpt-5.1-chat-latest.toml
+++ b/providers/302ai/models/gpt-5.1-chat-latest.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-14"
 last_updated = "2025-11-14"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.1.toml
+++ b/providers/302ai/models/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-14"
 last_updated = "2025-11-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.2-chat-latest.toml
+++ b/providers/302ai/models/gpt-5.2-chat-latest.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-12"
 last_updated = "2025-12-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.2.toml
+++ b/providers/302ai/models/gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-12"
 last_updated = "2025-12-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-mini-2026-03-17.toml
+++ b/providers/302ai/models/gpt-5.4-mini-2026-03-17.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-mini.toml
+++ b/providers/302ai/models/gpt-5.4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-nano-2026-03-17.toml
+++ b/providers/302ai/models/gpt-5.4-nano-2026-03-17.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-nano.toml
+++ b/providers/302ai/models/gpt-5.4-nano.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-pro.toml
+++ b/providers/302ai/models/gpt-5.4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = false

--- a/providers/302ai/models/gpt-5.4.toml
+++ b/providers/302ai/models/gpt-5.4.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.toml
+++ b/providers/302ai/models/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/grok-4-1-fast-reasoning.toml
+++ b/providers/302ai/models/grok-4-1-fast-reasoning.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-20"
 last_updated = "2025-11-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/grok-4-fast-reasoning.toml
+++ b/providers/302ai/models/grok-4-fast-reasoning.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-23"
 last_updated = "2025-09-23"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/grok-4.20-beta-0309-reasoning.toml
+++ b/providers/302ai/models/grok-4.20-beta-0309-reasoning.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/grok-4.20-multi-agent-beta-0309.toml
+++ b/providers/302ai/models/grok-4.20-multi-agent-beta-0309.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/kimi-k2-thinking-turbo.toml
+++ b/providers/302ai/models/kimi-k2-thinking-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/kimi-k2-thinking.toml
+++ b/providers/302ai/models/kimi-k2-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
## Summary
- classify all 52 effective `reasoning = true` 302AI models with provider-local `reasoning_options`
- expose only distinct controls supported by the model and 302AI request route
- mark fixed or unresolved reasoning routes with `[]`

## Classification
- 20 fixed/unresolved: `[]`
- 11 GLM toggles
- 10 GPT effort controls
- 11 Claude toggle + bounded token-budget controls

## Evidence
- 302AI Claude thinking contract documents `thinking.type = enabled` and `budget_tokens`: https://doc.302.ai/264079796e0
- 302AI GLM contract documents `thinking.type` for GLM 4.5+ and distinguishes auto/forced thinking behavior: https://doc.302.ai/160231357e0
- 302AI OpenAI reasoning contract documents `reasoning_effort`: https://doc.302.ai/285584960e0
- 302AI Kimi contract exposes no reasoning selector: https://doc.302.ai/160379433e0.md
- 302AI DeepSeek contract lists fixed reasoning model routes without a reasoning selector: https://doc.302.ai/171145944e0.md
- 302AI Doubao contract exposes reasoning output but no reasoning selector: https://doc.302.ai/185706884e0.md

Generic endpoint acceptance was not treated as proof of model-level effort. Fixed thinking aliases, Kimi/DeepSeek/Doubao/Grok routes without distinct provider-proven controls, `glm-for-coding`, fixed GPT variants, and unresolved Claude Opus 4.7 are explicitly `[]`.

## Validation
- `bun validate`
- `git diff --check`
- coverage scan: 52 reasoning models, 0 missing
- no-leak scan: 0 options on non-reasoning models
- budget scan: 11 budgets, all finite and bounded
- scope scan: 52 existing `providers/302ai/models/*.toml` files; only `reasoning_options` additions