### PR TITLE
[nano-gpt/allenai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/allenai/olmo-3-32b-think.toml
+++ b/providers/nano-gpt/models/allenai/olmo-3-32b-think.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the allenai changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/allenai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.