### PR TITLE
[merge-gateway/anthropic] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/anthropic/claude-haiku-4-5-20251001.toml
+++ b/providers/merge-gateway/models/anthropic/claude-haiku-4-5-20251001.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5-20251001"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 1

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-1-20250805.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-1-20250805.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 31_999 }]
 
 [cost]
 input = 15

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-20250514.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-20250514.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-20250514"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 31_999 }]
 
 [cost]
 input = 15

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-5-20251101.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-5-20251101.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5-20251101"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-5-20251101.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-5-20251101.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5-20251101"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-6.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-6.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-7.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-7.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-sonnet-4-20250514.toml
+++ b/providers/merge-gateway/models/anthropic/claude-sonnet-4-20250514.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-20250514"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/merge-gateway/models/anthropic/claude-sonnet-4-5-20250929.toml
+++ b/providers/merge-gateway/models/anthropic/claude-sonnet-4-5-20250929.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/merge-gateway/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/merge-gateway/models/anthropic/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/merge-gateway/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/merge-gateway/models/anthropic/claude-sonnet-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3


### PR DESCRIPTION
Adds Merge Gateway Claude reasoning controls for nine Anthropic models.

## Capability standard

These options describe controls accepted by Merge Gateway inference endpoints, not features typed by one client package. Merge explicitly supports pointing the Anthropic SDK at `https://api-gateway.merge.dev/v1/anthropic`, so native Anthropic request fields are part of the provider interface.

## Controls

- Manual thinking: `thinking.type = "enabled"` with `thinking.budget_tokens`; `thinking.type = "disabled"` turns it off.
- Adaptive thinking: `thinking.type = "adaptive"` with `output_config.effort`.
- Opus 4.5 efforts: `low`, `medium`, `high`.
- Opus/Sonnet 4.6 efforts: `low`, `medium`, `high`, `max`; manual budgets remain accepted but deprecated.
- Opus 4.7 efforts: `low`, `medium`, `high`, `xhigh`, `max`; manual budgets are rejected, but adaptive thinking can be enabled or disabled.

## Evidence

- [Merge get started](https://docs.merge.dev/merge-gateway/get-started) documents Anthropic SDK compatibility at `/v1/anthropic` without changing Anthropic request calls.
- [Merge Claude Code integration](https://docs.merge.dev/merge-gateway/features/use-in-your-ide/claude-code) routes Claude Opus 4.7 and Sonnet 4.6 through the same Anthropic-compatible endpoint.
- [Anthropic adaptive thinking](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking) documents `adaptive` versus `disabled` and the Opus 4.7 restriction.
- [Anthropic effort](https://platform.claude.com/docs/en/build-with-claude/effort) documents model-specific effort values.
- [Anthropic extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) documents manual budgets, minimum 1,024, and model support.

The earlier PR text incorrectly treated limitations in `merge-gateway-ai-sdk-provider` as limitations of the Merge inference API. That claim has been removed.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2246.