### PR TITLE
[zenmux/openai] Add reasoning options

### DIFF
--- a/providers/zenmux/models/openai/gpt-5-codex.toml
+++ b/providers/zenmux/models/openai/gpt-5-codex.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-23"
 last_updated = "2025-09-23"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/zenmux/models/openai/gpt-5.1-codex-mini.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.1-codex.toml
+++ b/providers/zenmux/models/openai/gpt-5.1-codex.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.1.toml
+++ b/providers/zenmux/models/openai/gpt-5.1.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.2-codex.toml
+++ b/providers/zenmux/models/openai/gpt-5.2-codex.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-15"
 last_updated = "2026-01-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.2-pro.toml
+++ b/providers/zenmux/models/openai/gpt-5.2-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = false
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/openai/gpt-5.2.toml
+++ b/providers/zenmux/models/openai/gpt-5.2.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/openai/gpt-5.3-codex.toml
+++ b/providers/zenmux/models/openai/gpt-5.3-codex.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/openai/gpt-5.4-pro.toml
+++ b/providers/zenmux/models/openai/gpt-5.4-pro.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/openai/gpt-5.4.toml
+++ b/providers/zenmux/models/openai/gpt-5.4.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/openai/gpt-5.5-instant.toml
+++ b/providers/zenmux/models/openai/gpt-5.5-instant.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-instant"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/zenmux/models/openai/gpt-5.5-pro.toml
+++ b/providers/zenmux/models/openai/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
 input = 30

--- a/providers/zenmux/models/openai/gpt-5.5.toml
+++ b/providers/zenmux/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/zenmux/models/openai/gpt-5.toml
+++ b/providers/zenmux/models/openai/gpt-5.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"


### PR DESCRIPTION
Splits the openai changes from #2168 into a reviewable 14-model PR.

Scope is limited to `zenmux/openai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.