### PR TITLE
[nano-gpt/pamanseau] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/pamanseau/OpenReasoning-Nemotron-32B.toml
+++ b/providers/nano-gpt/models/pamanseau/OpenReasoning-Nemotron-32B.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-21"
 last_updated = "2025-08-21"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the pamanseau changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/pamanseau` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.