### PR TITLE
[cortecs/multiple labs] Add reasoning options

### DIFF
--- a/providers/cortecs/models/gpt-5.4.toml
+++ b/providers/cortecs/models/gpt-5.4.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.4"
 base_model_omit = ["limit.input"]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 3

--- a/providers/cortecs/models/gpt-oss-120b.toml
+++ b/providers/cortecs/models/gpt-oss-120b.toml
@@ -5,6 +5,7 @@ last_updated = "2025-08-05"
 knowledge = "2024-01"
 attachment = false
 reasoning = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/hermes-4-70b.toml
+++ b/providers/cortecs/models/hermes-4-70b.toml
@@ -4,6 +4,7 @@ last_updated = "2025-08-26"
 knowledge = "2023-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/intellect-3.toml
+++ b/providers/cortecs/models/intellect-3.toml
@@ -4,6 +4,7 @@ last_updated = "2025-11-26"
 knowledge = "2025-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/kimi-k2-thinking.toml
+++ b/providers/cortecs/models/kimi-k2-thinking.toml
@@ -4,6 +4,7 @@ last_updated = "2025-12-08"
 knowledge = "2025-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/kimi-k2.5.toml
+++ b/providers/cortecs/models/kimi-k2.5.toml
@@ -5,6 +5,7 @@ last_updated = "2026-01-27"
 knowledge = "2025-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/kimi-k2.6.toml
+++ b/providers/cortecs/models/kimi-k2.6.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-17"
 last_updated = "2026-04-17"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/cortecs/models/llama-3.3-70b-instruct.toml
+++ b/providers/cortecs/models/llama-3.3-70b-instruct.toml
@@ -2,6 +2,7 @@ base_model = "meta/llama-3.3-70b-instruct"
 name = "Llama 3.3 70B Instruct"
 attachment = false
 reasoning = true
+reasoning_options = []
 
 [cost]
 input = 0.089

--- a/providers/cortecs/models/mixtral-8x7B-instruct-v0.1.toml
+++ b/providers/cortecs/models/mixtral-8x7B-instruct-v0.1.toml
@@ -4,6 +4,7 @@ last_updated = "2023-12-11"
 knowledge = "2023-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/nemotron-3-super-120b-a12b.toml
+++ b/providers/cortecs/models/nemotron-3-super-120b-a12b.toml
@@ -5,6 +5,7 @@ last_updated = "2026-03-11"
 knowledge = "2025-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 open_weights = true


### PR DESCRIPTION
Consolidates 7 small reasoning-options PRs into one reviewable 10-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2375: [cortecs/meta] Add reasoning options
- #2377: [cortecs/mistral] Add reasoning options
- #2378: [cortecs/moonshotai] Add reasoning options
- #2379: [cortecs/nousresearch] Add reasoning options
- #2380: [cortecs/nvidia] Add reasoning options
- #2381: [cortecs/openai] Add reasoning options
- #2382: [cortecs/prime-intellect] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`