### PR TITLE
feat(crof): name DeepSeek V4 Pro Lightning

### DIFF
--- a/providers/crof/models/deepseek-v4-pro-lightning.toml
+++ b/providers/crof/models/deepseek-v4-pro-lightning.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek V4 Pro Lightning"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]


### PR DESCRIPTION
## References

- None

## Summary

Added a distinct `name` for `providers/crof/models/deepseek-v4-pro-lightning.toml` so OpenCode can distinguish the Lightning variant from the base DeepSeek V4 Pro entry. Before this change, the selector showed two identical labels, which made it unclear which model was being chosen. That matters here because the Lightning model is much more expensive, so the picker needs to be explicit.

<img width="1058" height="520" alt="file-a038f10cb97808c64fffee95ed6d5958" src="https://github.com/user-attachments/assets/ca0311cb-73fc-4e73-bd58-7ceb7af68492" />


## Test Plan

- `bun validate`