### PR TITLE
[github-models/cohere] Add reasoning options

### DIFF
--- a/providers/github-models/models/cohere/cohere-command-a.toml
+++ b/providers/github-models/models/cohere/cohere-command-a.toml
@@ -4,6 +4,7 @@ release_date = "2024-11-01"
 last_updated = "2024-11-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-01"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-01"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r-plus.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-04"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r.toml
+++ b/providers/github-models/models/cohere/cohere-command-r.toml
@@ -4,6 +4,7 @@ release_date = "2024-03-11"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true


### PR DESCRIPTION
## Summary

- audit all five existing `github-models/cohere` definitions
- declare `reasoning_options = []`: no caller-selectable toggle, effort, or reasoning-token budget is exposed by GitHub Models
- add no controls inferred from upstream model behavior

## Evidence

- [GitHub Models inference API](https://docs.github.com/en/rest/models/inference) documents the accepted request body and exposes no reasoning toggle, effort, or budget field for these routed models.
- [Live GitHub Models catalog](https://models.github.ai/catalog/models), checked 2026-06-24, lists `cohere/cohere-command-a` without a reasoning-control capability. The four Command R IDs in this PR are no longer present in the current catalog.
- Model-native reasoning behavior is not treated as proof that the GitHub Models gateway exposes a caller control.

## Result

All five models remain `reasoning_options = []`. No toggle, effort, or budget is claimed.

Supersedes the Cohere portion of #2236.

## Validation

- `bun validate`
- `git diff --check`
