### PR TITLE
[zenmux/moonshotai] Add reasoning options

### DIFF
--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/moonshotai/kimi-k2.5.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2.5.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/moonshotai/kimi-k2.6.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 knowledge = "2025-01-01"


### PR DESCRIPTION
Splits the moonshotai changes from #2168 into a reviewable 4-model PR.

Scope is limited to `zenmux/moonshotai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.