### PR TITLE
fix(venice): preserve model update dates

### DIFF
--- a/packages/core/src/sync/providers/venice.ts
+++ b/packages/core/src/sync/providers/venice.ts
@@ -166,15 +166,12 @@ export function buildVeniceModel(
     limit,
     modalities: { input: [...new Set(input)], output: ["text" as const] },
   };
-  const changed = existing !== undefined && Object.entries(authoritative).some(([key, value]) => {
-    return stable(value) !== stable(existing[key as keyof ExistingModel]);
-  });
   const releaseDate = new Date(model.created * 1000).toISOString().slice(0, 10);
   const values: SyncedFullModel = {
     ...authoritative,
     family: baseModel == null ? inferFamily(model.id, spec.name) ?? existing?.family : existing?.family,
     release_date: releaseDate,
-    last_updated: existing === undefined || changed ? today : (existing.last_updated ?? today),
+    last_updated: existing?.last_updated ?? today,
     knowledge: existing?.knowledge,
     open_weights: spec.modelSource?.toLowerCase().includes("huggingface")
       ?? existing?.open_weights
@@ -241,16 +238,4 @@ function inferFamily(id: string, name: string) {
       if (family === "o") return new RegExp(`(^|[^a-z0-9])${value}(?=\\d|$|[^a-z0-9])`).test(target);
       return new RegExp(`(^|[^a-z0-9])${value}(?=$|[^a-z0-9])`).test(target);
     });
-}
-
-function stable(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(stable).sort().join(",")}]`;
-  if (value !== null && typeof value === "object") {
-    return `{${Object.entries(value)
-      .filter(([, item]) => item !== undefined)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([key, item]) => `${key}:${stable(item)}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(value);
 }

--- a/packages/core/test/venice-sync.test.ts
+++ b/packages/core/test/venice-sync.test.ts
@@ -91,7 +91,7 @@ test("Venice uses boundary-aware family matching", () => {
   expect(synced).toMatchObject({ family: "gemma" });
 });
 
-test("Venice maps API fields and keeps inherited models compact", () => {
+test("Venice maps API fields without bumping inherited model timestamps", () => {
   const synced = buildVeniceModel(catalogModel, {
     base_model: "openai/gpt-5.4",
     name: "GPT-5.4",
@@ -113,7 +113,7 @@ test("Venice maps API fields and keeps inherited models compact", () => {
   expect(synced).toMatchObject({
     base_model: "openai/gpt-5.4",
     base_model_omit: ["limit.input"],
-    last_updated: "2026-06-10",
+    last_updated: "2026-03-09",
     reasoning_options: [{ type: "effort", values: ["none", "low", "medium", "high"] }],
     interleaved: { field: "reasoning_content" },
     cost: {


### PR DESCRIPTION
## Summary
- preserve existing Venice `last_updated` values during catalog syncs
- assign the current date only to newly discovered models
- cover compact inherited models with a timestamp regression test

## Testing
- `bun test packages/core/test/venice-sync.test.ts`
- `bun validate`
- `bun test packages/core/test` (47 passed; 1 unrelated existing failure for missing open-weight metadata links)