### PR TITLE
feat: add GLM-5.2 to Zhipu AI provider models

### DIFF
--- a/providers/zhipuai/models/glm-5.2.toml
+++ b/providers/zhipuai/models/glm-5.2.toml
@@ -1,0 +1,31 @@
+name = "GLM-5.2"
+family = "glm"
+release_date = "2026-06-13"
+last_updated = "2026-06-13"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+cache_write = 0
+
+[limit]
+context = 1000000
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds the GLM-5.2 model to the Zhipu AI (zhipuai) provider's model catalog.

GLM-5.2 was released on 2026-06-13 and supports:
- 1M token context window
- Text-only input/output
- Reasoning with effort levels (high, max)
- Tool calling and structured output

Pricing (from https://docs.z.ai/guides/overview/pricing):
- Input: $1.4/1M tokens
- Output: $4.4/1M tokens
- Cache read: $0.26/1M tokens
- Cache write: Free (limited-time)

The model already exists in the coding-plan provider but was missing from the main zhipuai provider.