### PR TITLE
feat(minimax): update M3 context and pricing

### DIFF
--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -1,7 +1,7 @@
 name = "MiniMax-M3"
 family = "minimax"
 release_date = "2026-06-01"
-last_updated = "2026-06-01"
+last_updated = "2026-06-25"
 attachment = true
 reasoning = true
 temperature = true
@@ -18,7 +18,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -1,7 +1,7 @@
 name = "MiniMax-M3"
 family = "minimax"
 release_date = "2026-06-01"
-last_updated = "2026-06-01"
+last_updated = "2026-06-25"
 attachment = true
 reasoning = true
 temperature = true
@@ -12,12 +12,18 @@ open_weights = true
 type = "toggle"
 
 [cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+
+[[cost.tiers]]
+tier = { size = 512_000 }
 input = 0.60
 output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -1,7 +1,7 @@
 name = "MiniMax-M3"
 family = "minimax"
 release_date = "2026-06-01"
-last_updated = "2026-06-01"
+last_updated = "2026-06-25"
 attachment = true
 reasoning = true
 temperature = true
@@ -18,7 +18,7 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -1,7 +1,7 @@
 name = "MiniMax-M3"
 family = "minimax"
 release_date = "2026-06-01"
-last_updated = "2026-06-01"
+last_updated = "2026-06-25"
 attachment = true
 reasoning = true
 temperature = true
@@ -12,12 +12,18 @@ open_weights = true
 type = "toggle"
 
 [cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+
+[[cost.tiers]]
+tier = { size = 512_000 }
 input = 0.60
 output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 512_000
+context = 1_000_000
 output = 128_000
 
 [modalities]


### PR DESCRIPTION
## Summary
- increase MiniMax M3 context limits to 1M across the four first-party MiniMax providers
- update pay-as-you-go pricing to the permanent discounted rates
- add the higher pricing tier for requests above 512K input tokens
- keep Token Plan pricing zeroed without redundant cost tiers

## Sources
- https://platform.minimax.io/docs/guides/text-generation
- https://platform.minimax.io/docs/guides/pricing-paygo
- https://platform.minimaxi.com/docs/guides/pricing-paygo

## Validation
- `bun validate`
- `git diff --check`