### PR TITLE
[nearai/anthropic] Add reasoning options

### DIFF
--- a/providers/nearai/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 1

--- a/providers/nearai/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-haiku-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 1

--- a/providers/nearai/models/anthropic/claude-opus-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-opus-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-opus-4-7.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-opus-4-7.toml
+++ b/providers/nearai/models/anthropic/claude-opus-4-7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 3

--- a/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]
 input = 3

--- a/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/nearai/models/anthropic/claude-sonnet-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 3


### PR DESCRIPTION
Splits the Anthropic changes from #2242 into a reviewable 5-model PR.

Scope is limited to `nearai/anthropic`. Supersedes part of #2242.

## Reasoning controls

NEAR AI's Anthropic adapter forwards the native top-level `thinking` object verbatim. It does not translate OpenAI-style top-level `reasoning_effort` to Anthropic's native `output_config.effort`; unsupported `reasoning_effort` is forwarded for Anthropic to reject rather than silently ignored. No effort values are therefore declared.

- `claude-haiku-4-5` and `claude-sonnet-4-5`: on = `thinking: {"type":"enabled","budget_tokens":N}`; off = `thinking: {"type":"disabled"}`.
- `claude-opus-4-6` and `claude-sonnet-4-6`: on = `thinking: {"type":"adaptive"}`; off = `thinking: {"type":"disabled"}`. Manual `budget_tokens` remains functional but is deprecated.
- `claude-opus-4-7`: on = `thinking: {"type":"adaptive"}`; off = `thinking: {"type":"disabled"}`. Manual `thinking.type: "enabled"` and `budget_tokens` are rejected.
- The verified manual-budget minimum is 1,024. No fixed maximum is declared because Anthropic requires `budget_tokens < max_tokens`; the effective maximum is request-dependent.

## Evidence

- [NEAR AI reasoning configuration](https://docs.near.ai/cloud/reasoning-models) describes model-specific reasoning controls and directs callers to the model/provider-specific request field.
- [NEAR AI Anthropic adapter implementation](https://github.com/nearai/cloud-api/blob/e21ca30e340b9504c68a94d21ad6c8556271d3c1/crates/inference_providers/src/external/anthropic/mod.rs) allowlists and forwards `thinking` verbatim and documents the non-translated `reasoning_effort` behavior.
- [Anthropic extended thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) documents the 1,024 minimum, the `budget_tokens < max_tokens` constraint, deprecation on 4.6, and lack of manual-budget support on Opus 4.7.
- [Anthropic adaptive thinking](https://docs.anthropic.com/en/docs/build-with-claude/adaptive-thinking) documents `thinking.type: "adaptive"` and `thinking.type: "disabled"` by model.
- [Anthropic effort](https://docs.anthropic.com/en/docs/build-with-claude/effort) documents the native request path as `output_config.effort`, not top-level `reasoning_effort`.

## Validation

- `bun validate`
- `git diff --check`
