### PR TITLE
[llmgateway/bytedance] Add reasoning options

### DIFF
--- a/providers/llmgateway/models/seed-1-6-250615.toml
+++ b/providers/llmgateway/models/seed-1-6-250615.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-25"
 last_updated = "2025-06-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-6-250615.toml
+++ b/providers/llmgateway/models/seed-1-6-250615.toml
@@ -4,7 +4,7 @@ release_date = "2025-06-25"
 last_updated = "2025-06-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-6-250915.toml
+++ b/providers/llmgateway/models/seed-1-6-250915.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-6-250915.toml
+++ b/providers/llmgateway/models/seed-1-6-250915.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-6-flash-250715.toml
+++ b/providers/llmgateway/models/seed-1-6-flash-250715.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-26"
 last_updated = "2025-07-26"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-6-flash-250715.toml
+++ b/providers/llmgateway/models/seed-1-6-flash-250715.toml
@@ -4,7 +4,7 @@ release_date = "2025-07-26"
 last_updated = "2025-07-26"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-8-251228.toml
+++ b/providers/llmgateway/models/seed-1-8-251228.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-18"
 last_updated = "2025-12-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/seed-1-8-251228.toml
+++ b/providers/llmgateway/models/seed-1-8-251228.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-18"
 last_updated = "2025-12-18"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Adds audited LLMGateway reasoning-effort controls for ByteDance Seed models.

BytePlus defines `reasoning_effort` as `minimal`, `low`, `medium`, or `high`; `minimal` disables reasoning. LLMGateway forwards this field unchanged. The separate ByteDance `thinking.type` control is not advertised because the gateway does not translate its unified API to that field.

Sources:
- https://docs.byteplus.com/en/docs/Byteplus_LAS/Chat_API
- https://docs.byteplus.com/en/docs/Byteplus_LAS/Multimodal-Deep-Thinking-Doubao-Seed-1-8
- https://docs.byteplus.com/en/docs/Byteplus_LAS/Multimodal-Deep-Thinking-Doubao-Seed-1-6
- https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/actions/src/prepare-request-body.ts#L2913-L2922

Supersedes part of #2171.
