### PR TITLE
fix(sync): preserve TOML root fields

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -676,7 +676,7 @@ function formatReasoningValue(value: string | null) {
   return value === null ? quote("null") : quote(value);
 }
 
-function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
+export function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
   const lines: string[] = [];
 
   if (model.base_model !== undefined) lines.push(`base_model = ${quote(model.base_model)}`);
@@ -697,22 +697,7 @@ function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
   if (model.knowledge !== undefined) lines.push(`knowledge = ${quote(model.knowledge)}`);
   if (model.open_weights !== undefined) lines.push(`open_weights = ${model.open_weights}`);
   if (model.status !== undefined) lines.push(`status = ${quote(model.status)}`);
-
-  if (model.reasoning_options?.length === 0) {
-    lines.push("reasoning_options = []");
-  } else {
-    for (const option of model.reasoning_options ?? []) {
-      lines.push("", "[[reasoning_options]]");
-      lines.push(`type = ${quote(option.type)}`);
-      if (option.type === "effort") {
-        lines.push(`values = [${option.values.map(formatReasoningValue).join(", ")}]`);
-      }
-      if (option.type === "budget_tokens") {
-        if (option.min !== undefined) lines.push(`min = ${formatInteger(option.min)}`);
-        if (option.max !== undefined) lines.push(`max = ${formatInteger(option.max)}`);
-      }
-    }
-  }
+  if (model.reasoning_options?.length === 0) lines.push("reasoning_options = []");
 
   if (model.interleaved !== undefined) {
     lines.push("");
@@ -721,6 +706,18 @@ function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
     } else {
       lines.push("[interleaved]");
       lines.push(`field = ${quote(model.interleaved.field)}`);
+    }
+  }
+
+  for (const option of model.reasoning_options ?? []) {
+    lines.push("", "[[reasoning_options]]");
+    lines.push(`type = ${quote(option.type)}`);
+    if (option.type === "effort") {
+      lines.push(`values = [${option.values.map(formatReasoningValue).join(", ")}]`);
+    }
+    if (option.type === "budget_tokens") {
+      if (option.min !== undefined) lines.push(`min = ${formatInteger(option.min)}`);
+      if (option.max !== undefined) lines.push(`max = ${formatInteger(option.max)}`);
     }
   }
 

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+
+import { formatToml } from "../src/sync/index.js";
+
+test("formats interleaved as a root field before reasoning option tables", () => {
+  const content = formatToml({
+    id: "example/model",
+    name: "Example Model",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: false,
+    reasoning: true,
+    reasoning_options: [{ type: "toggle" }],
+    tool_call: true,
+    interleaved: true,
+    open_weights: false,
+    cost: { input: 1, output: 2 },
+    limit: { context: 1_000, output: 100 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(Bun.TOML.parse(content)).toMatchObject({
+    interleaved: true,
+    reasoning_options: [{ type: "toggle" }],
+  });
+});
+
+test("formats empty reasoning options outside the interleaved table", () => {
+  const content = formatToml({
+    id: "example/model",
+    name: "Example Model",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: false,
+    reasoning: true,
+    reasoning_options: [],
+    tool_call: true,
+    interleaved: { field: "reasoning_content" },
+    open_weights: false,
+    cost: { input: 1, output: 2 },
+    limit: { context: 1_000, output: 100 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(Bun.TOML.parse(content)).toMatchObject({
+    interleaved: { field: "reasoning_content" },
+    reasoning_options: [],
+  });
+});


### PR DESCRIPTION
## Summary

- emit empty `reasoning_options` before TOML tables
- emit non-empty reasoning option tables after `interleaved`
- add regression coverage for boolean and table-valued `interleaved`

This fixes the scheduled Vercel sync failure in [run 28122358354](https://github.com/anomalyco/models.dev/actions/runs/28122358354/job/83277320907), where generated `interleaved = true` was parsed inside `[[reasoning_options]]`.

## Validation

- `bun test packages/core/test/sync.test.ts`
- `bun validate`
- `bun models:sync vercel --dry-run`
- `git diff --check`

The full `bun test` run still has the pre-existing open-weight metadata test failure for 24 models missing weight links; both new regression tests pass.