### PR TITLE
fix: correct Wafer GLM-5.2 reasoning options

### DIFF
--- a/providers/wafer.ai/models/GLM-5.2.toml
+++ b/providers/wafer.ai/models/GLM-5.2.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5.2"
 last_updated = "2026-06-22"
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 1.20


### PR DESCRIPTION
## What changed

Corrects the `reasoning_options` for `wafer.ai`'s `GLM-5.2` to match the reasoning controls the provider exposes.

```diff
 base_model = "zhipuai/glm-5.2"
 last_updated = "2026-06-22"
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
```

- **Toggle** — reasoning is off by default and switched on/off via the `thinking` field.
- **Effort** — the full accepted scale is `none, low, medium, high, xhigh, max`, not just `high`/`max`.

I verified each value experimentally against the live API: every effort level is accepted, `none` returns no reasoning, and `low` through `max` produce progressively longer reasoning traces. Unsupported values are rejected with HTTP 400.
