### PR TITLE
fix: handle Windows path separators in catalog generation

### DIFF
--- a/packages/core/script/generate-chutes.ts
+++ b/packages/core/script/generate-chutes.ts
@@ -769,7 +769,7 @@ async function main() {
       cwd: modelsDir,
       absolute: false,
     })) {
-      existingFiles.add(file);
+      existingFiles.add(file.split(path.sep).join("/"));
     }
   } catch {
   }

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -39,7 +39,7 @@ export async function generateModels(directory: string) {
     absolute: true,
     followSymlinks: true,
   })) {
-    const modelID = path.relative(directory, modelPath).slice(0, -5);
+    const modelID = path.relative(directory, modelPath).split(path.sep).join("/").slice(0, -5);
     const toml = await import(modelPath, {
       with: {
         type: "toml",
@@ -94,7 +94,7 @@ async function generateProviders(
       absolute: true,
       followSymlinks: true,
     })) {
-      const modelID = path.relative(modelsPath, modelPath).slice(0, -5);
+      const modelID = path.relative(modelsPath, modelPath).split(path.sep).join("/").slice(0, -5);
       const toml = await import(modelPath, {
         with: {
           type: "toml",


### PR DESCRIPTION
## Summary

On Windows, `path.relative()` and `Bun.Glob` return paths with `\` separators, while model IDs and the Chutes API use `/`. This breaks catalog generation on Windows.

## Bugs

**1. `base_model` resolution — `packages/core/src/generate.ts`**
Model metadata is keyed by its path-style ID. On Windows the ID came out as `provider\model`, so every `base_model` lookup (`models[model.base_model]`) failed with `Unable to resolve base_model: …`. This makes `bun run validate`, `bun test` and the web build unusable on Windows — any model with a `base_model` throws.

**2. Orphan detection — `packages/core/script/generate-chutes.ts`**
The orphan check compares the on-disk file list (from `Bun.Glob`, backslashes on Windows) against the API model IDs (forward slashes). On Windows nothing matched, so every existing model was treated as orphaned and a real run (without `--keep-orphans`) would delete the entire provider.

## Fix

Normalize the affected paths to forward slashes with `.split(path.sep).join("/")`. No behaviour change on POSIX, where `path.sep` is already `/`.

## Verification (Windows)
- `bun run validate` — passes (previously threw `Unable to resolve base_model`).
- `bun test` — the path-related catalog tests now pass.
- `generate-chutes.ts --dry-run` — reports the correct orphan set instead of flagging every file for deletion.