### PR TITLE
[kilo/allenai] Add reasoning options

### DIFF
--- a/providers/kilo/models/allenai/olmo-3-32b-think.toml
+++ b/providers/kilo/models/allenai/olmo-3-32b-think.toml
@@ -2,6 +2,7 @@ name = "AllenAI: Olmo 3 32B Think"
 release_date = "2025-11-22"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false


### PR DESCRIPTION
Splits the allenai changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/allenai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.