### PR TITLE
Add GLM-5.2 for novita-ai provider

### DIFF
--- a/providers/novita-ai/models/zai-org/glm-5.2.toml
+++ b/providers/novita-ai/models/zai-org/glm-5.2.toml
@@ -1,0 +1,18 @@
+name = "GLM-5.2"
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
Adding GLM 5.2 for Novita AI provider. Same cost as GLM 5.1, 1M context.

`bun validate` passed.

<img width="1295" height="661" alt="image" src="https://github.com/user-attachments/assets/8269e4ff-98bb-4775-aa1f-9d9ca1f7fd86" />
