### PR TITLE
[nano-gpt/google part 3] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-flash-lite.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-03"
 last_updated = "2026-03-03"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-flash-lite.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-03"
 last_updated = "2026-03-03"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-27"
 last_updated = "2026-02-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-pro-preview-high.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-pro-preview-high.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-21"
 last_updated = "2026-02-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-pro-preview-low.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-pro-preview-low.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-21"
 last_updated = "2026-02-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/nano-gpt/models/google/gemini-3.1-pro-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.5-flash-thinking.toml
+++ b/providers/nano-gpt/models/google/gemini-3.5-flash-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-19"
 last_updated = "2026-05-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.5-flash.toml
+++ b/providers/nano-gpt/models/google/gemini-3.5-flash.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-19"
 last_updated = "2026-05-19"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-3.5-flash.toml
+++ b/providers/nano-gpt/models/google/gemini-3.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-19"
 last_updated = "2026-05-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-flash-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-flash-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-flash-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-flash-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-flash-lite-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-flash-lite-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-flash-lite-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-flash-lite-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemini-pro-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-pro-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/nano-gpt/models/google/gemma-4-26b-a4b-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemma-4-26b-a4b-it:thinking.toml
+++ b/providers/nano-gpt/models/google/gemma-4-26b-a4b-it:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemma-4-31b-it.toml
+++ b/providers/nano-gpt/models/google/gemma-4-31b-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/google/gemma-4-31b-it:thinking.toml
+++ b/providers/nano-gpt/models/google/gemma-4-31b-it:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = true
 open_weights = false


### PR DESCRIPTION
## Summary

Adds audited reasoning controls to 14 Nano-GPT Google-family models.

## Control audit

Nano-GPT Chat Completions accepts top-level `reasoning_effort` or `reasoning.effort`.

- Gemini 3.1 Flash-Lite and Gemini 3.5 Flash: `minimal`, `low`, `medium`, `high`
- Gemini Flash latest and Flash-Lite latest aliases: `minimal`, `low`, `medium`, `high`
- Gemini 3.1 Pro, custom-tools, and Pro latest routes: `low`, `medium`, `high`
- fixed high, low, and thinking variants: `reasoning_options = []`
- Gemma 4 base routes: toggle
- Gemma 4 `:thinking` routes: `reasoning_options = []`

Gemini 3 models cannot fully disable thinking. Flash and Flash-Lite use `minimal` as the lowest supported level; Pro starts at `low`.

## Evidence

- [Nano-GPT extended thinking](https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking)
- [Nano-GPT live detailed catalog](https://nano-gpt.com/api/v1/models?detailed=true)
- [Google Gemini thinking controls](https://ai.google.dev/gemini-api/docs/thinking)
- [Google Gemini 3 guide](https://ai.google.dev/gemini-api/docs/gemini-3)

Sources and live model mappings were accessed on 2026-06-24. Nano-GPT aliases and route mappings are live service data and may change after that date.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.