### PR TITLE
[jiekou/qwen] Add reasoning options

### DIFF
--- a/providers/jiekou/models/qwen/qwen3-235b-a22b-fp8.toml
+++ b/providers/jiekou/models/qwen/qwen3-235b-a22b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/jiekou/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/jiekou/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/jiekou/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/qwen/qwen3-30b-a3b-fp8.toml
+++ b/providers/jiekou/models/qwen/qwen3-30b-a3b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/jiekou/models/qwen/qwen3-32b-fp8.toml
+++ b/providers/jiekou/models/qwen/qwen3-32b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 structured_output = false

--- a/providers/jiekou/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/jiekou/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 65_535 }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/jiekou/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 65_535 }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the Qwen changes from #2239 into a reviewable 5-model PR.

Scope is limited to `jiekou/qwen`. Supersedes part of #2239.

## Reasoning controls

Jiekou's public model metadata and reasoning guide verify that these five model IDs reason. Neither source exposes a caller-selectable Qwen toggle, effort enum, or numeric reasoning-token budget through Jiekou.

All five models therefore use `reasoning_options = []`. In particular, the public `max_output_tokens` values for `qwen3-235b-a22b-thinking-2507` and `qwen3-next-80b-a3b-thinking` are total output limits; they are not used to infer reasoning-budget maxima. Separate thinking and instruct model IDs also do not establish an on/off toggle for the same ID.

## Evidence

- [Jiekou reasoning-model guide](https://docs.jiekou.ai/docs/model/inference) documents reasoning output but no Qwen reasoning-control request field.
- [Jiekou Chat Completions reference](https://docs.jiekou.ai/docs/models/reference-llm-create-chat-completion) contains no Qwen numeric budget or toggle field.
- [Qwen3 235B Thinking provider object](https://api.jiekou.ai/openai/models/qwen%2Fqwen3-235b-a22b-thinking-2507) reports reasoning and `max_output_tokens = 131072`, but no reasoning-budget control.
- [Qwen3 Next Thinking provider object](https://api.jiekou.ai/openai/models/qwen%2Fqwen3-next-80b-a3b-thinking) reports reasoning and `max_output_tokens = 65536`, but no reasoning-budget control.

## Validation

- `bun validate`
- `git diff --check`
