### PR TITLE
feat(zai): add GLM-5.2 to Z.AI API provider

### DIFF
--- a/providers/zai/models/glm-5.2.toml
+++ b/providers/zai/models/glm-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+cache_write = 0


### PR DESCRIPTION
Adds the GLM-5.2 model to the Z.AI (`zai`) provider's model catalog.

GLM-5.2 was released on 2026-06-13 and supports:
- 1M token context window
- Text-only input/output
- Reasoning with effort levels (high, max)
- Tool calling and structured output

Pricing (from https://docs.z.ai/guides/overview/pricing):
- Input: $1.4/1M tokens
- Output: $4.4/1M tokens
- Cache read: $0.26/1M tokens
- Cache write: Free (limited-time)

`zai-coding-plan/glm-5.2` already exists. `zhipuai/glm-5.2` was restored in #2670 with this pricing. The international `zai` provider was removed in #2286 before pricing was published; this restores parity with `zhipuai` for the standard API endpoint (`https://api.z.ai/api/paas/v4`).

Implementation follows other `zai` models: `base_model = "zhipuai/glm-5.2"` with provider-specific metered `[cost]` and effort-based `reasoning_options`, matching `providers/zhipuai/models/glm-5.2.toml`.

## Validation

- `bun validate`
- OpenCode smoke test: `OPENCODE_MODELS_PATH=<generated catalog> opencode models zai` lists `zai/glm-5.2`

Made with [Cursor](https://cursor.com)