### PR TITLE
[302ai/zhipuai] Add reasoning options

### DIFF
--- a/providers/302ai/models/glm-4.5-air.toml
+++ b/providers/302ai/models/glm-4.5-air.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.5.toml
+++ b/providers/302ai/models/glm-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.5v.toml
+++ b/providers/302ai/models/glm-4.5v.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-12"
 last_updated = "2025-08-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.6.toml
+++ b/providers/302ai/models/glm-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.6v.toml
+++ b/providers/302ai/models/glm-4.6v.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.7-flashx.toml
+++ b/providers/302ai/models/glm-4.7-flashx.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-20"
 last_updated = "2026-01-20"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-4.7.toml
+++ b/providers/302ai/models/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-5-turbo.toml
+++ b/providers/302ai/models/glm-5-turbo.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/glm-5.1.toml
+++ b/providers/302ai/models/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-10"
 last_updated = "2026-04-10"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/302ai/models/glm-5.toml
+++ b/providers/302ai/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/302ai/models/glm-5v-turbo.toml
+++ b/providers/302ai/models/glm-5v-turbo.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/glm-for-coding.toml
+++ b/providers/302ai/models/glm-for-coding.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/glm-for-coding.toml
+++ b/providers/302ai/models/glm-for-coding.toml
@@ -4,7 +4,6 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
-reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Adds native GLM thinking toggles to 11 GLM-4.5-and-later models exposed by 302AI.

## Wire field

The native control is:

```json
{ "thinking": { "type": "enabled" } }
```

or:

```json
{ "thinking": { "type": "disabled" } }
```

This is represented as `reasoning_options = [{ type = "toggle" }]`.

## Model behavior

- GLM-4.5 text models use hybrid thinking when enabled: the model decides whether the request needs reasoning.
- GLM-4.5V uses forced thinking when enabled.
- GLM-4.6 uses hybrid thinking.
- GLM-4.7 and GLM-5-family models default to thinking enabled and allow per-request disabling.
- `glm-for-coding` is excluded because neither 302AI nor Z.AI publicly documents whether that alias accepts the native thinking toggle or is fixed-thinking.

The native GLM toggle is distinct from 302AI's provider-wide `-fusion` feature. Fusion can add a second reasoning model to any model, but does not prove native `thinking.type` support for that model.

## Evidence

- 302AI GLM request schema, including `thinking.type = enabled|disabled` and the GLM-4.5+ support statement: https://doc.302.ai/160231357e0.md
- 302AI multimodal GLM endpoint: https://doc.302.ai/160328137e0.md
- 302AI's separate fusion reasoning mechanism: https://doc.302.ai/266051921e0.md
- Z.AI thinking-mode defaults and per-turn control: https://docs.z.ai/guides/capabilities/thinking-mode
- Z.AI Chat Completion API: https://docs.z.ai/api-reference/llm/chat-completion
- Z.AI model documentation index: https://docs.z.ai/llms.txt

## Verification boundary

Verified against 302AI's public OpenAPI documentation and Z.AI's model-specific documentation. No authenticated 302AI runtime requests were performed. The documented GLM controls are retained, while the undocumented `glm-for-coding` control assertion is deliberately omitted pending runtime evidence.

Split from #2231 and supersedes its 302AI/ZhipuAI scope.
