### PR TITLE
[vercel/meituan] Add reasoning options

### DIFF
--- a/providers/vercel/models/meituan/longcat-flash-thinking-2601.toml
+++ b/providers/vercel/models/meituan/longcat-flash-thinking-2601.toml
@@ -2,6 +2,7 @@ name = "LongCat Flash Thinking 2601"
 family = "longcat"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 temperature = true
 release_date = "2026-03-13"


### PR DESCRIPTION
Splits the meituan changes from #2165 into a reviewable 1-model PR.

Scope is limited to `vercel/meituan` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.