### PR TITLE
[vercel/stepfun] Add reasoning options

### DIFF
--- a/providers/vercel/models/stepfun/step-3.5-flash.toml
+++ b/providers/vercel/models/stepfun/step-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.5-flash"
+reasoning_options = []
 base_model_omit = ["limit.input"]
 name = "StepFun 3.5 Flash"
 family = "step"

--- a/providers/vercel/models/stepfun/step-3.7-flash.toml
+++ b/providers/vercel/models/stepfun/step-3.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 family = "step"
 release_date = "2026-05-28"
 open_weights = false


### PR DESCRIPTION
Splits the stepfun changes from #2165 into a reviewable 2-model PR.

Scope is limited to `vercel/stepfun` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.