### PR TITLE
[digitalocean] Add reasoning options

### DIFF
--- a/providers/digitalocean/models/alibaba-qwen3-32b.toml
+++ b/providers/digitalocean/models/alibaba-qwen3-32b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-30"
 last_updated = "2026-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/anthropic-claude-3.7-sonnet.toml
+++ b/providers/digitalocean/models/anthropic-claude-3.7-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-24"
 last_updated = "2025-02-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-11"

--- a/providers/digitalocean/models/anthropic-claude-4.1-opus.toml
+++ b/providers/digitalocean/models/anthropic-claude-4.1-opus.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/digitalocean/models/anthropic-claude-4.5-haiku.toml
+++ b/providers/digitalocean/models/anthropic-claude-4.5-haiku.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/digitalocean/models/anthropic-claude-4.5-sonnet.toml
+++ b/providers/digitalocean/models/anthropic-claude-4.5-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-07-31"

--- a/providers/digitalocean/models/anthropic-claude-4.6-sonnet.toml
+++ b/providers/digitalocean/models/anthropic-claude-4.6-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/digitalocean/models/anthropic-claude-fable-5.toml
+++ b/providers/digitalocean/models/anthropic-claude-fable-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-09"
 last_updated = "2026-06-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/digitalocean/models/anthropic-claude-haiku-4.5.toml
+++ b/providers/digitalocean/models/anthropic-claude-haiku-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/digitalocean/models/anthropic-claude-opus-4.5.toml
+++ b/providers/digitalocean/models/anthropic-claude-opus-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/digitalocean/models/anthropic-claude-opus-4.6.toml
+++ b/providers/digitalocean/models/anthropic-claude-opus-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/digitalocean/models/anthropic-claude-opus-4.7.toml
+++ b/providers/digitalocean/models/anthropic-claude-opus-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/digitalocean/models/anthropic-claude-opus-4.8.toml
+++ b/providers/digitalocean/models/anthropic-claude-opus-4.8.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-28"
 last_updated = "2026-05-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/digitalocean/models/anthropic-claude-opus-4.toml
+++ b/providers/digitalocean/models/anthropic-claude-opus-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/digitalocean/models/anthropic-claude-sonnet-4.toml
+++ b/providers/digitalocean/models/anthropic-claude-sonnet-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/digitalocean/models/arcee-trinity-large-thinking.toml
+++ b/providers/digitalocean/models/arcee-trinity-large-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/digitalocean/models/deepseek-3.2.toml
+++ b/providers/digitalocean/models/deepseek-3.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-02"
 last_updated = "2026-04-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/digitalocean/models/deepseek-r1-distill-llama-70b.toml
+++ b/providers/digitalocean/models/deepseek-r1-distill-llama-70b.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-30"
 last_updated = "2025-01-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/deepseek-v4-pro.toml
+++ b/providers/digitalocean/models/deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/digitalocean/models/glm-5.toml
+++ b/providers/digitalocean/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
 tool_call = true
 open_weights = true
 

--- a/providers/digitalocean/models/kimi-k2.5.toml
+++ b/providers/digitalocean/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/kimi-k2.6.toml
+++ b/providers/digitalocean/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/minimax-m2.5.toml
+++ b/providers/digitalocean/models/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08"

--- a/providers/digitalocean/models/nemotron-3-nano-30b.toml
+++ b/providers/digitalocean/models/nemotron-3-nano-30b.toml
@@ -5,6 +5,7 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/digitalocean/models/nemotron-3-nano-omni.toml
+++ b/providers/digitalocean/models/nemotron-3-nano-omni.toml
@@ -5,6 +5,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/nemotron-nano-12b-v2-vl.toml
+++ b/providers/digitalocean/models/nemotron-nano-12b-v2-vl.toml
@@ -5,6 +5,7 @@ release_date = "2025-12-01"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/digitalocean/models/nvidia-nemotron-3-super-120b.toml
+++ b/providers/digitalocean/models/nvidia-nemotron-3-super-120b.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-11"
 last_updated = "2026-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5-mini.toml
+++ b/providers/digitalocean/models/openai-gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5-nano.toml
+++ b/providers/digitalocean/models/openai-gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5.1-codex-max.toml
+++ b/providers/digitalocean/models/openai-gpt-5.1-codex-max.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5.2-pro.toml
+++ b/providers/digitalocean/models/openai-gpt-5.2-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/digitalocean/models/openai-gpt-5.2.toml
+++ b/providers/digitalocean/models/openai-gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5.3-codex.toml
+++ b/providers/digitalocean/models/openai-gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5.4-mini.toml
+++ b/providers/digitalocean/models/openai-gpt-5.4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5.4-nano.toml
+++ b/providers/digitalocean/models/openai-gpt-5.4-nano.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5.4-pro.toml
+++ b/providers/digitalocean/models/openai-gpt-5.4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/digitalocean/models/openai-gpt-5.4.toml
+++ b/providers/digitalocean/models/openai-gpt-5.4.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5.5.toml
+++ b/providers/digitalocean/models/openai-gpt-5.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-5.toml
+++ b/providers/digitalocean/models/openai-gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-oss-120b.toml
+++ b/providers/digitalocean/models/openai-gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2026-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-gpt-oss-20b.toml
+++ b/providers/digitalocean/models/openai-gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2026-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-o1.toml
+++ b/providers/digitalocean/models/openai-o1.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-05"
 last_updated = "2024-12-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-o3-mini.toml
+++ b/providers/digitalocean/models/openai-o3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-20"
 last_updated = "2025-01-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/openai-o3.toml
+++ b/providers/digitalocean/models/openai-o3.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/digitalocean/models/qwen3.5-397b-a17b.toml
+++ b/providers/digitalocean/models/qwen3.5-397b-a17b.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-15"
 last_updated = "2026-04-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- add finite reasoning effort values for all 44 current reasoning-capable DigitalOcean models
- cover the 7 previously uncovered Qwen3, DeepSeek R1 Distill, GLM 5, and Nemotron entries
- use only model-specific efforts or DigitalOcean route-documented `none`, `low`, `medium`, `high`, and `max` values
- add no model-native toggles or open-ended token budgets
- merge the latest `dev` into the existing PR branch

## Evidence
- DigitalOcean reasoning guide: https://docs.digitalocean.com/products/inference/how-to/use-reasoning/
- DigitalOcean serverless API: https://docs.digitalocean.com/reference/api/reference/serverless-inference/#inference_create_chat_completion
- DigitalOcean model catalog: https://docs.digitalocean.com/products/inference/details/models/

## Validation
- `bun validate`
- `git diff --check`
- audited 44 `reasoning = true` files against 44 `reasoning_options` entries