### PR TITLE
[frogbot/alibaba] Add reasoning options

### DIFF
--- a/providers/frogbot/models/qwen-3-6-plus.toml
+++ b/providers/frogbot/models/qwen-3-6-plus.toml
@@ -2,6 +2,7 @@ name = "Qwen 3.6 Plus"
 family = "qwen"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2026-04-02"


### PR DESCRIPTION
Splits the alibaba changes from #2232 into a reviewable 1-model PR.

Scope is limited to `frogbot/alibaba` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2232.