### PR TITLE
[neon] Add reasoning options

### DIFF
--- a/providers/neon/models/claude-haiku-4-5.toml
+++ b/providers/neon/models/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 1

--- a/providers/neon/models/claude-opus-4-1.toml
+++ b/providers/neon/models/claude-opus-4-1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 31_999 }]
 
 [cost]
 input = 15

--- a/providers/neon/models/claude-opus-4-5.toml
+++ b/providers/neon/models/claude-opus-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 5

--- a/providers/neon/models/claude-opus-4-6.toml
+++ b/providers/neon/models/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/neon/models/claude-opus-4-7.toml
+++ b/providers/neon/models/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/neon/models/claude-sonnet-4-5.toml
+++ b/providers/neon/models/claude-sonnet-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/neon/models/claude-sonnet-4-6.toml
+++ b/providers/neon/models/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/neon/models/claude-sonnet-4.toml
+++ b/providers/neon/models/claude-sonnet-4.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/neon/models/gemini-2-5-flash.toml
+++ b/providers/neon/models/gemini-2-5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 
 [cost]
 input = 0.3

--- a/providers/neon/models/gemini-2-5-pro.toml
+++ b/providers/neon/models/gemini-2-5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 
 [cost]
 input = 1.25

--- a/providers/neon/models/gemini-3-1-flash-lite.toml
+++ b/providers/neon/models/gemini-3-1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/neon/models/gemini-3-1-pro.toml
+++ b/providers/neon/models/gemini-3-1-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview-customtools"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/neon/models/gemini-3-flash.toml
+++ b/providers/neon/models/gemini-3-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.5

--- a/providers/neon/models/gemini-3-pro.toml
+++ b/providers/neon/models/gemini-3-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/neon/models/gpt-5-1.toml
+++ b/providers/neon/models/gpt-5-1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/neon/models/gpt-5-2.toml
+++ b/providers/neon/models/gpt-5-2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/neon/models/gpt-5-4-mini.toml
+++ b/providers/neon/models/gpt-5-4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.75

--- a/providers/neon/models/gpt-5-4-nano.toml
+++ b/providers/neon/models/gpt-5-4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.2

--- a/providers/neon/models/gpt-5-4.toml
+++ b/providers/neon/models/gpt-5-4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/neon/models/gpt-5-5.toml
+++ b/providers/neon/models/gpt-5-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/neon/models/gpt-5-mini.toml
+++ b/providers/neon/models/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/neon/models/gpt-5-nano.toml
+++ b/providers/neon/models/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/neon/models/gpt-5.toml
+++ b/providers/neon/models/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/neon/models/gpt-oss-120b.toml
+++ b/providers/neon/models/gpt-oss-120b.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.072

--- a/providers/neon/models/gpt-oss-20b.toml
+++ b/providers/neon/models/gpt-oss-20b.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.05


### PR DESCRIPTION
## Summary
- add routed reasoning controls to every existing Neon model
- use bounded thinking budgets for Claude and Gemini 2.5
- expose documented effort levels for GPT, GPT OSS, and Gemini 3

## Research
- Neon routes its OpenAI-compatible API through Databricks MLflow at `/ai-gateway/mlflow/v1`
- Databricks documents `reasoning_effort` for GPT/GPT OSS/Gemini 3 and `thinking` with `budget_tokens` for Claude/Gemini 2.5
- budget maxima are capped below each model output limit

## Validation
- `bun validate`