### PR TITLE
[frogbot/moonshotai] Add reasoning options

### DIFF
--- a/providers/frogbot/models/kimi-k2-6.toml
+++ b/providers/frogbot/models/kimi-k2-6.toml
@@ -3,6 +3,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/kimi-k2.5.toml
+++ b/providers/frogbot/models/kimi-k2.5.toml
@@ -3,6 +3,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the moonshotai changes from #2232 into a reviewable 2-model PR.

Scope is limited to `frogbot/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2232.