### PR TITLE
[aihubmix/moonshotai] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/kimi-k2.5.toml
+++ b/providers/aihubmix/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/kimi-k2.6.toml
+++ b/providers/aihubmix/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the moonshotai changes from #2228 into a reviewable 2-model PR.

Scope is limited to `aihubmix/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2228.