### PR TITLE
Fix release dates

### DIFF
--- a/models/google/gemini-2.5-flash.toml
+++ b/models/google/gemini-2.5-flash.toml
@@ -1,7 +1,7 @@
 name = "Gemini 2.5 Flash"
 family = "gemini-flash"
-release_date = "2025-03-20"
-last_updated = "2025-06-05"
+release_date = "2025-06-17"
+last_updated = "2025-06-17"
 attachment = true
 reasoning = true
 temperature = true

--- a/models/google/gemini-2.5-pro.toml
+++ b/models/google/gemini-2.5-pro.toml
@@ -1,7 +1,7 @@
 name = "Gemini 2.5 Pro"
 family = "gemini-pro"
-release_date = "2025-03-20"
-last_updated = "2025-06-05"
+release_date = "2025-06-17"
+last_updated = "2025-06-17"
 attachment = true
 reasoning = true
 temperature = true

--- a/models/mistral/mistral-large-2411.toml
+++ b/models/mistral/mistral-large-2411.toml
@@ -1,7 +1,7 @@
 name = "Mistral Large 2.1"
 family = "mistral-large"
-release_date = "2024-11-01"
-last_updated = "2024-11-04"
+release_date = "2024-11-18"
+last_updated = "2024-11-18"
 attachment = false
 reasoning = false
 temperature = true


### PR DESCRIPTION
Set Gemini 2.5 Flash and Gemini 2.5 Pro release_date metadata to 2025-06-17 (evidence for: [flash](https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models
), [pro](https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models))

Set mistral-large-2411 release_date metadata to 2024-11-18 ([evidence](https://github.com/mistralai/platform-docs-public/blob/main/src/schema/models/models/mistral-large-2-1-24-11.ts#L9))