### PR TITLE
[kilo/nvidia] Add reasoning options

### DIFF
--- a/providers/kilo/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
+++ b/providers/kilo/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/llama-3.3-nemotron-super-49b-v1.5"
 release_date = "2025-03-16"
 last_updated = "2025-03-16"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
+++ b/providers/kilo/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
@@ -3,7 +3,7 @@ base_model = "nvidia/llama-3.3-nemotron-super-49b-v1.5"
 release_date = "2025-03-16"
 last_updated = "2025-03-16"
 attachment = false
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -3,7 +3,7 @@ base_model = "nvidia/nemotron-3-nano-30b-a3b"
 release_date = "2024-12"
 last_updated = "2026-02-04"
 attachment = false
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-3-nano-30b-a3b"
 release_date = "2024-12"
 last_updated = "2026-02-04"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 release_date = "2026-04-28"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free.toml
@@ -3,7 +3,7 @@ base_model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 release_date = "2026-04-28"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -3,7 +3,7 @@ base_model = "nvidia/nemotron-3-super-120b-a12b"
 release_date = "2026-03-11"
 last_updated = "2026-04-11"
 attachment = false
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-3-super-120b-a12b"
 release_date = "2026-03-11"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b:free.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b:free.toml
@@ -3,7 +3,7 @@ base_model = "nvidia/nemotron-3-super-120b-a12b"
 release_date = "2026-03-12"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b:free.toml
+++ b/providers/kilo/models/nvidia/nemotron-3-super-120b-a12b:free.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-3-super-120b-a12b"
 release_date = "2026-03-12"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-nano-9b-v2.toml
+++ b/providers/kilo/models/nvidia/nemotron-nano-9b-v2.toml
@@ -3,7 +3,6 @@ base_model = "nvidia/nemotron-nano-9b-v2"
 release_date = "2025-08-18"
 last_updated = "2025-08-18"
 attachment = false
-reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nvidia/nemotron-nano-9b-v2.toml
+++ b/providers/kilo/models/nvidia/nemotron-nano-9b-v2.toml
@@ -3,6 +3,7 @@ base_model = "nvidia/nemotron-nano-9b-v2"
 release_date = "2025-08-18"
 last_updated = "2025-08-18"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Adds provider-level reasoning controls for current Kilo NVIDIA routes.

## Controls

- Llama 3.3 Nemotron Super 49B: toggle.
- Nemotron 3 Nano 30B: toggle.
- Nemotron 3 Nano Omni Reasoning Free: toggle plus numeric budget support.
- Nemotron 3 Super 120B and free alias: toggle.
- Stale Nano 9B route: no current provider-specific claim.

## Evidence

- [Kilo live model API](https://api.kilo.ai/api/openrouter/models) advertises the normalized `reasoning` request parameter for the five live routes.
- [Llama Nemotron model card](https://build.nvidia.com/nvidia/llama-3_3-nemotron-super-49b-v1_5/modelcard) documents `/no_think`.
- [Nemotron 3 Nano](https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b/modelcard) and [Nemotron 3 Super](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard) document `enable_thinking`.
- [Nemotron 3 Nano Omni API](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) documents both toggle and thinking-token budget.

The previous empty lists incorrectly treated missing Kilo UI variants as missing inference support.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2166.