### PR TITLE
[kilo/anthropic] Add reasoning options

### DIFF
--- a/providers/kilo/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-haiku-4.5.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Haiku 4.5"
 release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-haiku-4.5.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Haiku 4.5"
 release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.1.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.1.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.1"
 release_date = "2025-08-05"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.1.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.1.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Opus 4.1"
 release_date = "2025-08-05"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.5.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Opus 4.5"
 release_date = "2025-11-24"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.5.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.5"
 release_date = "2025-11-24"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.6-fast.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.6-fast.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.6 (Fast)"
 release_date = "2026-04-07"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.6-fast.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.6-fast.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Opus 4.6 (Fast)"
 release_date = "2026-04-07"
 last_updated = "2026-04-11"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.6.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.6.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.6"
 release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.6.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.6.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Opus 4.6"
 release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.7-fast.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.7-fast.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Opus 4.7 (Fast)"
 release_date = "2026-05-12"
 last_updated = "2026-05-16"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/anthropic/claude-opus-4.7-fast.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.7-fast.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.7 (Fast)"
 release_date = "2026-05-12"
 last_updated = "2026-05-16"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/anthropic/claude-opus-4.7-fast.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.7-fast.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Opus 4.7 (Fast)"
 release_date = "2026-05-12"
 last_updated = "2026-05-16"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/anthropic/claude-opus-4.7.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.7.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4.7"
 release_date = "2026-04-16"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/anthropic/claude-opus-4.7.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.7.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Opus 4.7"
 release_date = "2026-04-16"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/anthropic/claude-opus-4.7.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.7.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Opus 4.7"
 release_date = "2026-04-16"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/anthropic/claude-opus-4.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus 4"
 release_date = "2025-05-22"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-opus-4.toml
+++ b/providers/kilo/models/anthropic/claude-opus-4.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Opus 4"
 release_date = "2025-05-22"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.5.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Sonnet 4.5"
 release_date = "2025-09-29"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.5.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Sonnet 4.5"
 release_date = "2025-09-29"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.6.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Sonnet 4.6"
 release_date = "2026-02-17"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.6.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Sonnet 4.6"
 release_date = "2026-02-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-sonnet-4.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Sonnet 4"
 release_date = "2025-05-22"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/anthropic/claude-sonnet-4.toml
+++ b/providers/kilo/models/anthropic/claude-sonnet-4.toml
@@ -2,7 +2,7 @@ name = "Anthropic: Claude Sonnet 4"
 release_date = "2025-05-22"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Adds Kilo reasoning controls for 11 Anthropic models.

Kilo/OpenRouter exposes toggles and effort variants. Manual budgets are included only for Claude models that accept `thinking.type = enabled` with `budget_tokens`. Opus 4.7 and its fast alias are adaptive-only and therefore expose toggle plus efforts, but no numeric budget.

Evidence:
- https://api.kilo.ai/api/openrouter/models
- https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
- https://platform.claude.com/docs/en/build-with-claude/extended-thinking
- https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
- https://platform.claude.com/docs/en/build-with-claude/effort

Validation:
- `bun validate`
- `git diff --check`

Supersedes part of #2166.