### PR TITLE
[zenmux/z-ai] Add reasoning options

### DIFF
--- a/providers/zenmux/models/z-ai/glm-4.5-air.toml
+++ b/providers/zenmux/models/z-ai/glm-4.5-air.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-25"
 last_updated = "2025-07-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.5.toml
+++ b/providers/zenmux/models/z-ai/glm-4.5.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-25"
 last_updated = "2025-07-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.6.toml
+++ b/providers/zenmux/models/z-ai/glm-4.6.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.6v-flash-free.toml
+++ b/providers/zenmux/models/z-ai/glm-4.6v-flash-free.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.6v-flash.toml
+++ b/providers/zenmux/models/z-ai/glm-4.6v-flash.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.6v.toml
+++ b/providers/zenmux/models/z-ai/glm-4.6v.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-08"
 last_updated = "2025-12-08"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.7-flash-free.toml
+++ b/providers/zenmux/models/z-ai/glm-4.7-flash-free.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.7-flashx.toml
+++ b/providers/zenmux/models/z-ai/glm-4.7-flashx.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-4.7.toml
+++ b/providers/zenmux/models/z-ai/glm-4.7.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-23"
 last_updated = "2025-12-23"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-5-turbo.toml
+++ b/providers/zenmux/models/z-ai/glm-5-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-20"
 last_updated = "2026-03-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-5.1.toml
+++ b/providers/zenmux/models/z-ai/glm-5.1.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-03"
 last_updated = "2026-04-03"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/zenmux/models/z-ai/glm-5.toml
+++ b/providers/zenmux/models/z-ai/glm-5.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"

--- a/providers/zenmux/models/z-ai/glm-5v-turbo.toml
+++ b/providers/zenmux/models/z-ai/glm-5v-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-01"
 last_updated = "2026-04-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Splits the z-ai changes from #2168 into a reviewable 13-model PR.

Scope is limited to `zenmux/z-ai` and preserves the audited metadata from the aggregate branch on current `dev`.

Supersedes part of #2168.