### PR TITLE
[vercel/openai part 2] Add reasoning options

### DIFF
--- a/providers/vercel/models/openai/gpt-5.4-pro.toml
+++ b/providers/vercel/models/openai/gpt-5.4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 name = "GPT 5.4 Pro"
 family = "gpt"
 temperature = true

--- a/providers/vercel/models/openai/gpt-5.4.toml
+++ b/providers/vercel/models/openai/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.4"
 temperature = true
 

--- a/providers/vercel/models/openai/gpt-5.5-pro.toml
+++ b/providers/vercel/models/openai/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 name = "GPT 5.5 Pro"
 family = "gpt"
 release_date = "2026-04-24"

--- a/providers/vercel/models/openai/gpt-5.5.toml
+++ b/providers/vercel/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.5"
 release_date = "2026-04-24"
 temperature = true

--- a/providers/vercel/models/openai/gpt-oss-120b.toml
+++ b/providers/vercel/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-oss-20b.toml
+++ b/providers/vercel/models/openai/gpt-oss-20b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/vercel/models/openai/gpt-oss-safeguard-20b.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-01"
 last_updated = "2024-12-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/o3-deep-research.toml
+++ b/providers/vercel/models/openai/o3-deep-research.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-deep-research"
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 temperature = true
 knowledge = "2024-10"
 

--- a/providers/vercel/models/openai/o3-pro.toml
+++ b/providers/vercel/models/openai/o3-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 name = "o3 Pro"
 release_date = "2025-04-16"
 temperature = true


### PR DESCRIPTION
Splits the openai part 2 changes from #2165 into a reviewable 9-model PR.

Scope is limited to `vercel/openai part 2` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.