### PR TITLE
[aihubmix/anthropic] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/claude-opus-4-6-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-6-think.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-6-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-6-think.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-6.toml
+++ b/providers/aihubmix/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-6.toml
+++ b/providers/aihubmix/models/claude-opus-4-6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-7-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-7-think.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-7-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-7-think.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-7.toml
+++ b/providers/aihubmix/models/claude-opus-4-7.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-opus-4-7.toml
+++ b/providers/aihubmix/models/claude-opus-4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-sonnet-4-6-think.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6-think.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-sonnet-4-6-think.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6-think.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-sonnet-4-6.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/claude-sonnet-4-6.toml
+++ b/providers/aihubmix/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary

Adds provider-specific reasoning controls for six AIHubMix Claude 4.6/4.7 model IDs. AIHubMix routes `claude-*` IDs through its Anthropic-compatible `/v1/messages` interface.

## Controls

- Toggle: `thinking.type = "adaptive"` enables reasoning and `thinking.type = "disabled"` disables it.
- Opus/Sonnet 4.6 effort: `output_config.effort = "low" | "medium" | "high" | "max"`.
- Opus 4.7 effort adds `xhigh`.
- Opus/Sonnet 4.6 legacy budgets use `thinking = {"type":"enabled","budget_tokens":N}` with `N >= 1024` and `N < max_tokens`; no fixed maximum is claimed because it is request-dependent.
- Opus 4.7 rejects manual `budget_tokens`.

The `-think` IDs are convenience aliases with thinking pre-enabled. Explicit reasoning configuration takes precedence; their exact alias behavior on `/v1/messages` was not live-tested.

## Evidence

- [AIHubMix SDK routing](https://github.com/AIhubmix/ai-sdk-provider/blob/main/src/aihubmix-provider.ts) routes `claude-*` through `AnthropicMessagesLanguageModel`.
- [AIHubMix Anthropic compatibility](https://docs.aihubmix.com/en/api/Anthropic-Compatible) documents `/v1/messages` and `thinking`.
- [AIHubMix Claude native guide](https://docs.aihubmix.com/en/api/Claude-Native) recommends adaptive thinking and marks fixed budgets deprecated for Claude 4.6.
- [AIHubMix Opus 4.7 guide](https://docs.aihubmix.com/en/blogs/Claude-Opus4.7) documents adaptive effort including `xhigh`.
- [Anthropic adaptive thinking](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking) documents the toggle, deprecated 4.6 budgets, and rejection of budgets by Opus 4.7.
- [Anthropic effort](https://platform.claude.com/docs/en/build-with-claude/effort) documents the model-specific effort sets.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2228.