### PR TITLE
[nano-gpt/miromind] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/mirothinker-1-7-deepresearch-mini.toml
+++ b/providers/nano-gpt/models/mirothinker-1-7-deepresearch-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/mirothinker-1-7-deepresearch.toml
+++ b/providers/nano-gpt/models/mirothinker-1-7-deepresearch.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the miromind changes from #2164 into a reviewable 2-model PR.

Scope is limited to `nano-gpt/miromind` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.