### PR TITLE
[alibaba/alibaba part 3] Add reasoning options

### DIFF
--- a/providers/alibaba/models/qwen3.5-plus.toml
+++ b/providers/alibaba/models/qwen3.5-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.4
 output = 2.4

--- a/providers/alibaba/models/qwen3.6-27b.toml
+++ b/providers/alibaba/models/qwen3.6-27b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 0.6
 output = 3.6

--- a/providers/alibaba/models/qwen3.6-35b-a3b.toml
+++ b/providers/alibaba/models/qwen3.6-35b-a3b.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 0.248
 output = 1.485

--- a/providers/alibaba/models/qwen3.6-flash.toml
+++ b/providers/alibaba/models/qwen3.6-flash.toml
@@ -9,6 +9,13 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 0.1875
 output = 1.125

--- a/providers/alibaba/models/qwen3.6-max-preview.toml
+++ b/providers/alibaba/models/qwen3.6-max-preview.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [cost]
 input = 1.3
 output = 7.8

--- a/providers/alibaba/models/qwen3.6-plus.toml
+++ b/providers/alibaba/models/qwen3.6-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [cost]
 input = 0.50
 output = 3.00

--- a/providers/alibaba/models/qwen3.7-max.toml
+++ b/providers/alibaba/models/qwen3.7-max.toml
@@ -8,6 +8,13 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 2.50
 output = 7.50

--- a/providers/alibaba/models/qwen3.7-plus.toml
+++ b/providers/alibaba/models/qwen3.7-plus.toml
@@ -9,6 +9,13 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
 [cost]
 input = 0.50
 output = 3.00


### PR DESCRIPTION
Splits the Alibaba part 3 changes from #1987 into a reviewable 8-model PR on Alibaba Cloud Model Studio's international route.

Supersedes part of #1987.

## Audited models

| Model | Reasoning controls |
| --- | --- |
| `qwen3.5-plus` | toggle; budget up to 81,920 tokens |
| `qwen3.6-27b` | toggle; budget up to 131,072 tokens |
| `qwen3.6-35b-a3b` | toggle; budget up to 131,072 tokens |
| `qwen3.6-flash` | toggle; budget up to 131,072 tokens |
| `qwen3.6-max-preview` | toggle; budget up to 131,072 tokens |
| `qwen3.6-plus` | toggle; budget up to 81,920 tokens |
| `qwen3.7-max` | toggle; budget up to 262,144 tokens |
| `qwen3.7-plus` | toggle; budget up to 262,144 tokens |

## API fields

- OpenAI-compatible Chat Completions uses `enable_thinking: true | false` to switch hybrid thinking and `thinking_budget` to cap reasoning tokens.
- Python supplies these Alibaba-specific fields through `extra_body`; Node.js and raw HTTP use top-level fields.
- These are Chat Completions controls. Alibaba's Responses API instead uses `reasoning.effort` and does not accept `thinking_budget`.

## Primary evidence

- [Text generation model table](https://help.aliyun.com/zh/model-studio/text-generation-model) documents 256K thinking budgets for Qwen3.7 Max and Plus, 128K for Qwen3.6 Flash and Max Preview, and 80K for Qwen3.6 Plus and Qwen3.5 Plus. The TOML values are 262,144, 131,072, and 81,920 tokens respectively.
- [Deep thinking](https://help.aliyun.com/en/model-studio/deep-thinking) identifies Qwen3.7, Qwen3.6, and Qwen3.5 as hybrid-thinking families controlled by `enable_thinking`, and defines `thinking_budget` as the maximum reasoning-token count.
- [Visual reasoning](https://help.aliyun.com/en/model-studio/visual-reasoning) explicitly lists `qwen3.6-35b-a3b` as hybrid and documents the same controls for Qwen3.6 multimodal models.
- [Model deployment](https://help.aliyun.com/en/model-studio/model-deployment-introduction) documents Qwen3.6 open-model instruct/thinking deployment modes, including caller-switchable instruct/thinking operation where supported.
- [Model Studio error codes](https://help.aliyun.com/en/model-studio/error-code) distinguishes `thinking_budget` from `max_tokens` and enforces the model-specific reasoning limit.

`qwen3.6-27b` is covered by Alibaba's Qwen3-and-later thinking documentation and its regional model/deployment card; that card supplies the 128K maximum CoT value. This is route-specific provider evidence rather than an inference from the model's 262K context or 64K output limit.

## Audit result

All 8 entries match the documented international-route controls. No code corrections were required.
