### PR TITLE
feat(kilo): add minimax/MiniMax-M3 to Kilo Gateway catalog

### DIFF
--- a/providers/kilo/models/minimax/minimax-m3.toml
+++ b/providers/kilo/models/minimax/minimax-m3.toml
@@ -1,0 +1,22 @@
+name = "MiniMax: MiniMax M3"
+release_date = "2026-06-01"
+last_updated = "2026-06-24"
+attachment = true
+reasoning_options = [{ type = "toggle" }]
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["image", "text", "video"]
+output = ["text"]

--- a/providers/kilo/models/minimax/minimax-m3.toml
+++ b/providers/kilo/models/minimax/minimax-m3.toml
@@ -1,12 +1,7 @@
+base_model = "minimax/MiniMax-M3"
 name = "MiniMax: MiniMax M3"
-release_date = "2026-06-01"
 last_updated = "2026-06-24"
-attachment = true
 reasoning_options = [{ type = "toggle" }]
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
 
 [cost]
 input = 0.3
@@ -16,7 +11,3 @@ cache_read = 0.06
 [limit]
 context = 1_048_576
 output = 131_072
-
-[modalities]
-input = ["image", "text", "video"]
-output = ["text"]

--- a/providers/kilo/models/minimax/minimax-m3.toml
+++ b/providers/kilo/models/minimax/minimax-m3.toml
@@ -1,6 +1,6 @@
 base_model = "minimax/MiniMax-M3"
 name = "MiniMax: MiniMax M3"
-last_updated = "2026-06-24"
+last_updated = "2026-06-30"
 reasoning_options = [{ type = "toggle" }]
 
 [cost]
@@ -10,4 +10,4 @@ cache_read = 0.06
 
 [limit]
 context = 1_048_576
-output = 131_072
+output = 512_000


### PR DESCRIPTION
## What

Add `minimax/MiniMax-M3` to the **Kilo Gateway** (`kilo`) provider catalog.

## Why

Kilo Gateway already serves this model — `minimax/minimax-m3` is live at `https://api.kilo.ai/api/gateway/models` — but the catalog only went up to M2.7, so Kilo users don't get M3's metadata (notably its 1M context window).

## Data source

All fields come from the live gateway `/models` endpoint:

| field | value |
|---|---|
| context | 1,048,576 (1M) |
| output | 131,072 |
| input cost | $0.30 / M |
| output cost | $1.20 / M |
| cache read | $0.06 / M |
| modalities (in) | text, image, video |
| reasoning | toggle |

Pricing, context, and modalities match what the gateway reports; output limit and field style follow the sibling `minimax-m2.7.toml` in the same provider.