### PR TITLE
[aihubmix/qwen] Add Qwen3.7 models

### DIFF
--- a/providers/aihubmix/models/qwen3.7-max.toml
+++ b/providers/aihubmix/models/qwen3.7-max.toml
@@ -1,0 +1,20 @@
+base_model = "alibaba/qwen3.7-max"
+structured_output = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.69
+output = 5.07
+cache_read = 0.169
+cache_write = 2.1125
+
+[limit]
+context = 991_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aihubmix/models/qwen3.7-plus.toml
+++ b/providers/aihubmix/models/qwen3.7-plus.toml
@@ -1,0 +1,20 @@
+base_model = "alibaba/qwen3.7-plus"
+structured_output = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.282
+output = 1.128
+cache_read = 0.0564
+cache_write = 0.3525
+
+[limit]
+context = 991_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- add AIHubMix provider entries for `qwen3.7-max` and `qwen3.7-plus`
- inherit canonical Alibaba Qwen3.7 base model metadata via `base_model`
- use AIHubMix pricing, cache pricing, context/output limits, text modality, structured output, and reasoning metadata

## Validation

- `git diff --check`
- `bun run validate`