### PR TITLE
[jiekou/openai] Add reasoning options

### DIFF
--- a/providers/jiekou/models/gpt-5-mini.toml
+++ b/providers/jiekou/models/gpt-5-mini.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5-mini.toml
+++ b/providers/jiekou/models/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5-pro.toml
+++ b/providers/jiekou/models/gpt-5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5-pro.toml
+++ b/providers/jiekou/models/gpt-5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex-max.toml
+++ b/providers/jiekou/models/gpt-5.1-codex-max.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex-max.toml
+++ b/providers/jiekou/models/gpt-5.1-codex-max.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex-mini.toml
+++ b/providers/jiekou/models/gpt-5.1-codex-mini.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex-mini.toml
+++ b/providers/jiekou/models/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex.toml
+++ b/providers/jiekou/models/gpt-5.1-codex.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1-codex.toml
+++ b/providers/jiekou/models/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1.toml
+++ b/providers/jiekou/models/gpt-5.1.toml
@@ -4,7 +4,7 @@ release_date = "2026-02"
 last_updated = "2026-02"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.1.toml
+++ b/providers/jiekou/models/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-02"
 last_updated = "2026-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.2-codex.toml
+++ b/providers/jiekou/models/gpt-5.2-codex.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.2-codex.toml
+++ b/providers/jiekou/models/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.2-pro.toml
+++ b/providers/jiekou/models/gpt-5.2-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/gpt-5.2-pro.toml
+++ b/providers/jiekou/models/gpt-5.2-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Adds model-specific OpenAI reasoning effort controls for eight Jiekou routes.

## Capability standard

Jiekou inference capability is not limited to its Chat Completions compatibility schema or the npm package chosen in one sample OpenCode configuration. Jiekou explicitly requires its `/openai/v1/responses` endpoint for Codex and other Responses-only models.

## Request mechanism

Responses requests use:

```json
{"reasoning":{"effort":"high"}}
```

## Controls

- GPT-5 Mini: `minimal`, `low`, `medium`, `high`.
- GPT-5 Pro: `high`.
- GPT-5.1 Codex Max: `low`, `medium`, `high`, `xhigh`.
- GPT-5.1 Codex Mini/Codex: `low`, `medium`, `high`.
- GPT-5.1: `none`, `low`, `medium`, `high`.
- GPT-5.2 Codex: `low`, `medium`, `high`, `xhigh`.
- GPT-5.2 Pro: `medium`, `high`, `xhigh`.

## Evidence

- [Jiekou API FAQ](https://docs.jiekou.ai/docs/support/faq_api) explicitly directs GPT-5.1 and Codex requests to `/openai/v1/responses`.
- [Jiekou OpenCode guide](https://docs.jiekou.ai/docs/integration/opencode) requires the Responses-capable OpenAI client for Codex.
- [Jiekou model objects](https://api.jiekou.ai/openai/models) identify these exact routes as reasoning-capable and Responses-supported.
- [OpenAI reasoning guide](https://platform.openai.com/docs/guides/reasoning) documents `reasoning.effort`.
- [OpenAI model pages](https://platform.openai.com/docs/models) document each model-specific effort subset.

The earlier `reasoning_options = []` correction incorrectly treated the Chat endpoint and sample npm package as the full inference-provider capability.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2239.