### PR TITLE
[frogbot/xai] Add reasoning options

### DIFF
--- a/providers/frogbot/models/grok-4-1-fast-non-reasoning.toml
+++ b/providers/frogbot/models/grok-4-1-fast-non-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2025-11"
 tool_call = true

--- a/providers/frogbot/models/grok-4-1-fast-reasoning.toml
+++ b/providers/frogbot/models/grok-4-1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-11"
 tool_call = true

--- a/providers/frogbot/models/grok-4-3.toml
+++ b/providers/frogbot/models/grok-4-3.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-11"
 tool_call = true

--- a/providers/frogbot/models/grok-4-3.toml
+++ b/providers/frogbot/models/grok-4-3.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 knowledge = "2024-11"
 tool_call = true

--- a/providers/frogbot/models/grok-code-fast-1.toml
+++ b/providers/frogbot/models/grok-code-fast-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-28"
 last_updated = "2025-08-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true


### PR DESCRIPTION
Adds FrogBot-layer reasoning metadata for four routed xAI models.

`grok-4-3` accepts FrogBot top-level `reasoning_effort` values `low`, `medium`, and `high`. Although xAI also supports `none`, FrogBot does not document that value, so it is intentionally omitted.

The two Grok 4.1 Fast IDs encode reasoning behavior in model selection, and Grok Code Fast 1 has no documented tunable effort; those remain `reasoning_options = []`.

Primary sources:
- https://docs.frogbot.ai/api-reference/chat-completions
- https://docs.frogbot.ai/api-reference/models
- https://docs.x.ai/developers/model-capabilities/text/reasoning

Supersedes the FrogBot/xAI portion of #2232.