### PR TITLE
[nano-gpt/cohere] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/command-a-plus-05-2026.toml
+++ b/providers/nano-gpt/models/command-a-plus-05-2026.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-22"
 last_updated = "2026-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the cohere changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/cohere` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.