### PR TITLE
[merge-gateway/openai part 1] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/openai/gpt-5-chat-latest.toml
+++ b/providers/merge-gateway/models/openai/gpt-5-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-chat-latest"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/gpt-5-mini.toml
+++ b/providers/merge-gateway/models/openai/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/merge-gateway/models/openai/gpt-5-mini.toml
+++ b/providers/merge-gateway/models/openai/gpt-5-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-mini"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/merge-gateway/models/openai/gpt-5-nano.toml
+++ b/providers/merge-gateway/models/openai/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = []
 
 [cost]
 input = 0.05

--- a/providers/merge-gateway/models/openai/gpt-5-nano.toml
+++ b/providers/merge-gateway/models/openai/gpt-5-nano.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-nano"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/merge-gateway/models/openai/gpt-5.1-chat-latest.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.1-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-chat-latest"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/gpt-5.1.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/gpt-5.1.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.1.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.1"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/gpt-5.2-chat-latest.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.2-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-chat-latest"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/merge-gateway/models/openai/gpt-5.2.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/merge-gateway/models/openai/gpt-5.2.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/merge-gateway/models/openai/gpt-5.4-mini.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.4-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.75

--- a/providers/merge-gateway/models/openai/gpt-5.4-mini.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = []
 
 [cost]
 input = 0.75

--- a/providers/merge-gateway/models/openai/gpt-5.4-nano.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.4-nano.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.2

--- a/providers/merge-gateway/models/openai/gpt-5.4-nano.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/merge-gateway/models/openai/gpt-5.4.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = []
 
 [cost]
 input = 2.5

--- a/providers/merge-gateway/models/openai/gpt-5.4.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.4.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/merge-gateway/models/openai/gpt-5.5.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/openai/gpt-5.5.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/openai/gpt-5.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/gpt-5.toml
+++ b/providers/merge-gateway/models/openai/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/openai/o1.toml
+++ b/providers/merge-gateway/models/openai/o1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o1"
+reasoning_options = []
 
 [cost]
 input = 15

--- a/providers/merge-gateway/models/openai/o1.toml
+++ b/providers/merge-gateway/models/openai/o1.toml
@@ -1,5 +1,5 @@
 base_model = "openai/o1"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 15

--- a/providers/merge-gateway/models/openai/o3-mini.toml
+++ b/providers/merge-gateway/models/openai/o3-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-mini"
+reasoning_options = []
 
 [cost]
 input = 1.1

--- a/providers/merge-gateway/models/openai/o3-mini.toml
+++ b/providers/merge-gateway/models/openai/o3-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/o3-mini"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.1

--- a/providers/merge-gateway/models/openai/o3.toml
+++ b/providers/merge-gateway/models/openai/o3.toml
@@ -1,5 +1,5 @@
 base_model = "openai/o3"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/openai/o3.toml
+++ b/providers/merge-gateway/models/openai/o3.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3"
+reasoning_options = []
 
 [cost]
 input = 2


### PR DESCRIPTION
Adds Merge Gateway reasoning-effort controls for 15 OpenAI models.

## Capability standard

Merge explicitly supports the OpenAI SDK at `https://api-gateway.merge.dev/v1/openai` with existing API calls unchanged. Therefore native OpenAI reasoning controls are provider capabilities even when the Merge-specific AI SDK wrapper does not type them.

## Controls

- GPT-5, Mini, Nano: `minimal`, `low`, `medium`, `high`.
- GPT-5.1: `none`, `low`, `medium`, `high`.
- GPT-5.2, GPT-5.4, GPT-5.4 Mini/Nano, GPT-5.5: `none`, `low`, `medium`, `high`, `xhigh`.
- o1, o3-mini, o3: `low`, `medium`, `high`.
- Chat-latest aliases remain without selectable reasoning controls.

## Evidence

- [Merge get started](https://docs.merge.dev/merge-gateway/get-started) documents unchanged OpenAI SDK calls through `/v1/openai`.
- [Merge direct-SDK migration](https://github.com/merge-api/merge-gateway-skills/blob/main/skills/migrate-direct-sdk/SKILL.md) states existing `chat.completions.create()` calls work unchanged.
- [OpenAI reasoning guide](https://platform.openai.com/docs/guides/reasoning) documents native reasoning controls and model-dependent values.
- [OpenAI model pages](https://platform.openai.com/docs/models) provide the exact subsets.

The earlier body incorrectly treated a Merge client wrapper limitation as an inference API limitation.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2246.