### PR TITLE
[github-models/meta] Add reasoning options

### DIFF
--- a/providers/github-models/models/meta/llama-3.2-11b-vision-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.2-11b-vision-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-25"
 last_updated = "2024-09-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/llama-3.2-90b-vision-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.2-90b-vision-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-25"
 last_updated = "2024-09-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/llama-3.3-70b-instruct.toml
+++ b/providers/github-models/models/meta/llama-3.3-70b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-06"
 last_updated = "2024-12-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
+++ b/providers/github-models/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-12"
 tool_call = true

--- a/providers/github-models/models/meta/llama-4-scout-17b-16e-instruct.toml
+++ b/providers/github-models/models/meta/llama-4-scout-17b-16e-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3-70b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3-70b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-18"
 last_updated = "2024-04-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3-8b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3-8b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-18"
 last_updated = "2024-04-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3.1-405b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-405b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-23"
 last_updated = "2024-07-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3.1-70b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-70b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-23"
 last_updated = "2024-07-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true

--- a/providers/github-models/models/meta/meta-llama-3.1-8b-instruct.toml
+++ b/providers/github-models/models/meta/meta-llama-3.1-8b-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-23"
 last_updated = "2024-07-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-12"
 tool_call = true


### PR DESCRIPTION
## Summary

- audit all ten existing `github-models/meta` definitions
- declare `reasoning_options = []`
- add no controls inferred from model cards or general reasoning ability

## Evidence

- [GitHub Models inference API](https://docs.github.com/en/rest/models/inference) exposes no reasoning toggle, effort, or reasoning-token budget for these models.
- [Live GitHub Models catalog](https://models.github.ai/catalog/models), checked 2026-06-24, advertises streaming and tool capabilities but no reasoning-control field for the currently listed Meta IDs.
- `meta-llama-3-8b-instruct`, `meta-llama-3-70b-instruct`, and `meta-llama-3.1-70b-instruct` are absent from the current catalog.

## Result

All ten definitions use `reasoning_options = []`; no provider-selectable control was verified.

Supersedes the Meta portion of #2236.

## Validation

- `bun validate`
- `git diff --check`
