### PR TITLE
[kilo/bytedance-seed] Add reasoning options

### DIFF
--- a/providers/kilo/models/bytedance-seed/seed-1.6-flash.toml
+++ b/providers/kilo/models/bytedance-seed/seed-1.6-flash.toml
@@ -2,6 +2,7 @@ name = "ByteDance Seed: Seed 1.6 Flash"
 release_date = "2025-12-23"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-1.6-flash.toml
+++ b/providers/kilo/models/bytedance-seed/seed-1.6-flash.toml
@@ -2,7 +2,7 @@ name = "ByteDance Seed: Seed 1.6 Flash"
 release_date = "2025-12-23"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-1.6.toml
+++ b/providers/kilo/models/bytedance-seed/seed-1.6.toml
@@ -2,6 +2,7 @@ name = "ByteDance Seed: Seed 1.6"
 release_date = "2025-09"
 last_updated = "2025-09"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-1.6.toml
+++ b/providers/kilo/models/bytedance-seed/seed-1.6.toml
@@ -2,7 +2,7 @@ name = "ByteDance Seed: Seed 1.6"
 release_date = "2025-09"
 last_updated = "2025-09"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-2.0-lite.toml
+++ b/providers/kilo/models/bytedance-seed/seed-2.0-lite.toml
@@ -2,6 +2,7 @@ name = "ByteDance Seed: Seed-2.0-Lite"
 release_date = "2026-03-10"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-2.0-lite.toml
+++ b/providers/kilo/models/bytedance-seed/seed-2.0-lite.toml
@@ -2,7 +2,7 @@ name = "ByteDance Seed: Seed-2.0-Lite"
 release_date = "2026-03-10"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-2.0-mini.toml
+++ b/providers/kilo/models/bytedance-seed/seed-2.0-mini.toml
@@ -2,6 +2,7 @@ name = "ByteDance Seed: Seed-2.0-Mini"
 release_date = "2026-02-27"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-2.0-mini.toml
+++ b/providers/kilo/models/bytedance-seed/seed-2.0-mini.toml
@@ -2,7 +2,7 @@ name = "ByteDance Seed: Seed-2.0-Mini"
 release_date = "2026-02-27"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/bytedance-seed/seed-2.0-mini.toml
+++ b/providers/kilo/models/bytedance-seed/seed-2.0-mini.toml
@@ -2,7 +2,7 @@ name = "ByteDance Seed: Seed-2.0-Mini"
 release_date = "2026-02-27"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Adds provider-level reasoning controls for four Kilo ByteDance Seed models.

## Capability standard

The inference API contract is determined by Kilo gateway request handling, not whether Kilo publishes prebuilt UI variants for a model. Kilo server code accepts normalized reasoning controls and translates them for ByteDance Seed routes.

## Request mapping

- Disabled: Kilo sends `thinking.type = "disabled"`.
- Enabled: Kilo sends `thinking.type = "enabled"`.
- Effort: Kilo forwards `reasoning_effort` from `reasoning.effort`.

All four models therefore expose a toggle plus `minimal`, `low`, `medium`, and `high`.

## Evidence

- [Kilo Seed transformation](https://github.com/Kilo-Org/cloud/blob/deec94c0a6515cfeaf5748993ad9b2d601921e78/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts#L24-L43) implements the inference request mapping.
- [Kilo API reference](https://kilo.ai/docs/gateway/api-reference) documents the normalized gateway request surface.
- [BytePlus Seed 1.6 thinking](https://docs.byteplus.com/en/docs/Byteplus_LAS/Multimodal-Deep-Thinking-Doubao-Seed-1-6) documents thinking-mode behavior.
- [BytePlus Chat API](https://docs.byteplus.com/en/docs/Byteplus_LAS/Chat_API) documents `reasoning_effort`.

The previous `reasoning_options = []` correction incorrectly treated missing catalog UI variants as missing inference support.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2166.