### PR TITLE
feat: add glm-5.2 to ollama-cloud provider

### DIFF
--- a/providers/ollama-cloud/models/glm-5.2.toml
+++ b/providers/ollama-cloud/models/glm-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-name = "glm-5.2:cloud"
+name = "glm-5.2"
 reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
@@ -8,3 +8,8 @@ field = "reasoning_content"
 [limit]
 context = 976000
 output = 131072
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.39

--- a/providers/ollama-cloud/models/glm-5.2:cloud.toml
+++ b/providers/ollama-cloud/models/glm-5.2:cloud.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.2"
+name = "glm-5.2:cloud"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 976000
+output = 131072


### PR DESCRIPTION
Adds glm-5.2:cloud to the Ollama Cloud provider model list, using the existing model metadata at models/zhipuai/glm-5.2.toml via base_model.

This model is already available and can be used with ollama launch opencode --model glm-5.2:cloud, but currently does not appear in the model picker because it is not listed in the Ollama Cloud provider's model definitions.

**Question:** What is the pricing for glm-5.2:cloud on Ollama Cloud? I did not include a [cost] section since other ollama-cloud models omit it, but please add if applicable.