### PR TITLE
[nano-gpt/deepseek] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/deepseek-r1.toml
+++ b/providers/nano-gpt/models/deepseek-r1.toml
@@ -3,6 +3,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-latest.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-latest.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v3.2-speciale.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v3.2-speciale.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-02"
 last_updated = "2025-12-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v3.2-speciale.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v3.2-speciale.toml
@@ -4,7 +4,6 @@ release_date = "2025-12-02"
 last_updated = "2025-12-02"
 attachment = true
 reasoning = true
-reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v3.2:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v3.2:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-flash.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-flash:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-flash:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-flash:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-flash:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro:thinking.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro:thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Adds provider-specific reasoning controls for current Nano-GPT DeepSeek routes.

## Audit

DeepSeek V4 base IDs expose a toggle plus meaningful `high`/`xhigh` efforts; Nano-GPT `xhigh` maps to native DeepSeek `max`. Fixed V4 thinking aliases and `deepseek-latest` expose effort without a toggle. R1 and V3.2 Thinking remain fixed. The stale `deepseek-v3.2-speciale` entry receives no provider-specific claim.

## Evidence

- https://nano-gpt.com/api/v1/models?detailed=true
- https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking
- https://api-docs.deepseek.com/guides/thinking_mode
- https://api-docs.deepseek.com/quick_start/pricing

Catalog checked 2026-06-24.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.