### PR TITLE
feat(siliconflow): add zai-org/GLM-5.2

### DIFF
--- a/providers/siliconflow-cn/models/zai-org/GLM-5.2.toml
+++ b/providers/siliconflow-cn/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_input = 0.26
+cache_write = 0
+
+[limit]
+context = 205_000
+output = 205_000

--- a/providers/siliconflow/models/zai-org/GLM-5.2.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_input = 0.26
+cache_write = 0
+
+[limit]
+context = 205_000
+output = 205_000


### PR DESCRIPTION
Add zai-org/GLM-5.2 model to both siliconflow and siliconflow-cn providers.

GLM-5.2 is already available on SiliconFlow (confirmed from siliconflow.cn/pricing) but missing from the models.dev catalog.

Uses `base_model = "zhipuai/glm-5.2"` to inherit provider-agnostic metadata, with provider-specific cost (1.4/4.4/0.26), interleaved reasoning, and 205K context limit — consistent with existing GLM-5/GLM-5.1 entries.