### PR TITLE
[aihubmix/google] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/gemini-2.5-flash.toml
+++ b/providers/aihubmix/models/gemini-2.5-flash.toml
@@ -4,7 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-2.5-flash.toml
+++ b/providers/aihubmix/models/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-2.5-pro.toml
+++ b/providers/aihubmix/models/gemini-2.5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-2.5-pro.toml
+++ b/providers/aihubmix/models/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-2.5-pro.toml
+++ b/providers/aihubmix/models/gemini-2.5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-3-flash-preview.toml
+++ b/providers/aihubmix/models/gemini-3-flash-preview.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-3.1-flash-lite.toml
+++ b/providers/aihubmix/models/gemini-3.1-flash-lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-07"
 last_updated = "2026-05-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/aihubmix/models/gemini-3.1-pro-preview-customtools.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/gemini-3.1-pro-preview.toml
+++ b/providers/aihubmix/models/gemini-3.1-pro-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary

Adds provider-specific reasoning controls for six AIHubMix Gemini models.

## Controls

- AIHubMix maps `reasoning_effort` to Gemini thinking levels.
- Gemini 2.5 Flash retains its documented token-budget control.
- Gemini 2.5 Pro uses effort only because its thinking budget should not be set explicitly.
- Gemini 3 entries use their model-specific supported effort subsets.

## Evidence

- [AIHubMix unified reasoning](https://docs.aihubmix.com/en/api/unified-inference) documents `reasoning_effort`, the Gemini effort mapping, and `reasoning.max_tokens`.
- [Google Gemini thinking](https://ai.google.dev/gemini-api/docs/thinking) documents model-specific thinking levels and budgets, including Gemini 2.5 restrictions.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2228.