### PR TITLE
[kilo/aion-labs] Add reasoning options

### DIFF
--- a/providers/kilo/models/aion-labs/aion-1.0-mini.toml
+++ b/providers/kilo/models/aion-labs/aion-1.0-mini.toml
@@ -2,6 +2,7 @@ name = "AionLabs: Aion-1.0-Mini"
 release_date = "2025-02-05"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/aion-labs/aion-1.0.toml
+++ b/providers/kilo/models/aion-labs/aion-1.0.toml
@@ -2,6 +2,7 @@ name = "AionLabs: Aion-1.0"
 release_date = "2025-02-05"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/aion-labs/aion-2.0.toml
+++ b/providers/kilo/models/aion-labs/aion-2.0.toml
@@ -2,6 +2,7 @@ name = "AionLabs: Aion-2.0"
 release_date = "2026-02-24"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false


### PR DESCRIPTION
Splits the aion-labs changes from #2166 into a reviewable 3-model PR.

Scope is limited to `kilo/aion-labs` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.