### PR TITLE
[zenmux/anthropic] Add reasoning options

### DIFF
--- a/providers/zenmux/models/anthropic/claude-3.7-sonnet.toml
+++ b/providers/zenmux/models/anthropic/claude-3.7-sonnet.toml
@@ -3,6 +3,7 @@ release_date = "2025-02-24"
 last_updated = "2025-02-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-fable-5.toml
+++ b/providers/zenmux/models/anthropic/claude-fable-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 10.00

--- a/providers/zenmux/models/anthropic/claude-opus-4.1.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.1.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-opus-4.5.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.5.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-opus-4.6.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-06"
 last_updated = "2026-02-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/zenmux/models/anthropic/claude-opus-4.7.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.7.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/zenmux/models/anthropic/claude-opus-4.8.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5.00

--- a/providers/zenmux/models/anthropic/claude-opus-4.toml
+++ b/providers/zenmux/models/anthropic/claude-opus-4.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/zenmux/models/anthropic/claude-sonnet-4.5.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/zenmux/models/anthropic/claude-sonnet-4.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-18"
 last_updated = "2026-02-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/anthropic/claude-sonnet-4.toml
+++ b/providers/zenmux/models/anthropic/claude-sonnet-4.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"


### PR DESCRIPTION
Splits the anthropic changes from #2168 into a reviewable 11-model PR.

Scope is limited to `zenmux/anthropic` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.