### PR TITLE
[cortecs/nvidia] Add reasoning options

### DIFF
--- a/providers/cortecs/models/nemotron-3-super-120b-a12b.toml
+++ b/providers/cortecs/models/nemotron-3-super-120b-a12b.toml
@@ -5,6 +5,7 @@ last_updated = "2026-03-11"
 knowledge = "2025-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true


### PR DESCRIPTION
Splits the nvidia changes from #2230 into a reviewable 1-model PR.

Scope is limited to `cortecs/nvidia` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2230.