### PR TITLE
fix(azure-cognitive-services): correct env var in kimi model API URLs

### DIFF
--- a/providers/azure-cognitive-services/models/kimi-k2.5.toml
+++ b/providers/azure-cognitive-services/models/kimi-k2.5.toml
@@ -1,1 +1,30 @@
-../../azure/models/kimi-k2.5.toml
+name = "Kimi K2.5"
+family = "kimi-k2"
+release_date = "2026-02-06"
+last_updated = "2026-02-06"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+structured_output = true
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+interleaved = true
+open_weights = true
+
+[cost]
+input = 0.60
+output = 3.00
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[provider]
+shape = "completions"
+npm = "@ai-sdk/openai-compatible"
+api = "https://${AZURE_COGNITIVE_SERVICES_RESOURCE_NAME}.services.ai.azure.com/models"

--- a/providers/azure-cognitive-services/models/kimi-k2.5.toml
+++ b/providers/azure-cognitive-services/models/kimi-k2.5.toml
@@ -1,28 +1,14 @@
-name = "Kimi K2.5"
-family = "kimi-k2"
-release_date = "2026-02-06"
-last_updated = "2026-02-06"
-attachment = false
-reasoning = true
+base_model = "moonshotai/kimi-k2.5"
 reasoning_options = [{ type = "toggle" }]
-structured_output = true
 temperature = true
-tool_call = true
-knowledge = "2025-01"
 interleaved = true
-open_weights = true
 
 [cost]
 input = 0.60
 output = 3.00
 
-[limit]
-context = 262_144
-output = 262_144
-
 [modalities]
 input = ["text", "image"]
-output = ["text"]
 
 [provider]
 shape = "completions"

--- a/providers/azure-cognitive-services/models/kimi-k2.6.toml
+++ b/providers/azure-cognitive-services/models/kimi-k2.6.toml
@@ -1,28 +1,14 @@
-name = "Kimi K2.6"
-family = "kimi-k2"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
+base_model = "moonshotai/kimi-k2.6"
 attachment = false
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-structured_output = true
-temperature = true
-tool_call = true
-knowledge = "2025-01"
 interleaved = true
-open_weights = true
 
 [cost]
 input = 0.95
 output = 4.00
 
-[limit]
-context = 262_144
-output = 262_144
-
 [modalities]
 input = ["text", "image"]
-output = ["text"]
 
 [provider]
 shape = "completions"

--- a/providers/azure-cognitive-services/models/kimi-k2.6.toml
+++ b/providers/azure-cognitive-services/models/kimi-k2.6.toml
@@ -27,4 +27,4 @@ output = ["text"]
 [provider]
 shape = "completions"
 npm = "@ai-sdk/openai-compatible"
-api = "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/models"
+api = "https://${AZURE_COGNITIVE_SERVICES_RESOURCE_NAME}.services.ai.azure.com/models"


### PR DESCRIPTION
## Problem

The `kimi-k2.5.toml` and `kimi-k2.6.toml` model files in Azure Cognitive Services use `${AZURE_RESOURCE_NAME}` in their API URLs, but the provider declares `AZURE_COGNITIVE_SERVICES_RESOURCE_NAME` as the expected environment variable in `providers/azure-cognitive-services/provider.toml`.

At runtime, the provider would fail because `AZURE_RESOURCE_NAME` is not one of its declared environment variables.

## Changes

### `providers/azure-cognitive-services/models/kimi-k2.6.toml`
- Replaced `AZURE_RESOURCE_NAME` with `AZURE_COGNITIVE_SERVICES_RESOURCE_NAME` in the API URL

### `providers/azure-cognitive-services/models/kimi-k2.5.toml`
- Converted from a **symlink** pointing to `../../azure/models/kimi-k2.5.toml` into a standalone real file
- Uses the corrected env var `AZURE_COGNITIVE_SERVICES_RESOURCE_NAME`

## Why not keep the symlink?

Models that override the default `@ai-sdk/azure` provider with a different npm module (Claude models with `@ai-sdk/anthropic`, kimi models with `@ai-sdk/openai-compatible`) must be real files in each provider directory because their API URLs reference different environment variables per provider. This matches the existing pattern used by all Claude models in `azure-cognitive-services/models/`.

## Verification

- The Azure versions (in `providers/azure/models/`) are untouched and continue using `AZURE_RESOURCE_NAME`
- The Cognitive Services versions now correctly reference `AZURE_COGNITIVE_SERVICES_RESOURCE_NAME`
- The symlink was the only symlink with a `[provider]` block pointing to the Azure directory