### PR TITLE
[kilo/z-ai] Add reasoning options

### DIFF
--- a/providers/kilo/models/z-ai/glm-4.5-air.toml
+++ b/providers/kilo/models/z-ai/glm-4.5-air.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 4.5 Air"
 release_date = "2025-07-28"
 last_updated = "2025-07-28"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.5-air.toml
+++ b/providers/kilo/models/z-ai/glm-4.5-air.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.5 Air"
 release_date = "2025-07-28"
 last_updated = "2025-07-28"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.5.toml
+++ b/providers/kilo/models/z-ai/glm-4.5.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 4.5"
 release_date = "2025-07-28"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.5.toml
+++ b/providers/kilo/models/z-ai/glm-4.5.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.5"
 release_date = "2025-07-28"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.5v.toml
+++ b/providers/kilo/models/z-ai/glm-4.5v.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.5V"
 release_date = "2025-08-11"
 last_updated = "2025-08-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.5v.toml
+++ b/providers/kilo/models/z-ai/glm-4.5v.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 4.5V"
 release_date = "2025-08-11"
 last_updated = "2025-08-11"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.6.toml
+++ b/providers/kilo/models/z-ai/glm-4.6.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 4.6"
 release_date = "2025-09-30"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.6.toml
+++ b/providers/kilo/models/z-ai/glm-4.6.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.6"
 release_date = "2025-09-30"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.6v.toml
+++ b/providers/kilo/models/z-ai/glm-4.6v.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.6V"
 release_date = "2025-09-30"
 last_updated = "2026-01-10"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.6v.toml
+++ b/providers/kilo/models/z-ai/glm-4.6v.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 4.6V"
 release_date = "2025-09-30"
 last_updated = "2026-01-10"
 attachment = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.7-flash.toml
+++ b/providers/kilo/models/z-ai/glm-4.7-flash.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 4.7 Flash"
 release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.7-flash.toml
+++ b/providers/kilo/models/z-ai/glm-4.7-flash.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.7 Flash"
 release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.7.toml
+++ b/providers/kilo/models/z-ai/glm-4.7.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 4.7"
 release_date = "2025-12-22"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-4.7.toml
+++ b/providers/kilo/models/z-ai/glm-4.7.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 4.7"
 release_date = "2025-12-22"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5-turbo.toml
+++ b/providers/kilo/models/z-ai/glm-5-turbo.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 5 Turbo"
 release_date = "2026-03-15"
 last_updated = "2026-04-11"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5-turbo.toml
+++ b/providers/kilo/models/z-ai/glm-5-turbo.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 5 Turbo"
 release_date = "2026-03-15"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5.1.toml
+++ b/providers/kilo/models/z-ai/glm-5.1.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 5.1"
 release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5.1.toml
+++ b/providers/kilo/models/z-ai/glm-5.1.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 5.1"
 release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5.toml
+++ b/providers/kilo/models/z-ai/glm-5.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 5"
 release_date = "2026-02-12"
 last_updated = "2026-03-15"
 attachment = false
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5.toml
+++ b/providers/kilo/models/z-ai/glm-5.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 5"
 release_date = "2026-02-12"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5v-turbo.toml
+++ b/providers/kilo/models/z-ai/glm-5v-turbo.toml
@@ -2,7 +2,7 @@ name = "Z.ai: GLM 5V Turbo"
 release_date = "2026-04-01"
 last_updated = "2026-04-11"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/z-ai/glm-5v-turbo.toml
+++ b/providers/kilo/models/z-ai/glm-5v-turbo.toml
@@ -2,6 +2,7 @@ name = "Z.ai: GLM 5V Turbo"
 release_date = "2026-04-01"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
## Summary

- add Kilo's exact Z.AI reasoning toggle and normalized `high`/`xhigh` efforts to eleven routes
- distinguish Kilo-normalized efforts from Z.AI's native binary `thinking.type` API
- supersede the `z-ai` portion of #2166

## Exact controls

Every route in scope exposes:

```toml
reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
```

| Model | Toggle | Efforts | Token budget |
| --- | --- | --- | --- |
| `z-ai/glm-4.5-air` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-4.5` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-4.5v` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-4.6` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-4.6v` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-4.7-flash` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-4.7` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-5-turbo` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-5.1` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-5` | Yes | `high`, `xhigh` | None |
| `z-ai/glm-5v-turbo` | Yes | `high`, `xhigh` | None |

## Evidence

Audited 2026-06-24 against Kilo's live model catalog and Z.AI's primary API documentation.

- [Kilo live model catalog](https://api.kilo.ai/api/openrouter/models): every audited route publishes the same three normalized variants: `none` sends `reasoning.enabled = false` with `effort = "none"`; `high` sends enabled reasoning with `effort = "high"`; `xhigh` sends enabled reasoning with `effort = "xhigh"`.
- In this schema, enable/disable is represented by `toggle`; `none` therefore is not duplicated in the effort list. The independently selectable enabled efforts are exactly `high` and `xhigh`.
- [Z.AI Thinking Mode](https://docs.z.ai/guides/capabilities/thinking-mode): native control is binary `thinking.type = "enabled" | "disabled"`; GLM-5/5.1 and GLM-4.7 default to thinking enabled, while GLM-4.6 uses hybrid thinking behavior.
- [Z.AI GLM-4.5](https://docs.z.ai/guides/llm/glm-4.5): explicitly documents the native `thinking.type` values `enabled` and `disabled`.
- [Z.AI GLM-5V-Turbo](https://docs.z.ai/guides/vlm/glm-5v-turbo): request examples use `thinking: { "type": "enabled" }`, confirming that the route is controllable rather than fixed.

Thus `high` and `xhigh` are Kilo's normalized provider efforts layered over Z.AI's native binary switch. Kilo exposes no reasoning-token budget minimum or maximum for these routes.

## Scope

Only these eleven existing model files are changed. No catalog, pricing, limits, base-model, or unrelated metadata changes are included.

## Validation

- `bun validate`
- `git diff --check`
- post-push GitHub `validate` check passed
