### PR TITLE
[vercel/mistral] Correct Mistral Small reasoning

### DIFF
--- a/providers/vercel/models/mistral/mistral-small.toml
+++ b/providers/vercel/models/mistral/mistral-small.toml
@@ -1,1 +1,22 @@
-../../../mistral/models/mistral-small-latest.toml
+name = "Mistral Small (latest)"
+family = "mistral-small"
+release_date = "2026-03-16"
+last_updated = "2026-03-16"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-06"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.15
+output = 0.60
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Replaces the shared Mistral Small symlink with Vercel-specific metadata because the live Vercel model and all active endpoints no longer advertise reasoning.\n\nThe direct Mistral provider remains unchanged.\n\nValidation: bun validate; git diff --check