### PR TITLE
[kilo/tencent] Add reasoning options

### DIFF
--- a/providers/kilo/models/tencent/hunyuan-a13b-instruct.toml
+++ b/providers/kilo/models/tencent/hunyuan-a13b-instruct.toml
@@ -2,6 +2,7 @@ name = "Tencent: Hunyuan A13B Instruct"
 release_date = "2025-06-30"
 last_updated = "2025-11-25"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/tencent/hy3-preview.toml
+++ b/providers/kilo/models/tencent/hy3-preview.toml
@@ -2,6 +2,7 @@ name = "Tencent: Hy3 Preview"
 release_date = "2026-04-22"
 last_updated = "2026-05-16"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["none", "low", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
Splits the tencent changes from #2166 into a reviewable 2-model PR.

Scope is limited to `kilo/tencent` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.