### PR TITLE
[llmgateway/perplexity] Add reasoning options

### DIFF
--- a/providers/llmgateway/models/sonar-reasoning-pro.toml
+++ b/providers/llmgateway/models/sonar-reasoning-pro.toml
@@ -1,4 +1,5 @@
 base_model = "perplexity/sonar-reasoning-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2


### PR DESCRIPTION
Splits the perplexity changes from #2171 into a reviewable 1-model PR.

Scope is limited to `llmgateway/perplexity` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2171.