### PR TITLE
[nano-gpt/stepfun] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/stepfun/step-3.7-flash:thinking.toml
+++ b/providers/nano-gpt/models/stepfun/step-3.7-flash:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-29"
 last_updated = "2026-05-29"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the stepfun changes from #2164 into a reviewable 1-model PR.

Scope is limited to `nano-gpt/stepfun` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.