### PR TITLE
[kilo/moonshotai] Add reasoning options

### DIFF
--- a/providers/kilo/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2-thinking.toml
@@ -2,6 +2,7 @@ name = "MoonshotAI: Kimi K2 Thinking"
 release_date = "2025-11-06"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/moonshotai/kimi-k2.5.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2.5.toml
@@ -2,6 +2,7 @@ name = "MoonshotAI: Kimi K2.5"
 release_date = "2026-01-27"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/moonshotai/kimi-k2.6.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-20"
 last_updated = "2026-05-12"
 
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the moonshotai changes from #2166 into a reviewable 3-model PR.

Scope is limited to `kilo/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.