### PR TITLE
[cortecs/alibaba] Add reasoning options

### DIFF
--- a/providers/cortecs/models/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/cortecs/models/qwen3-235b-a22b-instruct-2507.toml
@@ -5,6 +5,7 @@ last_updated = "2025-07-23"
 knowledge = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/cortecs/models/qwen3-coder-30b-a3b-instruct.toml
@@ -3,6 +3,7 @@ name = "Qwen3 Coder 30B A3B Instruct"
 release_date = "2025-07-31"
 last_updated = "2025-07-31"
 reasoning = true
+reasoning_options = []
 
 [cost]
 input = 0.053

--- a/providers/cortecs/models/qwen3-coder-next.toml
+++ b/providers/cortecs/models/qwen3-coder-next.toml
@@ -5,6 +5,7 @@ last_updated = "2026-02-04"
 knowledge = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/cortecs/models/qwen3-next-80b-a3b-thinking.toml
@@ -4,6 +4,7 @@ last_updated = "2025-09-11"
 knowledge = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/qwen3.5-122b-a10b.toml
+++ b/providers/cortecs/models/qwen3.5-122b-a10b.toml
@@ -1,6 +1,6 @@
 base_model = "alibaba/qwen3.5-122b-a10b"
 base_model_omit = ["structured_output"]
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 name = "Qwen3.5 122B A10B"
 release_date = "2026-02-24"
 last_updated = "2026-02-24"

--- a/providers/cortecs/models/qwen3.5-122b-a10b.toml
+++ b/providers/cortecs/models/qwen3.5-122b-a10b.toml
@@ -1,5 +1,6 @@
 base_model = "alibaba/qwen3.5-122b-a10b"
 base_model_omit = ["structured_output"]
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen3.5 122B A10B"
 release_date = "2026-02-24"
 last_updated = "2026-02-24"

--- a/providers/cortecs/models/qwen3.5-397b-a17b.toml
+++ b/providers/cortecs/models/qwen3.5-397b-a17b.toml
@@ -1,5 +1,6 @@
 base_model = "alibaba/qwen3.5-397b-a17b"
 base_model_omit = ["structured_output"]
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen3.5 397B A17B"
 release_date = "2026-02-16"
 last_updated = "2026-02-16"

--- a/providers/cortecs/models/qwen3.5-397b-a17b.toml
+++ b/providers/cortecs/models/qwen3.5-397b-a17b.toml
@@ -1,6 +1,6 @@
 base_model = "alibaba/qwen3.5-397b-a17b"
 base_model_omit = ["structured_output"]
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 name = "Qwen3.5 397B A17B"
 release_date = "2026-02-16"
 last_updated = "2026-02-16"


### PR DESCRIPTION
## Summary

Adds conservative provider-layer reasoning metadata for six Cortecs Qwen routes.

## Audit result

- Qwen3 Instruct/Coder entries are fixed non-thinking checkpoints.
- Qwen3 Next Thinking is a fixed thinking-only checkpoint.
- Qwen3.5 supports an upstream toggle, but Cortecs does not document forwarding `enable_thinking` or `chat_template_kwargs.enable_thinking` across its Tensorix, Scaleway, and OVH routes.
- Cortecs accepts `reasoning_effort = low | medium | high`, but explicitly says unsupported controls may be silently ignored.
- Therefore all six entries use `reasoning_options = []`; no Cortecs-specific toggle, effort, or budget is claimed.

## Evidence

- [Cortecs reasoning](https://docs.cortecs.ai/usage/reasoning.md) documents generic effort and silent ignoring.
- [Cortecs parameter handling](https://docs.cortecs.ai/usage/advanced-usage.md) documents route eligibility and unsupported-parameter behavior.
- [Qwen3 235B Instruct](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507), [Qwen3 Coder 30B](https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct), and [Qwen3 Coder Next](https://huggingface.co/Qwen/Qwen3-Coder-Next) document fixed non-thinking behavior.
- [Qwen3 Next Thinking](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Thinking) documents fixed thinking-only behavior.
- [Qwen3.5 122B](https://huggingface.co/Qwen/Qwen3.5-122B-A10B) and [Qwen3.5 397B](https://huggingface.co/Qwen/Qwen3.5-397B-A17B) document upstream toggle forms, which are not treated as Cortecs proof.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2230.