### PR TITLE
[vercel/multiple labs] Add reasoning options

### DIFF
--- a/providers/vercel/models/alibaba/qwen3.7-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.7 Plus"
 family = "qwen3.7-plus"
 release_date = "2026-06-01"

--- a/providers/vercel/models/bytedance/seed-1.6.toml
+++ b/providers/vercel/models/bytedance/seed-1.6.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-01"
 last_updated = "2025-09"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/bytedance/seed-1.8.toml
+++ b/providers/vercel/models/bytedance/seed-1.8.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-01"
 last_updated = "2025-10"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/inception/mercury-2.toml
+++ b/providers/vercel/models/inception/mercury-2.toml
@@ -2,6 +2,7 @@ name = "Mercury 2"
 family = "mercury"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 release_date = "2026-02-24"

--- a/providers/vercel/models/kwaipilot/kat-coder-pro-v1.toml
+++ b/providers/vercel/models/kwaipilot/kat-coder-pro-v1.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-24"
 last_updated = "2025-10-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 knowledge = "2024-10"

--- a/providers/vercel/models/kwaipilot/kat-coder-pro-v2.toml
+++ b/providers/vercel/models/kwaipilot/kat-coder-pro-v2.toml
@@ -2,6 +2,7 @@ name = "Kat Coder Pro V2"
 family = "kat-coder"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 release_date = "2026-03-27"

--- a/providers/vercel/models/mistral/mistral-medium-3.5.toml
+++ b/providers/vercel/models/mistral/mistral-medium-3.5.toml
@@ -2,6 +2,7 @@ name = "Mistral Medium Latest"
 family = "mistral-medium"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 release_date = "2026-05-21"

--- a/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking"
+reasoning_options = []
 open_weights = false
 
 interleaved = true

--- a/providers/vercel/models/moonshotai/kimi-k2.5.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2026-01-26"
 attachment = true
 temperature = true

--- a/providers/vercel/models/moonshotai/kimi-k2.6.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2026-04-20"
 
 [cost]

--- a/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = false
 knowledge = "2025-09"

--- a/providers/vercel/models/stepfun/step-3.5-flash.toml
+++ b/providers/vercel/models/stepfun/step-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.5-flash"
+reasoning_options = []
 base_model_omit = ["limit.input"]
 name = "StepFun 3.5 Flash"
 family = "step"

--- a/providers/vercel/models/stepfun/step-3.7-flash.toml
+++ b/providers/vercel/models/stepfun/step-3.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 family = "step"
 release_date = "2026-05-28"
 open_weights = false


### PR DESCRIPTION
Consolidates 8 small reasoning-options PRs into one reviewable 13-model change.

Scope remains within one gateway/provider. The model metadata is unchanged from the source PR heads, rebased onto current `dev`.

Source PRs:
- #2515: [vercel/alibaba part 2] Add reasoning options
- #2519: [vercel/bytedance] Add reasoning options
- #2522: [vercel/inception] Add reasoning options
- #2524: [vercel/kwaipilot] Add reasoning options
- #2527: [vercel/mistral] Add reasoning options
- #2528: [vercel/moonshotai] Add reasoning options
- #2532: [vercel/perplexity] Add reasoning options
- #2533: [vercel/stepfun] Add reasoning options

Validation:
- `bun validate` on the combined consolidation tree
- `git diff --check`