### PR TITLE
Add/update llmgateway provider models

### DIFF
--- a/providers/llmgateway/models/mistral-ocr-latest.toml
+++ b/providers/llmgateway/models/mistral-ocr-latest.toml
@@ -1,0 +1,18 @@
+name = "Mistral OCR (latest)"
+family = "mistral"
+release_date = "2025-03-06"
+last_updated = "2025-03-06"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+structured_output = false
+open_weights = false
+
+[limit]
+context = 1_000
+output = 1_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Models added

- **mistral/mistral-ocr-latest** — Mistral OCR (latest), document OCR model priced at $5/1000 pages (per-page pricing, no token-based cost). Pricing source: https://mistral.ai/pricing/