### PR TITLE
[nearai/google] Add reasoning options

### DIFF
--- a/providers/nearai/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 512, max = 24_576 }]
 
 [cost]
 input = 0.1

--- a/providers/nearai/models/google/gemini-2.5-flash.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 
 [cost]
 input = 0.3

--- a/providers/nearai/models/google/gemini-2.5-pro.toml
+++ b/providers/nearai/models/google/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-3-pro.toml
+++ b/providers/nearai/models/google/gemini-3-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/nearai/models/google/gemini-3.5-flash.toml
+++ b/providers/nearai/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.5

--- a/providers/nearai/models/google/gemma-4-31B-it.toml
+++ b/providers/nearai/models/google/gemma-4-31B-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.13


### PR DESCRIPTION
Splits the google changes from #2242 into a reviewable 7-model PR.

Scope is limited to `nearai/google` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2242.