### PR TITLE
feat(alibaba-token-plan-cn): add reasoning options

### DIFF
--- a/providers/alibaba-token-plan-cn/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-token-plan-cn/models/MiniMax-M2.5.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/alibaba-token-plan-cn/models/deepseek-v3.2.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v3.2.toml
@@ -10,6 +10,9 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-flash.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-flash.toml
@@ -1,5 +1,8 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-pro.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-pro.toml
@@ -1,5 +1,8 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan-cn/models/glm-5.1.toml
+++ b/providers/alibaba-token-plan-cn/models/glm-5.1.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-5.1"
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan-cn/models/glm-5.toml
+++ b/providers/alibaba-token-plan-cn/models/glm-5.toml
@@ -1,6 +1,9 @@
 base_model = "zhipuai/glm-5"
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.5.toml
@@ -4,6 +4,9 @@ family = "kimi"
 attachment = true
 temperature = true
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan-cn/models/kimi-k2.6.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.6.toml
@@ -2,6 +2,9 @@ base_model = "moonshotai/kimi-k2.6"
 base_model_omit = ["structured_output"]
 family = "kimi"
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan-cn/models/qwen3.6-flash.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.6-flash.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.6-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/qwen3.6-plus.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.6-plus.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.6-plus"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/qwen3.7-max.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.7-max.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.7-max"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/qwen3.7-plus.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.7-plus.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.7-plus"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 0
 output = 0


### PR DESCRIPTION
## Summary
- add exact caller-selectable reasoning toggles for CN Token Plan hybrid-thinking models
- add bounded `thinking_budget` metadata for Qwen3.6 and Qwen3.7 models
- mark fixed-thinking MiniMax-M2.5 with an explicit empty option set
- avoid inferred effort tiers and unbounded token budgets

## Control matrix
- Qwen3.6 Plus/Flash: `toggle`, bounded `budget_tokens` (81,920)
- Qwen3.7 Plus/Max: `toggle`, bounded `budget_tokens` (262,144)
- DeepSeek V3.2/V4 Pro/V4 Flash: `toggle`
- Kimi K2.5/K2.6: `toggle`
- GLM-5/GLM-5.1: `toggle`
- MiniMax-M2.5: fixed reasoning, no caller-selectable options

## Sources
- CN Token Plan model matrix: https://help.aliyun.com/zh/model-studio/token-plan-overview
- Alibaba Cloud CN deep-thinking controls and model classifications: https://help.aliyun.com/zh/model-studio/deep-thinking

## Validation
- `bun install --frozen-lockfile`
- `bun validate`
- `git diff --check`