### PR TITLE
[github-models/core42] Add reasoning options

### DIFF
--- a/providers/github-models/models/core42/jais-30b-chat.toml
+++ b/providers/github-models/models/core42/jais-30b-chat.toml
@@ -4,6 +4,7 @@ release_date = "2023-08-30"
 last_updated = "2023-08-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-03"
 tool_call = true


### PR DESCRIPTION
Splits the core42 changes from #2236 into a reviewable 1-model PR.

Scope is limited to `github-models/core42` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2236.