### PR TITLE
[fastrouter] Add reasoning options

### DIFF
--- a/providers/fastrouter/models/anthropic/claude-opus-4.1.toml
+++ b/providers/fastrouter/models/anthropic/claude-opus-4.1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 15

--- a/providers/fastrouter/models/anthropic/claude-opus-4.8.toml
+++ b/providers/fastrouter/models/anthropic/claude-opus-4.8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 5

--- a/providers/fastrouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/fastrouter/models/anthropic/claude-sonnet-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 3

--- a/providers/fastrouter/models/anthropic/claude-sonnet-4.toml
+++ b/providers/fastrouter/models/anthropic/claude-sonnet-4.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-20250514"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 3

--- a/providers/fastrouter/models/deepseek-ai/deepseek-r1-distill-llama-70b.toml
+++ b/providers/fastrouter/models/deepseek-ai/deepseek-r1-distill-llama-70b.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-23"
 last_updated = "2025-01-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10"
 tool_call = false

--- a/providers/fastrouter/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/fastrouter/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 1.74

--- a/providers/fastrouter/models/google/gemini-2.5-flash.toml
+++ b/providers/fastrouter/models/google/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/fastrouter/models/google/gemini-2.5-pro.toml
+++ b/providers/fastrouter/models/google/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/fastrouter/models/google/gemini-3-pro-image-preview.toml
+++ b/providers/fastrouter/models/google/gemini-3-pro-image-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-image-preview"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/fastrouter/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/fastrouter/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-image-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.50

--- a/providers/fastrouter/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/fastrouter/models/google/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/fastrouter/models/google/gemini-3.5-flash.toml
+++ b/providers/fastrouter/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.50

--- a/providers/fastrouter/models/google/gemma-4-31b-it.toml
+++ b/providers/fastrouter/models/google/gemma-4-31b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = []
 
 [cost]
 input = 0.13

--- a/providers/fastrouter/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/fastrouter/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
 
 [cost]
 input = 0.60

--- a/providers/fastrouter/models/minimax/minimax-m2.7.toml
+++ b/providers/fastrouter/models/minimax/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
 
 [cost]
 input = 0.30

--- a/providers/fastrouter/models/moonshotai/kimi-k2.6.toml
+++ b/providers/fastrouter/models/moonshotai/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.75

--- a/providers/fastrouter/models/openai/gpt-5-mini.toml
+++ b/providers/fastrouter/models/openai/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true

--- a/providers/fastrouter/models/openai/gpt-5-nano.toml
+++ b/providers/fastrouter/models/openai/gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true

--- a/providers/fastrouter/models/openai/gpt-5.3-codex.toml
+++ b/providers/fastrouter/models/openai/gpt-5.3-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.75

--- a/providers/fastrouter/models/openai/gpt-5.4-mini.toml
+++ b/providers/fastrouter/models/openai/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.75

--- a/providers/fastrouter/models/openai/gpt-5.4-nano.toml
+++ b/providers/fastrouter/models/openai/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.20

--- a/providers/fastrouter/models/openai/gpt-5.5-pro.toml
+++ b/providers/fastrouter/models/openai/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 30

--- a/providers/fastrouter/models/openai/gpt-5.5.toml
+++ b/providers/fastrouter/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/fastrouter/models/openai/gpt-5.toml
+++ b/providers/fastrouter/models/openai/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true

--- a/providers/fastrouter/models/openai/gpt-oss-120b.toml
+++ b/providers/fastrouter/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/fastrouter/models/openai/gpt-oss-20b.toml
+++ b/providers/fastrouter/models/openai/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/fastrouter/models/sarvam/sarvam-105b.toml
+++ b/providers/fastrouter/models/sarvam/sarvam-105b.toml
@@ -1,4 +1,5 @@
 base_model = "sarvam/sarvam-105b"
+reasoning_options = []
 
 [cost]
 input = 0.04

--- a/providers/fastrouter/models/sarvam/sarvam-30b.toml
+++ b/providers/fastrouter/models/sarvam/sarvam-30b.toml
@@ -1,4 +1,5 @@
 base_model = "sarvam/sarvam-30b"
+reasoning_options = []
 
 [cost]
 input = 0.02

--- a/providers/fastrouter/models/x-ai/grok-4.3.toml
+++ b/providers/fastrouter/models/x-ai/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/fastrouter/models/x-ai/grok-4.toml
+++ b/providers/fastrouter/models/x-ai/grok-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-07"
 tool_call = true

--- a/providers/fastrouter/models/x-ai/grok-build-0.1.toml
+++ b/providers/fastrouter/models/x-ai/grok-build-0.1.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-build-0.1"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1

--- a/providers/fastrouter/models/z-ai/glm-5.1.toml
+++ b/providers/fastrouter/models/z-ai/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 1.05

--- a/providers/fastrouter/models/z-ai/glm-5.toml
+++ b/providers/fastrouter/models/z-ai/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- classify FastRouter reasoning controls from its normalized `reasoning` API and live route metadata
- record only distinct effective effort, toggle, and exact budget controls
- mark fixed or unproven controls with explicit empty options

## Classification
- effort: normalized low/medium/high routes for supported OpenAI, Gemini 3, and Grok models
- budget: Anthropic 1,024-32,000; Gemini 2.5 Flash 0-24,576; Gemini 2.5 Pro 128-32,768
- toggle: proven DeepSeek V4 Pro, Kimi K2.6, and GLM hybrid routes
- fixed/unproven: GPT-5 legacy route, Grok 4, R1 Distill, Gemma 4, MiniMax M2.7, Sarvam, and Gemini 3 Pro Image

## Validation
- `bun validate`