### PR TITLE
feat(friendli): add GLM-5.2

### DIFF
--- a/providers/friendli/models/zai-org/GLM-5.2.toml
+++ b/providers/friendli/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,14 @@
+name = "GLM-5.2"
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26


### PR DESCRIPTION
## What

Add GLM-5.2 model support for Friendli provider.

## Why

GLM-5.2 released 2026-06-13; Friendli serves it at `zai-org/GLM-5.2`.

## Changes

- `providers/friendli/models/zai-org/GLM-5.2.toml` — new model config
  - Uses `base_model = "zhipuai/glm-5.2"` to inherit provider-agnostic metadata
  - Friendli-specific: cost (1.4/4.4/0.26), limit (1M context / 128K output), interleaved reasoning via `reasoning_content`
  - `reasoning_options`: effort type with `["high", "max"]` only — `"none"` rejected by Friendli API

## Validation

Live API requests confirmed:
- `reasoning_effort=high` → works, returns `reasoning_content`
- `reasoning_effort=max` → works, more detailed reasoning
- `reasoning_effort=none` → rejected: `invalid JSON payload: unknown enum value: none`
- Default (no param) → reasoning active by default
- `bun validate` passes