### PR TITLE
[frogbot/deepseek] Add reasoning options

### DIFF
--- a/providers/frogbot/models/deepseek-v4-pro.toml
+++ b/providers/frogbot/models/deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2026-01"
 tool_call = true


### PR DESCRIPTION
Splits the deepseek changes from #2232 into a reviewable 1-model PR.

Scope is limited to `frogbot/deepseek` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2232.