### PR TITLE
[kilo/multiple labs 3] Add reasoning options

### DIFF
--- a/providers/kilo/models/openrouter/auto.toml
+++ b/providers/kilo/models/openrouter/auto.toml
@@ -2,6 +2,7 @@ name = "Auto Router"
 release_date = "2026-03-15"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openrouter/free.toml
+++ b/providers/kilo/models/openrouter/free.toml
@@ -2,6 +2,7 @@ name = "Free Models Router"
 release_date = "2026-02-01"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openrouter/owl-alpha.toml
+++ b/providers/kilo/models/openrouter/owl-alpha.toml
@@ -2,6 +2,7 @@ name = "Owl Alpha"
 release_date = "2026-04-28"
 last_updated = "2026-04-30"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/perceptron/perceptron-mk1.toml
+++ b/providers/kilo/models/perceptron/perceptron-mk1.toml
@@ -2,6 +2,7 @@ name = "Perceptron: Perceptron Mk1"
 release_date = "2026-05-12"
 last_updated = "2026-05-16"
 attachment = true
+reasoning_options = []
 reasoning = true
 tool_call = false
 temperature = true

--- a/providers/kilo/models/perplexity/sonar-deep-research.toml
+++ b/providers/kilo/models/perplexity/sonar-deep-research.toml
@@ -2,6 +2,7 @@ name = "Perplexity: Sonar Deep Research"
 release_date = "2025-01-27"
 last_updated = "2025-01-27"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/perplexity/sonar-pro-search.toml
+++ b/providers/kilo/models/perplexity/sonar-pro-search.toml
@@ -2,6 +2,7 @@ name = "Perplexity: Sonar Pro Search"
 release_date = "2025-10-31"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/kilo/models/perplexity/sonar-reasoning-pro.toml
@@ -2,6 +2,7 @@ name = "Perplexity: Sonar Reasoning Pro"
 release_date = "2024-01-01"
 last_updated = "2025-09-01"
 attachment = true
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/poolside/laguna-m.1:free.toml
+++ b/providers/kilo/models/poolside/laguna-m.1:free.toml
@@ -2,6 +2,7 @@ name = "Poolside: Laguna M.1 (free)"
 release_date = "2026-04-28"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/poolside/laguna-xs.2:free.toml
+++ b/providers/kilo/models/poolside/laguna-xs.2:free.toml
@@ -2,6 +2,7 @@ name = "Poolside: Laguna XS.2 (free)"
 release_date = "2026-04-28"
 last_updated = "2026-05-01"
 attachment = false
+reasoning_options = []
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/prime-intellect/intellect-3.toml
+++ b/providers/kilo/models/prime-intellect/intellect-3.toml
@@ -2,6 +2,7 @@ name = "Prime Intellect: INTELLECT-3"
 release_date = "2025-11-26"
 last_updated = "2026-02-04"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/rekaai/reka-flash-3.toml
+++ b/providers/kilo/models/rekaai/reka-flash-3.toml
@@ -2,6 +2,7 @@ name = "Reka Flash 3"
 release_date = "2025-03-12"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/stealth/claude-opus-4.6.toml
+++ b/providers/kilo/models/stealth/claude-opus-4.6.toml
@@ -2,6 +2,7 @@ name = "Stealth: Claude Opus 4.6 (20% off)"
 release_date = "2026-02-05"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/stealth/claude-opus-4.7.toml
+++ b/providers/kilo/models/stealth/claude-opus-4.7.toml
@@ -2,6 +2,7 @@ name = "Stealth: Claude Opus 4.7 (20% off)"
 release_date = "2026-04-16"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/stealth/claude-sonnet-4.6.toml
+++ b/providers/kilo/models/stealth/claude-sonnet-4.6.toml
@@ -2,6 +2,7 @@ name = "Stealth: Claude Sonnet 4.6 (20% off)"
 release_date = "2026-02-17"
 last_updated = "2026-05-27"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
 reasoning = true
 tool_call = true
 temperature = true


### PR DESCRIPTION
Consolidates 7 small reasoning-options PRs into one reviewable 14-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2416: [kilo/openrouter] Add reasoning options
- #2417: [kilo/perceptron] Add reasoning options
- #2418: [kilo/perplexity] Add reasoning options
- #2419: [kilo/poolside] Add reasoning options
- #2420: [kilo/prime-intellect] Add reasoning options
- #2423: [kilo/rekaai] Add reasoning options
- #2424: [kilo/stealth] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`