### PR TITLE
[kilo/openai part 3] Add reasoning options

### DIFF
--- a/providers/kilo/models/openai/o4-mini-deep-research.toml
+++ b/providers/kilo/models/openai/o4-mini-deep-research.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o4 Mini Deep Research"
 release_date = "2024-06-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/o4-mini-high.toml
+++ b/providers/kilo/models/openai/o4-mini-high.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o4 Mini High"
 release_date = "2025-04-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/o4-mini.toml
+++ b/providers/kilo/models/openai/o4-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o4 Mini"
 release_date = "2025-04-16"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true


### PR DESCRIPTION
Splits the openai part 3 changes from #2166 into a reviewable 3-model PR.

Scope is limited to `kilo/openai part 3` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.