### PR TITLE
[nano-gpt/nousresearch] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/hermes-high.toml
+++ b/providers/nano-gpt/models/hermes-high.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/hermes-low.toml
+++ b/providers/nano-gpt/models/hermes-low.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/hermes-medium.toml
+++ b/providers/nano-gpt/models/hermes-medium.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the nousresearch changes from #2164 into a reviewable 3-model PR.

Scope is limited to `nano-gpt/nousresearch` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.