### PR TITLE
[vercel/openai part 1] Add reasoning options

### DIFF
--- a/providers/vercel/models/openai/gpt-5-chat.toml
+++ b/providers/vercel/models/openai/gpt-5-chat.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5-pro.toml
+++ b/providers/vercel/models/openai/gpt-5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-pro"
+reasoning_options = [{ type = "effort", values = ["high"] }]
 name = "GPT-5 pro"
 family = "gpt"
 release_date = "2025-08-07"

--- a/providers/vercel/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/vercel/models/openai/gpt-5.1-codex-max.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex-max"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "GPT 5.1 Codex Max"
 family = "gpt"
 release_date = "2025-11-19"

--- a/providers/vercel/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/vercel/models/openai/gpt-5.1-codex-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 family = "gpt"
 release_date = "2025-11-12"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.1-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.1-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 name = "GPT-5.1-Codex"
 family = "gpt"
 release_date = "2025-11-12"

--- a/providers/vercel/models/openai/gpt-5.1-instant.toml
+++ b/providers/vercel/models/openai/gpt-5.1-instant.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.1-thinking.toml
+++ b/providers/vercel/models/openai/gpt-5.1-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.2-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.2-chat.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.2-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.2-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "GPT-5.2-Codex"
 release_date = "2025-12-18"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.2-pro.toml
+++ b/providers/vercel/models/openai/gpt-5.2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 name = "GPT 5.2 "
 family = "gpt"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.2.toml
+++ b/providers/vercel/models/openai/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = true
 knowledge = "2024-10"
 

--- a/providers/vercel/models/openai/gpt-5.3-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.3-chat.toml
@@ -2,6 +2,7 @@ name = "GPT-5.3 Chat"
 family = "gpt"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2026-03-03"

--- a/providers/vercel/models/openai/gpt-5.3-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.3-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "GPT 5.3 Codex"
 family = "gpt"
 release_date = "2026-02-24"

--- a/providers/vercel/models/openai/gpt-5.4-mini.toml
+++ b/providers/vercel/models/openai/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.4 Mini"
 family = "gpt"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.4-nano.toml
+++ b/providers/vercel/models/openai/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.4 Nano"
 family = "gpt"
 temperature = true


### PR DESCRIPTION
Splits the openai part 1 changes from #2165 into a reviewable 15-model PR.

Scope is limited to `vercel/openai part 1` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.