### PR TITLE
[302ai/anthropic part 2] Add reasoning options

### DIFF
--- a/providers/302ai/models/claude-sonnet-4-6-thinking.toml
+++ b/providers/302ai/models/claude-sonnet-4-6-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-18"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-6.toml
+++ b/providers/302ai/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-18"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Splits the anthropic part 2 changes from #2231 into a reviewable 2-model PR.

Scope is limited to `302ai/anthropic part 2` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2231.