### PR TITLE
feat(friendli): add GLM-5.2, link models to canonical pages

### DIFF
--- a/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/friendli/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,14 +1,9 @@
+base_model = "minimax/MiniMax-M2.5"
 name = "MiniMax-M2.5"
-family = "minimax"
-attachment = false
-reasoning = true
-reasoning_options = []
-tool_call = true
-structured_output = true
-temperature = true
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
-open_weights = true
+structured_output = true
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
@@ -21,7 +16,3 @@ cache_read = 0.06
 [limit]
 context = 196_608
 output = 196_608
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/friendli/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
+++ b/providers/friendli/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
@@ -1,13 +1,8 @@
+base_model = "alibaba/qwen3-235b-a22b"
 name = "Qwen3 235B A22B Instruct 2507"
-family = "qwen"
-attachment = false
-reasoning = false
-tool_call = true
-structured_output = true
-temperature = true
 release_date = "2025-07-29"
 last_updated = "2026-01-29"
-open_weights = true
+structured_output = true
 
 [cost]
 input = 0.2
@@ -16,7 +11,3 @@ output = 0.8
 [limit]
 context = 262_144
 output = 262_144
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/friendli/models/meta-llama/Llama-3.3-70B-Instruct.toml
+++ b/providers/friendli/models/meta-llama/Llama-3.3-70B-Instruct.toml
@@ -1,13 +1,8 @@
+base_model = "meta/llama-3.3-70b-instruct"
 name = "Llama 3.3 70B Instruct"
-family = "llama"
-attachment = false
-reasoning = false
-tool_call = true
-structured_output = true
-temperature = true
 release_date = "2024-08-01"
 last_updated = "2025-12-23"
-open_weights = true
+structured_output = true
 
 [cost]
 input = 0.6
@@ -16,7 +11,3 @@ output = 0.6
 [limit]
 context = 131_072
 output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/friendli/models/zai-org/GLM-5.1.toml
+++ b/providers/friendli/models/zai-org/GLM-5.1.toml
@@ -1,14 +1,9 @@
+base_model = "zhipuai/glm-5.1"
 name = "GLM-5.1"
-family = "glm"
-attachment = false
-reasoning = true
-reasoning_options = []
-tool_call = true
-structured_output = true
-temperature = true
 release_date = "2026-04-07"
 last_updated = "2026-04-07"
-open_weights = true
+structured_output = true
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
@@ -21,7 +16,3 @@ cache_read = 0.26
 [limit]
 context = 202_752
 output = 202_752
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/friendli/models/zai-org/GLM-5.toml
+++ b/providers/friendli/models/zai-org/GLM-5.toml
@@ -1,14 +1,9 @@
+base_model = "zhipuai/glm-5"
 name = "GLM-5"
-family = "glm"
-attachment = false
-reasoning = true
-reasoning_options = []
-tool_call = true
-structured_output = true
-temperature = true
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
-open_weights = true
+structured_output = true
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
@@ -21,7 +16,3 @@ cache_read = 0.50
 [limit]
 context = 202_752
 output = 202_752
-
-[modalities]
-input = ["text"]
-output = ["text"]


### PR DESCRIPTION
## Summary
- Add `providers/friendli/models/zai-org/GLM-5.2.toml` for Friendli's GLM-5.2 offering
- Add `base_model` references to existing Friendli models (MiniMax-M2.5, Qwen3-235B-A22B-Instruct-2507, Llama-3.3-70B-Instruct, GLM-5, GLM-5.1, GLM-5.2) so they appear on their canonical model pages (e.g. https://models.dev/models/zhipuai/glm-5.1/)
- Remove fields now inherited from the base model (family, attachment, tool_call, modalities, etc.)
- Pricing and limits aligned with live Friendli models API response from https://api.friendli.ai/serverless/v1/models

## Validation
`bun validate` ✅

## Reference
- https://api.friendli.ai/serverless/v1/models
- https://friendli.ai/pricing