### PR TITLE
[frogbot/minimax] Add reasoning options

### DIFF
--- a/providers/frogbot/models/minimax-m2-5.toml
+++ b/providers/frogbot/models/minimax-m2-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-15"
 last_updated = "2025-02-22"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true

--- a/providers/frogbot/models/minimax-m2-7.toml
+++ b/providers/frogbot/models/minimax-m2-7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-09"
 tool_call = true


### PR DESCRIPTION
Splits the minimax changes from #2232 into a reviewable 2-model PR.

Scope is limited to `frogbot/minimax` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2232.