### PR TITLE
[lmstudio] Add GPT-OSS reasoning options

### DIFF
--- a/providers/lmstudio/models/openai/gpt-oss-20b.toml
+++ b/providers/lmstudio/models/openai/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary
- expose low, medium, and high reasoning effort options for LM Studio GPT-OSS 20B
- keep the change scoped to `reasoning_options` metadata

## Evidence
- LM Studio documents `reasoning.effort` on its OpenAI-compatible Responses endpoint using `openai/gpt-oss-20b`: https://lmstudio.ai/docs/developer/openai-compat/responses
- OpenAI documents GPT-OSS reasoning levels as low, medium, and high: https://huggingface.co/openai/gpt-oss-20b

## Validation
- `bun validate`

## Related
- Provider removal remains open and unmerged in #794; this PR applies while `lmstudio` remains on `dev`.