### PR TITLE
[kilo/google part 1] Add reasoning options

### DIFF
--- a/providers/kilo/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Flash Lite Preview 09-2025"
 release_date = "2025-09-25"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -2,7 +2,7 @@ name = "Google: Gemini 2.5 Flash Lite Preview 09-2025"
 release_date = "2025-09-25"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash-lite.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Flash Lite"
 release_date = "2025-06-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash-lite.toml
@@ -2,7 +2,7 @@ name = "Google: Gemini 2.5 Flash Lite"
 release_date = "2025-06-17"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-flash.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Flash"
 release_date = "2025-07-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-flash.toml
+++ b/providers/kilo/models/google/gemini-2.5-flash.toml
@@ -2,7 +2,7 @@ name = "Google: Gemini 2.5 Flash"
 release_date = "2025-07-17"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro-preview-05-06.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Pro Preview 05-06"
 release_date = "2025-05-06"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro-preview-05-06.toml
@@ -2,7 +2,7 @@ name = "Google: Gemini 2.5 Pro Preview 05-06"
 release_date = "2025-05-06"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-pro-preview.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Pro Preview 06-05"
 release_date = "2025-06-05"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-pro-preview.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro-preview.toml
@@ -2,7 +2,7 @@ name = "Google: Gemini 2.5 Pro Preview 06-05"
 release_date = "2025-06-05"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-pro.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro.toml
@@ -2,7 +2,7 @@ name = "Google: Gemini 2.5 Pro"
 release_date = "2025-03-20"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-2.5-pro.toml
+++ b/providers/kilo/models/google/gemini-2.5-pro.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 2.5 Pro"
 release_date = "2025-03-20"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3-flash-preview.toml
+++ b/providers/kilo/models/google/gemini-3-flash-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3 Flash Preview"
 release_date = "2025-12-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3-pro-image-preview.toml
+++ b/providers/kilo/models/google/gemini-3-pro-image-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Nano Banana Pro (Gemini 3 Pro Image Preview)"
 release_date = "2025-11-20"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/kilo/models/google/gemini-3.1-flash-image-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Nano Banana 2 (Gemini 3.1 Flash Image Preview)"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/kilo/models/google/gemini-3.1-flash-lite-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.1 Flash Lite Preview"
 release_date = "2026-03-03"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/kilo/models/google/gemini-3.1-flash-lite.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.1 Flash Lite"
 release_date = "2026-05-07"
 last_updated = "2026-05-16"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/kilo/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.1 Pro Preview Custom Tools"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/kilo/models/google/gemini-3.1-pro-preview.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.1 Pro Preview"
 release_date = "2026-02-19"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/google/gemini-3.5-flash.toml
+++ b/providers/kilo/models/google/gemini-3.5-flash.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini 3.5 Flash"
 release_date = "2026-05-19"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/kilo/models/google/gemma-4-26b-a4b-it.toml
@@ -2,6 +2,7 @@ name = "Google: Gemma 4 26B A4B"
 release_date = "2026-04-03"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the Google part 1 changes from #2166 into a reviewable 15-model PR.

Scope is limited to `kilo/google part 1` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.

## Audited controls

### Gemini 3 family

The eight Gemini 3, 3.1, and 3.5 models expose Kilo variants `low`, `medium`, `high`, and `xhigh`. Kilo sends normalized `reasoning.effort` values; OpenRouter maps `xhigh` to Google's native `high` thinking level.

### Gemini 2.5

Gemini 2.5 uses token-budget reasoning through `reasoning.max_tokens` rather than Gemini 3 thinking levels.

- Stable Flash and Flash-Lite: budget `0..24_576`; zero disables thinking and therefore verifies the toggle.
- Stable Pro: budget `128..32_768`; reasoning cannot be disabled.
- Dated preview IDs retain verified budget support without asserted bounds because current stable-model bounds were not projected onto historical previews.

### Gemma 4

`google/gemma-4-26b-a4b-it` exposes `instant` (`reasoning.enabled = false`, effort `none`) and `thinking` (`reasoning.enabled = true`, effort `high`) variants, verifying the toggle.

## Evidence

- [Kilo Gemini 3 and Gemma variant assignment](https://github.com/Kilo-Org/cloud/blob/deec94c0a6515cfeaf5748993ad9b2d601921e78/apps/web/src/lib/ai-gateway/providers/model-settings.ts#L83-L119)
- [Kilo binary variant payloads](https://github.com/Kilo-Org/cloud/blob/deec94c0a6515cfeaf5748993ad9b2d601921e78/apps/web/src/lib/ai-gateway/providers/model-settings.ts#L24-L31)
- [Kilo request type including `reasoning.max_tokens`](https://github.com/Kilo-Org/cloud/blob/deec94c0a6515cfeaf5748993ad9b2d601921e78/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts#L35-L40)
- [Kilo live model catalog](https://api.kilo.ai/api/gateway/models)
- [OpenRouter reasoning controls](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#controlling-reasoning-tokens)
- [OpenRouter Gemini 3 effort mapping](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#google-gemini-3-models-with-thinking-levels)
- [OpenRouter Gemini 2.5 Flash model page](https://openrouter.ai/google/gemini-2.5-flash/api)
- [Google Gemini thinking budgets](https://ai.google.dev/gemini-api/docs/thinking#set-budget)

Catalog and source audited 2026-06-24 at Kilo cloud commit `deec94c0a6515cfeaf5748993ad9b2d601921e78`.

## Validation

- `bun validate`
- `git diff --check`
