### PR TITLE
feat: add z-ai/glm-5.2 model on OpenRouter

### DIFF
--- a/providers/openrouter/models/z-ai/glm-5.2.toml
+++ b/providers/openrouter/models/z-ai/glm-5.2.toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5.2"
+structured_output = false
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 1_048_576
+output = 131_072


### PR DESCRIPTION
Adds the z-ai/glm-5.2 model to the OpenRouter provider catalog. The canonical base model (models/zhipuai/glm-5.2.toml) already exists, so this just wires up the OpenRouter provider entry, mirroring z-ai/glm-5.1.toml.
