### PR TITLE
[kilo/minimax] Add reasoning options

### DIFF
--- a/providers/kilo/models/minimax/minimax-m1.toml
+++ b/providers/kilo/models/minimax/minimax-m1.toml
@@ -2,6 +2,7 @@ name = "MiniMax: MiniMax M1"
 release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m1.toml
+++ b/providers/kilo/models/minimax/minimax-m1.toml
@@ -2,7 +2,7 @@ name = "MiniMax: MiniMax M1"
 release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.1.toml
+++ b/providers/kilo/models/minimax/minimax-m2.1.toml
@@ -2,7 +2,7 @@ name = "MiniMax: MiniMax M2.1"
 release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.1.toml
+++ b/providers/kilo/models/minimax/minimax-m2.1.toml
@@ -2,6 +2,7 @@ name = "MiniMax: MiniMax M2.1"
 release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.5.toml
+++ b/providers/kilo/models/minimax/minimax-m2.5.toml
@@ -2,7 +2,7 @@ name = "MiniMax: MiniMax M2.5"
 release_date = "2026-02-12"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.5.toml
+++ b/providers/kilo/models/minimax/minimax-m2.5.toml
@@ -2,6 +2,7 @@ name = "MiniMax: MiniMax M2.5"
 release_date = "2026-02-12"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.7.toml
+++ b/providers/kilo/models/minimax/minimax-m2.7.toml
@@ -3,6 +3,7 @@ family = "minimax-m2.7"
 release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.7.toml
+++ b/providers/kilo/models/minimax/minimax-m2.7.toml
@@ -3,7 +3,7 @@ family = "minimax-m2.7"
 release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.toml
+++ b/providers/kilo/models/minimax/minimax-m2.toml
@@ -2,7 +2,7 @@ name = "MiniMax: MiniMax M2"
 release_date = "2025-10-23"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/minimax/minimax-m2.toml
+++ b/providers/kilo/models/minimax/minimax-m2.toml
@@ -2,6 +2,7 @@ name = "MiniMax: MiniMax M2"
 release_date = "2025-10-23"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
## Summary

Adds explicit non-configurable reasoning metadata for five Kilo MiniMax routes.

## Audit result

Kilo publishes `instant` and `thinking` request presets, but a preset is not an effective toggle when the model ignores the disabled state.

- MiniMax M1 does not support non-thinking mode.
- MiniMax M2, M2.1, M2.5, and M2.7 cannot disable thinking; `thinking.type = "disabled"` may be accepted but reasoning remains on.
- No graded effort or numeric budget is documented for these models.

All five therefore use `reasoning_options = []`.

## Evidence

- [Kilo live catalog](https://api.kilo.ai/api/openrouter/models) shows the request presets.
- [MiniMax OpenAI API](https://platform.minimax.io/docs/api-reference/text-openai-api) states M2.x thinking cannot be disabled and distinguishes M3 adaptive controls.
- [MiniMax M1 discussion](https://huggingface.co/MiniMaxAI/MiniMax-M1-40k/discussions/3) confirms M1 lacks non-thinking mode.

The previous toggle metadata incorrectly treated Kilo’s emitted request shape as proof of an effective model control.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2166.