### PR TITLE
fix(sync): normalize Kimi model families

### DIFF
--- a/packages/core/script/generate-chutes.ts
+++ b/packages/core/script/generate-chutes.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 import path from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
-import { ModelFamilyValues } from "../src/family.js";
+import { inferKimiFamily, ModelFamilyValues } from "../src/family.js";
 
 const API_ENDPOINT = "https://llm.chutes.ai/v1/models";
 const MODEL_METADATA_DIR = path.join(import.meta.dirname, "..", "..", "..", "models");
@@ -261,6 +261,9 @@ function matchesFamily(target: string, family: string): boolean {
 }
 
 function inferFamily(modelId: string, modelName: string): string | undefined {
+  const kimiFamily = inferKimiFamily(modelId, modelName);
+  if (kimiFamily !== undefined) return kimiFamily;
+
   const sortedFamilies = [...ModelFamilyValues].sort((a, b) => b.length - a.length);
 
   // First pass: try exact substring matches

--- a/packages/core/script/generate-digitalocean.ts
+++ b/packages/core/script/generate-digitalocean.ts
@@ -26,7 +26,7 @@
 import { z } from "zod";
 import path from "node:path";
 import { mkdir } from "node:fs/promises";
-import { ModelFamilyValues } from "../src/family.js";
+import { inferKimiFamily, ModelFamilyValues } from "../src/family.js";
 
 const MODELS_API = "https://api.digitalocean.com/v2/gen-ai/models";
 const PRICING_API = "https://www.digitalocean.com/api/static-content/v1/products";
@@ -311,6 +311,9 @@ function formatNumber(n: number): string {
 }
 
 function inferFamily(modelId: string, modelName: string): string | undefined {
+  const kimiFamily = inferKimiFamily(modelId, modelName);
+  if (kimiFamily !== undefined) return kimiFamily;
+
   const sorted = [...ModelFamilyValues].sort((a, b) => b.length - a.length);
   const targets = [modelId.toLowerCase(), modelName.toLowerCase()];
   for (const family of sorted) {

--- a/packages/core/script/generate-friendli.ts
+++ b/packages/core/script/generate-friendli.ts
@@ -4,6 +4,8 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 
+import { inferKimiFamily } from "../src/family.js";
+
 // Friendli API endpoint
 const API_ENDPOINT = "https://api.friendli.ai/serverless/v1/models";
 
@@ -53,6 +55,9 @@ const familyPatterns: [RegExp, string][] = [
 ];
 
 function inferFamily(modelId: string, modelName: string): string | undefined {
+  const kimiFamily = inferKimiFamily(modelId, modelName);
+  if (kimiFamily !== undefined) return kimiFamily;
+
   for (const [pattern, family] of familyPatterns) {
     if (pattern.test(modelId) || pattern.test(modelName)) {
       return family;

--- a/packages/core/script/generate-wandb.ts
+++ b/packages/core/script/generate-wandb.ts
@@ -3,7 +3,7 @@
 import path from "node:path";
 import { mkdir } from "node:fs/promises";
 import { z } from "zod";
-import { ModelFamilyValues } from "../src/family.js";
+import { inferKimiFamily, ModelFamilyValues } from "../src/family.js";
 
 const API_ENDPOINT = "https://trace.wandb.ai/inference/analysis/artificialanalysis/models";
 
@@ -176,6 +176,9 @@ function matchesFamily(target: string, family: string): boolean {
 }
 
 function inferFamily(modelId: string, modelName: string): string | undefined {
+  const kimiFamily = inferKimiFamily(modelId, modelName);
+  if (kimiFamily !== undefined) return kimiFamily;
+
   const sortedFamilies = [...ModelFamilyValues].sort((a, b) => b.length - a.length);
 
   for (const family of sortedFamilies) {

--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -422,3 +422,10 @@ export const ModelFamilyValues = [
 
 export const ModelFamily = z.enum(ModelFamilyValues);
 export type ModelFamily = z.infer<typeof ModelFamily>;
+
+export function inferKimiFamily(...values: string[]): ModelFamily | undefined {
+  const target = values.join(" ").toLowerCase();
+  if (/kimi[^a-z0-9]*k2(?:[^a-z0-9]*\d+)?[^a-z0-9]*thinking/.test(target)) return "kimi-thinking";
+  if (/kimi[\s_-]*k2/.test(target)) return "kimi-k2";
+  return undefined;
+}

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 
-import { ModelFamilyValues } from "../../family.js";
+import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
 
 const API_ENDPOINT = "https://openrouter.ai/api/v1/models";
@@ -113,6 +113,9 @@ function modalities(values: string[], fallback: Modality[]): Modality[] {
 }
 
 function inferFamily(model: OpenRouterModel, name: string) {
+  const kimiFamily = inferKimiFamily(model.id, name);
+  if (kimiFamily !== undefined) return kimiFamily;
+
   const target = `${model.id} ${name}`.toLowerCase();
   return [...ModelFamilyValues]
     .sort((a, b) => b.length - a.length)

--- a/packages/core/src/sync/providers/venice.ts
+++ b/packages/core/src/sync/providers/venice.ts
@@ -2,7 +2,7 @@ import { readdirSync } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 
-import { ModelFamilyValues } from "../../family.js";
+import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
 import { factorBaseModel } from "./openrouter.js";
 
@@ -230,6 +230,9 @@ function isReasoningEffort(value: string): value is ReasoningEffort {
 }
 
 function inferFamily(id: string, name: string) {
+  const kimiFamily = inferKimiFamily(id, name);
+  if (kimiFamily !== undefined) return kimiFamily;
+
   const target = `${id} ${name}`.toLowerCase();
   return [...ModelFamilyValues]
     .sort((a, b) => b.length - a.length)

--- a/packages/core/src/sync/providers/vercel.ts
+++ b/packages/core/src/sync/providers/vercel.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { ModelFamilyValues } from "../../family.js";
+import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
 import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
 
@@ -153,6 +153,9 @@ function buildCost(pricing: VercelModel["pricing"], existing?: ExistingModel["co
 }
 
 function inferFamily(modelID: string, name: string) {
+  const kimiFamily = inferKimiFamily(modelID, name);
+  if (kimiFamily !== undefined) return kimiFamily;
+
   const targets = [modelID, name].map((value) => value.toLowerCase());
   const families = [...ModelFamilyValues].sort((a, b) => b.length - a.length);
   return families.find((family) => targets.some((target) => target.includes(family.toLowerCase())))

--- a/packages/core/test/family.test.ts
+++ b/packages/core/test/family.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+
+import { inferKimiFamily } from "../src/family.js";
+
+test("Kimi family inference ignores K2 versions", () => {
+  expect(inferKimiFamily("moonshotai/kimi-k2.5")).toBe("kimi-k2");
+  expect(inferKimiFamily("moonshotai/kimi-k2.7-code")).toBe("kimi-k2");
+  expect(inferKimiFamily("Kimi K2.6")).toBe("kimi-k2");
+});
+
+test("Kimi family inference preserves thinking variants", () => {
+  expect(inferKimiFamily("moonshotai/kimi-k2-thinking")).toBe("kimi-thinking");
+  expect(inferKimiFamily("Kimi K2.5 Thinking")).toBe("kimi-thinking");
+  expect(inferKimiFamily("moonshotai/kimi-k2.6:thinking")).toBe("kimi-thinking");
+});


### PR DESCRIPTION
## Summary
- centralize version-independent Kimi K2 family inference
- map explicit K2 Thinking model IDs to `kimi-thinking`
- apply the shared inference to Vercel, OpenRouter, Venice, Chutes, DigitalOcean, Friendli, and W&B sync paths
- add regression coverage for dotted, spaced, code, and colon-suffixed Kimi model IDs

PR #2266 correctly removes redundant provider family overrides inherited through `base_model`; this prevents future non-inherited and newly discovered Kimi entries from receiving inconsistent families.

## Validation
- `bun test packages/core/test/family.test.ts packages/core/test/vercel-sync.test.ts packages/core/test/openrouter-sync.test.ts packages/core/test/venice-sync.test.ts`
- `bun validate`
- `git diff --check`