### PR TITLE
[opencode/anthropic] Add reasoning options

### DIFF
--- a/providers/opencode/models/claude-haiku-4-5.toml
+++ b/providers/opencode/models/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/opencode/models/claude-opus-4-1.toml
+++ b/providers/opencode/models/claude-opus-4-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 31_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/claude-opus-4-5.toml
+++ b/providers/opencode/models/claude-opus-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/claude-opus-4-6.toml
+++ b/providers/opencode/models/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/opencode/models/claude-opus-4-7.toml
+++ b/providers/opencode/models/claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/opencode/models/claude-opus-4-8.toml
+++ b/providers/opencode/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/opencode/models/claude-sonnet-4-5.toml
+++ b/providers/opencode/models/claude-sonnet-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/opencode/models/claude-sonnet-4-6.toml
+++ b/providers/opencode/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/opencode/models/claude-sonnet-4.toml
+++ b/providers/opencode/models/claude-sonnet-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"


### PR DESCRIPTION
Splits the anthropic changes from #2247 into a reviewable 9-model PR.

Scope is limited to `opencode/anthropic` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.