### PR TITLE
[nano-gpt/inception] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/mercury-2.toml
+++ b/providers/nano-gpt/models/mercury-2.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the inception changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/inception` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.