### PR TITLE
[cortecs/deepseek] Add reasoning options

### DIFF
--- a/providers/cortecs/models/deepseek-r1-0528.toml
+++ b/providers/cortecs/models/deepseek-r1-0528.toml
@@ -5,6 +5,7 @@ last_updated = "2025-05-28"
 knowledge = "2024-07"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/deepseek-v3.2.toml
+++ b/providers/cortecs/models/deepseek-v3.2.toml
@@ -5,6 +5,7 @@ last_updated = "2025-12-01"
 knowledge = "2024-07"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/deepseek-v4-flash.toml
+++ b/providers/cortecs/models/deepseek-v4-flash.toml
@@ -1,5 +1,6 @@
 base_model = "deepseek/deepseek-v4-flash"
 base_model_omit = ["structured_output"]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/cortecs/models/deepseek-v4-flash.toml
+++ b/providers/cortecs/models/deepseek-v4-flash.toml
@@ -1,6 +1,6 @@
 base_model = "deepseek/deepseek-v4-flash"
 base_model_omit = ["structured_output"]
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/cortecs/models/deepseek-v4-pro.toml
+++ b/providers/cortecs/models/deepseek-v4-pro.toml
@@ -1,5 +1,6 @@
 base_model = "deepseek/deepseek-v4-pro"
 base_model_omit = ["structured_output"]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/cortecs/models/deepseek-v4-pro.toml
+++ b/providers/cortecs/models/deepseek-v4-pro.toml
@@ -1,6 +1,6 @@
 base_model = "deepseek/deepseek-v4-pro"
 base_model_omit = ["structured_output"]
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Summary

Adds Cortecs reasoning metadata for four DeepSeek routes.

## Controls

- `deepseek-r1-0528`: fixed reasoning, no selectable control.
- `deepseek-v3.2`: no Cortecs graded effort control documented.
- `deepseek-v4-flash` and `deepseek-v4-pro`: Cortecs accepts top-level `reasoning_effort` values `low`, `medium`, and `high`.

Cortecs documents these as its provider-facing effort values. DeepSeek natively treats `low` and `medium` as compatibility aliases for `high`, but they are still accepted Cortecs request values and are therefore included. Native DeepSeek `max` is not included because Cortecs documents only `low|medium|high`.

No numeric reasoning budget is claimed.

## Evidence

- [Cortecs reasoning](https://docs.cortecs.ai/usage/reasoning.md) documents `reasoning_effort = low|medium|high` and translation for providers with configurable reasoning.
- [Cortecs DeepSeek V4 documentation answer](https://docs.cortecs.ai/usage/reasoning.md?ask=For%20DeepSeek%20V4%20Flash%20and%20Pro%2C%20which%20reasoning_effort%20values%20does%20Cortecs%20accept%3F) explicitly identifies all three values for V4 Flash and Pro.
- [DeepSeek thinking mode](https://api-docs.deepseek.com/guides/thinking_mode) documents native V4 effort handling: `high|max`, with compatibility mappings from `low|medium` to `high`.
- [DeepSeek reasoning model](https://api-docs.deepseek.com/guides/reasoning_model) documents fixed R1 reasoning behavior.

The earlier empty V4 option lists were incorrect because they discarded Cortecs-supported effort values merely because they do not preserve distinct native DeepSeek depth tiers.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2230.