### PR TITLE
fix(baseten): update DeepSeek V4 Pro context length to 1,048,576

### DIFF
--- a/providers/baseten/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/baseten/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -13,6 +13,3 @@ input = 1.74
 output = 3.48
 cache_read = 0.145
 
-[limit]
-context = 131_000
-output = 131_000


### PR DESCRIPTION
Update DeepSeek V4 Pro context and output limits from 131,000 to 1,048,576 tokens to match the model's actual context window.