### PR TITLE
[github-models/ai21-labs] Add reasoning options

### DIFF
--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-29"
 last_updated = "2024-08-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-29"
 last_updated = "2024-08-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true


### PR DESCRIPTION
Splits the ai21-labs changes from #2236 into a reviewable 2-model PR.

Scope is limited to `github-models/ai21-labs` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2236.