### PR TITLE
[poe/xai] Add reasoning options

### DIFF
--- a/providers/poe/models/xai/grok-3-mini.toml
+++ b/providers/poe/models/xai/grok-3-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-04-11"
 last_updated = "2025-04-11"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-3-mini.toml
+++ b/providers/poe/models/xai/grok-3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-11"
 last_updated = "2025-04-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-4-fast-reasoning.toml
+++ b/providers/poe/models/xai/grok-4-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-16"
 last_updated = "2025-09-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-4.1-fast-reasoning.toml
+++ b/providers/poe/models/xai/grok-4.1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-19"
 last_updated = "2025-11-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-4.toml
+++ b/providers/poe/models/xai/grok-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-10"
 last_updated = "2025-07-10"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/xai/grok-code-fast-1.toml
+++ b/providers/poe/models/xai/grok-code-fast-1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-22"
 last_updated = "2025-08-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true


### PR DESCRIPTION
Corrects Poe-specific xAI reasoning controls using Poe's live model catalog.

## Evidence

Audited against Poe's unauthenticated [`GET /v1/models`](https://api.poe.com/v1/models) response retrieved at `2026-06-24T04:24:36Z`:

- `grok-3-mini` exposes `reasoning_effort` with enum `low, medium, high` and default `low`.
- `grok-4-fast-reasoning`, `grok-4.1-fast-reasoning`, `grok-4`, and `grok-code-fast-1` expose no user-selectable reasoning parameter and retain audited empty lists.
- These five catalog entries advertise `/v1/chat/completions` and `/v1/messages`, not `/v1/responses`.

Poe's [Grok 3 Mini page](https://poe.com/Grok-3-Mini) independently states that the bot supports configurable reasoning effort. Poe's [model-list reference](https://creator.poe.com/api-reference/listModels) documents the public catalog. xAI's [reasoning guide](https://docs.x.ai/docs/guides/reasoning) corroborates that effort support is model-specific; Poe's catalog is authoritative for these Poe IDs.

## Wire Caveat

For `POST /v1/chat/completions`, `reasoning_effort` must be merged into the JSON body through the OpenAI SDK's `extra_body` mechanism; Poe documents the SDK's standard Chat Completions `reasoning_effort` argument as ignored. These audited xAI bots do not advertise Poe's Responses endpoint. Poe also describes custom forwarding as best-effort, so the model-specific catalog schema is used rather than assuming upstream passthrough.

Source: [Poe OpenAI-compatible API](https://creator.poe.com/docs/external-applications/openai-compatible-api#detailed-openai-compatible-api-support).

## Validation

- `bun validate`
- `git diff --check`

Supersedes the xAI portion of #2169.
