### PR TITLE
[vercel/kwaipilot] Add reasoning options

### DIFF
--- a/providers/vercel/models/kwaipilot/kat-coder-pro-v1.toml
+++ b/providers/vercel/models/kwaipilot/kat-coder-pro-v1.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-24"
 last_updated = "2025-10-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 knowledge = "2024-10"

--- a/providers/vercel/models/kwaipilot/kat-coder-pro-v2.toml
+++ b/providers/vercel/models/kwaipilot/kat-coder-pro-v2.toml
@@ -2,6 +2,7 @@ name = "Kat Coder Pro V2"
 family = "kat-coder"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2026-03-27"


### PR DESCRIPTION
Splits the kwaipilot changes from #2165 into a reviewable 2-model PR.

Scope is limited to `vercel/kwaipilot` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.