### PR TITLE
[opencode/moonshotai] Add reasoning options

### DIFF
--- a/providers/opencode/models/kimi-k2-thinking.toml
+++ b/providers/opencode/models/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/kimi-k2.5-free.toml
+++ b/providers/opencode/models/kimi-k2.5-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/kimi-k2.5.toml
+++ b/providers/opencode/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/opencode/models/kimi-k2.6.toml
+++ b/providers/opencode/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"


### PR DESCRIPTION
Adds provider-layer reasoning metadata for four OpenCode Zen Kimi models.

## Evidence

- OpenCode Zen serves Kimi K2.5 and K2.6 through its OpenAI-compatible Chat Completions endpoint: https://opencode.ai/docs/zen/
- Moonshot documents `thinking.type` values `"enabled"` and `"disabled"` for Kimi K2.5 and K2.6, with thinking enabled by default: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
- The exact K2.6 request field and values are also listed in the model parameter reference: https://platform.kimi.ai/docs/api/models-overview
- Kimi K2 Thinking is fixed-thinking and has no supported off switch, so it is explicitly `reasoning_options = []`.

No effort or token-budget control is claimed. Scope is limited to `opencode/moonshotai` and supersedes that portion of #2247.