### PR TITLE
feat(fireworks): add GLM 5.2 and Kimi K2.7 Code Fast to Firepass, sync K2.6 Turbo

### DIFF
--- a/providers/firepass/models/accounts/fireworks/models/glm-5p2.toml
+++ b/providers/firepass/models/accounts/fireworks/models/glm-5p2.toml
@@ -1,8 +1,8 @@
-name = "Kimi K2.6 Turbo"
-family = "kimi-thinking"
-release_date = "2026-04-17"
-last_updated = "2026-04-17"
-attachment = true
+name = "GLM 5.2"
+family = "glm"
+release_date = "2026-06-16"
+last_updated = "2026-06-16"
+attachment = false
 reasoning = true
 temperature = true
 tool_call = true
@@ -11,17 +11,21 @@ open_weights = true
 [[reasoning_options]]
 type = "toggle"
 
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [cost]
 input = 0
 output = 0
 cache_read = 0
 
 [limit]
-context = 262_000
-output = 262_000
+context = 1_048_576
+output = 131_072
 
 [modalities]
-input = ["text", "image"]
+input = ["text"]
 output = ["text"]
 
 [interleaved]

--- a/providers/firepass/models/accounts/fireworks/routers/kimi-k2p7-code-fast.toml
+++ b/providers/firepass/models/accounts/fireworks/routers/kimi-k2p7-code-fast.toml
@@ -1,7 +1,7 @@
-name = "Kimi K2.6 Turbo"
-family = "kimi-thinking"
-release_date = "2026-04-17"
-last_updated = "2026-04-17"
+name = "Kimi K2.7 Code Fast"
+family = "kimi-k2"
+release_date = "2026-06-12"
+last_updated = "2026-06-16"
 attachment = true
 reasoning = true
 temperature = true


### PR DESCRIPTION
## Summary

- Add **GLM 5.2** and **Kimi K2.7 Code Fast** models to the Firepass provider, mirroring the existing Fireworks AI provider definitions
- Sync **Kimi K2.6 Turbo**: fix `attachment` from `false` to `true` to match the Fireworks AI source
- All Firepass model costs are kept at `0` (zeroed out) to reflect Firepass billing semantics

## Files changed

| File | Change |
|------|--------|
| `providers/firepass/.../models/glm-5p2.toml` | Added. Copied from Fireworks AI, costs zeroed |
| `providers/firepass/.../routers/kimi-k2p7-code-fast.toml` | Added. Copied from Fireworks AI, costs zeroed |
| `providers/firepass/.../routers/kimi-k2p6-turbo.toml` | Synced. `attachment` fixed `false` → `true` |

## Validation

`bun validate` passes with no errors.