### PR TITLE
[kilo/rekaai] Add reasoning options

### DIFF
--- a/providers/kilo/models/rekaai/reka-flash-3.toml
+++ b/providers/kilo/models/rekaai/reka-flash-3.toml
@@ -2,6 +2,7 @@ name = "Reka Flash 3"
 release_date = "2025-03-12"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false


### PR DESCRIPTION
Splits the rekaai changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/rekaai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.