### PR TITLE
[nano-gpt/perceptron] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/perceptron/perceptron-mk1.toml
+++ b/providers/nano-gpt/models/perceptron/perceptron-mk1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the perceptron changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/perceptron` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.