### PR TITLE
[nano-gpt/nanogpt] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/nanogpt/coding-router.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router:high.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router:high.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router:low.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router:low.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router:max.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router:max.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/nanogpt/coding-router:medium.toml
+++ b/providers/nano-gpt/models/nanogpt/coding-router:medium.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the NanoGPT-native changes from #2164 into a reviewable 5-model PR.

Scope is limited to `nano-gpt/nanogpt`. Supersedes part of #2164.

## Audit result

- `nanogpt/coding-router` and its fixed `:low`, `:medium`, `:high`, and `:max` IDs use `reasoning_options = []`.
- Nano-GPT describes those suffixes as router tiers that select concrete coding routes, not as caller-selectable reasoning effort.
- No numeric reasoning budget is claimed.

## Provider mechanism

Nano-GPT Chat Completions accepts top-level `reasoning_effort` or nested `reasoning.effort`; top-level `reasoning_effort` is authoritative when both are present. `none` disables reasoning and non-`none` values request reasoning mode. This generic request mechanism does not establish that Coding Router quality tiers are reasoning effort levels.

## Evidence

- [Nano-GPT live model catalog](https://nano-gpt.com/api/v1/models?detailed=true) lists the base router and all four fixed-tier IDs. Its descriptions state that the base defaults to high, supports body tier overrides, and that each suffixed ID selects a routing tier.
- [Nano-GPT Extended Thinking](https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking) documents reasoning separately through `reasoning_effort` / `reasoning.effort`.
- [Nano-GPT Model Suffixes](https://docs.nano-gpt.com/api-reference/miscellaneous/model-suffixes) distinguishes model-identity suffixes from request controls.

Catalog and documentation checked 2026-06-24.

## Verification

- `bun validate`
- `git diff --check`