### PR TITLE
[merge-gateway/deepseek] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/merge-gateway/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/merge-gateway/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Splits the deepseek changes from #2246 into a reviewable 2-model PR.

Scope is limited to `merge-gateway/deepseek` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2246.