### PR TITLE
[kilo/mistralai] Add reasoning options

### DIFF
--- a/providers/kilo/models/mistralai/mistral-medium-3-5.toml
+++ b/providers/kilo/models/mistralai/mistral-medium-3-5.toml
@@ -2,6 +2,7 @@ name = "Mistral: Mistral Medium 3.5"
 release_date = "2026-04-30"
 last_updated = "2026-05-07"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/mistralai/mistral-small-2603.toml
+++ b/providers/kilo/models/mistralai/mistral-small-2603.toml
@@ -2,6 +2,7 @@ name = "Mistral: Mistral Small 4"
 release_date = "2026-03-16"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the mistralai changes from #2166 into a reviewable 2-model PR.

Scope is limited to `kilo/mistralai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.