### PR TITLE
[alibaba/moonshotai] Add reasoning options

### DIFF
--- a/providers/alibaba-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-cn/models/kimi-k2.5.toml
@@ -10,6 +10,13 @@ open_weights = true
 knowledge = "2025-01"
 structured_output = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/kimi-k2.6.toml
+++ b/providers/alibaba-cn/models/kimi-k2.6.toml
@@ -10,6 +10,13 @@ open_weights = true
 knowledge = "2025-01"
 structured_output = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
Splits the moonshotai changes from #1987 into a reviewable 2-model PR.

Scope is limited to `alibaba/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #1987.