### PR TITLE
chore: update stepai prices 20260615

### DIFF
--- a/providers/stepfun/models/step-3.5-flash.toml
+++ b/providers/stepfun/models/step-3.5-flash.toml
@@ -1,6 +1,6 @@
 name = "Step 3.5 Flash"
 release_date = "2026-01-29"
-last_updated = "2026-02-13"
+last_updated = "2026-06-15"
 attachment = false
 reasoning = true
 temperature = true
@@ -9,9 +9,9 @@ knowledge = "2025-01"
 open_weights = true
 
 [cost]
-input = 0.096
-output = 0.288
-cache_read = 0.019
+input = 0.1
+output = 0.3
+cache_read = 0.02
 
 [limit]
 context = 256_000


### PR DESCRIPTION
- updating Qwen prices from Step AI
- not adding any missing models for now (give me a thumbs up if you want these added as well 👍 )

There is one missing Step AI text model:
- step-3.7-flash

AI use disclosure: 
- used [Narev MCP](https://www.narev.ai/) to identify stale prices 
- manually cross checked with https://platform.stepfun.ai/docs/en/guides/pricing/details to confirm