### PR TITLE
[aihubmix/openai] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/gpt-5.1-codex-mini.toml
+++ b/providers/aihubmix/models/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.1-codex.toml
+++ b/providers/aihubmix/models/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.1.toml
+++ b/providers/aihubmix/models/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.2-codex.toml
+++ b/providers/aihubmix/models/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.2.toml
+++ b/providers/aihubmix/models/gpt-5.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.3-codex.toml
+++ b/providers/aihubmix/models/gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.3-codex.toml
+++ b/providers/aihubmix/models/gpt-5.3-codex.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.4-mini.toml
+++ b/providers/aihubmix/models/gpt-5.4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.4.toml
+++ b/providers/aihubmix/models/gpt-5.4.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/aihubmix/models/gpt-5.5.toml
+++ b/providers/aihubmix/models/gpt-5.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-12-01"
 tool_call = true


### PR DESCRIPTION
## Summary

Adds provider-local effort metadata for nine AIHubMix GPT models using each model documented OpenAI effort subset.

## Provider semantics

AIHubMix documents top-level `reasoning_effort` for Chat and `reasoning.effort` for `/v1/responses`. `none` disables reasoning only on models that support it. GPT-5.3 Codex supports `low`, `medium`, `high`, and `xhigh`, but not `none`.

AIHubMix model-specific suffix documentation says dynamic GPT-5.2 effort is Responses-only and recommends fixed aliases for Chat. These declarations describe provider capability and do not claim every value works through the npm provider default Chat route.

## Evidence

- [AIHubMix unified reasoning](https://docs.aihubmix.com/en/api/unified-inference) documents the provider effort fields and GPT mapping.
- [AIHubMix capability suffixes](https://docs.aihubmix.com/en/api/Capability-Suffix) documents the GPT-5.2 Chat/Responses qualification.
- [AIHubMix Responses reasoning](https://docs.aihubmix.com/en/api/responses/Reasoning) documents `reasoning.effort`.
- [GPT-5.1](https://developers.openai.com/api/docs/models/gpt-5.1), [GPT-5.2](https://developers.openai.com/api/docs/models/gpt-5.2), [GPT-5.2 Codex](https://developers.openai.com/api/docs/models/gpt-5.2-codex), [GPT-5.3 Codex](https://developers.openai.com/api/docs/models/gpt-5.3-codex), [GPT-5.4](https://developers.openai.com/api/docs/models/gpt-5.4), [GPT-5.4 Mini](https://developers.openai.com/api/docs/models/gpt-5.4-mini), and [GPT-5.5](https://developers.openai.com/api/docs/models/gpt-5.5) document model-specific effort sets.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2228.