### PR TITLE
feat: add Kevoryn provider with 20 core models

### DIFF
--- a/providers/kevoryn/models/alibaba/qwen3-coder-plus.toml
+++ b/providers/kevoryn/models/alibaba/qwen3-coder-plus.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-plus"
+
+[cost]
+input = 2
+output = 8

--- a/providers/kevoryn/models/alibaba/qwen3.6-plus.toml
+++ b/providers/kevoryn/models/alibaba/qwen3.6-plus.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3.6-plus"
+
+[cost]
+input = 2
+output = 8

--- a/providers/kevoryn/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/kevoryn/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 0.8
+output = 4

--- a/providers/kevoryn/models/anthropic/claude-opus-4-8.toml
+++ b/providers/kevoryn/models/anthropic/claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[cost]
+input = 15
+output = 75

--- a/providers/kevoryn/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/kevoryn/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3
+output = 15

--- a/providers/kevoryn/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/kevoryn/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,5 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[cost]
+input = 0.27
+output = 1.1

--- a/providers/kevoryn/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/kevoryn/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,5 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 2.5
+output = 8

--- a/providers/kevoryn/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/kevoryn/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/kevoryn/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/kevoryn/models/google/gemini-3.1-pro-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[cost]
+input = 3.5
+output = 14

--- a/providers/kevoryn/models/llama/llama-4-maverick.toml
+++ b/providers/kevoryn/models/llama/llama-4-maverick.toml
@@ -1,0 +1,5 @@
+base_model = "meta/llama-4-maverick-17b-instruct"
+
+[cost]
+input = 0.8
+output = 3.2

--- a/providers/kevoryn/models/minimax/MiniMax-M2.7.toml
+++ b/providers/kevoryn/models/minimax/MiniMax-M2.7.toml
@@ -1,0 +1,5 @@
+base_model = "minimax/MiniMax-M2.7"
+
+[cost]
+input = 0.8
+output = 3.2

--- a/providers/kevoryn/models/mistral/mistral-small-3.2-24b-instruct.toml
+++ b/providers/kevoryn/models/mistral/mistral-small-3.2-24b-instruct.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-small-2506"
+
+[cost]
+input = 0.2
+output = 0.6

--- a/providers/kevoryn/models/moonshotai/kimi-k2.6.toml
+++ b/providers/kevoryn/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 1.5
+output = 6

--- a/providers/kevoryn/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/kevoryn/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,5 @@
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+
+[cost]
+input = 1
+output = 4

--- a/providers/kevoryn/models/openai/gpt-5.4-mini.toml
+++ b/providers/kevoryn/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-mini"
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/kevoryn/models/openai/gpt-5.4.toml
+++ b/providers/kevoryn/models/openai/gpt-5.4.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4"
+
+[cost]
+input = 2.5
+output = 10

--- a/providers/kevoryn/models/openai/gpt-5.5.toml
+++ b/providers/kevoryn/models/openai/gpt-5.5.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.5"
+
+[cost]
+input = 3.75
+output = 15

--- a/providers/kevoryn/models/openai/gpt-image-2.toml
+++ b/providers/kevoryn/models/openai/gpt-image-2.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-image-2"
+
+[cost]
+input = 5
+output = 20

--- a/providers/kevoryn/models/xai/grok-4.20.toml
+++ b/providers/kevoryn/models/xai/grok-4.20.toml
@@ -1,0 +1,5 @@
+base_model = "xai/grok-4.20-0309-reasoning"
+
+[cost]
+input = 3
+output = 12

--- a/providers/kevoryn/models/zhipuai/glm-5.1.toml
+++ b/providers/kevoryn/models/zhipuai/glm-5.1.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-5.1"
+
+[cost]
+input = 1.5
+output = 6

--- a/providers/kevoryn/provider.toml
+++ b/providers/kevoryn/provider.toml
@@ -1,0 +1,5 @@
+name = "Kevoryn"
+env = ["KEVORYN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.kevoryn.com/v1"
+doc = "https://kevoryn.com"


### PR DESCRIPTION
## Provider: Kevoryn

**Website:** https://kevoryn.com
**API Base:** https://api.kevoryn.com/v1
**Auth:** `KEVORYN_API_KEY` environment variable
**SDK:** @ai-sdk/openai-compatible (OpenAI-compatible API)

Kevoryn is an AI model relay/aggregator providing access to a curated selection of models across multiple vendors.

### Included Models (20 core models)

| Vendor | Model | Input ($/1M) | Output ($/1M) |
|--------|-------|---------------|----------------|
| Anthropic | claude-opus-4-8 | $15 | $75 |
| Anthropic | claude-sonnet-4-6 | $3 | $15 |
| Anthropic | claude-haiku-4-5 | $0.80 | $4 |
| OpenAI | gpt-5.5 | $3.75 | $15 |
| OpenAI | gpt-5.4 | $2.50 | $10 |
| OpenAI | gpt-5.4-mini | $0.15 | $0.60 |
| OpenAI | gpt-image-2 | $5 | $20 |
| Google | gemini-3.1-pro-preview | $3.50 | $14 |
| Google | gemini-3.1-flash-lite-preview | $0.15 | $0.60 |
| DeepSeek | deepseek-v4-pro | $2.50 | $8 |
| DeepSeek | deepseek-v4-flash | $0.27 | $1.10 |
| Moonshot | kimi-k2.6 | $1.50 | $6 |
| Alibaba | qwen3.6-plus | $2 | $8 |
| Alibaba | qwen3-coder-plus | $2 | $8 |
| Zhipu | glm-5.1 | $1.50 | $6 |
| MiniMax | MiniMax-M2.7 | $0.80 | $3.20 |
| xAI | grok-4.20 | $3 | $12 |
| Meta | llama-4-maverick | $0.80 | $3.20 |
| Mistral | mistral-small-3.2-24b-instruct | $0.20 | $0.60 |
| Nvidia | nemotron-3-super-120b-a12b | $1 | $4 |

✅ Validated with `bun validate`