### PR TITLE
[kilo/inclusionai] Add reasoning options

### DIFF
--- a/providers/kilo/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/kilo/models/inclusionai/ring-2.6-1t.toml
@@ -2,6 +2,7 @@ name = "inclusionAI: Ring-2.6-1T"
 release_date = "2026-05-08"
 last_updated = "2026-05-16"
 attachment = false
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
Splits the inclusionai changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/inclusionai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.