### PR TITLE
[jiekou/multiple labs] Add reasoning options

### DIFF
--- a/providers/jiekou/models/baidu/ernie-4.5-vl-424b-a47b.toml
+++ b/providers/jiekou/models/baidu/ernie-4.5-vl-424b-a47b.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/jiekou/models/claude-opus-4-6.toml
+++ b/providers/jiekou/models/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02"
 last_updated = "2026-02"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/jiekou/models/deepseek/deepseek-r1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/deepseek/deepseek-v3.1.toml
+++ b/providers/jiekou/models/deepseek/deepseek-v3.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 32_767 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/minimax/minimax-m2.1.toml
+++ b/providers/jiekou/models/minimax/minimax-m2.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 131_071 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/minimaxai/minimax-m1-80k.toml
+++ b/providers/jiekou/models/minimaxai/minimax-m1-80k.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/jiekou/models/moonshotai/kimi-k2.5.toml
+++ b/providers/jiekou/models/moonshotai/kimi-k2.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 262_143 }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/jiekou/models/xiaomimimo/mimo-v2-flash.toml
+++ b/providers/jiekou/models/xiaomimimo/mimo-v2-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Consolidates 7 small reasoning-options PRs into one reviewable 8-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2316: [jiekou/anthropic] Add reasoning options
- #2317: [jiekou/baidu] Add reasoning options
- #2318: [jiekou/deepseek] Add reasoning options
- #2320: [jiekou/minimax] Add reasoning options
- #2321: [jiekou/minimaxai] Add reasoning options
- #2322: [jiekou/moonshotai] Add reasoning options
- #2325: [jiekou/xiaomimimo] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`