### PR TITLE
feat(alibaba-cn): add GLM-5.2 model

### DIFF
--- a/providers/alibaba-cn/models/glm-5.2.toml
+++ b/providers/alibaba-cn/models/glm-5.2.toml
@@ -11,4 +11,11 @@ field = "reasoning_content"
 input = 1.1
 output = 3.851
 cache_read = 0.275
-cache_write = 0
+
+[limit]
+context = 1000000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/alibaba-cn/models/glm-5.2.toml
+++ b/providers/alibaba-cn/models/glm-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.1
+output = 3.851
+cache_read = 0.275
+cache_write = 0

--- a/providers/alibaba-cn/models/glm-5.2.toml
+++ b/providers/alibaba-cn/models/glm-5.2.toml
@@ -1,16 +1,17 @@
 base_model = "zhipuai/glm-5.2"
 
-[[reasoning_options]]
-type = "effort"
-values = ["high", "max"]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
 
+# First party price citation here
+# https://bailian.console.alibabacloud.com/cn-beijing?tab=model#/model-market/detail/glm-5.2?serviceSite=asia-pacific-china
 [cost]
 input = 1.1
 output = 3.851
 cache_read = 0.275
+cache_write = 0
 
 [limit]
 context = 1000000


### PR DESCRIPTION
Add GLM-5.2 to the alibaba-cn provider.

- Inherits model metadata via `base_model = "zhipuai/glm-5.2"`
- Reasoning exposed as `effort` (`high`, `max`), aligned with the `zai-coding-plan` GLM-5.2 entry
- `interleaved` field set to `reasoning_content`
- `cost` set according to [official page](https://bailian.console.alibabacloud.com/cn-beijing?tab=model#/model-market/detail/glm-5.2?serviceSite=asia-pacific-china)