### PR TITLE
[cortecs/mistral] Add reasoning options

### DIFF
--- a/providers/cortecs/models/mixtral-8x7B-instruct-v0.1.toml
+++ b/providers/cortecs/models/mixtral-8x7B-instruct-v0.1.toml
@@ -4,6 +4,7 @@ last_updated = "2023-12-11"
 knowledge = "2023-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 temperature = true
 open_weights = true


### PR DESCRIPTION
Splits the mistral changes from #2230 into a reviewable 1-model PR.

Scope is limited to `cortecs/mistral` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2230.