### PR TITLE
Add BitRouter provider

### DIFF
--- a/providers/bitrouter/models/anthropic/claude-fable-5.toml
+++ b/providers/bitrouter/models/anthropic/claude-fable-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-fable-5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[limit]
+context = 1000000
+output = 128000

--- a/providers/bitrouter/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/bitrouter/models/anthropic/claude-haiku-4.5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25
+
+[limit]
+context = 200000
+output = 8192

--- a/providers/bitrouter/models/anthropic/claude-opus-4.5.toml
+++ b/providers/bitrouter/models/anthropic/claude-opus-4.5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-4-5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200000
+output = 64000

--- a/providers/bitrouter/models/anthropic/claude-opus-4.6.toml
+++ b/providers/bitrouter/models/anthropic/claude-opus-4.6.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-4-6"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200000
+output = 16384

--- a/providers/bitrouter/models/anthropic/claude-opus-4.7.toml
+++ b/providers/bitrouter/models/anthropic/claude-opus-4.7.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200000
+output = 16384

--- a/providers/bitrouter/models/anthropic/claude-opus-4.8.toml
+++ b/providers/bitrouter/models/anthropic/claude-opus-4.8.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 1000000
+output = 128000

--- a/providers/bitrouter/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/bitrouter/models/anthropic/claude-sonnet-4.5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-sonnet-4-5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+context = 200000
+output = 64000

--- a/providers/bitrouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/bitrouter/models/anthropic/claude-sonnet-4.6.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+context = 1000000
+output = 128000

--- a/providers/bitrouter/models/deepseek/deepseek-v3.2.toml
+++ b/providers/bitrouter/models/deepseek/deepseek-v3.2.toml
@@ -1,0 +1,26 @@
+name = "DeepSeek V3.2"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+knowledge = "2024-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.21
+output = 0.315
+cache_read = 0.105
+
+[limit]
+context = 131072
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/bitrouter/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/bitrouter/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,13 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.105
+output = 0.21
+cache_read = 0.0021
+
+[limit]
+context = 262144
+output = 262144

--- a/providers/bitrouter/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/bitrouter/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,13 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.305
+output = 2.61
+cache_read = 0.10875
+
+[limit]
+context = 256000
+output = 16384

--- a/providers/bitrouter/models/google/gemini-2.5-pro-preview.toml
+++ b/providers/bitrouter/models/google/gemini-2.5-pro-preview.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-2.5-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[limit]
+context = 1048576
+output = 65536

--- a/providers/bitrouter/models/google/gemini-3-flash-preview.toml
+++ b/providers/bitrouter/models/google/gemini-3-flash-preview.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3-flash-preview"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+
+[limit]
+context = 1048576
+output = 65536

--- a/providers/bitrouter/models/google/gemini-3-pro-preview.toml
+++ b/providers/bitrouter/models/google/gemini-3-pro-preview.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3-pro-preview"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[limit]
+context = 1048576
+output = 65536

--- a/providers/bitrouter/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/bitrouter/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,14 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+cache_write = 0.25
+
+[limit]
+context = 1000000
+output = 8192

--- a/providers/bitrouter/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/bitrouter/models/google/gemini-3.1-pro-preview.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[limit]
+context = 2000000
+output = 8192

--- a/providers/bitrouter/models/google/gemini-3.5-flash.toml
+++ b/providers/bitrouter/models/google/gemini-3.5-flash.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3.5-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+
+[limit]
+context = 1048576
+output = 65536

--- a/providers/bitrouter/models/minimax/minimax-m2.5.toml
+++ b/providers/bitrouter/models/minimax/minimax-m2.5.toml
@@ -1,0 +1,14 @@
+base_model = "minimax/MiniMax-M2.5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.225
+output = 0.9
+cache_read = 0.0225
+cache_write = 0.28125
+
+[limit]
+context = 196608
+output = 196608

--- a/providers/bitrouter/models/minimax/minimax-m2.7.toml
+++ b/providers/bitrouter/models/minimax/minimax-m2.7.toml
@@ -1,0 +1,14 @@
+base_model = "minimax/MiniMax-M2.7"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.225
+output = 0.9
+cache_read = 0.045
+cache_write = 0.28125
+
+[limit]
+context = 196608
+output = 196608

--- a/providers/bitrouter/models/minimax/minimax-m3.toml
+++ b/providers/bitrouter/models/minimax/minimax-m3.toml
@@ -1,0 +1,13 @@
+base_model = "minimax/MiniMax-M3"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.45
+output = 1.8
+cache_read = 0.09
+
+[limit]
+context = 1048576
+output = 512000

--- a/providers/bitrouter/models/moonshotai/kimi-k2.5.toml
+++ b/providers/bitrouter/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,13 @@
+base_model = "moonshotai/kimi-k2.5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.44
+output = 2
+cache_read = 0.22
+
+[limit]
+context = 262144
+output = 65535

--- a/providers/bitrouter/models/moonshotai/kimi-k2.6.toml
+++ b/providers/bitrouter/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,13 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.7125
+output = 3
+cache_read = 0.12
+
+[limit]
+context = 256000
+output = 8192

--- a/providers/bitrouter/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/bitrouter/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,13 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.7125
+output = 3
+cache_read = 0.1425
+
+[limit]
+context = 262144
+output = 32768

--- a/providers/bitrouter/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/bitrouter/models/openai/gpt-5.1-codex-mini.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.1-codex-mini"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025
+
+[limit]
+context = 400000
+output = 128000

--- a/providers/bitrouter/models/openai/gpt-5.1-codex.toml
+++ b/providers/bitrouter/models/openai/gpt-5.1-codex.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.1-codex"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[limit]
+context = 400000
+output = 128000

--- a/providers/bitrouter/models/openai/gpt-5.1.toml
+++ b/providers/bitrouter/models/openai/gpt-5.1.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.1"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.13
+
+[limit]
+context = 400000
+output = 128000

--- a/providers/bitrouter/models/openai/gpt-5.2-codex.toml
+++ b/providers/bitrouter/models/openai/gpt-5.2-codex.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.2-codex"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+
+[limit]
+context = 400000
+output = 128000

--- a/providers/bitrouter/models/openai/gpt-5.2.toml
+++ b/providers/bitrouter/models/openai/gpt-5.2.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+
+[limit]
+context = 400000
+output = 128000

--- a/providers/bitrouter/models/openai/gpt-5.3-codex.toml
+++ b/providers/bitrouter/models/openai/gpt-5.3-codex.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.3-codex"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+
+[limit]
+context = 400000
+output = 128000

--- a/providers/bitrouter/models/openai/gpt-5.4-mini.toml
+++ b/providers/bitrouter/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.4-mini"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+cache_write = 0.75
+
+[limit]
+context = 128000
+output = 16384

--- a/providers/bitrouter/models/openai/gpt-5.4-nano.toml
+++ b/providers/bitrouter/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.4-nano"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02
+
+[limit]
+context = 400000
+output = 128000

--- a/providers/bitrouter/models/openai/gpt-5.4.toml
+++ b/providers/bitrouter/models/openai/gpt-5.4.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.4"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[limit]
+context = 128000
+output = 16384

--- a/providers/bitrouter/models/openai/gpt-5.5.toml
+++ b/providers/bitrouter/models/openai/gpt-5.5.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[limit]
+context = 128000
+output = 16384

--- a/providers/bitrouter/models/openai/gpt-oss-120b.toml
+++ b/providers/bitrouter/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,24 @@
+name = "gpt-oss-120b"
+release_date = "2025-08-05"
+last_updated = "2025-08-05"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.25
+output = 0.69
+
+[limit]
+context = 131072
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/bitrouter/models/qwen/qwen3.6-flash.toml
+++ b/providers/bitrouter/models/qwen/qwen3.6-flash.toml
@@ -1,0 +1,13 @@
+base_model = "alibaba/qwen3.6-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.1875
+output = 1.125
+cache_read = 0.01875
+
+[limit]
+context = 1000000
+output = 65536

--- a/providers/bitrouter/models/qwen/qwen3.6-plus.toml
+++ b/providers/bitrouter/models/qwen/qwen3.6-plus.toml
@@ -1,0 +1,13 @@
+base_model = "alibaba/qwen3.6-plus"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.375
+output = 2.25
+cache_read = 0.0375
+
+[limit]
+context = 131072
+output = 8192

--- a/providers/bitrouter/models/qwen/qwen3.7-max.toml
+++ b/providers/bitrouter/models/qwen/qwen3.7-max.toml
@@ -1,0 +1,13 @@
+base_model = "alibaba/qwen3.7-max"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.875
+output = 5.625
+cache_read = 0.375
+
+[limit]
+context = 1000000
+output = 65536

--- a/providers/bitrouter/models/qwen/qwen3.7-plus.toml
+++ b/providers/bitrouter/models/qwen/qwen3.7-plus.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3.7-plus"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.375
+output = 2.25
+cache_read = 0.0375
+cache_write = 0.46875
+
+[limit]
+context = 1000000
+output = 65536

--- a/providers/bitrouter/models/stepfun/step-3.5-flash.toml
+++ b/providers/bitrouter/models/stepfun/step-3.5-flash.toml
@@ -1,0 +1,13 @@
+base_model = "stepfun/step-3.5-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.072
+output = 0.216
+cache_read = 0.01425
+
+[limit]
+context = 262144
+output = 16384

--- a/providers/bitrouter/models/stepfun/step-3.7-flash.toml
+++ b/providers/bitrouter/models/stepfun/step-3.7-flash.toml
@@ -1,0 +1,13 @@
+base_model = "stepfun/step-3.7-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.8625
+cache_read = 0.03
+
+[limit]
+context = 256000
+output = 256000

--- a/providers/bitrouter/models/x-ai/grok-4.1-fast.toml
+++ b/providers/bitrouter/models/x-ai/grok-4.1-fast.toml
@@ -1,0 +1,26 @@
+name = "Grok 4.1 Fast"
+release_date = "2025-11-20"
+last_updated = "2025-11-20"
+knowledge = "2025-06"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.2
+output = 0.5
+cache_read = 0.05
+cache_write = 0.2
+
+[limit]
+context = 131072
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/bitrouter/models/x-ai/grok-4.20.toml
+++ b/providers/bitrouter/models/x-ai/grok-4.20.toml
@@ -1,0 +1,24 @@
+name = "Grok 4.20"
+release_date = "2026-03-12"
+last_updated = "2026-03-12"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[limit]
+context = 131072
+output = 4096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/bitrouter/models/x-ai/grok-4.3.toml
+++ b/providers/bitrouter/models/x-ai/grok-4.3.toml
@@ -1,0 +1,13 @@
+base_model = "xai/grok-4.3"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[limit]
+context = 1000000
+output = 30000

--- a/providers/bitrouter/models/xiaomi/mimo-v2-flash.toml
+++ b/providers/bitrouter/models/xiaomi/mimo-v2-flash.toml
@@ -1,0 +1,13 @@
+base_model = "xiaomi/mimo-v2-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.09
+output = 0.29
+cache_read = 0.045
+
+[limit]
+context = 65536
+output = 32768

--- a/providers/bitrouter/models/xiaomi/mimo-v2-omni.toml
+++ b/providers/bitrouter/models/xiaomi/mimo-v2-omni.toml
@@ -1,0 +1,13 @@
+base_model = "xiaomi/mimo-v2-omni"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.3
+output = 1.5
+cache_read = 0.06
+
+[limit]
+context = 262144
+output = 131072

--- a/providers/bitrouter/models/xiaomi/mimo-v2-pro.toml
+++ b/providers/bitrouter/models/xiaomi/mimo-v2-pro.toml
@@ -1,0 +1,13 @@
+base_model = "xiaomi/mimo-v2-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.75
+output = 2.25
+cache_read = 0.15
+
+[limit]
+context = 1048576
+output = 131072

--- a/providers/bitrouter/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/bitrouter/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,0 +1,13 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.75
+output = 2.25
+cache_read = 0.15
+
+[limit]
+context = 262144
+output = 32768

--- a/providers/bitrouter/models/xiaomi/mimo-v2.5.toml
+++ b/providers/bitrouter/models/xiaomi/mimo-v2.5.toml
@@ -1,0 +1,13 @@
+base_model = "xiaomi/mimo-v2.5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.3
+output = 1.5
+cache_read = 0.06
+
+[limit]
+context = 262144
+output = 32768

--- a/providers/bitrouter/models/z-ai/glm-5.1.toml
+++ b/providers/bitrouter/models/z-ai/glm-5.1.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-5.1"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.05
+output = 3.3
+cache_read = 0.195
+
+[limit]
+context = 128000
+output = 8192

--- a/providers/bitrouter/models/z-ai/glm-5.toml
+++ b/providers/bitrouter/models/z-ai/glm-5.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-5"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.75
+output = 2.4
+cache_read = 0.15
+
+[limit]
+context = 202752
+output = 65535

--- a/providers/bitrouter/provider.toml
+++ b/providers/bitrouter/provider.toml
@@ -1,0 +1,5 @@
+name = "BitRouter"
+env = ["BITROUTER_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.bitrouter.ai/v1"
+doc = "https://docs.bitrouter.ai"


### PR DESCRIPTION
## What

Adds **BitRouter** as a provider. [BitRouter](https://bitrouter.ai) is an OpenAI-compatible LLM gateway, so it uses the generic `@ai-sdk/openai-compatible` package — no new SDK dependency.

```toml
name = "BitRouter"
env = ["BITROUTER_API_KEY"]
npm = "@ai-sdk/openai-compatible"
api = "https://api.bitrouter.ai/v1"
doc = "https://docs.bitrouter.ai"
```

## Models

50 models, mirrored from the live `https://api.bitrouter.ai/v1/models` catalog:

- **46 factored** onto existing canonical `base_model`s, overriding only `[cost]` and `[limit]` with BitRouter's live pricing/limits (same pattern as `providers/kilo` / `providers/anyapi`).
- **4 standalone** where no canonical base exists yet (`deepseek/deepseek-v3.2`, `openai/gpt-oss-120b`, `x-ai/grok-4.1-fast`, `x-ai/grok-4.20`).

## Reasoning

Each model declares `[interleaved] field = "reasoning_content"`. Verified live against the gateway: BitRouter normalizes upstream reasoning traces to the `reasoning_content` field on the Chat Completions envelope (both streamed output and replayed back on input), which matches the openai-compatible reasoning path.

## Validation

`bun run validate` passes.
