### PR TITLE
[jiekou/deepseek] Add reasoning options

### DIFF
--- a/providers/jiekou/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/jiekou/models/deepseek/deepseek-r1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/deepseek/deepseek-v3.1.toml
+++ b/providers/jiekou/models/deepseek/deepseek-v3.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_767 }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the deepseek changes from #2239 into a reviewable 2-model PR.

Scope is limited to `jiekou/deepseek` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2239.