### PR TITLE
[zenmux/deepseek] Add reasoning options

### DIFF
--- a/providers/zenmux/models/deepseek/deepseek-v3.2-exp.toml
+++ b/providers/zenmux/models/deepseek/deepseek-v3.2-exp.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/deepseek/deepseek-v3.2.toml
+++ b/providers/zenmux/models/deepseek/deepseek-v3.2.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-05"
 last_updated = "2025-12-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/zenmux/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/zenmux/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/zenmux/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Splits the deepseek changes from #2168 into a reviewable 4-model PR.

Scope is limited to `zenmux/deepseek` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.