### PR TITLE
Add CoderPlan provider

### DIFF
--- a/providers/coderplan/logo.svg
+++ b/providers/coderplan/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="2" y="2" width="20" height="20" rx="5" fill="currentColor" opacity="0.15"/>
+  <rect x="2" y="2" width="20" height="20" rx="5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+  <text x="12" y="16.5" font-family="monospace" font-size="13" font-weight="700" fill="currentColor" text-anchor="middle">$</text>
+</svg>

--- a/providers/coderplan/models/claude-haiku-4-5-20251001.toml
+++ b/providers/coderplan/models/claude-haiku-4-5-20251001.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 0.14
+output = 0.68
+cache_read = 0.01

--- a/providers/coderplan/models/claude-haiku-4-5-20251001.toml
+++ b/providers/coderplan/models/claude-haiku-4-5-20251001.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1024 }]
 
 [cost]
 input = 0.14

--- a/providers/coderplan/models/claude-opus-4-6.toml
+++ b/providers/coderplan/models/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1024 }]
 
 [cost]
 input = 0.68

--- a/providers/coderplan/models/claude-opus-4-6.toml
+++ b/providers/coderplan/models/claude-opus-4-6.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-opus-4-6"
+
+[cost]
+input = 0.68
+output = 3.42
+cache_read = 0.07

--- a/providers/coderplan/models/claude-opus-4-7.toml
+++ b/providers/coderplan/models/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1024 }]
 
 [cost]
 input = 0.68

--- a/providers/coderplan/models/claude-opus-4-7.toml
+++ b/providers/coderplan/models/claude-opus-4-7.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[cost]
+input = 0.68
+output = 3.42
+cache_read = 0.07

--- a/providers/coderplan/models/claude-opus-4-8.toml
+++ b/providers/coderplan/models/claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[cost]
+input = 10.20
+output = 51.00

--- a/providers/coderplan/models/claude-opus-4-8.toml
+++ b/providers/coderplan/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1024 }]
 
 [cost]
 input = 10.20

--- a/providers/coderplan/models/claude-sonnet-4-6.toml
+++ b/providers/coderplan/models/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1024 }]
 
 [cost]
 input = 0.41

--- a/providers/coderplan/models/claude-sonnet-4-6.toml
+++ b/providers/coderplan/models/claude-sonnet-4-6.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 0.41
+output = 2.05
+cache_read = 0.04

--- a/providers/coderplan/models/deepseek-v4-flash.toml
+++ b/providers/coderplan/models/deepseek-v4-flash.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[cost]
+input = 0.01
+output = 0.02
+cache_read = 0.002

--- a/providers/coderplan/models/deepseek-v4-flash.toml
+++ b/providers/coderplan/models/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
 
 [cost]
 input = 0.01

--- a/providers/coderplan/models/deepseek-v4-pro.toml
+++ b/providers/coderplan/models/deepseek-v4-pro.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 0.08
+output = 0.17
+cache_read = 0.007

--- a/providers/coderplan/models/deepseek-v4-pro.toml
+++ b/providers/coderplan/models/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
 
 [cost]
 input = 0.08

--- a/providers/coderplan/models/gemini-2.5-flash-image.toml
+++ b/providers/coderplan/models/gemini-2.5-flash-image.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash-image"
+
+[cost]
+input = 0.29
+output = 28.56
+cache_read = 0.07

--- a/providers/coderplan/models/gemini-2.5-flash.toml
+++ b/providers/coderplan/models/gemini-2.5-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash"
+
+[cost]
+input = 0.09
+output = 0.68
+cache_read = 0.003

--- a/providers/coderplan/models/gemini-2.5-flash.toml
+++ b/providers/coderplan/models/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32768 }]
 
 [cost]
 input = 0.09

--- a/providers/coderplan/models/gemini-2.5-pro.toml
+++ b/providers/coderplan/models/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32768 }]
 
 [cost]
 input = 1.20

--- a/providers/coderplan/models/gemini-2.5-pro.toml
+++ b/providers/coderplan/models/gemini-2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-pro"
+
+[cost]
+input = 1.20
+output = 9.59
+cache_read = 0.12

--- a/providers/coderplan/models/gemini-3-flash-preview.toml
+++ b/providers/coderplan/models/gemini-3-flash-preview.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3-flash-preview"
+
+[cost]
+input = 0.07
+output = 0.41
+cache_read = 0.007

--- a/providers/coderplan/models/gemini-3-flash-preview.toml
+++ b/providers/coderplan/models/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32768 }]
 
 [cost]
 input = 0.07

--- a/providers/coderplan/models/gemini-3-pro-preview.toml
+++ b/providers/coderplan/models/gemini-3-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32768 }]
 
 [cost]
 input = 0.54

--- a/providers/coderplan/models/gemini-3-pro-preview.toml
+++ b/providers/coderplan/models/gemini-3-pro-preview.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3-pro-preview"
+
+[cost]
+input = 0.54
+output = 3.27
+cache_read = 0.05

--- a/providers/coderplan/models/gemini-3.1-flash-image-preview.toml
+++ b/providers/coderplan/models/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-flash-image-preview"
+
+[cost]
+input = 0.24
+output = 57.12

--- a/providers/coderplan/models/gemini-3.1-pro-preview.toml
+++ b/providers/coderplan/models/gemini-3.1-pro-preview.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[cost]
+input = 1.90
+output = 11.42
+cache_read = 0.19

--- a/providers/coderplan/models/gemini-3.1-pro-preview.toml
+++ b/providers/coderplan/models/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32768 }]
 
 [cost]
 input = 1.90

--- a/providers/coderplan/models/glm-5.1.toml
+++ b/providers/coderplan/models/glm-5.1.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5.1"
+
+[cost]
+input = 0.15
+output = 0.48
+cache_read = 0.03

--- a/providers/coderplan/models/glm-5.1.toml
+++ b/providers/coderplan/models/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.15

--- a/providers/coderplan/models/glm-5.toml
+++ b/providers/coderplan/models/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.11

--- a/providers/coderplan/models/glm-5.toml
+++ b/providers/coderplan/models/glm-5.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5"
+
+[cost]
+input = 0.11
+output = 0.35
+cache_read = 0.02

--- a/providers/coderplan/models/gpt-5.4-mini.toml
+++ b/providers/coderplan/models/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/coderplan/models/gpt-5.4-mini.toml
+++ b/providers/coderplan/models/gpt-5.4-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4-mini"
+
+[cost]
+input = 0.05
+output = 0.31
+cache_read = 0.005

--- a/providers/coderplan/models/gpt-5.4.toml
+++ b/providers/coderplan/models/gpt-5.4.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4"
+
+[cost]
+input = 0.17
+output = 1.03
+cache_read = 0.02

--- a/providers/coderplan/models/gpt-5.4.toml
+++ b/providers/coderplan/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.17

--- a/providers/coderplan/models/gpt-5.5.toml
+++ b/providers/coderplan/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.34

--- a/providers/coderplan/models/gpt-5.5.toml
+++ b/providers/coderplan/models/gpt-5.5.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.5"
+
+[cost]
+input = 0.34
+output = 2.05
+cache_read = 0.03

--- a/providers/coderplan/models/hy3-preview.toml
+++ b/providers/coderplan/models/hy3-preview.toml
@@ -1,4 +1,5 @@
 base_model = "tencent/hy3-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.007

--- a/providers/coderplan/models/hy3-preview.toml
+++ b/providers/coderplan/models/hy3-preview.toml
@@ -1,0 +1,6 @@
+base_model = "tencent/hy3-preview"
+
+[cost]
+input = 0.007
+output = 0.03
+cache_read = 0.003

--- a/providers/coderplan/models/kimi-k2.5.toml
+++ b/providers/coderplan/models/kimi-k2.5.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.5"
+
+[cost]
+input = 0.07
+output = 0.33
+cache_read = 0.01

--- a/providers/coderplan/models/kimi-k2.5.toml
+++ b/providers/coderplan/models/kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.07

--- a/providers/coderplan/models/kimi-k2.6.toml
+++ b/providers/coderplan/models/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.10

--- a/providers/coderplan/models/kimi-k2.6.toml
+++ b/providers/coderplan/models/kimi-k2.6.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.10
+output = 0.44
+cache_read = 0.02

--- a/providers/coderplan/models/mimo-v2.5-pro.toml
+++ b/providers/coderplan/models/mimo-v2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 0.05
+output = 0.09
+cache_read = 0.0004

--- a/providers/coderplan/models/mimo-v2.5-pro.toml
+++ b/providers/coderplan/models/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/coderplan/models/mimo-v2.5.toml
+++ b/providers/coderplan/models/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.02

--- a/providers/coderplan/models/mimo-v2.5.toml
+++ b/providers/coderplan/models/mimo-v2.5.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5"
+
+[cost]
+input = 0.02
+output = 0.03
+cache_read = 0.0003

--- a/providers/coderplan/models/minimax-m2.5-highspeed.toml
+++ b/providers/coderplan/models/minimax-m2.5-highspeed.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.5-highspeed"
+
+[cost]
+input = 0.07
+output = 0.26
+cache_read = 0.007

--- a/providers/coderplan/models/minimax-m2.5-highspeed.toml
+++ b/providers/coderplan/models/minimax-m2.5-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5-highspeed"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.07

--- a/providers/coderplan/models/minimax-m2.5.toml
+++ b/providers/coderplan/models/minimax-m2.5.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.5"
+
+[cost]
+input = 0.03
+output = 0.13
+cache_read = 0.003

--- a/providers/coderplan/models/minimax-m2.5.toml
+++ b/providers/coderplan/models/minimax-m2.5.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.03

--- a/providers/coderplan/models/minimax-m2.7-highspeed.toml
+++ b/providers/coderplan/models/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.07

--- a/providers/coderplan/models/minimax-m2.7-highspeed.toml
+++ b/providers/coderplan/models/minimax-m2.7-highspeed.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
+
+[cost]
+input = 0.07
+output = 0.26
+cache_read = 0.007

--- a/providers/coderplan/models/minimax-m2.7.toml
+++ b/providers/coderplan/models/minimax-m2.7.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.7"
+
+[cost]
+input = 0.03
+output = 0.13
+cache_read = 0.007

--- a/providers/coderplan/models/minimax-m2.7.toml
+++ b/providers/coderplan/models/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.03

--- a/providers/coderplan/models/minimax-m3.toml
+++ b/providers/coderplan/models/minimax-m3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.03

--- a/providers/coderplan/models/minimax-m3.toml
+++ b/providers/coderplan/models/minimax-m3.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M3"
+
+[cost]
+input = 0.03
+output = 0.13
+cache_read = 0.007

--- a/providers/coderplan/models/qwen3.6-plus.toml
+++ b/providers/coderplan/models/qwen3.6-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.6-plus"
+
+[cost]
+input = 0.03
+output = 0.18
+cache_read = 0.003

--- a/providers/coderplan/models/qwen3.6-plus.toml
+++ b/providers/coderplan/models/qwen3.6-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-plus"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.03

--- a/providers/coderplan/models/qwen3.7-max.toml
+++ b/providers/coderplan/models/qwen3.7-max.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-max"
+
+[cost]
+input = 0.14
+output = 0.14
+cache_read = 0.03

--- a/providers/coderplan/models/qwen3.7-max.toml
+++ b/providers/coderplan/models/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.14

--- a/providers/coderplan/models/qwen3.7-plus.toml
+++ b/providers/coderplan/models/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.03

--- a/providers/coderplan/models/qwen3.7-plus.toml
+++ b/providers/coderplan/models/qwen3.7-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-plus"
+
+[cost]
+input = 0.03
+output = 0.14
+cache_read = 0.007

--- a/providers/coderplan/provider.toml
+++ b/providers/coderplan/provider.toml
@@ -1,0 +1,5 @@
+name = "CoderPlan"
+env = ["CODERPLAN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://coderplan.ai/docs/setup"
+api = "https://api.coderplan.ai/v1"


### PR DESCRIPTION
## CoderPlan Provider

Resubmission of #1973 (closed stale) — `logo.svg` added per @rekram1-node's earlier review ("no logo?").

**CoderPlan** (https://coderplan.ai) is an OpenAI-compatible LLM API relay serving developers in mainland China — Claude / GPT / Gemini / DeepSeek / GLM / Kimi / MiniMax / Qwen, pay-per-use, Alipay/WeChat Pay.

### Added
- `provider.toml` — `name`, `env = ["CODERPLAN_API_KEY"]`, `npm = "@ai-sdk/openai-compatible"`, `api = "https://api.coderplan.ai/v1"`, `doc` link
- `logo.svg`
- **33 model entries**: Claude (Opus 4.6/4.7/4.8, Sonnet 4.6, Haiku 4.5), GPT (5.4, 5.4-mini, 5.5), Gemini (2.5/3/3.1 flash & pro), DeepSeek V4 (pro/flash), GLM (5, 5.1), Kimi (K2.5/K2.6), MiMo (v2.5/v2.5-pro), MiniMax (M2.5-M3), Qwen (3.6/3.7)

### Notes
- OpenAI-compatible protocol (`@ai-sdk/openai-compatible`)
- Logo as SVG per repo convention
- Supersedes #1973

Happy to adjust fields/format. Thanks!