### PR TITLE
[nano-gpt/multiple labs 1] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/allenai/olmo-3-32b-think.toml
+++ b/providers/nano-gpt/models/allenai/olmo-3-32b-think.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-01"
 last_updated = "2025-11-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/arcee-ai/trinity-large-thinking.toml
+++ b/providers/nano-gpt/models/arcee-ai/trinity-large-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-01"
 last_updated = "2026-04-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:32768.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:32768.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:64000.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:64000.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claude-sonnet-4-thinking:8192.toml
+++ b/providers/nano-gpt/models/claude-sonnet-4-thinking:8192.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/command-a-plus-05-2026.toml
+++ b/providers/nano-gpt/models/command-a-plus-05-2026.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-22"
 last_updated = "2026-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek-ai/DeepSeek-R1-0528.toml
+++ b/providers/nano-gpt/models/deepseek-ai/DeepSeek-R1-0528.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-28"
 last_updated = "2025-05-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/deepseek-ai/deepseek-v3.2-exp-thinking.toml
+++ b/providers/nano-gpt/models/deepseek-ai/deepseek-v3.2-exp-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/ernie-5.0-thinking-preview.toml
+++ b/providers/nano-gpt/models/ernie-5.0-thinking-preview.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/ernie-5.1:thinking.toml
+++ b/providers/nano-gpt/models/ernie-5.1:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-10"
 last_updated = "2026-05-10"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/holo3-35b-a3b.toml
+++ b/providers/nano-gpt/models/holo3-35b-a3b.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/holo3-35b-a3b:thinking.toml
+++ b/providers/nano-gpt/models/holo3-35b-a3b:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Llama-70B-abliterated.toml
+++ b/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Llama-70B-abliterated.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated.toml
+++ b/providers/nano-gpt/models/huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated.toml
@@ -4,6 +4,7 @@ release_date = "2025-01-20"
 last_updated = "2025-01-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
Consolidates 8 small reasoning-options PRs into one reviewable 14-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2447: [nano-gpt/allenai] Add reasoning options
- #2450: [nano-gpt/anthropic part 3] Add reasoning options
- #2451: [nano-gpt/arcee-ai] Add reasoning options
- #2452: [nano-gpt/baidu] Add reasoning options
- #2453: [nano-gpt/cohere] Add reasoning options
- #2454: [nano-gpt/deepseek-ai] Add reasoning options
- #2459: [nano-gpt/holo] Add reasoning options
- #2460: [nano-gpt/huihui-ai] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`