### PR TITLE
[aihubmix/glm] Add GLM 5.2

### DIFF
--- a/providers/aihubmix/models/glm-5.2.toml
+++ b/providers/aihubmix/models/glm-5.2.toml
@@ -1,0 +1,21 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.1268
+output = 3.9438
+cache_read = 0.2817
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
﻿Adds AIHubMix provider metadata for GLM 5.2.

Scope:
- adds `providers/aihubmix/models/glm-5.2.toml`
- uses existing read-only base model `zhipuai/glm-5.2`
- overrides AIHubMix service-side pricing, limits, modalities, reasoning options, and reasoning content field

Validation:
- `python3 /mnt/c/Users/YOYO/.codex/skills/plugin-update/scripts/validate_aihubmix_opencode_model.py --repo /home/yoyo/models.dev-glm-5-2 --model glm-5.2`
- `bun run validate`
- `git diff --check`
