### PR TITLE
[llmgateway/openai part 1] Add reasoning options

### DIFF
--- a/providers/llmgateway/models/gpt-5-chat-latest.toml
+++ b/providers/llmgateway/models/gpt-5-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-chat-latest"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/gpt-5-mini.toml
+++ b/providers/llmgateway/models/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/llmgateway/models/gpt-5-nano.toml
+++ b/providers/llmgateway/models/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/llmgateway/models/gpt-5-pro.toml
+++ b/providers/llmgateway/models/gpt-5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-pro"
+reasoning_options = [{ type = "effort", values = ["high"] }]
 
 [cost]
 input = 15

--- a/providers/llmgateway/models/gpt-5.1-codex-mini.toml
+++ b/providers/llmgateway/models/gpt-5.1-codex-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/llmgateway/models/gpt-5.1-codex.toml
+++ b/providers/llmgateway/models/gpt-5.1-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/gpt-5.1.toml
+++ b/providers/llmgateway/models/gpt-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/gpt-5.2-chat-latest.toml
+++ b/providers/llmgateway/models/gpt-5.2-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-chat-latest"
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 
 [cost]
 input = 1.75

--- a/providers/llmgateway/models/gpt-5.2-codex.toml
+++ b/providers/llmgateway/models/gpt-5.2-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/llmgateway/models/gpt-5.2-pro.toml
+++ b/providers/llmgateway/models/gpt-5.2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
 input = 21

--- a/providers/llmgateway/models/gpt-5.2.toml
+++ b/providers/llmgateway/models/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/llmgateway/models/gpt-5.3-codex.toml
+++ b/providers/llmgateway/models/gpt-5.3-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/llmgateway/models/gpt-5.3-codex.toml
+++ b/providers/llmgateway/models/gpt-5.3-codex.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.75

--- a/providers/llmgateway/models/gpt-5.4-mini.toml
+++ b/providers/llmgateway/models/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.75

--- a/providers/llmgateway/models/gpt-5.4-nano.toml
+++ b/providers/llmgateway/models/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.2

--- a/providers/llmgateway/models/gpt-5.4-pro.toml
+++ b/providers/llmgateway/models/gpt-5.4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
 input = 30


### PR DESCRIPTION
Splits the OpenAI part 1 changes from #2171 into a reviewable 15-model PR.

## Result

The audited option sets are:

| Model | Reasoning options |
| --- | --- |
| `gpt-5-chat-latest` | none verified (`[]`) |
| `gpt-5-mini` | `minimal`, `low`, `medium`, `high` |
| `gpt-5-nano` | `minimal`, `low`, `medium`, `high` |
| `gpt-5-pro` | `high` |
| `gpt-5.1-codex-mini` | `low`, `medium`, `high` |
| `gpt-5.1-codex` | `low`, `medium`, `high` |
| `gpt-5.1` | `none`, `low`, `medium`, `high` |
| `gpt-5.2-chat-latest` | `medium` |
| `gpt-5.2-codex` | `low`, `medium`, `high`, `xhigh` |
| `gpt-5.2-pro` | `medium`, `high`, `xhigh` |
| `gpt-5.2` | `none`, `low`, `medium`, `high`, `xhigh` |
| `gpt-5.3-codex` | `low`, `medium`, `high`, `xhigh` |
| `gpt-5.4-mini` | `none`, `low`, `medium`, `high`, `xhigh` |
| `gpt-5.4-nano` | `none`, `low`, `medium`, `high`, `xhigh` |
| `gpt-5.4-pro` | `medium`, `high`, `xhigh` |

The audit removed unsupported `none` from `gpt-5.3-codex`.

## Evidence

- [LLMGateway OpenAI Responses translation at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/actions/src/prepare-request-body.ts#L1399-L1429) forwards the selected value as `reasoning.effort`.
- [LLMGateway request schema at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/apps/gateway/src/chat/schemas/completions.ts#L266-L289) accepts the gateway's generic effort enum. Model-specific support remains narrower.
- [OpenAI GPT-5.3-Codex](https://platform.openai.com/docs/models/gpt-5.3-codex), accessed 2026-06-24, documents only `low`, `medium`, `high`, and `xhigh`.
- [OpenAI GPT-5.2-Codex](https://platform.openai.com/docs/models/gpt-5.2-codex), accessed 2026-06-24, documents `low`, `medium`, `high`, and `xhigh`.
- [OpenAI GPT-5.4 Pro](https://platform.openai.com/docs/models/gpt-5.4-pro), accessed 2026-06-24, documents `medium`, `high`, and `xhigh`.
- [OpenAI reasoning guide](https://platform.openai.com/docs/guides/reasoning), accessed 2026-06-24, states that effort values are model-dependent.
- [LLMGateway `GET /v1/models`](https://api.llmgateway.io/v1/models), accessed 2026-06-24, reports all models here except `gpt-5-chat-latest` as reasoning-capable. `gpt-5-chat-latest` correctly has an audited empty list.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2171.
