### PR TITLE
chore: update fireworks pricing 20260615

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-120b.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-120b.toml
@@ -15,7 +15,7 @@ values = ["low", "medium", "high"]
 [cost]
 input = 0.15
 output = 0.60
-cache_read = 0.015
+cache_read = 0.01
 
 [limit]
 context = 131_072

--- a/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-120b.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-120b.toml
@@ -1,7 +1,7 @@
 name = "GPT OSS 120B"
 family = "gpt-oss"
 release_date = "2025-08-05"
-last_updated = "2025-08-05"
+last_updated = "2026-06-15"
 attachment = false
 reasoning = true
 temperature = true


### PR DESCRIPTION
last one for today.

- updating the cache price for fireworks


AI disclosure: Used narev.ai MCP to identify stale prices, then cross checked them with the fireworks pricing page: https://fireworks.ai/models/fireworks