### PR TITLE
[github-copilot/google] Add reasoning options

### DIFF
--- a/providers/github-copilot/models/gemini-2.5-pro.toml
+++ b/providers/github-copilot/models/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/github-copilot/models/gemini-3-flash-preview.toml
+++ b/providers/github-copilot/models/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = []
 
 [cost]
 input = 0.5

--- a/providers/github-copilot/models/gemini-3.1-pro-preview.toml
+++ b/providers/github-copilot/models/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/github-copilot/models/gemini-3.5-flash.toml
+++ b/providers/github-copilot/models/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.5


### PR DESCRIPTION
Splits the google changes from #2235 into a reviewable 4-model PR.

Scope is limited to `github-copilot/google` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2235.