### PR TITLE
[kilo/openai part 2] Add reasoning options

### DIFF
--- a/providers/kilo/models/openai/gpt-5.4-mini.toml
+++ b/providers/kilo/models/openai/gpt-5.4-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4 Mini"
 release_date = "2026-03-17"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.4-mini.toml
+++ b/providers/kilo/models/openai/gpt-5.4-mini.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.4 Mini"
 release_date = "2026-03-17"
 last_updated = "2026-04-11"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.4-nano.toml
+++ b/providers/kilo/models/openai/gpt-5.4-nano.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4 Nano"
 release_date = "2026-03-17"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.4-nano.toml
+++ b/providers/kilo/models/openai/gpt-5.4-nano.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.4 Nano"
 release_date = "2026-03-17"
 last_updated = "2026-04-11"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.4-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.4-pro.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.4 Pro"
 release_date = "2026-03-06"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/gpt-5.4-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.4-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4 Pro"
 release_date = "2026-03-06"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/gpt-5.4.toml
+++ b/providers/kilo/models/openai/gpt-5.4.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.4"
 release_date = "2026-03-06"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/gpt-5.4.toml
+++ b/providers/kilo/models/openai/gpt-5.4.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.4"
 release_date = "2026-03-06"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/gpt-5.5-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.5-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.5 Pro"
 release_date = "2026-04-24"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/openai/gpt-5.5-pro.toml
+++ b/providers/kilo/models/openai/gpt-5.5-pro.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.5 Pro"
 release_date = "2026-04-24"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/openai/gpt-5.5.toml
+++ b/providers/kilo/models/openai/gpt-5.5.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5.5"
 release_date = "2026-04-24"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/openai/gpt-5.5.toml
+++ b/providers/kilo/models/openai/gpt-5.5.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5.5"
 release_date = "2026-04-24"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/openai/gpt-5.toml
+++ b/providers/kilo/models/openai/gpt-5.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT-5"
 release_date = "2025-08-07"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-5.toml
+++ b/providers/kilo/models/openai/gpt-5.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT-5"
 release_date = "2025-08-07"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-chat-latest.toml
+++ b/providers/kilo/models/openai/gpt-chat-latest.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT Chat Latest"
 release_date = "2026-05-05"
 last_updated = "2026-05-07"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-chat-latest.toml
+++ b/providers/kilo/models/openai/gpt-chat-latest.toml
@@ -2,7 +2,7 @@ name = "OpenAI: GPT Chat Latest"
 release_date = "2026-05-05"
 last_updated = "2026-05-07"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/gpt-oss-120b.toml
+++ b/providers/kilo/models/openai/gpt-oss-120b.toml
@@ -2,6 +2,7 @@ name = "OpenAI: gpt-oss-120b"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-oss-20b.toml
+++ b/providers/kilo/models/openai/gpt-oss-20b.toml
@@ -2,6 +2,7 @@ name = "OpenAI: gpt-oss-20b"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/kilo/models/openai/gpt-oss-safeguard-20b.toml
@@ -2,6 +2,7 @@ name = "OpenAI: gpt-oss-safeguard-20b"
 release_date = "2025-10-29"
 last_updated = "2025-10-29"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/o1-pro.toml
+++ b/providers/kilo/models/openai/o1-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o1-pro"
 release_date = "2025-03-19"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = false

--- a/providers/kilo/models/openai/o1-pro.toml
+++ b/providers/kilo/models/openai/o1-pro.toml
@@ -2,7 +2,7 @@ name = "OpenAI: o1-pro"
 release_date = "2025-03-19"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = false

--- a/providers/kilo/models/openai/o3-deep-research.toml
+++ b/providers/kilo/models/openai/o3-deep-research.toml
@@ -2,7 +2,7 @@ name = "OpenAI: o3 Deep Research"
 release_date = "2024-06-26"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/o3-deep-research.toml
+++ b/providers/kilo/models/openai/o3-deep-research.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o3 Deep Research"
 release_date = "2024-06-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/o3-pro.toml
+++ b/providers/kilo/models/openai/o3-pro.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o3 Pro"
 release_date = "2025-04-16"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/o3-pro.toml
+++ b/providers/kilo/models/openai/o3-pro.toml
@@ -2,7 +2,7 @@ name = "OpenAI: o3 Pro"
 release_date = "2025-04-16"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/o3.toml
+++ b/providers/kilo/models/openai/o3.toml
@@ -2,7 +2,7 @@ name = "OpenAI: o3"
 release_date = "2025-04-16"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/openai/o3.toml
+++ b/providers/kilo/models/openai/o3.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o3"
 release_date = "2025-04-16"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true


### PR DESCRIPTION
Splits the OpenAI part 2 changes from #2166 into a reviewable 15-model PR.

This revision removes unsupported generic toggles and records each model exact effort subset. Kilo sends toggles as `reasoning: { enabled }` and efforts as `reasoning: { effort }`; its adapter projects these into upstream request fields.

Audited subsets in this PR:

- GPT-5: `minimal`, `low`, `medium`, `high`
- GPT-5.4/5.5: `none`, `low`, `medium`, `high`, `xhigh`
- GPT-5.4/5.5 Pro: `medium`, `high`, `xhigh`
- o1-pro, o3, and o3-pro: `low`, `medium`, `high`
- o3-deep-research: `medium` only
- GPT Chat Latest: no configurable reasoning option
- GPT-OSS models: `low`, `medium`, `high`

Evidence:

- OpenAI reasoning guide: https://developers.openai.com/api/docs/guides/reasoning
- GPT-5 model page: https://developers.openai.com/api/docs/models/gpt-5
- GPT-5.4 model page: https://developers.openai.com/api/docs/models/gpt-5.4
- GPT-5.5 Pro model page: https://developers.openai.com/api/docs/models/gpt-5.5-pro
- o1-pro model page: https://developers.openai.com/api/docs/models/o1-pro
- o3 model page: https://developers.openai.com/api/docs/models/o3
- o3-deep-research model page: https://developers.openai.com/api/docs/models/o3-deep-research
- Kilo request mapping: https://github.com/Kilo-Org/kilocode/blob/2e77e36e43b169a6f0f9c83e5e55313673eee241/packages/opencode/src/kilocode/provider-options.ts

Scope remains limited to `kilo/openai part 2`. Supersedes part of #2166.