### PR TITLE
[github-models/microsoft] Add reasoning options

### DIFF
--- a/providers/github-models/models/microsoft/mai-ds-r1.toml
+++ b/providers/github-models/models/microsoft/mai-ds-r1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-medium-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-medium-128k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-medium-4k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-medium-4k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-mini-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-mini-128k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-mini-4k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-mini-4k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-small-128k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-small-128k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3-small-8k-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3-small-8k-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-04-23"
 last_updated = "2024-04-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3.5-mini-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-mini-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-20"
 last_updated = "2024-08-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3.5-moe-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-moe-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-20"
 last_updated = "2024-08-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-3.5-vision-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-3.5-vision-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-20"
 last_updated = "2024-08-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4-mini-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-4-mini-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4-mini-reasoning.toml
+++ b/providers/github-models/models/microsoft/phi-4-mini-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4-multimodal-instruct.toml
+++ b/providers/github-models/models/microsoft/phi-4-multimodal-instruct.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4-reasoning.toml
+++ b/providers/github-models/models/microsoft/phi-4-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/microsoft/phi-4.toml
+++ b/providers/github-models/models/microsoft/phi-4.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-11"
 last_updated = "2024-12-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true


### PR DESCRIPTION
## Summary

- audit all fifteen existing `github-models/microsoft` definitions
- declare `reasoning_options = []`
- distinguish the catalog's coarse `reasoning` capability from a selectable reasoning control

## Evidence

- [GitHub Models inference API](https://docs.github.com/en/rest/models/inference) documents no toggle, effort, or reasoning-token-budget request field for these Microsoft models.
- [Live GitHub Models catalog](https://models.github.ai/catalog/models), checked 2026-06-24, lists `phi-4`, `phi-4-mini-instruct`, `phi-4-mini-reasoning`, `phi-4-multimodal-instruct`, and `phi-4-reasoning`.
- The catalog labels the two reasoning-specific Phi IDs with a `reasoning` capability, but does not advertise a caller-selectable level or budget.
- The MAI-DS-R1, Phi-3, and Phi-3.5 IDs in this PR are absent from the current catalog.

## Result

All fifteen definitions remain `reasoning_options = []`.

Supersedes the Microsoft portion of #2236.

## Validation

- `bun validate`
- `git diff --check`
