### PR TITLE
[jiekou/zai-org] Add reasoning options

### DIFF
--- a/providers/jiekou/models/zai-org/glm-4.5.toml
+++ b/providers/jiekou/models/zai-org/glm-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/zai-org/glm-4.5v.toml
+++ b/providers/jiekou/models/zai-org/glm-4.5v.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/zai-org/glm-4.7-flash.toml
+++ b/providers/jiekou/models/zai-org/glm-4.7-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/zai-org/glm-4.7.toml
+++ b/providers/jiekou/models/zai-org/glm-4.7.toml
@@ -4,7 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/zai-org/glm-4.7.toml
+++ b/providers/jiekou/models/zai-org/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the Z.AI changes from #2239 into a reviewable 4-model PR.

Scope is limited to `jiekou/zai-org`. Supersedes part of #2239.

## Reasoning controls

Jiekou documents one explicit GLM reasoning control:

- `zai-org/glm-4.5` toggles reasoning with top-level `enable_thinking: true` or `enable_thinking: false` on Chat Completions. The documented default is `true`.
- No selectable control is documented for `zai-org/glm-4.5v`, `zai-org/glm-4.7-flash`, or `zai-org/glm-4.7`; those models use `reasoning_options = []`.
- GLM-4.7's public `max_output_tokens = 131072` is a total output limit, not evidence for a `1,024..131,071` reasoning budget. No numeric budget is declared.

## Evidence

- [Jiekou Chat Completions reference](https://docs.jiekou.ai/docs/models/reference-llm-create-chat-completion) documents top-level `enable_thinking`, values `true|false`, default `true`, and supported model `zai-org/glm-4.5`.
- [GLM-4.5 provider object](https://api.jiekou.ai/openai/models/zai-org%2Fglm-4.5) verifies reasoning capability and hybrid thinking/non-thinking behavior.
- [GLM-4.7 provider object](https://api.jiekou.ai/openai/models/zai-org%2Fglm-4.7) reports reasoning and the total output limit, but no reasoning-budget request field.

## Validation

- `bun validate`
- `git diff --check`
