### PR TITLE
feat(fireworks-ai): add GLM-5.2 and fix Kimi/DeepSeek/GPT pricing

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+last_updated = "2026-06-16"
 
 [[reasoning_options]]
 type = "toggle"
@@ -13,4 +14,4 @@ field = "reasoning_content"
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.03
+cache_read = 0.028

--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p2.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p2.toml
@@ -1,0 +1,32 @@
+name = "GLM 5.2"
+family = "glm"
+release_date = "2026-06-16"
+last_updated = "2026-06-16"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.26
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-120b.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/gpt-oss-120b.toml
@@ -1,7 +1,7 @@
 name = "GPT OSS 120B"
 family = "gpt-oss"
 release_date = "2025-08-05"
-last_updated = "2026-06-15"
+last_updated = "2026-06-16"
 attachment = false
 reasoning = true
 temperature = true
@@ -15,7 +15,7 @@ values = ["low", "medium", "high"]
 [cost]
 input = 0.15
 output = 0.60
-cache_read = 0.01
+cache_read = 0.015
 
 [limit]
 context = 131_072

--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p7-code.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p7-code.toml
@@ -1,5 +1,12 @@
-base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi K2.7 Code"
+family = "kimi-k2"
+release_date = "2026-06-12"
+last_updated = "2026-06-16"
+attachment = true
+reasoning = true
 temperature = true
+tool_call = true
+open_weights = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p7-code-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k2p7-code-fast.toml
@@ -1,13 +1,19 @@
-base_model = "moonshotai/kimi-k2.7-code"
 name = "Kimi K2.7 Code Fast"
+family = "kimi-k2"
+release_date = "2026-06-12"
+last_updated = "2026-06-16"
+attachment = true
+reasoning = true
 temperature = true
+tool_call = true
+open_weights = true
 
 [[reasoning_options]]
 type = "toggle"
 
 [cost]
 cache_read = 0.38
-input = 2.00
+input = 1.90
 output = 8.00
 
 [limit]


### PR DESCRIPTION
- Add GLM-5.2 (accounts/fireworks/models/glm-5p2) with 1M context and

  Fireworks serverless pricing ($1.40 / $0.26 / $4.40).

- Normalize Kimi K2.7 Code and Kimi K2.7 Code Fast TOML files to be

  self-contained and follow the same metadata pattern as Kimi K2.6.

- Fix Kimi K2.7 Code Fast input price ($2.00 -> $1.90).

- Fix DeepSeek V4 Flash cache read price ($0.03 -> $0.028).

- Fix GPT OSS 120B cache read price ($0.01 -> $0.015).

- Set last_updated to 2026-06-16 for all touched provider files.

---

This reverts the GPT OSS 120B cache read pricing change merged as part of #2605