### PR TITLE
[cortecs/anthropic] Add reasoning options

### DIFF
--- a/providers/cortecs/models/claude-4-5-sonnet.toml
+++ b/providers/cortecs/models/claude-4-5-sonnet.toml
@@ -5,6 +5,7 @@ last_updated = "2025-09-29"
 knowledge = "2025-07-31"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 tool_call = true
 temperature = true
 open_weights = false

--- a/providers/cortecs/models/claude-4-5-sonnet.toml
+++ b/providers/cortecs/models/claude-4-5-sonnet.toml
@@ -5,7 +5,7 @@ last_updated = "2025-09-29"
 knowledge = "2025-07-31"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 tool_call = true
 temperature = true
 open_weights = false

--- a/providers/cortecs/models/claude-4-6-sonnet.toml
+++ b/providers/cortecs/models/claude-4-6-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/cortecs/models/claude-4-6-sonnet.toml
+++ b/providers/cortecs/models/claude-4-6-sonnet.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/cortecs/models/claude-haiku-4-5.toml
+++ b/providers/cortecs/models/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/cortecs/models/claude-haiku-4-5.toml
+++ b/providers/cortecs/models/claude-haiku-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/cortecs/models/claude-opus4-5.toml
+++ b/providers/cortecs/models/claude-opus4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cortecs/models/claude-opus4-5.toml
+++ b/providers/cortecs/models/claude-opus4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cortecs/models/claude-opus4-6.toml
+++ b/providers/cortecs/models/claude-opus4-6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/cortecs/models/claude-opus4-6.toml
+++ b/providers/cortecs/models/claude-opus4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/cortecs/models/claude-opus4-7.toml
+++ b/providers/cortecs/models/claude-opus4-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/cortecs/models/claude-opus4-7.toml
+++ b/providers/cortecs/models/claude-opus4-7.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/cortecs/models/claude-opus4-7.toml
+++ b/providers/cortecs/models/claude-opus4-7.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/cortecs/models/claude-opus4-8.toml
+++ b/providers/cortecs/models/claude-opus4-8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 5.64

--- a/providers/cortecs/models/claude-opus4-8.toml
+++ b/providers/cortecs/models/claude-opus4-8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5.64

--- a/providers/cortecs/models/claude-opus4-8.toml
+++ b/providers/cortecs/models/claude-opus4-8.toml
@@ -1,8 +1,8 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]
 input = 5.64
 output = 28.198
 cache_read = 0.563
 cache_write = 7.049
-


### PR DESCRIPTION
## Summary

Adds Cortecs reasoning controls for seven Claude models.

## Controls

Cortecs accepts top-level `reasoning_effort = low|medium|high` for Anthropic routes and maps those values to provider reasoning behavior.

Cortecs also accepts custom `thinking = {"type":"enabled","budget_tokens":N}` where the underlying Claude model supports manual extended thinking.

- Haiku 4.5, Opus 4.5, Sonnet 4.5: effort plus manual budget, minimum 1,024.
- Opus 4.6, Sonnet 4.6: effort plus deprecated-but-supported manual budget, minimum 1,024.
- Opus 4.7 and 4.8: effort only; manual `budget_tokens` returns 400 upstream and is not advertised.

No fixed maxima are inferred from output limits.

## Evidence

- [Cortecs reasoning](https://docs.cortecs.ai/usage/reasoning.md) documents `low|medium|high` and custom Anthropic budgets.
- [Cortecs Claude documentation answer](https://docs.cortecs.ai/usage/reasoning.md?ask=For%20Cortecs%20Claude%20models%2C%20which%20models%20support%20reasoning_effort%20low%2C%20medium%2C%20high%20and%20custom%20thinking.budget_tokens%3F) confirms the provider-facing effort and budget fields.
- [Anthropic extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) documents model-specific manual-budget support and the Opus 4.7/4.8 400 restriction.
- [Anthropic effort](https://platform.claude.com/docs/en/build-with-claude/effort) documents model reasoning behavior.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2230.