### PR TITLE
[databricks/google] Add reasoning options

### DIFF
--- a/providers/databricks/models/databricks-gemini-2-5-flash.toml
+++ b/providers/databricks/models/databricks-gemini-2-5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = [{ type = "budget_tokens", min = 0, max = 24_576 }]
 
 [cost]
 input = 0.3

--- a/providers/databricks/models/databricks-gemini-2-5-pro.toml
+++ b/providers/databricks/models/databricks-gemini-2-5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 
 [cost]
 input = 1.25

--- a/providers/databricks/models/databricks-gemini-3-1-flash-lite.toml
+++ b/providers/databricks/models/databricks-gemini-3-1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/databricks/models/databricks-gemini-3-1-pro.toml
+++ b/providers/databricks/models/databricks-gemini-3-1-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview-customtools"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/databricks/models/databricks-gemini-3-flash.toml
+++ b/providers/databricks/models/databricks-gemini-3-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.5

--- a/providers/databricks/models/databricks-gemini-3-pro.toml
+++ b/providers/databricks/models/databricks-gemini-3-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2


### PR DESCRIPTION
Adds provider-layer reasoning options for six Databricks-hosted Gemini endpoints.

Databricks Chat Completions exposes Gemini 2.5 through `thinking.type = "enabled"` plus `thinking.budget_tokens`; Flash supports `0..24576` and Pro supports `128..32768`. Databricks exposes Gemini 3 and later through top-level `reasoning_effort`, with exactly `low`, `medium`, and `high`.

Primary sources:
- https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
- https://ai.google.dev/gemini-api/docs/thinking

Supersedes the Databricks/Google portion of #2234.