### PR TITLE
[gitlab] Add reasoning options

### DIFF
--- a/providers/gitlab/models/duo-chat-fable-5.toml
+++ b/providers/gitlab/models/duo-chat-fable-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-09"
 last_updated = "2026-06-09"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/gitlab/models/duo-chat-gpt-5-1.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-1.toml
@@ -5,6 +5,7 @@ last_updated = "2026-01-22"
 knowledge = "2024-09-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-gpt-5-2-codex.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-2-codex.toml
@@ -5,6 +5,7 @@ last_updated = "2026-01-22"
 knowledge = "2025-08-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-gpt-5-2.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-2.toml
@@ -5,6 +5,7 @@ last_updated = "2026-01-23"
 knowledge = "2025-08-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-gpt-5-3-codex.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-3-codex.toml
@@ -5,6 +5,7 @@ last_updated = "2026-02-05"
 knowledge = "2025-08-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-gpt-5-4-mini.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-4-mini.toml
@@ -5,6 +5,7 @@ last_updated = "2026-03-17"
 knowledge = "2025-08-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-gpt-5-4-nano.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-4-nano.toml
@@ -5,6 +5,7 @@ last_updated = "2026-03-17"
 knowledge = "2025-08-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-gpt-5-4.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-4.toml
@@ -5,6 +5,7 @@ last_updated = "2026-03-05"
 knowledge = "2025-08-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-gpt-5-5.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-5.toml
@@ -5,6 +5,7 @@ last_updated = "2026-04-23"
 knowledge = "2025-08-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-gpt-5-codex.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-codex.toml
@@ -5,6 +5,7 @@ last_updated = "2026-01-22"
 knowledge = "2024-09-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-gpt-5-mini.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-mini.toml
@@ -5,6 +5,7 @@ last_updated = "2026-01-22"
 knowledge = "2024-05-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/gitlab/models/duo-chat-haiku-4-5.toml
+++ b/providers/gitlab/models/duo-chat-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-08"
 last_updated = "2026-01-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/gitlab/models/duo-chat-opus-4-5.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-08"
 last_updated = "2026-01-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/gitlab/models/duo-chat-opus-4-6.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/gitlab/models/duo-chat-opus-4-7.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/gitlab/models/duo-chat-opus-4-8.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-8.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-28"
 last_updated = "2026-05-28"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/gitlab/models/duo-chat-sonnet-4-5.toml
+++ b/providers/gitlab/models/duo-chat-sonnet-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-08"
 last_updated = "2026-01-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-07-31"

--- a/providers/gitlab/models/duo-chat-sonnet-4-6.toml
+++ b/providers/gitlab/models/duo-chat-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"


### PR DESCRIPTION
## Summary
- backfill reasoning options for all 18 existing GitLab Duo Chat reasoning models
- classify every route as fixed-control because GitLab AI Gateway and gitlab-ai-provider do not expose reasoning effort, thinking, or toggle request controls
- avoid inferring upstream OpenAI or Anthropic controls that the GitLab route does not forward

## Validation
- bun validate
- git diff --check