### PR TITLE
[opencode/minimax] Add reasoning options

### DIFF
--- a/providers/opencode/models/minimax-m2.1-free.toml
+++ b/providers/opencode/models/minimax-m2.1-free.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m2.1.toml
+++ b/providers/opencode/models/minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m2.5-free.toml
+++ b/providers/opencode/models/minimax-m2.5-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m2.5.toml
+++ b/providers/opencode/models/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m2.7.toml
+++ b/providers/opencode/models/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"

--- a/providers/opencode/models/minimax-m3-free.toml
+++ b/providers/opencode/models/minimax-m3-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-31"
 last_updated = "2026-05-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01"


### PR DESCRIPTION
Splits the minimax changes from #2247 into a reviewable 6-model PR.

Scope is limited to `opencode/minimax` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.