### PR TITLE
[github-copilot] Add reasoning options

### DIFF
--- a/providers/github-copilot/models/claude-fable-5.toml
+++ b/providers/github-copilot/models/claude-fable-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 10

--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.6.toml
+++ b/providers/github-copilot/models/claude-opus-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.7.toml
+++ b/providers/github-copilot/models/claude-opus-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.8.toml
+++ b/providers/github-copilot/models/claude-opus-4.8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/github-copilot/models/claude-sonnet-4.6.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [cost]
 input = 3

--- a/providers/github-copilot/models/claude-sonnet-4.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-0"
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/github-copilot/models/gemini-2.5-pro.toml
+++ b/providers/github-copilot/models/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/github-copilot/models/gemini-3-flash-preview.toml
+++ b/providers/github-copilot/models/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = []
 
 [cost]
 input = 0.5

--- a/providers/github-copilot/models/gemini-3.1-pro-preview.toml
+++ b/providers/github-copilot/models/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/github-copilot/models/gemini-3.5-flash.toml
+++ b/providers/github-copilot/models/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.5

--- a/providers/github-copilot/models/gpt-5-mini.toml
+++ b/providers/github-copilot/models/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/github-copilot/models/gpt-5.2-codex.toml
+++ b/providers/github-copilot/models/gpt-5.2-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-codex"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/github-copilot/models/gpt-5.2.toml
+++ b/providers/github-copilot/models/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/github-copilot/models/gpt-5.3-codex.toml
+++ b/providers/github-copilot/models/gpt-5.3-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/github-copilot/models/gpt-5.4-mini.toml
+++ b/providers/github-copilot/models/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.75

--- a/providers/github-copilot/models/gpt-5.4-nano.toml
+++ b/providers/github-copilot/models/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/github-copilot/models/gpt-5.4.toml
+++ b/providers/github-copilot/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/github-copilot/models/gpt-5.5.toml
+++ b/providers/github-copilot/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/raptor-mini.toml
+++ b/providers/github-copilot/models/raptor-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true


### PR DESCRIPTION
## Summary
- backfill `reasoning_options` for all 22 reasoning-capable GitHub Copilot model TOMLs
- use Copilot `/models` capability menus and GitHub supported-model documentation rather than upstream-only controls
- mark fixed aliases with empty options and omit unadvertised toggles and token budgets

## Control matrix
- effort menus: 12 models
- fixed aliases: 10 models
- standalone toggles: 0 models advertised by Copilot
- token budgets: 0

## Validation
- `bun validate`