### PR TITLE
[github-models/deepseek] Add reasoning options

### DIFF
--- a/providers/github-models/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/deepseek/deepseek-r1.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/deepseek/deepseek-v3-0324.toml
+++ b/providers/github-models/models/deepseek/deepseek-v3-0324.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-24"
 last_updated = "2025-03-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true


### PR DESCRIPTION
Splits the deepseek changes from #2236 into a reviewable 3-model PR.

Scope is limited to `github-models/deepseek` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2236.