### PR TITLE
fix(opencode-go): add MiniMax M3 long-context pricing

### DIFF
--- a/providers/opencode-go/models/minimax-m3.toml
+++ b/providers/opencode-go/models/minimax-m3.toml
@@ -15,6 +15,12 @@ input = 0.1
 output = 0.4
 cache_read = 0.02
 
+[[cost.tiers]]
+tier = { size = 512_000 }
+input = 0.2
+output = 0.8
+cache_read = 0.04
+
 [limit]
 context = 512_000
 output = 131_072


### PR DESCRIPTION
## Summary
- add a pricing tier for MiniMax M3 contexts above 512k tokens
- set input, output, and cache-read prices to 2x the base rates

## Validation
- `bun validate`
- `git diff --check`