### PR TITLE
[frogbot/anthropic] Add reasoning options

### DIFF
--- a/providers/frogbot/models/claude-haiku-4-5.toml
+++ b/providers/frogbot/models/claude-haiku-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/frogbot/models/claude-haiku-4-5.toml
+++ b/providers/frogbot/models/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/frogbot/models/claude-opus-4-6.toml
+++ b/providers/frogbot/models/claude-opus-4-6.toml
@@ -4,7 +4,10 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "high"] },
+  { type = "budget_tokens", min = 1_024 },
+]
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/frogbot/models/claude-opus-4-6.toml
+++ b/providers/frogbot/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/frogbot/models/claude-opus-4-7.toml
+++ b/providers/frogbot/models/claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/frogbot/models/claude-opus-4-7.toml
+++ b/providers/frogbot/models/claude-opus-4-7.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/frogbot/models/claude-sonnet-4-6.toml
+++ b/providers/frogbot/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/frogbot/models/claude-sonnet-4-6.toml
+++ b/providers/frogbot/models/claude-sonnet-4-6.toml
@@ -4,7 +4,10 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "high"] },
+  { type = "budget_tokens", min = 1_024 },
+]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"


### PR DESCRIPTION
Adds FrogBot-layer reasoning controls for four routed Anthropic models.

FrogBot Chat Completions accepts Anthropic `thinking: { "type": "enabled", "budget_tokens": N }` and generic top-level `reasoning_effort`, whose documented values are `low`, `medium`, and `high`.

Haiku 4.5 uses budget control. Opus 4.6 and Sonnet 4.6 expose both the FrogBot effort subset and the still-accepted manual budget mode. Opus 4.7 uses effort only because upstream rejects manual budget thinking.

Primary sources:
- https://docs.frogbot.ai/api-reference/chat-completions
- https://docs.frogbot.ai/api-reference/models
- https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking

Supersedes the FrogBot/Anthropic portion of #2232.