### PR TITLE
[kilo/poolside] Add reasoning options

### DIFF
--- a/providers/kilo/models/poolside/laguna-m.1:free.toml
+++ b/providers/kilo/models/poolside/laguna-m.1:free.toml
@@ -2,6 +2,7 @@ name = "Poolside: Laguna M.1 (free)"
 release_date = "2026-04-28"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/poolside/laguna-xs.2:free.toml
+++ b/providers/kilo/models/poolside/laguna-xs.2:free.toml
@@ -2,6 +2,7 @@ name = "Poolside: Laguna XS.2 (free)"
 release_date = "2026-04-28"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
Splits the poolside changes from #2166 into a reviewable 2-model PR.

Scope is limited to `kilo/poolside` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.