### PR TITLE
Add PleumRouter provider

### DIFF
--- a/providers/pleumrouter/logo.svg
+++ b/providers/pleumrouter/logo.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16M4 12h10M4 17h7"/><circle cx="18" cy="15" r="3"/></svg>

--- a/providers/pleumrouter/models/claude-fable-5.toml
+++ b/providers/pleumrouter/models/claude-fable-5.toml
@@ -1,0 +1,17 @@
+name = "Claude Fable 5"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2026-06"
+last_updated = "2026-06"
+[cost]
+input = 10.3
+output = 51.5
+[limit]
+context = 1000000
+output = 128000
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/models/claude-opus-4-8.toml
+++ b/providers/pleumrouter/models/claude-opus-4-8.toml
@@ -1,0 +1,17 @@
+name = "Claude Opus 4.8"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2026-05"
+last_updated = "2026-06"
+[cost]
+input = 5.15
+output = 25.75
+[limit]
+context = 1000000
+output = 128000
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/models/claude-sonnet-4-6.toml
+++ b/providers/pleumrouter/models/claude-sonnet-4-6.toml
@@ -1,0 +1,17 @@
+name = "Claude Sonnet 4.6"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2026-02"
+last_updated = "2026-06"
+[cost]
+input = 3.09
+output = 15.45
+[limit]
+context = 1000000
+output = 64000
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/models/deepseek-v4-pro.toml
+++ b/providers/pleumrouter/models/deepseek-v4-pro.toml
@@ -1,0 +1,17 @@
+name = "DeepSeek V4 Pro"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2026-01"
+last_updated = "2026-06"
+[cost]
+input = 0.44805
+output = 0.8961
+[limit]
+context = 1000000
+output = 384000
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/models/gemini-2.5-pro.toml
+++ b/providers/pleumrouter/models/gemini-2.5-pro.toml
@@ -1,0 +1,17 @@
+name = "Gemini 2.5 Pro"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2025-03"
+last_updated = "2026-06"
+[cost]
+input = 1.2875
+output = 10.3
+[limit]
+context = 1000000
+output = 65536
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
@@ -1,0 +1,17 @@
+name = "Gemini 3.1 Pro"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2026-05"
+last_updated = "2026-06"
+[cost]
+input = 2.06
+output = 12.36
+[limit]
+context = 1000000
+output = 65536
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/models/glm-5.1.toml
+++ b/providers/pleumrouter/models/glm-5.1.toml
@@ -1,0 +1,17 @@
+name = "GLM-5.1"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2026-04"
+last_updated = "2026-06"
+[cost]
+input = 1.442
+output = 4.532
+[limit]
+context = 200000
+output = 131072
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/models/gpt-5.4-pro.toml
+++ b/providers/pleumrouter/models/gpt-5.4-pro.toml
@@ -1,0 +1,17 @@
+name = "GPT-5.4 Pro"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2026-02"
+last_updated = "2026-06"
+[cost]
+input = 30.9
+output = 185.4
+[limit]
+context = 1050000
+output = 128000
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/models/gpt-5.5.toml
+++ b/providers/pleumrouter/models/gpt-5.5.toml
@@ -1,0 +1,17 @@
+name = "GPT-5.5"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2026-04"
+last_updated = "2026-06"
+[cost]
+input = 5.15
+output = 30.9
+[limit]
+context = 1050000
+output = 128000
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/models/qwen3-max.toml
+++ b/providers/pleumrouter/models/qwen3-max.toml
@@ -1,0 +1,17 @@
+name = "Qwen3-Max"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = false
+release_date = "2025-09"
+last_updated = "2026-06"
+[cost]
+input = 1.236
+output = 6.18
+[limit]
+context = 262144
+output = 65536
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pleumrouter/provider.toml
+++ b/providers/pleumrouter/provider.toml
@@ -1,0 +1,7 @@
+# PleumRouter — models.dev provider 정의
+# 제출 대상: https://github.com/sst/models.dev  (providers/pleumrouter/)
+name = "PleumRouter"
+npm = "@ai-sdk/openai-compatible"
+api = "https://router.pleum.ai/v1"
+doc = "https://pleum.ai/docs"
+env = ["PLEUMROUTER_API_KEY"]


### PR DESCRIPTION
## What

Adds [PleumRouter](https://router.pleum.ai) as a provider, with its featured text models.

PleumRouter is a Korea-region multi-provider LLM gateway that exposes an **OpenAI-compatible** API, so it integrates via `@ai-sdk/openai-compatible`.

- **Endpoint:** `https://router.pleum.ai/v1`
- **Auth:** `PLEUMROUTER_API_KEY` (Bearer)
- **Docs:** https://pleum.ai/docs
- Prices are **effective USD per 1M tokens** (gateway markup included), so cost estimates match actual billing.

## Models

10 featured flagship text models across providers (Claude, GPT, Gemini, DeepSeek, Qwen, GLM). `GET /v1/models` is public and returns the full live catalog.

## Validation

`bun run validate` passes (exit 0).

Note: `release_date` values are best-effort; happy to correct any if maintainers have more precise dates.