### PR TITLE
[siliconflow/stepfun-ai] Add reasoning options

### DIFF
--- a/providers/siliconflow-cn/models/stepfun-ai/Step-3.5-Flash.toml
+++ b/providers/siliconflow-cn/models/stepfun-ai/Step-3.5-Flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/siliconflow/models/stepfun-ai/Step-3.5-Flash.toml
+++ b/providers/siliconflow/models/stepfun-ai/Step-3.5-Flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Splits the stepfun-ai changes from #2136 into a reviewable 2-model PR.

Scope is limited to `siliconflow/stepfun-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2136.