### PR TITLE
chore(ambient): add Kimi K2.7 Code, refresh GLM 5.1

### DIFF
--- a/providers/ambient/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/ambient/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.7-code"
+temperature = true
+
+[cost]
+input = 0.75
+output = 3.5
+cache_read = 0.16
+cache_write = 0

--- a/providers/ambient/models/zai-org/GLM-5.1-FP8.toml
+++ b/providers/ambient/models/zai-org/GLM-5.1-FP8.toml
@@ -1,5 +1,6 @@
-reasoning_options = []
 base_model = "zhipuai/glm-5.1"
+name = "GLM 5.1"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Updates the Ambient provider catalog for two models, sourced from the live `https://api.ambient.xyz/v1/models` endpoint.

### Changes
- **add** `moonshotai/kimi-k2.7-code` — inherits `base_model = "moonshotai/kimi-k2.7-code"`, overriding only the fields Ambient's API reports (pricing, `temperature`).
- **refresh** `zai-org/GLM-5.1-FP8` — set the provider display name (`GLM 5.1`).

Both are thin `base_model` overlays over existing canonical metadata, so they only carry Ambient-specific fields. `bun validate` passes.

This is a small, targeted catalog update; a separate change will introduce a registered sync provider to keep the full Ambient catalog fresh automatically.