### PR TITLE
[kilo/multiple labs 1] Add reasoning options

### DIFF
--- a/providers/kilo/models/aion-labs/aion-1.0-mini.toml
+++ b/providers/kilo/models/aion-labs/aion-1.0-mini.toml
@@ -2,6 +2,7 @@ name = "AionLabs: Aion-1.0-Mini"
 release_date = "2025-02-05"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/aion-labs/aion-1.0.toml
+++ b/providers/kilo/models/aion-labs/aion-1.0.toml
@@ -2,6 +2,7 @@ name = "AionLabs: Aion-1.0"
 release_date = "2025-02-05"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/aion-labs/aion-2.0.toml
+++ b/providers/kilo/models/aion-labs/aion-2.0.toml
@@ -2,6 +2,7 @@ name = "AionLabs: Aion-2.0"
 release_date = "2026-02-24"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/allenai/olmo-3-32b-think.toml
+++ b/providers/kilo/models/allenai/olmo-3-32b-think.toml
@@ -2,6 +2,7 @@ name = "AllenAI: Olmo 3 32B Think"
 release_date = "2025-11-22"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/amazon/nova-2-lite-v1.toml
+++ b/providers/kilo/models/amazon/nova-2-lite-v1.toml
@@ -2,6 +2,7 @@ name = "Amazon: Nova 2 Lite"
 release_date = "2024-12-01"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/~anthropic/claude-haiku-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-haiku-latest.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Haiku Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~anthropic/claude-opus-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-opus-latest.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Opus Latest"
 release_date = "2026-04-16"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/~anthropic/claude-sonnet-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-sonnet-latest.toml
@@ -2,6 +2,7 @@ name = "Anthropic: Claude Sonnet Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~google/gemini-flash-latest.toml
+++ b/providers/kilo/models/~google/gemini-flash-latest.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini Flash Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~google/gemini-pro-latest.toml
+++ b/providers/kilo/models/~google/gemini-pro-latest.toml
@@ -2,6 +2,7 @@ name = "Google: Gemini Pro Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~moonshotai/kimi-latest.toml
+++ b/providers/kilo/models/~moonshotai/kimi-latest.toml
@@ -2,6 +2,7 @@ name = "MoonshotAI: Kimi Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~openai/gpt-latest.toml
+++ b/providers/kilo/models/~openai/gpt-latest.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/~openai/gpt-mini-latest.toml
+++ b/providers/kilo/models/~openai/gpt-mini-latest.toml
@@ -2,6 +2,7 @@ name = "OpenAI: GPT Mini Latest"
 release_date = "2026-04-27"
 last_updated = "2026-05-01"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false


### PR DESCRIPTION
Consolidates 7 small reasoning-options PRs into one reviewable 13-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2390: [kilo/aion-labs] Add reasoning options
- #2391: [kilo/~anthropic] Add reasoning options
- #2392: [kilo/~google] Add reasoning options
- #2393: [kilo/~moonshotai] Add reasoning options
- #2394: [kilo/~openai] Add reasoning options
- #2395: [kilo/allenai] Add reasoning options
- #2396: [kilo/amazon] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`