### PR TITLE
fix(zhipuai): add missing GLM-4.6V-Flash metadata and provider model

### DIFF
--- a/models/zhipuai/glm-4.6v-flash.toml
+++ b/models/zhipuai/glm-4.6v-flash.toml
@@ -1,0 +1,21 @@
+name = "GLM-4.6V-Flash"
+family = "glm"
+release_date = "2025-12-08"
+last_updated = "2025-12-08"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-4.6V-Flash"

--- a/providers/zai/models/glm-4.6v-flash.toml
+++ b/providers/zai/models/glm-4.6v-flash.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-4.6v-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
Adds missing GLM-4.6V-Flash model definition to fix the broken symlink at `providers/zhipuai/models/glm-4.6v-flash.toml`.

**Changes:**
- `models/zhipuai/glm-4.6v-flash.toml` — canonical metadata (128K context, vision-language model, open weights on Hugging Face)
- `providers/zai/models/glm-4.6v-flash.toml` — provider definition with free pricing (per Z.AI pricing page), reasoning toggle support

The broken symlink at `providers/zhipuai/models/glm-4.6v-flash.toml` → `../../zai/models/glm-4.6v-flash.toml` now resolves correctly.