### PR TITLE
feat(models): add Kimi K2.7 Code

### DIFF
--- a/models/moonshotai/kimi-k2.5.toml
+++ b/models/moonshotai/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi-k2.5"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false

--- a/models/moonshotai/kimi-k2.6.toml
+++ b/models/moonshotai/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi-k2.6"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/models/moonshotai/kimi-k2.7-code.toml
+++ b/models/moonshotai/kimi-k2.7-code.toml
@@ -1,22 +1,14 @@
-name = "kimi/kimi-k2.5"
+name = "Kimi K2.7 Code"
 family = "kimi-k2"
-release_date = "2026-01-27"
-last_updated = "2026-01-27"
-attachment = false
+release_date = "2026-06-12"
+last_updated = "2026-06-12"
+attachment = true
 reasoning = true
-structured_output = true
 temperature = false
 tool_call = true
+structured_output = true
 knowledge = "2025-01"
 open_weights = true
-
-[interleaved]
-field = "reasoning_content"
-
-[cost]
-input = 0.6
-output = 3.0
-cache_read = 0.1
 
 [limit]
 context = 262_144
@@ -25,3 +17,7 @@ output = 262_144
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/moonshotai/Kimi-K2.7-Code"

--- a/packages/core/script/generate-digitalocean.ts
+++ b/packages/core/script/generate-digitalocean.ts
@@ -142,7 +142,7 @@ const PRICING_NAME_MAP: Record<string, string> = {
   // DO-hosted
   "qwen3-32b": "alibaba-qwen3-32b",
   "minimax m2.5 (public preview)": "minimax-m2.5",
-  "kimi k2.5": "kimi-k2.5",
+  "kimi k2.5": "kimi-k2",
   "nvidia nemotron 3 super 120b (public preview)": "nvidia-nemotron-3-super-120b",
   "glm 5": "glm-5",
 };

--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -66,8 +66,7 @@ export const ModelFamilyValues = [
 
   // Moonshot Kimi
   "kimi",
-  "kimi-k2.5",
-  "kimi-k2.6",
+  "kimi-k2",
   "kimi-free",
   "kimi-thinking",
 

--- a/providers/abacus/models/kimi-k2-turbo-preview.toml
+++ b/providers/abacus/models/kimi-k2-turbo-preview.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 Turbo Preview"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-08"
 last_updated = "2025-07-08"
 attachment = false

--- a/providers/abacus/models/kimi-k2.5.toml
+++ b/providers/abacus/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false

--- a/providers/aihubmix/models/kimi-k2.5.toml
+++ b/providers/aihubmix/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi-k2.5"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true

--- a/providers/aihubmix/models/kimi-k2.6.toml
+++ b/providers/aihubmix/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi-k2.6"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/alibaba-cn/models/kimi-k2-thinking.toml
+++ b/providers/alibaba-cn/models/kimi-k2-thinking.toml
@@ -1,5 +1,5 @@
 name = "Moonshot Kimi K2 Thinking"
-family = "kimi"
+family = "kimi-thinking"
 release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false

--- a/providers/alibaba-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-cn/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Moonshot Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = false

--- a/providers/alibaba-cn/models/kimi-k2.6.toml
+++ b/providers/alibaba-cn/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Moonshot Kimi K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/alibaba-cn/models/moonshot-kimi-k2-instruct.toml
+++ b/providers/alibaba-cn/models/moonshot-kimi-k2-instruct.toml
@@ -1,5 +1,5 @@
 name = "Moonshot Kimi K2 Instruct"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-01-01"
 last_updated = "2025-01-01"
 attachment = false

--- a/providers/alibaba-coding-plan-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-coding-plan-cn/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/alibaba-coding-plan/models/kimi-k2.5.toml
+++ b/providers/alibaba-coding-plan/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/alibaba-token-plan-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.5.toml
@@ -1,6 +1,6 @@
 base_model = "moonshotai/kimi-k2.5"
 base_model_omit = ["structured_output"]
-family = "kimi"
+family = "kimi-k2"
 attachment = true
 temperature = true
 

--- a/providers/alibaba-token-plan-cn/models/kimi-k2.6.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.6.toml
@@ -1,6 +1,6 @@
 base_model = "moonshotai/kimi-k2.6"
 base_model_omit = ["structured_output"]
-family = "kimi"
+family = "kimi-k2"
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/alibaba-token-plan/models/kimi-k2.5.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.5.toml
@@ -1,6 +1,6 @@
 base_model = "moonshotai/kimi-k2.5"
 base_model_omit = ["structured_output"]
-family = "kimi"
+family = "kimi-k2"
 attachment = true
 temperature = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]

--- a/providers/alibaba-token-plan/models/kimi-k2.6.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.6.toml
@@ -1,6 +1,6 @@
 base_model = "moonshotai/kimi-k2.6"
 base_model_omit = ["structured_output"]
-family = "kimi"
+family = "kimi-k2"
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
 [interleaved]

--- a/providers/azure-cognitive-services/models/kimi-k2.6.toml
+++ b/providers/azure-cognitive-services/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = false

--- a/providers/azure/models/kimi-k2.5.toml
+++ b/providers/azure/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-02-06"
 last_updated = "2026-02-06"
 attachment = false

--- a/providers/azure/models/kimi-k2.6.toml
+++ b/providers/azure/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = false

--- a/providers/baseten/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-30"
 last_updated = "2026-02-12"
 attachment = true

--- a/providers/baseten/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi-k2.6"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.5.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.6.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/moonshotai/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = true

--- a/providers/cortecs/models/kimi-k2-instruct.toml
+++ b/providers/cortecs/models/kimi-k2-instruct.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 Instruct"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-11"
 last_updated = "2025-09-05"
 knowledge = "2024-07"

--- a/providers/crof/models/kimi-k2.5-lightning.toml
+++ b/providers/crof/models/kimi-k2.5-lightning.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5 (Lightning)"
-family = "kimi-k2.5"
+family = "kimi-k2"
 release_date = "2026-02-06"
 last_updated = "2026-02-06"
 attachment = false

--- a/providers/deepinfra/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/deepinfra/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/deepinfra/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/deepinfra/models/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/digitalocean/models/kimi-k2.5.toml
+++ b/providers/digitalocean/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-04-16"
 attachment = false

--- a/providers/digitalocean/models/kimi-k2.6.toml
+++ b/providers/digitalocean/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/evroc/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/evroc/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = false

--- a/providers/fastrouter/models/moonshotai/kimi-k2.toml
+++ b/providers/fastrouter/models/moonshotai/kimi-k2.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-11"
 last_updated = "2025-07-11"
 attachment = false

--- a/providers/helicone/models/kimi-k2-0711.toml
+++ b/providers/helicone/models/kimi-k2-0711.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 (07/11)"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-01-01"
 last_updated = "2025-01-01"
 attachment = false

--- a/providers/helicone/models/kimi-k2-0905.toml
+++ b/providers/helicone/models/kimi-k2-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 (09/05)"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false

--- a/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
+++ b/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-01"
 last_updated = "2026-06-01"
 attachment = false

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2-Instruct-0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-04"
 last_updated = "2025-09-04"
 attachment = false

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Instruct.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Instruct.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2-Instruct"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-14"
 last_updated = "2025-07-14"
 attachment = false

--- a/providers/huggingface/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-01"
 last_updated = "2026-01-01"
 attachment = true

--- a/providers/huggingface/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = true

--- a/providers/iflowcn/models/kimi-k2-0905.toml
+++ b/providers/iflowcn/models/kimi-k2-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2-0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false

--- a/providers/iflowcn/models/kimi-k2.toml
+++ b/providers/iflowcn/models/kimi-k2.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2024-12-01"
 last_updated = "2024-12-01"
 attachment = false

--- a/providers/io-net/models/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/io-net/models/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 Instruct"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2024-09-05"
 last_updated = "2024-09-05"
 attachment = false

--- a/providers/jiekou/models/moonshotai/kimi-k2-0905.toml
+++ b/providers/jiekou/models/moonshotai/kimi-k2-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false

--- a/providers/jiekou/models/moonshotai/kimi-k2-instruct.toml
+++ b/providers/jiekou/models/moonshotai/kimi-k2-instruct.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 Instruct"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false

--- a/providers/jiekou/models/moonshotai/kimi-k2.5.toml
+++ b/providers/jiekou/models/moonshotai/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true

--- a/providers/kimi-for-coding/models/k2p7.toml
+++ b/providers/kimi-for-coding/models/k2p7.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+output = 32_768

--- a/providers/llmgateway/models/kimi-k2.toml
+++ b/providers/llmgateway/models/kimi-k2.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-11"
 last_updated = "2025-07-11"
 attachment = false

--- a/providers/meganova/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/meganova/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = false

--- a/providers/moonshotai/models/kimi-k2-0711-preview.toml
+++ b/providers/moonshotai/models/kimi-k2-0711-preview.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0711"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-14"
 last_updated = "2025-07-14"
 attachment = false

--- a/providers/moonshotai/models/kimi-k2-0905-preview.toml
+++ b/providers/moonshotai/models/kimi-k2-0905-preview.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false

--- a/providers/moonshotai/models/kimi-k2-turbo-preview.toml
+++ b/providers/moonshotai/models/kimi-k2-turbo-preview.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 Turbo"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false

--- a/providers/moonshotai/models/kimi-k2.5.toml
+++ b/providers/moonshotai/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi-k2.5"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false

--- a/providers/moonshotai/models/kimi-k2.6.toml
+++ b/providers/moonshotai/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi-k2.6"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/moonshotai/models/kimi-k2.7-code.toml
+++ b/providers/moonshotai/models/kimi-k2.7-code.toml
@@ -1,0 +1,10 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4.0
+cache_read = 0.19

--- a/providers/nano-gpt/models/TEE/kimi-k2.5.toml
+++ b/providers/nano-gpt/models/TEE/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5 TEE"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-29"
 last_updated = "2026-01-29"
 attachment = false

--- a/providers/nano-gpt/models/baseten/Kimi-K2-Instruct-FP4.toml
+++ b/providers/nano-gpt/models/baseten/Kimi-K2-Instruct-FP4.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0711 Instruct FP4"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-11"
 last_updated = "2025-07-11"
 attachment = false

--- a/providers/nano-gpt/models/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/nano-gpt/models/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2-instruct-0711.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2-instruct-0711.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0711"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-11"
 last_updated = "2025-07-11"
 attachment = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2-instruct.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2-instruct.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 Instruct"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-01"
 last_updated = "2025-07-01"
 attachment = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-26"
 last_updated = "2026-01-26"
 attachment = true

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.6.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi-k2.6"
+family = "kimi-k2"
 release_date = "2026-04-16"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/nebius/models/moonshotai/Kimi-K2.5-fast.toml
+++ b/providers/nebius/models/moonshotai/Kimi-K2.5-fast.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2.5-fast"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-12-15"
 last_updated = "2026-02-04"
 attachment = true

--- a/providers/nebius/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/nebius/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-12-15"
 last_updated = "2026-02-04"
 attachment = true

--- a/providers/neuralwatt/models/kimi-k2.5-fast.toml
+++ b/providers/neuralwatt/models/kimi-k2.5-fast.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5 Fast"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/neuralwatt/models/kimi-k2.6-fast.toml
+++ b/providers/neuralwatt/models/kimi-k2.6-fast.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6 Fast"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/neuralwatt/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/neuralwatt/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/neuralwatt/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/neuralwatt/models/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/novita-ai/models/moonshotai/kimi-k2-0905.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false

--- a/providers/novita-ai/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2-thinking.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 Thinking"
-family = "kimi"
+family = "kimi-thinking"
 release_date = "2025-11-07"
 last_updated = "2025-11-07"
 attachment = false

--- a/providers/novita-ai/models/moonshotai/kimi-k2.5.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/nvidia/models/moonshotai/kimi-k2-instruct-0905.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k2-instruct-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false

--- a/providers/nvidia/models/moonshotai/kimi-k2.6.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi-k2.6"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/ollama-cloud/models/kimi-k2.5.toml
+++ b/providers/ollama-cloud/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "kimi-k2.5"
-family = "kimi"
+family = "kimi-k2"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]

--- a/providers/ollama-cloud/models/kimi-k2.6.toml
+++ b/providers/ollama-cloud/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "kimi-k2.6"
-family = "kimi"
+family = "kimi-k2"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]

--- a/providers/ollama-cloud/models/kimi-k2:1t.toml
+++ b/providers/ollama-cloud/models/kimi-k2:1t.toml
@@ -1,5 +1,5 @@
 name = "kimi-k2:1t"
-family = "kimi"
+family = "kimi-k2"
 attachment = false
 reasoning = false
 reasoning_options = []

--- a/providers/opencode-go/models/kimi-k2.5.toml
+++ b/providers/opencode-go/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi-k2.5"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/opencode-go/models/kimi-k2.6.toml
+++ b/providers/opencode-go/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi-k2.6"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/opencode/models/kimi-k2.5.toml
+++ b/providers/opencode/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/opencode/models/kimi-k2.6.toml
+++ b/providers/opencode/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/opencode/models/kimi-k2.toml
+++ b/providers/opencode/models/kimi-k2.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false

--- a/providers/openrouter/models/moonshotai/kimi-k2-0905.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-04"
 last_updated = "2025-09-04"
 attachment = false

--- a/providers/openrouter/models/moonshotai/kimi-k2.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0711"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-11"
 last_updated = "2025-07-11"
 attachment = false

--- a/providers/poe/models/novita/kimi-k2-thinking.toml
+++ b/providers/poe/models/novita/kimi-k2-thinking.toml
@@ -1,5 +1,5 @@
 name = "kimi-k2-thinking"
-family = "kimi"
+family = "kimi-thinking"
 release_date = "2025-11-07"
 last_updated = "2025-11-07"
 attachment = true

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,5 +1,5 @@
 name = "Pro/moonshotai/Kimi-K2-Instruct-0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-08"
 last_updated = "2025-11-25"
 attachment = false

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.5.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Pro/moonshotai/Kimi-K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = false

--- a/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.6.toml
+++ b/providers/siliconflow-cn/models/Pro/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,5 @@
 name = "Pro/moonshotai/Kimi-K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = false

--- a/providers/siliconflow/models/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,5 +1,5 @@
 name = "moonshotai/Kimi-K2-Instruct-0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-08"
 last_updated = "2025-11-25"
 attachment = false

--- a/providers/siliconflow/models/moonshotai/Kimi-K2-Instruct.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2-Instruct.toml
@@ -1,5 +1,5 @@
 name = "moonshotai/Kimi-K2-Instruct"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-07-13"
 last_updated = "2025-11-25"
 attachment = false

--- a/providers/siliconflow/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "moonshotai/Kimi-K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = false

--- a/providers/siliconflow/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,5 @@
 name = "moonshotai/Kimi-K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = false

--- a/providers/synthetic/models/hf:moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K2-Instruct-0905.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 0905"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false

--- a/providers/synthetic/models/hf:moonshotai/Kimi-K2.5.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false

--- a/providers/synthetic/models/hf:nvidia/Kimi-K2.5-NVFP4.toml
+++ b/providers/synthetic/models/hf:nvidia/Kimi-K2.5-NVFP4.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5 (NVFP4)"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false

--- a/providers/tencent-coding-plan/models/kimi-k2.5.toml
+++ b/providers/tencent-coding-plan/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true

--- a/providers/togetherai/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/togetherai/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = false

--- a/providers/togetherai/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/togetherai/models/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.6"
-family = "kimi-k2.6"
+family = "kimi-k2"
 release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true

--- a/providers/venice/models/kimi-k2-5.toml
+++ b/providers/venice/models/kimi-k2-5.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-06-11"
 attachment = true

--- a/providers/venice/models/kimi-k2-6.toml
+++ b/providers/venice/models/kimi-k2-6.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-04-20"
 last_updated = "2026-06-11"
 

--- a/providers/vercel/models/moonshotai/kimi-k2.5.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-26"
 attachment = true
 temperature = true

--- a/providers/vercel/models/moonshotai/kimi-k2.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2 Instruct"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false

--- a/providers/wafer.ai/models/Kimi-K2.6.toml
+++ b/providers/wafer.ai/models/Kimi-K2.6.toml
@@ -1,5 +1,5 @@
 name = "Kimi-K2.6"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-05-13"
 last_updated = "2026-06-01"
 knowledge = "2025-01"

--- a/providers/wandb/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/wandb/models/moonshotai/Kimi-K2.5.toml
@@ -1,5 +1,5 @@
 name = "Kimi K2.5"
-family = "kimi"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-03-12"
 attachment = true


### PR DESCRIPTION
## Summary
- add shared Kimi K2.7 Code metadata and Moonshot AI pricing
- expose K2.7 through Moonshot AI and Kimi For Coding
- mark K2.7 reasoning as always-on with no configurable reasoning options
- normalize Kimi K2 model families to `kimi-k2`, retaining `kimi-thinking` for explicit thinking variants

Supports anomalyco/opencode#32065.

## Validation
- `bun validate`
- `git diff --check`