### PR TITLE
Add frontier models to Merge Gateway provider

### DIFF
--- a/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.6-plus"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 81_920
 
 [cost]
 input = 0.5

--- a/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
@@ -11,3 +11,5 @@ max = 250_000
 [cost]
 input = 0.5
 output = 3
+cache_read = 0.05
+cache_write = 0.625

--- a/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
@@ -6,7 +6,7 @@ type = "toggle"
 [[reasoning_options]]
 type = "budget_tokens"
 min = 1
-max = 81_920
+max = 250_000
 
 [cost]
 input = 0.5

--- a/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-plus"
+reasoning_options = []
 
 [cost]
 input = 0.5

--- a/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3.6-plus"
+
+[cost]
+input = 0.5
+output = 3

--- a/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.6-plus.toml
@@ -11,5 +11,3 @@ max = 250_000
 [cost]
 input = 0.5
 output = 3
-cache_read = 0.05
-cache_write = 0.625

--- a/providers/merge-gateway/models/alibaba/qwen3.7-max.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.7-max.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3.7-max"
+
+[cost]
+input = 1.65
+output = 4.95

--- a/providers/merge-gateway/models/alibaba/qwen3.7-max.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+reasoning_options = []
 
 [cost]
 input = 1.65

--- a/providers/merge-gateway/models/alibaba/qwen3.7-max.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.7-max.toml
@@ -6,7 +6,7 @@ type = "toggle"
 [[reasoning_options]]
 type = "budget_tokens"
 min = 1
-max = 262_144
+max = 250_000
 
 [cost]
 input = 1.65

--- a/providers/merge-gateway/models/alibaba/qwen3.7-max.toml
+++ b/providers/merge-gateway/models/alibaba/qwen3.7-max.toml
@@ -1,5 +1,12 @@
 base_model = "alibaba/qwen3.7-max"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 262_144
 
 [cost]
 input = 1.65

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
@@ -1,5 +1,8 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
@@ -1,8 +1,12 @@
 base_model = "anthropic/claude-opus-4-8"
 
 [[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 128_000
 
 [cost]
 input = 5

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-4-8.toml
@@ -11,5 +11,3 @@ max = 128_000
 [cost]
 input = 5
 output = 25
-cache_read = 0.5
-cache_write = 6.25

--- a/providers/merge-gateway/models/minimax/minimax-m3.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m3.toml
@@ -3,6 +3,11 @@ base_model = "minimax/MiniMax-M3"
 [[reasoning_options]]
 type = "toggle"
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 128_000
+
 [cost]
 input = 0.6
 output = 2.4

--- a/providers/merge-gateway/models/minimax/minimax-m3.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m3.toml
@@ -11,3 +11,4 @@ max = 128_000
 [cost]
 input = 0.6
 output = 2.4
+cache_read = 0.12

--- a/providers/merge-gateway/models/minimax/minimax-m3.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m3.toml
@@ -11,4 +11,3 @@ max = 128_000
 [cost]
 input = 0.6
 output = 2.4
-cache_read = 0.12

--- a/providers/merge-gateway/models/minimax/minimax-m3.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/minimax/minimax-m3.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m3.toml
@@ -1,0 +1,5 @@
+base_model = "minimax/MiniMax-M3"
+
+[cost]
+input = 0.6
+output = 2.4

--- a/providers/merge-gateway/models/minimax/minimax-m3.toml
+++ b/providers/merge-gateway/models/minimax/minimax-m3.toml
@@ -1,5 +1,7 @@
 base_model = "minimax/MiniMax-M3"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
@@ -14,3 +14,4 @@ field = "reasoning_content"
 [cost]
 input = 0.6
 output = 2.5
+cache_read = 0.15

--- a/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2-thinking"
+
+[cost]
+input = 0.6
+output = 2.5

--- a/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
@@ -1,4 +1,8 @@
 base_model = "moonshotai/kimi-k2-thinking"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
@@ -14,4 +14,3 @@ field = "reasoning_content"
 [cost]
 input = 0.6
 output = 2.5
-cache_read = 0.15

--- a/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2-thinking.toml
@@ -1,5 +1,12 @@
 base_model = "moonshotai/kimi-k2-thinking"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 32_768
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
@@ -14,4 +14,3 @@ field = "reasoning_content"
 [cost]
 input = 0.6
 output = 3
-cache_read = 0.1

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2.5"
+
+[cost]
+input = 0.6
+output = 3

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
@@ -1,4 +1,8 @@
 base_model = "moonshotai/kimi-k2.5"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.6

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
@@ -1,5 +1,7 @@
 base_model = "moonshotai/kimi-k2.5"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
@@ -14,3 +14,4 @@ field = "reasoning_content"
 [cost]
 input = 0.6
 output = 3
+cache_read = 0.1

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.5.toml
@@ -3,6 +3,11 @@ base_model = "moonshotai/kimi-k2.5"
 [[reasoning_options]]
 type = "toggle"
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 262_144
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
@@ -1,4 +1,8 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.95

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
@@ -3,6 +3,11 @@ base_model = "moonshotai/kimi-k2.6"
 [[reasoning_options]]
 type = "toggle"
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 262_144
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.95
+output = 4

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
@@ -14,3 +14,4 @@ field = "reasoning_content"
 [cost]
 input = 0.95
 output = 4
+cache_read = 0.16

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
@@ -14,4 +14,3 @@ field = "reasoning_content"
 [cost]
 input = 0.95
 output = 4
-cache_read = 0.16

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.6.toml
@@ -1,5 +1,7 @@
 base_model = "moonshotai/kimi-k2.6"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -1,5 +1,12 @@
 base_model = "moonshotai/kimi-k2.7-code-highspeed"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 32_768
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -14,4 +14,3 @@ field = "reasoning_content"
 [cost]
 input = 1.9
 output = 8
-cache_read = 0.38

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -1,4 +1,8 @@
 base_model = "moonshotai/kimi-k2.7-code-highspeed"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 1.9

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
+
+[cost]
+input = 1.9
+output = 8

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -14,3 +14,4 @@ field = "reasoning_content"
 [cost]
 input = 1.9
 output = 8
+cache_read = 0.38

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
@@ -14,4 +14,3 @@ field = "reasoning_content"
 [cost]
 input = 0.95
 output = 4
-cache_read = 0.19

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
@@ -1,5 +1,12 @@
 base_model = "moonshotai/kimi-k2.7-code"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 32_768
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
@@ -1,4 +1,8 @@
 base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.95

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+[cost]
+input = 0.95
+output = 4

--- a/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/merge-gateway/models/moonshotai/kimi-k2.7-code.toml
@@ -14,3 +14,4 @@ field = "reasoning_content"
 [cost]
 input = 0.95
 output = 4
+cache_read = 0.19

--- a/providers/merge-gateway/models/zai/glm-5.2.toml
+++ b/providers/merge-gateway/models/zai/glm-5.2.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5.2.toml
+++ b/providers/merge-gateway/models/zai/glm-5.2.toml
@@ -14,5 +14,3 @@ field = "reasoning_content"
 [cost]
 input = 1.4
 output = 4.4
-cache_read = 0.26
-cache_write = 0

--- a/providers/merge-gateway/models/zai/glm-5.2.toml
+++ b/providers/merge-gateway/models/zai/glm-5.2.toml
@@ -14,3 +14,5 @@ field = "reasoning_content"
 [cost]
 input = 1.4
 output = 4.4
+cache_read = 0.26
+cache_write = 0

--- a/providers/merge-gateway/models/zai/glm-5.2.toml
+++ b/providers/merge-gateway/models/zai/glm-5.2.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-5.2"
+
+[cost]
+input = 1.4
+output = 4.4

--- a/providers/merge-gateway/models/zai/glm-5.2.toml
+++ b/providers/merge-gateway/models/zai/glm-5.2.toml
@@ -1,8 +1,12 @@
 base_model = "zhipuai/glm-5.2"
 
 [[reasoning_options]]
-type = "effort"
-values = ["high", "max"]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 50_000
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/merge-gateway/models/zai/glm-5.2.toml
+++ b/providers/merge-gateway/models/zai/glm-5.2.toml
@@ -1,4 +1,8 @@
 base_model = "zhipuai/glm-5.2"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 1.4


### PR DESCRIPTION
Follow-up to the initial Merge Gateway provider PR. Adds 10 models now available through Merge Gateway that have launched since, each defined via `base_model` extending its canonical entry with list pricing (USD per million tokens):

| Model | base_model | input | output |
|---|---|---|---|
| Claude Opus 4.8 | `anthropic/claude-opus-4-8` | 5 | 25 |
| GLM-5.2 | `zhipuai/glm-5.2` | 1.4 | 4.4 |
| Kimi K2.7 Code | `moonshotai/kimi-k2.7-code` | 0.95 | 4 |
| Kimi K2.7 Code Highspeed | `moonshotai/kimi-k2.7-code-highspeed` | 1.9 | 8 |
| Kimi K2.6 | `moonshotai/kimi-k2.6` | 0.95 | 4 |
| Kimi K2.5 | `moonshotai/kimi-k2.5` | 0.6 | 3 |
| Kimi K2 Thinking | `moonshotai/kimi-k2-thinking` | 0.6 | 2.5 |
| MiniMax-M3 | `minimax/MiniMax-M3` | 0.6 | 2.4 |
| Qwen3.7 Max | `alibaba/qwen3.7-max` | 1.65 | 4.95 |
| Qwen3.6 Plus | `alibaba/qwen3.6-plus` | 0.5 | 3 |

Adds two new canonical groupings under the provider (`moonshotai/`, `alibaba/`). `provider.toml` is unchanged. Validated locally with `bun validate`.