### PR TITLE
[jiekou/anthropic] Add reasoning options

### DIFF
--- a/providers/jiekou/models/claude-opus-4-6.toml
+++ b/providers/jiekou/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02"
 last_updated = "2026-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the anthropic changes from #2239 into a reviewable 1-model PR.

Scope is limited to `jiekou/anthropic` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2239.