### PR TITLE
[merge-gateway/openai part 2] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/openai/o4-mini.toml
+++ b/providers/merge-gateway/models/openai/o4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o4-mini"
+reasoning_options = []
 
 [cost]
 input = 1.1


### PR DESCRIPTION
Splits the openai part 2 changes from #2246 into a reviewable 1-model PR.

Scope is limited to `merge-gateway/openai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2246.