### PR TITLE
[vercel/perplexity] Add reasoning options

### DIFF
--- a/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 knowledge = "2025-09"


### PR DESCRIPTION
Splits the perplexity changes from #2165 into a reviewable 1-model PR.

Scope is limited to `vercel/perplexity` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.