### PR TITLE
[kilo/multiple labs 4] Add reasoning options

### DIFF
--- a/providers/kilo/models/arcee-ai/trinity-large-thinking.toml
+++ b/providers/kilo/models/arcee-ai/trinity-large-thinking.toml
@@ -2,6 +2,7 @@ name = "Arcee AI: Trinity Large Thinking"
 release_date = "2026-04-01"
 last_updated = "2026-04-11"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/arcee-ai/trinity-mini.toml
+++ b/providers/kilo/models/arcee-ai/trinity-mini.toml
@@ -2,6 +2,7 @@ name = "Arcee AI: Trinity Mini"
 release_date = "2025-12"
 last_updated = "2026-01-28"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/o4-mini-deep-research.toml
+++ b/providers/kilo/models/openai/o4-mini-deep-research.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o4 Mini Deep Research"
 release_date = "2024-06-26"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = true
 tool_call = true

--- a/providers/kilo/models/openai/o4-mini-high.toml
+++ b/providers/kilo/models/openai/o4-mini-high.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o4 Mini High"
 release_date = "2025-04-17"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 open_weights = false

--- a/providers/kilo/models/openai/o4-mini.toml
+++ b/providers/kilo/models/openai/o4-mini.toml
@@ -2,6 +2,7 @@ name = "OpenAI: o4 Mini"
 release_date = "2025-04-16"
 last_updated = "2026-03-15"
 attachment = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 reasoning = true
 temperature = false
 tool_call = true

--- a/providers/kilo/models/switchpoint/router.toml
+++ b/providers/kilo/models/switchpoint/router.toml
@@ -2,6 +2,7 @@ name = "Switchpoint Router"
 release_date = "2025-07-12"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/tencent/hunyuan-a13b-instruct.toml
+++ b/providers/kilo/models/tencent/hunyuan-a13b-instruct.toml
@@ -2,6 +2,7 @@ name = "Tencent: Hunyuan A13B Instruct"
 release_date = "2025-06-30"
 last_updated = "2025-11-25"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = false

--- a/providers/kilo/models/tencent/hy3-preview.toml
+++ b/providers/kilo/models/tencent/hy3-preview.toml
@@ -2,6 +2,7 @@ name = "Tencent: Hy3 Preview"
 release_date = "2026-04-22"
 last_updated = "2026-05-16"
 attachment = false
+reasoning_options = [{ type = "effort", values = ["none", "low", "high"] }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/upstage/solar-pro-3.toml
+++ b/providers/kilo/models/upstage/solar-pro-3.toml
@@ -2,6 +2,7 @@ name = "Upstage: Solar Pro 3"
 release_date = "2026-01-27"
 last_updated = "2026-03-15"
 attachment = false
+reasoning_options = []
 reasoning = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
Consolidates 5 small reasoning-options PRs into one reviewable 9-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2398: [kilo/arcee-ai] Add reasoning options
- #2415: [kilo/openai part 3] Add reasoning options
- #2426: [kilo/switchpoint] Add reasoning options
- #2427: [kilo/tencent] Add reasoning options
- #2428: [kilo/upstage] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`