### PR TITLE
[vercel/alibaba part 1] Add reasoning options

### DIFF
--- a/providers/vercel/models/alibaba/qwen-3-14b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-14b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen-3-30b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-30b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen-3-32b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-32b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen-3-32b.toml
+++ b/providers/vercel/models/alibaba/qwen-3-32b.toml
@@ -4,7 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 38_912 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen-3.6-max-preview.toml
+++ b/providers/vercel/models/alibaba/qwen-3.6-max-preview.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 131_072 }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/vercel/models/alibaba/qwen-3.6-max-preview.toml
+++ b/providers/vercel/models/alibaba/qwen-3.6-max-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/vercel/models/alibaba/qwen3-235b-a22b-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-235b-a22b-thinking.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-24"
 last_updated = "2025-04"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1, max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen3-235b-a22b-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-235b-a22b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-24"
 last_updated = "2025-04"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen3-coder-30b-a3b.toml
+++ b/providers/vercel/models/alibaba/qwen3-coder-30b-a3b.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen3-coder-30b-a3b.toml
+++ b/providers/vercel/models/alibaba/qwen3-coder-30b-a3b.toml
@@ -4,7 +4,7 @@ release_date = "2025-04-01"
 last_updated = "2025-04"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/vercel/models/alibaba/qwen3-coder-next.toml
+++ b/providers/vercel/models/alibaba/qwen3-coder-next.toml
@@ -2,6 +2,7 @@ name = "Qwen3 Coder Next"
 family = "qwen"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 temperature = true
 release_date = "2025-07-22"

--- a/providers/vercel/models/alibaba/qwen3-coder-next.toml
+++ b/providers/vercel/models/alibaba/qwen3-coder-next.toml
@@ -2,7 +2,7 @@ name = "Qwen3 Coder Next"
 family = "qwen"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2025-07-22"

--- a/providers/vercel/models/alibaba/qwen3-max-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-max-thinking.toml
@@ -4,7 +4,7 @@ release_date = "2025-01"
 last_updated = "2025-01"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1, max = 81_920 }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/vercel/models/alibaba/qwen3-max-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-max-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-01"
 last_updated = "2025-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/vercel/models/alibaba/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-next-80b-a3b-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-next-80b-a3b-thinking"
+reasoning_options = []
 name = "Qwen3 Next 80B A3B Thinking"
 release_date = "2025-09-12"
 knowledge = "2025-09"

--- a/providers/vercel/models/alibaba/qwen3-vl-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-vl-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-24"
 last_updated = "2025-09-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-09"

--- a/providers/vercel/models/alibaba/qwen3-vl-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-vl-thinking.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-24"
 last_updated = "2025-09-24"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1, max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-09"

--- a/providers/vercel/models/alibaba/qwen3.5-flash.toml
+++ b/providers/vercel/models/alibaba/qwen3.5-flash.toml
@@ -2,6 +2,7 @@ name = "Qwen 3.5 Flash"
 family = "qwen"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 temperature = true
 release_date = "2026-02-24"

--- a/providers/vercel/models/alibaba/qwen3.5-flash.toml
+++ b/providers/vercel/models/alibaba/qwen3.5-flash.toml
@@ -2,7 +2,7 @@ name = "Qwen 3.5 Flash"
 family = "qwen"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 81_920 }]
 tool_call = true
 temperature = true
 release_date = "2026-02-24"

--- a/providers/vercel/models/alibaba/qwen3.5-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.5-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-plus"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.5 Plus"
 attachment = true
 

--- a/providers/vercel/models/alibaba/qwen3.5-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.5-plus.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.5-plus"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 81_920 }]
 name = "Qwen 3.5 Plus"
 attachment = true
 

--- a/providers/vercel/models/alibaba/qwen3.6-27b.toml
+++ b/providers/vercel/models/alibaba/qwen3.6-27b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-27b"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.6 27B"
 family = "qwen3.6"
 open_weights = false

--- a/providers/vercel/models/alibaba/qwen3.6-27b.toml
+++ b/providers/vercel/models/alibaba/qwen3.6-27b.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.6-27b"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 131_072 }]
 name = "Qwen 3.6 27B"
 family = "qwen3.6"
 open_weights = false

--- a/providers/vercel/models/alibaba/qwen3.6-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.6-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-plus"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.6 Plus"
 attachment = true
 

--- a/providers/vercel/models/alibaba/qwen3.6-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.6-plus.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.6-plus"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 131_072 }]
 name = "Qwen 3.6 Plus"
 attachment = true
 

--- a/providers/vercel/models/alibaba/qwen3.7-max.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-max.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 262_144 }]
 name = "Qwen 3.7 Max"
 attachment = true
 

--- a/providers/vercel/models/alibaba/qwen3.7-max.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.7 Max"
 attachment = true
 


### PR DESCRIPTION
Splits the Alibaba part 1 changes from #2165 into a reviewable 15-model PR.

## Result

Adds provider-specific reasoning controls for 15 Alibaba/Qwen model IDs on Vercel AI Gateway.

- Hybrid Qwen models use an explicit reasoning toggle.
- Thinking-only model IDs do not receive a toggle.
- Numeric budgets are included only where the Gateway/provider path and model-specific bound were verified.
- Models without a verified caller-selectable control use `reasoning_options = []`.

## Controls

- Toggle only:
  - `alibaba/qwen-3-14b`
  - `alibaba/qwen-3-30b`
- Toggle plus budget:
  - `alibaba/qwen-3-32b`: `1..38_912`
  - `alibaba/qwen-3.6-max-preview`: `1..131_072`
  - `alibaba/qwen3.5-flash`: `1..81_920`
  - `alibaba/qwen3.5-plus`: `1..81_920`
  - `alibaba/qwen3.6-27b`: `1..131_072`
  - `alibaba/qwen3.6-plus`: `1..131_072`
  - `alibaba/qwen3.7-max`: `1..262_144`
- Thinking-only budget:
  - `alibaba/qwen3-235b-a22b-thinking`: `1..81_920`
  - `alibaba/qwen3-max-thinking`: `1..81_920`
  - `alibaba/qwen3-vl-thinking`: `1..81_920`
- Reasoning present but no route-safe control verified:
  - `alibaba/qwen3-coder-30b-a3b`
  - `alibaba/qwen3-coder-next`
  - `alibaba/qwen3-next-80b-a3b-thinking`

## Request Mapping

The AI SDK Alibaba adapter maps:

- disabled reasoning to `enable_thinking: false`
- enabled reasoning to `enable_thinking: true`
- numeric reasoning budgets to `thinking_budget`

Source:
https://github.com/vercel/ai/blob/eb024b69fa2b00350a825abb755cec006fbc6ffe/packages/alibaba/src/alibaba-chat-language-model.ts#L440-L483

## Evidence

- Vercel documents the unified Gateway `reasoning` object, including `enabled`, `effort`, and `max_tokens`:
  https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/advanced#reasoning-configuration
- Vercel's endpoint API supplies the current provider routes and whether each route exposes `reasoning`:
  https://ai-gateway.vercel.sh/v1/models
- Alibaba documents `enable_thinking: true|false` for hybrid Qwen models, identifies thinking-only model IDs, and documents `thinking_budget` as the reasoning-token limit:
  https://www.alibabacloud.com/help/en/model-studio/deep-thinking
- Alibaba's model table documents model-specific maximum chain-of-thought lengths, including `38,912` for April Qwen3 hybrid models and `81,920` for Qwen3.5 and the audited thinking-only Qwen3 models:
  https://www.alibabacloud.com/help/en/model-studio/models

## Route Caveats

- `qwen-3-14b` and `qwen-3-30b` currently route only through DeepInfra.
- `qwen-3-32b` currently has Alibaba, Bedrock, DeepInfra, and Groq routes.
- `qwen3-next-80b-a3b-thinking` currently has Alibaba, Novita, and Vertex routes, but only Vertex advertises unified `reasoning`.
- Some thinking-only IDs have routes that expose no `reasoning` request parameter, so `reasoning_options = []` is retained instead of inheriting Alibaba-native controls.
- The public endpoint metadata does not publish numeric reasoning bounds. The Qwen3.6/Qwen3.7 bounds retain the existing authenticated Gateway boundary audit represented by this PR's commits.

AI SDK source revision audited: [`eb024b69fa2b00350a825abb755cec006fbc6ffe`](https://github.com/vercel/ai/tree/eb024b69fa2b00350a825abb755cec006fbc6ffe).

Endpoint metadata and mutable documentation were rechecked on **2026-06-24**.

Validation:
- GitHub `validate` check passes

Supersedes part of #2165.
