### PR TITLE
[zenmux/x-ai] Add reasoning options

### DIFF
--- a/providers/zenmux/models/x-ai/grok-4-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4-fast.toml
@@ -3,7 +3,7 @@ release_date = "2025-09-19"
 last_updated = "2025-09-19"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-4-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4-fast.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-19"
 last_updated = "2025-09-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-4.1-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4.1-fast.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-20"
 last_updated = "2025-11-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-4.1-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4.1-fast.toml
@@ -3,7 +3,7 @@ release_date = "2025-11-20"
 last_updated = "2025-11-20"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-4.2-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4.2-fast.toml
@@ -3,7 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/x-ai/grok-4.2-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4.2-fast.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-08-31"

--- a/providers/zenmux/models/x-ai/grok-4.3.toml
+++ b/providers/zenmux/models/x-ai/grok-4.3.toml
@@ -1,5 +1,5 @@
 base_model = "xai/grok-4.3"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/zenmux/models/x-ai/grok-4.3.toml
+++ b/providers/zenmux/models/x-ai/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/zenmux/models/x-ai/grok-4.toml
+++ b/providers/zenmux/models/x-ai/grok-4.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-4.toml
+++ b/providers/zenmux/models/x-ai/grok-4.toml
@@ -3,7 +3,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-build-0.1.toml
+++ b/providers/zenmux/models/x-ai/grok-build-0.1.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-build-0.1"
+reasoning_options = []
 
 [cost]
 input = 1.00

--- a/providers/zenmux/models/x-ai/grok-code-fast-1.toml
+++ b/providers/zenmux/models/x-ai/grok-code-fast-1.toml
@@ -3,7 +3,7 @@ release_date = "2025-08-26"
 last_updated = "2025-08-26"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/x-ai/grok-code-fast-1.toml
+++ b/providers/zenmux/models/x-ai/grok-code-fast-1.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-26"
 last_updated = "2025-08-26"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"


### PR DESCRIPTION
Splits the x-ai changes from #2168 into a reviewable 7-model PR.

Scope is limited to `zenmux/x-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.