### PR TITLE
[aihubmix/zhipuai] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/alicloud-glm-5.1.toml
+++ b/providers/aihubmix/models/alicloud-glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-glm-5.1-free.toml
+++ b/providers/aihubmix/models/coding-glm-5.1-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-11"
 last_updated = "2026-04-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/coding-glm-5.1.toml
+++ b/providers/aihubmix/models/coding-glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-11"
 last_updated = "2026-04-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/glm-5v-turbo.toml
+++ b/providers/aihubmix/models/glm-5v-turbo.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/zai-glm-5.1.toml
+++ b/providers/aihubmix/models/zai-glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
## Summary

Adds provider-local binary reasoning toggles for five AIHubMix GLM models. AIHubMix normalizes these GLM routes as toggles rather than distinct effort scales.

## Toggle mechanism

- `reasoning_effort = "none"` disables thinking.
- Any other accepted value enables thinking.
- AIHubMix also accepts `reasoning = {"effort":"..."}`.

Native upstream controls differ: Z.ai uses `thinking.type = "enabled" | "disabled"`; Alibaba Cloud uses `enable_thinking = true | false`. Values such as `low`, `medium`, and `high` collapse to the enabled state here and are not advertised as distinct efforts.

## Evidence

- [AIHubMix unified reasoning](https://docs.aihubmix.com/en/api/unified-inference) documents the binary GLM mapping.
- [AIHubMix OpenAPI](https://docs.aihubmix.com/openapi.json) documents the accepted provider request field.
- [Z.ai thinking](https://docs.z.ai/guides/capabilities/thinking) and [thinking mode](https://docs.z.ai/guides/capabilities/thinking-mode) document native enabled/disabled controls.
- [Z.ai parameter concepts](https://docs.z.ai/guides/overview/concept-param) distinguishes newer graded-effort models from these binary models.
- [Alibaba Cloud deep thinking](https://help.aliyun.com/en/model-studio/deep-thinking) documents `enable_thinking`.

## Validation

- `bun validate`

Supersedes part of #2228.