### PR TITLE
[kilo/openrouter] Add reasoning options

### DIFF
--- a/providers/kilo/models/openrouter/auto.toml
+++ b/providers/kilo/models/openrouter/auto.toml
@@ -2,6 +2,7 @@ name = "Auto Router"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openrouter/free.toml
+++ b/providers/kilo/models/openrouter/free.toml
@@ -2,6 +2,7 @@ name = "Free Models Router"
 release_date = "2026-02-01"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openrouter/owl-alpha.toml
+++ b/providers/kilo/models/openrouter/owl-alpha.toml
@@ -2,6 +2,7 @@ name = "Owl Alpha"
 release_date = "2026-04-28"
 last_updated = "2026-04-30"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the openrouter changes from #2166 into a reviewable 3-model PR.

Scope is limited to `kilo/openrouter` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.