### PR TITLE
[nano-gpt/huihui-ai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Llama-70B-abliterated.toml
+++ b/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Llama-70B-abliterated.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated.toml
+++ b/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the huihui-ai changes from #2164 into a reviewable 2-model PR.

Scope is limited to `nano-gpt/huihui-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.