### PR TITLE
feat(crossmodel): add CrossModel provider

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -7,6 +7,7 @@ import { AuthoredModel, AuthoredModelShape, ModelMetadata } from "../schema.js";
 import { baseten } from "./providers/baseten.js";
 import { chutes } from "./providers/chutes.js";
 import { cloudflareWorkersAi } from "./providers/cloudflare-workers-ai.js";
+import { crossmodel } from "./providers/crossmodel.js";
 import { deepinfra } from "./providers/deepinfra.js";
 import { google } from "./providers/google.js";
 import { huggingface } from "./providers/huggingface.js";
@@ -87,6 +88,7 @@ export const providers: {
   baseten: SyncProvider<any>;
   chutes: SyncProvider<any>;
   "cloudflare-workers-ai": SyncProvider<any>;
+  crossmodel: SyncProvider<any>;
   deepinfra: SyncProvider<any>;
   google: SyncProvider<any>;
   huggingface: SyncProvider<any>;
@@ -100,6 +102,7 @@ export const providers: {
   baseten,
   chutes,
   "cloudflare-workers-ai": cloudflareWorkersAi,
+  crossmodel,
   deepinfra,
   google,
   huggingface,
@@ -112,7 +115,7 @@ export const providers: {
 };
 
 export const groups = {
-  aggregators: ["huggingface", "llmgateway", "openrouter", "vercel"],
+  aggregators: ["crossmodel", "huggingface", "llmgateway", "openrouter", "vercel"],
   cloudflare: ["cloudflare-workers-ai"],
   direct: ["baseten", "chutes", "deepinfra", "google", "ovhcloud", "venice", "xai"],
 } as const;

--- a/packages/core/src/sync/providers/crossmodel.ts
+++ b/packages/core/src/sync/providers/crossmodel.ts
@@ -1,0 +1,229 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { z } from "zod";
+
+import type { ExistingModel, SyncProvider, SyncedModel } from "../index.js";
+import { factorBaseModel } from "./openrouter.js";
+
+// Repo-level base-model metadata directory (mirrors openrouter.ts MODELS_DIR).
+const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
+
+function baseModelExists(modelID: string): boolean {
+  return existsSync(path.join(MODELS_DIR, `${modelID}.toml`));
+}
+
+// CrossModel is an OpenAI- and Anthropic-compatible multi-provider gateway. Its
+// public catalog endpoint carries the volatile, gateway-specific data we sync:
+// served price (USD micro / 1M tokens, threshold-tiered), modalities, context /
+// output limits, and a `capabilities.reasoning` object describing the reasoning
+// controls CrossModel itself exposes (the internal shape behind models.dev's
+// reasoning_options). https://www.crossmodel.ai/api/models
+// CROSSMODEL_MODELS_URL overrides the endpoint (e.g. a local backend) for testing.
+const API_ENDPOINT = process.env.CROSSMODEL_MODELS_URL ?? "https://www.crossmodel.ai/api/models";
+
+const ReasoningCapability = z
+  .object({
+    toggle: z.boolean().optional(),
+    effort: z.array(z.string()).optional(),
+    budget_tokens: z
+      .object({ min: z.number().optional(), max: z.number().optional() })
+      .optional(),
+  })
+  .passthrough();
+
+const PriceTier = z
+  .object({
+    threshold: z.number().nullable().optional(),
+    input_micro_per_1m: z.number().nullable().optional(),
+    output_micro_per_1m: z.number().nullable().optional(),
+    cache_read_micro_per_1m: z.number().nullable().optional(),
+    cache_creation_micro_per_1m: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+export const CrossModelModel = z
+  .object({
+    id: z.string(),
+    vendor_code: z.string(),
+    display_name: z.string().optional(),
+    context_window_tokens: z.number().nullable().optional(),
+    max_output_tokens: z.number().nullable().optional(),
+    modalities: z
+      .object({ input: z.array(z.string()), output: z.array(z.string()) })
+      .optional(),
+    capabilities: z
+      .object({ reasoning: ReasoningCapability.optional() })
+      .passthrough()
+      .nullable()
+      .optional(),
+    status: z.string().optional(),
+    currency: z.string().nullable().optional(),
+    pricing: z.object({ tiers: z.array(PriceTier).nullable() }).nullable().optional(),
+  })
+  .passthrough();
+
+export const CrossModelResponse = z.object({ data: z.array(CrossModelModel) }).passthrough();
+
+export type CrossModelModel = z.infer<typeof CrossModelModel>;
+
+// vendor_code -> models.dev base_model author prefix. Used only for brand-new
+// models without an existing factored TOML; existing rows reuse their base_model.
+const AUTHOR_BY_VENDOR: Record<string, string> = {
+  openai: "openai",
+  anthropic: "anthropic",
+  gemini: "google",
+  moonshot: "moonshotai",
+  deepseek: "deepseek",
+  qwen: "alibaba",
+  xiaomi: "xiaomi",
+  minimax: "minimax",
+  "z-ai": "zhipuai",
+  tencent: "tencent",
+};
+
+export const crossmodel = {
+  id: "crossmodel",
+  name: "CrossModel",
+  modelsDir: "providers/crossmodel/models",
+  async fetchModels() {
+    const headers = process.env.CROSSMODEL_API_KEY
+      ? { Authorization: `Bearer ${process.env.CROSSMODEL_API_KEY}` }
+      : undefined;
+    const response = await fetch(API_ENDPOINT, { headers });
+    if (!response.ok) {
+      throw new Error(`CrossModel request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return CrossModelResponse.parse(raw).data.filter(
+      (model) => model.status !== "hidden",
+    );
+  },
+  translateModel(model, context) {
+    const existing = context.existing(model.id);
+    const built = buildCrossModel(model, existing);
+    if (built === undefined) return undefined;
+    return { id: model.id, model: built };
+  },
+} satisfies SyncProvider<CrossModelModel>;
+
+/** Integer USD micro / 1M tokens -> USD / 1M tokens; undefined when absent. */
+function price(micro: number | null | undefined): number | undefined {
+  if (micro === undefined || micro === null) return undefined;
+  return Math.round(micro) / 1_000_000;
+}
+
+function nonZeroPrice(micro: number | null | undefined): number | undefined {
+  const value = price(micro);
+  return value !== undefined && value > 0 ? value : undefined;
+}
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+function modalities(values: string[] | undefined, fallback: Modality[]): Modality[] {
+  const allowed = new Set<Modality>(["text", "audio", "image", "video", "pdf"]);
+  const result = (values ?? [])
+    .map((value) => value.toLowerCase())
+    .map((value) => (value === "file" ? "pdf" : value))
+    .filter((value): value is Modality => allowed.has(value as Modality));
+  return [...new Set(result.length > 0 ? result : fallback)];
+}
+
+// Project CrossModel's capabilities.reasoning onto models.dev reasoning_options.
+//   reasoning absent  -> undefined (non-reasoning model; option omitted)
+//   reasoning === {}  -> [] (model reasons, no verified user-selectable control)
+//   otherwise         -> toggle / effort / budget_tokens entries
+function reasoningOptions(model: CrossModelModel): SyncedModel["reasoning_options"] {
+  const reasoning = model.capabilities?.reasoning;
+  if (reasoning === undefined) return undefined;
+  const options: NonNullable<SyncedModel["reasoning_options"]> = [];
+  if (reasoning.toggle === true) options.push({ type: "toggle" });
+  if (reasoning.effort !== undefined && reasoning.effort.length > 0) {
+    options.push({ type: "effort", values: reasoning.effort as never });
+  }
+  if (reasoning.budget_tokens !== undefined) {
+    const budget: { type: "budget_tokens"; min?: number; max?: number } = { type: "budget_tokens" };
+    if (reasoning.budget_tokens.min !== undefined) budget.min = reasoning.budget_tokens.min;
+    if (reasoning.budget_tokens.max !== undefined) budget.max = reasoning.budget_tokens.max;
+    options.push(budget);
+  }
+  return options;
+}
+
+function buildCrossModel(
+  model: CrossModelModel,
+  existing: ExistingModel | undefined,
+): SyncedModel | undefined {
+  // Base tier (smallest input-context threshold) drives the headline cost; any
+  // hand-authored context tiers on the existing entry are preserved as-is.
+  const tiers = model.pricing?.tiers ?? [];
+  const base = [...tiers].sort(
+    (a, b) => (a.threshold ?? 0) - (b.threshold ?? 0),
+  )[0];
+  const input = price(base?.input_micro_per_1m);
+  const output = price(base?.output_micro_per_1m);
+  const cost =
+    input !== undefined && output !== undefined
+      ? {
+          input,
+          output,
+          cache_read: nonZeroPrice(base?.cache_read_micro_per_1m) ?? existing?.cost?.cache_read,
+          cache_write: nonZeroPrice(base?.cache_creation_micro_per_1m) ?? existing?.cost?.cache_write,
+          tiers: existing?.cost?.tiers,
+        }
+      : existing?.cost;
+
+  const context = model.context_window_tokens ?? existing?.limit?.context ?? undefined;
+  const limit = {
+    context: context as number,
+    input: existing?.limit?.input,
+    output: model.max_output_tokens ?? existing?.limit?.output ?? (context as number),
+  };
+
+  const modality = {
+    input: modalities(model.modalities?.input, existing?.modalities?.input ?? ["text"]),
+    output: modalities(model.modalities?.output, existing?.modalities?.output ?? ["text"]),
+  };
+
+  const reasoning_options = reasoningOptions(model);
+
+  // Resolve the base_model: prefer the existing factored entry; otherwise derive
+  // from vendor_code. Skip models we can't map or whose base isn't in models.dev
+  // yet — those need their author metadata hand-added first.
+  const baseModel = existing?.base_model ?? deriveBaseModel(model);
+  if (baseModel === undefined || !baseModelExists(baseModel)) return undefined;
+
+  // Curated capability fields stay inherited from the base model (undefined here);
+  // we only drive the volatile cost/limit/modalities plus the gateway-specific
+  // reasoning_options.
+  return factorBaseModel(
+    baseModel,
+    {
+      attachment: existing?.attachment,
+      reasoning: existing?.reasoning,
+      temperature: existing?.temperature,
+      tool_call: existing?.tool_call,
+      structured_output: existing?.structured_output,
+      knowledge: existing?.knowledge,
+      modalities: modality,
+      reasoning_options,
+      limit,
+      cost,
+    },
+    limit,
+    existing?.base_model_omit,
+  );
+}
+
+function deriveBaseModel(model: CrossModelModel): string | undefined {
+  const author = AUTHOR_BY_VENDOR[model.vendor_code];
+  if (author === undefined) return undefined;
+  const short = model.id.includes("/") ? model.id.split("/").slice(1).join("/") : model.id;
+  // MiniMax base ids are TitleCased incl. the model letter (e.g. minimax/MiniMax-M3).
+  if (author === "minimax") {
+    return `minimax/${short.replace(/^minimax-m/i, "MiniMax-M")}`;
+  }
+  return `${author}/${short}`;
+}

--- a/packages/core/src/sync/providers/crossmodel.ts
+++ b/packages/core/src/sync/providers/crossmodel.ts
@@ -212,11 +212,15 @@ function buildCrossModel(
       ? { ...base, tiers: contextTiers.length > 0 ? contextTiers : existing?.cost?.tiers }
       : existing?.cost;
 
-  const context = model.context_window_tokens ?? existing?.limit?.context ?? undefined;
+  // Every served model reports a context window; without one (and no existing
+  // value to fall back on) there's no valid limit to emit, so skip the model
+  // rather than fabricate a context. The guard also narrows `context` to number.
+  const context = model.context_window_tokens ?? existing?.limit?.context;
+  if (context === undefined) return undefined;
   const limit = {
-    context: context as number,
+    context,
     input: existing?.limit?.input,
-    output: model.max_output_tokens ?? existing?.limit?.output ?? (context as number),
+    output: model.max_output_tokens ?? existing?.limit?.output ?? context,
   };
 
   const modality = {

--- a/packages/core/src/sync/providers/crossmodel.ts
+++ b/packages/core/src/sync/providers/crossmodel.ts
@@ -42,6 +42,8 @@ const PriceTier = z
   })
   .passthrough();
 
+type PriceTier = z.infer<typeof PriceTier>;
+
 export const CrossModelModel = z
   .object({
     id: z.string(),
@@ -120,6 +122,27 @@ function nonZeroPrice(micro: number | null | undefined): number | undefined {
   return value !== undefined && value > 0 ? value : undefined;
 }
 
+type TierCost = { input: number; output: number; cache_read?: number; cache_write?: number };
+
+// Convert one CrossModel price tier into a models.dev cost block. Cache fields
+// are emitted only when cache_read is a genuine discount (< input); a cache_read
+// at or above input means the model offers no caching benefit (e.g. OpenAI
+// "pro" tiers, which every other provider ships without cache pricing), so both
+// cache fields are dropped. Returns undefined when the tier lacks input/output.
+function tierCost(tier: PriceTier | undefined): TierCost | undefined {
+  const input = price(tier?.input_micro_per_1m);
+  const output = price(tier?.output_micro_per_1m);
+  if (input === undefined || output === undefined) return undefined;
+  const cost: TierCost = { input, output };
+  const cacheRead = nonZeroPrice(tier?.cache_read_micro_per_1m);
+  if (cacheRead !== undefined && cacheRead < input) {
+    cost.cache_read = cacheRead;
+    const cacheWrite = nonZeroPrice(tier?.cache_creation_micro_per_1m);
+    if (cacheWrite !== undefined) cost.cache_write = cacheWrite;
+  }
+  return cost;
+}
+
 type Modality = "text" | "audio" | "image" | "video" | "pdf";
 
 function modalities(values: string[] | undefined, fallback: Modality[]): Modality[] {
@@ -131,6 +154,15 @@ function modalities(values: string[] | undefined, fallback: Modality[]): Modalit
   return [...new Set(result.length > 0 ? result : fallback)];
 }
 
+// models.dev's reasoning_options effort enum (schema.ts ReasoningEffortValue).
+// Guarding against it means an unexpected upstream value is dropped instead of
+// silently producing a TOML that fails `validate`.
+const REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "default"] as const;
+type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+function isReasoningEffort(value: string): value is ReasoningEffort {
+  return (REASONING_EFFORTS as readonly string[]).includes(value);
+}
+
 // Project CrossModel's capabilities.reasoning onto models.dev reasoning_options.
 //   reasoning absent  -> undefined (non-reasoning model; option omitted)
 //   reasoning === {}  -> [] (model reasons, no verified user-selectable control)
@@ -140,8 +172,9 @@ function reasoningOptions(model: CrossModelModel): SyncedModel["reasoning_option
   if (reasoning === undefined) return undefined;
   const options: NonNullable<SyncedModel["reasoning_options"]> = [];
   if (reasoning.toggle === true) options.push({ type: "toggle" });
-  if (reasoning.effort !== undefined && reasoning.effort.length > 0) {
-    options.push({ type: "effort", values: reasoning.effort as never });
+  if (reasoning.effort !== undefined) {
+    const values = reasoning.effort.filter(isReasoningEffort);
+    if (values.length > 0) options.push({ type: "effort", values });
   }
   if (reasoning.budget_tokens !== undefined) {
     const budget: { type: "budget_tokens"; min?: number; max?: number } = { type: "budget_tokens" };
@@ -156,23 +189,27 @@ function buildCrossModel(
   model: CrossModelModel,
   existing: ExistingModel | undefined,
 ): SyncedModel | undefined {
-  // Base tier (smallest input-context threshold) drives the headline cost; any
-  // hand-authored context tiers on the existing entry are preserved as-is.
-  const tiers = model.pricing?.tiers ?? [];
-  const base = [...tiers].sort(
+  // CrossModel serves threshold-tiered pricing. The lowest-threshold tier is the
+  // headline [cost]; every higher tier maps to a [[cost.tiers]] context band
+  // (threshold -> tier size), so tier pricing stays fresh on each sync instead of
+  // being frozen at hand-authored values. Fall back to the existing tiers only
+  // when the API reports none.
+  const tiers = [...(model.pricing?.tiers ?? [])].sort(
     (a, b) => (a.threshold ?? 0) - (b.threshold ?? 0),
-  )[0];
-  const input = price(base?.input_micro_per_1m);
-  const output = price(base?.output_micro_per_1m);
+  );
+  const base = tierCost(tiers[0]);
+  const contextTiers = tiers
+    .slice(1)
+    .map((tier) => {
+      const c = tierCost(tier);
+      return c === undefined
+        ? undefined
+        : { tier: { type: "context" as const, size: tier.threshold ?? 0 }, ...c };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined);
   const cost =
-    input !== undefined && output !== undefined
-      ? {
-          input,
-          output,
-          cache_read: nonZeroPrice(base?.cache_read_micro_per_1m) ?? existing?.cost?.cache_read,
-          cache_write: nonZeroPrice(base?.cache_creation_micro_per_1m) ?? existing?.cost?.cache_write,
-          tiers: existing?.cost?.tiers,
-        }
+    base !== undefined
+      ? { ...base, tiers: contextTiers.length > 0 ? contextTiers : existing?.cost?.tiers }
       : existing?.cost;
 
   const context = model.context_window_tokens ?? existing?.limit?.context ?? undefined;

--- a/providers/crossmodel/logo.svg
+++ b/providers/crossmodel/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M4 32 L60 32" stroke="currentColor" stroke-width="5" stroke-linecap="round"/>
+  <path d="M12 32 A20 20 0 0 1 52 32" stroke="currentColor" stroke-width="5" stroke-linecap="round"/>
+  <path d="M12 32 A20 20 0 0 0 52 32" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-dasharray="2 5" opacity="0.5"/>
+</svg>

--- a/providers/crossmodel/models/anthropic/claude-fable-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-fable-5.toml
@@ -1,0 +1,22 @@
+base_model = "anthropic/claude-fable-5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+max = 32_000
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/crossmodel/models/anthropic/claude-fable-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-fable-5.toml
@@ -1,16 +1,8 @@
 base_model = "anthropic/claude-fable-5"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
-max = 32_000
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 10

--- a/providers/crossmodel/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-haiku-4-5.toml
@@ -1,5 +1,17 @@
 base_model = "anthropic/claude-haiku-4-5"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+max = 32_000
+
 [cost]
 input = 1
 output = 5
@@ -8,4 +20,3 @@ cache_write = 1.25
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-haiku-4-5.toml
@@ -1,16 +1,8 @@
 base_model = "anthropic/claude-haiku-4-5"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high"]
-
-[[reasoning_options]]
 type = "budget_tokens"
 min = 1_024
-max = 32_000
 
 [cost]
 input = 1

--- a/providers/crossmodel/models/anthropic/claude-opus-4-7.toml
+++ b/providers/crossmodel/models/anthropic/claude-opus-4-7.toml
@@ -1,5 +1,17 @@
 base_model = "anthropic/claude-opus-4-7"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+max = 32_000
+
 [cost]
 input = 5
 output = 25
@@ -8,4 +20,3 @@ cache_write = 6.25
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/anthropic/claude-opus-4-7.toml
+++ b/providers/crossmodel/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/anthropic/claude-opus-4-7.toml
+++ b/providers/crossmodel/models/anthropic/claude-opus-4-7.toml
@@ -1,16 +1,8 @@
 base_model = "anthropic/claude-opus-4-7"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
-max = 32_000
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5

--- a/providers/crossmodel/models/anthropic/claude-opus-4-8.toml
+++ b/providers/crossmodel/models/anthropic/claude-opus-4-8.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/anthropic/claude-opus-4-8.toml
+++ b/providers/crossmodel/models/anthropic/claude-opus-4-8.toml
@@ -1,5 +1,17 @@
 base_model = "anthropic/claude-opus-4-8"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+max = 32_000
+
 [cost]
 input = 5
 output = 25
@@ -8,4 +20,3 @@ cache_write = 6.25
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/anthropic/claude-opus-4-8.toml
+++ b/providers/crossmodel/models/anthropic/claude-opus-4-8.toml
@@ -1,16 +1,8 @@
 base_model = "anthropic/claude-opus-4-8"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
-max = 32_000
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5

--- a/providers/crossmodel/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/crossmodel/models/anthropic/claude-sonnet-4-6.toml
@@ -1,5 +1,17 @@
 base_model = "anthropic/claude-sonnet-4-6"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+max = 32_000
+
 [cost]
 input = 3
 output = 15
@@ -8,4 +20,3 @@ cache_write = 3.75
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/crossmodel/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/crossmodel/models/anthropic/claude-sonnet-4-6.toml
@@ -1,16 +1,12 @@
 base_model = "anthropic/claude-sonnet-4-6"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
+values = ["low", "medium", "high", "max"]
 
 [[reasoning_options]]
 type = "budget_tokens"
 min = 1_024
-max = 32_000
 
 [cost]
 input = 3

--- a/providers/crossmodel/models/anthropic/claude-sonnet-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-sonnet-5.toml
@@ -1,5 +1,16 @@
 base_model = "anthropic/claude-sonnet-5"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+max = 32_000
 
 [cost]
 input = 2

--- a/providers/crossmodel/models/anthropic/claude-sonnet-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-sonnet-5.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/crossmodel/models/anthropic/claude-sonnet-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-sonnet-5.toml
@@ -5,12 +5,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
-max = 32_000
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 2

--- a/providers/crossmodel/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/crossmodel/models/deepseek/deepseek-v4-flash.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "xhigh"]
+
 [cost]
 input = 0.16
 output = 0.32
@@ -7,4 +14,4 @@ cache_read = 0.004
 cache_write = 0.16
 
 [limit]
-output = 65000
+output = 65_000

--- a/providers/crossmodel/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/crossmodel/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,10 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[cost]
+input = 0.16
+output = 0.32
+cache_read = 0.004
+cache_write = 0.16
+
+[limit]
+output = 65000

--- a/providers/crossmodel/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/crossmodel/models/deepseek/deepseek-v4-pro.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "xhigh"]
+
 [cost]
 input = 0.47
 output = 0.94
@@ -7,4 +14,4 @@ cache_read = 0.005
 cache_write = 0.47
 
 [limit]
-output = 65000
+output = 65_000

--- a/providers/crossmodel/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/crossmodel/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,10 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 0.47
+output = 0.94
+cache_read = 0.005
+cache_write = 0.47
+
+[limit]
+output = 65000

--- a/providers/crossmodel/models/gemini/gemini-2.5-flash-lite.toml
+++ b/providers/crossmodel/models/gemini/gemini-2.5-flash-lite.toml
@@ -1,5 +1,12 @@
 base_model = "google/gemini-2.5-flash-lite"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 0.1
 output = 0.4
@@ -8,4 +15,3 @@ cache_write = 0.1
 
 [modalities]
 input = ["text", "image", "audio", "video"]
-output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-2.5-flash-lite.toml
+++ b/providers/crossmodel/models/gemini/gemini-2.5-flash-lite.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-2.5-flash-lite"
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01
+cache_write = 0.1
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-2.5-flash.toml
+++ b/providers/crossmodel/models/gemini/gemini-2.5-flash.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-2.5-flash"
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03
+cache_write = 0.3
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-2.5-flash.toml
+++ b/providers/crossmodel/models/gemini/gemini-2.5-flash.toml
@@ -1,5 +1,12 @@
 base_model = "google/gemini-2.5-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 0.3
 output = 2.5
@@ -8,4 +15,3 @@ cache_write = 0.3
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-2.5-flash.toml
+++ b/providers/crossmodel/models/gemini/gemini-2.5-flash.toml
@@ -14,4 +14,4 @@ cache_read = 0.03
 cache_write = 0.3
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image", "video", "audio"]

--- a/providers/crossmodel/models/gemini/gemini-2.5-pro.toml
+++ b/providers/crossmodel/models/gemini/gemini-2.5-pro.toml
@@ -1,0 +1,18 @@
+base_model = "google/gemini-2.5-pro"
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+cache_write = 1.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 200000 }
+input = 2.5
+output = 15
+cache_read = 0.25
+cache_write = 2.5
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-2.5-pro.toml
+++ b/providers/crossmodel/models/gemini/gemini-2.5-pro.toml
@@ -1,5 +1,9 @@
 base_model = "google/gemini-2.5-pro"
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 1.25
 output = 10
@@ -7,7 +11,7 @@ cache_read = 0.125
 cache_write = 1.25
 
 [[cost.tiers]]
-tier = { type = "context", size = 200000 }
+tier = { type = "context", size = 200_000 }
 input = 2.5
 output = 15
 cache_read = 0.25
@@ -15,4 +19,3 @@ cache_write = 2.5
 
 [modalities]
 input = ["text", "image", "audio", "video"]
-output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-3-flash-preview.toml
+++ b/providers/crossmodel/models/gemini/gemini-3-flash-preview.toml
@@ -1,5 +1,12 @@
 base_model = "google/gemini-3-flash-preview"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 0.5
 output = 3
@@ -8,4 +15,3 @@ cache_write = 0.5
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-3-flash-preview.toml
+++ b/providers/crossmodel/models/gemini/gemini-3-flash-preview.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3-flash-preview"
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+cache_write = 0.5
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-3-flash-preview.toml
+++ b/providers/crossmodel/models/gemini/gemini-3-flash-preview.toml
@@ -14,4 +14,4 @@ cache_read = 0.05
 cache_write = 0.5
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image", "video", "audio"]

--- a/providers/crossmodel/models/gemini/gemini-3.1-pro-preview.toml
+++ b/providers/crossmodel/models/gemini/gemini-3.1-pro-preview.toml
@@ -1,5 +1,9 @@
 base_model = "google/gemini-3.1-pro-preview"
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 2
 output = 12
@@ -7,7 +11,7 @@ cache_read = 0.2
 cache_write = 2
 
 [[cost.tiers]]
-tier = { type = "context", size = 200000 }
+tier = { type = "context", size = 200_000 }
 input = 4
 output = 18
 cache_read = 0.4
@@ -15,4 +19,3 @@ cache_write = 4
 
 [modalities]
 input = ["text", "image", "audio", "video"]
-output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-3.1-pro-preview.toml
+++ b/providers/crossmodel/models/gemini/gemini-3.1-pro-preview.toml
@@ -1,0 +1,18 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200000 }
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 4
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-3.5-flash.toml
+++ b/providers/crossmodel/models/gemini/gemini-3.5-flash.toml
@@ -1,5 +1,12 @@
 base_model = "google/gemini-3.5-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 1.5
 output = 9
@@ -8,4 +15,3 @@ cache_write = 1.5
 
 [modalities]
 input = ["text", "image", "audio", "video"]
-output = ["text"]

--- a/providers/crossmodel/models/gemini/gemini-3.5-flash.toml
+++ b/providers/crossmodel/models/gemini/gemini-3.5-flash.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.5-flash"
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+cache_write = 1.5
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/crossmodel/models/minimax/minimax-m2.7.toml
+++ b/providers/crossmodel/models/minimax/minimax-m2.7.toml
@@ -1,7 +1,11 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
 
 [cost]
 input = 0.33
 output = 1.32
 cache_read = 0.066
 cache_write = 0.42
+
+[limit]
+output = 131_100

--- a/providers/crossmodel/models/minimax/minimax-m2.7.toml
+++ b/providers/crossmodel/models/minimax/minimax-m2.7.toml
@@ -1,0 +1,7 @@
+base_model = "minimax/MiniMax-M2.7"
+
+[cost]
+input = 0.33
+output = 1.32
+cache_read = 0.066
+cache_write = 0.42

--- a/providers/crossmodel/models/minimax/minimax-m2.7.toml
+++ b/providers/crossmodel/models/minimax/minimax-m2.7.toml
@@ -6,6 +6,3 @@ input = 0.33
 output = 1.32
 cache_read = 0.066
 cache_write = 0.42
-
-[limit]
-output = 131_100

--- a/providers/crossmodel/models/minimax/minimax-m3.toml
+++ b/providers/crossmodel/models/minimax/minimax-m3.toml
@@ -1,5 +1,8 @@
 base_model = "minimax/MiniMax-M3"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.33
 output = 1.32
@@ -7,12 +10,12 @@ cache_read = 0.066
 cache_write = 0.33
 
 [[cost.tiers]]
-tier = { type = "context", size = 512000 }
+tier = { type = "context", size = 512_000 }
 input = 0.66
 output = 2.63
 cache_read = 0.132
 cache_write = 0.66
 
 [limit]
-context = 1024000
-output = 512000
+context = 1_024_000
+output = 512_000

--- a/providers/crossmodel/models/minimax/minimax-m3.toml
+++ b/providers/crossmodel/models/minimax/minimax-m3.toml
@@ -1,0 +1,18 @@
+base_model = "minimax/MiniMax-M3"
+
+[cost]
+input = 0.33
+output = 1.32
+cache_read = 0.066
+cache_write = 0.33
+
+[[cost.tiers]]
+tier = { type = "context", size = 512000 }
+input = 0.66
+output = 2.63
+cache_read = 0.132
+cache_write = 0.66
+
+[limit]
+context = 1024000
+output = 512000

--- a/providers/crossmodel/models/moonshot/kimi-k2.5.toml
+++ b/providers/crossmodel/models/moonshot/kimi-k2.5.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.5"
+
+[cost]
+input = 0.62
+output = 3.3
+cache_read = 0.11
+cache_write = 0.62
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/moonshot/kimi-k2.5.toml
+++ b/providers/crossmodel/models/moonshot/kimi-k2.5.toml
@@ -1,11 +1,17 @@
 base_model = "moonshotai/kimi-k2.5"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.62
 output = 3.3
 cache_read = 0.11
 cache_write = 0.62
 
+[limit]
+context = 262_000
+output = 262_000
+
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/moonshot/kimi-k2.6.toml
+++ b/providers/crossmodel/models/moonshot/kimi-k2.6.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 1
+output = 4.16
+cache_read = 0.18
+cache_write = 1
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/moonshot/kimi-k2.6.toml
+++ b/providers/crossmodel/models/moonshot/kimi-k2.6.toml
@@ -1,11 +1,17 @@
 base_model = "moonshotai/kimi-k2.6"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 1
 output = 4.16
 cache_read = 0.18
 cache_write = 1
 
+[limit]
+context = 262_000
+output = 262_000
+
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/moonshot/kimi-k2.7-code.toml
+++ b/providers/crossmodel/models/moonshot/kimi-k2.7-code.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
 
 [cost]
 input = 1
@@ -6,6 +7,9 @@ output = 4.16
 cache_read = 0.18
 cache_write = 1
 
+[limit]
+context = 262_000
+output = 262_000
+
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/moonshot/kimi-k2.7-code.toml
+++ b/providers/crossmodel/models/moonshot/kimi-k2.7-code.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+[cost]
+input = 1
+output = 4.16
+cache_read = 0.18
+cache_write = 1
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/openai/gpt-4o-mini.toml
+++ b/providers/crossmodel/models/openai/gpt-4o-mini.toml
@@ -8,4 +8,3 @@ cache_write = 0.15
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/openai/gpt-4o-mini.toml
+++ b/providers/crossmodel/models/openai/gpt-4o-mini.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-4o-mini"
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.075
+cache_write = 0.15
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/openai/gpt-5.4-mini.toml
+++ b/providers/crossmodel/models/openai/gpt-5.4-mini.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.4-mini"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
 [cost]
 input = 0.75
 output = 4.5

--- a/providers/crossmodel/models/openai/gpt-5.4-mini.toml
+++ b/providers/crossmodel/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.4-mini"
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+cache_write = 0.75

--- a/providers/crossmodel/models/openai/gpt-5.4-nano.toml
+++ b/providers/crossmodel/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.4-nano"
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02
+cache_write = 0.2

--- a/providers/crossmodel/models/openai/gpt-5.4-nano.toml
+++ b/providers/crossmodel/models/openai/gpt-5.4-nano.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.4-nano"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
 [cost]
 input = 0.2
 output = 1.25

--- a/providers/crossmodel/models/openai/gpt-5.4.toml
+++ b/providers/crossmodel/models/openai/gpt-5.4.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5.4"
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+cache_write = 2.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272000 }
+input = 5
+output = 22.5
+cache_read = 0.5
+cache_write = 5
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/openai/gpt-5.4.toml
+++ b/providers/crossmodel/models/openai/gpt-5.4.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.4"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
 [cost]
 input = 2.5
 output = 15
@@ -7,7 +11,7 @@ cache_read = 0.25
 cache_write = 2.5
 
 [[cost.tiers]]
-tier = { type = "context", size = 272000 }
+tier = { type = "context", size = 272_000 }
 input = 5
 output = 22.5
 cache_read = 0.5
@@ -15,4 +19,3 @@ cache_write = 5
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/openai/gpt-5.5-pro.toml
+++ b/providers/crossmodel/models/openai/gpt-5.5-pro.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5.5-pro"
+
+[cost]
+input = 30
+output = 180
+cache_read = 30
+cache_write = 30
+
+[[cost.tiers]]
+tier = { type = "context", size = 272000 }
+input = 60
+output = 270
+cache_read = 60
+cache_write = 60
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/openai/gpt-5.5-pro.toml
+++ b/providers/crossmodel/models/openai/gpt-5.5-pro.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.5-pro"
 
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high", "xhigh"]
+
 [cost]
 input = 30
 output = 180
@@ -7,7 +11,7 @@ cache_read = 30
 cache_write = 30
 
 [[cost.tiers]]
-tier = { type = "context", size = 272000 }
+tier = { type = "context", size = 272_000 }
 input = 60
 output = 270
 cache_read = 60
@@ -15,4 +19,3 @@ cache_write = 60
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/openai/gpt-5.5-pro.toml
+++ b/providers/crossmodel/models/openai/gpt-5.5-pro.toml
@@ -7,15 +7,11 @@ values = ["medium", "high", "xhigh"]
 [cost]
 input = 30
 output = 180
-cache_read = 30
-cache_write = 30
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
 input = 60
 output = 270
-cache_read = 60
-cache_write = 60
 
 [modalities]
 input = ["text", "image"]

--- a/providers/crossmodel/models/openai/gpt-5.5.toml
+++ b/providers/crossmodel/models/openai/gpt-5.5.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.5"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
 [cost]
 input = 5
 output = 30
@@ -7,7 +11,7 @@ cache_read = 0.5
 cache_write = 5
 
 [[cost.tiers]]
-tier = { type = "context", size = 272000 }
+tier = { type = "context", size = 272_000 }
 input = 10
 output = 45
 cache_read = 1
@@ -15,4 +19,3 @@ cache_write = 10
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/openai/gpt-5.5.toml
+++ b/providers/crossmodel/models/openai/gpt-5.5.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5.5"
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+cache_write = 5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272000 }
+input = 10
+output = 45
+cache_read = 1
+cache_write = 10
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/qwen/qwen3.6-flash.toml
+++ b/providers/crossmodel/models/qwen/qwen3.6-flash.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3.6-flash"
+
+[cost]
+input = 0.19
+output = 1.13
+cache_read = 0.019
+cache_write = 0.24
+
+[[cost.tiers]]
+tier = { type = "context", size = 256000 }
+input = 0.75
+output = 4.5
+cache_read = 0.075
+cache_write = 0.94

--- a/providers/crossmodel/models/qwen/qwen3.6-flash.toml
+++ b/providers/crossmodel/models/qwen/qwen3.6-flash.toml
@@ -1,5 +1,11 @@
 base_model = "alibaba/qwen3.6-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.19
 output = 1.13
@@ -7,7 +13,7 @@ cache_read = 0.019
 cache_write = 0.24
 
 [[cost.tiers]]
-tier = { type = "context", size = 256000 }
+tier = { type = "context", size = 256_000 }
 input = 0.75
 output = 4.5
 cache_read = 0.075

--- a/providers/crossmodel/models/qwen/qwen3.6-plus.toml
+++ b/providers/crossmodel/models/qwen/qwen3.6-plus.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3.6-plus"
+
+[cost]
+input = 0.32
+output = 1.88
+cache_read = 0.032
+cache_write = 0.4
+
+[[cost.tiers]]
+tier = { type = "context", size = 256000 }
+input = 1.25
+output = 7.5
+cache_read = 0.124
+cache_write = 1.57

--- a/providers/crossmodel/models/qwen/qwen3.6-plus.toml
+++ b/providers/crossmodel/models/qwen/qwen3.6-plus.toml
@@ -1,5 +1,11 @@
 base_model = "alibaba/qwen3.6-plus"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.32
 output = 1.88
@@ -7,7 +13,7 @@ cache_read = 0.032
 cache_write = 0.4
 
 [[cost.tiers]]
-tier = { type = "context", size = 256000 }
+tier = { type = "context", size = 256_000 }
 input = 1.25
 output = 7.5
 cache_read = 0.124

--- a/providers/crossmodel/models/qwen/qwen3.7-max.toml
+++ b/providers/crossmodel/models/qwen/qwen3.7-max.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.7-max"
+
+[cost]
+input = 1.88
+output = 5.63
+cache_read = 0.375
+cache_write = 2.35

--- a/providers/crossmodel/models/qwen/qwen3.7-max.toml
+++ b/providers/crossmodel/models/qwen/qwen3.7-max.toml
@@ -1,5 +1,11 @@
 base_model = "alibaba/qwen3.7-max"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 1.88
 output = 5.63

--- a/providers/crossmodel/models/qwen/qwen3.7-plus.toml
+++ b/providers/crossmodel/models/qwen/qwen3.7-plus.toml
@@ -1,0 +1,18 @@
+base_model = "alibaba/qwen3.7-plus"
+
+[cost]
+input = 0.32
+output = 1.25
+cache_read = 0.032
+cache_write = 0.4
+
+[[cost.tiers]]
+tier = { type = "context", size = 256000 }
+input = 0.94
+output = 3.75
+cache_read = 0.094
+cache_write = 0.18
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/crossmodel/models/qwen/qwen3.7-plus.toml
+++ b/providers/crossmodel/models/qwen/qwen3.7-plus.toml
@@ -1,5 +1,11 @@
 base_model = "alibaba/qwen3.7-plus"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.32
 output = 1.25
@@ -7,7 +13,7 @@ cache_read = 0.032
 cache_write = 0.4
 
 [[cost.tiers]]
-tier = { type = "context", size = 256000 }
+tier = { type = "context", size = 256_000 }
 input = 0.94
 output = 3.75
 cache_read = 0.094
@@ -15,4 +21,3 @@ cache_write = 0.18
 
 [modalities]
 input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/crossmodel/models/qwen/qwen3.7-plus.toml
+++ b/providers/crossmodel/models/qwen/qwen3.7-plus.toml
@@ -14,10 +14,10 @@ cache_write = 0.4
 
 [[cost.tiers]]
 tier = { type = "context", size = 256_000 }
-input = 0.94
+input = 0.96
 output = 3.75
-cache_read = 0.094
-cache_write = 0.18
+cache_read = 0.096
+cache_write = 1.2
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/crossmodel/models/tencent/hy3-preview.toml
+++ b/providers/crossmodel/models/tencent/hy3-preview.toml
@@ -1,5 +1,9 @@
 base_model = "tencent/hy3-preview"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "high"]
+
 [cost]
 input = 0.19
 output = 0.63
@@ -7,18 +11,18 @@ cache_read = 0.063
 cache_write = 0.19
 
 [[cost.tiers]]
-tier = { type = "context", size = 16000 }
+tier = { type = "context", size = 16_000 }
 input = 0.25
 output = 1
 cache_read = 0.094
 cache_write = 0.25
 
 [[cost.tiers]]
-tier = { type = "context", size = 32000 }
+tier = { type = "context", size = 32_000 }
 input = 0.32
 output = 1.25
 cache_read = 0.125
 cache_write = 0.32
 
 [limit]
-output = 128000
+output = 128_000

--- a/providers/crossmodel/models/tencent/hy3-preview.toml
+++ b/providers/crossmodel/models/tencent/hy3-preview.toml
@@ -1,0 +1,24 @@
+base_model = "tencent/hy3-preview"
+
+[cost]
+input = 0.19
+output = 0.63
+cache_read = 0.063
+cache_write = 0.19
+
+[[cost.tiers]]
+tier = { type = "context", size = 16000 }
+input = 0.25
+output = 1
+cache_read = 0.094
+cache_write = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 32000 }
+input = 0.32
+output = 1.25
+cache_read = 0.125
+cache_write = 0.32
+
+[limit]
+output = 128000

--- a/providers/crossmodel/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/crossmodel/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,0 +1,11 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 0.47
+output = 0.94
+cache_read = 0.005
+cache_write = 0.47
+
+[limit]
+context = 1000000
+output = 128000

--- a/providers/crossmodel/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/crossmodel/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,5 +1,8 @@
 base_model = "xiaomi/mimo-v2.5-pro"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.47
 output = 0.94
@@ -7,5 +10,5 @@ cache_read = 0.005
 cache_write = 0.47
 
 [limit]
-context = 1000000
-output = 128000
+context = 1_000_000
+output = 128_000

--- a/providers/crossmodel/models/xiaomi/mimo-v2.5.toml
+++ b/providers/crossmodel/models/xiaomi/mimo-v2.5.toml
@@ -1,0 +1,15 @@
+base_model = "xiaomi/mimo-v2.5"
+
+[cost]
+input = 0.16
+output = 0.32
+cache_read = 0.004
+cache_write = 0.16
+
+[limit]
+context = 1000000
+output = 128000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/crossmodel/models/xiaomi/mimo-v2.5.toml
+++ b/providers/crossmodel/models/xiaomi/mimo-v2.5.toml
@@ -1,5 +1,8 @@
 base_model = "xiaomi/mimo-v2.5"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.16
 output = 0.32
@@ -7,9 +10,8 @@ cache_read = 0.004
 cache_write = 0.16
 
 [limit]
-context = 1000000
-output = 128000
+context = 1_000_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/crossmodel/models/z-ai/glm-4.7.toml
+++ b/providers/crossmodel/models/z-ai/glm-4.7.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-4.7"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.47
 output = 2.16
@@ -7,12 +10,12 @@ cache_read = 0.1
 cache_write = 0.47
 
 [[cost.tiers]]
-tier = { type = "context", size = 32000 }
+tier = { type = "context", size = 32_000 }
 input = 0.62
 output = 2.47
 cache_read = 0.13
 cache_write = 0.62
 
 [limit]
-context = 200000
-output = 128000
+context = 200_000
+output = 128_000

--- a/providers/crossmodel/models/z-ai/glm-4.7.toml
+++ b/providers/crossmodel/models/z-ai/glm-4.7.toml
@@ -1,0 +1,18 @@
+base_model = "zhipuai/glm-4.7"
+
+[cost]
+input = 0.47
+output = 2.16
+cache_read = 0.1
+cache_write = 0.47
+
+[[cost.tiers]]
+tier = { type = "context", size = 32000 }
+input = 0.62
+output = 2.47
+cache_read = 0.13
+cache_write = 0.62
+
+[limit]
+context = 200000
+output = 128000

--- a/providers/crossmodel/models/z-ai/glm-5-turbo.toml
+++ b/providers/crossmodel/models/z-ai/glm-5-turbo.toml
@@ -1,0 +1,17 @@
+base_model = "zhipuai/glm-5-turbo"
+
+[cost]
+input = 0.9
+output = 3.7
+cache_read = 0.18
+cache_write = 0.9
+
+[[cost.tiers]]
+tier = { type = "context", size = 32000 }
+input = 1.1
+output = 4.3
+cache_read = 0.27
+cache_write = 1.1
+
+[limit]
+output = 128000

--- a/providers/crossmodel/models/z-ai/glm-5-turbo.toml
+++ b/providers/crossmodel/models/z-ai/glm-5-turbo.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-5-turbo"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.9
 output = 3.7
@@ -7,11 +10,11 @@ cache_read = 0.18
 cache_write = 0.9
 
 [[cost.tiers]]
-tier = { type = "context", size = 32000 }
+tier = { type = "context", size = 32_000 }
 input = 1.1
 output = 4.3
 cache_read = 0.27
 cache_write = 1.1
 
 [limit]
-output = 128000
+output = 128_000

--- a/providers/crossmodel/models/z-ai/glm-5.1.toml
+++ b/providers/crossmodel/models/z-ai/glm-5.1.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-5.1"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 1
 output = 3.8
@@ -7,11 +10,11 @@ cache_read = 0.2
 cache_write = 1
 
 [[cost.tiers]]
-tier = { type = "context", size = 32000 }
+tier = { type = "context", size = 32_000 }
 input = 1.2
 output = 4.4
 cache_read = 0.3
 cache_write = 1.2
 
 [limit]
-output = 128000
+output = 128_000

--- a/providers/crossmodel/models/z-ai/glm-5.1.toml
+++ b/providers/crossmodel/models/z-ai/glm-5.1.toml
@@ -1,0 +1,17 @@
+base_model = "zhipuai/glm-5.1"
+
+[cost]
+input = 1
+output = 3.8
+cache_read = 0.2
+cache_write = 1
+
+[[cost.tiers]]
+tier = { type = "context", size = 32000 }
+input = 1.2
+output = 4.4
+cache_read = 0.3
+cache_write = 1.2
+
+[limit]
+output = 128000

--- a/providers/crossmodel/models/z-ai/glm-5.2.toml
+++ b/providers/crossmodel/models/z-ai/glm-5.2.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.2"
+
+[cost]
+input = 1.2
+output = 4.4
+cache_read = 0.3
+cache_write = 1.2
+
+[limit]
+output = 128000

--- a/providers/crossmodel/models/z-ai/glm-5.2.toml
+++ b/providers/crossmodel/models/z-ai/glm-5.2.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-5.2"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 1.2
 output = 4.4
@@ -7,4 +10,4 @@ cache_read = 0.3
 cache_write = 1.2
 
 [limit]
-output = 128000
+output = 128_000

--- a/providers/crossmodel/models/z-ai/glm-5.toml
+++ b/providers/crossmodel/models/z-ai/glm-5.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-5"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.6
 output = 3
@@ -7,12 +10,12 @@ cache_read = 0.16
 cache_write = 0.6
 
 [[cost.tiers]]
-tier = { type = "context", size = 32000 }
+tier = { type = "context", size = 32_000 }
 input = 0.8
 output = 3.4
 cache_read = 0.2
 cache_write = 0.8
 
 [limit]
-context = 200000
-output = 128000
+context = 200_000
+output = 128_000

--- a/providers/crossmodel/models/z-ai/glm-5.toml
+++ b/providers/crossmodel/models/z-ai/glm-5.toml
@@ -1,0 +1,18 @@
+base_model = "zhipuai/glm-5"
+
+[cost]
+input = 0.6
+output = 3
+cache_read = 0.16
+cache_write = 0.6
+
+[[cost.tiers]]
+tier = { type = "context", size = 32000 }
+input = 0.8
+output = 3.4
+cache_read = 0.2
+cache_write = 0.8
+
+[limit]
+context = 200000
+output = 128000

--- a/providers/crossmodel/provider.toml
+++ b/providers/crossmodel/provider.toml
@@ -1,0 +1,5 @@
+name = "CrossModel"
+env = ["CROSSMODEL_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.crossmodel.ai/v1"
+doc = "https://www.crossmodel.ai/docs"

--- a/providers/crossmodel/provider.toml
+++ b/providers/crossmodel/provider.toml
@@ -1,3 +1,12 @@
+# CrossModel is a multi-provider gateway with three inbound surfaces: OpenAI
+# Chat Completions (/v1/chat/completions), OpenAI Responses (/v1/responses), and
+# Anthropic Messages (/v1/messages). Reasoning controls are model-dependent and
+# declared per model in reasoning_options: a thinking toggle, an effort enum whose
+# accepted values vary by model (e.g. low|medium|high for Claude, none|low|medium|
+# high|xhigh for GPT-5.x, minimal|low|medium|high for Gemini), and Anthropic-style
+# budget_tokens clamped to 1024..32000. Always-thinking models (MiniMax M2.x,
+# Kimi K2.7-code) expose no user-selectable control (reasoning_options = []).
+# https://www.crossmodel.ai/docs (accessed 2026-07-09)
 name = "CrossModel"
 env = ["CROSSMODEL_API_KEY"]
 npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
Adds **CrossModel**, an OpenAI- and Anthropic-compatible multi-provider API gateway, as a provider.

- Uses the `@ai-sdk/openai-compatible` SDK against `https://api.crossmodel.ai/v1`.
- All 35 models reference existing `base_model` metadata and carry CrossModel's serving price (USD / 1M tokens), plus context-tier pricing where applicable.
- `[limit]` / `[modalities]` are overridden only where CrossModel serves the model differently from the base metadata (e.g. capped output, image-only input).
- Validated locally with `bun run validate` (exit 0).

Docs: https://www.crossmodel.ai/docs · Models: https://www.crossmodel.ai/models

---

## Update: explicit `reasoning_options` + sync module

Addresses the review (explicit provider-specific `reasoning_options`; sync for the mutable catalog).

### Sync module
Added `packages/core/src/sync/providers/crossmodel.ts` (registered under `aggregators`). It pulls the catalog from CrossModel's public `https://www.crossmodel.ai/api/models` and regenerates the provider TOMLs — cost (USD micro/1M → USD, context tiers preserved), limits, modalities, and `reasoning_options`. The 35 model TOMLs in this PR are now generated by it; CI's hourly sync keeps them fresh.

### `reasoning_options` — provider capability, not inherited
These are authored per model from **CrossModel's own request surface**, not copied from base_model or a peer gateway. CrossModel is itself the inference provider here, so the controls below are first-party.

**Evidence**

- CrossModel accepts OpenAI `reasoning_effort` (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`) and Anthropic `thinking` (toggle + `budget_tokens`) on the inbound surface and forwards/translates them to the routed upstream. For protocol-matched routes the request body is byte-transparent passthrough, so the caller reaches each upstream's native reasoning control directly.
- **Anthropic** models: the gateway clamps `thinking.budget_tokens` to **1024..32000** (its own limit, not Anthropic's native 63999), so `budget_tokens` is declared with `min=1024,max=32000`.
- **OpenAI** models: `reasoning_effort` per model — `gpt-5.x` = `none/low/medium/high/xhigh`, `gpt-5.5-pro` = `medium/high/xhigh` (no low tier). `gpt-4o-mini` is non-reasoning → no `reasoning_options`.
- **Gemini** (served via the OpenAI-compatible endpoint): `reasoning_effort`; `flash` variants can disable reasoning → add `toggle`; `pro` cannot.
- **Domestic upstreams** (Qwen/GLM/Kimi/MiniMax/MiMo/Hunyuan/DeepSeek): each model's native control via passthrough — `toggle` (`enable_thinking`, `thinking.type`), `budget_tokens` (Qwen `thinking_budget`), or `effort`. Unverified bounds are omitted per the audit guidance.
- `reasoning_options = []` where the model reasons but exposes no user-selectable control through CrossModel — e.g. `kimi-k2.7-code` (always-thinking) and `MiniMax M2.x` (thinking cannot be disabled).

Re-validated with `bun run validate` (exit 0); `bun models:sync crossmodel --dry-run` → `0 created, 35 updated, 0 removed`.