### PR TITLE
Update context lengths for Poolside Laguna models

### DIFF
--- a/providers/kilo/models/poolside/laguna-m.1:free.toml
+++ b/providers/kilo/models/poolside/laguna-m.1:free.toml
@@ -14,7 +14,7 @@ output = 0.0
 
 [limit]
 context = 262144
-output = 8192
+output = 32768
 
 [modalities]
 input = ["text"]

--- a/providers/kilo/models/poolside/laguna-m.1:free.toml
+++ b/providers/kilo/models/poolside/laguna-m.1:free.toml
@@ -1,6 +1,6 @@
 name = "Poolside: Laguna M.1 (free)"
 release_date = "2026-04-28"
-last_updated = "2026-05-01"
+last_updated = "2026-06-13"
 attachment = false
 reasoning_options = []
 reasoning = true
@@ -13,7 +13,7 @@ input = 0.0
 output = 0.0
 
 [limit]
-context = 131072
+context = 262144
 output = 8192
 
 [modalities]

--- a/providers/kilo/models/poolside/laguna-xs.2:free.toml
+++ b/providers/kilo/models/poolside/laguna-xs.2:free.toml
@@ -14,7 +14,7 @@ output = 0.0
 
 [limit]
 context = 262144
-output = 8192
+output = 32768
 
 [modalities]
 input = ["text"]

--- a/providers/kilo/models/poolside/laguna-xs.2:free.toml
+++ b/providers/kilo/models/poolside/laguna-xs.2:free.toml
@@ -1,6 +1,6 @@
 name = "Poolside: Laguna XS.2 (free)"
 release_date = "2026-04-28"
-last_updated = "2026-05-01"
+last_updated = "2026-06-13"
 attachment = false
 reasoning_options = []
 reasoning = true
@@ -13,7 +13,7 @@ input = 0.0
 output = 0.0
 
 [limit]
-context = 131072
+context = 262144
 output = 8192
 
 [modalities]

--- a/providers/poolside/models/poolside/laguna-m.1.toml
+++ b/providers/poolside/models/poolside/laguna-m.1.toml
@@ -1,6 +1,6 @@
 name = "Laguna M.1"
 release_date = "2026-04-28"
-last_updated = "2026-04-28"
+last_updated = "2026-06-13"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
@@ -18,7 +18,7 @@ cache_read = 0.0
 cache_write = 0.0
 
 [limit]
-context = 131_040
+context = 262_144
 output = 8_192
 
 [modalities]

--- a/providers/poolside/models/poolside/laguna-m.1.toml
+++ b/providers/poolside/models/poolside/laguna-m.1.toml
@@ -19,7 +19,7 @@ cache_write = 0.0
 
 [limit]
 context = 262_144
-output = 8_192
+output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/poolside/models/poolside/laguna-xs.2.toml
+++ b/providers/poolside/models/poolside/laguna-xs.2.toml
@@ -1,6 +1,6 @@
 name = "Laguna XS.2"
 release_date = "2026-04-28"
-last_updated = "2026-04-28"
+last_updated = "2026-06-13"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
@@ -18,7 +18,7 @@ cache_read = 0.0
 cache_write = 0.0
 
 [limit]
-context = 131_040
+context = 262_144
 output = 8_192
 
 [modalities]

--- a/providers/poolside/models/poolside/laguna-xs.2.toml
+++ b/providers/poolside/models/poolside/laguna-xs.2.toml
@@ -19,7 +19,7 @@ cache_write = 0.0
 
 [limit]
 context = 262_144
-output = 8_192
+output = 32_768
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Updated context lengths from 128K to 256K, per https://poolside.ai/blog/long-context-update-laguna-xs-2-and-m-1 