### PR TITLE
[vercel/xai] Add reasoning options

### DIFF
--- a/providers/vercel/models/xai/grok-4.1-fast-reasoning.toml
+++ b/providers/vercel/models/xai/grok-4.1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/xai/grok-4.20-multi-agent-beta.toml
+++ b/providers/vercel/models/xai/grok-4.20-multi-agent-beta.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-13"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.20-multi-agent.toml
+++ b/providers/vercel/models/xai/grok-4.20-multi-agent.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-09"
 last_updated = "2026-03-23"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.20-reasoning-beta.toml
+++ b/providers/vercel/models/xai/grok-4.20-reasoning-beta.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.20-reasoning.toml
+++ b/providers/vercel/models/xai/grok-4.20-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-09"
 last_updated = "2026-03-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.3.toml
+++ b/providers/vercel/models/xai/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 release_date = "2026-04-30"
 
 [cost]

--- a/providers/vercel/models/xai/grok-build-0.1.toml
+++ b/providers/vercel/models/xai/grok-build-0.1.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-build-0.1"
+reasoning_options = []
 release_date = "2026-05-20"
 
 [cost]


### PR DESCRIPTION
Splits the xai changes from #2165 into a reviewable 7-model PR.

Scope is limited to `vercel/xai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2165.