### PR TITLE
[nano-gpt/sarvam] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/sarvam-105b.toml
+++ b/providers/nano-gpt/models/sarvam-105b.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/sarvam-30b.toml
+++ b/providers/nano-gpt/models/sarvam-30b.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the sarvam changes from #2164 into a reviewable 2-model PR.

Scope is limited to `nano-gpt/sarvam` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.