### PR TITLE
[jiekou/google] Add reasoning options

### DIFF
--- a/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -3,7 +3,8 @@ family = "gemini-flash-lite"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-lite.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-lite.toml
@@ -3,7 +3,8 @@ family = "gemini-flash-lite"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
@@ -3,7 +3,8 @@ family = "gemini-flash"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
+++ b/providers/jiekou/models/gemini-2.5-flash-preview-05-20.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash.toml
+++ b/providers/jiekou/models/gemini-2.5-flash.toml
@@ -3,7 +3,8 @@ family = "gemini-flash"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-flash.toml
+++ b/providers/jiekou/models/gemini-2.5-flash.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/jiekou/models/gemini-2.5-pro-preview-06-05.toml
@@ -3,7 +3,8 @@ family = "gemini-pro"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-pro.toml
+++ b/providers/jiekou/models/gemini-2.5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gemini-2.5-pro.toml
+++ b/providers/jiekou/models/gemini-2.5-pro.toml
@@ -3,7 +3,8 @@ family = "gemini-pro"
 release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the Google changes from #2239 into a reviewable 7-model PR.

Scope is limited to `jiekou/google`. Supersedes part of #2239.

## Reasoning controls

Jiekou's OpenAI-compatible Gemini route accepts top-level `reasoning_effort` and translates it to fixed Gemini thinking budgets:

| `reasoning_effort` | Jiekou translation |
| --- | --- |
| `none` or non-standard `disable` | `thinkingBudget = 0` |
| `low` | `thinkingBudget = 1024` |
| `medium` | `thinkingBudget = 2048` |
| `high` | `thinkingBudget = 4096` |

For Gemini 2.5 Pro, `none` does not disable reasoning; Jiekou translates it to the model minimum `thinkingBudget = 128`. Consequently this PR declares effort values but no toggle.

Jiekou separately accepts arbitrary `generationConfig.thinkingConfig.thinkingBudget` on its native `/gemini` endpoint. This models.dev provider is configured against the OpenAI-compatible `/openai` endpoint, so native-route numeric budgets are not declared as `budget_tokens` here.

## Evidence

- [Jiekou Gemini documentation](https://docs.jiekou.ai/docs/providers/gemini) documents the exact effort-to-budget translation, defaults, Pro's non-disable behavior, and the separate native Gemini request shape.
- [Jiekou Chat Completions reference](https://docs.jiekou.ai/docs/models/reference-llm-create-chat-completion) does not expose a generic numeric `thinkingBudget` or `budget_tokens` request field on the configured route.
- [`providers/jiekou/provider.toml`](https://github.com/anomalyco/models.dev/blob/dev/providers/jiekou/provider.toml) configures `@ai-sdk/openai-compatible` against the `/openai` API.

## Validation

- `bun validate`
- `git diff --check`
