### PR TITLE
[vercel/alibaba openai] Complete reasoning audit

### DIFF
--- a/providers/vercel/models/alibaba/qwen3.7-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [{ type = "toggle" }]
 name = "Qwen 3.7 Plus"
 family = "qwen3.7-plus"
 release_date = "2026-06-01"

--- a/providers/vercel/models/openai/gpt-5.2-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.2-chat.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"


### PR DESCRIPTION
Adds the omitted Qwen 3.7 Plus reasoning toggle and marks GPT-5.2 Chat as having no verified selectable reasoning control.\n\nThe GPT-5.2 Chat singleton medium value could not be substantiated from current Vercel or OpenAI documentation.\n\nValidation: bun validate; git diff --check