### PR TITLE
[vercel/alibaba part 2] Add reasoning options

### DIFF
--- a/providers/vercel/models/alibaba/qwen3.7-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.7 Plus"
 family = "qwen3.7-plus"
 release_date = "2026-06-01"


### PR DESCRIPTION
Splits the alibaba part 2 changes from #2165 into a reviewable 1-model PR.

Scope is limited to `vercel/alibaba part 2` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.