### PR TITLE
feat: add LLM Gateway kimi-k2.7-code, nemotron-3-ultra-550b, grok-build-0-1

### DIFF
--- a/providers/llmgateway/models/grok-build-0-1.toml
+++ b/providers/llmgateway/models/grok-build-0-1.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-build-0.1"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1

--- a/providers/llmgateway/models/grok-build-0-1.toml
+++ b/providers/llmgateway/models/grok-build-0-1.toml
@@ -1,0 +1,12 @@
+base_model = "xai/grok-build-0.1"
+
+[cost]
+input = 1
+output = 2
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2
+output = 4
+cache_read = 0.4

--- a/providers/llmgateway/models/kimi-k2.7-code.toml
+++ b/providers/llmgateway/models/kimi-k2.7-code.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/kimi-k2.7-code.toml
+++ b/providers/llmgateway/models/kimi-k2.7-code.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19

--- a/providers/llmgateway/models/nemotron-3-ultra-550b.toml
+++ b/providers/llmgateway/models/nemotron-3-ultra-550b.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+
+[cost]
+input = 0.5
+output = 2.5
+cache_read = 0.15

--- a/providers/llmgateway/models/nemotron-3-ultra-550b.toml
+++ b/providers/llmgateway/models/nemotron-3-ultra-550b.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.5


### PR DESCRIPTION
Adds the newest **text** models from the LLM Gateway catalog that aren't yet in the repo, using the `base_model` structure to inherit from the canonical model registry with gateway-specific cost overrides.

## Models added (under `providers/llmgateway/models/`)

| Model | `base_model` | Released | Cost (in/out, $/1M) |
|---|---|---|---|
| `kimi-k2.7-code` | `moonshotai/kimi-k2.7-code` | 2026-06-12 | 0.95 / 4 (cache_read 0.19, `[interleaved]`) |
| `nemotron-3-ultra-550b` | `nvidia/nemotron-3-ultra-550b-a55b` | 2026-06-04 | 0.5 / 2.5 (cache_read 0.15) |
| `grok-build-0-1` | `xai/grok-build-0.1` | 2026-04-16 | 1 / 2 (cache_read 0.2, +200k context tier 2/4/0.4) |

## Notes
- Cost values reflect LLM Gateway's pricing; all other metadata (limits, modalities, family, reasoning) is inherited from the existing registry base specs.
- Image / video / TTS / embedding models from the gateway are intentionally excluded — this PR is text models only.
- `bun validate` passes; all three resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)