### PR TITLE
feat(alibaba-token-plan): add glm-5.2 and kimi-k2.7-code

### DIFF
--- a/providers/alibaba-token-plan-cn/models/kimi-k2.7-code.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.7-code.toml
@@ -1,0 +1,13 @@
+base_model = "moonshotai/kimi-k2.7-code"
+base_model_omit = ["structured_output"]
+family = "kimi-k2"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan/models/glm-5.2.toml
+++ b/providers/alibaba-token-plan/models/glm-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan/models/kimi-k2.7-code.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.7-code.toml
@@ -1,0 +1,13 @@
+base_model = "moonshotai/kimi-k2.7-code"
+base_model_omit = ["structured_output"]
+family = "kimi-k2"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
## Summary

Add the two newest Token Plan models, both live on the gateways but missing from the providers:

- **glm-5.2** added to `alibaba-token-plan` (Global). `alibaba-token-plan-cn` already has it.
- **kimi-k2.7-code** added to both `alibaba-token-plan` and `alibaba-token-plan-cn`.

Both inherit verified facts from their base models (`zhipuai/glm-5.2`, `moonshotai/kimi-k2.7-code`) with Token Plan's prepaid cost zeroed, consistent with the other models in these providers.

## Verification

- `bun validate` passes; `git diff --check` clean.
- Limits confirmed against the live Token Plan gateway (`/compatible-mode/v1`):
  - glm-5.2: context 1,000,000 / output 131,072 (inherited from `zhipuai/glm-5.2`).
  - kimi-k2.7-code: context 262,144 / output 262,144. The output ceiling is confirmed by the gateway itself, which rejects a larger `max_tokens` with `Range of max_tokens should be [1, 262144]`.
- Both models serve inference on the Global (Singapore) and China (Beijing) gateways (HTTP 200, reasoning returned).

## Notes

- `kimi-k2.7-code` mirrors the sibling `kimi-k2.6` token-plan entry (family `kimi-k2`, `reasoning_options` toggle + budget_tokens, `structured_output` omitted, interleaved `reasoning_content`) but does not cap output at 16,384, because the gateway allows the full 262,144 for this model.
- Cost is zeroed because Token Plan is a prepaid subscription, matching the existing models in these providers.

---

🤖 Generated with Claude Code (Claude Opus 4.8)
🧑‍💻 Ideated, directed and reviewed by a human, @Omee11
