### PR TITLE
[nearai/Qwen] Add reasoning options

### DIFF
--- a/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-122b-a10b"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.4

--- a/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
+++ b/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.6 35B A3B FP8"
 
 [cost]


### PR DESCRIPTION
Splits the Qwen changes from #2242 into a reviewable 2-model PR.

Scope is limited to `nearai/Qwen` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2242.