### PR TITLE
[nano-gpt/anthropic part 1] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-haiku-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-haiku-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-haiku-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-haiku-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-haiku-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-haiku-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:low.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:low.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:max.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:max.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:medium.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.6:thinking:medium.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.7.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.7.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.7.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.7:thinking.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.7:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.8.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.8.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-28"
 last_updated = "2026-05-28"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.8.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.8.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-28"
 last_updated = "2026-05-28"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-4.8:thinking.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-4.8:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-28"
 last_updated = "2026-05-28"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-opus-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-opus-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-sonnet-4.6:thinking.toml
+++ b/providers/nano-gpt/models/anthropic/claude-sonnet-4.6:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 knowledge = "2025-08-31"

--- a/providers/nano-gpt/models/anthropic/claude-sonnet-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-sonnet-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-sonnet-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-sonnet-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/anthropic/claude-sonnet-latest.toml
+++ b/providers/nano-gpt/models/anthropic/claude-sonnet-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-haiku-4-5-20251001-thinking.toml
+++ b/providers/nano-gpt/models/claude-haiku-4-5-20251001-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
## Summary

Adds reasoning controls for 15 Nano-GPT Anthropic-family models across Nano-GPT inference endpoints.

## Endpoint coverage

- Chat Completions accepts `reasoning_effort` / `reasoning.effort`.
- Anthropic-compatible `/api/v1/messages` accepts native `thinking.type = "enabled"` with `thinking.budget_tokens`. Nano-GPT documents full Anthropic compatibility and no-code-change migration.

## Controls

- Haiku latest: toggle plus budget `1_024..63_999`.
- Opus 4.6: Nano effort values plus manual budget `1_024..127_999`.
- Sonnet latest, currently Sonnet 4.6: Nano effort values plus budget `1_024..63_999`.
- Opus 4.7/4.8/latest: effort only; no manual budget.
- Fixed thinking/preset IDs remain `[]`.

## Evidence

- [Nano-GPT Messages](https://docs.nano-gpt.com/api-reference/endpoint/messages) documents full Anthropic compatibility, extended thinking, budget minimum, and exact supported Claude models.
- [Nano-GPT extended thinking](https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking) documents Chat effort controls.
- [Nano-GPT live catalog](https://nano-gpt.com/api/v1/models?detailed=true) supplies mutable alias targets.
- [Anthropic extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) documents model-specific manual-budget support.

The previous body incorrectly excluded `/messages` controls because one configured npm package used Chat Completions.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.