### PR TITLE
[opencode/alibaba] Add reasoning options

### DIFF
--- a/providers/opencode/models/qwen3.5-plus.toml
+++ b/providers/opencode/models/qwen3.5-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/qwen3.6-plus-free.toml
+++ b/providers/opencode/models/qwen3.6-plus-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/qwen3.6-plus.toml
+++ b/providers/opencode/models/qwen3.6-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"


### PR DESCRIPTION
Splits the alibaba changes from #2247 into a reviewable 3-model PR.

Scope is limited to `opencode/alibaba` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.