### PR TITLE
[cortecs/moonshotai] Add reasoning options

### DIFF
--- a/providers/cortecs/models/kimi-k2-thinking.toml
+++ b/providers/cortecs/models/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ last_updated = "2025-12-08"
 knowledge = "2025-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/kimi-k2.5.toml
+++ b/providers/cortecs/models/kimi-k2.5.toml
@@ -5,6 +5,7 @@ last_updated = "2026-01-27"
 knowledge = "2025-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/kimi-k2.6.toml
+++ b/providers/cortecs/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-17"
 last_updated = "2026-04-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
Splits the moonshotai changes from #2230 into a reviewable 3-model PR.

Scope is limited to `cortecs/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2230.