### PR TITLE
[kilo/perceptron] Add reasoning options

### DIFF
--- a/providers/kilo/models/perceptron/perceptron-mk1.toml
+++ b/providers/kilo/models/perceptron/perceptron-mk1.toml
@@ -2,6 +2,7 @@ name = "Perceptron: Perceptron Mk1"
 release_date = "2026-05-12"
 last_updated = "2026-05-16"
 attachment = true
+reasoning_options = []
 reasoning = true
 tool_call = false
 temperature = true


### PR DESCRIPTION
Splits the perceptron changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/perceptron` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.