### PR TITLE
[nano-gpt/nvidia] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/providers/nano-gpt/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -5,6 +5,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b:thinking.toml
+++ b/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b:thinking.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the nvidia changes from #2164 into a reviewable 3-model PR.

Scope is limited to `nano-gpt/nvidia` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.