### PR TITLE
[github-models/multiple labs] Add reasoning options

### DIFF
--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-large.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-29"
 last_updated = "2024-08-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
+++ b/providers/github-models/models/ai21-labs/ai21-jamba-1.5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-08-29"
 last_updated = "2024-08-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/core42/jais-30b-chat.toml
+++ b/providers/github-models/models/core42/jais-30b-chat.toml
@@ -4,6 +4,7 @@ release_date = "2023-08-30"
 last_updated = "2023-08-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2023-03"
 tool_call = true

--- a/providers/github-models/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/deepseek/deepseek-r1.toml
+++ b/providers/github-models/models/deepseek/deepseek-r1.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/deepseek/deepseek-v3-0324.toml
+++ b/providers/github-models/models/deepseek/deepseek-v3-0324.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-24"
 last_updated = "2025-03-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-06"
 tool_call = true

--- a/providers/github-models/models/xai/grok-3-mini.toml
+++ b/providers/github-models/models/xai/grok-3-mini.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-09"
 last_updated = "2024-12-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10"
 tool_call = true

--- a/providers/github-models/models/xai/grok-3.toml
+++ b/providers/github-models/models/xai/grok-3.toml
@@ -4,6 +4,7 @@ release_date = "2024-12-09"
 last_updated = "2024-12-09"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10"
 tool_call = true


### PR DESCRIPTION
Consolidates 4 small reasoning-options PRs into one reviewable 8-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2327: [github-models/ai21-labs] Add reasoning options
- #2329: [github-models/core42] Add reasoning options
- #2330: [github-models/deepseek] Add reasoning options
- #2335: [github-models/xai] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`