### PR TITLE
Add kimi-k2.7-code for moonshotai-cn

### DIFF
--- a/providers/moonshotai-cn/models/kimi-k2.7-code.toml
+++ b/providers/moonshotai-cn/models/kimi-k2.7-code.toml
@@ -1,0 +1,1 @@
+../../moonshotai/models/kimi-k2.7-code.toml


### PR DESCRIPTION
Add 'kimi2.7-code' to 'moonshotai-cn'. 

This model has already been added to 'moonshotai' but is missing from 'moonshotai-cn', preventing OpenCode from selecting the latest Kimi 2.7-code model in the 'moonshotai-cn' provider.