### PR TITLE
[frogbot/openai] Add reasoning options

### DIFF
--- a/providers/frogbot/models/gpt-4o.toml
+++ b/providers/frogbot/models/gpt-4o.toml
@@ -4,6 +4,7 @@ release_date = "2024-05-13"
 last_updated = "2024-08-06"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2023-09"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-3-codex.toml
+++ b/providers/frogbot/models/gpt-5-3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-15"
 last_updated = "2026-02-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2026-01-31"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-4-mini.toml
+++ b/providers/frogbot/models/gpt-5-4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-4-mini.toml
+++ b/providers/frogbot/models/gpt-5-4-mini.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-4-nano.toml
+++ b/providers/frogbot/models/gpt-5-4-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-4-nano.toml
+++ b/providers/frogbot/models/gpt-5-4-nano.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/frogbot/models/gpt-5-5.toml
+++ b/providers/frogbot/models/gpt-5-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/frogbot/models/gpt-oss-120b.toml
+++ b/providers/frogbot/models/gpt-oss-120b.toml
@@ -4,7 +4,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/gpt-oss-120b.toml
+++ b/providers/frogbot/models/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/gpt-oss-20b.toml
+++ b/providers/frogbot/models/gpt-oss-20b.toml
@@ -4,7 +4,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/frogbot/models/gpt-oss-20b.toml
+++ b/providers/frogbot/models/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "1970-01-01"
 last_updated = "1970-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Adds exact FrogBot `reasoning_effort` metadata for routed OpenAI and Bedrock GPT models.

FrogBot Chat Completions accepts top-level `reasoning_effort` with exactly `low`, `medium`, or `high`. This applies to GPT-5.3 Codex, GPT-5.4 mini/nano, GPT-5.5, and the routed Bedrock GPT OSS models. GPT-4o remains non-reasoning with no options.

Primary sources:
- https://docs.frogbot.ai/api-reference/chat-completions
- https://docs.frogbot.ai/api-reference/models
- https://docs.aws.amazon.com/java/api/latest/software/amazon/awssdk/services/bedrock/model/ReasoningEffort.html

Supersedes the FrogBot/OpenAI portion of #2232.