### PR TITLE
[kimi-for-coding] Add Kimi K2.7 Code

### DIFF
--- a/providers/kimi-for-coding/models/k2p7.toml
+++ b/providers/kimi-for-coding/models/k2p7.toml
@@ -1,0 +1,25 @@
+name = "Kimi K2.7 Code"
+family = "kimi-thinking"
+release_date = "2026-06-12"
+last_updated = "2026-06-12"
+attachment = false
+reasoning = true
+reasoning_options = []
+structured_output = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- add Kimi K2.7 Code to the Kimi For Coding provider catalog
- mark reasoning as fixed because Kimi K2.7 Code always enables thinking
- keep Kimi For Coding membership-benefit pricing at zero, matching the existing K2.5 and K2.6 entries

## Sources

- Kimi Code release notes announce Kimi K2.7 Code on June 12, 2026: https://www.kimi.com/code/docs/en/kimi-code/whats-new.html
- Kimi API docs list `kimi-k2.7-code` and document fixed enabled thinking / preserved reasoning behavior: https://platform.kimi.com/docs/api/chat
- Kimi Code third-party agent docs show the Kimi Code endpoint, 262144 context window, 32768 max output tokens, and image support: https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html

## Validation

- `bun validate`
- `git diff --check`
