### PR TITLE
[merge-gateway] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/anthropic/claude-haiku-4-5-20251001.toml
+++ b/providers/merge-gateway/models/anthropic/claude-haiku-4-5-20251001.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5-20251001"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 1

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-1-20250805.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-1-20250805.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 31_999 }]
 
 [cost]
 input = 15

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-20250514.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-20250514.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-20250514"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 31_999 }]
 
 [cost]
 input = 15

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-5-20251101.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-5-20251101.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5-20251101"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-6.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-7.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-sonnet-4-20250514.toml
+++ b/providers/merge-gateway/models/anthropic/claude-sonnet-4-20250514.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-20250514"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/merge-gateway/models/anthropic/claude-sonnet-4-5-20250929.toml
+++ b/providers/merge-gateway/models/anthropic/claude-sonnet-4-5-20250929.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/merge-gateway/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/merge-gateway/models/anthropic/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/merge-gateway/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/merge-gateway/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/merge-gateway/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/merge-gateway/models/google/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/merge-gateway/models/google/gemini-2.5-flash.toml
+++ b/providers/merge-gateway/models/google/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/google/gemini-2.5-pro.toml
+++ b/providers/merge-gateway/models/google/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/google/gemini-3-flash-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = []
 
 [cost]
 input = 0.5

--- a/providers/merge-gateway/models/google/gemini-3-pro-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/merge-gateway/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/merge-gateway/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview-customtools"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/google/gemini-3.5-flash.toml
+++ b/providers/merge-gateway/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = []
 
 [cost]
 input = 1.5

--- a/providers/merge-gateway/models/google/gemini-flash-latest.toml
+++ b/providers/merge-gateway/models/google/gemini-flash-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-flash-latest"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/google/gemini-flash-lite-latest.toml
+++ b/providers/merge-gateway/models/google/gemini-flash-lite-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-flash-lite-latest"
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/merge-gateway/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/merge-gateway/models/google/gemma-4-26b-a4b-it.toml
@@ -1,1 +1,2 @@
 base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = []

--- a/providers/merge-gateway/models/google/gemma-4-31b-it.toml
+++ b/providers/merge-gateway/models/google/gemma-4-31b-it.toml
@@ -1,1 +1,2 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = []

--- a/providers/merge-gateway/models/minimax/minimax-m2.1.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.1.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.1"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/minimax/minimax-m2.5-highspeed.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.5-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5-highspeed"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/minimax/minimax-m2.5.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.5.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/minimax/minimax-m2.7.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/minimax/minimax-m2.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/mistral/magistral-medium-latest.toml
+++ b/providers/merge-gateway/models/mistral/magistral-medium-latest.toml
@@ -1,4 +1,5 @@
 base_model = "mistral/magistral-medium-latest"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/mistral/mistral-small-latest.toml
+++ b/providers/merge-gateway/models/mistral/mistral-small-latest.toml
@@ -1,4 +1,5 @@
 base_model = "mistral/mistral-small-latest"
+reasoning_options = []
 
 [cost]
 input = 0.15

--- a/providers/merge-gateway/models/openai/gpt-5-chat-latest.toml
+++ b/providers/merge-gateway/models/openai/gpt-5-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-chat-latest"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/gpt-5-mini.toml
+++ b/providers/merge-gateway/models/openai/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/merge-gateway/models/openai/gpt-5-nano.toml
+++ b/providers/merge-gateway/models/openai/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = []
 
 [cost]
 input = 0.05

--- a/providers/merge-gateway/models/openai/gpt-5.1-chat-latest.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.1-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-chat-latest"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/gpt-5.1.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/gpt-5.2-chat-latest.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.2-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-chat-latest"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/merge-gateway/models/openai/gpt-5.2.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/merge-gateway/models/openai/gpt-5.4-mini.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = []
 
 [cost]
 input = 0.75

--- a/providers/merge-gateway/models/openai/gpt-5.4-nano.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/merge-gateway/models/openai/gpt-5.4.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = []
 
 [cost]
 input = 2.5

--- a/providers/merge-gateway/models/openai/gpt-5.5.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/openai/gpt-5.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/o1.toml
+++ b/providers/merge-gateway/models/openai/o1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o1"
+reasoning_options = []
 
 [cost]
 input = 15

--- a/providers/merge-gateway/models/openai/o3-mini.toml
+++ b/providers/merge-gateway/models/openai/o3-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-mini"
+reasoning_options = []
 
 [cost]
 input = 1.1

--- a/providers/merge-gateway/models/openai/o3.toml
+++ b/providers/merge-gateway/models/openai/o3.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/openai/o4-mini.toml
+++ b/providers/merge-gateway/models/openai/o4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o4-mini"
+reasoning_options = []
 
 [cost]
 input = 1.1

--- a/providers/merge-gateway/models/xai/grok-4.20-0309-reasoning.toml
+++ b/providers/merge-gateway/models/xai/grok-4.20-0309-reasoning.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/xai/grok-4.3.toml
+++ b/providers/merge-gateway/models/xai/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/zai/glm-4.5-air.toml
+++ b/providers/merge-gateway/models/zai/glm-4.5-air.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/merge-gateway/models/zai/glm-4.5.toml
+++ b/providers/merge-gateway/models/zai/glm-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/zai/glm-4.6.toml
+++ b/providers/merge-gateway/models/zai/glm-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/zai/glm-4.7-flashx.toml
+++ b/providers/merge-gateway/models/zai/glm-4.7-flashx.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flashx"
+reasoning_options = []
 
 [cost]
 input = 0.07

--- a/providers/merge-gateway/models/zai/glm-4.7.toml
+++ b/providers/merge-gateway/models/zai/glm-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5-turbo.toml
+++ b/providers/merge-gateway/models/zai/glm-5-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5-turbo"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5.1.toml
+++ b/providers/merge-gateway/models/zai/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5.toml
+++ b/providers/merge-gateway/models/zai/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Summary
- backfill explicit reasoning options for all 59 reasoning-capable Merge Gateway routes
- expose Merge's documented Anthropic extended-thinking controls on eight supported Claude routes
- retain `[]` where Merge does not publish a selectable control or provider-family mapping

## Evidence standard
- Merge documents `/v1/openai` and `/v1/anthropic` as translation adapters, not raw-body proxies: https://api-gateway.merge.dev/v1/openapi.json
- The live native `ResponseRequest` documents top-level `thinking` and free-form `provider_options`, but publishes no provider-family schemas for Gemini, GLM, DeepSeek, Mistral, xAI, or OpenAI reasoning controls.
- Merge's official Gateway feature guide documents extended thinking specifically for Anthropic Claude: https://github.com/merge-api/merge-gateway-skills/blob/main/skills/gateway-features/SKILL.md
- Merge's public model catalog identifies model availability but does not publish per-model reasoning controls: https://docs.merge.dev/merge-gateway/api-overview/models/list
- Unknown fields and `additionalProperties` establish parser tolerance, not translation or upstream propagation. Native model capability alone is not treated as a Merge control.

## Result
- 8 configurable Claude routes with toggle plus bounded manual budgets
- 51 fixed/no-Merge-documented-control routes
- `[]` means no verified selectable control through Merge, not that the model lacks reasoning

## Validation
- `bun validate`
- `git diff --check`
- resolved coverage: 59/59 explicit
- no options on non-reasoning models
- no unbounded token budgets