### PR TITLE
chore(sync): add claudius-pro model with audio/video input + add audio/video to claudinio

### DIFF
--- a/providers/claudinio/models/claudinio.toml
+++ b/providers/claudinio/models/claudinio.toml
@@ -17,5 +17,5 @@ context = 256_000
 output = 64_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "audio", "video"]
 output = ["text"]

--- a/providers/claudinio/models/claudius.toml
+++ b/providers/claudinio/models/claudius.toml
@@ -1,11 +1,21 @@
 name = "Claudius"
 release_date = "2026-05-12"
 last_updated = "2026-05-12"
-
-[extends]
-from = "claudinio/claudinio"
+attachment = true
+reasoning = true
+tool_call = true
+open_weights = false
+knowledge = "2026-05"
 
 [cost]
 input = 3.00
 output = 8.00
 cache_read = 0.900
+
+[limit]
+context = 256_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/claudinio/models/claudius.toml
+++ b/providers/claudinio/models/claudius.toml
@@ -17,5 +17,5 @@ context = 256_000
 output = 64_000
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "audio", "video"]
 output = ["text"]

--- a/providers/claudinio/models/claudius.toml
+++ b/providers/claudinio/models/claudius.toml
@@ -1,0 +1,11 @@
+name = "Claudius"
+release_date = "2026-05-12"
+last_updated = "2026-05-12"
+
+[extends]
+from = "claudinio/claudinio"
+
+[cost]
+input = 3.00
+output = 8.00
+cache_read = 0.900


### PR DESCRIPTION
Adds **Claudius Pro** model under the claudinio provider, matching claudinio's configuration with different pricing:
- input: $3.00/MTok
- output: $8.00/MTok
- cache_read: $0.90/MTok

Also adds **audio** and **video** input modalities to both claudinio and claudius-pro.