### PR TITLE
feat(moonshotai): add Kimi K2.7 Code HighSpeed

### DIFF
--- a/providers/moonshotai-cn/models/kimi-k2.7-code-highspeed.toml
+++ b/providers/moonshotai-cn/models/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,1 @@
+../../moonshotai/models/kimi-k2.7-code-highspeed.toml

--- a/providers/moonshotai/models/kimi-k2.7-code-highspeed.toml
+++ b/providers/moonshotai/models/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi K2.7 Code HighSpeed"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.90
+output = 8.0
+cache_read = 0.38


### PR DESCRIPTION
## Summary
- add the public `kimi-k2.7-code-highspeed` serving tier to Moonshot AI
- expose the same model through Moonshot AI China using the existing provider symlink convention
- inherit Kimi K2.7 Code capabilities while applying official HighSpeed pricing

## Verification
- `bun validate`
- `git diff --check`

## Sources
- https://platform.kimi.ai/docs/models
- https://platform.kimi.ai/docs/pricing/chat-k27-code
- https://platform.kimi.com/docs/models
- https://platform.kimi.com/docs/pricing/chat-k27-code

Resolves anomalyco/opencode#32493