### PR TITLE
[siliconflow/openai] Add reasoning options

### DIFF
--- a/providers/siliconflow/models/openai/gpt-oss-120b.toml
+++ b/providers/siliconflow/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-13"
 last_updated = "2025-11-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the openai changes from #2136 into a reviewable 1-model PR.

Scope is limited to `siliconflow/openai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2136.