### PR TITLE
[opencode/xai] Add reasoning options

### DIFF
--- a/providers/opencode/models/grok-build-0.1.toml
+++ b/providers/opencode/models/grok-build-0.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-20"
 last_updated = "2026-05-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/grok-code.toml
+++ b/providers/opencode/models/grok-code.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-20"
 last_updated = "2025-08-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Splits the xai changes from #2247 into a reviewable 2-model PR.

Scope is limited to `opencode/xai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2247.