### PR TITLE
[vercel/zai] Add reasoning toggles

### DIFF
--- a/providers/vercel/models/zai/glm-4.5-air.toml
+++ b/providers/vercel/models/zai/glm-4.5-air.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.5 Air"
 
 [cost]

--- a/providers/vercel/models/zai/glm-4.5.toml
+++ b/providers/vercel/models/zai/glm-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.5"
 knowledge = "2025-07"
 

--- a/providers/vercel/models/zai/glm-4.5v.toml
+++ b/providers/vercel/models/zai/glm-4.5v.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5v"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.5V"
 knowledge = "2025-08"
 

--- a/providers/vercel/models/zai/glm-4.6.toml
+++ b/providers/vercel/models/zai/glm-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.6"
 
 interleaved = true

--- a/providers/vercel/models/zai/glm-4.6v-flash.toml
+++ b/providers/vercel/models/zai/glm-4.6v-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/zai/glm-4.6v.toml
+++ b/providers/vercel/models/zai/glm-4.6v.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6v"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2025-09-30"
 knowledge = "2024-10"
 open_weights = false

--- a/providers/vercel/models/zai/glm-4.7-flash.toml
+++ b/providers/vercel/models/zai/glm-4.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.7 Flash"
 family = "glm"
 release_date = "2026-03-13"

--- a/providers/vercel/models/zai/glm-4.7-flashx.toml
+++ b/providers/vercel/models/zai/glm-4.7-flashx.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flashx"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.7 FlashX"
 release_date = "2025-01-01"
 knowledge = "2025-01"

--- a/providers/vercel/models/zai/glm-4.7.toml
+++ b/providers/vercel/models/zai/glm-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 4.7"
 knowledge = "2024-10"
 open_weights = false

--- a/providers/vercel/models/zai/glm-5-turbo.toml
+++ b/providers/vercel/models/zai/glm-5-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5-turbo"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 5 Turbo"
 release_date = "2026-03-15"
 

--- a/providers/vercel/models/zai/glm-5.1.toml
+++ b/providers/vercel/models/zai/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 5.1"
 release_date = "2026-04-07"
 attachment = true

--- a/providers/vercel/models/zai/glm-5.toml
+++ b/providers/vercel/models/zai/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+reasoning_options = [{ type = "toggle" }]
 release_date = "2026-02-12"
 
 [cost]

--- a/providers/vercel/models/zai/glm-5v-turbo.toml
+++ b/providers/vercel/models/zai/glm-5v-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5v-turbo"
+reasoning_options = [{ type = "toggle" }]
 name = "GLM 5V Turbo"
 
 [cost]


### PR DESCRIPTION
Audits all reasoning-capable Z.AI models currently configured for Vercel AI Gateway.\n\nAdds the documented enabled/disabled thinking toggle without inferring effort levels or token budgets.\n\nValidation: bun validate; git diff --check