### PR TITLE
[302ai/moonshotai] Add reasoning options

### DIFF
--- a/providers/302ai/models/kimi-k2-thinking-turbo.toml
+++ b/providers/302ai/models/kimi-k2-thinking-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/kimi-k2-thinking.toml
+++ b/providers/302ai/models/kimi-k2-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Splits the moonshotai changes from #2231 into a reviewable 2-model PR.

Scope is limited to `302ai/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2231.