### PR TITLE
[merge-gateway/google] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/merge-gateway/models/google/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/merge-gateway/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/merge-gateway/models/google/gemini-2.5-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 512, max = 24_576 }]
 
 [cost]
 input = 0.1

--- a/providers/merge-gateway/models/google/gemini-2.5-flash.toml
+++ b/providers/merge-gateway/models/google/gemini-2.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/google/gemini-2.5-flash.toml
+++ b/providers/merge-gateway/models/google/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/google/gemini-2.5-pro.toml
+++ b/providers/merge-gateway/models/google/gemini-2.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-pro"
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/google/gemini-2.5-pro.toml
+++ b/providers/merge-gateway/models/google/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/google/gemini-3-flash-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3-flash-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.5

--- a/providers/merge-gateway/models/google/gemini-3-flash-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = []
 
 [cost]
 input = 0.5

--- a/providers/merge-gateway/models/google/gemini-3-pro-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/google/gemini-3-pro-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3-pro-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "high"] }]
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/merge-gateway/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/merge-gateway/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/merge-gateway/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/merge-gateway/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview-customtools"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview-customtools"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/merge-gateway/models/google/gemini-3.1-pro-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/google/gemini-3.5-flash.toml
+++ b/providers/merge-gateway/models/google/gemini-3.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.5-flash"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.5

--- a/providers/merge-gateway/models/google/gemini-3.5-flash.toml
+++ b/providers/merge-gateway/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = []
 
 [cost]
 input = 1.5

--- a/providers/merge-gateway/models/google/gemini-flash-latest.toml
+++ b/providers/merge-gateway/models/google/gemini-flash-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-flash-latest"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/google/gemini-flash-latest.toml
+++ b/providers/merge-gateway/models/google/gemini-flash-latest.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-flash-latest"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/google/gemini-flash-lite-latest.toml
+++ b/providers/merge-gateway/models/google/gemini-flash-lite-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-flash-lite-latest"
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/merge-gateway/models/google/gemini-flash-lite-latest.toml
+++ b/providers/merge-gateway/models/google/gemini-flash-lite-latest.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-flash-lite-latest"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.1

--- a/providers/merge-gateway/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/merge-gateway/models/google/gemma-4-26b-a4b-it.toml
@@ -1,1 +1,2 @@
 base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = []

--- a/providers/merge-gateway/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/merge-gateway/models/google/gemma-4-26b-a4b-it.toml
@@ -1,2 +1,2 @@
 base_model = "google/gemma-4-26b-a4b-it"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]

--- a/providers/merge-gateway/models/google/gemma-4-31b-it.toml
+++ b/providers/merge-gateway/models/google/gemma-4-31b-it.toml
@@ -1,1 +1,2 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = []

--- a/providers/merge-gateway/models/google/gemma-4-31b-it.toml
+++ b/providers/merge-gateway/models/google/gemma-4-31b-it.toml
@@ -1,2 +1,2 @@
 base_model = "google/gemma-4-31b-it"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]


### PR DESCRIPTION
Adds Merge Gateway reasoning controls for 14 Google models.

## Capability standard

These entries describe controls accepted by the inference provider, independent of which controls are typed by `merge-gateway-ai-sdk-provider`. Merge routes Google models through its multi-provider inference service; client-package omissions are not treated as capability limits.

## Controls

- Gemini 2.5 Flash/Flash-Lite: toggle plus `thinkingBudget`; Flash `0..24576`, Flash-Lite positive budgets `512..24576` with zero as off.
- Gemini 2.5 Pro: `thinkingBudget` `128..32768`; no full off switch.
- Gemini 3 Flash-family models: model-specific `thinkingLevel` values including `minimal`.
- Gemini 3 Pro-family models: documented `low`/`medium`/`high` subsets.
- Gemma 4: `chat_template_kwargs.enable_thinking = true|false`.

## Evidence

- [Merge Gateway overview](https://docs.merge.dev/merge-gateway/get-started) documents provider-independent model routing and Google model support.
- [Merge model catalog](https://docs.merge.dev/merge-gateway/models/catalog) lists these exact Google routes.
- [Google thinking controls](https://ai.google.dev/gemini-api/docs/thinking) documents Gemini 2.5 budgets and Gemini 3 levels.
- [Google Gemini 3 guide](https://ai.google.dev/gemini-api/docs/gemini-3) documents model-specific level sets.

The earlier body incorrectly inferred absence of support from a client SDK type definition.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2246.