### PR TITLE
[databricks/openai] Add reasoning options

### DIFF
--- a/providers/databricks/models/databricks-gpt-5-1.toml
+++ b/providers/databricks/models/databricks-gpt-5-1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/databricks/models/databricks-gpt-5-2.toml
+++ b/providers/databricks/models/databricks-gpt-5-2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.75

--- a/providers/databricks/models/databricks-gpt-5-4-mini.toml
+++ b/providers/databricks/models/databricks-gpt-5-4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.75

--- a/providers/databricks/models/databricks-gpt-5-4-nano.toml
+++ b/providers/databricks/models/databricks-gpt-5-4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.2

--- a/providers/databricks/models/databricks-gpt-5-4.toml
+++ b/providers/databricks/models/databricks-gpt-5-4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2.5

--- a/providers/databricks/models/databricks-gpt-5-5.toml
+++ b/providers/databricks/models/databricks-gpt-5-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/databricks/models/databricks-gpt-5-mini.toml
+++ b/providers/databricks/models/databricks-gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/databricks/models/databricks-gpt-5-nano.toml
+++ b/providers/databricks/models/databricks-gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/databricks/models/databricks-gpt-5.toml
+++ b/providers/databricks/models/databricks-gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/databricks/models/databricks-gpt-oss-120b.toml
+++ b/providers/databricks/models/databricks-gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/databricks/models/databricks-gpt-oss-20b.toml
+++ b/providers/databricks/models/databricks-gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Adds exact Databricks Chat Completions `reasoning_effort` options for eleven hosted OpenAI-family endpoints.

Values are intentionally limited to those documented by Databricks. Upstream OpenAI Responses values such as `xhigh` are not assumed to pass through the Databricks Chat surface.

GPT-5.1/5.2 include `none`; GPT-5/mini/nano include `minimal`; GPT-5.4-family and GPT-5.5 expose `low`, `medium`, and `high`; GPT OSS exposes `low`, `medium`, and `high`.

Primary sources:
- https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models
- https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference

Supersedes the Databricks/OpenAI portion of #2234.