### PR TITLE
[kilo/multiple labs 2] Add reasoning options

### DIFF
--- a/providers/kilo/models/deepcogito/cogito-v2.1-671b.toml
+++ b/providers/kilo/models/deepcogito/cogito-v2.1-671b.toml
@@ -2,6 +2,7 @@ name = "Deep Cogito: Cogito v2.1 671B"
 release_date = "2025-11-14"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/google/gemma-4-31b-it.toml
+++ b/providers/kilo/models/google/gemma-4-31b-it.toml
@@ -2,6 +2,7 @@ name = "Google: Gemma 4 31B"
 release_date = "2026-04-02"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/inception/mercury-2.toml
+++ b/providers/kilo/models/inception/mercury-2.toml
@@ -2,6 +2,7 @@ name = "Inception: Mercury 2"
 release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/kilo/models/inclusionai/ring-2.6-1t.toml
@@ -2,6 +2,7 @@ name = "inclusionAI: Ring-2.6-1T"
 release_date = "2026-05-08"
 last_updated = "2026-05-16"
 attachment = false
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/mistralai/mistral-medium-3-5.toml
+++ b/providers/kilo/models/mistralai/mistral-medium-3-5.toml
@@ -2,6 +2,7 @@ name = "Mistral: Mistral Medium 3.5"
 release_date = "2026-04-30"
 last_updated = "2026-05-07"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/mistralai/mistral-small-2603.toml
+++ b/providers/kilo/models/mistralai/mistral-small-2603.toml
@@ -2,6 +2,7 @@ name = "Mistral: Mistral Small 4"
 release_date = "2026-03-16"
 last_updated = "2026-04-11"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2-thinking.toml
@@ -2,6 +2,7 @@ name = "MoonshotAI: Kimi K2 Thinking"
 release_date = "2025-11-06"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/moonshotai/kimi-k2.5.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2.5.toml
@@ -2,6 +2,7 @@ name = "MoonshotAI: Kimi K2.5"
 release_date = "2026-01-27"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/moonshotai/kimi-k2.6.toml
+++ b/providers/kilo/models/moonshotai/kimi-k2.6.toml
@@ -3,6 +3,7 @@ release_date = "2026-04-20"
 last_updated = "2026-05-12"
 
 attachment = true
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/nousresearch/hermes-4-405b.toml
+++ b/providers/kilo/models/nousresearch/hermes-4-405b.toml
@@ -2,6 +2,7 @@ name = "Nous: Hermes 4 405B"
 release_date = "2025-08-25"
 last_updated = "2025-08-25"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/nousresearch/hermes-4-70b.toml
+++ b/providers/kilo/models/nousresearch/hermes-4-70b.toml
@@ -2,6 +2,7 @@ name = "Nous: Hermes 4 70B"
 release_date = "2025-08-25"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = [{ type = "toggle" }]
 reasoning = true
 temperature = true
 tool_call = false


### PR DESCRIPTION
Consolidates 7 small reasoning-options PRs into one reviewable 11-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2401: [kilo/deepcogito] Add reasoning options
- #2404: [kilo/google part 2] Add reasoning options
- #2405: [kilo/inception] Add reasoning options
- #2406: [kilo/inclusionai] Add reasoning options
- #2409: [kilo/mistralai] Add reasoning options
- #2410: [kilo/moonshotai] Add reasoning options
- #2411: [kilo/nousresearch] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`