### PR TITLE
[kilo/stealth] Add reasoning options

### DIFF
--- a/providers/kilo/models/stealth/claude-opus-4.6.toml
+++ b/providers/kilo/models/stealth/claude-opus-4.6.toml
@@ -2,6 +2,7 @@ name = "Stealth: Claude Opus 4.6 (20% off)"
 release_date = "2026-02-05"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/stealth/claude-opus-4.7.toml
+++ b/providers/kilo/models/stealth/claude-opus-4.7.toml
@@ -2,6 +2,7 @@ name = "Stealth: Claude Opus 4.7 (20% off)"
 release_date = "2026-04-16"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/stealth/claude-sonnet-4.6.toml
+++ b/providers/kilo/models/stealth/claude-sonnet-4.6.toml
@@ -2,6 +2,7 @@ name = "Stealth: Claude Sonnet 4.6 (20% off)"
 release_date = "2026-02-17"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
Splits the stealth changes from #2166 into a reviewable 3-model PR.

Scope is limited to `kilo/stealth` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.