### PR TITLE
[kilo/stepfun] Add reasoning options

### DIFF
--- a/providers/kilo/models/stepfun/step-3.5-flash.toml
+++ b/providers/kilo/models/stepfun/step-3.5-flash.toml
@@ -2,6 +2,7 @@ name = "StepFun: Step 3.5 Flash"
 release_date = "2026-01-29"
 last_updated = "2026-01-29"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the stepfun changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/stepfun` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.