### PR TITLE
[kilo/switchpoint] Add reasoning options

### DIFF
--- a/providers/kilo/models/switchpoint/router.toml
+++ b/providers/kilo/models/switchpoint/router.toml
@@ -2,6 +2,7 @@ name = "Switchpoint Router"
 release_date = "2025-07-12"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false


### PR DESCRIPTION
Splits the switchpoint changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/switchpoint` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.