### PR TITLE
[vercel/mistral] Add reasoning options

### DIFF
--- a/providers/vercel/models/mistral/mistral-medium-3.5.toml
+++ b/providers/vercel/models/mistral/mistral-medium-3.5.toml
@@ -2,6 +2,7 @@ name = "Mistral Medium Latest"
 family = "mistral-medium"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 release_date = "2026-05-21"


### PR DESCRIPTION
Splits the mistral changes from #2165 into a reviewable 1-model PR.

Scope is limited to `vercel/mistral` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.