### PR TITLE
[nearai/openai] Add reasoning options

### DIFF
--- a/providers/nearai/models/openai/gpt-5-mini.toml
+++ b/providers/nearai/models/openai/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/nearai/models/openai/gpt-5-nano.toml
+++ b/providers/nearai/models/openai/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/nearai/models/openai/gpt-5.1.toml
+++ b/providers/nearai/models/openai/gpt-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/openai/gpt-5.2.toml
+++ b/providers/nearai/models/openai/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.8

--- a/providers/nearai/models/openai/gpt-5.4-mini.toml
+++ b/providers/nearai/models/openai/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.75

--- a/providers/nearai/models/openai/gpt-5.4-nano.toml
+++ b/providers/nearai/models/openai/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.2

--- a/providers/nearai/models/openai/gpt-5.4.toml
+++ b/providers/nearai/models/openai/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/nearai/models/openai/gpt-5.5.toml
+++ b/providers/nearai/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/nearai/models/openai/gpt-5.toml
+++ b/providers/nearai/models/openai/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/openai/gpt-oss-120b.toml
+++ b/providers/nearai/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/nearai/models/openai/o3-mini.toml
+++ b/providers/nearai/models/openai/o3-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.1

--- a/providers/nearai/models/openai/o3.toml
+++ b/providers/nearai/models/openai/o3.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/nearai/models/openai/o4-mini.toml
+++ b/providers/nearai/models/openai/o4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.1


### PR DESCRIPTION
Splits the OpenAI changes from #2242 into a reviewable 13-model PR.

Scope is limited to `nearai/openai`. Supersedes part of #2242.

## Reasoning controls

NEAR AI exposes OpenAI reasoning effort on `/v1/chat/completions` through the top-level `reasoning_effort` request field. The equivalent OpenAI Responses request path is `reasoning.effort`; this provider is configured through `@ai-sdk/openai-compatible`, so the authored options describe Chat Completions.

- `gpt-5`, `gpt-5-mini`, `gpt-5-nano`: `minimal`, `low`, `medium`, `high`.
- `gpt-5.1`: `none`, `low`, `medium`, `high`.
- `gpt-5.2`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.5`: `none`, `low`, `medium`, `high`, `xhigh`.
- `gpt-oss-120b`, `o3-mini`, `o3`, `o4-mini`: `low`, `medium`, `high`.
- No toggle or numeric reasoning-token budget is claimed for these routes.

## Evidence

- [NEAR AI reasoning configuration](https://docs.near.ai/cloud/reasoning-models) explicitly documents top-level `reasoning_effort` values `low|medium|high` for GPT-OSS-120B and provider-standard controls for routed OpenAI models.
- [NEAR AI provider test evidence](https://github.com/nearai/cloud-api/issues/666#issuecomment-4543826657) records a successful GPT-5.5 request with `reasoning_effort: "low"` and structured rejection of an invalid value listing `none|low|medium|high|xhigh`.
- [OpenAI reasoning guide](https://developers.openai.com/api/docs/guides/reasoning) documents the model-dependent effort control and Responses request path.
- OpenAI model pages document exact current sets for [GPT-5.1](https://developers.openai.com/api/docs/models/gpt-5.1), [GPT-5.2](https://developers.openai.com/api/docs/models/gpt-5.2), [GPT-5.4](https://developers.openai.com/api/docs/models/gpt-5.4), [GPT-5.4 mini](https://developers.openai.com/api/docs/models/gpt-5.4-mini), [GPT-5.4 nano](https://developers.openai.com/api/docs/models/gpt-5.4-nano), and [GPT-5.5](https://developers.openai.com/api/docs/models/gpt-5.5).

## Validation

- `bun validate`
- `git diff --check`
