### PR TITLE
feat(alibaba-token-plan-cn): add GLM-5.2 model

### DIFF
--- a/providers/alibaba-token-plan-cn/models/glm-5.2.toml
+++ b/providers/alibaba-token-plan-cn/models/glm-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
Add GLM-5.2 to the alibaba-token-plan-cn provider.

- Inherits model metadata via `base_model = "zhipuai/glm-5.2"`
- Reasoning exposed as `effort` (`high`, `max`), aligned with the `zai-coding-plan` GLM-5.2 entry
- `interleaved` field set to `reasoning_content`
- `cost` set to 0 (Token Plan is a subscription/Credits-based service, no per-token pay-as-you-go price — consistent with all other models under this provider)