### PR TITLE
feat(friendli): add gemma-4-31B-it model

### DIFF
--- a/providers/friendli/models/google/gemma-4-31B-it.toml
+++ b/providers/friendli/models/google/gemma-4-31B-it.toml
@@ -1,7 +1,4 @@
 base_model = "google/gemma-4-31b-it"
-release_date = "2026-04-30"
-last_updated = "2026-04-30"
-structured_output = true
 reasoning_options = [{ type = "toggle" }]
 
 [cost]

--- a/providers/friendli/models/google/gemma-4-31B-it.toml
+++ b/providers/friendli/models/google/gemma-4-31B-it.toml
@@ -1,0 +1,9 @@
+base_model = "google/gemma-4-31b-it"
+release_date = "2026-04-30"
+last_updated = "2026-04-30"
+structured_output = true
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0.14
+output = 0.4


### PR DESCRIPTION
## Summary
- Add Google Gemma 4 31B IT to Friendli provider
- Uses `base_model = "google/gemma-4-31b-it"` to inherit provider-agnostic metadata from `models/google/gemma-4-31b-it.toml`
- Provider-specific overrides: `reasoning_options = [{ type = "toggle" }]` and `[cost]`

## Validation
- `bun validate` passes
- AI SDK inference test via `@ai-sdk/openai-compatible` (using `_api.json` config):
  - Basic inference: OK
  - Reasoning toggle (`chat_template_kwargs.enable_thinking`): OK
  - Structured output (`generateObject` with Zod schema): OK