### PR TITLE
[nano-gpt/anthropic part 2] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/claude-opus-4-1-thinking.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-1-thinking:1024.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking:1024.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-1-thinking:32000.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking:32000.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-1-thinking:32768.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking:32768.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-1-thinking:8192.toml
+++ b/providers/nano-gpt/models/claude-opus-4-1-thinking:8192.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-5-20251101.toml
+++ b/providers/nano-gpt/models/claude-opus-4-5-20251101.toml
@@ -3,7 +3,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-5-20251101.toml
+++ b/providers/nano-gpt/models/claude-opus-4-5-20251101.toml
@@ -3,7 +3,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-5-20251101.toml
+++ b/providers/nano-gpt/models/claude-opus-4-5-20251101.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-5-20251101:thinking.toml
+++ b/providers/nano-gpt/models/claude-opus-4-5-20251101:thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-15"
 last_updated = "2025-07-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking:1024.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking:1024.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking:32000.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking:32000.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking:32768.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking:32768.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-opus-4-thinking:8192.toml
+++ b/providers/nano-gpt/models/claude-opus-4-thinking:8192.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-5-20250929-thinking.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-5-20250929-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-02-24"
 last_updated = "2025-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:1024.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:1024.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
## Summary

Adds reasoning controls for 15 Nano-GPT Anthropic-family models.

## Controls

`claude-opus-4-5-20251101` supports Nano-GPT Chat effort values `none|low|medium|high` and native Messages budget `1_024..63_999`. Fixed `-thinking`, `:thinking`, and numeric-budget aliases remain `reasoning_options = []` because their reasoning configuration is encoded in model identity.

## Evidence

- [Nano-GPT Messages](https://docs.nano-gpt.com/api-reference/endpoint/messages) documents full Anthropic compatibility and `thinking.budget_tokens`.
- [Nano-GPT extended thinking](https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking) documents Chat effort controls.
- [Nano-GPT suffixes](https://docs.nano-gpt.com/api-reference/miscellaneous/model-suffixes) documents fixed aliases.
- [Anthropic effort](https://platform.claude.com/docs/en/build-with-claude/effort) and [extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) document Opus 4.5 support.

The previous body incorrectly excluded the provider’s Messages endpoint.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.