### PR TITLE
[opencode/nvidia] Add reasoning options

### DIFF
--- a/providers/opencode/models/nemotron-3-super-free.toml
+++ b/providers/opencode/models/nemotron-3-super-free.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2026-02"

--- a/providers/opencode/models/nemotron-3-ultra-free.toml
+++ b/providers/opencode/models/nemotron-3-ultra-free.toml
@@ -5,6 +5,7 @@ release_date = "2026-06-04"
 last_updated = "2026-06-04"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2026-02"


### PR DESCRIPTION
Splits the nvidia changes from #2247 into a reviewable 2-model PR.

Scope is limited to `opencode/nvidia` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.