### PR TITLE
[nano-gpt/moonshotai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/moonshotai/kimi-k2-thinking-original.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2-thinking-original.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2-thinking-turbo-original.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2-thinking-turbo-original.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.5:thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.5:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-26"
 last_updated = "2026-01-26"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/moonshotai/kimi-k2.6:thinking.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-k2.6:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = true

--- a/providers/nano-gpt/models/moonshotai/kimi-latest.toml
+++ b/providers/nano-gpt/models/moonshotai/kimi-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the moonshotai changes from #2164 into a reviewable 5-model PR.

Scope is limited to `nano-gpt/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.