### PR TITLE
[zenmux/volcengine] Add reasoning options

### DIFF
--- a/providers/zenmux/models/volcengine/doubao-seed-1.8.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-1.8.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-18"
 last_updated = "2025-12-18"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/volcengine/doubao-seed-2.0-lite.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-2.0-lite.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02-14"

--- a/providers/zenmux/models/volcengine/doubao-seed-2.0-mini.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-2.0-mini.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02-14"

--- a/providers/zenmux/models/volcengine/doubao-seed-2.0-pro.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-2.0-pro.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2026-02-14"

--- a/providers/zenmux/models/volcengine/doubao-seed-code.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-code.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-11"
 last_updated = "2025-11-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"


### PR DESCRIPTION
Splits the volcengine changes from #2168 into a reviewable 5-model PR.

Scope is limited to `zenmux/volcengine` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.