### PR TITLE
Add Minimax-M3

### DIFF
--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -2,7 +2,7 @@ name = "MiniMax M3"
 release_date = "2026-06-07"
 last_updated = "2026-06-07"
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["enabled", "disabled", "adaptive"] }]
 temperature = true
 tool_call = true
 

--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -1,13 +1,5 @@
-name = "MiniMax M3"
-release_date = "2026-06-07"
-last_updated = "2026-06-07"
-reasoning = true
-reasoning_options = [
-  { type = "effort", values = ["low", "medium", "high"] }
-]temperature = true
-tool_call = true
-attachment = true
-open_weights = true
+base_model = "minimax/MiniMax-M3"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.0
@@ -16,7 +8,3 @@ output = 0.0
 [limit]
 context = 1_000_000
 output = 16_384
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -1,15 +1,18 @@
-base_model = "minimax/MiniMax-M3"
+name = "MiniMax M3"
+release_date = "2026-06-07"
+last_updated = "2026-06-07"
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+tool_call = true
 
 [cost]
 input = 0.0
 output = 0.0
-cache_read = 0.0
 
 [limit]
-context = 1000000
-input = 1000000
-output = 16384
+context = 1_000_000
+output = 16_384
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -1,6 +1,5 @@
 base_model = "minimax/MiniMax-M3"
 reasoning = true
-reasoning_options = ["enabled", "disabled"]
 
 [cost]
 input = 0.0

--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -1,5 +1,6 @@
 base_model = "minimax/MiniMax-M3"
 reasoning = true
+reasoning_options = ["enabled", "disabled"]
 
 [cost]
 input = 0.0

--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -1,7 +1,5 @@
-
-base_model = "minimaxai/minimax-m3"
-structured_output = true
-reasoning_options = []
+base_model = "minimax/MiniMax-M3"
+reasoning = true
 
 [cost]
 input = 0.0
@@ -11,7 +9,7 @@ cache_read = 0.0
 [limit]
 context = 1000000
 input = 1000000
-output = 131072
+output = 16384
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -2,9 +2,12 @@ name = "MiniMax M3"
 release_date = "2026-06-07"
 last_updated = "2026-06-07"
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["enabled", "disabled", "adaptive"] }]
-temperature = true
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "high"] }
+]temperature = true
 tool_call = true
+attachment = true
+open_weights = true
 
 [cost]
 input = 0.0

--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -1,0 +1,18 @@
+
+base_model = "minimaxai/minimax-m3"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.0
+output = 0.0
+cache_read = 0.0
+
+[limit]
+context = 1000000
+input = 1000000
+output = 131072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
Adds NVIDIA's `minimaxai/minimax-m3` model using the canonical MiniMax M3 metadata plus NVIDIA-specific limits.

## Changes

- Adds `providers/nvidia/models/minimaxai/minimax-m3.toml`.
- Inherits model facts from `base_model = "minimax/MiniMax-M3"`.
- Sets NVIDIA's trial pricing to zero, matching existing NVIDIA-hosted preview models.
- Overrides NVIDIA's documented 1M input context and `max_tokens` output limit of `16_384`.
- Adds a reasoning toggle because NVIDIA documents `chat_template_kwargs.thinking_mode = "enabled" | "disabled" | "adaptive"` for this model.

## Evidence

- NVIDIA model list includes `minimaxai/minimax-m3`: https://integrate.api.nvidia.com/v1/models
- NVIDIA MiniMax M3 page documents text, image, and video inputs, text output, 1M context, and release date: https://build.nvidia.com/minimaxai/minimax-m3
- NVIDIA MiniMax M3 inference reference documents `max_tokens` range `1..16_384` and `chat_template_kwargs.thinking_mode`: https://docs.api.nvidia.com/nim/reference/minimaxai-minimax-m3-infer

## Validation

- `bun validate`
- `git diff --check`
