### PR TITLE
feat: add Kevoryn provider — 66+ models, OpenAI-compatible API

### DIFF
--- a/providers/kevoryn/logo.svg
+++ b/providers/kevoryn/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <rect width="128" height="128" rx="28" fill="#6C5CE7"/>
+  <text x="64" y="82" text-anchor="middle" font-family="system-ui,sans-serif" font-size="52" font-weight="800" fill="white">K</text>
+</svg>

--- a/providers/kevoryn/models/claude-haiku-4-5.toml
+++ b/providers/kevoryn/models/claude-haiku-4-5.toml
@@ -1,0 +1,28 @@
+name = "Claude Haiku 4.5"
+family = "claude"
+release_date = "2026-03-15"
+last_updated = "2026-03-15"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2026-01-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.05
+output = 5.25
+cache_read = 0.30
+
+[limit]
+context = 200_000
+input = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[provider]
+order = ["kevoryn"]

--- a/providers/kevoryn/models/claude-opus-4-8.toml
+++ b/providers/kevoryn/models/claude-opus-4-8.toml
@@ -1,0 +1,28 @@
+name = "Claude Opus 4.8"
+family = "claude"
+release_date = "2026-05-15"
+last_updated = "2026-05-15"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-01-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5.25
+output = 26.25
+cache_read = 1.25
+
+[limit]
+context = 200_000
+input = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[provider]
+order = ["kevoryn"]

--- a/providers/kevoryn/models/claude-sonnet-4-6.toml
+++ b/providers/kevoryn/models/claude-sonnet-4-6.toml
@@ -1,0 +1,28 @@
+name = "Claude Sonnet 4.6"
+family = "claude"
+release_date = "2026-04-15"
+last_updated = "2026-04-15"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-01-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3.15
+output = 15.75
+cache_read = 0.80
+
+[limit]
+context = 200_000
+input = 200_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[provider]
+order = ["kevoryn"]

--- a/providers/kevoryn/models/deepseek-v4-pro.toml
+++ b/providers/kevoryn/models/deepseek-v4-pro.toml
@@ -1,0 +1,28 @@
+name = "DeepSeek V4 Pro"
+family = "deepseek"
+release_date = "2026-03-15"
+last_updated = "2026-03-15"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-06-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.75
+output = 3.00
+cache_read = 0.10
+
+[limit]
+context = 1_000_000
+input = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[provider]
+order = ["kevoryn"]

--- a/providers/kevoryn/models/gemini-3.1-pro-preview.toml
+++ b/providers/kevoryn/models/gemini-3.1-pro-preview.toml
@@ -1,0 +1,28 @@
+name = "Gemini 3.1 Pro Preview"
+family = "gemini"
+release_date = "2026-05-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2026-01-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.25
+output = 10.00
+cache_read = 0.30
+
+[limit]
+context = 1_000_000
+input = 1_000_000
+output = 65_000
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]
+
+[provider]
+order = ["kevoryn"]

--- a/providers/kevoryn/models/gpt-5.5.toml
+++ b/providers/kevoryn/models/gpt-5.5.toml
@@ -1,0 +1,28 @@
+name = "GPT-5.5"
+family = "gpt"
+release_date = "2026-04-23"
+last_updated = "2026-04-23"
+attachment = true
+reasoning = true
+temperature = true
+knowledge = "2025-12-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 4.50
+output = 18.00
+cache_read = 0.50
+
+[limit]
+context = 256_000
+input = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[provider]
+order = ["kevoryn"]

--- a/providers/kevoryn/provider.toml
+++ b/providers/kevoryn/provider.toml
@@ -1,0 +1,5 @@
+name = "Kevoryn"
+npm = "@ai-sdk/openai-compatible"
+env = ["KEVORYN_API_KEY"]
+api = "https://api.kevoryn.com/v1"
+doc = "https://kevoryn.com"


### PR DESCRIPTION
## Summary
Add Kevoryn (kevoryn.com) as an AI model provider.

Kevoryn is an API aggregator providing OpenAI-compatible access to 66+ AI models.

## Models included
- claude-opus-4-8 (Anthropic flagship)
- claude-sonnet-4-6 (cost-effective coding)
- claude-haiku-4-5 (fast lightweight)
- gpt-5.5 (OpenAI latest)
- deepseek-v4-pro (Chinese/NLP)
- gemini-3.1-pro-preview (multimodal)

## Details
- Provider type: `@ai-sdk/openai-compatible`
- API: `https://api.kevoryn.com/v1`
- Auth: `KEVORYN_API_KEY`
- Web: https://kevoryn.com