### PR TITLE
[poe/empiriolabs] Add reasoning options

### DIFF
--- a/providers/poe/models/empiriolabs/deepseek-v4-flash-el.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-flash-el.toml
@@ -1,6 +1,7 @@
 name = "DeepSeek-V4-Flash-EL"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 release_date = "2026-04-24"
 last_updated = "2026-05-02"

--- a/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
@@ -1,6 +1,7 @@
 name = "DeepSeek-V4-Pro-EL"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 release_date = "2026-04-24"
 last_updated = "2026-05-02"


### PR DESCRIPTION
Splits the empiriolabs changes from #2169 into a reviewable 2-model PR.

Scope is limited to `poe/empiriolabs` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2169.