### PR TITLE
[alibaba-token-plan] Add reasoning options

### DIFF
--- a/providers/alibaba-token-plan/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-token-plan/models/MiniMax-M2.5.toml
@@ -1,5 +1,7 @@
 base_model = "minimax/MiniMax-M2.5"
 
+reasoning_options = []
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan/models/deepseek-v3.2.toml
+++ b/providers/alibaba-token-plan/models/deepseek-v3.2.toml
@@ -9,6 +9,7 @@ temperature = true
 tool_call = true
 knowledge = "2025-01"
 open_weights = true
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0

--- a/providers/alibaba-token-plan/models/deepseek-v4-flash.toml
+++ b/providers/alibaba-token-plan/models/deepseek-v4-flash.toml
@@ -1,5 +1,7 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan/models/deepseek-v4-pro.toml
+++ b/providers/alibaba-token-plan/models/deepseek-v4-pro.toml
@@ -1,5 +1,7 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan/models/glm-5.1.toml
+++ b/providers/alibaba-token-plan/models/glm-5.1.toml
@@ -1,5 +1,7 @@
 base_model = "zhipuai/glm-5.1"
 
+reasoning_options = [{ type = "toggle" }]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-token-plan/models/glm-5.toml
+++ b/providers/alibaba-token-plan/models/glm-5.toml
@@ -1,5 +1,6 @@
 base_model = "zhipuai/glm-5"
 open_weights = false
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/alibaba-token-plan/models/kimi-k2.5.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.5.toml
@@ -3,6 +3,7 @@ base_model_omit = ["structured_output"]
 family = "kimi"
 attachment = true
 temperature = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/alibaba-token-plan/models/kimi-k2.6.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.6.toml
@@ -1,6 +1,7 @@
 base_model = "moonshotai/kimi-k2.6"
 base_model_omit = ["structured_output"]
 family = "kimi"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/alibaba-token-plan/models/qwen3.6-flash.toml
+++ b/providers/alibaba-token-plan/models/qwen3.6-flash.toml
@@ -1,5 +1,7 @@
 base_model = "alibaba/qwen3.6-flash"
 
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
+
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/qwen3.6-plus.toml
+++ b/providers/alibaba-token-plan/models/qwen3.6-plus.toml
@@ -1,5 +1,7 @@
 base_model = "alibaba/qwen3.6-plus"
 
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
+
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/qwen3.7-max.toml
+++ b/providers/alibaba-token-plan/models/qwen3.7-max.toml
@@ -1,5 +1,7 @@
 base_model = "alibaba/qwen3.7-max"
 
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
+
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/qwen3.7-plus.toml
+++ b/providers/alibaba-token-plan/models/qwen3.7-plus.toml
@@ -1,5 +1,7 @@
 base_model = "alibaba/qwen3.7-plus"
 
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
+
 [cost]
 input = 0
 output = 0


### PR DESCRIPTION
## Summary
- add provider-specific reasoning controls for every reasoning-capable Alibaba Token Plan model
- model the Token Plan compatible transport precisely: `enable_thinking` as `toggle`, `thinking_budget` as `budget_tokens`, and DeepSeek V4 discrete effort values as `effort`
- distinguish caller-selectable controls from MiniMax M2.5 fixed reasoning with an explicit empty option set

## Control matrix
| Models | Reasoning options |
| --- | --- |
| Qwen3.6 Plus / Flash | toggle, budget tokens (max 81,920) |
| Qwen3.7 Max / Plus | toggle, budget tokens (max 262,144) |
| DeepSeek V4 Pro / Flash | toggle, effort (`high`, `max`) |
| DeepSeek V3.2 | toggle |
| Kimi K2.5 / K2.6 | toggle, budget tokens |
| GLM-5 / GLM-5.1 | toggle |
| MiniMax M2.5 | fixed reasoning |

## Scope
- changes only `reasoning_options` in `providers/alibaba-token-plan/models/`
- leaves image-generation records and all unrelated providers unchanged

## Validation
- `bun install --frozen-lockfile`
- `bun validate`
- `git diff --check`