### PR TITLE
fix(llmgateway): sync only chat/text-completion models

### DIFF
--- a/packages/core/src/sync/providers/llmgateway.ts
+++ b/packages/core/src/sync/providers/llmgateway.ts
@@ -12,7 +12,23 @@ const Pricing = z.object({
   internal_reasoning: z.string().optional(),
   input_cache_read: z.string().optional(),
   input_cache_write: z.string().optional(),
-});
+}).passthrough();
+
+// Chat / text-completion models bill per token (plus cache, image, web search
+// and reasoning add-ons). Specialty models — OCR (ocr_page), rerank, etc. —
+// carry their own billing unit. A non-zero price on any key outside this set
+// marks a non-chat model we don't want in the catalog.
+const CHAT_PRICING_KEYS = new Set([
+  "prompt",
+  "completion",
+  "image",
+  "request",
+  "input_cache_read",
+  "input_cache_write",
+  "input_cache_write_1h",
+  "web_search",
+  "internal_reasoning",
+]);
 
 export const LLMGatewayModel = z.object({
   id: z.string(),
@@ -50,10 +66,7 @@ export const llmgateway = {
     return response.json();
   },
   parseModels(raw) {
-    return LLMGatewayResponse.parse(raw).data.filter((model) => {
-      const output = model.architecture.output_modalities;
-      return output.length === 1 && output[0] === "text";
-    });
+    return LLMGatewayResponse.parse(raw).data.filter(isChatModel);
   },
   translateModel(model, context) {
     return {
@@ -62,6 +75,16 @@ export const llmgateway = {
     };
   },
 } satisfies SyncProvider<LLMGatewayModel>;
+
+// Keep only chat / text-completion models: text-only output and no specialty
+// (non-chat) billing unit such as OCR pages.
+function isChatModel(model: LLMGatewayModel) {
+  const output = model.architecture.output_modalities;
+  if (output.length !== 1 || output[0] !== "text") return false;
+  return Object.entries(model.pricing).every(([key, value]) => {
+    return CHAT_PRICING_KEYS.has(key) || !(Number(value) > 0);
+  });
+}
 
 function dateFromTimestamp(timestamp: number) {
   return new Date(timestamp * 1000).toISOString().slice(0, 10);


### PR DESCRIPTION
## Summary

Follow-up to #2773. The LLM Gateway sync was adding non-chat models — the automated sync PR #2791 created `mistral-ocr-latest`. We only want **chat / text-completion** models in the catalog.

The original filter only checked `output_modalities == ["text"]`, which OCR passes (image+text in → text out). The robust distinction: chat models bill **per token**, while OCR/rerank/other specialty models bill on their own unit (`ocr_page`, etc.).

## Change

`parseModels` now keeps a model only when:
1. its output modality is exactly `["text"]`, **and**
2. it has no non-zero price on a key outside the chat-billing set (`prompt`, `completion`, `image`, `request`, `input_cache_read`/`write`/`write_1h`, `web_search`, `internal_reasoning`).

Any non-zero specialty key (`ocr_page` today, and any future non-chat unit) excludes the model. The `pricing` schema is now `passthrough()` so those keys survive parsing.

## Verification

- `bun models:sync llmgateway --dry-run` → `mistral-ocr-latest` no longer created; no OCR models in output.
- `bun validate` → passes
- `tsc --noEmit` (core) → passes

Supersedes #2791 (which should be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)