### PR TITLE
[zenmux/stepfun] Add reasoning options

### DIFF
--- a/providers/zenmux/models/stepfun/step-3.7-flash-free.toml
+++ b/providers/zenmux/models/stepfun/step-3.7-flash-free.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 name = "Step 3.7 Flash (Free)"
 
 [cost]

--- a/providers/zenmux/models/stepfun/step-3.7-flash.toml
+++ b/providers/zenmux/models/stepfun/step-3.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.20

--- a/providers/zenmux/models/stepfun/step-3.toml
+++ b/providers/zenmux/models/stepfun/step-3.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-31"
 last_updated = "2025-07-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"


### PR DESCRIPTION
Splits the stepfun changes from #2168 into a reviewable 3-model PR.

Scope is limited to `zenmux/stepfun` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.