### PR TITLE
[aihubmix/multiple labs] Add reasoning options

### DIFF
--- a/providers/aihubmix/models/grok-4.3.toml
+++ b/providers/aihubmix/models/grok-4.3.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/kimi-k2.5.toml
+++ b/providers/aihubmix/models/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/kimi-k2.6.toml
+++ b/providers/aihubmix/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/qwen3.6-flash.toml
+++ b/providers/aihubmix/models/qwen3.6-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/qwen3.6-max-preview.toml
+++ b/providers/aihubmix/models/qwen3.6-max-preview.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/aihubmix/models/qwen3.6-plus.toml
+++ b/providers/aihubmix/models/qwen3.6-plus.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Consolidates 3 small reasoning-options PRs into one reviewable 6-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2354: [aihubmix/alibaba] Add reasoning options
- #2360: [aihubmix/moonshotai] Add reasoning options
- #2362: [aihubmix/xai] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`