### PR TITLE
Add GLM-5.2 to Baseten provider

### DIFF
--- a/providers/baseten/models/zai-org/GLM-5.2.toml
+++ b/providers/baseten/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 131_072
+output = 131_072

--- a/providers/baseten/models/zai-org/GLM-5.2.toml
+++ b/providers/baseten/models/zai-org/GLM-5.2.toml
@@ -6,6 +6,11 @@ type = "toggle"
 [interleaved]
 field = "reasoning_content"
 
+[cost]
+input = 1.5
+output = 4.5
+cache_read = 0.3
+
 [limit]
 context = 131_072
 output = 131_072


### PR DESCRIPTION
## Summary
- Add GLM-5.2 model configuration for the Baseten provider
- Model supports reasoning, tool calling, and structured output (via `zhipuai/glm-5.2` base model)
- 128K context window with 128K output limit (per Baseten `/v1/models` API)
- Pricing: $1.50 input / $0.30 cached input / $4.50 output per 1M tokens

## Changes
- New model file: `providers/baseten/models/zai-org/GLM-5.2.toml`
- Uses `base_model = "zhipuai/glm-5.2"` with Baseten-specific limits and reasoning options
- Includes `[[reasoning_options]]` toggle and interleaved reasoning field, matching other GLM entries

## Notes
- Supersedes the automated sync draft in #2626 with complete reasoning metadata and published pricing.
- Metadata sourced from `GET https://inference.baseten.co/v1/models` on 2026-06-16.

## Test plan
- [x] `bun validate` passes locally
- [ ] Model metadata matches Baseten Model APIs catalog