### PR TITLE
[vercel/interfaze] Add reasoning options

### DIFF
--- a/providers/vercel/models/interfaze/interfaze-beta.toml
+++ b/providers/vercel/models/interfaze/interfaze-beta.toml
@@ -1,6 +1,7 @@
 name = "Interfaze Beta"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 temperature = true
 release_date = "2025-10-07"


### PR DESCRIPTION
Splits the interfaze changes from #2165 into a reviewable 1-model PR.

Scope is limited to `vercel/interfaze` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.