### PR TITLE
[kilo/amazon] Add reasoning options

### DIFF
--- a/providers/kilo/models/amazon/nova-2-lite-v1.toml
+++ b/providers/kilo/models/amazon/nova-2-lite-v1.toml
@@ -2,6 +2,7 @@ name = "Amazon: Nova 2 Lite"
 release_date = "2024-12-01"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the amazon changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/amazon` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.