### PR TITLE
[nano-gpt/minimax] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/MiniMax-M2.toml
+++ b/providers/nano-gpt/models/MiniMax-M2.toml
@@ -3,6 +3,7 @@ release_date = "2025-10-25"
 last_updated = "2025-10-25"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-latest.toml
+++ b/providers/nano-gpt/models/minimax/minimax-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-latest.toml
+++ b/providers/nano-gpt/models/minimax/minimax-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m2.1.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-19"
 last_updated = "2025-12-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m2.5.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m2.7-turbo.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.7-turbo.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m2.7.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m2.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/minimax/minimax-m3:thinking.toml
+++ b/providers/nano-gpt/models/minimax/minimax-m3:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-01"
 last_updated = "2026-06-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Adds provider-specific reasoning controls for seven Nano-GPT MiniMax models.

## Audit

MiniMax M2.x reasoning is mandatory and cannot be disabled, so those IDs use empty controls. `minimax-latest` currently routes to MiniMax M3 adaptive thinking and exposes a toggle; the exact M3 thinking alias remains fixed. No effort or numeric budget is documented.

## Evidence

- https://nano-gpt.com/api/v1/models?detailed=true
- https://platform.minimax.io/docs/api-reference/text-openai-api
- https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking

Catalog checked 2026-06-24.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.