### PR TITLE
[llmgateway/xai] Add reasoning options

### DIFF
--- a/providers/llmgateway/models/grok-4-1-fast-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-19"
 last_updated = "2025-11-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/grok-4-20-beta-0309-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-20-beta-0309-reasoning.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/grok-4-20-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-20-reasoning.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/grok-4-3.toml
+++ b/providers/llmgateway/models/grok-4-3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/grok-4-fast-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the xai changes from #2171 into a reviewable 5-model PR.

Scope is limited to `llmgateway/xai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2171.