### PR TITLE
[nano-gpt/qwen] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
+++ b/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-19"
 last_updated = "2026-04-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
+++ b/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
@@ -4,7 +4,6 @@ release_date = "2026-04-19"
 last_updated = "2026-04-19"
 attachment = true
 reasoning = true
-reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b-thinking.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b-thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b-thinking.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-397b-a17b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/qwen3.5-9b.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-9b.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-10"
 last_updated = "2026-03-10"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/qwen3.5-9b.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-9b.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-10"
 last_updated = "2026-03-10"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/qwen3.5-plus-thinking.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-plus-thinking.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 81_920 }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/qwen/qwen3.5-plus-thinking.toml
+++ b/providers/nano-gpt/models/qwen/qwen3.5-plus-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Adds Nano-GPT reasoning controls for three live Qwen models.

- `qwen3.5-9b`: toggle plus budget `1_024..81_920`.
- `qwen3.5-397b-a17b-thinking` and `qwen3.5-plus-thinking`: thinking-only budget `1_024..81_920`.
- Stale `Qwen3.6-35B-A3B:thinking`: no provider-specific claim.

Evidence:
- https://docs.nano-gpt.com/api-reference/endpoint/messages
- https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking
- https://docs.qwencloud.com/developer-guides/text-generation/thinking
- https://nano-gpt.com/api/v1/models?detailed=true

The earlier body incorrectly omitted Messages-compatible budgets.

Validation:
- `bun validate`
- `git diff --check`

Supersedes part of #2164.