### PR TITLE
[vercel/amazon] Add reasoning options

### DIFF
--- a/providers/vercel/models/amazon/nova-2-lite.toml
+++ b/providers/vercel/models/amazon/nova-2-lite.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-01"
 last_updated = "2024-12-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = false
 knowledge = "2024-10"


### PR DESCRIPTION
Splits the amazon changes from #2165 into a reviewable 1-model PR.

Scope is limited to `vercel/amazon` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.