### PR TITLE
[poe/novita] Add reasoning options

### DIFF
--- a/providers/poe/models/novita/deepseek-v3.2.toml
+++ b/providers/poe/models/novita/deepseek-v3.2.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 open_weights = true
 tool_call = true

--- a/providers/poe/models/novita/glm-4.6v.toml
+++ b/providers/poe/models/novita/glm-4.6v.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-09"
 last_updated = "2025-12-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-4.7-flash.toml
+++ b/providers/poe/models/novita/glm-4.7-flash.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-4.7-n.toml
+++ b/providers/poe/models/novita/glm-4.7-n.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-4.7.toml
+++ b/providers/poe/models/novita/glm-4.7.toml
@@ -3,7 +3,6 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = true
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-4.7.toml
+++ b/providers/poe/models/novita/glm-4.7.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-5.toml
+++ b/providers/poe/models/novita/glm-5.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-15"
 last_updated = "2026-02-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/kimi-k2-thinking.toml
+++ b/providers/poe/models/novita/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-07"
 last_updated = "2025-11-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/kimi-k2-thinking.toml
+++ b/providers/poe/models/novita/kimi-k2-thinking.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-07"
 last_updated = "2025-11-07"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/kimi-k2.5.toml
+++ b/providers/poe/models/novita/kimi-k2.5.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/kimi-k2.6.toml
+++ b/providers/poe/models/novita/kimi-k2.6.toml
@@ -1,6 +1,7 @@
 name = "Kimi-K2.6"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 temperature = true
 knowledge = "2025-04"

--- a/providers/poe/models/novita/minimax-m2.1.toml
+++ b/providers/poe/models/novita/minimax-m2.1.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-26"
 last_updated = "2025-12-26"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/minimax-m2.1.toml
+++ b/providers/poe/models/novita/minimax-m2.1.toml
@@ -3,7 +3,7 @@ release_date = "2025-12-26"
 last_updated = "2025-12-26"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 open_weights = false
 tool_call = true


### PR DESCRIPTION
Corrects Poe-specific Novita reasoning controls using Poe's live model catalog.

## Evidence

Audited against Poe's unauthenticated [`GET /v1/models`](https://api.poe.com/v1/models) response retrieved at `2026-06-24T04:24:36Z`.

The following Poe model IDs expose `enable_thinking` with a boolean schema and default `false`, establishing an explicit same-ID toggle with `true` and `false`:

- `deepseek-v3.2`
- `glm-4.6v`
- `glm-4.7-flash`
- `glm-4.7-n`
- `glm-5`
- `kimi-k2-thinking`
- `kimi-k2.5`
- `kimi-k2.6`
- `minimax-m2.1`

`glm-4.7` was absent from the current public catalog, so only the reasoning claim added by this PR was removed. Poe's [Kimi K2.5 page](https://poe.com/Kimi-K2.5) independently describes its on/off thinking parameter. Poe's [model-list reference](https://creator.poe.com/api-reference/listModels) documents the public catalog.

## Wire Caveat

For `POST /v1/chat/completions`, `enable_thinking` is a custom Poe bot field merged into the JSON body through the OpenAI SDK's `extra_body` mechanism. Poe documents the standard Chat Completions `reasoning_effort` argument as ignored. For `POST /v1/responses`, Poe uses `reasoning: {"effort": "..."}` only where that bot supports Responses. Poe also describes custom forwarding as best-effort, so the model-specific catalog schemas above are used rather than assuming upstream passthrough.

Source: [Poe OpenAI-compatible API](https://creator.poe.com/docs/external-applications/openai-compatible-api#detailed-openai-compatible-api-support).

## Validation

- `bun validate`
- `git diff --check`

Supersedes the Novita portion of #2169.
