### PR TITLE
[nano-gpt/alibaba part 1] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/Qwen3.5-27B-Anko.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Anko.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Anko.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Anko.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted-Lite.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-Derestricted.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted-Lite.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v2-Derestricted.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-06"
 last_updated = "2026-04-06"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted-Lite.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-BlueStar-v3-Derestricted.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Derestricted.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Infracelestial.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Infracelestial.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Infracelestial.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Infracelestial.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted-Lite.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-DPO-V2-Derestricted.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted-Lite.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Marvin-V2-Derestricted.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Musica-v1.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Musica-v1.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-Musica-v1.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-Musica-v1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-NaNovel-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-NaNovel-Derestricted-Lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Qwen3.5-27B-NaNovel-Derestricted-Lite.toml
+++ b/providers/nano-gpt/models/Qwen3.5-27B-NaNovel-Derestricted-Lite.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Adds reasoning toggles and `1_024..81_920` token budgets for 15 live Nano-GPT Qwen3.5 27B finetunes.

Nano-GPT Chat provides the toggle; Nano-GPT Messages accepts `thinking.budget_tokens` for exact reasoning model IDs and translates non-Anthropic requests.

Evidence:
- https://nano-gpt.com/api/v1/models?detailed=true
- https://docs.nano-gpt.com/api-reference/endpoint/messages
- https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking
- https://docs.qwencloud.com/developer-guides/text-generation/thinking

Validation:
- `bun validate`
- `git diff --check`

Supersedes part of #2164.