### PR TITLE
[github-copilot/anthropic] Add reasoning options

### DIFF
--- a/providers/github-copilot/models/claude-fable-5.toml
+++ b/providers/github-copilot/models/claude-fable-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 10

--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 1

--- a/providers/github-copilot/models/claude-haiku-4.5.toml
+++ b/providers/github-copilot/models/claude-haiku-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.5.toml
+++ b/providers/github-copilot/models/claude-opus-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.6.toml
+++ b/providers/github-copilot/models/claude-opus-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.7.toml
+++ b/providers/github-copilot/models/claude-opus-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024, max = 32_000 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.7.toml
+++ b/providers/github-copilot/models/claude-opus-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.7.toml
+++ b/providers/github-copilot/models/claude-opus-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.8.toml
+++ b/providers/github-copilot/models/claude-opus-4.8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.8.toml
+++ b/providers/github-copilot/models/claude-opus-4.8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024, max = 32_000 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-opus-4.8.toml
+++ b/providers/github-copilot/models/claude-opus-4.8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 5

--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/github-copilot/models/claude-sonnet-4.5.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 3

--- a/providers/github-copilot/models/claude-sonnet-4.6.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 32_000 }]
 
 [cost]
 input = 3

--- a/providers/github-copilot/models/claude-sonnet-4.6.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [cost]
 input = 3

--- a/providers/github-copilot/models/claude-sonnet-4.toml
+++ b/providers/github-copilot/models/claude-sonnet-4.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-0"
+reasoning_options = []
 
 [cost]
 input = 3


### PR DESCRIPTION
## Summary

- audit nine GitHub Copilot Anthropic aliases
- use Copilot-advertised effort menus and thinking-budget bounds
- remove manual budget claims from Opus 4.7 and 4.8, which only accept adaptive thinking

## Request mechanisms

- Adaptive thinking: `thinking.type = "adaptive"` plus `output_config.effort`
- Manual thinking: `thinking.type = "enabled"` plus `thinking.budget_tokens`
- No standalone provider toggle is claimed

## Evidence

- [GitHub's supported-model table](https://docs.github.com/en/copilot/reference/ai-models/supported-models#models-with-extended-capabilities) identifies Sonnet 4.6, Opus 4.6, Opus 4.7, Opus 4.8, and Fable 5 as configurable-reasoning models.
- [Copilot metadata schema](https://github.com/microsoft/vscode/blob/7b91f5f7bb81e755b04efd4dbd37c1c2e8689e5f/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts#L45-L56) exposes `adaptive_thinking`, thinking-budget bounds, and per-model `reasoning_effort` arrays.
- [Copilot Messages request construction](https://github.com/microsoft/vscode/blob/7b91f5f7bb81e755b04efd4dbd37c1c2e8689e5f/extensions/copilot/src/platform/endpoint/node/messagesApi.ts#L151-L188) sends adaptive thinking for adaptive models and fixed `budget_tokens` only for the non-adaptive branch.
- [Anthropic adaptive-thinking documentation](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking) states that Opus 4.7 and Opus 4.8 reject manual `budget_tokens` with HTTP 400.
- [Anthropic effort documentation](https://platform.claude.com/docs/en/build-with-claude/effort#effort-levels) gives the exact model-specific effort sets.
- A synchronized Copilot model-capabilities response supplied the retained `1_024..32_000` bounds for Haiku 4.5, Opus 4.5, Sonnet 4.5, and Sonnet 4.6.

## Result

- Fable 5, Opus 4.7, Opus 4.8: `low`, `medium`, `high`, `xhigh`, `max`
- Opus 4.6, Sonnet 4.6: `low`, `medium`, `high`, `max`
- Haiku 4.5, Opus 4.5, Sonnet 4.5: budget `1_024..32_000`
- Sonnet 4.6: effort plus retained budget `1_024..32_000`
- Sonnet 4: no verified control

Supersedes the Anthropic portion of #2235.

## Validation

- `bun validate`
- `git diff --check`
