### PR TITLE
feat(friendli): add DeepSeek-V3.2 model

### DIFF
--- a/providers/friendli/models/deepseek-ai/DeepSeek-V3.2.toml
+++ b/providers/friendli/models/deepseek-ai/DeepSeek-V3.2.toml
@@ -1,12 +1,14 @@
-base_model = "deepseek/deepseek-chat"
-base_model_omit = ["knowledge"]
 name = "DeepSeek-V3.2"
-release_date = "2026-09-09"
-last_updated = "2026-09-09"
+family = "deepseek"
 attachment = false
 reasoning = true
-structured_output = true
 reasoning_options = [{ type = "toggle" }]
+tool_call = true
+structured_output = true
+temperature = true
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -19,3 +21,7 @@ cache_read = 0.25
 [limit]
 context = 163_840
 output = 163_840
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/friendli/models/deepseek-ai/DeepSeek-V3.2.toml
+++ b/providers/friendli/models/deepseek-ai/DeepSeek-V3.2.toml
@@ -1,0 +1,21 @@
+base_model = "deepseek/deepseek-chat"
+base_model_omit = ["knowledge"]
+name = "DeepSeek-V3.2"
+release_date = "2026-09-09"
+last_updated = "2026-09-09"
+attachment = false
+reasoning = true
+structured_output = true
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.5
+output = 1.5
+cache_read = 0.25
+
+[limit]
+context = 163_840
+output = 163_840


### PR DESCRIPTION
## Summary
- Add DeepSeek-V3.2 to Friendli provider
- Provider-specific config (no `base_model` inheritance) since V3.2 details differ from other providers — different limits, no attachment, toggle reasoning, etc.
- API confirmed: `enable_thinking` toggle works, no image input support

## Validation
- `bun validate` passes
- API inference test confirmed:
  - Basic inference: OK
  - Reasoning toggle (`chat_template_kwargs.enable_thinking`): OK (`reasoning_content` field returned)
  - `reasoning_effort`: not supported
  - Image input: not supported (`attachment = false`)