### PR TITLE
Add Nebius Token Factory GLM-5.2

### DIFF
--- a/providers/nebius/models/zai-org/GLM-5.2.toml
+++ b/providers/nebius/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,26 @@
+name = "GLM-5.2"
+family = "glm"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2026-06-13"
+last_updated = "2026-06-13"
+open_weights = false
+
+[cost]
+input = 1.4
+output = 4.4
+
+[limit]
+context = 432_000
+output = 432_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/nebius/models/zai-org/GLM-5.2.toml
+++ b/providers/nebius/models/zai-org/GLM-5.2.toml
@@ -1,14 +1,11 @@
-name = "GLM-5.2"
-family = "glm"
-attachment = false
-reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
-tool_call = true
-structured_output = true
-temperature = true
-release_date = "2026-06-13"
-last_updated = "2026-06-13"
-open_weights = false
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 1.4
@@ -17,10 +14,3 @@ output = 4.4
 [limit]
 context = 432_000
 output = 432_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
-
-[interleaved]
-field = "reasoning_content"


### PR DESCRIPTION
Adds the `zai-org/GLM-5.2` model served by Nebius Token Factory.

All facts sourced from the Nebius Token Factory models API (`GET /v1/models?verbose=true`) and verified against the live endpoint:

- **Pricing**: \$1.40/M input, \$4.40/M output (`prompt 0.0000014`, `completion 0.0000044`). No cache discount offered, so cache fields omitted.
- **Context**: 432k. Output capped by total budget — probing an oversized `max_tokens` returns `max_total_tokens=432000`.
- **Capabilities**: tools, JSON mode, structured outputs, reasoning, temperature (from `supported_features` / `supported_sampling_parameters`).
- **Reasoning**: `reasoning_effort` accepts only `low`/`medium`/`high` (tested live; `max`/`none`/`toggle` rejected).
- **Modality**: text → text (`architecture.modality`).
- `release_date`/`open_weights` align with the canonical `zhipuai/glm-5.2.toml`.

`bun validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)