### PR TITLE
feat(neuralwatt): add GLM 5.2 Fast

### DIFF
--- a/providers/neuralwatt/README.md
+++ b/providers/neuralwatt/README.md
@@ -21,6 +21,7 @@ Reasoning Models (with interleaved thinking):
 Fast Variants (optimized for speed, non-reasoning):
 - glm-5-fast — GLM 5 Fast
 - glm-5.1-fast — GLM 5.1 Fast
+- glm-5.2-fast — GLM 5.2 Fast
 - kimi-k2.5-fast — Kimi K2.5 Fast, image input
 - kimi-k2.6-fast — Kimi K2.6 Fast, image input
 - qwen3.5-397b-fast — Qwen3.5 397B Fast

--- a/providers/neuralwatt/models/glm-5.2-fast.toml
+++ b/providers/neuralwatt/models/glm-5.2-fast.toml
@@ -1,0 +1,21 @@
+name = "GLM 5.2 Fast"
+family = "glm"
+release_date = "2026-06-17"
+last_updated = "2026-06-17"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.45
+output = 4.5
+
+[limit]
+context = 1_048_560
+output = 1_048_560
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds the non-thinking Fast tier for GLM 5.2 (`glm-5.2-fast`). GLM 5.2 base was added in #2636; this is its fast counterpart - `reasoning = false` with `reasoning_options` dropped (thinking skipped, `reasoning_effort=none`).

Per the Neuralwatt model docs it "mirrors glm-5.1-fast" structurally (non-thinking tier). Unlike glm-5.1-fast, the 5.2 fast tier **shares base-5.2 pricing and context**, so those values are inherited unchanged from `glm-5.2.toml`.

## Reference PRs
- #2636 - feat(neuralwatt): add GLM 5.2 and retire MiniMax M2.5, Devstral, GPT OSS 20B (base card)
- #2645 - feat(neuralwatt): expose full GLM 5.2 reasoning effort scale (reasoning follow-up)

## Source of truth
- https://portal.neuralwatt.com/models/glm-5.2-fast
- Pricing: Input $1.45 / Output $4.50 per M tokens (same as base 5.2)
- Context Length: 1048K tokens (same as base 5.2)
- Reasoning: No · Tool Use: Yes · Vision Support: No · Provider: ZhipuAI

## Changes
- **New**: `providers/neuralwatt/models/glm-5.2-fast.toml`
- **Edit**: `providers/neuralwatt/README.md` - added `glm-5.2-fast` to the Fast Variants list (after `glm-5.1-fast`, keeping GLM fast variants grouped)

Delta vs `glm-5.2.toml` (only two fields):
- `name`: `GLM 5.2` → `GLM 5.2 Fast`
- `reasoning`: `true` → `false`, `reasoning_options` line removed (22 → 21 lines)

All other fields (`family`, dates, `attachment`, `temperature`, `tool_call`, `open_weights`, `cost` 1.45/4.5, `limit` 1_048_560/1_048_560, `modalities` text/text) inherited verbatim from the 5.2 base.

## Validation
`bun validate` passes (exit 0); neuralwatt model count 13 → 14.