### PR TITLE
feat: add LLM Gateway gemma-4, kimi-k2.7-code-highspeed, qwen3.5-9b, glm-5.2

### DIFF
--- a/models/alibaba/qwen3.5-9b.toml
+++ b/models/alibaba/qwen3.5-9b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5 9B"
+family = "qwen"
+release_date = "2026-02-23"
+last_updated = "2026-02-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3.5-9B"

--- a/models/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/models/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,23 @@
+name = "Kimi K2.7 Code Highspeed"
+family = "kimi-k2"
+release_date = "2026-06-12"
+last_updated = "2026-06-12"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2025-01"
+open_weights = true
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/moonshotai/Kimi-K2.7-Code"

--- a/providers/llmgateway/models/gemma-4-26b-a4b-it.toml
+++ b/providers/llmgateway/models/gemma-4-26b-a4b-it.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemma-4-26b-a4b-it"
+
+[cost]
+input = 0.07
+output = 0.34

--- a/providers/llmgateway/models/gemma-4-31b-it.toml
+++ b/providers/llmgateway/models/gemma-4-31b-it.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemma-4-31b-it"
+
+[cost]
+input = 0.13
+output = 0.38

--- a/providers/llmgateway/models/glm-5.2.toml
+++ b/providers/llmgateway/models/glm-5.2.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+cache_write = 0

--- a/providers/llmgateway/models/kimi-k2.7-code-highspeed.toml
+++ b/providers/llmgateway/models/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,10 @@
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.9
+output = 8
+cache_read = 0.38

--- a/providers/llmgateway/models/qwen3.5-9b.toml
+++ b/providers/llmgateway/models/qwen3.5-9b.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3.5-9b"
+
+[cost]
+input = 0.1
+output = 0.15


### PR DESCRIPTION
Adds LLM Gateway provider entries for newly available text models.

## Models added (`providers/llmgateway/models/`)
| model | base_model | input | output | cache_read | reasoning |
|---|---|---|---|---|---|
| `gemma-4-31b-it` | `google/gemma-4-31b-it` | 0.13 | 0.38 | — | yes |
| `gemma-4-26b-a4b-it` | `google/gemma-4-26b-a4b-it` | 0.07 | 0.34 | — | yes |
| `kimi-k2.7-code-highspeed` | `moonshotai/kimi-k2.7-code-highspeed` | 1.9 | 8 | 0.38 | effort + interleaved |
| `qwen3.5-9b` | `alibaba/qwen3.5-9b` | 0.1 | 0.15 | — | yes |
| `glm-5.2` | `zhipuai/glm-5.2` | 1.4 | 4.4 | 0.26 | interleaved |

## Base metadata added (`models/`)
- `models/moonshotai/kimi-k2.7-code-highspeed.toml` — highspeed tier of `kimi-k2.7-code` (same weights)
- `models/alibaba/qwen3.5-9b.toml`

`gemma-4-*` and `glm-5.2` base definitions already existed in `models/`.

## Sources
- Pricing/capabilities for gemma-4, kimi-k2.7-code-highspeed, qwen3.5-9b from the live `api.llmgateway.io/v1/models` catalog.
- `glm-5.2` pricing from the [Z.AI docs](https://docs.z.ai/guides/llm/glm-5.2): input \$1.4, cached input \$0.26, output \$4.4 (not yet live on LLM Gateway; added ahead of rollout).

`bun validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)