### PR TITLE
Add ZAI Coding Plan GLM-5.2

### DIFF
--- a/providers/zai-coding-plan/models/glm-5.2.toml
+++ b/providers/zai-coding-plan/models/glm-5.2.toml
@@ -1,0 +1,31 @@
+name = "GLM-5.2"
+family = "glm"
+release_date = "2026-06-13"
+last_updated = "2026-06-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Add `glm-5.2` to the Z.AI Coding Plan provider catalog.
- Use the limits and model metadata published in Z.AI's latest-model guide.

## Source

Z.AI docs: https://docs.z.ai/devpack/latest-model.md

The guide states that GLM Coding Plan supports GLM-5.2 for Max, Pro, and Lite users, and includes an OpenClaw custom model snippet with:

- `id`: `glm-5.2`
- `name`: `GLM-5.2`
- `reasoning`: `true`
- `input`: `["text"]`
- `contextWindow`: `1000000`
- `maxTokens`: `131072`
- zeroed plan costs

The page also documents the Coding Plan endpoint as `https://api.z.ai/api/coding/paas/v4`.

## Notes

- I used `2026-06-13` for `release_date` / `last_updated` based on the docs page observed `lastModified` timestamp (`2026-06-13T07:44:48.943Z`), since the page does not list a separate release date.
- I did not add provider-agnostic `models/zhipuai/glm-5.2.toml` metadata because the cited page is specifically for GLM Coding Plan configuration.

## Validation

```sh
/opt/homebrew/bin/bun validate
```

Passed locally.
