### PR TITLE
[zenmux/qwen] Add reasoning options

### DIFF
--- a/providers/zenmux/models/qwen/qwen3-max.toml
+++ b/providers/zenmux/models/qwen/qwen3-max.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-23"
 last_updated = "2026-01-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/qwen/qwen3.5-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.5-plus.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/qwen/qwen3.6-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.6-plus.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-30"
 last_updated = "2026-03-30"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/zenmux/models/qwen/qwen3.7-max.toml
+++ b/providers/zenmux/models/qwen/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 2.50

--- a/providers/zenmux/models/qwen/qwen3.7-plus.toml
+++ b/providers/zenmux/models/qwen/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.40


### PR DESCRIPTION
Splits the qwen changes from #2168 into a reviewable 5-model PR.

Scope is limited to `zenmux/qwen` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.