### PR TITLE
[merge-gateway/minimax] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/minimax/minimax-m2.1.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.1.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.1"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/minimax/minimax-m2.5-highspeed.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.5-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5-highspeed"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/minimax/minimax-m2.5.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.5.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/minimax/minimax-m2.7.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/merge-gateway/models/minimax/minimax-m2.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m2.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2"
+reasoning_options = []
 
 [cost]
 input = 0.3


### PR DESCRIPTION
Explicitly records the absence of effective reasoning controls for six Merge Gateway MiniMax M2.x models.

## Evidence

- MiniMax documents that for M2.x, `thinking: {"type":"disabled"}` is accepted but thinking remains on: https://platform.minimax.io/docs/api-reference/text-openai-api
- The Anthropic-compatible API documents the same fixed-thinking behavior: https://platform.minimax.io/docs/api-reference/text-anthropic-api
- The Responses API accepts `reasoning: {"effort":"none"}` for compatibility but still cannot disable M2.x reasoning: https://platform.minimax.io/docs/api-reference/responses-create
- `reasoning_split` only changes output formatting; it does not control whether reasoning runs.
- High-speed IDs have the same model behavior and differ only in serving speed: https://platform.minimax.io/docs/guides/text-generation

All six entries are therefore intentionally `reasoning_options = []`. Scope is limited to `merge-gateway/minimax` and supersedes that portion of #2246.