### PR TITLE
Add GLM-5.2 model config to zai and zhipuai providers

### DIFF
--- a/providers/zai/models/glm-5.2.toml
+++ b/providers/zai/models/glm-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/zhipuai-coding-plan/models/glm-5.2.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5.2.toml
@@ -1,0 +1,1 @@
+../../zai-coding-plan/models/glm-5.2.toml

--- a/providers/zhipuai/models/glm-5.2.toml
+++ b/providers/zhipuai/models/glm-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
## Summary

GLM-5.2 was released on 2026-06-13 with a 1M context window. The provider-agnostic metadata (`models/zhipuai/glm-5.2.toml`) already exists, but the provider-specific configs were missing.

This PR adds GLM-5.2 to all four GLM providers:

| Provider | Approach |
|----------|----------|
| `zai` | New file, `base_model` inheritance + cost=0 |
| `zhipuai` | New file, `base_model` inheritance + cost=0 |
| `zai-coding-plan` | Already existed |
| `zhipuai-coding-plan` | Symlink → `zai-coding-plan` |

All configs use effort-based reasoning (`["high", "max"]`) and interleaved `reasoning_content`, consistent with the existing `zai-coding-plan` GLM-5.2 config.

## Notes

- Pricing is set to `0` across all providers for now, as official pricing has not been announced yet. Will be updated when available.
