### PR TITLE
[jiekou/baidu] Add reasoning options

### DIFF
--- a/providers/jiekou/models/baidu/ernie-4.5-vl-424b-a47b.toml
+++ b/providers/jiekou/models/baidu/ernie-4.5-vl-424b-a47b.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false


### PR DESCRIPTION
Splits the baidu changes from #2239 into a reviewable 1-model PR.

Scope is limited to `jiekou/baidu` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2239.