### PR TITLE
[vercel/alibaba openai] Add tested reasoning controls

### DIFF
--- a/providers/vercel/models/alibaba/qwen3.7-plus.toml
+++ b/providers/vercel/models/alibaba/qwen3.7-plus.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 262_144 }]
 name = "Qwen 3.7 Plus"
 family = "qwen3.7-plus"
 release_date = "2026-06-01"

--- a/providers/vercel/models/openai/gpt-5.1-instant.toml
+++ b/providers/vercel/models/openai/gpt-5.1-instant.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.1-thinking.toml
+++ b/providers/vercel/models/openai/gpt-5.1-thinking.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-12"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.2-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.2-chat.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.3-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.3-chat.toml
@@ -2,7 +2,7 @@ name = "GPT-5.3 Chat"
 family = "gpt"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["medium"] }]
 tool_call = true
 temperature = true
 release_date = "2026-03-03"

--- a/providers/vercel/models/openai/gpt-5.3-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.3-codex.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.3 Codex"
 family = "gpt"
 release_date = "2026-02-24"

--- a/providers/vercel/models/openai/gpt-5.5.toml
+++ b/providers/vercel/models/openai/gpt-5.5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.5"
 release_date = "2026-04-24"
 temperature = true


### PR DESCRIPTION
Follows merged PR #2611 with authenticated AI Gateway results.\n\n- Adds Qwen 3.7 Plus tested thinking budget range: 1..262144.\n- Adds exact effort sets returned by Vercel/OpenAI validation for GPT-5.1 Instant, GPT-5.1 Thinking, GPT-5.2 Chat, GPT-5.3 Chat, GPT-5.3 Codex, and GPT-5.5.\n\nValidation: bun validate; git diff --check