### PR TITLE
[kilo/perplexity] Add reasoning options

### DIFF
--- a/providers/kilo/models/perplexity/sonar-deep-research.toml
+++ b/providers/kilo/models/perplexity/sonar-deep-research.toml
@@ -2,6 +2,7 @@ name = "Perplexity: Sonar Deep Research"
 release_date = "2025-01-27"
 last_updated = "2025-01-27"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/perplexity/sonar-pro-search.toml
+++ b/providers/kilo/models/perplexity/sonar-pro-search.toml
@@ -2,6 +2,7 @@ name = "Perplexity: Sonar Pro Search"
 release_date = "2025-10-31"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/kilo/models/perplexity/sonar-reasoning-pro.toml
@@ -2,6 +2,7 @@ name = "Perplexity: Sonar Reasoning Pro"
 release_date = "2024-01-01"
 last_updated = "2025-09-01"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false


### PR DESCRIPTION
Splits the perplexity changes from #2166 into a reviewable 3-model PR.

Scope is limited to `kilo/perplexity` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.