### PR TITLE
[cortecs/zhipuai] Add reasoning options

### DIFF
--- a/providers/cortecs/models/glm-4.5-air.toml
+++ b/providers/cortecs/models/glm-4.5-air.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-01"
 last_updated = "2025-08-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-4.5-air.toml
+++ b/providers/cortecs/models/glm-4.5-air.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-01"
 last_updated = "2025-08-01"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-4.5.toml
+++ b/providers/cortecs/models/glm-4.5.toml
@@ -4,7 +4,7 @@ release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-4.5.toml
+++ b/providers/cortecs/models/glm-4.5.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-4.7-flash.toml
+++ b/providers/cortecs/models/glm-4.7-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-08"
 last_updated = "2025-08-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-4.7.toml
+++ b/providers/cortecs/models/glm-4.7.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-4.7.toml
+++ b/providers/cortecs/models/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/cortecs/models/glm-5.1.toml
+++ b/providers/cortecs/models/glm-5.1.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-14"
 last_updated = "2026-04-14"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 structured_output = true
 temperature = true
 tool_call = true

--- a/providers/cortecs/models/glm-5.1.toml
+++ b/providers/cortecs/models/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-14"
 last_updated = "2026-04-14"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
 temperature = true
 tool_call = true

--- a/providers/cortecs/models/glm-5.toml
+++ b/providers/cortecs/models/glm-5.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/glm-5.toml
+++ b/providers/cortecs/models/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary

Adds conservative provider-layer reasoning metadata for six Cortecs GLM routes.

## Audit result

Z.AI natively toggles these models with `thinking.type = "enabled" | "disabled"`; self-hosted routes may instead require `chat_template_kwargs.enable_thinking`. Cortecs does not document either field or normalization across Tensorix, Amazon, Inceptron, and Nebius routes.

Cortecs only documents generic `reasoning_effort = low | medium | high` and may silently ignore unsupported controls. Z.AI documents graded effort only for GLM-5.2 and above, excluding every model here. All six entries therefore use `reasoning_options = []`.

## Live-route caveat

The Cortecs catalog checked on 2026-06-24 no longer returned `glm-4.5` or `glm-4.5-air`. Their existing repository files are retained by this reasoning-only PR; catalog cleanup should be separate.

## Evidence

- [Cortecs reasoning](https://docs.cortecs.ai/usage/reasoning.md) documents generic effort and silent ignoring.
- [Cortecs parameter handling](https://docs.cortecs.ai/usage/advanced-usage.md#parameter-handling) documents route-specific unsupported fields.
- [Cortecs live models](https://api.cortecs.ai/v1/models) provides current route metadata.
- [Z.AI Chat Completions](https://docs.z.ai/api-reference/llm/chat-completion) and [thinking modes](https://docs.z.ai/guides/capabilities/thinking-mode) document native toggles.
- [Z.AI parameter concepts](https://docs.z.ai/guides/overview/concept-param) restricts graded effort to GLM-5.2 and above.
- [GLM-4.7 Flash template](https://huggingface.co/zai-org/GLM-4.7-Flash/raw/main/chat_template.jinja) demonstrates the different self-hosted toggle shape.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2230.