### PR TITLE
[aihubmix/alibaba] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/qwen3.6-flash.toml
+++ b/providers/aihubmix/models/qwen3.6-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/qwen3.6-max-preview.toml
+++ b/providers/aihubmix/models/qwen3.6-max-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/qwen3.6-plus.toml
+++ b/providers/aihubmix/models/qwen3.6-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the alibaba changes from #2228 into a reviewable 3-model PR.

Scope is limited to `aihubmix/alibaba` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2228.