### PR TITLE
[llmgateway/openai part 2] Add reasoning options

### DIFF
--- a/providers/llmgateway/models/gpt-5.4.toml
+++ b/providers/llmgateway/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/llmgateway/models/gpt-5.5-pro.toml
+++ b/providers/llmgateway/models/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
 input = 30

--- a/providers/llmgateway/models/gpt-5.5.toml
+++ b/providers/llmgateway/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/llmgateway/models/gpt-5.toml
+++ b/providers/llmgateway/models/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/gpt-oss-120b.toml
+++ b/providers/llmgateway/models/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/gpt-oss-20b.toml
+++ b/providers/llmgateway/models/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/o1.toml
+++ b/providers/llmgateway/models/o1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o1"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 15

--- a/providers/llmgateway/models/o3-mini.toml
+++ b/providers/llmgateway/models/o3-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/o3-mini"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.1

--- a/providers/llmgateway/models/o3-mini.toml
+++ b/providers/llmgateway/models/o3-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.1

--- a/providers/llmgateway/models/o3.toml
+++ b/providers/llmgateway/models/o3.toml
@@ -1,5 +1,5 @@
 base_model = "openai/o3"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/llmgateway/models/o3.toml
+++ b/providers/llmgateway/models/o3.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2

--- a/providers/llmgateway/models/o4-mini.toml
+++ b/providers/llmgateway/models/o4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.1


### PR DESCRIPTION
Splits the OpenAI part 2 changes from #2171 into a reviewable 10-model PR.

## Result

The audited option sets are:

| Model | Reasoning options |
| --- | --- |
| `gpt-5.4` | `none`, `low`, `medium`, `high`, `xhigh` |
| `gpt-5.5-pro` | `medium`, `high`, `xhigh` |
| `gpt-5.5` | `none`, `low`, `medium`, `high`, `xhigh` |
| `gpt-5` | `minimal`, `low`, `medium`, `high` |
| `gpt-oss-120b` | `low`, `medium`, `high` |
| `gpt-oss-20b` | `low`, `medium`, `high` |
| `o1` | `low`, `medium`, `high` |
| `o3-mini` | currently unavailable through LLMGateway (`[]`) |
| `o3` | currently unavailable through LLMGateway (`[]`) |
| `o4-mini` | `low`, `medium`, `high` |

Direct OpenAI supports effort selection for `o3` and `o3-mini`, but LLMGateway's current registry causes its capability guard to reject those controls before forwarding.

## Evidence

- [LLMGateway's `o3` mapping at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/models/src/models/openai.ts#L521-L544) lists `reasoning_effort` but omits `reasoning: true`.
- [LLMGateway's `o3-mini` mapping at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/models/src/models/openai.ts#L565-L587) has the same inconsistency.
- [LLMGateway capability validation at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/apps/gateway/src/chat/tools/validate-model-capabilities.ts#L157-L190) returns HTTP 400 when `reasoning_effort` is supplied and no selected mapping has `reasoning: true`.
- [LLMGateway `GET /v1/models`](https://api.llmgateway.io/v1/models), accessed 2026-06-24, reports `reasoning: false` for both the `o3` and `o3-mini` OpenAI mappings. Their options can be restored after LLMGateway corrects those registry entries.
- [OpenAI GPT-5.4](https://platform.openai.com/docs/models/gpt-5.4), accessed 2026-06-24, documents `none`, `low`, `medium`, `high`, and `xhigh`.
- [OpenAI GPT-5.5](https://platform.openai.com/docs/models/gpt-5.5), accessed 2026-06-24, documents `none`, `low`, `medium`, `high`, and `xhigh`.
- [OpenAI GPT-5.5 Pro](https://platform.openai.com/docs/models/gpt-5.5-pro), accessed 2026-06-24, documents `medium`, `high`, and `xhigh`.
- [LLMGateway reasoning examples at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/apps/docs/content/features/reasoning.mdx#L51-L64) demonstrate `gpt-oss-120b` with `medium`; the same document defines the gateway effort interface.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2171.
