### PR TITLE
fix(cohere): correct Command R7B release date to 2024-12-02

### DIFF
--- a/models/cohere/command-r7b-12-2024.toml
+++ b/models/cohere/command-r7b-12-2024.toml
@@ -1,7 +1,7 @@
 name = "Command R7B"
 family = "command-r"
-release_date = "2024-02-27"
-last_updated = "2024-02-27"
+release_date = "2024-12-02"
+last_updated = "2024-12-02"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/cohere/models/command-r7b-12-2024.toml
+++ b/providers/cohere/models/command-r7b-12-2024.toml
@@ -1,7 +1,7 @@
 name = "Command R7B"
 family = "command-r"
-release_date = "2024-02-27"
-last_updated = "2024-02-27"
+release_date = "2024-12-02"
+last_updated = "2024-12-02"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/kilo/models/cohere/command-r7b-12-2024.toml
+++ b/providers/kilo/models/cohere/command-r7b-12-2024.toml
@@ -1,6 +1,6 @@
 name = "Cohere: Command R7B (12-2024)"
-release_date = "2024-02-27"
-last_updated = "2024-02-27"
+release_date = "2024-12-02"
+last_updated = "2024-12-02"
 attachment = false
 reasoning = false
 temperature = true


### PR DESCRIPTION
`command-r7b-12-2024` had `release_date`/`last_updated` set to `2024-02-27`, which predates the model — the `12-2024` in its id is December 2024, and `02-27` was evidently copied from the sibling `command-r7b-arabic-02-2025` entry.

Cohere's official announcement ([Announcing Command R7b](https://docs.cohere.com/v2/changelog/command-r-7b)) is dated **December 2, 2024**, so this sets both dates to `2024-12-02` across the base metadata and the `cohere`/`kilo` provider copies.

Verified with `bun validate` (exit 0); no `2024-02-27` remains on any `command-r7b` file.
