### PR TITLE
[opencode] Add reasoning options

### DIFF
--- a/providers/opencode/models/big-pickle.toml
+++ b/providers/opencode/models/big-pickle.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-17"
 last_updated = "2025-10-17"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/opencode/models/claude-haiku-4-5.toml
+++ b/providers/opencode/models/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/opencode/models/claude-haiku-4-5.toml
+++ b/providers/opencode/models/claude-haiku-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/opencode/models/claude-opus-4-1.toml
+++ b/providers/opencode/models/claude-opus-4-1.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 31_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/claude-opus-4-1.toml
+++ b/providers/opencode/models/claude-opus-4-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/claude-opus-4-5.toml
+++ b/providers/opencode/models/claude-opus-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/claude-opus-4-5.toml
+++ b/providers/opencode/models/claude-opus-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/claude-opus-4-6.toml
+++ b/providers/opencode/models/claude-opus-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/opencode/models/claude-opus-4-6.toml
+++ b/providers/opencode/models/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [cost]
 input = 5

--- a/providers/opencode/models/claude-opus-4-7.toml
+++ b/providers/opencode/models/claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/opencode/models/claude-opus-4-8.toml
+++ b/providers/opencode/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/opencode/models/claude-sonnet-4-5.toml
+++ b/providers/opencode/models/claude-sonnet-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/opencode/models/claude-sonnet-4-5.toml
+++ b/providers/opencode/models/claude-sonnet-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/opencode/models/claude-sonnet-4-6.toml
+++ b/providers/opencode/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/opencode/models/claude-sonnet-4-6.toml
+++ b/providers/opencode/models/claude-sonnet-4-6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/opencode/models/claude-sonnet-4.toml
+++ b/providers/opencode/models/claude-sonnet-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/claude-sonnet-4.toml
+++ b/providers/opencode/models/claude-sonnet-4.toml
@@ -4,7 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/deepseek-v4-flash-free.toml
+++ b/providers/opencode/models/deepseek-v4-flash-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode/models/deepseek-v4-flash-free.toml
+++ b/providers/opencode/models/deepseek-v4-flash-free.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode/models/deepseek-v4-flash.toml
+++ b/providers/opencode/models/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/opencode/models/deepseek-v4-flash.toml
+++ b/providers/opencode/models/deepseek-v4-flash.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/opencode/models/deepseek-v4-pro.toml
+++ b/providers/opencode/models/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/opencode/models/deepseek-v4-pro.toml
+++ b/providers/opencode/models/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/opencode/models/gemini-3-flash.toml
+++ b/providers/opencode/models/gemini-3-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/gemini-3-pro.toml
+++ b/providers/opencode/models/gemini-3-pro.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/gemini-3-pro.toml
+++ b/providers/opencode/models/gemini-3-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/gemini-3.1-pro.toml
+++ b/providers/opencode/models/gemini-3.1-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/gemini-3.5-flash.toml
+++ b/providers/opencode/models/gemini-3.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-19"
 last_updated = "2026-05-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/glm-4.6.toml
+++ b/providers/opencode/models/glm-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-4.6.toml
+++ b/providers/opencode/models/glm-4.6.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-4.7-free.toml
+++ b/providers/opencode/models/glm-4.7-free.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-4.7-free.toml
+++ b/providers/opencode/models/glm-4.7-free.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-4.7.toml
+++ b/providers/opencode/models/glm-4.7.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-4.7.toml
+++ b/providers/opencode/models/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-5-free.toml
+++ b/providers/opencode/models/glm-5-free.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-5-free.toml
+++ b/providers/opencode/models/glm-5-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-5.1.toml
+++ b/providers/opencode/models/glm-5.1.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-07"
 last_updated = "2026-04-07"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-5.1.toml
+++ b/providers/opencode/models/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-07"
 last_updated = "2026-04-07"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-5.toml
+++ b/providers/opencode/models/glm-5.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-5.toml
+++ b/providers/opencode/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/gpt-5-codex.toml
+++ b/providers/opencode/models/gpt-5-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5-nano.toml
+++ b/providers/opencode/models/gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.1-codex-max.toml
+++ b/providers/opencode/models/gpt-5.1-codex-max.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.1-codex-mini.toml
+++ b/providers/opencode/models/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.1-codex.toml
+++ b/providers/opencode/models/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.1.toml
+++ b/providers/opencode/models/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.2-codex.toml
+++ b/providers/opencode/models/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.2.toml
+++ b/providers/opencode/models/gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.3-codex-spark.toml
+++ b/providers/opencode/models/gpt-5.3-codex-spark.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.3-codex.toml
+++ b/providers/opencode/models/gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.4-mini.toml
+++ b/providers/opencode/models/gpt-5.4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.4-nano.toml
+++ b/providers/opencode/models/gpt-5.4-nano.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.4-pro.toml
+++ b/providers/opencode/models/gpt-5.4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.4.toml
+++ b/providers/opencode/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/opencode/models/gpt-5.5-pro.toml
+++ b/providers/opencode/models/gpt-5.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-12-01"
 tool_call = true

--- a/providers/opencode/models/gpt-5.5.toml
+++ b/providers/opencode/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/opencode/models/gpt-5.toml
+++ b/providers/opencode/models/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/grok-build-0.1.toml
+++ b/providers/opencode/models/grok-build-0.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-20"
 last_updated = "2026-05-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/grok-code.toml
+++ b/providers/opencode/models/grok-code.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-20"
 last_updated = "2025-08-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/opencode/models/hy3-preview-free.toml
+++ b/providers/opencode/models/hy3-preview-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 knowledge = "2025-06"
 tool_call = true

--- a/providers/opencode/models/hy3-preview-free.toml
+++ b/providers/opencode/models/hy3-preview-free.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 knowledge = "2025-06"
 tool_call = true

--- a/providers/opencode/models/kimi-k2-thinking.toml
+++ b/providers/opencode/models/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/kimi-k2.5-free.toml
+++ b/providers/opencode/models/kimi-k2.5-free.toml
@@ -4,7 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/kimi-k2.5-free.toml
+++ b/providers/opencode/models/kimi-k2.5-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/kimi-k2.5.toml
+++ b/providers/opencode/models/kimi-k2.5.toml
@@ -4,7 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/kimi-k2.5.toml
+++ b/providers/opencode/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/kimi-k2.6.toml
+++ b/providers/opencode/models/kimi-k2.6.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/kimi-k2.6.toml
+++ b/providers/opencode/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/mimo-v2-flash-free.toml
+++ b/providers/opencode/models/mimo-v2-flash-free.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-16"
 last_updated = "2025-12-16"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2-flash-free.toml
+++ b/providers/opencode/models/mimo-v2-flash-free.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-16"
 last_updated = "2025-12-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2-omni-free.toml
+++ b/providers/opencode/models/mimo-v2-omni-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2-omni-free.toml
+++ b/providers/opencode/models/mimo-v2-omni-free.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2-pro-free.toml
+++ b/providers/opencode/models/mimo-v2-pro-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2-pro-free.toml
+++ b/providers/opencode/models/mimo-v2-pro-free.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2.5-free.toml
+++ b/providers/opencode/models/mimo-v2.5-free.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2.5-free.toml
+++ b/providers/opencode/models/mimo-v2.5-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/minimax-m2.1-free.toml
+++ b/providers/opencode/models/minimax-m2.1-free.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m2.1.toml
+++ b/providers/opencode/models/minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m2.5-free.toml
+++ b/providers/opencode/models/minimax-m2.5-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m2.5.toml
+++ b/providers/opencode/models/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m2.7.toml
+++ b/providers/opencode/models/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m3-free.toml
+++ b/providers/opencode/models/minimax-m3-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-31"
 last_updated = "2026-05-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/nemotron-3-super-free.toml
+++ b/providers/opencode/models/nemotron-3-super-free.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02"

--- a/providers/opencode/models/nemotron-3-super-free.toml
+++ b/providers/opencode/models/nemotron-3-super-free.toml
@@ -5,7 +5,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2026-02"

--- a/providers/opencode/models/nemotron-3-ultra-free.toml
+++ b/providers/opencode/models/nemotron-3-ultra-free.toml
@@ -5,6 +5,7 @@ release_date = "2026-06-04"
 last_updated = "2026-06-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02"

--- a/providers/opencode/models/nemotron-3-ultra-free.toml
+++ b/providers/opencode/models/nemotron-3-ultra-free.toml
@@ -5,7 +5,7 @@ release_date = "2026-06-04"
 last_updated = "2026-06-04"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2026-02"

--- a/providers/opencode/models/qwen3.5-plus.toml
+++ b/providers/opencode/models/qwen3.5-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/qwen3.5-plus.toml
+++ b/providers/opencode/models/qwen3.5-plus.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/qwen3.6-plus-free.toml
+++ b/providers/opencode/models/qwen3.6-plus-free.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/qwen3.6-plus-free.toml
+++ b/providers/opencode/models/qwen3.6-plus-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/qwen3.6-plus.toml
+++ b/providers/opencode/models/qwen3.6-plus.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/qwen3.6-plus.toml
+++ b/providers/opencode/models/qwen3.6-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/ring-2.6-1t-free.toml
+++ b/providers/opencode/models/ring-2.6-1t-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-08"
 last_updated = "2026-05-08"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 knowledge = "2025-06"
 tool_call = true

--- a/providers/opencode/models/ring-2.6-1t-free.toml
+++ b/providers/opencode/models/ring-2.6-1t-free.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-08"
 last_updated = "2026-05-08"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 knowledge = "2025-06"
 tool_call = true


### PR DESCRIPTION
## Summary
- add explicit reasoning controls to all 65 OpenCode Zen reasoning models
- source controls primarily from each originating lab when Zen uses that lab's native format
- preserve provider-specific semantics instead of normalizing unrelated models to generic effort levels
- leave shared OpenAI-compatible routes empty where Zen does not document translation to a model-specific native control

## Native mappings
- Anthropic: manual `budget_tokens` for Haiku 4.5, Sonnet 4/4.5, and Opus 4.1; effort plus budgets for Opus 4.5, Sonnet 4.6, and Opus 4.6; adaptive effort only for Opus 4.7/4.8
- Google: model-specific Gemini thinking levels, including only `low|high` for Gemini 3 Pro
- OpenAI: exact per-model GPT effort enums from the native OpenAI route
- DeepSeek: thinking toggle plus effective `high|max` effort for V4
- Z.AI, Moonshot, and Xiaomi: native thinking toggles for GLM, Kimi hybrid, and MiMo models
- Alibaba: toggle plus an 81,920-token thinking budget on Qwen models using the Anthropic-compatible route
- MiniMax: fixed reasoning for M2.x and a toggle for M3

## Coverage
- 65 reasoning-capable models with 65 explicit declarations
- 31 models with effort controls
- 20 models with toggles
- 10 models with bounded token budgets
- 13 fixed or unresolved routes represented by `[]`
- 0 reasoning models missing options
- 0 non-reasoning models with leaked options
- 0 unbounded token-budget controls

## Primary sources
- Anthropic effort and extended thinking: https://platform.claude.com/docs/en/build-with-claude/effort and https://platform.claude.com/docs/en/build-with-claude/extended-thinking
- Google thinking levels: https://ai.google.dev/gemini-api/docs/interactions/thinking
- DeepSeek thinking mode: https://api-docs.deepseek.com/guides/thinking_mode
- Z.AI thinking mode: https://docs.z.ai/guides/capabilities/thinking-mode
- Moonshot thinking API: https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model
- Qwen Anthropic compatibility and thinking: https://docs.qwencloud.com/api-reference/toolkitframework/anthropic-api-compatibility and https://docs.qwencloud.com/developer-guides/text-generation/thinking
- MiniMax API: https://platform.minimax.io/docs/api-reference/text-anthropic-api
- Xiaomi API: https://platform.xiaomimimo.com/docs/en-US/api/chat/openai-api

## Validation
- `bun validate`
- `git diff --check origin/dev...HEAD`
- resolved-catalog audit for complete reasoning coverage, no option leaks, and bounded budgets