### PR TITLE
[kilo/x-ai] Add reasoning options

### DIFF
--- a/providers/kilo/models/x-ai/grok-4.20-multi-agent.toml
+++ b/providers/kilo/models/x-ai/grok-4.20-multi-agent.toml
@@ -2,7 +2,7 @@ name = "xAI: Grok 4.20 Multi-Agent"
 release_date = "2026-03-31"
 last_updated = "2026-04-11"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/x-ai/grok-4.20-multi-agent.toml
+++ b/providers/kilo/models/x-ai/grok-4.20-multi-agent.toml
@@ -2,6 +2,7 @@ name = "xAI: Grok 4.20 Multi-Agent"
 release_date = "2026-03-31"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/x-ai/grok-4.20.toml
+++ b/providers/kilo/models/x-ai/grok-4.20.toml
@@ -2,6 +2,7 @@ name = "xAI: Grok 4.20"
 release_date = "2026-03-31"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/x-ai/grok-4.3.toml
+++ b/providers/kilo/models/x-ai/grok-4.3.toml
@@ -2,6 +2,7 @@ name = "xAI: Grok 4.3"
 release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/x-ai/grok-build-0.1.toml
+++ b/providers/kilo/models/x-ai/grok-build-0.1.toml
@@ -2,6 +2,7 @@ name = "xAI: Grok Build 0.1"
 release_date = "2026-05-20"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
## Summary

- add provider-specific reasoning controls to four xAI routes on Kilo
- include all four xAI multi-agent effort values in addition to Kilo's normalized toggle
- supersede the `x-ai` portion of #2166

## Exact controls

| Model | Toggle | Efforts | Token budget |
| --- | --- | --- | --- |
| `x-ai/grok-4.20-multi-agent` | Yes | `low`, `medium`, `high`, `xhigh` | None |
| `x-ai/grok-4.20` | Yes | None | None |
| `x-ai/grok-4.3` | No separate toggle | `none`, `low`, `medium`, `high` | None |
| `x-ai/grok-build-0.1` | No | None | None |

## Evidence

Audited 2026-06-24 against Kilo's live model catalog and xAI's primary API documentation.

- [Kilo live model catalog](https://api.kilo.ai/api/openrouter/models): both Grok 4.20 routes publish normalized `instant` and `thinking` variants, establishing a Kilo toggle. Grok 4.3 and Grok Build publish no Kilo variant map.
- [xAI Multi Agent documentation](https://docs.x.ai/developers/model-capabilities/text/multi-agent#configuration): `grok-4.20-multi-agent` accepts `reasoning.effort` values `low`, `medium`, `high`, and `xhigh`. `low`/`medium` select 4 agents; `high`/`xhigh` select 16 agents. This controls agent count rather than ordinary reasoning depth. `none` is not an accepted multi-agent effort.
- [xAI Reasoning documentation](https://docs.x.ai/developers/model-capabilities/text/reasoning): `grok-4.3` accepts exactly `none`, `low`, `medium`, and `high`; `low` is the default and `none` disables reasoning.
- [xAI Grok 4.20 Reasoning](https://docs.x.ai/developers/models/grok-4.20-reasoning) and [Non-Reasoning](https://docs.x.ai/developers/models/grok-4.20-0309-non-reasoning): Grok 4.20 has distinct reasoning/non-reasoning forms, matching Kilo's toggle rather than an effort continuum.
- [xAI Models](https://docs.x.ai/developers/models): lists `grok-build-0.1` without a selectable reasoning effort or budget control.

No audited xAI route exposes a reasoning-token budget.

## Scope

Only these four existing model files are changed. No catalog, pricing, limits, base-model, or unrelated metadata changes are included.

## Validation

- `bun validate`
- `git diff --check`
- post-push GitHub `validate` check passed
