### PR TITLE
[nano-gpt/alibaba part 3] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/alibaba/qwen3.6-27b:thinking.toml
+++ b/providers/nano-gpt/models/alibaba/qwen3.6-27b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-23"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/alibaba/qwen3.6-27b:thinking.toml
+++ b/providers/nano-gpt/models/alibaba/qwen3.6-27b:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-23"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_072 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen-plus.toml
+++ b/providers/nano-gpt/models/qwen-plus.toml
@@ -3,7 +3,7 @@ release_date = "2024-01-25"
 last_updated = "2024-01-25"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen-plus.toml
+++ b/providers/nano-gpt/models/qwen-plus.toml
@@ -3,6 +3,7 @@ release_date = "2024-01-25"
 last_updated = "2024-01-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen-plus.toml
+++ b/providers/nano-gpt/models/qwen-plus.toml
@@ -3,7 +3,7 @@ release_date = "2024-01-25"
 last_updated = "2024-01-25"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/nano-gpt/models/qwen3-vl-235b-a22b-thinking.toml
@@ -3,7 +3,7 @@ release_date = "2025-08-26"
 last_updated = "2025-08-26"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/nano-gpt/models/qwen3-vl-235b-a22b-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-26"
 last_updated = "2025-08-26"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-122b-a10b:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-122b-a10b:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-122b-a10b:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-122b-a10b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-27b:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-27b:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-27b:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-27b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-35b-a3b:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-35b-a3b:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-35b-a3b:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-35b-a3b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-flash:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-flash:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.5-flash:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.5-flash:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.7-max:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.7-max:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-21"
 last_updated = "2026-05-21"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 262_144 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.7-max:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.7-max:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-21"
 last_updated = "2026-05-21"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.7-plus:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.7-plus:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-01"
 last_updated = "2026-06-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen3.7-plus:thinking.toml
+++ b/providers/nano-gpt/models/qwen3.7-plus:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-06-01"
 last_updated = "2026-06-01"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 262_144 }]
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Adds provider-level reasoning controls for nine Nano-GPT Alibaba/Qwen models across Chat Completions and Anthropic-compatible Messages.

## Controls

- `qwen-plus`: toggle plus budget `1_024..81_920`.
- Qwen3.5 thinking IDs and Qwen3-VL Thinking: budget `1_024..81_920`; no toggle because model identity is thinking-only.
- Qwen3.6 27B Thinking: budget `1_024..131_072`.
- Qwen3.7 Max/Plus Thinking: budget `1_024..262_144`.

## Evidence

- [Nano-GPT Messages](https://docs.nano-gpt.com/api-reference/endpoint/messages) accepts `thinking.budget_tokens` for exact reasoning model IDs and translates non-Anthropic models internally.
- [Nano-GPT Chat reasoning](https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking) documents toggle/effort behavior.
- [Alibaba deep thinking](https://help.aliyun.com/en/model-studio/deep-thinking) documents Qwen toggles and `thinking_budget`.
- [Alibaba model table](https://help.aliyun.com/zh/model-studio/text-generation-model) documents model-specific maxima.

The earlier body incorrectly excluded budgets because they were not on Nano-GPT’s Chat endpoint.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.