### PR TITLE
[vercel/anthropic] Add reasoning options

### DIFF
--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
 name = "Claude Haiku 4.5"
 
 interleaved = true

--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }]
 name = "Claude Haiku 4.5"
 
 interleaved = true

--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 name = "Claude Haiku 4.5"
 
 interleaved = true

--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 name = "Claude Haiku 4.5"
 
 interleaved = true

--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024 }]
 name = "Claude Haiku 4.5"
 
 interleaved = true

--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
 name = "Claude Haiku 4.5"
 
 interleaved = true

--- a/providers/vercel/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-haiku-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
 name = "Claude Haiku 4.5"
 
 interleaved = true

--- a/providers/vercel/models/anthropic/claude-opus-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
+reasoning_options = []
 name = "Claude Opus 4.5"
 release_date = "2024-11-24"
 

--- a/providers/vercel/models/anthropic/claude-opus-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
 name = "Claude Opus 4.5"
 release_date = "2024-11-24"
 

--- a/providers/vercel/models/anthropic/claude-opus-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 name = "Claude Opus 4.5"
 release_date = "2024-11-24"
 

--- a/providers/vercel/models/anthropic/claude-opus-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 name = "Claude Opus 4.5"
 release_date = "2024-11-24"
 

--- a/providers/vercel/models/anthropic/claude-opus-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 name = "Claude Opus 4.5"
 release_date = "2024-11-24"
 

--- a/providers/vercel/models/anthropic/claude-opus-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024 }]
 name = "Claude Opus 4.5"
 release_date = "2024-11-24"
 

--- a/providers/vercel/models/anthropic/claude-opus-4.5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 name = "Claude Opus 4.5"
 release_date = "2024-11-24"
 

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 64_000 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024, max = 64_000 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 64_000 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024, max = 64_000 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-opus-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-opus-4.7.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.7.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.7.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.7.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.7.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.8.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.8.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.8.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.8.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-4.8.toml
+++ b/providers/vercel/models/anthropic/claude-opus-4.8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = true
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 64_000 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 64_000 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 64_000 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, { type = "budget_tokens", min = 1_024, max = 64_000 }]
 
 interleaved = true
 

--- a/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
 
 interleaved = true
 


### PR DESCRIPTION
Splits the Anthropic changes from #2165 into a reviewable 6-model PR.

## Result

Adds raw Vercel AI Gateway reasoning controls for six Claude models.

This audit is about what the Gateway accepts over the wire on `POST /v1/chat/completions`, not AI SDK convenience mappings. The raw Gateway field is:

```json
{
  "reasoning": {
    "enabled": true,
    "max_tokens": 2048,
    "effort": "high",
    "exclude": false
  }
}
```

`reasoning.max_tokens` and `reasoning.effort` are mutually exclusive.

## Controls

- `anthropic/claude-haiku-4.5`
  - toggle
  - budget control with verified minimum `1_024`; no route-safe maximum claimed
- `anthropic/claude-opus-4.5`
  - toggle
  - budget control with verified minimum `1_024`; no route-safe maximum claimed
- `anthropic/claude-opus-4.6`
  - toggle
  - raw Gateway efforts: `low`, `medium`, `high`
  - budget control with verified minimum `1_024`; no route-safe maximum claimed
- `anthropic/claude-sonnet-4.6`
  - toggle
  - raw Gateway efforts: `low`, `medium`, `high`
  - budget control with verified minimum `1_024`; no route-safe maximum claimed
- `anthropic/claude-opus-4.7`
  - toggle
  - raw Gateway efforts: `low`, `medium`, `high`, `xhigh`
  - no fixed-budget control claimed
- `anthropic/claude-opus-4.8`
  - toggle
  - raw Gateway efforts: `low`, `medium`, `high`, `xhigh`
  - no fixed-budget control claimed

## Evidence

- Vercel raw Chat Completions docs define top-level `reasoning.enabled`, `reasoning.max_tokens`, `reasoning.effort`, and `reasoning.exclude`, with `effort` values `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`: https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/advanced#reasoning-configuration
- Vercel Anthropic docs define model-specific adaptive and fixed-budget support, including the adaptive effort sets and 400s for unsupported efforts: https://vercel.com/docs/ai-gateway/models-and-providers/reasoning/anthropic
- Vercel endpoint metadata confirms every route for the six IDs exposes raw `reasoning`: https://ai-gateway.vercel.sh/v1/models/anthropic/claude-opus-4.7/endpoints

## Caveats

- `max` is not listed in Vercel's raw `reasoning.effort` values, so this PR does not claim it even when provider-specific/native docs mention `max`.
- Exact maximum fixed-budget bounds are not documented route-safely on the raw Gateway surface, especially with Bedrock fallbacks, so this PR keeps only the verified minimum.
- No authenticated Gateway POST probes were run; no `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` was available.

Validation:
- `bun validate`
- `git diff --check`

Supersedes part of #2165.
