### PR TITLE
[github-copilot/github-copilot] Add reasoning options

### DIFF
--- a/providers/github-copilot/models/raptor-mini.toml
+++ b/providers/github-copilot/models/raptor-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true


### PR DESCRIPTION
Splits the github-copilot changes from #2235 into a reviewable 1-model PR.

Scope is limited to `github-copilot/github-copilot` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2235.