### PR TITLE
[302ai/xai] Add reasoning options

### DIFF
--- a/providers/302ai/models/grok-4-1-fast-reasoning.toml
+++ b/providers/302ai/models/grok-4-1-fast-reasoning.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-20"
 last_updated = "2025-11-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/grok-4-fast-reasoning.toml
+++ b/providers/302ai/models/grok-4-fast-reasoning.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-23"
 last_updated = "2025-09-23"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/grok-4.20-beta-0309-reasoning.toml
+++ b/providers/302ai/models/grok-4.20-beta-0309-reasoning.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/grok-4.20-multi-agent-beta-0309.toml
+++ b/providers/302ai/models/grok-4.20-multi-agent-beta-0309.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/grok-4.20-multi-agent-beta-0309.toml
+++ b/providers/302ai/models/grok-4.20-multi-agent-beta-0309.toml
@@ -3,7 +3,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Adds reasoning-option metadata to four xAI-family models exposed by 302AI.

## Controls

- `grok-4-1-fast-reasoning`, `grok-4-fast-reasoning`, and `grok-4.20-beta-0309-reasoning` are fixed-reasoning SKUs, so they use `reasoning_options = []`.
- `grok-4.20-multi-agent-beta-0309` supports `reasoning.effort` values `low`, `medium`, `high`, and `xhigh`.

For the multi-agent model, effort controls agent count rather than ordinary reasoning depth:

| Effort | Effective behavior |
| --- | --- |
| `low` or `medium` | 4 collaborating agents |
| `high` or `xhigh` | 16 collaborating agents |

This is model-specific effective support. The fact that a generic gateway or SDK accepts a broader reasoning enum does not establish that another value changes this model's behavior.

## Evidence

- xAI reasoning behavior and model-specific support: https://docs.x.ai/developers/model-capabilities/text/reasoning
- xAI multi-agent effort and agent-count mapping: https://docs.x.ai/developers/model-capabilities/text/multi-agent
- xAI model inventory: https://docs.x.ai/developers/models
- 302AI Responses endpoint: https://doc.302.ai/308390849e0.md

## Verification boundary

Verified against 302AI's public Responses documentation and xAI's model-specific documentation. The upstream multi-agent model is Responses-only. 302AI's public documentation does not enumerate this beta alias or its effort values, so the metadata assumes transparent forwarding through 302AI's Responses endpoint. No authenticated 302AI runtime requests were performed, so alias mapping and runtime forwarding remain unconfirmed.

Split from #2231 and supersedes its 302AI/xAI scope.
