### PR TITLE
[nano-gpt/mistral] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/mistral/mistral-medium-3.5.toml
+++ b/providers/nano-gpt/models/mistral/mistral-medium-3.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-29"
 last_updated = "2026-04-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mistral/mistral-medium-3.5:thinking.toml
+++ b/providers/nano-gpt/models/mistral/mistral-medium-3.5:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the mistral changes from #2164 into a reviewable 2-model PR.

Scope is limited to `nano-gpt/mistral` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.