### PR TITLE
[merge-gateway/xai] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/xai/grok-4.20-0309-reasoning.toml
+++ b/providers/merge-gateway/models/xai/grok-4.20-0309-reasoning.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/xai/grok-4.3.toml
+++ b/providers/merge-gateway/models/xai/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = []
 
 [cost]
 input = 1.25


### PR DESCRIPTION
Splits the xai changes from #2246 into a reviewable 2-model PR.

Scope is limited to `merge-gateway/xai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2246.