### PR TITLE
[databricks/anthropic] Add reasoning options

### DIFF
--- a/providers/databricks/models/databricks-claude-haiku-4-5.toml
+++ b/providers/databricks/models/databricks-claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/databricks/models/databricks-claude-opus-4-1.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 15

--- a/providers/databricks/models/databricks-claude-opus-4-1.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-1.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-1"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 15

--- a/providers/databricks/models/databricks-claude-opus-4-5.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-claude-opus-4-5.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-claude-opus-4-6.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-claude-opus-4-6.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-claude-opus-4-7.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-claude-opus-4-7.toml
+++ b/providers/databricks/models/databricks-claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-claude-sonnet-4-5.toml
+++ b/providers/databricks/models/databricks-claude-sonnet-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 3

--- a/providers/databricks/models/databricks-claude-sonnet-4-5.toml
+++ b/providers/databricks/models/databricks-claude-sonnet-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 3

--- a/providers/databricks/models/databricks-claude-sonnet-4-6.toml
+++ b/providers/databricks/models/databricks-claude-sonnet-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 3

--- a/providers/databricks/models/databricks-claude-sonnet-4-6.toml
+++ b/providers/databricks/models/databricks-claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 3

--- a/providers/databricks/models/databricks-claude-sonnet-4.toml
+++ b/providers/databricks/models/databricks-claude-sonnet-4.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
 
 [cost]
 input = 3

--- a/providers/databricks/models/databricks-claude-sonnet-4.toml
+++ b/providers/databricks/models/databricks-claude-sonnet-4.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_768 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 3


### PR DESCRIPTION
Adds Databricks-layer reasoning metadata for eight hosted Claude models.

Databricks Chat Completions enables supported Claude reasoning with `thinking: { "type": "enabled", "budget_tokens": N }`. `budget_tokens` has a 1,024-token minimum and must be less than `max_tokens`; 32K is not a hard documented maximum, so no fixed `max` is declared.

`databricks-claude-haiku-4-5` remains `reasoning_options = []` because Databricks does not list it among endpoints accepting the hosted Claude reasoning control.

Primary source: https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models

Supersedes the Databricks/Anthropic portion of #2234.