### PR TITLE
[alibaba/alibaba part 1] Add reasoning options

### DIFF
--- a/providers/alibaba-cn/models/qwen-flash.toml
+++ b/providers/alibaba-cn/models/qwen-flash.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.022
 output = 0.216

--- a/providers/alibaba-cn/models/qwen-plus.toml
+++ b/providers/alibaba-cn/models/qwen-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.115
 output = 0.287

--- a/providers/alibaba-cn/models/qwen-turbo.toml
+++ b/providers/alibaba-cn/models/qwen-turbo.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.044
 output = 0.087

--- a/providers/alibaba-cn/models/qwen3-14b.toml
+++ b/providers/alibaba-cn/models/qwen3-14b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.144
 output = 0.574

--- a/providers/alibaba-cn/models/qwen3-235b-a22b.toml
+++ b/providers/alibaba-cn/models/qwen3-235b-a22b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.287
 output = 1.147

--- a/providers/alibaba-cn/models/qwen3-32b.toml
+++ b/providers/alibaba-cn/models/qwen3-32b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.287
 output = 1.147

--- a/providers/alibaba-cn/models/qwen3-8b.toml
+++ b/providers/alibaba-cn/models/qwen3-8b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.072
 output = 0.287

--- a/providers/alibaba-cn/models/qwen3-omni-flash.toml
+++ b/providers/alibaba-cn/models/qwen3-omni-flash.toml
@@ -9,6 +9,9 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.058
 output = 0.230

--- a/providers/alibaba-cn/models/qwen3-vl-plus.toml
+++ b/providers/alibaba-cn/models/qwen3-vl-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.143353
 output = 1.433525

--- a/providers/alibaba-cn/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba-cn/models/qwen3.5-397b-a17b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.430
 output = 2.58

--- a/providers/alibaba-cn/models/qwen3.5-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.5-flash.toml
@@ -10,6 +10,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.172
 output = 1.72

--- a/providers/alibaba-cn/models/qwen3.5-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.5-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.573
 output = 3.44

--- a/providers/alibaba-cn/models/qwen3.6-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.6-flash.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.6-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 0.1875
 output = 1.125

--- a/providers/alibaba-cn/models/qwen3.6-max-preview.toml
+++ b/providers/alibaba-cn/models/qwen3.6-max-preview.toml
@@ -9,6 +9,13 @@ tool_call = true
 open_weights = false
 structured_output = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 1.32
 cache_read = 0.132

--- a/providers/alibaba-cn/models/qwen3.6-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.6-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.50
 output = 3.00


### PR DESCRIPTION
Splits the Alibaba part 1 changes from #1987 into a reviewable 15-model PR.

Scope is limited to Alibaba Cloud Model Studio's China route (`https://dashscope.aliyuncs.com/compatible-mode/v1`). Supersedes part of #1987.

## Audited models

| Model | Reasoning controls |
| --- | --- |
| `qwen-flash` | toggle; budget up to 81,920 tokens |
| `qwen-plus` | toggle; budget up to 81,920 tokens |
| `qwen-turbo` | toggle; budget up to 38,912 tokens |
| `qwen3-14b` | toggle; budget up to 38,912 tokens |
| `qwen3-235b-a22b` | toggle; budget up to 38,912 tokens |
| `qwen3-32b` | toggle; budget up to 38,912 tokens |
| `qwen3-8b` | toggle; budget up to 38,912 tokens |
| `qwen3-omni-flash` | toggle |
| `qwen3-vl-plus` | toggle; budget up to 81,920 tokens |
| `qwen3.5-397b-a17b` | toggle; budget up to 81,920 tokens |
| `qwen3.5-flash` | toggle; budget up to 81,920 tokens |
| `qwen3.5-plus` | toggle; budget up to 81,920 tokens |
| `qwen3.6-flash` | toggle; budget up to 131,072 tokens |
| `qwen3.6-max-preview` | toggle; budget up to 131,072 tokens |
| `qwen3.6-plus` | toggle; budget up to 81,920 tokens |

## API fields

- On OpenAI-compatible Chat Completions, `enable_thinking: true | false` switches the same hybrid model ID between thinking and non-thinking modes.
- `thinking_budget` is a positive integer that caps reasoning tokens, not total output or context tokens. In the Python OpenAI SDK these non-standard fields are passed through `extra_body`; in Node.js and raw HTTP they are top-level request fields.
- The separate Responses API uses `reasoning.effort` and does not replace these Chat Completions controls.

## Primary evidence

- [Deep thinking](https://help.aliyun.com/en/model-studio/deep-thinking) defines hybrid mode through `enable_thinking: true | false`, defines `thinking_budget` as the reasoning-token cap, and lists Qwen Plus, Flash, Turbo, open Qwen3, Qwen3.5, and Qwen3.6 as supported hybrid families.
- [Text generation model table](https://help.aliyun.com/zh/model-studio/text-generation-model) separates context, maximum output, and thinking budget. It documents 80K budgets for Qwen3.5 and Qwen3.6 Plus and 128K for Qwen3.6 Flash and Max Preview. The TOML values use binary token counts: 80K = 81,920 and 128K = 131,072.
- [Visual reasoning](https://help.aliyun.com/en/model-studio/visual-reasoning) identifies `qwen3-vl-plus` as hybrid and documents both `enable_thinking` and `thinking_budget`; its request examples use 81,920.
- [Qwen-Omni](https://help.aliyun.com/en/model-studio/qwen-omni) says `qwen3-omni-flash` is the Qwen-Omni hybrid model and documents `enable_thinking: true | false`. It does not document a numeric budget, so this PR claims toggle only.
- [Model Studio error codes](https://help.aliyun.com/en/model-studio/error-code) documents that `thinking_budget` must be positive and no greater than the model-specific maximum, and distinguishes it from `max_tokens`.

Legacy Qwen exact CoT maxima are shown on Alibaba's region-specific model cards, to which the deep-thinking documentation directs users for per-model maximum chain-of-thought length.

## Audit result

All 15 entries match the documented China-route controls. No code corrections were required.
