### PR TITLE
[nano-gpt/z-ai] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/z-ai/glm-4.5v.toml
+++ b/providers/nano-gpt/models/z-ai/glm-4.5v.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-22"
 last_updated = "2025-11-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/z-ai/glm-4.5v:thinking.toml
+++ b/providers/nano-gpt/models/z-ai/glm-4.5v:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-22"
 last_updated = "2025-11-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/z-ai/glm-4.6.toml
+++ b/providers/nano-gpt/models/z-ai/glm-4.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/z-ai/glm-4.6:thinking.toml
+++ b/providers/nano-gpt/models/z-ai/glm-4.6:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/z-ai/glm-5v-turbo:thinking.toml
+++ b/providers/nano-gpt/models/z-ai/glm-5v-turbo:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Adds provider-specific reasoning controls for five Nano-GPT Z.AI models.

## Audit

All exact IDs were live on 2026-06-24. GLM-4.5V and GLM-4.6 base routes expose toggles; exact thinking variants and GLM-5V Turbo Thinking are fixed. Z.AI effort begins with GLM-5.2, so no effort or budget is claimed here.

## Evidence

- https://nano-gpt.com/api/v1/models?detailed=true
- https://docs.z.ai/guides/capabilities/thinking
- https://docs.z.ai/guides/capabilities/thinking-mode
- https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking

Supersedes part of #2164.