### PR TITLE
[nano-gpt/zai-org part 2] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/zai-org/glm-5.1:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.1:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-5.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-5:thinking.toml
+++ b/providers/nano-gpt/models/zai-org/glm-5:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = true

--- a/providers/nano-gpt/models/zai-org/glm-latest.toml
+++ b/providers/nano-gpt/models/zai-org/glm-latest.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/zai-org/glm-latest.toml
+++ b/providers/nano-gpt/models/zai-org/glm-latest.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-03"
 last_updated = "2026-05-03"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Adds provider-specific reasoning controls for four Nano-GPT zai-org models.

## Audit

GLM-5 exposes a toggle; exact GLM-5 and GLM-5.1 thinking aliases are fixed. `glm-latest` currently routes to GLM-5.2 Thinking and has two meaningful Nano-GPT effort levels: `high` and `xhigh`; Z.AI maps `xhigh` to native `max`, while `low` and `medium` collapse to `high`.

## Evidence

- https://nano-gpt.com/api/v1/models?detailed=true
- https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking
- https://docs.z.ai/guides/capabilities/thinking
- https://docs.z.ai/guides/capabilities/thinking-mode

Catalog checked 2026-06-24.

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of #2164.