### PR TITLE
[kilo/nousresearch] Add reasoning options

### DIFF
--- a/providers/kilo/models/nousresearch/hermes-4-405b.toml
+++ b/providers/kilo/models/nousresearch/hermes-4-405b.toml
@@ -2,6 +2,7 @@ name = "Nous: Hermes 4 405B"
 release_date = "2025-08-25"
 last_updated = "2025-08-25"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/nousresearch/hermes-4-70b.toml
+++ b/providers/kilo/models/nousresearch/hermes-4-70b.toml
@@ -2,6 +2,7 @@ name = "Nous: Hermes 4 70B"
 release_date = "2025-08-25"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = false


### PR DESCRIPTION
Splits the nousresearch changes from #2166 into a reviewable 2-model PR.

Scope is limited to `kilo/nousresearch` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.