### PR TITLE
[llmgateway/search and xAI] Add reasoning options

### DIFF
--- a/providers/llmgateway/models/grok-4-1-fast-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-1-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-19"
 last_updated = "2025-11-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/grok-4-20-beta-0309-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-20-beta-0309-reasoning.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/grok-4-20-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-20-reasoning.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/grok-4-3.toml
+++ b/providers/llmgateway/models/grok-4-3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/grok-4-fast-reasoning.toml
+++ b/providers/llmgateway/models/grok-4-fast-reasoning.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/sonar-reasoning-pro.toml
+++ b/providers/llmgateway/models/sonar-reasoning-pro.toml
@@ -1,4 +1,5 @@
 base_model = "perplexity/sonar-reasoning-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2


### PR DESCRIPTION
Consolidates 2 small reasoning-options PRs into one reviewable 6-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2441: [llmgateway/perplexity] Add reasoning options
- #2442: [llmgateway/xai] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`