### PR TITLE
[cortecs/openai] Add reasoning options

### DIFF
--- a/providers/cortecs/models/gpt-5.4.toml
+++ b/providers/cortecs/models/gpt-5.4.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.4"
 base_model_omit = ["limit.input"]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 3

--- a/providers/cortecs/models/gpt-oss-120b.toml
+++ b/providers/cortecs/models/gpt-oss-120b.toml
@@ -5,6 +5,7 @@ last_updated = "2025-08-05"
 knowledge = "2024-01"
 attachment = false
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 open_weights = true


### PR DESCRIPTION
Splits the openai changes from #2230 into a reviewable 2-model PR.

Scope is limited to `cortecs/openai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2230.