### PR TITLE
[opencode/opencode] Add reasoning options

### DIFF
--- a/providers/opencode/models/big-pickle.toml
+++ b/providers/opencode/models/big-pickle.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-17"
 last_updated = "2025-10-17"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true


### PR DESCRIPTION
Splits the opencode changes from #2247 into a reviewable 1-model PR.

Scope is limited to `opencode/opencode` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.