### PR TITLE
[zenmux/minimax] Add reasoning options

### DIFF
--- a/providers/zenmux/models/minimax/minimax-m2.1.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.1.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.5-lightning.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.5-lightning.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-13"
 last_updated = "2026-02-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.5.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.5.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-13"
 last_updated = "2026-02-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.7-highspeed.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.7.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.7.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m2.toml
+++ b/providers/zenmux/models/minimax/minimax-m2.toml
@@ -3,6 +3,7 @@ release_date = "2025-10-27"
 last_updated = "2025-10-27"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/minimax/minimax-m3.toml
+++ b/providers/zenmux/models/minimax/minimax-m3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = []
 
 [cost]
 input = 0.60

--- a/providers/zenmux/models/minimax/minimax-m3.toml
+++ b/providers/zenmux/models/minimax/minimax-m3.toml
@@ -1,5 +1,5 @@
 base_model = "minimax/MiniMax-M3"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.60


### PR DESCRIPTION
Splits the minimax changes from #2168 into a reviewable 7-model PR.

Scope is limited to `zenmux/minimax` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.