### PR TITLE
Fix Kimi K2.7 Code pricing for Baseten provider

### DIFF
--- a/providers/baseten/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.7-Code.toml
@@ -2,8 +2,9 @@ base_model = "moonshotai/kimi-k2.7-code"
 temperature = true
 
 [cost]
-input = 0.16
+input = 0.95
 output = 4
+cache_read = 0.16
 
 [limit]
 context = 262_000


### PR DESCRIPTION
## Summary
- Correct Kimi K2.7 Code pricing for the Baseten provider
- Previous entry used $0.16 input (likely conflated with cached input pricing from the API)
- Updated to match published Baseten Model APIs pricing

## Changes
- `providers/baseten/models/moonshotai/Kimi-K2.7-Code.toml`
  - Input: $0.95 / 1M tokens
  - Cached input: $0.16 / 1M tokens
  - Output: $4.00 / 1M tokens

## Test plan
- [x] `bun validate` passes locally
- [ ] Pricing matches Baseten pricing page