### PR TITLE
[nano-gpt/mistralai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603.toml
+++ b/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603:thinking.toml
+++ b/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the mistralai changes from #2164 into a reviewable 2-model PR.

Scope is limited to `nano-gpt/mistralai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.