### PR TITLE
[frogbot/google] Add reasoning options

### DIFF
--- a/providers/frogbot/models/gemini-2.5-flash.toml
+++ b/providers/frogbot/models/gemini-2.5-flash.toml
@@ -4,7 +4,7 @@ release_date = "2025-07-17"
 last_updated = "2025-07-17"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/frogbot/models/gemini-2.5-flash.toml
+++ b/providers/frogbot/models/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-17"
 last_updated = "2025-07-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/frogbot/models/gemini-2.5-pro.toml
+++ b/providers/frogbot/models/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/frogbot/models/gemini-2.5-pro.toml
+++ b/providers/frogbot/models/gemini-2.5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/frogbot/models/gemini-3-1-pro-preview.toml
+++ b/providers/frogbot/models/gemini-3-1-pro-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-18"
 last_updated = "2026-02-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/gemini-3-flash-preview.toml
+++ b/providers/frogbot/models/gemini-3-flash-preview.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Adds FrogBot-layer reasoning controls for four routed Gemini models.

FrogBot forwards Google-specific settings through `generation_config`. Gemini 2.5 reasoning budgets therefore map to `generation_config.thinkingConfig.thinkingBudget`: Flash supports `0..24576`; Pro supports `128..32768`.

Gemini 3 uses FrogBot top-level `reasoning_effort`, whose documented proxy values are exactly `low`, `medium`, and `high`.

Primary sources:
- https://docs.frogbot.ai/api-reference/chat-completions
- https://docs.frogbot.ai/api-reference/models
- https://ai.google.dev/gemini-api/docs/thinking

Supersedes the FrogBot/Google portion of #2232.