### PR TITLE
[nearai/zai-org] Add reasoning options

### DIFF
--- a/providers/nearai/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/nearai/models/zai-org/GLM-5.1-FP8.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the zai-org changes from #2242 into a reviewable 1-model PR.

Scope is limited to `nearai/zai-org` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2242.