### PR TITLE
[nearai] Add reasoning options

### DIFF
--- a/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-122b-a10b"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.4

--- a/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
+++ b/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.6 35B A3B FP8"
 
 [cost]

--- a/providers/nearai/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-haiku-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 1

--- a/providers/nearai/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-haiku-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 1

--- a/providers/nearai/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/nearai/models/anthropic/claude-opus-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-opus-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-opus-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-opus-4-7.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-opus-4-7.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-opus-4-7.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/nearai/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/nearai/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 512, max = 24_576 }]
 
 [cost]
 input = 0.1

--- a/providers/nearai/models/google/gemini-2.5-flash.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 
 [cost]
 input = 0.3

--- a/providers/nearai/models/google/gemini-2.5-flash.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/nearai/models/google/gemini-2.5-pro.toml
+++ b/providers/nearai/models/google/gemini-2.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-pro"
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-2.5-pro.toml
+++ b/providers/nearai/models/google/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-3-pro.toml
+++ b/providers/nearai/models/google/gemini-3-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-3-pro.toml
+++ b/providers/nearai/models/google/gemini-3-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/nearai/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-3.1-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/nearai/models/google/gemini-3.5-flash.toml
+++ b/providers/nearai/models/google/gemini-3.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.5-flash"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.5

--- a/providers/nearai/models/google/gemini-3.5-flash.toml
+++ b/providers/nearai/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = []
 
 [cost]
 input = 1.5

--- a/providers/nearai/models/google/gemma-4-31B-it.toml
+++ b/providers/nearai/models/google/gemma-4-31B-it.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemma-4-31b-it"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.13

--- a/providers/nearai/models/google/gemma-4-31B-it.toml
+++ b/providers/nearai/models/google/gemma-4-31B-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = []
 
 [cost]
 input = 0.13

--- a/providers/nearai/models/openai/gpt-5-mini.toml
+++ b/providers/nearai/models/openai/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/nearai/models/openai/gpt-5-nano.toml
+++ b/providers/nearai/models/openai/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/nearai/models/openai/gpt-5.1.toml
+++ b/providers/nearai/models/openai/gpt-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/openai/gpt-5.2.toml
+++ b/providers/nearai/models/openai/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.8

--- a/providers/nearai/models/openai/gpt-5.4-mini.toml
+++ b/providers/nearai/models/openai/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.75

--- a/providers/nearai/models/openai/gpt-5.4-nano.toml
+++ b/providers/nearai/models/openai/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.2

--- a/providers/nearai/models/openai/gpt-5.4.toml
+++ b/providers/nearai/models/openai/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/nearai/models/openai/gpt-5.5.toml
+++ b/providers/nearai/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/openai/gpt-5.toml
+++ b/providers/nearai/models/openai/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/openai/gpt-oss-120b.toml
+++ b/providers/nearai/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/nearai/models/openai/o3-mini.toml
+++ b/providers/nearai/models/openai/o3-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.1

--- a/providers/nearai/models/openai/o3.toml
+++ b/providers/nearai/models/openai/o3.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/nearai/models/openai/o4-mini.toml
+++ b/providers/nearai/models/openai/o4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.1

--- a/providers/nearai/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/nearai/models/zai-org/GLM-5.1-FP8.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary
- cover all 28 NEAR AI reasoning-capable models with explicit documented controls
- preserve NEAR's explicit Qwen, GLM, and GPT-OSS controls
- include native OpenAI, Anthropic, Gemini, and Gemma controls under NEAR's published provider-control contract

## Evidence standard
- NEAR reasoning controls: https://docs.near.ai/cloud/reasoning-models
- NEAR OpenAI compatibility and third-party provider controls: https://docs.near.ai/cloud/guides/openai-compatibility
- NEAR model capability contract: https://docs.near.ai/cloud/models
- Anthropic model controls: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking and https://platform.claude.com/docs/en/build-with-claude/effort
- Gemini controls: https://ai.google.dev/gemini-api/docs/thinking
- Gemma thinking mode: https://ai.google.dev/gemma/docs/capabilities/thinking
- OpenAI model-specific efforts: https://developers.openai.com/api/docs/guides/reasoning

## Result
- 28/28 routes expose a documented control
- Claude manual budgets are finitely bounded by route output limits; adaptive models expose toggles and native efforts
- Gemini 2.5 exposes bounded budgets and valid toggles; Gemini 3.x exposes model-specific levels
- Gemma, Qwen, and GLM expose documented thinking toggles

## Validation
- `bun validate`
- `git diff --check`
- resolved coverage: 28/28 explicit and configurable
- no options on non-reasoning models
- no unbounded token budgets