### PR TITLE
[zenmux/tencent] Add reasoning options

### DIFF
--- a/providers/zenmux/models/tencent/hy3-preview.toml
+++ b/providers/zenmux/models/tencent/hy3-preview.toml
@@ -1,4 +1,5 @@
 base_model = "tencent/hy3-preview"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high"] }]
 
 [cost]
 input = 0.172


### PR DESCRIPTION
Splits the tencent changes from #2168 into a reviewable 1-model PR.

Scope is limited to `zenmux/tencent` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.