### PR TITLE
[nano-gpt/TEE] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/TEE/deepseek-v4-pro.toml
+++ b/providers/nano-gpt/models/TEE/deepseek-v4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/deepseek-v4-pro:thinking.toml
+++ b/providers/nano-gpt/models/TEE/deepseek-v4-pro:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-29"
 last_updated = "2026-04-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/gemma-4-31b-it.toml
+++ b/providers/nano-gpt/models/TEE/gemma-4-31b-it.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-26"
 last_updated = "2026-05-26"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/TEE/gemma4-31b:thinking.toml
+++ b/providers/nano-gpt/models/TEE/gemma4-31b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-02"
 last_updated = "2026-05-02"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/glm-5.1-thinking.toml
+++ b/providers/nano-gpt/models/TEE/glm-5.1-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/kimi-k2.5-thinking.toml
+++ b/providers/nano-gpt/models/TEE/kimi-k2.5-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-29"
 last_updated = "2026-01-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/TEE/minimax-m2.5.toml
+++ b/providers/nano-gpt/models/TEE/minimax-m2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/qwen3.5-122b-a10b.toml
+++ b/providers/nano-gpt/models/TEE/qwen3.5-122b-a10b.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-26"
 last_updated = "2026-05-26"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/TEE/qwen3.6-35b-a3b-uncensored.toml
+++ b/providers/nano-gpt/models/TEE/qwen3.6-35b-a3b-uncensored.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-23"
 last_updated = "2026-05-23"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/qwen3.6-35b-a3b-uncensored.toml
+++ b/providers/nano-gpt/models/TEE/qwen3.6-35b-a3b-uncensored.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-23"
 last_updated = "2026-05-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/TEE/qwen3.6-35b-a3b-uncensored.toml
+++ b/providers/nano-gpt/models/TEE/qwen3.6-35b-a3b-uncensored.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-23"
 last_updated = "2026-05-23"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 131_072 }]
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Adds Nano-GPT reasoning controls for nine TEE models.

Exact thinking identities remain `[]`; hybrid reasoning models expose toggles. `TEE/qwen3.6-35b-a3b-uncensored` additionally exposes a Messages-compatible reasoning budget `1_024..131_072`.

Evidence:
- https://docs.nano-gpt.com/api-reference/endpoint/messages
- https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking
- https://nano-gpt.com/api/v1/models?detailed=true
- https://help.aliyun.com/en/model-studio/deep-thinking

The previous metadata omitted the provider’s Messages budget control.

Validation:
- `bun validate`
- `git diff --check`

Supersedes part of #2164.