### PR TITLE
[alibaba/siliconflow] Add reasoning options

### DIFF
--- a/providers/alibaba-cn/models/siliconflow/deepseek-v3.1-terminus.toml
+++ b/providers/alibaba-cn/models/siliconflow/deepseek-v3.1-terminus.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.27
 output = 1.0

--- a/providers/alibaba-cn/models/siliconflow/deepseek-v3.2.toml
+++ b/providers/alibaba-cn/models/siliconflow/deepseek-v3.2.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.27
 output = 0.42


### PR DESCRIPTION
Splits the siliconflow changes from #1987 into a reviewable 2-model PR.

Scope is limited to `alibaba/siliconflow` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #1987.