### PR TITLE
[aihubmix/deepseek] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/alicloud-deepseek-v4-flash.toml
+++ b/providers/aihubmix/models/alicloud-deepseek-v4-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/alicloud-deepseek-v4-flash.toml
+++ b/providers/aihubmix/models/alicloud-deepseek-v4-flash.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/alicloud-deepseek-v4-pro.toml
+++ b/providers/aihubmix/models/alicloud-deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/alicloud-deepseek-v4-pro.toml
+++ b/providers/aihubmix/models/alicloud-deepseek-v4-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/deep-deepseek-v4-flash.toml
+++ b/providers/aihubmix/models/deep-deepseek-v4-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/deep-deepseek-v4-flash.toml
+++ b/providers/aihubmix/models/deep-deepseek-v4-flash.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/deep-deepseek-v4-pro.toml
+++ b/providers/aihubmix/models/deep-deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/deep-deepseek-v4-pro.toml
+++ b/providers/aihubmix/models/deep-deepseek-v4-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary

Records the provider-layer binary reasoning control for four retained AIHubMix DeepSeek V4 route entries.

## Controls

- AIHubMix documents `reasoning_effort = "none"` as reasoning off and any other documented effort as on for binary providers such as DeepSeek.
- Native DeepSeek V4 separately supports `thinking.type = "enabled" | "disabled"` and `reasoning_effort = "high" | "max"`.
- This PR intentionally advertises only `toggle`: AIHubMix does not document `max` in its incoming unified enum or prove that native `high` and `max` remain distinct through these routes.

## Catalog caveat

The current public catalog exposes `deepseek-v4-flash` and `deepseek-v4-pro`, not the four channel-prefixed IDs changed here. This reasoning-only PR retains the existing repository entries; catalog migration should be handled separately.

## Evidence

- [AIHubMix unified reasoning](https://docs.aihubmix.com/en/api/unified-inference) documents binary DeepSeek behavior and the provider request field.
- [AIHubMix Models API](https://docs.aihubmix.com/en/api/Models-API) documents the catalog endpoint.
- [Current DeepSeek V4 catalog](https://aihubmix.com/api/v1/models?model=deepseek-v4) shows the current unprefixed IDs.
- [DeepSeek thinking mode](https://api-docs.deepseek.com/guides/thinking_mode) documents native toggle and effort controls.
- [DeepSeek V4 release](https://api-docs.deepseek.com/news/news260424) confirms Flash and Pro dual thinking/non-thinking modes.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2228.