### PR TITLE
[nano-gpt/multiple labs 3] Add reasoning options

### DIFF
--- a/providers/nano-gpt/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/providers/nano-gpt/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -5,6 +5,7 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b:thinking.toml
+++ b/providers/nano-gpt/models/nvidia/nemotron-3-super-120b-a12b:thinking.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-01"
 last_updated = "2026-03-01"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/o4-mini.toml
+++ b/providers/nano-gpt/models/openai/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/pamanseau/OpenReasoning-Nemotron-32B.toml
+++ b/providers/nano-gpt/models/pamanseau/OpenReasoning-Nemotron-32B.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-21"
 last_updated = "2025-08-21"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/perceptron/perceptron-mk1.toml
+++ b/providers/nano-gpt/models/perceptron/perceptron-mk1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/sarvam-105b.toml
+++ b/providers/nano-gpt/models/sarvam-105b.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/sarvam-30b.toml
+++ b/providers/nano-gpt/models/sarvam-30b.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/sonar-reasoning-pro.toml
+++ b/providers/nano-gpt/models/sonar-reasoning-pro.toml
@@ -3,6 +3,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/stepfun-ai/step-3.5-flash-2603.toml
+++ b/providers/nano-gpt/models/stepfun-ai/step-3.5-flash-2603.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-14"
 last_updated = "2026-04-14"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/stepfun-ai/step-3.5-flash.toml
+++ b/providers/nano-gpt/models/stepfun-ai/step-3.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-02"
 last_updated = "2026-02-02"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/stepfun/step-3.7-flash:thinking.toml
+++ b/providers/nano-gpt/models/stepfun/step-3.7-flash:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-29"
 last_updated = "2026-05-29"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 structured_output = true
 open_weights = false


### PR DESCRIPTION
Consolidates 8 small reasoning-options PRs into one reviewable 12-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2471: [nano-gpt/nvidia] Add reasoning options
- #2474: [nano-gpt/openai part 3] Add reasoning options
- #2475: [nano-gpt/pamanseau] Add reasoning options
- #2476: [nano-gpt/perceptron] Add reasoning options
- #2477: [nano-gpt/perplexity] Add reasoning options
- #2479: [nano-gpt/sarvam] Add reasoning options
- #2480: [nano-gpt/stepfun-ai] Add reasoning options
- #2481: [nano-gpt/stepfun] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`