### PR TITLE
[poe/openai part 2] Add reasoning options

### DIFF
--- a/providers/poe/models/openai/gpt-5.4-nano.toml
+++ b/providers/poe/models/openai/gpt-5.4-nano.toml
@@ -3,7 +3,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4-nano.toml
+++ b/providers/poe/models/openai/gpt-5.4-nano.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4-pro.toml
+++ b/providers/poe/models/openai/gpt-5.4-pro.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4-pro.toml
+++ b/providers/poe/models/openai/gpt-5.4-pro.toml
@@ -3,7 +3,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4.toml
+++ b/providers/poe/models/openai/gpt-5.4.toml
@@ -3,7 +3,7 @@ release_date = "2026-02-26"
 last_updated = "2026-02-26"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.4.toml
+++ b/providers/poe/models/openai/gpt-5.4.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-26"
 last_updated = "2026-02-26"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.5-pro.toml
+++ b/providers/poe/models/openai/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high"] }]
 base_model_omit = ["limit.input"]
 name = "GPT-5.5-Pro"
 release_date = "2026-04-08"

--- a/providers/poe/models/openai/gpt-5.5-pro.toml
+++ b/providers/poe/models/openai/gpt-5.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
-reasoning_options = [{ type = "effort", values = ["medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 base_model_omit = ["limit.input"]
 name = "GPT-5.5-Pro"
 release_date = "2026-04-08"

--- a/providers/poe/models/openai/gpt-5.5.toml
+++ b/providers/poe/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 base_model_omit = ["limit.input"]
 release_date = "2026-04-08"
 last_updated = "2026-04-08"

--- a/providers/poe/models/openai/gpt-5.5.toml
+++ b/providers/poe/models/openai/gpt-5.5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 base_model_omit = ["limit.input"]
 release_date = "2026-04-08"
 last_updated = "2026-04-08"

--- a/providers/poe/models/openai/gpt-5.toml
+++ b/providers/poe/models/openai/gpt-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.toml
+++ b/providers/poe/models/openai/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o1-pro.toml
+++ b/providers/poe/models/openai/o1-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-19"
 last_updated = "2025-03-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o1.toml
+++ b/providers/poe/models/openai/o1.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-18"
 last_updated = "2024-12-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3-deep-research.toml
+++ b/providers/poe/models/openai/o3-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-27"
 last_updated = "2025-06-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3-mini-high.toml
+++ b/providers/poe/models/openai/o3-mini-high.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3-mini.toml
+++ b/providers/poe/models/openai/o3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3-pro.toml
+++ b/providers/poe/models/openai/o3-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-10"
 last_updated = "2025-06-10"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o3.toml
+++ b/providers/poe/models/openai/o3.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o4-mini-deep-research.toml
+++ b/providers/poe/models/openai/o4-mini-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-27"
 last_updated = "2025-06-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/o4-mini.toml
+++ b/providers/poe/models/openai/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true


### PR DESCRIPTION
Corrects Poe-specific OpenAI reasoning controls using Poe's live model catalog, part 2.

## Evidence

Audited against Poe's unauthenticated [`GET /v1/models`](https://api.poe.com/v1/models) response retrieved at `2026-06-24T04:24:36Z`. The catalog exposes the custom field `reasoning_effort` with exact per-model enums:

- `gpt-5.4-nano`, `gpt-5.4`, `gpt-5.5`: `none, low, medium, high, xhigh`.
- `gpt-5.4-pro`, `gpt-5.5-pro`: `medium, high, xhigh`.
- `gpt-5`: `minimal, low, medium, high`.
- `o1`, `o1-pro`, `o3-mini`, `o3`, `o3-pro`, `o4-mini`: `low, medium, high`.

`o3-deep-research` and `o4-mini-deep-research` expose no selectable reasoning parameter. `o3-mini-high` is a fixed-high bot and also exposes no selector. These three therefore use audited empty lists.

Poe's [model-list reference](https://creator.poe.com/api-reference/listModels) documents the public catalog. OpenAI's [reasoning guide](https://platform.openai.com/docs/guides/reasoning#reasoning-effort) corroborates that values are model-dependent; Poe's catalog is authoritative for Poe exposure.

## Wire Caveat

For `POST /v1/chat/completions`, `reasoning_effort` must be merged into the JSON body through the OpenAI SDK's `extra_body` mechanism; Poe documents the SDK's standard Chat Completions `reasoning_effort` argument as ignored. For `POST /v1/responses`, the wire shape is `reasoning: {"effort": "..."}`. Poe also describes custom forwarding as best-effort, so the model-specific catalog enums above are used rather than assuming upstream support.

Source: [Poe OpenAI-compatible API](https://creator.poe.com/docs/external-applications/openai-compatible-api#detailed-openai-compatible-api-support).

## Validation

- `bun validate`
- `git diff --check`

Supersedes part of the OpenAI portion of #2169.
