### PR TITLE
[merge-gateway/mistral] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/mistral/magistral-medium-latest.toml
+++ b/providers/merge-gateway/models/mistral/magistral-medium-latest.toml
@@ -1,4 +1,5 @@
 base_model = "mistral/magistral-medium-latest"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/mistral/mistral-small-latest.toml
+++ b/providers/merge-gateway/models/mistral/mistral-small-latest.toml
@@ -1,4 +1,5 @@
 base_model = "mistral/mistral-small-latest"
+reasoning_options = []
 
 [cost]
 input = 0.15


### PR DESCRIPTION
Splits the mistral changes from #2246 into a reviewable 2-model PR.

Scope is limited to `merge-gateway/mistral` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2246.