### PR TITLE
[kilo/deepcogito] Add reasoning options

### DIFF
--- a/providers/kilo/models/deepcogito/cogito-v2.1-671b.toml
+++ b/providers/kilo/models/deepcogito/cogito-v2.1-671b.toml
@@ -2,6 +2,7 @@ name = "Deep Cogito: Cogito v2.1 671B"
 release_date = "2025-11-14"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false


### PR DESCRIPTION
Splits the deepcogito changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/deepcogito` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.