### PR TITLE
[nano-gpt/holo] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/holo3-35b-a3b.toml
+++ b/providers/nano-gpt/models/holo3-35b-a3b.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/holo3-35b-a3b:thinking.toml
+++ b/providers/nano-gpt/models/holo3-35b-a3b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the holo changes from #2164 into a reviewable 2-model PR.

Scope is limited to `nano-gpt/holo` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.