### PR TITLE
[nearai/google, Qwen, and Z.AI] Add reasoning options

### DIFF
--- a/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/nearai/models/Qwen/Qwen3.5-122B-A10B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-122b-a10b"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.4

--- a/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
+++ b/providers/nearai/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.6 35B A3B FP8"
 
 [cost]

--- a/providers/nearai/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 512, max = 24_576 }]
 
 [cost]
 input = 0.1

--- a/providers/nearai/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 512, max = 24_576 }]
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/nearai/models/google/gemini-2.5-flash.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 
 [cost]
 input = 0.3

--- a/providers/nearai/models/google/gemini-2.5-flash.toml
+++ b/providers/nearai/models/google/gemini-2.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/nearai/models/google/gemini-2.5-pro.toml
+++ b/providers/nearai/models/google/gemini-2.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-pro"
-reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-2.5-pro.toml
+++ b/providers/nearai/models/google/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-3-pro.toml
+++ b/providers/nearai/models/google/gemini-3-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
-reasoning_options = [{ type = "effort", values = ["low", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-3-pro.toml
+++ b/providers/nearai/models/google/gemini-3-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/nearai/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/nearai/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nearai/models/google/gemini-3.1-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/nearai/models/google/gemini-3.5-flash.toml
+++ b/providers/nearai/models/google/gemini-3.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.5-flash"
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.5

--- a/providers/nearai/models/google/gemini-3.5-flash.toml
+++ b/providers/nearai/models/google/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.5

--- a/providers/nearai/models/google/gemma-4-31B-it.toml
+++ b/providers/nearai/models/google/gemma-4-31B-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.13

--- a/providers/nearai/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/nearai/models/zai-org/GLM-5.1-FP8.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-27"
 last_updated = "2026-03-27"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true


### PR DESCRIPTION
Consolidates 3 small reasoning-options PRs into one reviewable 10-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2312: [nearai/google] Add reasoning options
- #2314: [nearai/Qwen] Add reasoning options
- #2315: [nearai/zai-org] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`