### PR TITLE
[huggingface] Add reasoning options

### DIFF
--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M2.1.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-10"

--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M2.7.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M2.7.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M2.7.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/huggingface/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-235B-A22B-Thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-25"
 last_updated = "2025-07-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-23"
 last_updated = "2025-07-23"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/Qwen/Qwen3-Coder-Next.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Coder-Next.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-03"
 last_updated = "2026-02-03"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/Qwen/Qwen3-Embedding-4B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Embedding-4B.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-01"
 last_updated = "2025-01-01"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = false
 knowledge = "2024-12"
 tool_call = false

--- a/providers/huggingface/models/Qwen/Qwen3-Embedding-8B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Embedding-8B.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-01"
 last_updated = "2025-01-01"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = false
 knowledge = "2024-12"
 tool_call = false

--- a/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-11"
 last_updated = "2025-09-11"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-11"
 last_updated = "2025-09-11"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-397B-A17B.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-01"
 last_updated = "2026-02-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/XiaomiMiMo/MiMo-V2-Flash.toml
+++ b/providers/huggingface/models/XiaomiMiMo/MiMo-V2-Flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-16"
 last_updated = "2025-12-16"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/huggingface/models/deepseek-ai/DeepSeek-R1-0528.toml
+++ b/providers/huggingface/models/deepseek-ai/DeepSeek-R1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-05"

--- a/providers/huggingface/models/deepseek-ai/DeepSeek-V3.2.toml
+++ b/providers/huggingface/models/deepseek-ai/DeepSeek-V3.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-07"

--- a/providers/huggingface/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/huggingface/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-04"
 last_updated = "2025-09-04"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Instruct.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Instruct.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-14"
 last_updated = "2025-07-14"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Thinking.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-08"

--- a/providers/huggingface/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-01"
 last_updated = "2026-01-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/huggingface/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/huggingface/models/zai-org/GLM-4.7-Flash.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.7-Flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/zai-org/GLM-4.7.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "default"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/zai-org/GLM-4.7.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.7.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "default"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/zai-org/GLM-5.1.toml
+++ b/providers/huggingface/models/zai-org/GLM-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-03"
 last_updated = "2026-04-03"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/huggingface/models/zai-org/GLM-5.toml
+++ b/providers/huggingface/models/zai-org/GLM-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- backfill explicit reasoning options across 24 Hugging Face routed models
- declare MiniMax M2.5 and M2.7 as fixed reasoning
- represent Cerebras GLM-4.7 `none/default` behavior as a toggle rather than graded effort
- retain route-specific controls only where the selected HF inference provider exposes them

## Validation
- `bun validate`
- `git diff --check`
- complete coverage; no unbounded budgets