### PR TITLE
[cortecs/nousresearch] Add reasoning options

### DIFF
--- a/providers/cortecs/models/hermes-4-70b.toml
+++ b/providers/cortecs/models/hermes-4-70b.toml
@@ -4,6 +4,7 @@ last_updated = "2025-08-26"
 knowledge = "2023-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true


### PR DESCRIPTION
Splits the nousresearch changes from #2230 into a reviewable 1-model PR.

Scope is limited to `cortecs/nousresearch` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2230.