### PR TITLE
feat(huggingface): add new flagship models from the inference router

### DIFF
--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,0 +1,13 @@
+base_model = "minimax/MiniMax-M3"
+reasoning_options = []
+structured_output = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.30
+output = 1.20
+
+[limit]
+context = 524_288

--- a/providers/huggingface/models/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-122B-A10B.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3.5-122b-a10b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.40
+output = 3.20

--- a/providers/huggingface/models/Qwen/Qwen3.5-27B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-27B.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3.5-27b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.30
+output = 2.40

--- a/providers/huggingface/models/Qwen/Qwen3.5-35B-A3B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-35B-A3B.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3.5-35b-a3b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.25
+output = 2.00

--- a/providers/huggingface/models/Qwen/Qwen3.5-9B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-9B.toml
@@ -1,0 +1,27 @@
+name = "Qwen3.5-9B"
+family = "qwen"
+release_date = "2026-02-23"
+last_updated = "2026-02-23"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-04"
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.17
+output = 0.25
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/huggingface/models/Qwen/Qwen3.6-27B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.6-27B.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3.6-27b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.47
+output = 3.19

--- a/providers/huggingface/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.95

--- a/providers/huggingface/models/XiaomiMiMo/MiMo-V2.5-Pro.toml
+++ b/providers/huggingface/models/XiaomiMiMo/MiMo-V2.5-Pro.toml
@@ -1,0 +1,7 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
+structured_output = true
+
+[cost]
+input = 1.00
+output = 3.00

--- a/providers/huggingface/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/huggingface/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.14
+output = 0.28
+
+[limit]
+context = 1_048_576

--- a/providers/huggingface/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4.00

--- a/providers/huggingface/models/zai-org/GLM-5.2.toml
+++ b/providers/huggingface/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.40
+output = 4.40
+
+[limit]
+context = 262_144


### PR DESCRIPTION
## What

Adds 11 flagship models served by the Hugging Face Inference router (`router.huggingface.co/v1/models`) that were missing from the catalog.

| Model | Context | Cost (in/out, per 1M) | Multimodal |
|---|--:|--:|:--:|
| zai-org/GLM-5.2 | 262K | $1.40 / $4.40 | |
| deepseek-ai/DeepSeek-V4-Flash | 1.05M | $0.14 / $0.28 | |
| MiniMaxAI/MiniMax-M3 | 524K | $0.30 / $1.20 | yes |
| Qwen/Qwen3.5-122B-A10B | 262K | $0.40 / $3.20 | yes |
| Qwen/Qwen3.5-27B | 262K | $0.30 / $2.40 | yes |
| Qwen/Qwen3.5-35B-A3B | 262K | $0.25 / $2.00 | yes |
| Qwen/Qwen3.5-9B | 262K | $0.17 / $0.25 | yes |
| Qwen/Qwen3.6-27B | 262K | $0.47 / $3.19 | yes |
| Qwen/Qwen3.6-35B-A3B | 262K | $0.15 / $0.95 | yes |
| XiaomiMiMo/MiMo-V2.5-Pro | 1.05M | $1.00 / $3.00 | |
| moonshotai/Kimi-K2.7-Code | 262K | $0.95 / $4.00 | yes |

## How

- Pricing and context come from the router. Where multiple providers serve a model, novita's pricing is used (this matches every existing Hugging Face entry, which all align with novita's numbers); together / deepinfra are used as a fallback when novita does not price the model.
- The router list does not price `MiMo-V2.5-Pro` or `Qwen3.6-27B`. Their rates were taken from the serving provider's catalog (deepinfra, OVHcloud) and verified with live calls to the router: MiMo's `estimated_cost` confirms $1.00 / $3.00 exactly, and Qwen3.6-27B uses OVHcloud's published $0.47 / $3.19. Both were confirmed live.
- 10 of the 11 reuse existing `models/` metadata via `base_model` plus provider-specific overrides (cost, reasoning options, interleaved reasoning, and a context override where the HF-served context differs from canonical). `Qwen/Qwen3.5-9B` is standalone (no metadata file existed).
- `bun validate` passes.
