### PR TITLE
[kilo/qwen part 1] Add reasoning options

### DIFF
--- a/providers/kilo/models/qwen/qwen-plus-2025-07-28:thinking.toml
+++ b/providers/kilo/models/qwen/qwen-plus-2025-07-28:thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen Plus 0728 (thinking)"
 release_date = "2025-09-09"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen-plus-2025-07-28:thinking.toml
+++ b/providers/kilo/models/qwen/qwen-plus-2025-07-28:thinking.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen Plus 0728 (thinking)"
 release_date = "2025-09-09"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "budget_tokens", min = 1, max = 81_920 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-14b.toml
+++ b/providers/kilo/models/qwen/qwen3-14b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 14B"
 release_date = "2025-04"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-235b-a22b-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b-2507.toml
@@ -2,8 +2,7 @@ name = "Qwen: Qwen3 235B A22B Instruct 2507"
 release_date = "2025-04"
 last_updated = "2026-01"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
-reasoning = true
+reasoning = false
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/kilo/models/qwen/qwen3-235b-a22b-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b-2507.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 235B A22B Instruct 2507"
 release_date = "2025-04"
 last_updated = "2026-01"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3 235B A22B Thinking 2507"
 release_date = "2025-07-25"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b-thinking-2507.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 235B A22B Thinking 2507"
 release_date = "2025-07-25"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-235b-a22b.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3 235B A22B"
 release_date = "2024-12-01"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 38_912 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-235b-a22b.toml
+++ b/providers/kilo/models/qwen/qwen3-235b-a22b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 235B A22B"
 release_date = "2024-12-01"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-30b-a3b-thinking-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-30b-a3b-thinking-2507.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 30B A3B Thinking 2507"
 release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-30b-a3b-thinking-2507.toml
+++ b/providers/kilo/models/qwen/qwen3-30b-a3b-thinking-2507.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3 30B A3B Thinking 2507"
 release_date = "2025-07-29"
 last_updated = "2025-07-29"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-30b-a3b.toml
+++ b/providers/kilo/models/qwen/qwen3-30b-a3b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 30B A3B"
 release_date = "2025-04"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-32b.toml
+++ b/providers/kilo/models/qwen/qwen3-32b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 32B"
 release_date = "2024-12-01"
 last_updated = "2026-02-04"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-8b.toml
+++ b/providers/kilo/models/qwen/qwen3-8b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 8B"
 release_date = "2025-04"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-max-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-max-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 Max Thinking"
 release_date = "2026-01-23"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-max-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-max-thinking.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3 Max Thinking"
 release_date = "2026-01-23"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "budget_tokens", min = 1, max = 81_920 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3 Next 80B A3B Thinking"
 release_date = "2025-09-11"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 Next 80B A3B Thinking"
 release_date = "2025-09-11"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-235b-a22b-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 VL 235B A22B Thinking"
 release_date = "2025-09-24"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-235b-a22b-thinking.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3 VL 235B A22B Thinking"
 release_date = "2025-09-24"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-vl-30b-a3b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-30b-a3b-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 VL 30B A3B Thinking"
 release_date = "2025-10-11"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-vl-30b-a3b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-30b-a3b-thinking.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3 VL 30B A3B Thinking"
 release_date = "2025-10-11"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-vl-8b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-8b-thinking.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3 VL 8B Thinking"
 release_date = "2025-10-15"
 last_updated = "2025-11-25"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3-vl-8b-thinking.toml
+++ b/providers/kilo/models/qwen/qwen3-vl-8b-thinking.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3 VL 8B Thinking"
 release_date = "2025-10-15"
 last_updated = "2025-11-25"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-122b-a10b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-122B-A10B"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the Qwen part 1 changes from #2166 into a reviewable 15-model PR.

This revision distinguishes hybrid Qwen models from fixed-thinking and instruct-only IDs. Kilo sends a toggle as `reasoning: { enabled }`; its adapter projects that to Alibaba `enableThinking`. Kilo/OpenRouter normalize supported token budgets as `reasoning.max_tokens`, translated upstream to `thinking_budget` where supported.

Audited controls in this PR:

- Hybrid Qwen3 8B/14B/30B/32B and Qwen3.5 122B: toggle
- Fixed `*-thinking*` snapshots and VL thinking IDs: no toggle
- Qwen Plus 0728 Thinking and Qwen3 Max Thinking: budget only, 1 through 81,920
- Qwen3 235B A22B: toggle plus budget, 1 through 38,912
- Qwen3 235B A22B Instruct 2507: non-reasoning instruct model

Evidence:

- Alibaba hybrid versus fixed-thinking model list and `enable_thinking` behavior: https://help.aliyun.com/zh/model-studio/deep-thinking
- OpenRouter normalized reasoning and Alibaba `thinking_budget` mapping: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
- Kilo request mapping: https://github.com/Kilo-Org/kilocode/blob/2e77e36e43b169a6f0f9c83e5e55313673eee241/packages/opencode/src/kilocode/provider-options.ts
- Kilo live model metadata: https://api.kilo.ai/api/gateway/models

Scope remains limited to `kilo/qwen part 1`. Supersedes part of #2166.