### PR TITLE
[nano-gpt/inclusionai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/nano-gpt/models/inclusionai/ring-2.6-1t.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-08"
 last_updated = "2026-05-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the inclusionai changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/inclusionai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.