### PR TITLE
[alibaba/zhipuai] Add reasoning options

### DIFF
--- a/providers/alibaba-cn/models/glm-5.1.toml
+++ b/providers/alibaba-cn/models/glm-5.1.toml
@@ -9,6 +9,13 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/glm-5.toml
+++ b/providers/alibaba-cn/models/glm-5.toml
@@ -8,6 +8,13 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 32_768
+
 [interleaved]
 field = "reasoning_content"
 


### PR DESCRIPTION
Splits the zhipuai changes from #1987 into a reviewable 2-model PR.

Scope is limited to `alibaba/zhipuai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #1987.