### PR TITLE
chore: update siliconflow prices 20260615

### DIFF
--- a/providers/siliconflow/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/siliconflow/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,7 +1,7 @@
 name = "MiniMaxAI/MiniMax-M2.5"
 family = "minimax"
 release_date = "2026-02-15"
-last_updated = "2026-02-15"
+last_updated = "2026-06-15"
 attachment = false
 reasoning = false
 temperature = true
@@ -11,6 +11,7 @@ open_weights = false
 
 [cost]
 input = 0.3
+cache_input = 0.03
 output = 1.2
 
 [limit]

--- a/providers/siliconflow/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/siliconflow/models/moonshotai/Kimi-K2.6.toml
@@ -1,7 +1,7 @@
 name = "moonshotai/Kimi-K2.6"
 family = "kimi-k2"
 release_date = "2026-04-21"
-last_updated = "2026-04-21"
+last_updated = "2026-06-15"
 attachment = false
 reasoning = true
 temperature = true
@@ -13,9 +13,9 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 0.95
+input = 0.77
 output = 4.0
-cache_read = 0.16
+cache_read = 0.2
 
 [limit]
 context = 262_000

--- a/providers/siliconflow/models/zai-org/GLM-5.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.toml
@@ -1,7 +1,7 @@
 name = "zai-org/GLM-5"
 family = "glm"
 release_date = "2026-02-12"
-last_updated = "2026-02-12"
+last_updated = "2026-06-15"
 attachment = false
 reasoning = true
 temperature = true
@@ -13,8 +13,9 @@ open_weights = true
 field = "reasoning_content"
 
 [cost]
-input = 1
-output = 3.20
+input = 0.95
+output = 2.55
+cache_input = 0.2
 
 [limit]
 context = 205_000


### PR DESCRIPTION
- updating Qwen prices from Siliconflow
- not adding any missing models for now

AI use disclosure: 
- used [Narev MCP](https://www.narev.ai/) to identify stale prices 
- manually cross checked with https://www.siliconflow.com/pricing to confirm