### PR TITLE
fix(minimax): set MiniMax-M3 context window to 1M

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -1,7 +1,7 @@
 name = "MiniMax-M3"
 family = "minimax"
 release_date = "2026-06-01"
-last_updated = "2026-06-01"
+last_updated = "2026-06-24"
 attachment = true
 reasoning = true
 temperature = true
@@ -18,7 +18,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -1,7 +1,7 @@
 name = "MiniMax-M3"
 family = "minimax"
 release_date = "2026-06-01"
-last_updated = "2026-06-01"
+last_updated = "2026-06-24"
 attachment = true
 reasoning = true
 temperature = true
@@ -17,7 +17,7 @@ output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -1,7 +1,7 @@
 name = "MiniMax-M3"
 family = "minimax"
 release_date = "2026-06-01"
-last_updated = "2026-06-01"
+last_updated = "2026-06-24"
 attachment = true
 reasoning = true
 temperature = true
@@ -18,7 +18,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -1,7 +1,7 @@
 name = "MiniMax-M3"
 family = "minimax"
 release_date = "2026-06-01"
-last_updated = "2026-06-01"
+last_updated = "2026-06-24"
 attachment = true
 reasoning = true
 temperature = true
@@ -17,7 +17,7 @@ output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
## What

Set the context window for `MiniMax-M3` to **1,000,000** tokens across the four MiniMax-owned providers:

- `minimax`
- `minimax-cn`
- `minimax-coding-plan`
- `minimax-cn-coding-plan`

## Why

The previous value (`512_000`) was the **pricing-tier boundary** — MiniMax-M3 is billed at a standard rate for ≤512K input and a long-context rate above it — not the model's actual context window. The model supports up to **1M** tokens, which is what the `limit.context` field is meant to represent.

This aligns models.dev with where the rest of the ecosystem already sits (OpenClaw, Hermes, Cline, Qwen Code, Dify all declare M3 at 1M).

## Diff

8 lines: `context = 512_000` → `1_000_000` in each of the 4 tomls (plus `last_updated` bumped). `output = 128_000` unchanged.