### PR TITLE
Add Sakana AI Fugu models

### DIFF
--- a/models/sakana/fugu-ultra.toml
+++ b/models/sakana/fugu-ultra.toml
@@ -1,0 +1,82 @@
+name = "Fugu Ultra"
+family = "fugu"
+release_date = "2026-06-15"
+last_updated = "2026-06-15"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[links]]
+label = "Official model catalog"
+url = "https://raw.githubusercontent.com/SakanaAI/fugu/refs/heads/main/configs/files/fugu.json"
+type = "docs"
+
+[[benchmarks]]
+name = "SWE Bench Pro"
+score = 73.7
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "Terminal Bench 2.1"
+score = 82.1
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "LiveCodeBench"
+score = 93.2
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "LiveCodeBench Pro"
+score = 90.8
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "Humanity’s Last Exam"
+score = 50.0
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "CharXiv Reasoning"
+score = 86.6
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "GPQA Diamond"
+score = 95.5
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "SciCode"
+score = 58.7
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "τ3 Banking"
+score = 20.6
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "Long Context Reasoning"
+score = 73.3
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "MRCRv2"
+score = 93.6
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "CTI-REALM"
+score = 69.4
+source = "https://console.sakana.ai/models"

--- a/models/sakana/fugu.toml
+++ b/models/sakana/fugu.toml
@@ -1,0 +1,82 @@
+name = "Fugu"
+family = "fugu"
+release_date = "2026-06-15"
+last_updated = "2026-06-15"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[links]]
+label = "Official model catalog"
+url = "https://raw.githubusercontent.com/SakanaAI/fugu/refs/heads/main/configs/files/fugu.json"
+type = "docs"
+
+[[benchmarks]]
+name = "SWE Bench Pro"
+score = 59.0
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "Terminal Bench 2.1"
+score = 80.2
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "LiveCodeBench"
+score = 92.9
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "LiveCodeBench Pro"
+score = 87.8
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "Humanity’s Last Exam"
+score = 47.2
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "CharXiv Reasoning"
+score = 85.1
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "GPQA Diamond"
+score = 95.5
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "SciCode"
+score = 60.1
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "τ3 Banking"
+score = 21.7
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "Long Context Reasoning"
+score = 74.7
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "MRCRv2"
+score = 86.6
+source = "https://console.sakana.ai/models"
+
+[[benchmarks]]
+name = "CTI-REALM"
+score = 67.5
+source = "https://console.sakana.ai/models"

--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -347,6 +347,9 @@ export const ModelFamilyValues = [
   "auto",
   "model-router",
 
+  // Conductor
+  "fugu",
+
   // V0
   "v0",
 

--- a/providers/sakana/models/fugu-ultra-20260615.toml
+++ b/providers/sakana/models/fugu-ultra-20260615.toml
@@ -1,0 +1,19 @@
+base_model = "sakana/fugu-ultra"
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
+
+[limit]
+output = 1_000_000
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+
+[provider]
+shape = "responses"

--- a/providers/sakana/models/fugu-ultra.toml
+++ b/providers/sakana/models/fugu-ultra.toml
@@ -1,0 +1,19 @@
+base_model = "sakana/fugu-ultra"
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
+
+[limit]
+output = 1_000_000
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+
+[provider]
+shape = "responses"

--- a/providers/sakana/models/fugu.toml
+++ b/providers/sakana/models/fugu.toml
@@ -1,0 +1,8 @@
+base_model = "sakana/fugu"
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
+
+[limit]
+output = 1_000_000
+
+[provider]
+shape = "responses"

--- a/providers/sakana/provider.toml
+++ b/providers/sakana/provider.toml
@@ -1,0 +1,5 @@
+name = "Sakana AI"
+env = ["SAKANA_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.sakana.ai/v1"
+doc = "https://console.sakana.ai/models"


### PR DESCRIPTION
## Summary

Adds **Sakana AI** as an OpenAI-compatible provider and registers the canonical **Fugu** model family, sourced from the official Fugu catalog (`SakanaAI/fugu/configs/files/fugu.json`) and the Sakana console docs.

## Changes

- `providers/sakana/provider.toml` — new provider (`@ai-sdk/openai-compatible`, `https://api.sakana.ai/v1`, `SAKANA_API_KEY`)
- `models/sakana/fugu.toml`, `models/sakana/fugu-ultra.toml` — provider-agnostic model metadata (1M context, text+image input, `high` reasoning effort, benchmark scores)
- `providers/sakana/models/fugu.toml`, `providers/sakana/models/fugu-ultra.toml` — provider serving details (`responses` shape; Fugu Ultra pricing incl. >272K context tier)
- `packages/core/src/family.ts` — register the `fugu` model family

## Validation

- `bun validate` passes
- `packages/web` `bun run build` passes