### PR TITLE
[opencode/multiple labs] Add reasoning options

### DIFF
--- a/providers/opencode/models/big-pickle.toml
+++ b/providers/opencode/models/big-pickle.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-17"
 last_updated = "2025-10-17"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/opencode/models/deepseek-v4-flash-free.toml
+++ b/providers/opencode/models/deepseek-v4-flash-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode/models/deepseek-v4-flash.toml
+++ b/providers/opencode/models/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/opencode/models/deepseek-v4-pro.toml
+++ b/providers/opencode/models/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/opencode/models/gpt-5.5.toml
+++ b/providers/opencode/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/opencode/models/gpt-5.toml
+++ b/providers/opencode/models/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/opencode/models/grok-build-0.1.toml
+++ b/providers/opencode/models/grok-build-0.1.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-20"
 last_updated = "2026-05-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/opencode/models/grok-code.toml
+++ b/providers/opencode/models/grok-code.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-20"
 last_updated = "2025-08-20"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/opencode/models/hy3-preview-free.toml
+++ b/providers/opencode/models/hy3-preview-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-20"
 last_updated = "2026-04-20"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-06"
 tool_call = true

--- a/providers/opencode/models/nemotron-3-super-free.toml
+++ b/providers/opencode/models/nemotron-3-super-free.toml
@@ -5,6 +5,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-11"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2026-02"

--- a/providers/opencode/models/nemotron-3-ultra-free.toml
+++ b/providers/opencode/models/nemotron-3-ultra-free.toml
@@ -5,6 +5,7 @@ release_date = "2026-06-04"
 last_updated = "2026-06-04"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2026-02"

--- a/providers/opencode/models/ring-2.6-1t-free.toml
+++ b/providers/opencode/models/ring-2.6-1t-free.toml
@@ -4,6 +4,7 @@ release_date = "2026-05-08"
 last_updated = "2026-05-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-06"
 tool_call = true


### PR DESCRIPTION
Consolidates 7 small reasoning-options PRs into one reviewable 12-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2290: [opencode/deepseek] Add reasoning options
- #2292: [opencode/inclusionai] Add reasoning options
- #2295: [opencode/nvidia] Add reasoning options
- #2297: [opencode/openai part 2] Add reasoning options
- #2298: [opencode/opencode] Add reasoning options
- #2299: [opencode/tencent] Add reasoning options
- #2300: [opencode/xai] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`