### PR TITLE
[vercel/bytedance] Add reasoning options

### DIFF
--- a/providers/vercel/models/bytedance/seed-1.6.toml
+++ b/providers/vercel/models/bytedance/seed-1.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-01"
 last_updated = "2025-09"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/bytedance/seed-1.8.toml
+++ b/providers/vercel/models/bytedance/seed-1.8.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-01"
 last_updated = "2025-10"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"


### PR DESCRIPTION
Splits the bytedance changes from #2165 into a reviewable 2-model PR.

Scope is limited to `vercel/bytedance` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.