### PR TITLE
[github-models] Add reasoning options

### DIFF
--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-29"
 last_updated = "2024-08-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-29"
 last_updated = "2024-08-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-a.toml
+++ b/providers/github-models/models/cohere/cohere-command-a.toml
@@ -4,6 +4,7 @@ release_date = "2024-11-01"
 last_updated = "2024-11-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-01"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-01"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r-plus.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-04"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r.toml
+++ b/providers/github-models/models/cohere/cohere-command-r.toml
@@ -4,6 +4,7 @@ release_date = "2024-03-11"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/core42/jais-30b-chat.toml
+++ b/providers/github-models/models/core42/jais-30b-chat.toml
@@ -4,6 +4,7 @@ release_date = "2023-08-30"
 last_updated = "2023-08-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-03"
 tool_call = true

--- a/providers/github-models/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/deepseek/deepseek-r1.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/deepseek/deepseek-v3-0324.toml
+++ b/providers/github-models/models/deepseek/deepseek-v3-0324.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-24"
 last_updated = "2025-03-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/meta/llama-3.2-11b-vision-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.2-11b-vision-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-25"
 last_updated = "2024-09-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/llama-3.2-90b-vision-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.2-90b-vision-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-25"
 last_updated = "2024-09-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/llama-3.3-70b-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.3-70b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-06"
 last_updated = "2024-12-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
+++ b/providers/github-models/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-12"
 tool_call = true

--- a/providers/github-models/models/meta/llama-4-scout-17b-16e-instruct.toml
+++ b/providers/github-models/models/meta/llama-4-scout-17b-16e-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3-70b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3-70b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-18"
 last_updated = "2024-04-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3-8b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3-8b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-18"
 last_updated = "2024-04-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3.1-405b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-405b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-23"
 last_updated = "2024-07-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3.1-70b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-70b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-23"
 last_updated = "2024-07-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3.1-8b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-8b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-23"
 last_updated = "2024-07-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/microsoft/mai-ds-r1.toml
+++ b/providers/github-models/models/microsoft/mai-ds-r1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-medium-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-medium-128k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-medium-4k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-medium-4k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-mini-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-mini-128k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-mini-4k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-mini-4k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-small-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-small-128k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-small-8k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-small-8k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3.5-mini-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-mini-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-20"
 last_updated = "2024-08-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3.5-moe-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-moe-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-20"
 last_updated = "2024-08-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3.5-vision-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-vision-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-20"
 last_updated = "2024-08-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4-mini-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-4-mini-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4-mini-reasoning.toml
+++ b/providers/github-models/models/microsoft/phi-4-mini-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4-multimodal-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-4-multimodal-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4-reasoning.toml
+++ b/providers/github-models/models/microsoft/phi-4-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4.toml
+++ b/providers/github-models/models/microsoft/phi-4.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/codestral-2501.toml
+++ b/providers/github-models/models/mistral-ai/codestral-2501.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-01"
 last_updated = "2025-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/ministral-3b.toml
+++ b/providers/github-models/models/mistral-ai/ministral-3b.toml
@@ -4,6 +4,7 @@ release_date = "2024-10-22"
 last_updated = "2024-10-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/mistral-large-2411.toml
+++ b/providers/github-models/models/mistral-ai/mistral-large-2411.toml
@@ -4,6 +4,7 @@ release_date = "2024-11-01"
 last_updated = "2024-11-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/mistral-medium-2505.toml
+++ b/providers/github-models/models/mistral-ai/mistral-medium-2505.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-01"
 last_updated = "2025-05-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/mistral-nemo.toml
+++ b/providers/github-models/models/mistral-ai/mistral-nemo.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-18"
 last_updated = "2024-07-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/mistral-small-2503.toml
+++ b/providers/github-models/models/mistral-ai/mistral-small-2503.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-01"
 last_updated = "2025-03-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4.1-mini.toml
+++ b/providers/github-models/models/openai/gpt-4.1-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4.1-nano.toml
+++ b/providers/github-models/models/openai/gpt-4.1-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4.1.toml
+++ b/providers/github-models/models/openai/gpt-4.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4o-mini.toml
+++ b/providers/github-models/models/openai/gpt-4o-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-18"
 last_updated = "2024-07-18"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4o.toml
+++ b/providers/github-models/models/openai/gpt-4o.toml
@@ -4,6 +4,7 @@ release_date = "2024-05-13"
 last_updated = "2024-05-13"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/openai/o1-mini.toml
+++ b/providers/github-models/models/openai/o1-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o1-preview.toml
+++ b/providers/github-models/models/openai/o1-preview.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-09-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o1.toml
+++ b/providers/github-models/models/openai/o1.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o3-mini.toml
+++ b/providers/github-models/models/openai/o3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/openai/o3.toml
+++ b/providers/github-models/models/openai/o3.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/openai/o4-mini.toml
+++ b/providers/github-models/models/openai/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/xai/grok-3-mini.toml
+++ b/providers/github-models/models/xai/grok-3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-09"
 last_updated = "2024-12-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10"
 tool_call = true

--- a/providers/github-models/models/xai/grok-3.toml
+++ b/providers/github-models/models/xai/grok-3.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-09"
 last_updated = "2024-12-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10"
 tool_call = true


### PR DESCRIPTION
## Summary
- backfill `reasoning_options` on all 55 existing GitHub Models definitions
- expose `low`, `medium`, and `high` effort only for GitHub-served `o1`, `o3`, `o3-mini`, and `o4-mini`
- mark fixed or unresolved controls as `[]`; add no models or unrelated metadata

## Evidence
- GitHub catalog and inference API: https://docs.github.com/en/rest/models
- GitHub catalog identifies the active Azure-backed model versions/capabilities: https://models.github.ai/catalog/models
- Azure model-specific support matrix documents effort for `o1`, `o3`, `o3-mini`, and `o4-mini`, and excludes `o1-mini`: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning
- live GitHub inference probe accepted `reasoning_effort=low` for `openai/o3-mini` and reported 64 reasoning tokens; an invalid value was rejected with the supported effort enum

## Validation
- `bun validate`
- `git diff --check`