### PR TITLE
[zenmux/sapiens-ai] Add reasoning options

### DIFF
--- a/providers/zenmux/models/sapiens-ai/agnes-1.5-pro.toml
+++ b/providers/zenmux/models/sapiens-ai/agnes-1.5-pro.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-21"
 last_updated = "2026-03-21"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Splits the sapiens-ai changes from #2168 into a reviewable 1-model PR.

Scope is limited to `zenmux/sapiens-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.