### PR TITLE
[vercel/inception] Add reasoning options

### DIFF
--- a/providers/vercel/models/inception/mercury-2.toml
+++ b/providers/vercel/models/inception/mercury-2.toml
@@ -2,6 +2,7 @@ name = "Mercury 2"
 family = "mercury"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 release_date = "2026-02-24"


### PR DESCRIPTION
Splits the inception changes from #2165 into a reviewable 1-model PR.

Scope is limited to `vercel/inception` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.