### PR TITLE
feat(neuralwatt): add GLM 5.2 Fast variant

### DIFF
--- a/providers/neuralwatt/README.md
+++ b/providers/neuralwatt/README.md
@@ -21,6 +21,7 @@ Reasoning Models (with interleaved thinking):
 Fast Variants (optimized for speed, non-reasoning):
 - glm-5-fast — GLM 5 Fast
 - glm-5.1-fast — GLM 5.1 Fast
+- glm-5.2-fast — GLM 5.2 Fast
 - kimi-k2.5-fast — Kimi K2.5 Fast, image input
 - kimi-k2.6-fast — Kimi K2.6 Fast, image input
 - qwen3.5-397b-fast — Qwen3.5 397B Fast

--- a/providers/neuralwatt/models/glm-5.2-fast.toml
+++ b/providers/neuralwatt/models/glm-5.2-fast.toml
@@ -1,0 +1,21 @@
+name = "GLM 5.2 Fast"
+family = "glm"
+release_date = "2026-06-18"
+last_updated = "2026-06-18"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 1.45
+output = 4.5
+
+[limit]
+context = 1_048_560
+output = 1_048_560
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Follow-up to #2645. Adds the speed-optimized, non-reasoning counterpart to GLM 5.2.

## Context

`pi-neuralwatt-provider` now exposes `glm-5.2-fast` as a fast variant of GLM 5.2. Per the provider's `models.json`, it is identical to `glm-5.2` in context, pricing, and modalities, but has `reasoning: false` and is intended for lower-latency use without thinking.

## Changes

- New file `providers/neuralwatt/models/glm-5.2-fast.toml`
  - `name = "GLM 5.2 Fast"`
  - `reasoning = false` (the thinking-capable version remains `glm-5.2`)
  - Cost: `input = 1.45`, `output = 4.5`
  - Limit: `context = 1_048_560`, `output = 1_048_560`
  - Modalities: text-only
  - Released: `2026-06-18`
- Updated `providers/neuralwatt/README.md`
  - Added `glm-5.2-fast — GLM 5.2 Fast` to the Fast Variants list

## Validation

`bun validate` passes (exit 0). Generated `providers.neuralwatt.models["glm-5.2-fast"]` entry has `reasoning: false` and the expected cost/limits/modalities.
