### PR TITLE
[merge-gateway/zai] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/zai/glm-4.5-air.toml
+++ b/providers/merge-gateway/models/zai/glm-4.5-air.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.2

--- a/providers/merge-gateway/models/zai/glm-4.5-air.toml
+++ b/providers/merge-gateway/models/zai/glm-4.5-air.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/merge-gateway/models/zai/glm-4.5.toml
+++ b/providers/merge-gateway/models/zai/glm-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.5"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/zai/glm-4.5.toml
+++ b/providers/merge-gateway/models/zai/glm-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/zai/glm-4.6.toml
+++ b/providers/merge-gateway/models/zai/glm-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.6"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/zai/glm-4.6.toml
+++ b/providers/merge-gateway/models/zai/glm-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/zai/glm-4.7-flashx.toml
+++ b/providers/merge-gateway/models/zai/glm-4.7-flashx.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flashx"
+reasoning_options = []
 
 [cost]
 input = 0.07

--- a/providers/merge-gateway/models/zai/glm-4.7-flashx.toml
+++ b/providers/merge-gateway/models/zai/glm-4.7-flashx.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.7-flashx"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.07

--- a/providers/merge-gateway/models/zai/glm-4.7.toml
+++ b/providers/merge-gateway/models/zai/glm-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-4.7.toml
+++ b/providers/merge-gateway/models/zai/glm-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.7"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5-turbo.toml
+++ b/providers/merge-gateway/models/zai/glm-5-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5-turbo"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5-turbo.toml
+++ b/providers/merge-gateway/models/zai/glm-5-turbo.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5-turbo"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5.1.toml
+++ b/providers/merge-gateway/models/zai/glm-5.1.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.1"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5.1.toml
+++ b/providers/merge-gateway/models/zai/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5.toml
+++ b/providers/merge-gateway/models/zai/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5.toml
+++ b/providers/merge-gateway/models/zai/glm-5.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Adds Merge Gateway reasoning toggles for eight Z.AI models.

## Capability standard

These options describe inference request controls, not the feature set of one typed client wrapper. Merge provides OpenAI-compatible multi-provider routing, and Z.AI models expose their native OpenAI-compatible extension through the request body.

## Toggle

The exact model-native request is:

```json
{"thinking":{"type":"enabled"}}
```

or:

```json
{"thinking":{"type":"disabled"}}
```

These GLM versions do not expose genuine graded effort; that begins with GLM-5.2.

## Evidence

- [Merge get started](https://docs.merge.dev/merge-gateway/get-started) documents OpenAI-compatible and multi-provider inference endpoints.
- [Merge model catalog](https://docs.merge.dev/merge-gateway/models/catalog) lists the routed GLM models.
- [Z.AI Chat Completions](https://docs.z.ai/api-reference/llm/chat-completion) documents `thinking.type = enabled|disabled`.
- [Z.AI thinking modes](https://docs.z.ai/guides/capabilities/thinking-mode) documents model behavior.
- [Z.AI parameter concepts](https://docs.z.ai/guides/overview/concept-param) limits graded effort to GLM-5.2 and later.

The earlier body incorrectly used a client SDK omission as evidence that Merge inference rejected the control.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2246.