### PR TITLE
chore(models): mark GLM 5.2 as open-weighted

### DIFF
--- a/models/zhipuai/glm-5.2.toml
+++ b/models/zhipuai/glm-5.2.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [limit]
 context = 1_000_000
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/zai-org/GLM-5.2"


### PR DESCRIPTION
Weights have been released on [Hugging Face](https://huggingface.co/zai-org/GLM-5.2) a couple of days ago.