### PR TITLE
[poe/poetools] Add reasoning options

### DIFF
--- a/providers/poe/models/poetools/claude-code.toml
+++ b/providers/poe/models/poetools/claude-code.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-27"
 last_updated = "2025-11-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true


### PR DESCRIPTION
Splits the poetools changes from #2169 into a reviewable 1-model PR.

Scope is limited to `poe/poetools` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2169.