### PR TITLE
[alibaba/alibaba part 2] Add reasoning options

### DIFF
--- a/providers/alibaba-cn/models/qwen3.7-max.toml
+++ b/providers/alibaba-cn/models/qwen3.7-max.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.7-max"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 2.5
 output = 7.5

--- a/providers/alibaba-cn/models/qwen3.7-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.7-plus.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.7-plus"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 0.5
 output = 3

--- a/providers/alibaba/models/qwen-flash.toml
+++ b/providers/alibaba/models/qwen-flash.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.05
 output = 0.4

--- a/providers/alibaba/models/qwen-plus.toml
+++ b/providers/alibaba/models/qwen-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.4
 output = 1.2

--- a/providers/alibaba/models/qwen-turbo.toml
+++ b/providers/alibaba/models/qwen-turbo.toml
@@ -9,6 +9,13 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.05
 output = 0.2

--- a/providers/alibaba/models/qwen3-14b.toml
+++ b/providers/alibaba/models/qwen3-14b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.35
 output = 1.4

--- a/providers/alibaba/models/qwen3-235b-a22b.toml
+++ b/providers/alibaba/models/qwen3-235b-a22b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.7
 output = 2.8

--- a/providers/alibaba/models/qwen3-32b.toml
+++ b/providers/alibaba/models/qwen3-32b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.7
 output = 2.8

--- a/providers/alibaba/models/qwen3-8b.toml
+++ b/providers/alibaba/models/qwen3-8b.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 38_912
+
 [cost]
 input = 0.18
 output = 0.7

--- a/providers/alibaba/models/qwen3-omni-flash.toml
+++ b/providers/alibaba/models/qwen3-omni-flash.toml
@@ -9,6 +9,9 @@ knowledge = "2024-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.43
 output = 1.66

--- a/providers/alibaba/models/qwen3-vl-plus.toml
+++ b/providers/alibaba/models/qwen3-vl-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.2
 output = 1.6

--- a/providers/alibaba/models/qwen3.5-122b-a10b.toml
+++ b/providers/alibaba/models/qwen3.5-122b-a10b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.4
 output = 3.2

--- a/providers/alibaba/models/qwen3.5-27b.toml
+++ b/providers/alibaba/models/qwen3.5-27b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.3
 output = 2.4

--- a/providers/alibaba/models/qwen3.5-35b-a3b.toml
+++ b/providers/alibaba/models/qwen3.5-35b-a3b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.25
 output = 2

--- a/providers/alibaba/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba/models/qwen3.5-397b-a17b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.6
 output = 3.6


### PR DESCRIPTION
Splits the Alibaba part 2 changes from #1987 into a reviewable 15-model PR.

Scope covers the remaining China-route entries and the first international-route entries. Supersedes part of #1987.

## Audited models

| Route | Model | Reasoning controls |
| --- | --- | --- |
| China | `qwen3.7-max` | toggle; budget up to 262,144 tokens |
| China | `qwen3.7-plus` | toggle; budget up to 262,144 tokens |
| International | `qwen-flash` | toggle; budget up to 81,920 tokens |
| International | `qwen-plus` | toggle; budget up to 81,920 tokens |
| International | `qwen-turbo` | toggle; budget up to 38,912 tokens |
| International | `qwen3-14b` | toggle; budget up to 38,912 tokens |
| International | `qwen3-235b-a22b` | toggle; budget up to 38,912 tokens |
| International | `qwen3-32b` | toggle; budget up to 38,912 tokens |
| International | `qwen3-8b` | toggle; budget up to 38,912 tokens |
| International | `qwen3-omni-flash` | toggle |
| International | `qwen3-vl-plus` | toggle; budget up to 81,920 tokens |
| International | `qwen3.5-122b-a10b` | toggle; budget up to 81,920 tokens |
| International | `qwen3.5-27b` | toggle; budget up to 81,920 tokens |
| International | `qwen3.5-35b-a3b` | toggle; budget up to 81,920 tokens |
| International | `qwen3.5-397b-a17b` | toggle; budget up to 81,920 tokens |

## API fields and routes

- `providers/alibaba-cn` calls the China OpenAI-compatible route; `providers/alibaba` calls Alibaba's international route. Alibaba states that API keys and endpoint availability are region-specific.
- `enable_thinking: true | false` is the Chat Completions toggle. `thinking_budget` is the numeric reasoning-token cap. Python passes both through `extra_body`; Node.js and raw HTTP use top-level fields.
- The budget is not inferred from context or maximum output. Qwen3.7 has a 1M context, 64K maximum response, and a separately documented 256K thinking budget.

## Primary evidence

- [Text generation model table](https://help.aliyun.com/zh/model-studio/text-generation-model) lists both `qwen3.7-max` and `qwen3.7-plus` with a 256K thinking budget, separately from their 1M context and 64K maximum output. This corresponds to `max = 262_144`.
- [Deep thinking](https://help.aliyun.com/en/model-studio/deep-thinking) lists Qwen3.7 Max and Plus as hybrid-thinking series and documents `enable_thinking: true | false` plus the `thinking_budget` cap.
- [Visual reasoning](https://help.aliyun.com/en/model-studio/visual-reasoning) documents `qwen3-vl-plus` as hybrid and exposes `enable_thinking` and `thinking_budget`.
- [Qwen-Omni](https://help.aliyun.com/en/model-studio/qwen-omni) documents `qwen3-omni-flash` as hybrid through `enable_thinking`, without a numeric budget claim.
- [Model Studio error codes](https://help.aliyun.com/en/model-studio/error-code) requires a positive `thinking_budget` no greater than the model maximum and separately validates `max_tokens`.

The international endpoint configured by this repository remains an accepted Alibaba endpoint; current Alibaba documentation recommends workspace-specific international domains for improved stability while stating that existing domains continue to work.

## Audit result

All 15 entries match the documented controls for their exact Alibaba route. No code corrections were required.
