### PR TITLE
[alibaba/multiple labs] Add reasoning options

### DIFF
--- a/providers/alibaba-cn/models/deepseek-v4-flash.toml
+++ b/providers/alibaba-cn/models/deepseek-v4-flash.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/deepseek-v4-pro.toml
+++ b/providers/alibaba-cn/models/deepseek-v4-pro.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/glm-5.1.toml
+++ b/providers/alibaba-cn/models/glm-5.1.toml
@@ -9,6 +9,13 @@ temperature = true
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131_072
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/glm-5.toml
+++ b/providers/alibaba-cn/models/glm-5.toml
@@ -8,6 +8,13 @@ temperature = true
 tool_call = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 32_768
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-cn/models/kimi-k2.5.toml
@@ -10,6 +10,13 @@ open_weights = true
 knowledge = "2025-01"
 structured_output = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/kimi-k2.6.toml
+++ b/providers/alibaba-cn/models/kimi-k2.6.toml
@@ -10,6 +10,13 @@ open_weights = true
 knowledge = "2025-01"
 structured_output = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/kimi/kimi-k2.5.toml
+++ b/providers/alibaba-cn/models/kimi/kimi-k2.5.toml
@@ -10,6 +10,13 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = true
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 81_920
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/kimi/kimi-k2.5.toml
+++ b/providers/alibaba-cn/models/kimi/kimi-k2.5.toml
@@ -13,10 +13,6 @@ open_weights = true
 [[reasoning_options]]
 type = "toggle"
 
-[[reasoning_options]]
-type = "budget_tokens"
-max = 81_920
-
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/siliconflow/deepseek-v3.1-terminus.toml
+++ b/providers/alibaba-cn/models/siliconflow/deepseek-v3.1-terminus.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.27
 output = 1.0

--- a/providers/alibaba-cn/models/siliconflow/deepseek-v3.2.toml
+++ b/providers/alibaba-cn/models/siliconflow/deepseek-v3.2.toml
@@ -9,6 +9,9 @@ tool_call = true
 structured_output = true
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.27
 output = 0.42


### PR DESCRIPTION
Consolidates the Alibaba DeepSeek, Kimi, Moonshot, SiliconFlow, and GLM reasoning-option changes into one 9-model PR.

Source PRs: #2367, #2368, #2369, #2370, and #2371.

## Audited models

| Provider route | Model | Reasoning controls |
| --- | --- | --- |
| Alibaba-hosted | `deepseek-v4-flash` | toggle; effort `high`, `max` |
| Alibaba-hosted | `deepseek-v4-pro` | toggle; effort `high`, `max` |
| Alibaba-hosted | `glm-5.1` | toggle; budget up to 131,072 tokens |
| Alibaba-hosted | `glm-5` | toggle; budget up to 32,768 tokens |
| Alibaba-hosted | `kimi-k2.5` | toggle; budget up to 81,920 tokens |
| Alibaba-hosted | `kimi-k2.6` | toggle; budget up to 81,920 tokens |
| Moonshot-hosted | `kimi/kimi-k2.5` | toggle only |
| SiliconFlow-hosted | `siliconflow/deepseek-v3.1-terminus` | toggle only |
| SiliconFlow-hosted | `siliconflow/deepseek-v3.2` | toggle only |

## Route-specific controls

- All entries use Alibaba's China OpenAI-compatible endpoint, but slash-prefixed IDs are separately hosted lab routes with different capabilities.
- Toggle uses top-level `enable_thinking: true | false` on Chat Completions.
- Numeric budget uses top-level `thinking_budget` and controls reasoning tokens rather than context or total output.
- DeepSeek V4 effort uses the standard top-level Chat Completions field `reasoning_effort`.

## Primary evidence

- [DeepSeek on Alibaba Cloud](https://help.aliyun.com/en/model-studio/deepseek-api) documents `enable_thinking` for `deepseek-v4-pro` and `deepseek-v4-flash`. Its reasoning-effort section says the only distinct values are `high` and `max`; `low` and `medium` map to `high`, while `xhigh` maps to `max`.
- [GLM on Alibaba Cloud](https://help.aliyun.com/en/model-studio/glm) documents GLM as hybrid reasoning controlled by `enable_thinking`. Alibaba's model data gives 128K Max CoT for `glm-5.1` and 32,768 for `glm-5`; [Deep thinking](https://help.aliyun.com/en/model-studio/deep-thinking) identifies `thinking_budget` as the GLM reasoning cap.
- [Kimi deployed by Alibaba Cloud](https://help.aliyun.com/en/model-studio/kimi-api) documents unprefixed `kimi-k2.5` and `kimi-k2.6` as hybrid models controlled by `enable_thinking`. [Visual reasoning](https://help.aliyun.com/en/model-studio/visual-reasoning) includes these unprefixed IDs among the models supporting `thinking_budget`; Alibaba's model table gives an 80K budget.
- [Kimi provided by Moonshot AI](https://help.aliyun.com/en/model-studio/kimi-api-by-moonshot-ai) is a separate Beijing-only `kimi/...` route. It documents the toggle for `kimi/kimi-k2.5` but explicitly says `thinking_budget` cannot limit chain-of-thought for any model on this route. Therefore this PR retains only `toggle` for `kimi/kimi-k2.5`.
- [DeepSeek provided by SiliconFlow](https://help.aliyun.com/en/model-studio/siliconflow-deepseek-api) is another Beijing-only route and explicitly classifies `siliconflow/deepseek-v3.2` and `siliconflow/deepseek-v3.1-terminus` as hybrid models controlled by `enable_thinking`. No budget or effort control is documented for those IDs.

## Correction

Removed the unsupported `budget_tokens` option from `providers/alibaba-cn/models/kimi/kimi-k2.5.toml` in `c8af5fb3`. The documented toggle remains.

## Validation

- `bun validate`
- `git diff --check`

Both pass on the corrected isolated worktree.
