### PR TITLE
[google] Complete reasoning options

### DIFF
--- a/providers/google/models/gemini-2.5-flash-image.toml
+++ b/providers/google/models/gemini-2.5-flash-image.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = false
 knowledge = "2025-06"
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/google/models/gemini-3-pro-image-preview.toml
+++ b/providers/google/models/gemini-3-pro-image-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-image-preview"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/google/models/gemini-3.1-flash-image-preview.toml
+++ b/providers/google/models/gemini-3.1-flash-image-preview.toml
@@ -9,6 +9,10 @@ tool_call = false
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "high"]
+
 [cost]
 input = 0.5
 output = 60

--- a/providers/google/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/google/models/gemini-3.1-flash-lite-preview.toml
@@ -11,6 +11,10 @@ knowledge = "2025-01"
 open_weights = false
 status = "deprecated"
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 0.25
 output = 1.50

--- a/providers/google/models/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/google/models/gemini-3.1-pro-preview-customtools.toml
@@ -10,6 +10,10 @@ structured_output = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 2.00
 output = 12.00

--- a/providers/google/models/gemini-flash-latest.toml
+++ b/providers/google/models/gemini-flash-latest.toml
@@ -10,6 +10,14 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 24_576
+
 [cost]
 input = 0.30
 output = 2.50

--- a/providers/google/models/gemini-flash-lite-latest.toml
+++ b/providers/google/models/gemini-flash-lite-latest.toml
@@ -10,6 +10,14 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 512
+max = 24_576
+
 [cost]
 input = 0.10
 output = 0.40

--- a/providers/google/models/gemma-4-26b-a4b-it.toml
+++ b/providers/google/models/gemma-4-26b-a4b-it.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
+reasoning_options = [{ type = "toggle" }]
 
 [limit]
 context = 262_144

--- a/providers/google/models/gemma-4-31b-it.toml
+++ b/providers/google/models/gemma-4-31b-it.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
+reasoning_options = [{ type = "toggle" }]
 
 [limit]
 context = 262_144


### PR DESCRIPTION
## Summary
- backfill missing native Gemini thinking levels and finite budgets
- mark fixed-reasoning image models explicitly and expose Gemma thinking toggles
- preserve existing Google catalog metadata and synced models

## Validation
- bun validate