### PR TITLE
[kilo/qwen part 2] Add reasoning options

### DIFF
--- a/providers/kilo/models/qwen/qwen3.5-27b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-27b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-27B"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-35b-a3b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-35b-a3b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-35B-A3B"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-397b-a17b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5 397B A17B"
 release_date = "2026-02-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-9b.toml
+++ b/providers/kilo/models/qwen/qwen3.5-9b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-9B"
 release_date = "2026-03-10"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-flash-02-23.toml
+++ b/providers/kilo/models/qwen/qwen3.5-flash-02-23.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5-Flash"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-flash-02-23.toml
+++ b/providers/kilo/models/qwen/qwen3.5-flash-02-23.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3.5-Flash"
 release_date = "2026-02-26"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 81_920 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-plus-02-15.toml
+++ b/providers/kilo/models/qwen/qwen3.5-plus-02-15.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5 Plus 2026-02-15"
 release_date = "2026-02-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-plus-02-15.toml
+++ b/providers/kilo/models/qwen/qwen3.5-plus-02-15.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3.5 Plus 2026-02-15"
 release_date = "2026-02-15"
 last_updated = "2026-03-15"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 81_920 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.5-plus-20260420.toml
+++ b/providers/kilo/models/qwen/qwen3.5-plus-20260420.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.5 Plus 2026-04-20"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.5-plus-20260420.toml
+++ b/providers/kilo/models/qwen/qwen3.5-plus-20260420.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3.5 Plus 2026-04-20"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 81_920 }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-27b.toml
+++ b/providers/kilo/models/qwen/qwen3.6-27b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 27B"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-35b-a3b.toml
+++ b/providers/kilo/models/qwen/qwen3.6-35b-a3b.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 35B A3B"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = false
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-flash.toml
+++ b/providers/kilo/models/qwen/qwen3.6-flash.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 Flash"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-flash.toml
+++ b/providers/kilo/models/qwen/qwen3.6-flash.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3.6 Flash"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 81_920 }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-max-preview.toml
+++ b/providers/kilo/models/qwen/qwen3.6-max-preview.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3.6 Max Preview"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 131_072 }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-max-preview.toml
+++ b/providers/kilo/models/qwen/qwen3.6-max-preview.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 Max Preview"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.6-plus.toml
+++ b/providers/kilo/models/qwen/qwen3.6-plus.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3.6 Plus"
 release_date = "2025-08-26"
 last_updated = "2026-04-11"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 81_920 }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.6-plus.toml
+++ b/providers/kilo/models/qwen/qwen3.6-plus.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.6 Plus"
 release_date = "2025-08-26"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/qwen/qwen3.7-max.toml
+++ b/providers/kilo/models/qwen/qwen3.7-max.toml
@@ -2,6 +2,7 @@ name = "Qwen: Qwen3.7 Max"
 release_date = "2025-08-26"
 last_updated = "2026-05-27"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/qwen/qwen3.7-max.toml
+++ b/providers/kilo/models/qwen/qwen3.7-max.toml
@@ -2,7 +2,7 @@ name = "Qwen: Qwen3.7 Max"
 release_date = "2025-08-26"
 last_updated = "2026-05-27"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 262_144 }]
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
Splits the Qwen part 2 changes from #2166 into a reviewable 13-model PR.

This revision keeps toggles for the listed hybrid Qwen models and adds explicit token budgets where Kilo supports normalized `reasoning.max_tokens`. The gateway translates those budgets to Alibaba `thinking_budget` where supported.

Audited controls in this PR:

- Qwen3.5 9B/27B/35B/397B and Qwen3.6 27B/35B: toggle only
- Qwen3.5 Flash and both Qwen3.5 Plus snapshots: toggle plus budget, 1 through 81,920
- Qwen3.6 Flash and Plus: toggle plus budget, 1 through 81,920
- Qwen3.6 Max Preview: toggle plus budget, 1 through 131,072
- Qwen3.7 Max: toggle plus budget, 1 through 262,144

`qwen3.6-max-preview` and `qwen3.7-max` are hybrid according to the current Alibaba model list. The separate `qwen3.7-max-preview` ID is fixed-thinking and is not changed here.

Evidence:

- Alibaba hybrid versus fixed-thinking model list and `enable_thinking` behavior: https://help.aliyun.com/zh/model-studio/deep-thinking
- OpenRouter normalized reasoning and Alibaba `thinking_budget` mapping: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
- Kilo request mapping: https://github.com/Kilo-Org/kilocode/blob/2e77e36e43b169a6f0f9c83e5e55313673eee241/packages/opencode/src/kilocode/provider-options.ts
- Kilo live model metadata: https://api.kilo.ai/api/gateway/models

Scope remains limited to `kilo/qwen part 2`. Supersedes part of #2166.