### PR TITLE
feat(stepfun): add Step 3.7 Flash

### DIFF
--- a/providers/stepfun/models/step-3.7-flash.toml
+++ b/providers/stepfun/models/step-3.7-flash.toml
@@ -1,5 +1,9 @@
 base_model = "stepfun/step-3.7-flash"
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 0.19
 output = 1.13

--- a/providers/stepfun/models/step-3.7-flash.toml
+++ b/providers/stepfun/models/step-3.7-flash.toml
@@ -1,0 +1,6 @@
+base_model = "stepfun/step-3.7-flash"
+
+[cost]
+input = 0.19
+output = 1.13
+cache_read = 0.04


### PR DESCRIPTION
Closes #<issue-number>

## What
Add provider definition for `step-3.7-flash` to the `stepfun` provider.

## Why
Model metadata at `models/stepfun/step-3.7-flash.toml` already exists, but the provider-specific file was missing. This unblocks opencode and other consumers that rely on the catalog.

## How to verify
- `bun validate` passes
- `curl https://models.dev/api.json` after merge will include `stepfun/step-3.7-flash` with cost