### PR TITLE
[cortecs/minimax] Add reasoning options

### DIFF
--- a/providers/cortecs/models/minimax-m2.1.toml
+++ b/providers/cortecs/models/minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/minimax-m2.5.toml
+++ b/providers/cortecs/models/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/minimax-m2.7.toml
+++ b/providers/cortecs/models/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/cortecs/models/minimax-m2.toml
+++ b/providers/cortecs/models/minimax-m2.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-27"
 last_updated = "2025-10-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-11"
 tool_call = true


### PR DESCRIPTION
## Summary

Adds explicit non-configurable reasoning metadata to four Cortecs MiniMax M2.x routes.

## Audit result

All four entries use `reasoning_options = []`. MiniMax documents that M2.x reasoning cannot be disabled. `thinking.type = "disabled"` may be accepted but reasoning remains enabled, while `reasoning_split` only changes response representation.

Cortecs accepts generic `reasoning_effort = low | medium | high`, but says unsupported controls may be ignored and does not document model-specific M2.x effort behavior. No toggle or effort is therefore claimed.

## Evidence

- [Cortecs reasoning](https://docs.cortecs.ai/usage/reasoning.md) documents generic effort and silent ignoring.
- [Cortecs Chat Completions](https://docs.cortecs.ai/api-overview/chat-completions.md) documents the exposed API route.
- [Cortecs live models](https://api.cortecs.ai/v1/models) provides current route metadata.
- [MiniMax OpenAI-compatible API](https://platform.minimax.io/docs/api-reference/text-openai-api) documents fixed M2.x thinking behavior.

## Validation

- `bun validate`

Supersedes part of #2230.