### PR TITLE
[opencode/tencent] Add reasoning options

### DIFF
--- a/providers/opencode/models/hy3-preview-free.toml
+++ b/providers/opencode/models/hy3-preview-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-06"
 tool_call = true


### PR DESCRIPTION
Splits the tencent changes from #2247 into a reviewable 1-model PR.

Scope is limited to `opencode/tencent` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.