### PR TITLE
feat: add GLM-5.2 to Berget AI

### DIFF
--- a/providers/berget/models/openai/gpt-oss-120b.toml
+++ b/providers/berget/models/openai/gpt-oss-120b.toml
@@ -12,8 +12,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.44
-output = 0.99
+input = 0.22
+output = 0.83
 
 [limit]
 context = 128_000

--- a/providers/berget/models/zai-org/GLM-5.2.toml
+++ b/providers/berget/models/zai-org/GLM-5.2.toml
@@ -1,15 +1,5 @@
-name = "GLM 5.2"
-family = "glm"
-release_date = "2026-06-20"
-last_updated = "2026-06-20"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-knowledge = "2026-06"
-tool_call = true
-structured_output = true
-open_weights = true
+base_model = "zhipuai/glm-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
 
 [cost]
 input = 1.54

--- a/providers/berget/models/zai-org/GLM-5.2.toml
+++ b/providers/berget/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,24 @@
+name = "GLM 5.2"
+family = "glm"
+release_date = "2026-06-20"
+last_updated = "2026-06-20"
+attachment = false
+reasoning = true
+reasoning_options = []
+temperature = true
+knowledge = "2026-06"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 1.54
+output = 4.84
+
+[limit]
+context = 524_288
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Changes

### New model: GLM-5.2
Add [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2-FP8) to the existing Berget AI provider.

- **Model**: GLM-5.2 (~743B params, 39B active, MoE with Dynamic Sparse Attention)
- **Context**: 524,288 tokens
- **Output**: 32,768 tokens
- **Pricing**: $1.54 / $4.84 per M tokens (input/output)
- **Capabilities**: reasoning, tool calling, structured output
- **Weights**: [Open (HuggingFace)](https://huggingface.co/zai-org/GLM-5.2-FP8)
- **Release**: 2026-06-20

### Updated pricing: gpt-oss-120b
- **Before**: $0.44 / $0.99 per M tokens
- **After**: $0.22 / $0.83 per M tokens