### PR TITLE
[github-models/mistral-ai] Add reasoning options

### DIFF
--- a/providers/github-models/models/mistral-ai/codestral-2501.toml
+++ b/providers/github-models/models/mistral-ai/codestral-2501.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-01"
 last_updated = "2025-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/ministral-3b.toml
+++ b/providers/github-models/models/mistral-ai/ministral-3b.toml
@@ -4,6 +4,7 @@ release_date = "2024-10-22"
 last_updated = "2024-10-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/mistral-large-2411.toml
+++ b/providers/github-models/models/mistral-ai/mistral-large-2411.toml
@@ -4,6 +4,7 @@ release_date = "2024-11-01"
 last_updated = "2024-11-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/mistral-medium-2505.toml
+++ b/providers/github-models/models/mistral-ai/mistral-medium-2505.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-01"
 last_updated = "2025-05-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/mistral-nemo.toml
+++ b/providers/github-models/models/mistral-ai/mistral-nemo.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-18"
 last_updated = "2024-07-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/mistral-ai/mistral-small-2503.toml
+++ b/providers/github-models/models/mistral-ai/mistral-small-2503.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-01"
 last_updated = "2025-03-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true


### PR DESCRIPTION
## Summary

- audit all six existing `github-models/mistral-ai` definitions
- declare `reasoning_options = []`
- add no controls inferred from upstream model capabilities

## Evidence

- [GitHub Models inference API](https://docs.github.com/en/rest/models/inference) exposes no reasoning toggle, effort, or reasoning-token-budget field for these routes.
- [Live GitHub Models catalog](https://models.github.ai/catalog/models), checked 2026-06-24, lists Codestral 25.01, Ministral 3B, Mistral Medium 25.05, and Mistral Small 25.03 without a reasoning-control capability.
- `mistral-large-2411` and `mistral-nemo` are absent from the current catalog.

## Result

All six definitions use `reasoning_options = []`; no provider-layer control was verified.

Supersedes the Mistral AI portion of #2236.

## Validation

- `bun validate`
- `git diff --check`
