### PR TITLE
[nano-gpt/perplexity] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/sonar-reasoning-pro.toml
+++ b/providers/nano-gpt/models/sonar-reasoning-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the perplexity changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/perplexity` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.