### PR TITLE
[jiekou/minimax] Add reasoning options

### DIFF
--- a/providers/jiekou/models/minimax/minimax-m2.1.toml
+++ b/providers/jiekou/models/minimax/minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the minimax changes from #2239 into a reviewable 1-model PR.

Scope is limited to `jiekou/minimax` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2239.