### PR TITLE
[frogbot/zhipuai] Add reasoning options

### DIFF
--- a/providers/frogbot/models/zai-glm-5-1.toml
+++ b/providers/frogbot/models/zai-glm-5-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-02-22"
 attachment = true
 reasoning = false
+reasoning_options = []
 temperature = true
 knowledge = "2024-10"
 tool_call = true


### PR DESCRIPTION
Splits the zhipuai changes from #2232 into a reviewable 1-model PR.

Scope is limited to `frogbot/zhipuai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2232.