### PR TITLE
fix(xiaomi): mark MiMo-V2 Pro/Flash/Omni as deprecated

### DIFF
--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-omni.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-omni.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-omni"
+status = "deprecated"
 reasoning_options = [{ type = "toggle" }]
 
 [interleaved]

--- a/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
+++ b/providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+status = "deprecated"
 reasoning_options = [{ type = "toggle" }]
 
 [interleaved]

--- a/providers/xiaomi/models/mimo-v2-flash.toml
+++ b/providers/xiaomi/models/mimo-v2-flash.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-12-01"
 tool_call = true
 open_weights = true
+status = "deprecated"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/xiaomi/models/mimo-v2-omni.toml
+++ b/providers/xiaomi/models/mimo-v2-omni.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2024-12"
 open_weights = false
+status = "deprecated"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/xiaomi/models/mimo-v2-pro.toml
+++ b/providers/xiaomi/models/mimo-v2-pro.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2024-12"
 open_weights = false
+status = "deprecated"
 
 [[reasoning_options]]
 type = "toggle"


### PR DESCRIPTION
## Summary

The MiMo-V2 **Pro**, **Flash**, and **Omni** models have been migrated to the MiMo-V2.5 series. Requests using the old names are already routed to their V2.5 replacements and billed at V2.5 rates, and the old names will stop resolving on 2026-06-30 (Beijing time).

This PR marks them `status = "deprecated"` following the existing convention (e.g. `opencode-go`), keeping the files in place rather than deleting them, so the model picker reflects that these are superseded.

| Deprecated model | Replacement (already in effect) |
|---|---|
| `mimo-v2-pro` | `mimo-v2.5-pro` |
| `mimo-v2-omni` | `mimo-v2.5` |
| `mimo-v2-flash` | `mimo-v2.5` |

## Scope

First-party Xiaomi providers only:

- `providers/xiaomi/models/mimo-v2-pro.toml`
- `providers/xiaomi/models/mimo-v2-flash.toml`
- `providers/xiaomi/models/mimo-v2-omni.toml`
- `providers/xiaomi-token-plan-cn/models/mimo-v2-pro.toml`
- `providers/xiaomi-token-plan-cn/models/mimo-v2-omni.toml`

The `xiaomi-token-plan-ams` and `xiaomi-token-plan-sgp` entries are symlinks to the `-cn` files, so they inherit the change automatically.

The provider-agnostic `models/xiaomi/*` metadata is not changed: `status` is a provider-level field and is rejected by the `models/` schema (`bun run validate`).

## Validation

`bun run validate` passes (exit code 0).

## References

- https://mimo.mi.com/docs/en-US/updates/deprecate
- https://mimo.mi.com/docs/zh-CN/updates/deprecate