### PR TITLE
[frogbot] Add reasoning options

### DIFF
--- a/providers/frogbot/models/claude-haiku-4-5.toml
+++ b/providers/frogbot/models/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/frogbot/models/claude-opus-4-6.toml
+++ b/providers/frogbot/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/frogbot/models/claude-opus-4-7.toml
+++ b/providers/frogbot/models/claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/frogbot/models/claude-sonnet-4-6.toml
+++ b/providers/frogbot/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/frogbot/models/deepseek-v4-pro.toml
+++ b/providers/frogbot/models/deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2026-01"
 tool_call = true

--- a/providers/frogbot/models/gemini-2.5-flash.toml
+++ b/providers/frogbot/models/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-17"
 last_updated = "2025-07-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/frogbot/models/gemini-2.5-pro.toml
+++ b/providers/frogbot/models/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/frogbot/models/gemini-3-1-pro-preview.toml
+++ b/providers/frogbot/models/gemini-3-1-pro-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-18"
 last_updated = "2026-02-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/gemini-3-flash-preview.toml
+++ b/providers/frogbot/models/gemini-3-flash-preview.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/gpt-4o.toml
+++ b/providers/frogbot/models/gpt-4o.toml
@@ -4,6 +4,7 @@ release_date = "2024-05-13"
 last_updated = "2024-08-06"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2023-09"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-3-codex.toml
+++ b/providers/frogbot/models/gpt-5-3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-15"
 last_updated = "2026-02-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2026-01-31"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-4-mini.toml
+++ b/providers/frogbot/models/gpt-5-4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-4-nano.toml
+++ b/providers/frogbot/models/gpt-5-4-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-5.toml
+++ b/providers/frogbot/models/gpt-5-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/frogbot/models/gpt-oss-120b.toml
+++ b/providers/frogbot/models/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/gpt-oss-20b.toml
+++ b/providers/frogbot/models/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/grok-4-1-fast-non-reasoning.toml
+++ b/providers/frogbot/models/grok-4-1-fast-non-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2025-11"
 tool_call = true

--- a/providers/frogbot/models/grok-4-1-fast-reasoning.toml
+++ b/providers/frogbot/models/grok-4-1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-11"
 tool_call = true

--- a/providers/frogbot/models/grok-4-3.toml
+++ b/providers/frogbot/models/grok-4-3.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-11"
 tool_call = true

--- a/providers/frogbot/models/grok-code-fast-1.toml
+++ b/providers/frogbot/models/grok-code-fast-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-28"
 last_updated = "2025-08-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/frogbot/models/kimi-k2-6.toml
+++ b/providers/frogbot/models/kimi-k2-6.toml
@@ -3,6 +3,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/kimi-k2.5.toml
+++ b/providers/frogbot/models/kimi-k2.5.toml
@@ -3,6 +3,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/minimax-m2-5.toml
+++ b/providers/frogbot/models/minimax-m2-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-15"
 last_updated = "2025-02-22"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true

--- a/providers/frogbot/models/minimax-m2-7.toml
+++ b/providers/frogbot/models/minimax-m2-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true

--- a/providers/frogbot/models/qwen-3-6-plus.toml
+++ b/providers/frogbot/models/qwen-3-6-plus.toml
@@ -2,6 +2,7 @@ name = "Qwen 3.6 Plus"
 family = "qwen"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2026-04-02"

--- a/providers/frogbot/models/zai-glm-5-1.toml
+++ b/providers/frogbot/models/zai-glm-5-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-02-22"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-10"
 tool_call = true


### PR DESCRIPTION
## Summary
- add explicit `reasoning_options` metadata to all existing Frogbot chat models
- expose Frogbot-documented `low`, `medium`, and `high` effort controls only for models explicitly identified as reasoning models in Frogbot documentation
- mark unresolved controls as `[]`, including Anthropic thinking budgets because Frogbot documents no upper bound

## Sources
- https://docs.frogbot.ai/api-reference/chat-completions
- https://docs.frogbot.ai/api-reference/models

## Validation
- `bun validate`