### PR TITLE
[kilo/arcee-ai] Add reasoning options

### DIFF
--- a/providers/kilo/models/arcee-ai/trinity-large-thinking.toml
+++ b/providers/kilo/models/arcee-ai/trinity-large-thinking.toml
@@ -2,6 +2,7 @@ name = "Arcee AI: Trinity Large Thinking"
 release_date = "2026-04-01"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/arcee-ai/trinity-mini.toml
+++ b/providers/kilo/models/arcee-ai/trinity-mini.toml
@@ -2,6 +2,7 @@ name = "Arcee AI: Trinity Mini"
 release_date = "2025-12"
 last_updated = "2026-01-28"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the arcee-ai changes from #2166 into a reviewable 2-model PR.

Scope is limited to `kilo/arcee-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.