### PR TITLE
[alibaba-coding-plan] Add reasoning options

### DIFF
--- a/providers/alibaba-coding-plan/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-coding-plan/models/MiniMax-M2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/alibaba-coding-plan/models/glm-4.7.toml
+++ b/providers/alibaba-coding-plan/models/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/alibaba-coding-plan/models/glm-5.toml
+++ b/providers/alibaba-coding-plan/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/alibaba-coding-plan/models/kimi-k2.5.toml
+++ b/providers/alibaba-coding-plan/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/alibaba-coding-plan/models/qwen3.5-plus.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.5-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true

--- a/providers/alibaba-coding-plan/models/qwen3.6-flash.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.6-flash.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-flash"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.1875

--- a/providers/alibaba-coding-plan/models/qwen3.6-plus.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.6-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true

--- a/providers/alibaba-coding-plan/models/qwen3.7-max.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 2.5

--- a/providers/alibaba-coding-plan/models/qwen3.7-plus.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0


### PR DESCRIPTION
## Summary
- add binary reasoning toggles for Coding Plan Qwen, GLM, and Kimi models
- mark MiniMax-M2.5 reasoning as fixed
- keep changes scoped to provider-level reasoning options

## Validation
- `bun validate`