### PR TITLE
Add/update llmgateway provider models

### DIFF
--- a/providers/llmgateway/models/fugu-ultra.toml
+++ b/providers/llmgateway/models/fugu-ultra.toml
@@ -1,0 +1,22 @@
+name = "Fugu Ultra"
+family = "aura"
+release_date = "2026-06-21"
+last_updated = "2026-06-21"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[limit]
+context = 1_000_000
+output = 1_000_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/llmgateway/models/grok-4.toml
+++ b/providers/llmgateway/models/grok-4.toml
@@ -1,0 +1,22 @@
+name = "Grok 4"
+family = "grok"
+release_date = "2025-07-09"
+last_updated = "2025-07-09"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 3.00
+output = 15.00
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Models added

- `fugu-ultra` — Sakana AI Fugu Ultra
  - Pricing (per 1M tokens): input $5, output $30, cache_read $0.50
  - Source: https://sakana.ai/fugu
  - Context: 1M tokens, output: 1M tokens
  - Modalities: text+image → text
  - Reasoning: true