### PR TITLE
[302ai/openai] Add reasoning options

### DIFF
--- a/providers/302ai/models/gpt-5-mini.toml
+++ b/providers/302ai/models/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5-pro.toml
+++ b/providers/302ai/models/gpt-5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-08"
 last_updated = "2025-10-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5-pro.toml
+++ b/providers/302ai/models/gpt-5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2025-10-08"
 last_updated = "2025-10-08"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5-thinking.toml
+++ b/providers/302ai/models/gpt-5-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/gpt-5.1-chat-latest.toml
+++ b/providers/302ai/models/gpt-5.1-chat-latest.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-14"
 last_updated = "2025-11-14"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.1-chat-latest.toml
+++ b/providers/302ai/models/gpt-5.1-chat-latest.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-14"
 last_updated = "2025-11-14"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.1.toml
+++ b/providers/302ai/models/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-14"
 last_updated = "2025-11-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.2-chat-latest.toml
+++ b/providers/302ai/models/gpt-5.2-chat-latest.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-12"
 last_updated = "2025-12-12"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.2-chat-latest.toml
+++ b/providers/302ai/models/gpt-5.2-chat-latest.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-12"
 last_updated = "2025-12-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.2.toml
+++ b/providers/302ai/models/gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-12"
 last_updated = "2025-12-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-mini-2026-03-17.toml
+++ b/providers/302ai/models/gpt-5.4-mini-2026-03-17.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-mini.toml
+++ b/providers/302ai/models/gpt-5.4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-nano-2026-03-17.toml
+++ b/providers/302ai/models/gpt-5.4-nano-2026-03-17.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-nano.toml
+++ b/providers/302ai/models/gpt-5.4-nano.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-19"
 last_updated = "2026-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.4-pro.toml
+++ b/providers/302ai/models/gpt-5.4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = false

--- a/providers/302ai/models/gpt-5.4.toml
+++ b/providers/302ai/models/gpt-5.4.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/gpt-5.toml
+++ b/providers/302ai/models/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Adds model-specific reasoning-effort metadata to 14 OpenAI-family models exposed by 302AI.

## Effective subsets

| Model | Effective values |
| --- | --- |
| GPT-5 and GPT-5 mini | `minimal`, `low`, `medium`, `high` |
| GPT-5 Pro | `high` only |
| GPT-5.1 | `none`, `low`, `medium`, `high` |
| GPT-5.1 Chat Latest | `medium` only |
| GPT-5.2 | `none`, `low`, `medium`, `high`, `xhigh` |
| GPT-5.2 Chat Latest | `medium` only |
| GPT-5.4, GPT-5.4 mini, and GPT-5.4 nano | `none`, `low`, `medium`, `high`, `xhigh` |
| GPT-5.4 Pro | `medium`, `high`, `xhigh` |
| `gpt-5-thinking` | Fixed 302AI alias with no selectable effort |

These are model-specific effective subsets, not the full enum accepted by a generic OpenAI-compatible gateway or SDK schema. In Chat Completions the wire field is `reasoning_effort`; in Responses it is `reasoning.effort`. A singleton such as `medium` or `high` records the only effective accepted value rather than implying that the model is uncontrolled.

## Evidence

- OpenAI reasoning guide, including the model-dependent support warning: https://developers.openai.com/api/docs/guides/reasoning
- GPT-5: https://developers.openai.com/api/docs/models/gpt-5
- GPT-5 Pro: https://developers.openai.com/api/docs/models/gpt-5-pro
- GPT-5.1: https://developers.openai.com/api/docs/models/gpt-5.1
- GPT-5.2: https://developers.openai.com/api/docs/models/gpt-5.2
- GPT-5.4: https://developers.openai.com/api/docs/models/gpt-5.4
- GPT-5.4 Pro: https://developers.openai.com/api/docs/models/gpt-5.4-pro
- GPT-5.4 mini: https://developers.openai.com/api/docs/models/gpt-5.4-mini
- GPT-5.4 nano: https://developers.openai.com/api/docs/models/gpt-5.4-nano
- 302AI Chat endpoint: https://doc.302.ai/147522039e0.md
- 302AI Responses endpoint: https://doc.302.ai/308390849e0.md

## Verification boundary

Verified against 302AI's public OpenAPI documentation and OpenAI's model-specific documentation. 302AI's public OpenAPI pages do not enumerate request-side reasoning-effort values. The listed subsets therefore follow effective upstream model support and assume 302AI transparently forwards the native fields. No authenticated 302AI runtime requests were performed, so runtime forwarding remains unconfirmed.

Split from #2231 and supersedes its 302AI/OpenAI scope.
