### PR TITLE
[kilo/prime-intellect] Add reasoning options

### DIFF
--- a/providers/kilo/models/prime-intellect/intellect-3.toml
+++ b/providers/kilo/models/prime-intellect/intellect-3.toml
@@ -2,6 +2,7 @@ name = "Prime Intellect: INTELLECT-3"
 release_date = "2025-11-26"
 last_updated = "2026-02-04"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the prime-intellect changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/prime-intellect` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.