### PR TITLE
[jiekou] Complete reasoning options inventory

### DIFF
--- a/providers/jiekou/models/baidu/ernie-4.5-vl-424b-a47b.toml
+++ b/providers/jiekou/models/baidu/ernie-4.5-vl-424b-a47b.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/jiekou/models/claude-opus-4-6.toml
+++ b/providers/jiekou/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02"
 last_updated = "2026-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/claude-opus-4-6.toml
+++ b/providers/jiekou/models/claude-opus-4-6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02"
 last_updated = "2026-02"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/jiekou/models/deepseek/deepseek-r1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/deepseek/deepseek-v3.1.toml
+++ b/providers/jiekou/models/deepseek/deepseek-v3.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/deepseek/deepseek-v3.1.toml
+++ b/providers/jiekou/models/deepseek/deepseek-v3.1.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_767 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -3,7 +3,7 @@ family = "gemini-flash-lite"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite.toml
@@ -3,7 +3,7 @@ family = "gemini-flash-lite"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
@@ -3,7 +3,7 @@ family = "gemini-flash"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/jiekou/models/gemini-2.5-flash.toml
+++ b/providers/jiekou/models/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash.toml
+++ b/providers/jiekou/models/gemini-2.5-flash.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash.toml
+++ b/providers/jiekou/models/gemini-2.5-flash.toml
@@ -3,7 +3,7 @@ family = "gemini-flash"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
@@ -3,7 +3,7 @@ family = "gemini-pro"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-pro.toml
+++ b/providers/jiekou/models/gemini-2.5-pro.toml
@@ -3,7 +3,7 @@ family = "gemini-pro"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/jiekou/models/gemini-2.5-pro.toml
+++ b/providers/jiekou/models/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-pro.toml
+++ b/providers/jiekou/models/gemini-2.5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5-mini.toml
+++ b/providers/jiekou/models/gpt-5-mini.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5-mini.toml
+++ b/providers/jiekou/models/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5-pro.toml
+++ b/providers/jiekou/models/gpt-5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5-pro.toml
+++ b/providers/jiekou/models/gpt-5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex-max.toml
+++ b/providers/jiekou/models/gpt-5.1-codex-max.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex-max.toml
+++ b/providers/jiekou/models/gpt-5.1-codex-max.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex-mini.toml
+++ b/providers/jiekou/models/gpt-5.1-codex-mini.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex-mini.toml
+++ b/providers/jiekou/models/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex.toml
+++ b/providers/jiekou/models/gpt-5.1-codex.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex.toml
+++ b/providers/jiekou/models/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1.toml
+++ b/providers/jiekou/models/gpt-5.1.toml
@@ -4,7 +4,7 @@ release_date = "2026-02"
 last_updated = "2026-02"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1.toml
+++ b/providers/jiekou/models/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-02"
 last_updated = "2026-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.2-codex.toml
+++ b/providers/jiekou/models/gpt-5.2-codex.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.2-codex.toml
+++ b/providers/jiekou/models/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.2-pro.toml
+++ b/providers/jiekou/models/gpt-5.2-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.2-pro.toml
+++ b/providers/jiekou/models/gpt-5.2-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/minimax/minimax-m2.1.toml
+++ b/providers/jiekou/models/minimax/minimax-m2.1.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/minimax/minimax-m2.1.toml
+++ b/providers/jiekou/models/minimax/minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/minimaxai/minimax-m1-80k.toml
+++ b/providers/jiekou/models/minimaxai/minimax-m1-80k.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/jiekou/models/moonshotai/kimi-k2.5.toml
+++ b/providers/jiekou/models/moonshotai/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/moonshotai/kimi-k2.5.toml
+++ b/providers/jiekou/models/moonshotai/kimi-k2.5.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 262_143 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/qwen/qwen3-235b-a22b-fp8.toml
+++ b/providers/jiekou/models/qwen/qwen3-235b-a22b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/jiekou/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/jiekou/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/jiekou/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/qwen/qwen3-30b-a3b-fp8.toml
+++ b/providers/jiekou/models/qwen/qwen3-30b-a3b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/jiekou/models/qwen/qwen3-32b-fp8.toml
+++ b/providers/jiekou/models/qwen/qwen3-32b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/jiekou/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/jiekou/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/jiekou/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 65_535 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/xiaomimimo/mimo-v2-flash.toml
+++ b/providers/jiekou/models/xiaomimimo/mimo-v2-flash.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/xiaomimimo/mimo-v2-flash.toml
+++ b/providers/jiekou/models/xiaomimimo/mimo-v2-flash.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/xiaomimimo/mimo-v2-flash.toml
+++ b/providers/jiekou/models/xiaomimimo/mimo-v2-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/zai-org/glm-4.5.toml
+++ b/providers/jiekou/models/zai-org/glm-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/zai-org/glm-4.5v.toml
+++ b/providers/jiekou/models/zai-org/glm-4.5v.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/zai-org/glm-4.7-flash.toml
+++ b/providers/jiekou/models/zai-org/glm-4.7-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/zai-org/glm-4.7.toml
+++ b/providers/jiekou/models/zai-org/glm-4.7.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/zai-org/glm-4.7.toml
+++ b/providers/jiekou/models/zai-org/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- cover all 32 Jiekou reasoning-capable models with explicit `reasoning_options`
- expose controls available through each model's Jiekou-advertised `responses`, `anthropic`, or `gemini` endpoint
- retain `[]` where Jiekou does not document an applicable model control

## Evidence standard
- Jiekou's live model catalog advertises supported endpoint families per model: https://api.jiekou.ai/openai/models
- Jiekou documents Responses API support for GPT/Codex: https://docs.jiekou.ai/docs/support/faq_api
- Jiekou documents Anthropic protocol compatibility and extended thinking: https://docs.jiekou.ai/docs/model/llm-anthropic-compatibility and https://docs.jiekou.ai/docs/providers/anthropic
- Jiekou documents Gemini effort translation and native `thinkingBudget`: https://docs.jiekou.ai/docs/providers/gemini
- Jiekou documents `enable_thinking` for GLM-4.5: https://docs.jiekou.ai/docs/models/reference-llm-create-chat-completion
- Native model controls are included only when Jiekou documents the relevant model mapping or matching protocol behavior. MiMo remains `[]`: Jiekou documents its reasoning output but no toggle, effort, or token-budget request control.

## Result
- 23 configurable routes
- 9 fixed/no-documented-control routes
- GPT routes use model-specific Responses effort enums
- Gemini routes expose Jiekou effort aliases and native bounded budgets
- verified Anthropic routes expose bounded manual budgets; Claude Opus 4.6 also exposes native effort
- MiMo does not inherit an Anthropic token budget merely because the route accepts Anthropic-shaped requests

## Validation
- `bun validate`
- `git diff --check`
- resolved coverage: 32/32 explicit
- no options on non-reasoning models
- no unbounded token budgets