### PR TITLE
Use base model metadata for GLM-5 and GLM-5.1, and fix release dates

### DIFF
--- a/models/zhipuai/glm-5.1.toml
+++ b/models/zhipuai/glm-5.1.toml
@@ -1,7 +1,7 @@
 name = "GLM-5.1"
 family = "glm"
-release_date = "2026-03-27"
-last_updated = "2026-03-27"
+release_date = "2026-04-07"
+last_updated = "2026-04-07"
 attachment = false
 reasoning = true
 temperature = true

--- a/models/zhipuai/glm-5.toml
+++ b/models/zhipuai/glm-5.toml
@@ -1,7 +1,7 @@
 name = "GLM-5"
 family = "glm"
-release_date = "2026-02-11"
-last_updated = "2026-02-11"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
 attachment = false
 reasoning = true
 temperature = true

--- a/providers/zai/models/glm-5.1.toml
+++ b/providers/zai/models/glm-5.1.toml
@@ -1,13 +1,4 @@
-name = "GLM-5.1"
-family = "glm"
-release_date = "2026-03-27"
-last_updated = "2026-03-27"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = false
+base_model = "zhipuai/glm-5.1"
 
 [[reasoning_options]]
 type = "toggle"
@@ -20,11 +11,3 @@ input = 1.4
 output = 4.4
 cache_read = 0.26
 cache_write = 0
-
-[limit]
-context = 200000
-output = 131072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/zai/models/glm-5.toml
+++ b/providers/zai/models/glm-5.toml
@@ -1,12 +1,4 @@
-name = "GLM-5"
-family = "glm"
-release_date = "2026-02-11"
-last_updated = "2026-02-11"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
+base_model = "zhipuai/glm-5"
 
 [[reasoning_options]]
 type = "toggle"
@@ -19,11 +11,3 @@ input = 1.00
 output = 3.20
 cache_read = 0.20
 cache_write = 0
-
-[limit]
-context = 204800
-output = 131072
-
-[modalities]
-input = ["text"]
-output = ["text"]


### PR DESCRIPTION
glm-5 release date: https://docs.z.ai/release-notes/new-released?utm_source=chatgpt.com#2026-02-12
glm-5.1 release date: https://docs.z.ai/release-notes/new-released?utm_source=chatgpt.com#2026-04-07