### PR TITLE
fix(vercel): sync audio model types

### DIFF
--- a/packages/core/src/sync/providers/vercel.ts
+++ b/packages/core/src/sync/providers/vercel.ts
@@ -6,7 +6,16 @@ import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://ai-gateway.vercel.sh/v1/models";
 
-const ModelType = z.enum(["language", "embedding", "image", "video", "reranking"]);
+const ModelType = z.enum([
+  "language",
+  "embedding",
+  "image",
+  "video",
+  "reranking",
+  "transcription",
+  "speech",
+  "realtime",
+]);
 
 const PricingTier = z.object({
   cost: z.string(),
@@ -30,8 +39,8 @@ export const VercelModel = z.object({
   name: z.string(),
   created: z.number(),
   released: z.number().optional(),
-  context_window: z.number(),
-  max_tokens: z.number(),
+  context_window: z.number().optional().default(0),
+  max_tokens: z.number().optional().default(0),
   type: ModelType,
   tags: z.array(z.string()).optional().default([]),
   pricing: Pricing.optional(),
@@ -107,9 +116,17 @@ export function buildVercelModel(model: VercelModel, existing: ExistingModel | u
     cost,
     limit: { context, input, output },
     modalities: {
-      input: ["text", tags.has("vision") ? "image" : undefined, tags.has("file-input") ? "pdf" : undefined]
-        .filter((value): value is "text" | "image" | "pdf" => value !== undefined),
-      output: model.type === "image"
+      input: model.type === "transcription"
+        ? ["audio"]
+        : model.type === "realtime"
+        ? ["text", "audio"]
+        : ["text", tags.has("vision") ? "image" : undefined, tags.has("file-input") ? "pdf" : undefined]
+          .filter((value): value is "text" | "image" | "pdf" => value !== undefined),
+      output: model.type === "speech"
+        ? ["audio"]
+        : model.type === "realtime"
+        ? ["text", "audio"]
+        : model.type === "image"
         ? ["image"]
         : model.type === "video"
         ? ["video"]


### PR DESCRIPTION
## Summary
- accept Vercel Gateway `transcription`, `speech`, and `realtime` model types
- default omitted token limits to zero, matching existing unknown-limit handling
- map transcription, speech, and realtime models to their audio modalities

## Verification
- `bun validate`
- parsed and translated all 290 models from the live Vercel Gateway response
- full Vercel dry run: 9 created, 0 updated, 0 removed, 281 unchanged
- `git diff --check`