### PR TITLE
[github-models/openai] Add reasoning options

### DIFF
--- a/providers/github-models/models/openai/gpt-4.1-mini.toml
+++ b/providers/github-models/models/openai/gpt-4.1-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4.1-nano.toml
+++ b/providers/github-models/models/openai/gpt-4.1-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4.1.toml
+++ b/providers/github-models/models/openai/gpt-4.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4o-mini.toml
+++ b/providers/github-models/models/openai/gpt-4o-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-07-18"
 last_updated = "2024-07-18"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4o.toml
+++ b/providers/github-models/models/openai/gpt-4o.toml
@@ -4,6 +4,7 @@ release_date = "2024-05-13"
 last_updated = "2024-05-13"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/openai/o1-mini.toml
+++ b/providers/github-models/models/openai/o1-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o1-mini.toml
+++ b/providers/github-models/models/openai/o1-mini.toml
@@ -4,7 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o1-preview.toml
+++ b/providers/github-models/models/openai/o1-preview.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-09-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o1.toml
+++ b/providers/github-models/models/openai/o1.toml
@@ -4,7 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o1.toml
+++ b/providers/github-models/models/openai/o1.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o3-mini.toml
+++ b/providers/github-models/models/openai/o3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/openai/o3-mini.toml
+++ b/providers/github-models/models/openai/o3-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/openai/o3.toml
+++ b/providers/github-models/models/openai/o3.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/openai/o3.toml
+++ b/providers/github-models/models/openai/o3.toml
@@ -4,7 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/openai/o4-mini.toml
+++ b/providers/github-models/models/openai/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/openai/o4-mini.toml
+++ b/providers/github-models/models/openai/o4-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2024-04"
 tool_call = false


### PR DESCRIPTION
## Summary

- audit all eleven existing `github-models/openai` definitions against the live GitHub Models route
- expose `low`, `medium`, `high`, and `xhigh` for `o1`, `o1-mini`, `o3-mini`, `o3`, and `o4-mini`
- keep `o1-preview` and the GPT-4.x models at `reasoning_options = []`

## Request mechanism

GitHub Models accepts reasoning effort as the top-level Chat Completions field:

```json
{
  "model": "openai/o3-mini",
  "messages": [{"role": "user", "content": "Reply OK."}],
  "max_completion_tokens": 64,
  "reasoning_effort": "xhigh"
}
```

## Evidence

- [Live GitHub Models catalog](https://models.github.ai/catalog/models) identifies the current Azure-backed versions and marks the o-series IDs as reasoning models.
- [GitHub Models inference API](https://docs.github.com/en/rest/models/inference) documents the inference endpoint, although its published body schema currently omits `reasoning_effort` and still describes `max_tokens`.
- Live negative-control requests on 2026-06-24 to `o1`, `o1-mini`, `o3-mini`, `o3`, and `o4-mini` rejected `reasoning_effort: "invalid"` with the explicit accepted enum `low`, `medium`, `high`, `xhigh`.
- `o1-preview` could not be independently completed before endpoint throttling, so it remains `[]` under the least-permissive evidence rule.
- No toggle or numeric reasoning-token budget was verified.

## Result

- `o1`, `o1-mini`, `o3-mini`, `o3`, `o4-mini`: `low`, `medium`, `high`, `xhigh`
- `o1-preview`, GPT-4.1, and GPT-4o families: no verified provider control

Supersedes the OpenAI portion of #2236.

## Validation

- `bun validate`
- `git diff --check`
