### PR TITLE
[nano-gpt/stepfun-ai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/stepfun-ai/step-3.5-flash-2603.toml
+++ b/providers/nano-gpt/models/stepfun-ai/step-3.5-flash-2603.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-14"
 last_updated = "2026-04-14"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/stepfun-ai/step-3.5-flash.toml
+++ b/providers/nano-gpt/models/stepfun-ai/step-3.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-02"
 last_updated = "2026-02-02"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Splits the stepfun-ai changes from #2164 into a reviewable 2-model PR.

Scope is limited to `nano-gpt/stepfun-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.