### PR TITLE
[zenmux/google] Add reasoning options

### DIFF
--- a/providers/zenmux/models/google/gemini-2.5-flash.toml
+++ b/providers/zenmux/models/google/gemini-2.5-flash.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/google/gemini-2.5-pro.toml
+++ b/providers/zenmux/models/google/gemini-2.5-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/google/gemini-3-flash-preview.toml
+++ b/providers/zenmux/models/google/gemini-3-flash-preview.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/zenmux/models/google/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/zenmux/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/zenmux/models/google/gemini-3.1-pro-preview.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02-19"

--- a/providers/zenmux/models/google/gemini-3.5-flash.toml
+++ b/providers/zenmux/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.50


### PR DESCRIPTION
Splits the google changes from #2168 into a reviewable 6-model PR.

Scope is limited to `zenmux/google` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.