### PR TITLE
[cortecs/meta] Add reasoning options

### DIFF
--- a/providers/cortecs/models/llama-3.3-70b-instruct.toml
+++ b/providers/cortecs/models/llama-3.3-70b-instruct.toml
@@ -2,6 +2,7 @@ base_model = "meta/llama-3.3-70b-instruct"
 name = "Llama 3.3 70B Instruct"
 attachment = false
 reasoning = true
+reasoning_options = []
 
 [cost]
 input = 0.089


### PR DESCRIPTION
Splits the meta changes from #2230 into a reviewable 1-model PR.

Scope is limited to `cortecs/meta` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2230.