### PR TITLE
[github-models/xai] Add reasoning options

### DIFF
--- a/providers/github-models/models/xai/grok-3-mini.toml
+++ b/providers/github-models/models/xai/grok-3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-09"
 last_updated = "2024-12-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10"
 tool_call = true

--- a/providers/github-models/models/xai/grok-3.toml
+++ b/providers/github-models/models/xai/grok-3.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-09"
 last_updated = "2024-12-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10"
 tool_call = true


### PR DESCRIPTION
Splits the xai changes from #2236 into a reviewable 2-model PR.

Scope is limited to `github-models/xai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2236.