### PR TITLE
feat: add Berget AI as provider with 9 models

### DIFF
--- a/providers/berget/models/google/gemma-4-31B-it.toml
+++ b/providers/berget/models/google/gemma-4-31B-it.toml
@@ -1,0 +1,22 @@
+# https://berget.ai
+name = "Gemma 4 31B IT"
+family = "gemma"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.27
+output = 0.55
+
+[limit]
+context = 262_144
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/berget/models/intfloat/multilingual-e5-large-instruct.toml
+++ b/providers/berget/models/intfloat/multilingual-e5-large-instruct.toml
@@ -1,0 +1,22 @@
+# https://berget.ai
+name = "Multilingual E5 Large Instruct"
+family = "text-embedding"
+release_date = "2024-01-01"
+last_updated = "2024-01-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.03
+output = 0.02
+
+[limit]
+context = 512
+output = 512
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/berget/models/meta-llama/Llama-3.1-8B-Instruct.toml
+++ b/providers/berget/models/meta-llama/Llama-3.1-8B-Instruct.toml
@@ -1,0 +1,22 @@
+# https://berget.ai
+name = "Llama 3.1 8B Instruct"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 0.22
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/berget/models/meta-llama/Llama-3.3-70B-Instruct.toml
+++ b/providers/berget/models/meta-llama/Llama-3.3-70B-Instruct.toml
@@ -1,0 +1,22 @@
+# https://berget.ai
+name = "Llama 3.3 70B Instruct"
+family = "llama"
+release_date = "2024-12-06"
+last_updated = "2024-12-06"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.98
+output = 0.98
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/berget/models/mistralai/Mistral-Small-3.2-24B-Instruct-2506.toml
+++ b/providers/berget/models/mistralai/Mistral-Small-3.2-24B-Instruct-2506.toml
@@ -1,0 +1,22 @@
+# https://berget.ai
+name = "Mistral Small 3.2 24B Instruct"
+family = "mistral-small"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.33
+output = 0.33
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/berget/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/berget/models/moonshotai/Kimi-K2.6.toml
@@ -1,0 +1,22 @@
+# https://berget.ai
+name = "Kimi K2.6"
+family = "kimi"
+release_date = "2026-04-21"
+last_updated = "2026-04-21"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.82
+output = 3.82
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/berget/models/openai/gpt-oss-120b.toml
+++ b/providers/berget/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,22 @@
+# https://berget.ai
+name = "GPT OSS 120B"
+family = "gpt-oss"
+release_date = "2026-01-01"
+last_updated = "2026-01-01"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 0.82
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/berget/models/zai-org/GLM-4.7.toml
+++ b/providers/berget/models/zai-org/GLM-4.7.toml
@@ -1,0 +1,22 @@
+# https://berget.ai
+name = "GLM-4.7"
+family = "glm"
+release_date = "2025-12-22"
+last_updated = "2025-12-22"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.76
+output = 2.73
+
+[limit]
+context = 202_752
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/berget/models/zai-org/GLM-5.2.toml
+++ b/providers/berget/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,22 @@
+# https://berget.ai
+name = "GLM-5.2"
+family = "glm"
+release_date = "2026-06-20"
+last_updated = "2026-06-20"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 1.53
+output = 4.80
+
+[limit]
+context = 524_288
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/berget/provider.toml
+++ b/providers/berget/provider.toml
@@ -1,0 +1,5 @@
+name = "Berget AI"
+env = ["BERGET_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.berget.ai/v1"
+doc = "https://docs.berget.ai"


### PR DESCRIPTION
## Add Berget AI as a new provider

[Berget AI](https://berget.ai) is a Swedish AI infrastructure provider running open-weight models on NVIDIA H200 and AMD MI300X GPUs in Stockholm, Sweden. OpenAI-compatible API at `https://api.berget.ai/v1`.

### Provider
- **Name**: Berget AI
- **API**: `https://api.berget.ai/v1` (OpenAI-compatible)
- **Docs**: https://docs.berget.ai
- **SDK**: `@ai-sdk/openai-compatible`

### Models (9)

| Model | Family | Context | Input $/M | Output $/M |
|---|---|---|---|---|
| GLM-5.2 | glm | 524k | $1.53 | $4.80 |
| GLM-4.7 | glm | 202k | $0.76 | $2.73 |
| Kimi K2.6 | kimi | 262k | $0.82 | $3.82 |
| Gemma 4 31B IT | gemma | 262k | $0.27 | $0.55 |
| Mistral Small 3.2 24B | mistral-small | 32k | $0.33 | $0.33 |
| GPT-OSS-120B | gpt-oss | 128k | $0.22 | $0.82 |
| Llama 3.3 70B Instruct | llama | 32k | $0.98 | $0.98 |
| Llama 3.1 8B Instruct | llama | 32k | $0.22 | $0.22 |
| E5 Large Instruct | text-embedding | 512 | $0.03 | $0.02 |

Pricing is in USD, converted from EUR at current rates.