### PR TITLE
[github-copilot/openai] Add reasoning options

### DIFF
--- a/providers/github-copilot/models/gpt-5-mini.toml
+++ b/providers/github-copilot/models/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/github-copilot/models/gpt-5.2-codex.toml
+++ b/providers/github-copilot/models/gpt-5.2-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-codex"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/github-copilot/models/gpt-5.2.toml
+++ b/providers/github-copilot/models/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/github-copilot/models/gpt-5.3-codex.toml
+++ b/providers/github-copilot/models/gpt-5.3-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/github-copilot/models/gpt-5.4-mini.toml
+++ b/providers/github-copilot/models/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.75

--- a/providers/github-copilot/models/gpt-5.4-nano.toml
+++ b/providers/github-copilot/models/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/github-copilot/models/gpt-5.4.toml
+++ b/providers/github-copilot/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/github-copilot/models/gpt-5.5.toml
+++ b/providers/github-copilot/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5


### PR DESCRIPTION
## Summary

- audit eight GitHub Copilot OpenAI aliases
- use Copilot's per-model effort menus rather than upstream OpenAI capability alone
- keep retired or non-advertised aliases at `reasoning_options = []`

## Request mechanism

For Copilot-hosted OpenAI Responses requests, the selected value is sent as:

```json
{
  "reasoning": {
    "effort": "high"
  }
}
```

`none` is the provider's explicit disabled/no-reasoning selection on models where Copilot advertises it.

## Evidence

- [GitHub's configurable-reasoning table](https://docs.github.com/en/copilot/reference/ai-models/supported-models#models-with-extended-capabilities) identifies GPT-5.3-Codex, GPT-5.4, and GPT-5.5 as extended-capability models.
- [Copilot Responses request construction](https://github.com/microsoft/vscode/blob/7b91f5f7bb81e755b04efd4dbd37c1c2e8689e5f/extensions/copilot/src/platform/endpoint/node/responsesApi.ts#L158-L173) places the selected value at `reasoning.effort`.
- [`@github/copilot` 1.0.64](https://www.npmjs.com/package/@github/copilot/v/1.0.64) embeds these base menus: GPT-5 mini `low|medium|high`; GPT-5.3-Codex `low|medium|high|xhigh`; GPT-5.4 mini, GPT-5.4, and GPT-5.5 `low|medium|high|xhigh`. Copilot's model layer adds the explicit `none` selection where synchronized endpoint metadata advertises it.
- [GitHub's retirement table](https://docs.github.com/en/copilot/reference/ai-models/supported-models#model-retirement-history) records GPT-5.2 and GPT-5.2-Codex as retired on 2026-06-01.
- No numeric reasoning-token budget or separate toggle is advertised for these OpenAI aliases.

## Result

- `gpt-5-mini`: `low`, `medium`, `high`
- `gpt-5.3-codex`: `low`, `medium`, `high`, `xhigh`
- `gpt-5.4-mini`, `gpt-5.4`, `gpt-5.5`: `none`, `low`, `medium`, `high`, `xhigh`
- `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.4-nano`: no advertised provider control

Supersedes the OpenAI portion of #2235.

## Validation

- `bun validate`
- `git diff --check`
