### PR TITLE
[poe/cerebras] Add reasoning options

### DIFF
--- a/providers/poe/models/cerebras/gpt-oss-120b-cs.toml
+++ b/providers/poe/models/cerebras/gpt-oss-120b-cs.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/cerebras/qwen3-235b-2507-cs.toml
+++ b/providers/poe/models/cerebras/qwen3-235b-2507-cs.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/cerebras/qwen3-32b-cs.toml
+++ b/providers/poe/models/cerebras/qwen3-32b-cs.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-15"
 last_updated = "2025-05-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true


### PR DESCRIPTION
Splits the cerebras changes from #2169 into a reviewable 3-model PR.

Scope is limited to `poe/cerebras` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2169.