### PR TITLE
[nano-gpt/openai part 3] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/openai/o4-mini.toml
+++ b/providers/nano-gpt/models/openai/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the openai part 3 changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/openai part 3` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.