### PR TITLE
[opencode/google] Add reasoning options

### DIFF
--- a/providers/opencode/models/gemini-3-flash.toml
+++ b/providers/opencode/models/gemini-3-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/gemini-3-pro.toml
+++ b/providers/opencode/models/gemini-3-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/gemini-3.1-pro.toml
+++ b/providers/opencode/models/gemini-3.1-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/gemini-3.5-flash.toml
+++ b/providers/opencode/models/gemini-3.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-19"
 last_updated = "2026-05-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the google changes from #2247 into a reviewable 4-model PR.

Scope is limited to `opencode/google` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.