### PR TITLE
Correct Azure DeepSeek V4 model prices

### DIFF
--- a/providers/azure/models/deepseek-v4-flash.toml
+++ b/providers/azure/models/deepseek-v4-flash.toml
@@ -3,8 +3,8 @@ name = "DeepSeek-V4-Flash"
 tool_call = false
 
 [cost]
-input = 1.74
-output = 3.48
+input = 0.19
+output = 0.51
 
 [provider]
 shape = "completions"

--- a/providers/azure/models/deepseek-v4-pro.toml
+++ b/providers/azure/models/deepseek-v4-pro.toml
@@ -3,8 +3,8 @@ name = "DeepSeek-V4-Pro"
 tool_call = false
 
 [cost]
-input = 0.19
-output = 0.51
+input = 1.74
+output = 3.48
 
 [provider]
 shape = "completions"


### PR DESCRIPTION
The Azure DeepSeek V4 model prices were accidentally the wrong way around Flash <-> Pro, this PR corrects that.