### PR TITLE
[302ai/multiple labs] Add reasoning options

### DIFF
--- a/providers/302ai/models/claude-sonnet-4-6-thinking.toml
+++ b/providers/302ai/models/claude-sonnet-4-6-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2026-02-18"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/claude-sonnet-4-6.toml
+++ b/providers/302ai/models/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-18"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/deepseek-reasoner.toml
+++ b/providers/302ai/models/deepseek-reasoner.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/deepseek-v3.2-thinking.toml
+++ b/providers/302ai/models/deepseek-v3.2-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/doubao-seed-1-6-thinking-250715.toml
+++ b/providers/302ai/models/doubao-seed-1-6-thinking-250715.toml
@@ -3,6 +3,7 @@ release_date = "2025-07-15"
 last_updated = "2025-07-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/kimi-k2-thinking-turbo.toml
+++ b/providers/302ai/models/kimi-k2-thinking-turbo.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/302ai/models/kimi-k2-thinking.toml
+++ b/providers/302ai/models/kimi-k2-thinking.toml
@@ -3,6 +3,7 @@ release_date = "2025-09-05"
 last_updated = "2025-09-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
Consolidates 4 small reasoning-options PRs into one reviewable 7-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2347: [302ai/anthropic part 2] Add reasoning options
- #2348: [302ai/bytedance] Add reasoning options
- #2349: [302ai/deepseek] Add reasoning options
- #2350: [302ai/moonshotai] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`