### PR TITLE
[kilo/inception] Add reasoning options

### DIFF
--- a/providers/kilo/models/inception/mercury-2.toml
+++ b/providers/kilo/models/inception/mercury-2.toml
@@ -2,6 +2,7 @@ name = "Inception: Mercury 2"
 release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the inception changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/inception` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.