### PR TITLE
[kilo/~moonshotai] Add reasoning options

### DIFF
--- a/providers/kilo/models/~moonshotai/kimi-latest.toml
+++ b/providers/kilo/models/~moonshotai/kimi-latest.toml
@@ -2,6 +2,7 @@ name = "MoonshotAI: Kimi Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
Splits the ~moonshotai changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/~moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.