### PR TITLE
[nano-gpt/zai-org part 1] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/zai-org/GLM-4.5-Air:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/GLM-4.5-Air:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/GLM-4.5:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/GLM-4.5:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/GLM-4.6-turbo:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/GLM-4.6-turbo:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-02"
 last_updated = "2025-10-02"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.6-original.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.6-original.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.6-original.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.6-original.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-flash-original.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-flash-original.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-flash-original:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-flash-original:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-flash.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-4.7-flash:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-flash:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-original.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-original.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7-original:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7-original:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-4.7.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-29"
 last_updated = "2026-01-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-4.7:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-4.7:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-5-original.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5-original.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-5-original:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5-original:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-5.1.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = true


### PR DESCRIPTION
Adds provider-specific reasoning controls for 15 Nano-GPT zai-org models.

## Audit

Exact thinking variants are fixed. Base/original GLM 4.6, GLM 4.7, GLM 5, and GLM 5.1 routes expose toggles through Nano-GPT `reasoning_effort = "none"` versus non-`none`. GLM 4.6 does not support graded effort; Z.AI effort starts with GLM-5.2.

## Evidence

- https://nano-gpt.com/api/v1/models?detailed=true
- https://docs.z.ai/guides/capabilities/thinking
- https://docs.z.ai/guides/capabilities/thinking-mode
- https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking

Catalog checked 2026-06-24.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.