### PR TITLE
[302ai/bytedance] Add reasoning options

### DIFF
--- a/providers/302ai/models/doubao-seed-1-6-thinking-250715.toml
+++ b/providers/302ai/models/doubao-seed-1-6-thinking-250715.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-15"
 last_updated = "2025-07-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Splits the bytedance changes from #2231 into a reviewable 1-model PR.

Scope is limited to `302ai/bytedance` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2231.