### PR TITLE
[cortecs/prime-intellect] Add reasoning options

### DIFF
--- a/providers/cortecs/models/intellect-3.toml
+++ b/providers/cortecs/models/intellect-3.toml
@@ -4,6 +4,7 @@ last_updated = "2025-11-26"
 knowledge = "2025-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true


### PR DESCRIPTION
Splits the prime-intellect changes from #2230 into a reviewable 1-model PR.

Scope is limited to `cortecs/prime-intellect` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2230.