### PR TITLE
fix MiMo reasoning options across providers

### DIFF
--- a/providers/aihubmix/models/coding-xiaomi-mimo-v2.5-pro.toml
+++ b/providers/aihubmix/models/coding-xiaomi-mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "Coding Xiaomi MiMo-V2.5-Pro"
 family = "mimo-v2.5-pro"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/coding-xiaomi-mimo-v2.5.toml
+++ b/providers/aihubmix/models/coding-xiaomi-mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 name = "Coding Xiaomi MiMo-V2.5"
 family = "mimo-v2.5"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/xiaomi-mimo-v2.5-free.toml
+++ b/providers/aihubmix/models/xiaomi-mimo-v2.5-free.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 name = "Xiaomi MiMo-V2.5 (free)"
 family = "mimo-v2.5"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/xiaomi-mimo-v2.5-pro-free.toml
+++ b/providers/aihubmix/models/xiaomi-mimo-v2.5-pro-free.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "Xiaomi MiMo-V2.5-Pro (free)"
 family = "mimo-v2.5-pro"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/xiaomi-mimo-v2.5-pro.toml
+++ b/providers/aihubmix/models/xiaomi-mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "Xiaomi MiMo-V2.5-Pro"
 family = "mimo-v2.5-pro"
 last_updated = "2026-05-13"

--- a/providers/aihubmix/models/xiaomi-mimo-v2.5.toml
+++ b/providers/aihubmix/models/xiaomi-mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 name = "Xiaomi MiMo-V2.5"
 family = "mimo-v2.5"
 last_updated = "2026-05-13"

--- a/providers/huggingface/models/XiaomiMiMo/MiMo-V2-Flash.toml
+++ b/providers/huggingface/models/XiaomiMiMo/MiMo-V2-Flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-16"
 last_updated = "2025-12-16"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/kilo/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-flash.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-flash"
+reasoning_options = []
 name = "Xiaomi: MiMo-V2-Flash"
 
 [cost]

--- a/providers/kilo/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-omni.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-omni"
+reasoning_options = []
 name = "Xiaomi: MiMo-V2-Omni"
 
 [cost]

--- a/providers/kilo/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+reasoning_options = []
 name = "Xiaomi: MiMo-V2-Pro"
 
 [cost]

--- a/providers/kilo/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
 name = "Xiaomi: MiMo V2.5 Pro"
 
 [interleaved]

--- a/providers/kilo/models/xiaomi/mimo-v2.5.toml
+++ b/providers/kilo/models/xiaomi/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = []
 name = "Xiaomi: MiMo-V2.5"
 
 [interleaved]

--- a/providers/llmgateway/models/mimo-v2-flash.toml
+++ b/providers/llmgateway/models/mimo-v2-flash.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-flash"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/mimo-v2-omni.toml
+++ b/providers/llmgateway/models/mimo-v2-omni.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-omni"
+reasoning = false
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/mimo-v2-pro.toml
+++ b/providers/llmgateway/models/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/mimo-v2.5-pro.toml
+++ b/providers/llmgateway/models/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/mimo-v2.5.toml
+++ b/providers/llmgateway/models/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/meganova/models/XiaomiMiMo/MiMo-V2-Flash.toml
+++ b/providers/meganova/models/XiaomiMiMo/MiMo-V2-Flash.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 temperature = true
 knowledge = "2024-12-01"
 tool_call = true

--- a/providers/nano-gpt/models/xiaomi/mimo-v2-flash-original.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2-flash-original.toml
@@ -3,7 +3,8 @@ family = "mimo"
 release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2-flash-thinking-original.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2-flash-thinking-original.toml
@@ -3,7 +3,8 @@ family = "mimo"
 release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2-flash-thinking.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2-flash-thinking.toml
@@ -3,7 +3,8 @@ family = "mimo"
 release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2-flash.toml
@@ -3,7 +3,8 @@ family = "mimo"
 release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2-omni.toml
@@ -3,7 +3,8 @@ name = "MiMo V2 Omni"
 release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/xiaomi/mimo-v2.5.toml
+++ b/providers/nano-gpt/models/xiaomi/mimo-v2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/opencode-go/models/mimo-v2-omni.toml
+++ b/providers/opencode-go/models/mimo-v2-omni.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode-go/models/mimo-v2-pro.toml
+++ b/providers/opencode-go/models/mimo-v2-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode-go/models/mimo-v2.5-pro.toml
+++ b/providers/opencode-go/models/mimo-v2.5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode-go/models/mimo-v2.5.toml
+++ b/providers/opencode-go/models/mimo-v2.5.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2-flash-free.toml
+++ b/providers/opencode/models/mimo-v2-flash-free.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-16"
 last_updated = "2025-12-16"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2-omni-free.toml
+++ b/providers/opencode/models/mimo-v2-omni-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2-pro-free.toml
+++ b/providers/opencode/models/mimo-v2-pro-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/opencode/models/mimo-v2.5-free.toml
+++ b/providers/opencode/models/mimo-v2.5-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-12"

--- a/providers/openrouter/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,6 +1,6 @@
 base_model = "xiaomi/mimo-v2.5-pro"
 structured_output = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/openrouter/models/xiaomi/mimo-v2.5.toml
+++ b/providers/openrouter/models/xiaomi/mimo-v2.5.toml
@@ -1,6 +1,6 @@
 base_model = "xiaomi/mimo-v2.5"
 structured_output = false
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_details"

--- a/providers/qiniu-ai/models/mimo-v2-flash.toml
+++ b/providers/qiniu-ai/models/mimo-v2-flash.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-flash"
+reasoning_options = []
 name = "Mimo-V2-Flash"
 
 [cost]

--- a/providers/qiniu-ai/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/qiniu-ai/models/xiaomi/mimo-v2-flash.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-flash"
+reasoning_options = []
 name = "Xiaomi/Mimo-V2-Flash"
 
 [cost]

--- a/providers/routing-run/models/route/mimo-v2.5-pro-6bit.toml
+++ b/providers/routing-run/models/route/mimo-v2.5-pro-6bit.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
 name = "MiMo V2.5 Pro 6bit"
 attachment = true
 

--- a/providers/routing-run/models/route/mimo-v2.5-pro.toml
+++ b/providers/routing-run/models/route/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
 name = "MiMo V2.5 Pro"
 attachment = true
 

--- a/providers/routing-run/models/route/mimo-v2.5.toml
+++ b/providers/routing-run/models/route/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
 name = "MiMo V2.5"
 attachment = true
 

--- a/providers/vercel/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2-flash.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-flash"
+reasoning_options = [{ type = "toggle" }]
 name = "MiMo V2 Flash"
 release_date = "2025-12-17"
 knowledge = "2024-10"

--- a/providers/vercel/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "MiMo V2 Pro"
 
 [cost]

--- a/providers/vercel/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "MiMo V2.5 Pro"
 family = "mimo-v2.5-pro"
 attachment = true

--- a/providers/vercel/models/xiaomi/mimo-v2.5.toml
+++ b/providers/vercel/models/xiaomi/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 name = "MiMo M2.5"
 family = "mimo-v2.5"
 open_weights = false

--- a/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-flash.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-flash"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.1

--- a/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-omni.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-omni"
+reasoning_options = [{ type = "toggle" }]
 name = "MiMo V2 Omni"
 
 [cost]

--- a/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+reasoning_options = [{ type = "toggle" }]
 name = "MiMo V2 Pro"
 
 [cost]

--- a/providers/zenmux/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zenmux/models/xiaomi/mimo-v2.5.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Summary
- audit every Xiaomi MiMo route against provider-owned reasoning documentation and live capability metadata
- represent native and normalized binary controls as toggles
- retain effort levels only for Crof and Venice, which publish exact MiMo-specific effort support
- use explicit empty options where a provider exposes reasoning but does not document a selectable MiMo control
- correct LLMGateway MiMo V2 Omni to non-reasoning based on its live catalog

## Evidence
- Xiaomi documents only `thinking.type = enabled | disabled`; no native effort levels or token budgets: https://platform.xiaomimimo.com/docs/en-US/api/chat/openai-api
- Crof documents `none | low | medium | high`, and its live MiMo route advertises `reasoning_effort: true`: https://crof.ai/docs.md and https://crof.ai/v1/models
- Venice publishes MiMo-specific `reasoningEffortOptions = [none, low, medium, high]`: https://api.venice.ai/api/v1/models?type=text
- OpenRouter documents `reasoning.enabled`, and its MiMo endpoint metadata lists `reasoning`: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
- LLMGateway documents binary disable behavior for non-OpenAI routes; its live catalog lists `reasoning` on four MiMo routes and marks Omni non-reasoning: https://docs.llmgateway.io/features/reasoning and https://api.llmgateway.io/v1/models
- AIHubMix and NanoGPT document binary normalization for models with switch-only reasoning controls
- Vercel documents `reasoning.enabled`, and its exact MiMo endpoint metadata lists `reasoning`: https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/advanced
- ZenMux documents `reasoning.enabled` and publishes MiMo routes as reasoning-capable: https://docs.zenmux.ai/guide/advanced/reasoning.html

## Key corrections
- remove unsupported `low | medium | high` efforts from four OpenCode Go routes
- change OpenRouter MiMo 2.5 and 2.5 Pro from `[]` to toggles
- add documented toggles for AIHubMix, LLMGateway, NanoGPT, Vercel, and ZenMux
- replace MegaNova's undocumented toggle with `[]`
- add explicit `[]` to reviewed unresolved Kilo, Hugging Face, OpenCode, Qiniu, and routing.run routes
- no MiMo route in this PR receives a token-budget control

## Validation
- `bun validate`
- `git diff --check`
- resolved catalog audit leaves MiMo effort enums only on Crof and Venice
- Xiaomi Token Plan is handled separately by #2221
- Jiekou is handled on #2239