### PR TITLE
[302ai/deepseek] Add reasoning options

### DIFF
--- a/providers/302ai/models/deepseek-reasoner.toml
+++ b/providers/302ai/models/deepseek-reasoner.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/deepseek-v3.2-thinking.toml
+++ b/providers/302ai/models/deepseek-v3.2-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Splits the deepseek changes from #2231 into a reviewable 2-model PR.

Scope is limited to `302ai/deepseek` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2231.