### PR TITLE
[helicone] Add reasoning options

### DIFF
--- a/providers/helicone/models/claude-4.5-opus.toml
+++ b/providers/helicone/models/claude-4.5-opus.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-11"

--- a/providers/helicone/models/claude-4.5-sonnet.toml
+++ b/providers/helicone/models/claude-4.5-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-09"

--- a/providers/helicone/models/claude-opus-4-1-20250805.toml
+++ b/providers/helicone/models/claude-opus-4-1-20250805.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 31_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-08"

--- a/providers/helicone/models/claude-opus-4-1.toml
+++ b/providers/helicone/models/claude-opus-4-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 31_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-08"

--- a/providers/helicone/models/claude-opus-4.toml
+++ b/providers/helicone/models/claude-opus-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-14"
 last_updated = "2025-05-14"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 31_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-05"

--- a/providers/helicone/models/claude-sonnet-4-5-20250929.toml
+++ b/providers/helicone/models/claude-sonnet-4-5-20250929.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-09"

--- a/providers/helicone/models/claude-sonnet-4.toml
+++ b/providers/helicone/models/claude-sonnet-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-14"
 last_updated = "2025-05-14"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-05"

--- a/providers/helicone/models/deepseek-r1-distill-llama-70b.toml
+++ b/providers/helicone/models/deepseek-r1-distill-llama-70b.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/helicone/models/deepseek-v3.1-terminus.toml
+++ b/providers/helicone/models/deepseek-v3.1-terminus.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-22"
 last_updated = "2025-09-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-09"

--- a/providers/helicone/models/ernie-4.5-21b-a3b-thinking.toml
+++ b/providers/helicone/models/ernie-4.5-21b-a3b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-16"
 last_updated = "2025-03-16"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 knowledge = "2025-03"

--- a/providers/helicone/models/gemini-2.5-flash-lite.toml
+++ b/providers/helicone/models/gemini-2.5-flash-lite.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-22"
 last_updated = "2025-07-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 512, max = 24_576 }]
 temperature = true
 tool_call = true
 knowledge = "2025-07"

--- a/providers/helicone/models/gemini-2.5-flash.toml
+++ b/providers/helicone/models/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 tool_call = true
 knowledge = "2025-06"

--- a/providers/helicone/models/gemini-2.5-pro.toml
+++ b/providers/helicone/models/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 tool_call = true
 knowledge = "2025-06"

--- a/providers/helicone/models/gemini-3-pro-preview.toml
+++ b/providers/helicone/models/gemini-3-pro-preview.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-11"

--- a/providers/helicone/models/glm-4.6.toml
+++ b/providers/helicone/models/glm-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-18"
 last_updated = "2024-07-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-07"

--- a/providers/helicone/models/gpt-oss-120b.toml
+++ b/providers/helicone/models/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2024-06-01"
 last_updated = "2024-06-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-06"

--- a/providers/helicone/models/gpt-oss-20b.toml
+++ b/providers/helicone/models/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2024-06-01"
 last_updated = "2024-06-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-06"

--- a/providers/helicone/models/grok-4-1-fast-reasoning.toml
+++ b/providers/helicone/models/grok-4-1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-17"
 last_updated = "2025-11-17"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-11"

--- a/providers/helicone/models/grok-4-fast-reasoning.toml
+++ b/providers/helicone/models/grok-4-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-01"
 last_updated = "2025-09-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-09"

--- a/providers/helicone/models/qwen3-235b-a22b-thinking.toml
+++ b/providers/helicone/models/qwen3-235b-a22b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-25"
 last_updated = "2025-07-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 knowledge = "2025-07"

--- a/providers/helicone/models/qwen3-32b.toml
+++ b/providers/helicone/models/qwen3-32b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-28"
 last_updated = "2025-04-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/helicone/models/sonar-deep-research.toml
+++ b/providers/helicone/models/sonar-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-27"
 last_updated = "2025-01-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = false
 knowledge = "2025-01"

--- a/providers/helicone/models/sonar-reasoning-pro.toml
+++ b/providers/helicone/models/sonar-reasoning-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-27"
 last_updated = "2025-01-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = false
 knowledge = "2025-01"

--- a/providers/helicone/models/sonar-reasoning.toml
+++ b/providers/helicone/models/sonar-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-27"
 last_updated = "2025-01-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 knowledge = "2025-01"


### PR DESCRIPTION
## Summary
- add `reasoning_options` to all 24 existing Helicone reasoning models
- model controls from Helicone gateway route/provider behavior rather than blanket intrinsic capabilities
- use exact finite Claude and Gemini token-budget bounds and mark fixed-reasoning routes with empty options

## Validation
- `bun validate`
- strict Helicone reasoning-options coverage check
- `git diff --check origin/dev...HEAD`