### PR TITLE
[evroc] Add reasoning options

### DIFF
--- a/providers/evroc/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/evroc/models/moonshotai/Kimi-K2.5.toml
@@ -7,6 +7,9 @@ reasoning = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 1.47
 output = 5.90

--- a/providers/evroc/models/openai/gpt-oss-120b.toml
+++ b/providers/evroc/models/openai/gpt-oss-120b.toml
@@ -7,6 +7,10 @@ reasoning = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 0.24
 output = 0.94


### PR DESCRIPTION
## Summary
- add low, medium, and high reasoning effort options for GPT OSS 120B
- add the thinking-mode toggle for Kimi K2.5
- leave non-reasoning models and all other catalog metadata unchanged

## Validation
- bun validate