### PR TITLE
[aihubmix/minimax] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/coding-minimax-m2.7-free.toml
+++ b/providers/aihubmix/models/coding-minimax-m2.7-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-minimax-m2.7-highspeed.toml
+++ b/providers/aihubmix/models/coding-minimax-m2.7-highspeed.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-minimax-m2.7.toml
+++ b/providers/aihubmix/models/coding-minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/minimax-m2.7.toml
+++ b/providers/aihubmix/models/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary

Adds explicit empty reasoning controls for four live AIHubMix MiniMax M2.7 routes. These are fixed/forced-reasoning models, so `reasoning_options = []` means reasoning is present but no effective user-selectable control is advertised.

## Toggle audit

AIHubMix notes that `reasoning_effort = "none"` may not disable `minimax-m2.7`. Upstream MiniMax states that M2.x thinking cannot be disabled: `thinking.type = "disabled"` may be accepted, but thinking remains enabled. It therefore does not qualify as a toggle.

## Evidence

- [AIHubMix unified reasoning](https://docs.aihubmix.com/en/api/unified-inference) identifies MiniMax M2.7 as forced-thinking.
- [Current MiniMax M2.7 catalog](https://aihubmix.com/api/v1/models?model=minimax-m2.7) lists all four routes.
- [MiniMax OpenAI-compatible API](https://platform.minimax.io/docs/api-reference/text-openai-api#thinking-control) documents ineffective disable behavior for M2.x.
- [MiniMax Anthropic-compatible API](https://platform.minimax.io/docs/api-reference/text-anthropic-api#thinking-control) independently documents the same restriction.

## Validation

- `bun validate`

Supersedes part of #2228.