### PR TITLE
feat(pleumrouter): add PleumRouter provider

### DIFF
--- a/providers/pleumrouter/logo.svg
+++ b/providers/pleumrouter/logo.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16M4 12h10M4 17h7"/><circle cx="18" cy="15" r="3"/></svg>

--- a/providers/pleumrouter/models/claude-fable-5.toml
+++ b/providers/pleumrouter/models/claude-fable-5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 10.3
+output = 51.5

--- a/providers/pleumrouter/models/claude-fable-5.toml
+++ b/providers/pleumrouter/models/claude-fable-5.toml
@@ -1,5 +1,10 @@
 base_model = "anthropic/claude-fable-5"
-reasoning_options = [{ type = "toggle" }]
+attachment = false
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
 [cost]
-input = 10.3
-output = 51.5
+input = 10
+output = 50

--- a/providers/pleumrouter/models/claude-opus-4-8.toml
+++ b/providers/pleumrouter/models/claude-opus-4-8.toml
@@ -1,5 +1,10 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }]
+attachment = false
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
 [cost]
-input = 5.15
-output = 25.75
+input = 5
+output = 25

--- a/providers/pleumrouter/models/claude-opus-4-8.toml
+++ b/providers/pleumrouter/models/claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 5.15
+output = 25.75

--- a/providers/pleumrouter/models/claude-sonnet-4-6.toml
+++ b/providers/pleumrouter/models/claude-sonnet-4-6.toml
@@ -1,5 +1,10 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }]
+attachment = false
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
 [cost]
-input = 3.09
-output = 15.45
+input = 3
+output = 15

--- a/providers/pleumrouter/models/claude-sonnet-4-6.toml
+++ b/providers/pleumrouter/models/claude-sonnet-4-6.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 3.09
+output = 15.45

--- a/providers/pleumrouter/models/deepseek-v4-pro.toml
+++ b/providers/pleumrouter/models/deepseek-v4-pro.toml
@@ -1,0 +1,5 @@
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.44805
+output = 0.8961

--- a/providers/pleumrouter/models/deepseek-v4-pro.toml
+++ b/providers/pleumrouter/models/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "toggle" }]
+
 [cost]
-input = 0.44805
-output = 0.8961
+input = 0.435
+output = 0.87

--- a/providers/pleumrouter/models/gemini-2.5-pro.toml
+++ b/providers/pleumrouter/models/gemini-2.5-pro.toml
@@ -1,5 +1,13 @@
 base_model = "google/gemini-2.5-pro"
-reasoning_options = [{ type = "toggle" }]
+attachment = false
+
+[limit]
+context = 1_000_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
 [cost]
-input = 1.2875
-output = 10.3
+input = 1.25
+output = 10

--- a/providers/pleumrouter/models/gemini-2.5-pro.toml
+++ b/providers/pleumrouter/models/gemini-2.5-pro.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 1.2875
+output = 10.3

--- a/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 2.06
+output = 12.36

--- a/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
@@ -1,5 +1,13 @@
 base_model = "google/gemini-3.1-pro-preview"
-reasoning_options = [{ type = "toggle" }]
+attachment = false
+
+[limit]
+context = 1_000_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
 [cost]
-input = 2.06
-output = 12.36
+input = 2
+output = 12

--- a/providers/pleumrouter/models/glm-5.1.toml
+++ b/providers/pleumrouter/models/glm-5.1.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.1"
-reasoning_options = [{ type = "toggle" }]
+
 [cost]
-input = 1.442
-output = 4.532
+input = 1.4
+output = 4.4

--- a/providers/pleumrouter/models/glm-5.1.toml
+++ b/providers/pleumrouter/models/glm-5.1.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 1.442
+output = 4.532

--- a/providers/pleumrouter/models/gpt-5.4-pro.toml
+++ b/providers/pleumrouter/models/gpt-5.4-pro.toml
@@ -1,5 +1,10 @@
 base_model = "openai/gpt-5.4-pro"
-reasoning_options = [{ type = "toggle" }]
+attachment = false
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
 [cost]
-input = 30.9
-output = 185.4
+input = 30
+output = 180

--- a/providers/pleumrouter/models/gpt-5.4-pro.toml
+++ b/providers/pleumrouter/models/gpt-5.4-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-pro"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 30.9
+output = 185.4

--- a/providers/pleumrouter/models/gpt-5.5.toml
+++ b/providers/pleumrouter/models/gpt-5.5.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 5.15
+output = 30.9

--- a/providers/pleumrouter/models/gpt-5.5.toml
+++ b/providers/pleumrouter/models/gpt-5.5.toml
@@ -1,5 +1,10 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = [{ type = "toggle" }]
+attachment = false
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
 [cost]
-input = 5.15
-output = 30.9
+input = 5
+output = 30

--- a/providers/pleumrouter/models/qwen3-max.toml
+++ b/providers/pleumrouter/models/qwen3-max.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-max"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 1.236
+output = 6.18

--- a/providers/pleumrouter/models/qwen3-max.toml
+++ b/providers/pleumrouter/models/qwen3-max.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3-max"
-reasoning_options = [{ type = "toggle" }]
+
 [cost]
-input = 1.236
-output = 6.18
+input = 1.2
+output = 6

--- a/providers/pleumrouter/provider.toml
+++ b/providers/pleumrouter/provider.toml
@@ -3,5 +3,5 @@
 name = "PleumRouter"
 npm = "@ai-sdk/openai-compatible"
 api = "https://router.pleum.ai/v1"
-doc = "https://pleum.ai/docs"
+doc = "https://router.pleum.ai/docs"
 env = ["PLEUMROUTER_API_KEY"]

--- a/providers/pleumrouter/provider.toml
+++ b/providers/pleumrouter/provider.toml
@@ -1,0 +1,7 @@
+# PleumRouter — models.dev provider 정의
+# 제출 대상: https://github.com/sst/models.dev  (providers/pleumrouter/)
+name = "PleumRouter"
+npm = "@ai-sdk/openai-compatible"
+api = "https://router.pleum.ai/v1"
+doc = "https://pleum.ai/docs"
+env = ["PLEUMROUTER_API_KEY"]


### PR DESCRIPTION
## What

Adds [PleumRouter](https://router.pleum.ai), a Korea-region multi-provider gateway with an OpenAI-compatible API.

- **Base URL:** `https://router.pleum.ai/v1`
- **Auth:** `PLEUMROUTER_API_KEY`
- **SDK:** `@ai-sdk/openai-compatible`
- **Documentation:** [PleumRouter quickstart](https://router.pleum.ai/docs)

## Models and metadata

Adds ten featured text models using `base_model` inheritance. Provider-specific overrides are based on the current public PleumRouter catalog:

- Prices match the live unauthenticated [`GET /v1/models`](https://router.pleum.ai/v1/models) values. The [Models API reference](https://router.pleum.ai/docs/api/models) defines these as USD per 1M tokens.
- Models advertised by the live catalog as text-only override inherited attachment and multimodal metadata.
- Both Gemini models use the catalog context limit of 1,000,000 tokens.
- Provider documentation uses the working `https://router.pleum.ai/docs` URL.

## Reasoning controls

No `reasoning_options` are declared. The provider must document and expose provider-layer request controls before model-side reasoning controls can be represented accurately.

The [Chat Completions reference](https://router.pleum.ai/docs/api/chat-completions) does not document a reasoning, thinking, effort, or budget parameter, and the live [`GET /v1/models`](https://router.pleum.ai/v1/models) `supported_parameters` arrays do not advertise any such controls for these models. This avoids presenting a generic toggle for models whose native controls differ or whose reasoning cannot be disabled.

## Validation

- `bun validate`
- `git diff --check`

Both pass on commit `56f2704b`.