### PR TITLE
[nano-gpt/arcee-ai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/arcee-ai/trinity-large-thinking.toml
+++ b/providers/nano-gpt/models/arcee-ai/trinity-large-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-01"
 last_updated = "2026-04-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the arcee-ai changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/arcee-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.