### PR TITLE
[nano-gpt/google part 1] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/Gemma-4-31B-Cognitive-Unshackled.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Cognitive-Unshackled.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-DarkIdol.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-DarkIdol.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-GarnetV2.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-GarnetV2.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-Gemopus.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Gemopus.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-Musica-v1.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Musica-v1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-Queen.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-Queen.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/Gemma-4-31B-it.toml
+++ b/providers/nano-gpt/models/Gemma-4-31B-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-09"
 last_updated = "2026-04-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.0-flash-thinking-exp-01-21.toml
+++ b/providers/nano-gpt/models/gemini-2.0-flash-thinking-exp-01-21.toml
@@ -3,6 +3,7 @@ release_date = "2025-01-21"
 last_updated = "2025-01-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025-thinking.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -3,7 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -3,7 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
@@ -3,6 +3,7 @@ release_date = "2025-04-17"
 last_updated = "2025-04-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
@@ -3,7 +3,7 @@ release_date = "2025-04-17"
 last_updated = "2025-04-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
@@ -3,7 +3,7 @@ release_date = "2025-04-17"
 last_updated = "2025-04-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17:thinking.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17:thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-04-17"
 last_updated = "2025-04-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-05-20:thinking.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-05-20:thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-20"
 last_updated = "2025-05-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
## Summary

Adds Nano-GPT reasoning controls for 15 Google-family models across Chat Completions and Messages compatibility APIs.

## Controls

Configurable Gemini 2.5 Flash/Flash-Lite routes expose Nano Chat efforts, toggles, and numeric budgets through Nano-GPT Messages translation:

- Flash-Lite: positive budget `512..24576`, plus off toggle.
- Flash: budget `0..24576`, where zero disables thinking.
- Fixed thinking aliases remain `[]`.
- Gemma routes retain toggles.

## Evidence

- [Nano-GPT Messages](https://docs.nano-gpt.com/api-reference/endpoint/messages) documents extended thinking for reasoning models and translation for non-Anthropic models.
- [Nano-GPT Chat reasoning](https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking) documents effort controls.
- [Google Gemini thinking](https://ai.google.dev/gemini-api/docs/thinking) documents exact budget ranges.

The previous body incorrectly excluded controls available through Nano-GPT’s Messages endpoint.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.