### PR TITLE
[merge-gateway/multiple labs] Add reasoning options

### DIFF
--- a/providers/merge-gateway/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/merge-gateway/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/merge-gateway/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/mistral/magistral-medium-latest.toml
+++ b/providers/merge-gateway/models/mistral/magistral-medium-latest.toml
@@ -1,4 +1,5 @@
 base_model = "mistral/magistral-medium-latest"
+reasoning_options = []
 
 [cost]
 input = 2

--- a/providers/merge-gateway/models/mistral/mistral-small-latest.toml
+++ b/providers/merge-gateway/models/mistral/mistral-small-latest.toml
@@ -1,4 +1,5 @@
 base_model = "mistral/mistral-small-latest"
+reasoning_options = []
 
 [cost]
 input = 0.15

--- a/providers/merge-gateway/models/openai/o4-mini.toml
+++ b/providers/merge-gateway/models/openai/o4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o4-mini"
+reasoning_options = []
 
 [cost]
 input = 1.1

--- a/providers/merge-gateway/models/xai/grok-4.20-0309-reasoning.toml
+++ b/providers/merge-gateway/models/xai/grok-4.20-0309-reasoning.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/merge-gateway/models/xai/grok-4.3.toml
+++ b/providers/merge-gateway/models/xai/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = []
 
 [cost]
 input = 1.25


### PR DESCRIPTION
Consolidates 4 small reasoning-options PRs into one reviewable 7-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2303: [merge-gateway/deepseek] Add reasoning options
- #2306: [merge-gateway/mistral] Add reasoning options
- #2308: [merge-gateway/openai part 2] Add reasoning options
- #2309: [merge-gateway/xai] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`