### PR TITLE
[freemodel] Add reasoning options

### DIFF
--- a/providers/freemodel/models/claude-haiku-4-5-20251001.toml
+++ b/providers/freemodel/models/claude-haiku-4-5-20251001.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5-20251001"
+reasoning_options = []
 
 [cost]
 input = 1.00

--- a/providers/freemodel/models/claude-haiku-4-5-20251001.toml
+++ b/providers/freemodel/models/claude-haiku-4-5-20251001.toml
@@ -1,5 +1,8 @@
 base_model = "anthropic/claude-haiku-4-5-20251001"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
 
 [cost]
 input = 1.00

--- a/providers/freemodel/models/claude-opus-4-6.toml
+++ b/providers/freemodel/models/claude-opus-4-6.toml
@@ -1,5 +1,12 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
 
 [cost]
 input = 5.00

--- a/providers/freemodel/models/claude-opus-4-6.toml
+++ b/providers/freemodel/models/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = []
 
 [cost]
 input = 5.00

--- a/providers/freemodel/models/claude-opus-4-7.toml
+++ b/providers/freemodel/models/claude-opus-4-7.toml
@@ -1,5 +1,8 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5.00

--- a/providers/freemodel/models/claude-opus-4-7.toml
+++ b/providers/freemodel/models/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = []
 
 [cost]
 input = 5.00

--- a/providers/freemodel/models/claude-opus-4-8.toml
+++ b/providers/freemodel/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = []
 
 [cost]
 input = 5.00

--- a/providers/freemodel/models/claude-opus-4-8.toml
+++ b/providers/freemodel/models/claude-opus-4-8.toml
@@ -1,5 +1,8 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5.00

--- a/providers/freemodel/models/claude-sonnet-4-6.toml
+++ b/providers/freemodel/models/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = []
 
 [cost]
 input = 3.00

--- a/providers/freemodel/models/claude-sonnet-4-6.toml
+++ b/providers/freemodel/models/claude-sonnet-4-6.toml
@@ -1,5 +1,12 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
 
 [cost]
 input = 3.00

--- a/providers/freemodel/models/gpt-5.3-codex.toml
+++ b/providers/freemodel/models/gpt-5.3-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/freemodel/models/gpt-5.3-codex.toml
+++ b/providers/freemodel/models/gpt-5.3-codex.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/freemodel/models/gpt-5.4-mini.toml
+++ b/providers/freemodel/models/gpt-5.4-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.75

--- a/providers/freemodel/models/gpt-5.4-mini.toml
+++ b/providers/freemodel/models/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = []
 
 [cost]
 input = 0.75

--- a/providers/freemodel/models/gpt-5.4.toml
+++ b/providers/freemodel/models/gpt-5.4.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.50

--- a/providers/freemodel/models/gpt-5.4.toml
+++ b/providers/freemodel/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = []
 
 [cost]
 input = 2.50

--- a/providers/freemodel/models/gpt-5.5.toml
+++ b/providers/freemodel/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["xhigh"] }]
 
 [cost]
 input = 5.00

--- a/providers/freemodel/models/gpt-5.5.toml
+++ b/providers/freemodel/models/gpt-5.5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = [{ type = "effort", values = ["xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5.00


### PR DESCRIPTION
## Summary
- complete explicit reasoning-option coverage for all existing FreeModel reasoning models
- expose `none|low|medium|high|xhigh` on every FreeModel OpenAI route
- preserve native Anthropic controls on FreeModel's native Messages endpoint: extended-thinking budgets where supported and adaptive effort on newer Claude models

## Evidence
- FreeModel public model routes: https://api.freemodel.dev/v1/models and https://cc.freemodel.dev/v1/models
- FreeModel documents `/v1/chat/completions` and `/v1/responses` as OpenAI-compatible formats and describes official Codex as fully compatible: https://freemodel.dev
- FreeModel describes `/v1/messages` as the native Anthropic Messages API with extended thinking and Anthropic SDK support: https://freemodel.dev
- The Codex setup selects `xhigh` as a recommended value; it does not restrict the API to that single effort.
- Claude controls follow the corresponding native Anthropic models: Haiku 4.5 supports budgeted extended thinking; Sonnet 4.6 and Opus 4.6 support effort and budget controls; Opus 4.7, Opus 4.8, and Fable 5 support adaptive effort.

## Validation
- `bun validate`
- `git diff --check`
- coverage audit: every reasoning model has explicit provider-accurate controls
- scope audit: only existing FreeModel model files and `reasoning_options`