### PR TITLE
[poe/multiple labs] Add reasoning options

### DIFF
--- a/providers/poe/models/cerebras/gpt-oss-120b-cs.toml
+++ b/providers/poe/models/cerebras/gpt-oss-120b-cs.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/cerebras/qwen3-235b-2507-cs.toml
+++ b/providers/poe/models/cerebras/qwen3-235b-2507-cs.toml
@@ -3,6 +3,7 @@ release_date = "2025-08-06"
 last_updated = "2025-08-06"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/cerebras/qwen3-32b-cs.toml
+++ b/providers/poe/models/cerebras/qwen3-32b-cs.toml
@@ -3,6 +3,7 @@ release_date = "2025-05-15"
 last_updated = "2025-05-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/empiriolabs/deepseek-v4-flash-el.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-flash-el.toml
@@ -1,6 +1,7 @@
 name = "DeepSeek-V4-Flash-EL"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 release_date = "2026-04-24"
 last_updated = "2026-05-02"

--- a/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
@@ -1,6 +1,7 @@
 name = "DeepSeek-V4-Pro-EL"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 release_date = "2026-04-24"
 last_updated = "2026-05-02"

--- a/providers/poe/models/poetools/claude-code.toml
+++ b/providers/poe/models/poetools/claude-code.toml
@@ -3,6 +3,7 @@ release_date = "2025-11-27"
 last_updated = "2025-11-27"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true


### PR DESCRIPTION
Consolidates 3 small reasoning-options PRs into one reviewable 6-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2488: [poe/cerebras] Add reasoning options
- #2489: [poe/empiriolabs] Add reasoning options
- #2494: [poe/poetools] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`