### PR TITLE
[nano-gpt/anthropic part 3] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:32768.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:32768.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:64000.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:64000.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:8192.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:8192.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the anthropic part 3 changes from #2164 into a reviewable 3-model PR.

Scope is limited to `nano-gpt/anthropic part 3` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.