### PR TITLE
[zenmux/inclusionai] Add reasoning options

### DIFF
--- a/providers/zenmux/models/inclusionai/ring-1t.toml
+++ b/providers/zenmux/models/inclusionai/ring-1t.toml
@@ -3,6 +3,7 @@ release_date = "2025-10-12"
 last_updated = "2025-10-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/zenmux/models/inclusionai/ring-2.6-1t.toml
@@ -3,6 +3,7 @@ release_date = "2026-05-07"
 last_updated = "2026-05-14"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-12-31"


### PR DESCRIPTION
Splits the inclusionai changes from #2168 into a reviewable 2-model PR.

Scope is limited to `zenmux/inclusionai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.