### PR TITLE
[opencode/openai part 2] Add reasoning options

### DIFF
--- a/providers/opencode/models/gpt-5.5.toml
+++ b/providers/opencode/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/opencode/models/gpt-5.toml
+++ b/providers/opencode/models/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true


### PR DESCRIPTION
Splits the openai part 2 changes from #2247 into a reviewable 2-model PR.

Scope is limited to `opencode/openai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.