### PR TITLE
[kilo/~openai] Add reasoning options

### DIFF
--- a/providers/kilo/models/~openai/gpt-latest.toml
+++ b/providers/kilo/models/~openai/gpt-latest.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/~openai/gpt-mini-latest.toml
+++ b/providers/kilo/models/~openai/gpt-mini-latest.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT Mini Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false


### PR DESCRIPTION
Splits the ~openai changes from #2166 into a reviewable 2-model PR.

Scope is limited to `kilo/~openai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.