### PR TITLE
fix(opencode-go): set MiniMax-M3 context window to 1M

### DIFF
--- a/providers/opencode-go/models/minimax-m3.toml
+++ b/providers/opencode-go/models/minimax-m3.toml
@@ -1,7 +1,7 @@
 name = "MiniMax M3 (3x usage)"
 family = "minimax-m3"
 release_date = "2026-05-31"
-last_updated = "2026-05-31"
+last_updated = "2026-06-24"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
@@ -22,7 +22,7 @@ output = 0.8
 cache_read = 0.04
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 131_072
 
 [modalities]


### PR DESCRIPTION
## What

Set the context window for `MiniMax M3 (3x usage)` to **1,000,000** tokens in the `opencode-go` provider.

```
providers/opencode-go/models/minimax-m3.toml
  [limit]
- context = 512_000
+ context = 1_000_000
```

## Why

The previous value (`512_000`) is the **pricing-tier boundary** — MiniMax-M3 is billed at a standard rate for ≤512K input and a long-context rate above it — not the model's actual context window. The model supports up to **1M** tokens, which is what `limit.context` is meant to represent.

This aligns `opencode-go` with the minimax-owned providers (same change in #2762 for `minimax` / `minimax-cn` / `minimax-coding-plan` / `minimax-cn-coding-plan`). Scope is `context` only; `output` left unchanged.