### PR TITLE
umans-ai: curate reasoning_options to match each model's real reasoning support

### DIFF
--- a/providers/umans-ai-coding-plan/models/umans-coder.toml
+++ b/providers/umans-ai-coding-plan/models/umans-coder.toml
@@ -1,7 +1,7 @@
 base_model = "moonshotai/kimi-k2.7-code"
 name = "Umans Coder"
 temperature = false
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/umans-ai-coding-plan/models/umans-glm-5.1.toml
+++ b/providers/umans-ai-coding-plan/models/umans-glm-5.1.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5.1"
 name = "GLM 5.1"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/umans-ai-coding-plan/models/umans-glm-5.2.toml
+++ b/providers/umans-ai-coding-plan/models/umans-glm-5.2.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/umans-ai-coding-plan/models/umans-kimi-k2.7.toml
+++ b/providers/umans-ai-coding-plan/models/umans-kimi-k2.7.toml
@@ -1,6 +1,6 @@
 base_model = "moonshotai/kimi-k2.7-code"
 name = "Kimi K2.7 Code"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/umans-ai/models/umans-coder.toml
+++ b/providers/umans-ai/models/umans-coder.toml
@@ -1,7 +1,7 @@
 base_model = "moonshotai/kimi-k2.7-code"
 name = "Umans Coder"
 temperature = false
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/umans-ai/models/umans-glm-5.1.toml
+++ b/providers/umans-ai/models/umans-glm-5.1.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5.1"
 name = "GLM 5.1"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/umans-ai/models/umans-glm-5.2.toml
+++ b/providers/umans-ai/models/umans-glm-5.2.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/umans-ai/models/umans-kimi-k2.7.toml
+++ b/providers/umans-ai/models/umans-kimi-k2.7.toml
@@ -1,6 +1,6 @@
 base_model = "moonshotai/kimi-k2.7-code"
 name = "Kimi K2.7 Code"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## What

Updates `reasoning_options` for the Umans models (in both `umans-ai` and `umans-ai-coding-plan`) so they advertise only the reasoning controls each model actually supports through the Umans gateway. Today several of these over-advertise effort levels the gateway collapses or ignores.

| Model | Before | After | Why |
|---|---|---|---|
| `umans-glm-5.1` | `toggle` + `effort[low,medium,high]` | `toggle` | Reasoning is on/off; effort level is not meaningful for GLM 5.1. |
| `umans-glm-5.2` | `toggle` + `effort[low,medium,high]` | `toggle` + `effort[high,max]` | Only `high`/`max` are real, distinct levels. |
| `umans-coder` | `effort[low,medium,high]` | `[]` | Aliases Kimi K2.7 (always-thinking): no toggle, no effort tiers. |
| `umans-kimi-k2.7` | `effort[low,medium,high]` | `[]` | Always-thinking: reasoning can't be disabled and has no effort tiers. |

`umans-flash` and `umans-qwen3.6-35b-a3b` are intentionally unchanged (`toggle` + `effort[low,medium,high]`).

This mirrors a matching change to the Umans gateway's own `GET /v1/models/info` `capabilities.reasoning` descriptor.

## Notes
- All values are from the `ReasoningEffortValue` enum (`high`/`max` are valid).
- `reasoning = true` is inherited from each base model and is unchanged.
- Opened as **draft** for maintainer review.