### PR TITLE
[nano-gpt/openai part 2] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/openai/gpt-5.5.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-latest.toml
+++ b/providers/nano-gpt/models/openai/gpt-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-latest.toml
+++ b/providers/nano-gpt/models/openai/gpt-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-29"
 last_updated = "2026-03-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-oss-120b.toml
+++ b/providers/nano-gpt/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-oss-20b.toml
+++ b/providers/nano-gpt/models/openai/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/nano-gpt/models/openai/gpt-oss-safeguard-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-29"
 last_updated = "2025-10-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o1-preview.toml
+++ b/providers/nano-gpt/models/openai/o1-preview.toml
@@ -4,6 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-09-12"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o1.toml
+++ b/providers/nano-gpt/models/openai/o1.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-17"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-deep-research.toml
+++ b/providers/nano-gpt/models/openai/o3-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-mini-high.toml
+++ b/providers/nano-gpt/models/openai/o3-mini-high.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-mini-low.toml
+++ b/providers/nano-gpt/models/openai/o3-mini-low.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-mini.toml
+++ b/providers/nano-gpt/models/openai/o3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/o3-pro-2025-06-10.toml
+++ b/providers/nano-gpt/models/openai/o3-pro-2025-06-10.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-10"
 last_updated = "2025-06-10"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/o4-mini-deep-research.toml
+++ b/providers/nano-gpt/models/openai/o4-mini-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o4-mini-high.toml
+++ b/providers/nano-gpt/models/openai/o4-mini-high.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits OpenAI part 2 changes from #2164 into a reviewable 15-model PR.

Scope is limited to `nano-gpt/openai part 2`. Supersedes part of #2164.

## Audit result

- GPT-5.5: `none`, `low`, `medium`, `high`, `xhigh`.
- GPT-5: `minimal`, `low`, `medium`, `high`.
- `openai/gpt-latest` currently routes to GPT-5.5, so it uses `none`, `low`, `medium`, `high`, `xhigh`. This mutable alias must be revisited when Nano-GPT changes its target.
- GPT-OSS 120B, 20B, and Safeguard 20B: `low`, `medium`, `high`.
- o1/o1-preview, o3-mini, and versioned o3-pro: `low`, `medium`, `high`.
- o3/o4-mini deep-research routes: `medium`.
- Fixed `o3-mini-low`, `o3-mini-high`, and `o4-mini-high` identities use `reasoning_options = []`.
- No numeric reasoning budget is claimed.

## Provider mechanism

Nano-GPT Chat Completions accepts top-level `reasoning_effort` or nested `reasoning.effort`; `none` disables reasoning and non-`none` values request it. Fixed-effort model IDs have no additional verified caller-selectable control. Nano-GPT Responses does not support deep-research variants, so those entries describe Chat Completions behavior.

## Evidence

- [Nano-GPT Extended Thinking](https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking) documents effort fields, precedence, and values.
- [Nano-GPT Responses](https://docs.nano-gpt.com/api-reference/endpoint/responses) states that deep-research variants are unsupported on that endpoint.
- [Nano-GPT live model catalog](https://nano-gpt.com/api/v1/models?detailed=true) states that `openai/gpt-latest` currently routes to GPT-5.5.
- [GPT-5.5](https://platform.openai.com/docs/models/gpt-5.5) documents `none`, `low`, `medium`, `high`, `xhigh`.
- [GPT-5](https://platform.openai.com/docs/models/gpt-5) documents `minimal`, `low`, `medium`, `high`.
- [GPT-OSS 120B](https://platform.openai.com/docs/models/gpt-oss-120b) documents configurable `low`, `medium`, `high`.
- [o3-mini](https://platform.openai.com/docs/models/o3-mini), [o3-pro](https://platform.openai.com/docs/models/o3-pro), [o3 deep research](https://platform.openai.com/docs/models/o3-deep-research), and [o4-mini deep research](https://platform.openai.com/docs/models/o4-mini-deep-research) identify the corresponding reasoning models and route constraints.

Catalog and documentation checked 2026-06-24.

## Verification

- `bun validate`
- `git diff --check`