### PR TITLE
[aihubmix/xai] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/grok-4.3.toml
+++ b/providers/aihubmix/models/grok-4.3.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the xai changes from #2228 into a reviewable 1-model PR.

Scope is limited to `aihubmix/xai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2228.