### PR TITLE
feat(providers): add MiniMax M3 to Synthetic provider

### DIFF
--- a/models/minimax/MiniMax-M3.toml
+++ b/models/minimax/MiniMax-M3.toml
@@ -6,7 +6,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
 
 [limit]
 context = 512_000

--- a/models/minimax/MiniMax-M3.toml
+++ b/models/minimax/MiniMax-M3.toml
@@ -15,3 +15,7 @@ output = 128_000
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/MiniMaxAI/MiniMax-M3"

--- a/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M3.toml
+++ b/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M3.toml
@@ -1,11 +1,9 @@
 base_model = "minimax/MiniMax-M3"
 release_date = "2026-06-12"
 last_updated = "2026-06-12"
+reasoning_options = []
 structured_output = true
 status = "beta"
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0.60

--- a/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M3.toml
+++ b/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M3.toml
@@ -1,0 +1,21 @@
+base_model = "minimax/MiniMax-M3"
+release_date = "2026-06-12"
+last_updated = "2026-06-12"
+structured_output = true
+status = "beta"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.60
+output = 1.20
+cache_read = 0.60
+
+[limit]
+context = 524_288
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
This PR adds MiniMax M3 to [Synthetic](https://synthetic.new/)'s model catalog.

It also marks MiniMax M3 as an open-weighted model since its [weights](https://huggingface.co/MiniMaxAI/MiniMax-M3/tree/main) are now publicly available.

This is the response body from Synthetic:

```json
{
  "provider": "synthetic",
  "always_on": true,
  "id": "hf:MiniMaxAI/MiniMax-M3",
  "hugging_face_id": "MiniMaxAI/MiniMax-M3",
  "name": "MiniMaxAI/MiniMax-M3",
  "input_modalities": [
    "text",
    "image"
  ],
  "output_modalities": [
    "text"
  ],
  "context_length": 524288,
  "max_output_length": 65536,
  "pricing": {
    "prompt": "$0.0000006",
    "completion": "$0.0000012",
    "image": "0",
    "request": "0",
    "input_cache_reads": "$0.0000006",
    "input_cache_writes": "0"
  },
  "created": 1781222400,
  "quantization": "fp8",
  "supported_sampling_parameters": [
    "temperature",
    "top_k",
    "top_p",
    "repetition_penalty",
    "frequency_penalty",
    "presence_penalty",
    "stop",
    "seed"
  ],
  "supported_features": [
    "tools",
    "json_mode",
    "structured_outputs",
    "reasoning"
  ],
  "openrouter": {
    "slug": "minimax/minimax-m3"
  },
  "datacenters": [
    {
      "country_code": "US"
    }
  ]
}
```

Synthetic's model catalog seems to be a bit outdated in general. I'll see if I can clean it up in the following weeks.