### PR TITLE
[vercel/minimax] Add reasoning options

### DIFF
--- a/providers/vercel/models/minimax/minimax-m2.1-lightning.toml
+++ b/providers/vercel/models/minimax/minimax-m2.1-lightning.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-27"
 last_updated = "2025-10-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/minimax/minimax-m2.1.toml
+++ b/providers/vercel/models/minimax/minimax-m2.1.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.1"
+reasoning_options = []
 name = "MiniMax M2.1"
 release_date = "2025-10-27"
 knowledge = "2024-10"

--- a/providers/vercel/models/minimax/minimax-m2.5-highspeed.toml
+++ b/providers/vercel/models/minimax/minimax-m2.5-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5-highspeed"
+reasoning_options = []
 name = "MiniMax M2.5 High Speed"
 release_date = "2026-02-12"
 open_weights = false

--- a/providers/vercel/models/minimax/minimax-m2.5.toml
+++ b/providers/vercel/models/minimax/minimax-m2.5.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
 name = "MiniMax M2.5"
 open_weights = false
 

--- a/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
 name = "MiniMax M2.7 High Speed"
 attachment = true
 

--- a/providers/vercel/models/minimax/minimax-m2.7.toml
+++ b/providers/vercel/models/minimax/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
 name = "Minimax M2.7"
 attachment = true
 

--- a/providers/vercel/models/minimax/minimax-m2.toml
+++ b/providers/vercel/models/minimax/minimax-m2.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2"
+reasoning_options = []
 name = "MiniMax M2"
 knowledge = "2024-10"
 

--- a/providers/vercel/models/minimax/minimax-m3.toml
+++ b/providers/vercel/models/minimax/minimax-m3.toml
@@ -1,5 +1,5 @@
 base_model = "minimax/MiniMax-M3"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 name = "MiniMax M3"
 family = "minimax-m3"
 release_date = "2026-05-31"

--- a/providers/vercel/models/minimax/minimax-m3.toml
+++ b/providers/vercel/models/minimax/minimax-m3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = []
 name = "MiniMax M3"
 family = "minimax-m3"
 release_date = "2026-05-31"


### PR DESCRIPTION
Splits the minimax changes from #2165 into a reviewable 8-model PR.

Scope is limited to `vercel/minimax` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.