### PR TITLE
[jiekou/minimaxai] Add reasoning options

### DIFF
--- a/providers/jiekou/models/minimaxai/minimax-m1-80k.toml
+++ b/providers/jiekou/models/minimaxai/minimax-m1-80k.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false


### PR DESCRIPTION
Splits the minimaxai changes from #2239 into a reviewable 1-model PR.

Scope is limited to `jiekou/minimaxai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2239.