### PR TITLE
[opencode-go] Add reasoning options

### DIFF
--- a/providers/opencode-go/models/deepseek-v4-flash.toml
+++ b/providers/opencode-go/models/deepseek-v4-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode-go/models/deepseek-v4-flash.toml
+++ b/providers/opencode-go/models/deepseek-v4-flash.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode-go/models/deepseek-v4-pro.toml
+++ b/providers/opencode-go/models/deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode-go/models/deepseek-v4-pro.toml
+++ b/providers/opencode-go/models/deepseek-v4-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode-go/models/glm-5.1.toml
+++ b/providers/opencode-go/models/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-07"
 last_updated = "2026-04-07"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode-go/models/glm-5.toml
+++ b/providers/opencode-go/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode-go/models/kimi-k2.5.toml
+++ b/providers/opencode-go/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode-go/models/kimi-k2.6.toml
+++ b/providers/opencode-go/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode-go/models/mimo-v2-omni.toml
+++ b/providers/opencode-go/models/mimo-v2-omni.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode-go/models/mimo-v2-pro.toml
+++ b/providers/opencode-go/models/mimo-v2-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode-go/models/mimo-v2.5-pro.toml
+++ b/providers/opencode-go/models/mimo-v2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode-go/models/mimo-v2.5.toml
+++ b/providers/opencode-go/models/mimo-v2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode-go/models/minimax-m2.5.toml
+++ b/providers/opencode-go/models/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode-go/models/minimax-m2.7.toml
+++ b/providers/opencode-go/models/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode-go/models/minimax-m3.toml
+++ b/providers/opencode-go/models/minimax-m3.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-31"
 last_updated = "2026-05-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode-go/models/qwen3.5-plus.toml
+++ b/providers/opencode-go/models/qwen3.5-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode-go/models/qwen3.6-plus.toml
+++ b/providers/opencode-go/models/qwen3.6-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode-go/models/qwen3.7-max.toml
+++ b/providers/opencode-go/models/qwen3.7-max.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-21"
 last_updated = "2026-05-21"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/opencode-go/models/qwen3.7-plus.toml
+++ b/providers/opencode-go/models/qwen3.7-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-02"
 last_updated = "2026-06-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
## Summary
- backfill reasoning controls for every existing OpenCode Go model
- expose effective `high|max` effort levels for DeepSeek V4
- expose provider-supported MiMo effort controls
- mark MiniMax M3 as toggleable and fixed-reasoning models as having no user control
- preserve existing pricing and non-reasoning metadata

## Validation
- `bun validate`
- `git diff --check`