### PR TITLE
[vercel/moonshotai] Add reasoning options

### DIFF
--- a/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking"
+reasoning_options = []
 open_weights = false
 
 interleaved = true

--- a/providers/vercel/models/moonshotai/kimi-k2.5.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2026-01-26"
 attachment = true
 temperature = true

--- a/providers/vercel/models/moonshotai/kimi-k2.6.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2026-04-20"
 
 [cost]


### PR DESCRIPTION
Splits the moonshotai changes from #2165 into a reviewable 3-model PR.

Scope is limited to `vercel/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.