### PR TITLE
feat(blueclaw): add Blue Claw provider

### DIFF
--- a/providers/blueclaw/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
+++ b/providers/blueclaw/models/Qwen/Qwen3.6-35B-A3B-FP8.toml
@@ -1,0 +1,17 @@
+name = "Qwen3.6 35B A3B FP8"
+family = "qwen"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+release_date = "2026-04-17"
+last_updated = "2026-06-24"
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/blueclaw/models/Qwen3.6-27B.toml
+++ b/providers/blueclaw/models/Qwen3.6-27B.toml
@@ -1,0 +1,17 @@
+name = "Qwen3.6 27B"
+family = "qwen"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+open_weights = true
+release_date = "2026-04-22"
+last_updated = "2026-06-24"
+
+[limit]
+context = 196_608
+output = 196_608
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/blueclaw/provider.toml
+++ b/providers/blueclaw/provider.toml
@@ -1,0 +1,5 @@
+name = "Blue Claw"
+npm = "@ai-sdk/openai-compatible"
+api = "https://openai.blueclaw.network/v1"
+env = ["BLUECLAW_API_KEY"]
+doc = "https://blueclaw.network"


### PR DESCRIPTION
Adds [BlueClaw](https://blueclaw.network), an OpenAI-compatible provider built on the [Livepeer](https://livepeer.org) network (`https://openai.blueclaw.network/v1`) serving open Qwen models. Auth is a bearer token from `BLUECLAW_API_KEY`.

Two models, both verified live against the endpoint today:

- `Qwen/Qwen3.6-35B-A3B-FP8` — context 131072 (read from the vLLM `max_model_len` error)
- `Qwen3.6-27B` — context 196608

For each I confirmed chat completions, streaming, and tool calls (`finish_reason: tool_calls` with a real function call). Reasoning comes back in a separate `reasoning` field; I left `interleaved` off since the field name is not one of the two the schema allows. No `cost` block — it is a free fair-use beta with no published pricing, so I would rather omit it than guess. `release_date` uses the underlying Qwen3.6 dates; limits/modalities reflect what the FP8 text endpoint actually serves (text only, narrower context than the native model).