### PR TITLE
[vercel/arcee-ai] Add reasoning options

### DIFF
--- a/providers/vercel/models/arcee-ai/trinity-large-thinking.toml
+++ b/providers/vercel/models/arcee-ai/trinity-large-thinking.toml
@@ -2,6 +2,7 @@ name = "Trinity Large Thinking"
 family = "trinity"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2026-04-01"


### PR DESCRIPTION
Splits the arcee-ai changes from #2165 into a reviewable 1-model PR.

Scope is limited to `vercel/arcee-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.