### PR TITLE
feat(siliconflow-cn): add DeepSeek V4 Flash

### DIFF
--- a/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/siliconflow-cn/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.003


### PR DESCRIPTION
## Summary

- add `deepseek-ai/DeepSeek-V4-Flash` to the SiliconFlow China catalog
- inherit canonical DeepSeek V4 Flash metadata and configure `reasoning_content` interleaving
- expose SiliconFlow's documented `thinking_budget` control through `reasoning_options` (128-32,768 tokens)
- use SiliconFlow China pricing for input, output, and cache reads

The global `siliconflow` provider already contains this model; its reasoning-options audit is tracked separately in #2497. This PR addresses the missing `siliconflow-cn` catalog entry reported in https://github.com/anomalyco/models.dev/pull/1894#issuecomment-4777656416.

## Validation

- `bun validate`
- `git diff --check`