### PR TITLE
[nano-gpt/google part 2] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025-thinking.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
@@ -3,7 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
@@ -3,7 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-exp-03-25.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-exp-03-25.toml
@@ -3,6 +3,7 @@ release_date = "2025-03-25"
 last_updated = "2025-03-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-exp-03-25.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-exp-03-25.toml
@@ -3,7 +3,7 @@ release_date = "2025-03-25"
 last_updated = "2025-03-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-03-25.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-03-25.toml
@@ -3,6 +3,7 @@ release_date = "2025-03-25"
 last_updated = "2025-03-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-03-25.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-03-25.toml
@@ -3,7 +3,7 @@ release_date = "2025-03-25"
 last_updated = "2025-03-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-05-06.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-06"
 last_updated = "2025-05-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-05-06.toml
@@ -3,7 +3,7 @@ release_date = "2025-05-06"
 last_updated = "2025-05-06"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-06-05.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-06-05.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-Fabled.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-Fabled.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-Garnet.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-Garnet.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-K1-v5.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-K1-v5.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-Larkspur-v0.5.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-Larkspur-v0.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemma-4-31B-MeroMero.toml
+++ b/providers/nano-gpt/models/gemma-4-31B-MeroMero.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3-flash-preview-thinking.toml
+++ b/providers/nano-gpt/models/google/gemini-3-flash-preview-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3-flash-preview.toml
+++ b/providers/nano-gpt/models/google/gemini-3-flash-preview.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3-flash-preview.toml
+++ b/providers/nano-gpt/models/google/gemini-3-flash-preview.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
## Summary

Adds Nano-GPT reasoning controls for 15 Google-family models across all inference compatibility endpoints.

## Controls

- Gemini 2.5 Flash routes: Chat efforts, toggle, and budget `0..24576`.
- Gemini 2.5 Pro routes: Chat efforts plus budget `128..32768`; no off toggle.
- Gemini 3 Flash: `minimal|low|medium|high`.
- Fixed thinking aliases remain `[]`; Gemma routes retain toggles.

## Evidence

- [Nano-GPT Messages](https://docs.nano-gpt.com/api-reference/endpoint/messages) documents extended-thinking requests and non-Anthropic translation.
- [Nano-GPT Chat reasoning](https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking) documents effort controls.
- [Google Gemini thinking](https://ai.google.dev/gemini-api/docs/thinking) documents 2.5 budgets and model restrictions.
- [Google Gemini 3](https://ai.google.dev/gemini-api/docs/gemini-3) documents levels.

The previous body incorrectly limited provider capability to Chat Completions.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.