### PR TITLE
[llmgateway/moonshotai] Add reasoning options

### DIFF
--- a/providers/llmgateway/models/kimi-k2-thinking-turbo.toml
+++ b/providers/llmgateway/models/kimi-k2-thinking-turbo.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking-turbo"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2-thinking-turbo.toml
+++ b/providers/llmgateway/models/kimi-k2-thinking-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking-turbo"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2-thinking.toml
+++ b/providers/llmgateway/models/kimi-k2-thinking.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2-thinking.toml
+++ b/providers/llmgateway/models/kimi-k2-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2.5.toml
+++ b/providers/llmgateway/models/kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2.5.toml
+++ b/providers/llmgateway/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2.6.toml
+++ b/providers/llmgateway/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2.6.toml
+++ b/providers/llmgateway/models/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Splits the MoonshotAI changes from #2171 into a reviewable 4-model PR.

## Result

All four models use `reasoning_options = []`:

- `kimi-k2-thinking-turbo`
- `kimi-k2-thinking`
- `kimi-k2.5`
- `kimi-k2.6`

These models reason, but no effective caller-selectable reasoning control is currently verified through LLMGateway.

## Evidence

- [LLMGateway's `kimi-k2.5` mapping at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/models/src/models/moonshot.ts#L193-L220) limits the native Moonshot route to `max_tokens`, `response_format`, `tools`, and `tool_choice`.
- [LLMGateway's `kimi-k2.6` mapping at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/models/src/models/moonshot.ts#L323-L350) has the same restriction.
- [LLMGateway's generic forwarding guard at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/actions/src/prepare-request-body.ts#L2913-L2922) drops `reasoning_effort` when a mapping's `supportedParameters` does not include it.
- [Moonshot Using Thinking Models](https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model), accessed 2026-06-24, documents the native `thinking.type = "enabled" | "disabled"` toggle for `kimi-k2.5` and `kimi-k2.6`. LLMGateway does not translate its public reasoning control into that field.
- [LLMGateway `GET /v1/models`](https://api.llmgateway.io/v1/models), accessed 2026-06-24, reports the four IDs as reasoning-capable but does not enumerate selectable effort levels.

`kimi-k2-thinking` and `kimi-k2-thinking-turbo` are dedicated thinking models. No provider-level evidence establishes meaningful `low`, `medium`, and `high` depth levels through LLMGateway.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2171.
