### PR TITLE
[kilo/openai part 1] Add reasoning options

### DIFF
--- a/providers/kilo/models/openai/gpt-5-codex.toml
+++ b/providers/kilo/models/openai/gpt-5-codex.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Codex"
 release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-codex.toml
+++ b/providers/kilo/models/openai/gpt-5-codex.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5 Codex"
 release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-image-mini.toml
+++ b/providers/kilo/models/openai/gpt-5-image-mini.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5 Image Mini"
 release_date = "2025-10-16"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-image-mini.toml
+++ b/providers/kilo/models/openai/gpt-5-image-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Image Mini"
 release_date = "2025-10-16"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-image.toml
+++ b/providers/kilo/models/openai/gpt-5-image.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Image"
 release_date = "2025-10-14"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-image.toml
+++ b/providers/kilo/models/openai/gpt-5-image.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5 Image"
 release_date = "2025-10-14"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-mini.toml
+++ b/providers/kilo/models/openai/gpt-5-mini.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5 Mini"
 release_date = "2025-08-07"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-mini.toml
+++ b/providers/kilo/models/openai/gpt-5-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Mini"
 release_date = "2025-08-07"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-nano.toml
+++ b/providers/kilo/models/openai/gpt-5-nano.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5 Nano"
 release_date = "2025-08-07"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-nano.toml
+++ b/providers/kilo/models/openai/gpt-5-nano.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Nano"
 release_date = "2025-08-07"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-pro.toml
+++ b/providers/kilo/models/openai/gpt-5-pro.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5 Pro"
 release_date = "2025-10-06"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5-pro.toml
+++ b/providers/kilo/models/openai/gpt-5-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5 Pro"
 release_date = "2025-10-06"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex-max.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.1-Codex-Max"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.1-Codex-Mini"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex-mini.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.1-Codex-Mini"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1-codex.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.1-Codex"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1-codex.toml
+++ b/providers/kilo/models/openai/gpt-5.1-codex.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.1-Codex"
 release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1.toml
+++ b/providers/kilo/models/openai/gpt-5.1.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.1"
 release_date = "2025-11-13"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.1.toml
+++ b/providers/kilo/models/openai/gpt-5.1.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.1"
 release_date = "2025-11-13"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.2-codex.toml
+++ b/providers/kilo/models/openai/gpt-5.2-codex.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.2-Codex"
 release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.2-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.2-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.2 Pro"
 release_date = "2025-12-11"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.2-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.2-pro.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.2 Pro"
 release_date = "2025-12-11"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.2.toml
+++ b/providers/kilo/models/openai/gpt-5.2.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.2"
 release_date = "2025-12-11"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.2.toml
+++ b/providers/kilo/models/openai/gpt-5.2.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.2"
 release_date = "2025-12-11"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.3-codex.toml
+++ b/providers/kilo/models/openai/gpt-5.3-codex.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.3-Codex"
 release_date = "2026-02-25"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/gpt-5.4-image-2.toml
+++ b/providers/kilo/models/openai/gpt-5.4-image-2.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.4 Image 2"
 release_date = "2026-04-21"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 reasoning = true
 tool_call = false
 temperature = false

--- a/providers/kilo/models/openai/gpt-5.4-image-2.toml
+++ b/providers/kilo/models/openai/gpt-5.4-image-2.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4 Image 2"
 release_date = "2026-04-21"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = false
 temperature = false


### PR DESCRIPTION
Splits the OpenAI part 1 changes from #2166 into a reviewable 15-model PR.

This revision uses exact per-model reasoning controls rather than a blanket option set. Kilo sends effort selections as `reasoning: { effort }`, and its adapter maps those to upstream OpenAI/OpenAI-compatible reasoning effort fields. These values are therefore request parameters, not descriptive UI metadata.

Audited subsets in this PR:

- GPT-5 Mini/Nano: `minimal`, `low`, `medium`, `high`
- GPT-5 Pro: `high` only
- GPT-5.1: `none`, `low`, `medium`, `high`
- GPT-5.2 Pro: `medium`, `high`, `xhigh`
- GPT-5 and GPT-5.1 Codex: `low`, `medium`, `high`; Codex Max additionally supports `xhigh`
- GPT-5.2 and GPT-5.3 Codex: `low`, `medium`, `high`, `xhigh`
- GPT image aliases: no configurable reasoning option

Evidence:

- OpenAI states that reasoning effort values are model-dependent: https://developers.openai.com/api/docs/guides/reasoning
- GPT-5 model page: https://developers.openai.com/api/docs/models/gpt-5
- GPT-5.1 model page: https://developers.openai.com/api/docs/models/gpt-5.1
- GPT-5 Pro model page: https://developers.openai.com/api/docs/models/gpt-5-pro
- GPT-5.2 Pro model page: https://developers.openai.com/api/docs/models/gpt-5.2-pro
- GPT-5.3-Codex model page: https://developers.openai.com/api/docs/models/gpt-5.3-codex
- Kilo request mapping: https://github.com/Kilo-Org/kilocode/blob/2e77e36e43b169a6f0f9c83e5e55313673eee241/packages/opencode/src/kilocode/provider-options.ts

Scope remains limited to `kilo/openai part 1`. Supersedes part of #2166.