### PR TITLE
chore(providers): synthetic model catalog housekeeping

### DIFF
--- a/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M3.toml
+++ b/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M3.toml
@@ -1,9 +1,13 @@
 base_model = "minimax/MiniMax-M3"
 release_date = "2026-06-12"
 last_updated = "2026-06-12"
-reasoning_options = []
 structured_output = true
-status = "beta"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.60

--- a/providers/synthetic/models/hf:moonshotai/Kimi-K2.6.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,8 @@
 base_model = "moonshotai/kimi-k2.6"
 
+[[reasoning_options]]
+type = "toggle"
+
 [interleaved]
 field = "reasoning_content"
 
@@ -9,7 +12,9 @@ output = 4
 cache_read = 0.95
 
 [limit]
+context = 262_144
 output = 65_536
 
 [modalities]
 input = ["text", "image"]
+output = ["text"]

--- a/providers/synthetic/models/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4.toml
+++ b/providers/synthetic/models/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4.toml
@@ -1,15 +1,7 @@
-name = "Nemotron 3 Super 120B"
 base_model = "nvidia/nemotron-3-super-120b-a12b"
-family = "nemotron"
-attachment = false
-reasoning = true
-tool_call = true
-structured_output = true
-temperature = true
-release_date = "2026-03-11"
-knowledge = "2024-04"
-last_updated = "2026-04-03"
-open_weights = true
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"
@@ -20,9 +12,5 @@ output = 1
 cache_read = 0.3
 
 [limit]
-context = 262144
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 262_144
+output = 65_536


### PR DESCRIPTION
This pull request includes the following changes:

- MiniMax M3
  - remove `status` field (according to Synthetic, it's no longer in beta)
  - make reasoning mode toggleable
  - add `interleaved` table
- Kimi K2.6
  - make reasoning mode toggleable
  - set context limit
  - provide all values for the `modalities` table
- Nemotron 3 Super 120B
  - remove redundant fields already defined by base model definition
  - make reasoning mode toggleable
  - make limits more readable (although I'd consider it my personal preference)

I know you guys got a lot on your to-do list, but if you don't mind, could you take a look at #2660 and check whether it's now in a mergable state? We've reviewed this pull request for you.