### PR TITLE
[vercel/deepseek] Add reasoning options

### DIFF
--- a/providers/vercel/models/deepseek/deepseek-v3.1-terminus.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.1-terminus.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-22"
 last_updated = "2025-09-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-07"

--- a/providers/vercel/models/deepseek/deepseek-v3.1.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-21"
 last_updated = "2025-08-21"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2024-07"

--- a/providers/vercel/models/deepseek/deepseek-v3.2-thinking.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.2-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-07"

--- a/providers/vercel/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/vercel/models/deepseek/deepseek-v4-flash.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 family = "deepseek"
 release_date = "2026-04-23"
 

--- a/providers/vercel/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/vercel/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 family = "deepseek"
 release_date = "2026-04-23"
 

--- a/providers/vercel/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/vercel/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 family = "deepseek"
 release_date = "2026-04-23"
 

--- a/providers/vercel/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/vercel/models/deepseek/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 family = "deepseek"
 release_date = "2026-04-23"
 


### PR DESCRIPTION
Splits the DeepSeek changes from #2165 into a reviewable 5-model PR.

## Result

Adds raw Vercel AI Gateway reasoning controls for five DeepSeek model IDs.

This audit is about Gateway wire format, not AI SDK adapter mappings. The raw Chat Completions control is top-level `reasoning` with `enabled`, `max_tokens`, `effort`, and `exclude`.

## Controls

- Toggle:
  - `deepseek/deepseek-v3.1`
  - `deepseek/deepseek-v3.1-terminus`
- Thinking-only, with no caller-selectable control:
  - `deepseek/deepseek-v3.2-thinking`
- Toggle plus raw Gateway effort values:
  - `deepseek/deepseek-v4-flash`: `high`, `xhigh`
  - `deepseek/deepseek-v4-pro`: `high`, `xhigh`

No numeric reasoning-budget control is claimed.

## Evidence

- Vercel raw Chat Completions docs define `reasoning.enabled` and `reasoning.effort`; raw Gateway `effort` values include `xhigh` but not `max`: https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/advanced#reasoning-configuration
- DeepSeek documents `thinking.type = "enabled"|"disabled"`, native V4 `reasoning_effort = "high"|"max"`, and compatibility mapping where `xhigh` maps to native `max`: https://api-docs.deepseek.com/guides/thinking_mode
- Vercel endpoint metadata confirms current route-level raw `reasoning` support for the affected IDs:
  - https://ai-gateway.vercel.sh/v1/models/deepseek/deepseek-v3.1/endpoints
  - https://ai-gateway.vercel.sh/v1/models/deepseek/deepseek-v3.1-terminus/endpoints
  - https://ai-gateway.vercel.sh/v1/models/deepseek/deepseek-v3.2-thinking/endpoints
  - https://ai-gateway.vercel.sh/v1/models/deepseek/deepseek-v4-flash/endpoints
  - https://ai-gateway.vercel.sh/v1/models/deepseek/deepseek-v4-pro/endpoints

## Caveats

- `max` is a DeepSeek-native value, but Vercel's raw Gateway spelling is `xhigh`; this PR tracks the caller-facing Gateway value.
- `deepseek/deepseek-v3.1` has mixed route support; some routes expose raw `reasoning` and one current Novita route does not.
- No authenticated Gateway POST probes were run; no `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` was available.

Validation:
- `bun validate`
- `git diff --check`

Supersedes part of #2165.
