### PR TITLE
[kilo/google part 2] Add reasoning options

### DIFF
--- a/providers/kilo/models/google/gemma-4-31b-it.toml
+++ b/providers/kilo/models/google/gemma-4-31b-it.toml
@@ -2,6 +2,7 @@ name = "Google: Gemma 4 31B"
 release_date = "2026-04-02"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the google part 2 changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/google part 2` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.