### PR TITLE
[aihubmix/bytedance] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/doubao-seed-2-0-code-preview.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-code-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-code-preview.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-code-preview.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-lite-260428.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-lite-260428.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-mini-260428.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-mini-260428.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-pro.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/doubao-seed-2-0-pro.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary

Adds provider-specific reasoning controls for four AIHubMix Doubao Seed 2.0 models routed through OpenAI-compatible `/v1/chat/completions`.

## Controls

- `reasoning_effort = "none"` disables reasoning; a supported non-`none` value enables it.
- Distinct efforts are `minimal`, `low`, `medium`, and `high`.
- AIHubMix accepts `xhigh` but coerces it to Doubao `high`, so it is not advertised as a distinct level.
- AIHubMix also accepts `reasoning = {"effort":"..."}`; top-level `reasoning_effort` has precedence.

## Evidence

- [AIHubMix SDK routing](https://github.com/AIhubmix/ai-sdk-provider/blob/main/src/aihubmix-provider.ts) shows non-Claude/non-Gemini models use the OpenAI-compatible Chat adapter.
- [AIHubMix unified reasoning](https://docs.aihubmix.com/en/api/unified-inference) documents `reasoning_effort`, `none` as disabled, and the Doubao effort mapping.
- [BytePlus Seed 2.0](https://docs.byteplus.com/en/docs/Byteplus_LAS/Multimodal-Deep-Thinking-Doubao-Seed-2-0) confirms native deep-thinking support.
- [Volcengine thinking controls](https://www.volcengine.com/docs/6492/2165109?lang=zh) documents upstream `thinking.type = "enabled" | "disabled" | "auto"`.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2228.