### PR TITLE
[nano-gpt/deepseek-ai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/deepseek-ai/DeepSeek-R1-0528.toml
+++ b/providers/nano-gpt/models/deepseek-ai/DeepSeek-R1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/deepseek-ai/deepseek-v3.2-exp-thinking.toml
+++ b/providers/nano-gpt/models/deepseek-ai/deepseek-v3.2-exp-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the deepseek-ai changes from #2164 into a reviewable 2-model PR.

Scope is limited to `nano-gpt/deepseek-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.