### PR TITLE
chore: update TogetherAI prices 20260615

### DIFF
--- a/providers/togetherai/models/Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/togetherai/models/Qwen/Qwen3.5-397B-A17B.toml
@@ -1,7 +1,7 @@
 name = "Qwen3.5 397B A17B"
 family = "qwen"
 release_date = "2026-02-16"
-last_updated = "2026-02-16"
+last_updated = "2026-06-14"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
@@ -12,6 +12,7 @@ open_weights = true
 [cost]
 input = 0.60
 output = 3.60
+cached_input = 0.35
 
 [limit]
 context = 262_144

--- a/providers/togetherai/models/Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/togetherai/models/Qwen/Qwen3.5-397B-A17B.toml
@@ -1,7 +1,7 @@
 name = "Qwen3.5 397B A17B"
 family = "qwen"
 release_date = "2026-02-16"
-last_updated = "2026-06-14"
+last_updated = "2026-06-15"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "toggle" }]

--- a/providers/togetherai/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/togetherai/models/Qwen/Qwen3.7-Max.toml
@@ -1,7 +1,7 @@
 name = "Qwen3.7 Max"
 family = "qwen"
 release_date = "2026-05-21"
-last_updated = "2026-05-21"
+last_updated = "2026-06-15"
 attachment = false
 reasoning = false
 temperature = true

--- a/providers/togetherai/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/togetherai/models/Qwen/Qwen3.7-Max.toml
@@ -9,8 +9,9 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 2.50
-output = 7.50
+input = 1.25
+output = 3.75
+cached_input = 0.13
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
- updating Qwen prices from Together AI
- not adding any missing models for now

Missing Together AI models from the Qwen family (give me a thumbs up if you want these added as well 👍 ):
- Qwen3-235B-A22B-FP8-Throughput
- Qwen3.5-397B-A17B
- Qwen3.6-Plus


AI use disclosure: 
- used [Narev MCP](https://www.narev.ai/) to identify stale prices 
- manually cross checked with https://www.together.ai/pricing to confirm