### PR TITLE
[databricks] Add reasoning options

### DIFF
--- a/providers/databricks/models/databricks-claude-haiku-4-5.toml
+++ b/providers/databricks/models/databricks-claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/databricks/models/databricks-claude-opus-4-1.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 15

--- a/providers/databricks/models/databricks-claude-opus-4-5.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-claude-opus-4-6.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-claude-opus-4-7.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-claude-sonnet-4-5.toml
+++ b/providers/databricks/models/databricks-claude-sonnet-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 3

--- a/providers/databricks/models/databricks-claude-sonnet-4-6.toml
+++ b/providers/databricks/models/databricks-claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 3

--- a/providers/databricks/models/databricks-claude-sonnet-4.toml
+++ b/providers/databricks/models/databricks-claude-sonnet-4.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 3

--- a/providers/databricks/models/databricks-gemini-2-5-flash.toml
+++ b/providers/databricks/models/databricks-gemini-2-5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = [{ type = "budget_tokens", min = 0, max = 24_576 }]
 
 [cost]
 input = 0.3

--- a/providers/databricks/models/databricks-gemini-2-5-pro.toml
+++ b/providers/databricks/models/databricks-gemini-2-5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 
 [cost]
 input = 1.25

--- a/providers/databricks/models/databricks-gemini-3-1-flash-lite.toml
+++ b/providers/databricks/models/databricks-gemini-3-1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/databricks/models/databricks-gemini-3-1-pro.toml
+++ b/providers/databricks/models/databricks-gemini-3-1-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview-customtools"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/databricks/models/databricks-gemini-3-flash.toml
+++ b/providers/databricks/models/databricks-gemini-3-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.5

--- a/providers/databricks/models/databricks-gemini-3-pro.toml
+++ b/providers/databricks/models/databricks-gemini-3-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/databricks/models/databricks-gpt-5-1.toml
+++ b/providers/databricks/models/databricks-gpt-5-1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/databricks/models/databricks-gpt-5-2.toml
+++ b/providers/databricks/models/databricks-gpt-5-2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.75

--- a/providers/databricks/models/databricks-gpt-5-4-mini.toml
+++ b/providers/databricks/models/databricks-gpt-5-4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.75

--- a/providers/databricks/models/databricks-gpt-5-4-nano.toml
+++ b/providers/databricks/models/databricks-gpt-5-4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.2

--- a/providers/databricks/models/databricks-gpt-5-4.toml
+++ b/providers/databricks/models/databricks-gpt-5-4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2.5

--- a/providers/databricks/models/databricks-gpt-5-5.toml
+++ b/providers/databricks/models/databricks-gpt-5-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-gpt-5-mini.toml
+++ b/providers/databricks/models/databricks-gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/databricks/models/databricks-gpt-5-nano.toml
+++ b/providers/databricks/models/databricks-gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/databricks/models/databricks-gpt-5.toml
+++ b/providers/databricks/models/databricks-gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/databricks/models/databricks-gpt-oss-120b.toml
+++ b/providers/databricks/models/databricks-gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/databricks/models/databricks-gpt-oss-20b.toml
+++ b/providers/databricks/models/databricks-gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- backfill Databricks Foundation Model API reasoning controls for all existing reasoning models
- preserve Databricks route-specific effort values instead of inheriting unsupported upstream controls
- bound Claude and Gemini thinking budgets and mark Claude Haiku 4.5 as fixed-control

## Validation
- `bun validate`
- `git diff --check origin/dev...HEAD`

## Sources
- https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
- https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference