### PR TITLE
[opencode/zhipuai] Add reasoning options

### DIFF
--- a/providers/opencode/models/glm-4.6.toml
+++ b/providers/opencode/models/glm-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-4.7-free.toml
+++ b/providers/opencode/models/glm-4.7-free.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-4.7.toml
+++ b/providers/opencode/models/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-5-free.toml
+++ b/providers/opencode/models/glm-5-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-5.1.toml
+++ b/providers/opencode/models/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-07"
 last_updated = "2026-04-07"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode/models/glm-5.toml
+++ b/providers/opencode/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"


### PR DESCRIPTION
Adds binary reasoning controls for six OpenCode Zen GLM models.

## Evidence

- OpenCode Zen serves these GLM IDs through its OpenAI-compatible Chat Completions endpoint: https://opencode.ai/docs/zen/
- Z.AI defines `thinking.type` exactly as `"enabled"` or `"disabled"` for GLM-4.5 and newer: https://docs.z.ai/api-reference/llm/chat-completion
- GLM-4.6 uses hybrid or dynamic thinking when enabled; GLM-4.7, GLM-5, and GLM-5.1 use forced thinking: https://docs.z.ai/guides/capabilities/thinking-mode
- Adjustable `reasoning_effort` begins with GLM-5.2, so these entries intentionally advertise a toggle only: https://docs.z.ai/guides/overview/concept-param

There is no token-budget claim. `clear_thinking` controls history preservation, not reasoning amount. Scope is limited to `opencode/zhipuai` and supersedes that portion of #2247.