### PR TITLE
[crof] Add reasoning options

### DIFF
--- a/providers/crof/models/deepseek-v4-flash.toml
+++ b/providers/crof/models/deepseek-v4-flash.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/deepseek-v4-flash.toml
+++ b/providers/crof/models/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/deepseek-v4-pro-lightning.toml
+++ b/providers/crof/models/deepseek-v4-pro-lightning.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/deepseek-v4-pro-lightning.toml
+++ b/providers/crof/models/deepseek-v4-pro-lightning.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/deepseek-v4-pro.toml
+++ b/providers/crof/models/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/deepseek-v4-pro.toml
+++ b/providers/crof/models/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/gemma-4-31b-it.toml
+++ b/providers/crof/models/gemma-4-31b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 0.1

--- a/providers/crof/models/glm-4.7-flash.toml
+++ b/providers/crof/models/glm-4.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = []
 
 [cost]
 input = 0.04

--- a/providers/crof/models/glm-4.7.toml
+++ b/providers/crof/models/glm-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/glm-5.1.toml
+++ b/providers/crof/models/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/glm-5.toml
+++ b/providers/crof/models/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/kimi-k2.5-lightning.toml
+++ b/providers/crof/models/kimi-k2.5-lightning.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-06"
 last_updated = "2026-02-06"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/crof/models/kimi-k2.5.toml
+++ b/providers/crof/models/kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/kimi-k2.6.toml
+++ b/providers/crof/models/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/mimo-v2.5-pro.toml
+++ b/providers/crof/models/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/minimax-m2.5.toml
+++ b/providers/crof/models/minimax-m2.5.toml
@@ -1,5 +1,6 @@
 base_model = "minimax/MiniMax-M2.5"
 reasoning = false
+reasoning_options = []
 
 [cost]
 input = 0.11

--- a/providers/crof/models/qwen3.5-397b-a17b.toml
+++ b/providers/crof/models/qwen3.5-397b-a17b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-397b-a17b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 0.35

--- a/providers/crof/models/qwen3.5-9b.toml
+++ b/providers/crof/models/qwen3.5-9b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-13"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/crof/models/qwen3.6-27b.toml
+++ b/providers/crof/models/qwen3.6-27b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-27b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 0.2


### PR DESCRIPTION
## Summary
- Backfill explicit `reasoning_options` for all existing Crof reasoning-model TOMLs.
- Expose `none|low|medium|high` on routes marked `reasoning_effort: true` by Crof, including all DeepSeek V4 and Kimi routes.
- Retain empty options for fixed or unmarked GLM and MiniMax routes.
- Add no models, budgets, provider metadata, or unrelated fields; Crof currently lists no GPT-OSS route.

## Evidence
- Crof API docs list `reasoning_effort`, accepted values `none`, `low`, `medium`, and `high`, and state that higher values receive more compute: https://crof.ai/docs.md
- Crof live model metadata identifies the exact routes with `reasoning_effort: true`, including `deepseek-v4-flash`, `deepseek-v4-pro`, and `deepseek-v4-pro-lightning`: https://crof.ai/v1/models
- The live route metadata does not advertise reasoning effort for GLM 4.7, GLM 4.7 Flash, GLM 5, or MiniMax M2.5.

## Validation
- `bun validate`
- Resolved Crof generation audit: every reasoning route has an explicit option or `[]`.
- Scope audit: 16 existing files under `providers/crof/models/`; 16 `reasoning_options` additions; no `budget_tokens` or `max`; no changes outside Crof.
- `git diff --check origin/dev...HEAD`