### PR TITLE
feat: add Wafer GLM-5.2

### DIFF
--- a/providers/wafer.ai/models/GLM-5.2.toml
+++ b/providers/wafer.ai/models/GLM-5.2.toml
@@ -1,8 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-release_date = "2026-06-19"
-last_updated = "2026-06-19"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high", "max"] }]
-open_weights = true
 
 [cost]
 input = 1.20

--- a/providers/wafer.ai/models/GLM-5.2.toml
+++ b/providers/wafer.ai/models/GLM-5.2.toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5.2"
+release_date = "2026-06-19"
+last_updated = "2026-06-19"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+open_weights = true
+
+[cost]
+input = 1.20
+output = 4.10
+cache_read = 0.20
+cache_write = 0
+
+[limit]
+context = 1_048_576
+output = 131_072


### PR DESCRIPTION
## What changed

Wafer.ai added `GLM-5.2`:

- 1,048,576 token context
- 131,072 token output
- $1.20 input / $4.10 output / $0.20 cache read per 1M tokens

