### PR TITLE
[opencode/deepseek] Add reasoning options

### DIFF
--- a/providers/opencode/models/deepseek-v4-flash-free.toml
+++ b/providers/opencode/models/deepseek-v4-flash-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode/models/deepseek-v4-flash.toml
+++ b/providers/opencode/models/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/opencode/models/deepseek-v4-pro.toml
+++ b/providers/opencode/models/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Splits the deepseek changes from #2247 into a reviewable 3-model PR.

Scope is limited to `opencode/deepseek` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.