### PR TITLE
feat(neuralwatt): expose full GLM 5.2 reasoning effort scale

### DIFF
--- a/providers/neuralwatt/models/glm-5.2.toml
+++ b/providers/neuralwatt/models/glm-5.2.toml
@@ -4,7 +4,7 @@ release_date = "2026-06-17"
 last_updated = "2026-06-17"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 open_weights = true


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/anomalyco/models.dev/pull/2636#issuecomment-4728895731. GLM 5.2 accepts the OpenAI-standard `reasoning_effort` field and supports a wider depth range than the three levels (`low`, `medium`, `high`) that were advertised in the merged model file. This exposes the full effort scale.

## Context

Per the Neuralwatt [chat-completions docs](https://portal.neuralwatt.com/docs/api/chat-completions), the gateway accepts the full OpenAI-style `reasoning_effort` scale and normalizes it onto GLM-5.2's two native levels (`high` and `max`):

| Effort | Resolves to | Behavior |
|--------|-------------|----------|
| `minimal` | (skips reasoning) | Equivalent to `enable_thinking: false` |
| `low` | `high` | |
| `medium` | `high` | |
| `high` | `high` | Enhanced reasoning — balanced depth/latency |
| `xhigh` | `max` | Deepest — best for complex math, multi-step planning, agentic/coding tasks (default when `reasoning_effort` is unset) |

The pi provider extension ([`pi-neuralwatt-provider/patch.json`](https://github.com/monotykamary/pi-neuralwatt-provider/blob/main/patch.json)) already exposes all five pi reasoning tiers via `thinkingLevelMap` (`minimal`, `low`, `medium`, `high`, `xhigh`, with `xhigh` mapped to `max`). The `models.dev` catalog was the side missing the extra efforts.

## Changes

- `providers/neuralwatt/models/glm-5.2.toml`
  - `reasoning_options` `effort.values`: `["low", "medium", "high"]` → `["minimal", "low", "medium", "high", "xhigh"]`

No other GLM-5.2 fields change. The other neuralwatt models already match the provider data and are unaffected.

## Validation

`bun validate` passes (exit 0); the generated `glm-5.2` entry now lists `minimal` and `xhigh` in its `reasoning_options.values`.
