### PR TITLE
[kilo/kilo-auto] Add reasoning options

### DIFF
--- a/providers/kilo/models/kilo-auto/balanced.toml
+++ b/providers/kilo/models/kilo-auto/balanced.toml
@@ -2,6 +2,7 @@ name = "Kilo Auto Balanced"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/kilo-auto/free.toml
+++ b/providers/kilo/models/kilo-auto/free.toml
@@ -2,6 +2,7 @@ name = "Kilo Auto Free"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/kilo-auto/frontier.toml
+++ b/providers/kilo/models/kilo-auto/frontier.toml
@@ -2,6 +2,7 @@ name = "Kilo Auto Frontier"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/kilo-auto/small.toml
+++ b/providers/kilo/models/kilo-auto/small.toml
@@ -2,6 +2,7 @@ name = "Kilo Auto Small"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
## Summary

- add explicit `reasoning_options = []` to the four Kilo Auto routes
- record that these dynamic routers expose reasoning capability but no stable user-selectable reasoning variant
- supersede the `kilo-auto` portion of #2166

## Exact controls

| Model | Toggle | Efforts | Token budget | Metadata |
| --- | --- | --- | --- | --- |
| `kilo-auto/balanced` | No | None | None | `[]` |
| `kilo-auto/free` | No | None | None | `[]` |
| `kilo-auto/frontier` | No | None | None | `[]` |
| `kilo-auto/small` | No | None | None | `[]` |

## Evidence

Audited 2026-06-24 against Kilo's live model catalog and documentation.

- [Kilo live model catalog](https://api.kilo.ai/api/openrouter/models): each route advertises generic `reasoning` support in `supported_parameters`, but none publishes an `opencode.variants` map. Generic parameter support does not establish a stable toggle, effort set, or budget for a router whose backing model can change.
- [Kilo Auto Model documentation](https://kilocode.ai/docs/code-with-ai/agents/auto-model): Kilo states that Auto selects an underlying model per request and that mappings are updated server-side as models, pricing, and availability change. It also states that no reasoning configuration is required.
- [Kilo Model Selection guide](https://kilocode.ai/docs/code-with-ai/agents/model-selection): `/variant` is available only when the selected model supports variants. The audited Auto catalog entries expose none.

Because these IDs are dynamic routers rather than fixed model contracts, inferring controls from any current backing model would overstate what Kilo exposes. `[]` therefore means reasoning-capable with no stable selectable control. No token-budget range is evidenced for any route.

## Scope

Only these four existing model files are changed. No catalog, pricing, limits, base-model, or unrelated metadata changes are included.

## Validation

- `bun validate`
- `git diff --check`
