### PR TITLE
 Reuse base model metadata for Gemini and Mistral provider entries

### DIFF
--- a/providers/google/models/gemini-2.5-flash.toml
+++ b/providers/google/models/gemini-2.5-flash.toml
@@ -1,14 +1,4 @@
-name = "Gemini 2.5 Flash"
-family = "gemini-flash"
-release_date = "2025-03-20"
-last_updated = "2025-06-05"
-attachment = true
-reasoning = true
-temperature = true
-knowledge = "2025-01"
-tool_call = true
-structured_output = true
-open_weights = false
+base_model = "google/gemini-2.5-flash"
 
 [[reasoning_options]]
 type = "toggle"
@@ -23,11 +13,3 @@ input = 0.30
 output = 2.50
 cache_read = 0.03
 input_audio = 1.00
-
-[limit]
-context = 1_048_576
-output = 65_536
-
-[modalities]
-input = ["text", "image", "audio", "video", "pdf"]
-output = ["text"]

--- a/providers/google/models/gemini-2.5-pro.toml
+++ b/providers/google/models/gemini-2.5-pro.toml
@@ -1,14 +1,4 @@
-name = "Gemini 2.5 Pro"
-family = "gemini-pro"
-release_date = "2025-03-20"
-last_updated = "2025-06-05"
-attachment = true
-reasoning = true
-temperature = true
-knowledge = "2025-01"
-tool_call = true
-structured_output = true
-open_weights = false
+base_model = "google/gemini-2.5-pro"
 
 [[reasoning_options]]
 type = "budget_tokens"
@@ -25,11 +15,3 @@ tier = { size = 200_000 }
 input = 2.50
 output = 15.00
 cache_read = 0.25
-
-[limit]
-context = 1_048_576
-output = 65_536
-
-[modalities]
-input = ["text", "image", "audio", "video", "pdf"]
-output = ["text"]

--- a/providers/mistral/models/mistral-large-2411.toml
+++ b/providers/mistral/models/mistral-large-2411.toml
@@ -1,13 +1,4 @@
-name = "Mistral Large 2.1"
-family = "mistral-large"
-release_date = "2024-11-01"
-last_updated = "2024-11-04"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-11"
-tool_call = true
-open_weights = true
+base_model = "mistral/mistral-large-2411"
 
 [cost]
 input = 2.00


### PR DESCRIPTION
Replace duplicated provider-agnostic metadata with base_model references for `Gemini 2.5 Flash`, `Gemini 2.5 Pro`, and `mistral-large-2411`.

Follow on to 5a8f9d4, 61a153e and PR #2251