### PR TITLE
[jiekou/moonshotai] Add reasoning options

### DIFF
--- a/providers/jiekou/models/moonshotai/kimi-k2.5.toml
+++ b/providers/jiekou/models/moonshotai/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 262_143 }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the moonshotai changes from #2239 into a reviewable 1-model PR.

Scope is limited to `jiekou/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2239.