### PR TITLE
[alibaba/kimi] Add reasoning options

### DIFF
--- a/providers/alibaba-cn/models/kimi/kimi-k2.5.toml
+++ b/providers/alibaba-cn/models/kimi/kimi-k2.5.toml
@@ -10,6 +10,13 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
Splits the kimi changes from #1987 into a reviewable 1-model PR.

Scope is limited to `alibaba/kimi` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #1987.