### PR TITLE
[nano-gpt/multiple labs 2] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/claw-high.toml
+++ b/providers/nano-gpt/models/claw-high.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claw-low.toml
+++ b/providers/nano-gpt/models/claw-low.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/claw-medium.toml
+++ b/providers/nano-gpt/models/claw-medium.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/hermes-high.toml
+++ b/providers/nano-gpt/models/hermes-high.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/hermes-low.toml
+++ b/providers/nano-gpt/models/hermes-low.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/hermes-medium.toml
+++ b/providers/nano-gpt/models/hermes-medium.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/nano-gpt/models/inclusionai/ring-2.6-1t.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-08"
 last_updated = "2026-05-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mercury-2.toml
+++ b/providers/nano-gpt/models/mercury-2.toml
@@ -4,6 +4,7 @@ release_date = "2024-01-01"
 last_updated = "2024-01-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mirothinker-1-7-deepresearch-mini.toml
+++ b/providers/nano-gpt/models/mirothinker-1-7-deepresearch-mini.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/mirothinker-1-7-deepresearch.toml
+++ b/providers/nano-gpt/models/mirothinker-1-7-deepresearch.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-11"
 last_updated = "2026-05-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/mistral/mistral-medium-3.5.toml
+++ b/providers/nano-gpt/models/mistral/mistral-medium-3.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-29"
 last_updated = "2026-04-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mistral/mistral-medium-3.5:thinking.toml
+++ b/providers/nano-gpt/models/mistral/mistral-medium-3.5:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-30"
 last_updated = "2026-04-30"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603.toml
+++ b/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-16"
 last_updated = "2026-03-16"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603:thinking.toml
+++ b/providers/nano-gpt/models/mistralai/mistral-small-4-119b-2603:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Consolidates 7 small reasoning-options PRs into one reviewable 14-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2461: [nano-gpt/inception] Add reasoning options
- #2462: [nano-gpt/inclusionai] Add reasoning options
- #2464: [nano-gpt/miromind] Add reasoning options
- #2465: [nano-gpt/mistral] Add reasoning options
- #2466: [nano-gpt/mistralai] Add reasoning options
- #2468: [nano-gpt/nano-gpt] Add reasoning options
- #2470: [nano-gpt/nousresearch] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`