### PR TITLE
[kilo/~google] Add reasoning options

### DIFF
--- a/providers/kilo/models/~google/gemini-flash-latest.toml
+++ b/providers/kilo/models/~google/gemini-flash-latest.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini Flash Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~google/gemini-pro-latest.toml
+++ b/providers/kilo/models/~google/gemini-pro-latest.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini Pro Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
Splits the ~google changes from #2166 into a reviewable 2-model PR.

Scope is limited to `kilo/~google` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.