### PR TITLE
[llmgateway/zhipuai] Add reasoning options

### DIFF
--- a/providers/llmgateway/models/glm-4.5-air.toml
+++ b/providers/llmgateway/models/glm-4.5-air.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/llmgateway/models/glm-4.5-air.toml
+++ b/providers/llmgateway/models/glm-4.5-air.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.2

--- a/providers/llmgateway/models/glm-4.5-flash.toml
+++ b/providers/llmgateway/models/glm-4.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0

--- a/providers/llmgateway/models/glm-4.5-flash.toml
+++ b/providers/llmgateway/models/glm-4.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.5-flash"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 0

--- a/providers/llmgateway/models/glm-4.5-x.toml
+++ b/providers/llmgateway/models/glm-4.5-x.toml
@@ -4,7 +4,7 @@ release_date = "2025-07-28"
 last_updated = "2025-07-28"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.5-x.toml
+++ b/providers/llmgateway/models/glm-4.5-x.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-28"
 last_updated = "2025-07-28"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.5.toml
+++ b/providers/llmgateway/models/glm-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/glm-4.5.toml
+++ b/providers/llmgateway/models/glm-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/glm-4.5v.toml
+++ b/providers/llmgateway/models/glm-4.5v.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5v"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/glm-4.5v.toml
+++ b/providers/llmgateway/models/glm-4.5v.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.5v"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/glm-4.6.toml
+++ b/providers/llmgateway/models/glm-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/glm-4.6.toml
+++ b/providers/llmgateway/models/glm-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.6"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/glm-4.6v-flash.toml
+++ b/providers/llmgateway/models/glm-4.6v-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.6v-flash.toml
+++ b/providers/llmgateway/models/glm-4.6v-flash.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.6v-flashx.toml
+++ b/providers/llmgateway/models/glm-4.6v-flashx.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.6v-flashx.toml
+++ b/providers/llmgateway/models/glm-4.6v-flashx.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/glm-4.6v.toml
+++ b/providers/llmgateway/models/glm-4.6v.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.6v"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.3

--- a/providers/llmgateway/models/glm-4.6v.toml
+++ b/providers/llmgateway/models/glm-4.6v.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6v"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/llmgateway/models/glm-4.7-flash.toml
+++ b/providers/llmgateway/models/glm-4.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0

--- a/providers/llmgateway/models/glm-4.7-flash.toml
+++ b/providers/llmgateway/models/glm-4.7-flash.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 0

--- a/providers/llmgateway/models/glm-4.7-flashx.toml
+++ b/providers/llmgateway/models/glm-4.7-flashx.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.7-flashx"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.07

--- a/providers/llmgateway/models/glm-4.7-flashx.toml
+++ b/providers/llmgateway/models/glm-4.7-flashx.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flashx"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.07

--- a/providers/llmgateway/models/glm-4.7.toml
+++ b/providers/llmgateway/models/glm-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/glm-4.7.toml
+++ b/providers/llmgateway/models/glm-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.7"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/glm-5.1.toml
+++ b/providers/llmgateway/models/glm-5.1.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.1"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/glm-5.1.toml
+++ b/providers/llmgateway/models/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/glm-5.toml
+++ b/providers/llmgateway/models/glm-5.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/glm-5.toml
+++ b/providers/llmgateway/models/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Splits the ZhipuAI changes from #2171 into a reviewable 14-model PR.

## Result

LLMGateway exposes a binary toggle, rather than distinct effort levels, for:

- `glm-4.5-x`
- `glm-4.5`
- `glm-4.5v`
- `glm-4.6`
- `glm-4.6v-flash`
- `glm-4.6v-flashx`
- `glm-4.6v`
- `glm-4.7-flashx`
- `glm-4.7`
- `glm-5.1`
- `glm-5`

These models use `reasoning_options = [{ type = "toggle" }]`.

The following root IDs use `reasoning_options = []` because LLMGateway's current live mappings are not reasoning-capable:

- `glm-4.5-air`
- `glm-4.5-flash`
- `glm-4.7-flash`

## Exact toggle semantics

For a selected Z.AI mapping with `reasoning: true`, LLMGateway translates:

| Caller value | Provider request |
| --- | --- |
| omitted, JSON `null`, `none`, or `minimal` | `thinking.type = "disabled"` |
| `low`, `medium`, `high`, `xhigh`, or `max` | `thinking.type = "enabled"` |

`low`, `medium`, and `high` therefore produce the same provider request and are not distinct effort levels through LLMGateway.

## Evidence

- [LLMGateway Z.AI translation at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/actions/src/prepare-request-body.ts#L1660-L1669) maps any supplied value other than `minimal` to `thinking.type = "enabled"`; omission and `minimal` map to `disabled`.
- [LLMGateway `none` normalization at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/actions/src/prepare-request-body.ts#L806-L835) removes `none` before the Z.AI branch and aliases generic `max` to `high` outside native Anthropic handling.
- [Z.AI Thinking Mode](https://docs.z.ai/guides/capabilities/thinking-mode), accessed 2026-06-24, documents `thinking.type = "enabled" | "disabled"` as the model thinking switch.
- [Z.AI Core Parameters](https://docs.z.ai/guides/overview/concept-param), accessed 2026-06-24, documents genuine multi-level `reasoning_effort` only for GLM-5.2 and later, outside this PR.
- [LLMGateway's Z.AI registry at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/models/src/models/zai.ts#L405-L535) marks `glm-4.5-air` and `glm-4.5-flash` non-reasoning.
- [LLMGateway's GLM-4.7 Flash registry at audited commit `93715fc7`](https://github.com/theopenco/llmgateway/blob/93715fc71a25cd1face731aac9e79bca4c264ea5/packages/models/src/models/zai.ts#L727-L797) routes the `glm-4.7-flash` root ID only to Embercloud with no reasoning flag; Z.AI's reasoning-capable free mapping is exposed under the separate `glm-4.7-flash-free` ID.
- [LLMGateway `GET /v1/models`](https://api.llmgateway.io/v1/models), accessed 2026-06-24, confirms the live provider mappings and capability flags above.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2171.
