### PR TITLE
[poe/openai part 1] Add reasoning options

### DIFF
--- a/providers/poe/models/openai/gpt-5-codex.toml
+++ b/providers/poe/models/openai/gpt-5-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-23"
 last_updated = "2025-09-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5-mini.toml
+++ b/providers/poe/models/openai/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-25"
 last_updated = "2025-06-25"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5-mini.toml
+++ b/providers/poe/models/openai/gpt-5-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-06-25"
 last_updated = "2025-06-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5-nano.toml
+++ b/providers/poe/models/openai/gpt-5-nano.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5-nano.toml
+++ b/providers/poe/models/openai/gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5-pro.toml
+++ b/providers/poe/models/openai/gpt-5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-06"
 last_updated = "2025-10-06"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/poe/models/openai/gpt-5.1-codex-max.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/poe/models/openai/gpt-5.1-codex-max.toml
@@ -3,7 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/poe/models/openai/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-codex.toml
+++ b/providers/poe/models/openai/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-instant.toml
+++ b/providers/poe/models/openai/gpt-5.1-instant.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1-instant.toml
+++ b/providers/poe/models/openai/gpt-5.1-instant.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1.toml
+++ b/providers/poe/models/openai/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.1.toml
+++ b/providers/poe/models/openai/gpt-5.1.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-11-12"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.2-codex.toml
+++ b/providers/poe/models/openai/gpt-5.2-codex.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.2-codex.toml
+++ b/providers/poe/models/openai/gpt-5.2-codex.toml
@@ -3,7 +3,7 @@ release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.2-pro.toml
+++ b/providers/poe/models/openai/gpt-5.2-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.2-pro.toml
+++ b/providers/poe/models/openai/gpt-5.2-pro.toml
@@ -3,7 +3,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.2.toml
+++ b/providers/poe/models/openai/gpt-5.2.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.2.toml
+++ b/providers/poe/models/openai/gpt-5.2.toml
@@ -3,7 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.3-codex-spark.toml
+++ b/providers/poe/models/openai/gpt-5.3-codex-spark.toml
@@ -3,7 +3,6 @@ release_date = "2026-03-04"
 last_updated = "2026-03-04"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.3-codex-spark.toml
+++ b/providers/poe/models/openai/gpt-5.3-codex-spark.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-04"
 last_updated = "2026-03-04"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.3-codex.toml
+++ b/providers/poe/models/openai/gpt-5.3-codex.toml
@@ -3,7 +3,7 @@ release_date = "2026-02-10"
 last_updated = "2026-02-10"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.3-codex.toml
+++ b/providers/poe/models/openai/gpt-5.3-codex.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-10"
 last_updated = "2026-02-10"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4-mini.toml
+++ b/providers/poe/models/openai/gpt-5.4-mini.toml
@@ -3,7 +3,7 @@ release_date = "2026-03-12"
 last_updated = "2026-03-12"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4-mini.toml
+++ b/providers/poe/models/openai/gpt-5.4-mini.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-12"
 last_updated = "2026-03-12"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true


### PR DESCRIPTION
Corrects Poe-specific OpenAI reasoning controls using Poe's live model catalog, part 1.

## Evidence

Audited against Poe's unauthenticated [`GET /v1/models`](https://api.poe.com/v1/models) response retrieved at `2026-06-24T04:24:36Z`. The catalog exposes the custom field `reasoning_effort` with exact per-model enums:

- `gpt-5-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex`: `low, medium, high`.
- `gpt-5-mini`, `gpt-5-nano`: `minimal, low, medium, high`.
- `gpt-5.1-codex-max`, `gpt-5.2-codex`, `gpt-5.3-codex`: `low, medium, high, xhigh`.
- `gpt-5.1`: `none, low, medium, high`.
- `gpt-5.2`: `none, low, medium, high, xhigh`.
- `gpt-5.2-pro`: `medium, high, xhigh`.
- `gpt-5.4-mini`: `none, low, medium, high, xhigh`.

`gpt-5-pro` exposes no selectable reasoning parameter. `gpt-5.1-instant` reports `supports_reasoning_effort: false` and exposes no reasoning parameter; both therefore use audited empty lists. `gpt-5.3-codex-spark` was absent from the current public catalog, so only the claim added by this PR was removed.

Poe's [model-list reference](https://creator.poe.com/api-reference/listModels) documents the public catalog. OpenAI's [reasoning guide](https://platform.openai.com/docs/guides/reasoning#reasoning-effort) corroborates that values are model-dependent; Poe's catalog is authoritative for Poe exposure.

## Wire Caveat

For `POST /v1/chat/completions`, `reasoning_effort` must be merged into the JSON body through the OpenAI SDK's `extra_body` mechanism; Poe documents the SDK's standard Chat Completions `reasoning_effort` argument as ignored. For `POST /v1/responses`, the wire shape is `reasoning: {"effort": "..."}`. Poe also describes custom forwarding as best-effort, so the model-specific catalog enums above are used rather than assuming upstream support.

Source: [Poe OpenAI-compatible API](https://creator.poe.com/docs/external-applications/openai-compatible-api#detailed-openai-compatible-api-support).

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of the OpenAI portion of #2169.
