### PR TITLE
[alibaba/deepseek] Add reasoning options

### DIFF
--- a/providers/alibaba-cn/models/deepseek-v4-flash.toml
+++ b/providers/alibaba-cn/models/deepseek-v4-flash.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/deepseek-v4-pro.toml
+++ b/providers/alibaba-cn/models/deepseek-v4-pro.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
Splits the deepseek changes from #1987 into a reviewable 2-model PR.

Scope is limited to `alibaba/deepseek` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #1987.