### PR TITLE
[nano-gpt/baidu] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/ernie-5.0-thinking-preview.toml
+++ b/providers/nano-gpt/models/ernie-5.0-thinking-preview.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/ernie-5.1:thinking.toml
+++ b/providers/nano-gpt/models/ernie-5.1:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-10"
 last_updated = "2026-05-10"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the baidu changes from #2164 into a reviewable 2-model PR.

Scope is limited to `nano-gpt/baidu` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.