### PR TITLE
[vercel/nvidia] Add reasoning options

### DIFF
--- a/providers/vercel/models/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/vercel/models/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-nano-30b-a3b"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2024-12-01"
 tool_call = false
 knowledge = "2024-10"

--- a/providers/vercel/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/vercel/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+reasoning_options = [{ type = "toggle" }]
 name = "Nemotron 3 Ultra"
 open_weights = false
 

--- a/providers/vercel/models/nvidia/nemotron-nano-12b-v2-vl.toml
+++ b/providers/vercel/models/nvidia/nemotron-nano-12b-v2-vl.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-nano-12b-v2-vl"
+reasoning_options = [{ type = "toggle" }]
 name = "Nvidia Nemotron Nano 12B V2 VL"
 release_date = "2024-12-01"
 knowledge = "2024-10"

--- a/providers/vercel/models/nvidia/nemotron-nano-9b-v2.toml
+++ b/providers/vercel/models/nvidia/nemotron-nano-9b-v2.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-nano-9b-v2"
+reasoning_options = [{ type = "toggle" }]
 name = "Nvidia Nemotron Nano 9B V2"
 knowledge = "2024-10"
 open_weights = false


### PR DESCRIPTION
Splits the nvidia changes from #2165 into a reviewable 4-model PR.

Scope is limited to `vercel/nvidia` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.