### PR TITLE
[siliconflow/google] Add reasoning options

### DIFF
--- a/providers/siliconflow/models/google/gemma-4-26B-A4B-it.toml
+++ b/providers/siliconflow/models/google/gemma-4-26B-A4B-it.toml
@@ -1,0 +1,16 @@
+base_model = "google/gemma-4-26b-a4b-it"
+attachment = false
+reasoning = false
+open_weights = false
+
+[cost]
+input = 0.12
+output = 0.40
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/siliconflow/models/google/gemma-4-31B-it.toml
+++ b/providers/siliconflow/models/google/gemma-4-31B-it.toml
@@ -1,0 +1,16 @@
+base_model = "google/gemma-4-31b-it"
+attachment = false
+reasoning = false
+open_weights = false
+
+[cost]
+input = 0.13
+output = 0.40
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Splits the google changes from #2136 into a reviewable 2-model PR.

Scope is limited to `siliconflow/google` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2136.