### PR TITLE
[opencode/openai part 1] Add reasoning options

### DIFF
--- a/providers/opencode/models/gpt-5-codex.toml
+++ b/providers/opencode/models/gpt-5-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5-nano.toml
+++ b/providers/opencode/models/gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.1-codex-max.toml
+++ b/providers/opencode/models/gpt-5.1-codex-max.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.1-codex-mini.toml
+++ b/providers/opencode/models/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.1-codex.toml
+++ b/providers/opencode/models/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.1.toml
+++ b/providers/opencode/models/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/gpt-5.2-codex.toml
+++ b/providers/opencode/models/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.2.toml
+++ b/providers/opencode/models/gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.3-codex-spark.toml
+++ b/providers/opencode/models/gpt-5.3-codex-spark.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.3-codex-spark.toml
+++ b/providers/opencode/models/gpt-5.3-codex-spark.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.3-codex.toml
+++ b/providers/opencode/models/gpt-5.3-codex.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.3-codex.toml
+++ b/providers/opencode/models/gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.4-mini.toml
+++ b/providers/opencode/models/gpt-5.4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.4-nano.toml
+++ b/providers/opencode/models/gpt-5.4-nano.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.4-pro.toml
+++ b/providers/opencode/models/gpt-5.4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/opencode/models/gpt-5.4.toml
+++ b/providers/opencode/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/opencode/models/gpt-5.5-pro.toml
+++ b/providers/opencode/models/gpt-5.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-12-01"
 tool_call = true


### PR DESCRIPTION
Adds OpenCode Zen reasoning-effort metadata for 15 OpenAI models.

## Provider behavior

- Zen routes these model IDs through its Responses endpoint using `@ai-sdk/openai`: https://opencode.ai/docs/zen/
- OpenCode configures this as the AI SDK `reasoningEffort` option: https://opencode.ai/docs/models/
- The Responses wire field is `reasoning.effort`, and accepted values are model-dependent: https://platform.openai.com/docs/guides/reasoning

## Model evidence

- GPT-5.1 supports `none`, `low`, `medium`, `high`: https://platform.openai.com/docs/models/gpt-5.1
- GPT-5.2 supports `none`, `low`, `medium`, `high`, `xhigh`: https://platform.openai.com/docs/models/gpt-5.2
- GPT-5.3-Codex supports only `low`, `medium`, `high`, `xhigh`: https://platform.openai.com/docs/models/gpt-5.3-codex
- OpenAI Codex canonical metadata enumerates the same four GPT-5.3-Codex levels: https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json#L291-L312
- GPT-5.4, Mini, and Nano support `none`, `low`, `medium`, `high`, `xhigh`: https://platform.openai.com/docs/models/gpt-5.4 https://platform.openai.com/docs/models/gpt-5.4-mini https://platform.openai.com/docs/models/gpt-5.4-nano
- GPT-5.4 Pro and GPT-5.5 Pro support `medium`, `high`, `xhigh`: https://platform.openai.com/docs/models/gpt-5.4-pro https://platform.openai.com/docs/models/gpt-5.5-pro

No token-budget or binary-toggle controls are claimed. Scope is limited to `opencode/openai` and supersedes that portion of #2247.