### PR TITLE
[zenmux/baidu] Add reasoning options

### DIFF
--- a/providers/zenmux/models/baidu/ernie-5.0-thinking-preview.toml
+++ b/providers/zenmux/models/baidu/ernie-5.0-thinking-preview.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-22"
 last_updated = "2026-01-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"


### PR DESCRIPTION
Splits the baidu changes from #2168 into a reviewable 1-model PR.

Scope is limited to `zenmux/baidu` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.