### PR TITLE
feat(providers): add Together AI provider

### DIFF
--- a/providers/togetherai/models/Qwen/Qwen2.5-Coder-32B-Instruct.toml
+++ b/providers/togetherai/models/Qwen/Qwen2.5-Coder-32B-Instruct.toml
@@ -1,7 +1,7 @@
-name = "DeepSeek V3"
-family = "deepseek"
-release_date = "2024-12-26"
-last_updated = "2024-12-26"
+name = "Qwen 2.5 Coder 32B Instruct"
+family = "qwen"
+release_date = "2024-11-11"
+last_updated = "2024-11-11"
 attachment = true
 reasoning = false
 temperature = true
@@ -10,8 +10,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 1.00
-output = 1.00
+input = 0.30
+output = 0.30
 
 [limit]
 context = 131_072

--- a/providers/togetherai/models/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/togetherai/models/deepseek-ai/DeepSeek-R1.toml
@@ -1,23 +1,22 @@
-name = "DeepSeek-R1"
-family = "deepseek-thinking"
+name = "DeepSeek R1"
+family = "deepseek"
 release_date = "2025-01-20"
-last_updated = "2025-03-24"
-attachment = false
+last_updated = "2025-01-20"
+attachment = true
 reasoning = true
-reasoning_options = []
-status = "deprecated"
 temperature = true
-knowledge = "2024-07"
-tool_call = false
+tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]
-input = 3
-output = 7
+input = 7.00
+output = 7.00
+reasoning = 7.00
 
 [limit]
-context = 163_839
-output = 163_839
+context = 131_072
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/togetherai/models/meta-llama/Llama-3.3-70B-Instruct-Turbo.toml
+++ b/providers/togetherai/models/meta-llama/Llama-3.3-70B-Instruct-Turbo.toml
@@ -1,12 +1,12 @@
-name = "Llama 3.3 70B"
+name = "Llama 3.3 70B Instruct Turbo"
 family = "llama"
 release_date = "2024-12-06"
 last_updated = "2024-12-06"
-attachment = false
+attachment = true
 reasoning = false
 temperature = true
-knowledge = "2023-12"
 tool_call = true
+structured_output = true
 open_weights = true
 
 [cost]
@@ -15,7 +15,7 @@ output = 0.88
 
 [limit]
 context = 131_072
-output = 131_072
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/togetherai/provider.toml
+++ b/providers/togetherai/provider.toml
@@ -1,4 +1,5 @@
 name = "Together AI"
 env = ["TOGETHER_API_KEY"]
-npm = "@ai-sdk/togetherai"
-doc = "https://docs.together.ai/docs/serverless-models"
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.together.xyz/v1"
+doc = "https://docs.together.ai/docs/inference-models"


### PR DESCRIPTION
Add Together AI as an OpenAI-compatible inference provider.

Together AI provides access to 200+ open-source models through an OpenAI-compatible API. This adds the provider definition and 4 popular model entries:
- meta-llama/Llama-3.3-70B-Instruct-Turbo
- deepseek-ai/DeepSeek-V3
- deepseek-ai/DeepSeek-R1
- Qwen/Qwen2.5-Coder-32B-Instruct

Provider uses @ai-sdk/openai-compatible with api = "https://api.together.xyz/v1".

Closes #