### PR TITLE
[302ai/anthropic part 1] Add reasoning options

### DIFF
--- a/providers/302ai/models/claude-haiku-4-5-20251001.toml
+++ b/providers/302ai/models/claude-haiku-4-5-20251001.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-16"
 last_updated = "2025-10-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-haiku-4-5.toml
+++ b/providers/302ai/models/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-16"
 last_updated = "2025-10-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-1-20250805-thinking.toml
+++ b/providers/302ai/models/claude-opus-4-1-20250805-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-27"
 last_updated = "2025-05-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-1-20250805.toml
+++ b/providers/302ai/models/claude-opus-4-1-20250805.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 31999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-20250514.toml
+++ b/providers/302ai/models/claude-opus-4-20250514.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 31999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-5-20251101-thinking.toml
+++ b/providers/302ai/models/claude-opus-4-5-20251101-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-5-20251101.toml
+++ b/providers/302ai/models/claude-opus-4-5-20251101.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-5-20251101.toml
+++ b/providers/302ai/models/claude-opus-4-5-20251101.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-5.toml
+++ b/providers/302ai/models/claude-opus-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-5.toml
+++ b/providers/302ai/models/claude-opus-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-6-thinking.toml
+++ b/providers/302ai/models/claude-opus-4-6-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-06"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-6.toml
+++ b/providers/302ai/models/claude-opus-4-6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-06"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 127999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1024, max = 127999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-6.toml
+++ b/providers/302ai/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-06"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 127999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-7.toml
+++ b/providers/302ai/models/claude-opus-4-7.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-17"
 last_updated = "2026-04-17"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-opus-4-7.toml
+++ b/providers/302ai/models/claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-17"
 last_updated = "2026-04-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-20250514.toml
+++ b/providers/302ai/models/claude-sonnet-4-20250514.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-5-20250929-thinking.toml
+++ b/providers/302ai/models/claude-sonnet-4-5-20250929-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-5-20250929.toml
+++ b/providers/302ai/models/claude-sonnet-4-5-20250929.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-5.toml
+++ b/providers/302ai/models/claude-sonnet-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Adds model-specific reasoning controls to 15 Claude models exposed by 302AI.

## Controls

- Manual-thinking Claude models use `thinking.type = "enabled"` with `budget_tokens`.
- `budget_tokens` is a maximum allocation, may not be fully consumed, must be at least 1,024, and must be lower than the request's `max_tokens`.
- The metadata upper bounds are one token below each 302AI model's maximum output: 31,999, 63,999, or 127,999.
- Claude Opus 4.5 additionally supports effort `low`, `medium`, and `high`.
- Claude Opus 4.6 supports effort `low`, `medium`, `high`, and `max`; manual budgets remain accepted but are deprecated upstream.
- Claude Opus 4.7 uses adaptive thinking and supports effort `low`, `medium`, `high`, `xhigh`, and `max`; manual `budget_tokens` is not supported.
- 302AI `-thinking` model IDs are fixed-thinking aliases and therefore use `reasoning_options = []`.

## Wire semantics

302AI's native Claude control is distinct from its provider-wide `-fusion` feature. Native Claude thinking uses the Anthropic Messages request fields; `-fusion`, `"-fusion": true`, and `thinking-model` invoke 302AI's separate multi-model reasoning feature and are not evidence for a model's native controls.

## Evidence

- 302AI native Claude thinking example with `thinking: { type: "enabled", budget_tokens: N }`: https://doc.302.ai/264079796e0.md
- 302AI native Anthropic Messages endpoint and supported Claude IDs: https://doc.302.ai/221170151e0.md
- 302AI's separate fusion reasoning mechanism: https://doc.302.ai/266051921e0.md
- Anthropic manual-thinking and budget semantics: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
- Anthropic adaptive-thinking model matrix: https://docs.anthropic.com/en/docs/build-with-claude/adaptive-thinking
- Anthropic model-specific effort levels: https://docs.anthropic.com/en/docs/build-with-claude/effort

## Verification boundary

Verified against 302AI's public OpenAPI documentation and Anthropic's model-specific documentation. 302AI's public schema currently demonstrates manual thinking but does not enumerate `output_config.effort` or Opus 4.7. The effort metadata follows the upstream model subsets and assumes transparent forwarding through 302AI's native Messages endpoint. No authenticated 302AI runtime requests were performed, so runtime forwarding remains unconfirmed.

Split from #2231 and supersedes its 302AI/Anthropic part-1 scope.
