### PR TITLE
feat: add Kimi K2.5 to Fireworks AI provider models

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k2p5.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k2.5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.60
+cache_read = 0.10
+output = 3.00


### PR DESCRIPTION
Fireworks serves Moonshot's Kimi K2.5 (accounts/fireworks/models/kimi-k2p5) but the catalog had no entry for it, so the model resolved no pricing. Add it via base_model with Fireworks' published serverless rate ($0.60 / $0.10 / $3.00 input/cache-read/output): https://docs.fireworks.ai/serverless/pricing