### PR TITLE
[opencode/inclusionai] Add reasoning options

### DIFF
--- a/providers/opencode/models/ring-2.6-1t-free.toml
+++ b/providers/opencode/models/ring-2.6-1t-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-08"
 last_updated = "2026-05-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-06"
 tool_call = true


### PR DESCRIPTION
Splits the inclusionai changes from #2247 into a reviewable 1-model PR.

Scope is limited to `opencode/inclusionai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.