### PR TITLE
[nano-gpt/x-ai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/x-ai/grok-4.20-multi-agent.toml
+++ b/providers/nano-gpt/models/x-ai/grok-4.20-multi-agent.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-31"
 last_updated = "2026-03-31"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/x-ai/grok-4.20.toml
+++ b/providers/nano-gpt/models/x-ai/grok-4.20.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-31"
 last_updated = "2026-03-31"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/x-ai/grok-4.3.toml
+++ b/providers/nano-gpt/models/x-ai/grok-4.3.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/x-ai/grok-build-0.1.toml
+++ b/providers/nano-gpt/models/x-ai/grok-build-0.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-20"
 last_updated = "2026-05-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/x-ai/grok-latest.toml
+++ b/providers/nano-gpt/models/x-ai/grok-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Splits the x-ai changes from #2164 into a reviewable 5-model PR.

Scope is limited to `nano-gpt/x-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2164.