### PR TITLE
[kilo/~anthropic] Add reasoning options

### DIFF
--- a/providers/kilo/models/~anthropic/claude-haiku-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-haiku-latest.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Haiku Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~anthropic/claude-opus-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-opus-latest.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus Latest"
 release_date = "2026-04-16"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/~anthropic/claude-sonnet-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-sonnet-latest.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Sonnet Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
Splits the ~anthropic changes from #2166 into a reviewable 3-model PR.

Scope is limited to `kilo/~anthropic` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.