### PR TITLE
[kilo/upstage] Add reasoning options

### DIFF
--- a/providers/kilo/models/upstage/solar-pro-3.toml
+++ b/providers/kilo/models/upstage/solar-pro-3.toml
@@ -2,6 +2,7 @@ name = "Upstage: Solar Pro 3"
 release_date = "2026-01-27"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Splits the upstage changes from #2166 into a reviewable 1-model PR.

Scope is limited to `kilo/upstage` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2166.