### PR TITLE
feat(requesty): add automated model catalog sync

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -11,6 +11,7 @@ import { huggingface } from "./providers/huggingface.js";
 import { llmgateway } from "./providers/llmgateway.js";
 import { openrouter } from "./providers/openrouter.js";
 import { ovhcloud } from "./providers/ovhcloud.js";
+import { requesty } from "./providers/requesty.js";
 import { vercel } from "./providers/vercel.js";
 import { venice } from "./providers/venice.js";
 import { xai } from "./providers/xai.js";
@@ -86,6 +87,7 @@ export const providers: {
   llmgateway: SyncProvider<any>;
   openrouter: SyncProvider<any>;
   ovhcloud: SyncProvider<any>;
+  requesty: SyncProvider<any>;
   vercel: SyncProvider<any>;
   venice: SyncProvider<any>;
   xai: SyncProvider<any>;
@@ -97,13 +99,14 @@ export const providers: {
   llmgateway,
   openrouter,
   ovhcloud,
+  requesty,
   vercel,
   venice,
   xai,
 };
 
 export const groups = {
-  aggregators: ["huggingface", "llmgateway", "openrouter", "vercel"],
+  aggregators: ["huggingface", "llmgateway", "openrouter", "requesty", "vercel"],
   cloudflare: ["cloudflare-workers-ai"],
   direct: ["baseten", "google", "ovhcloud", "venice", "xai"],
 } as const;

--- a/packages/core/src/sync/providers/requesty.ts
+++ b/packages/core/src/sync/providers/requesty.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+
+import type { ExistingModel, SyncProvider, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://router.requesty.ai/v1/models";
+
+export const RequestyModel = z.object({
+  id: z.string(),
+  api: z.string().optional(),
+  object: z.string().optional(),
+  created: z.number().optional(),
+  description: z.string().optional(),
+  input_price: z.number().optional(),
+  output_price: z.number().optional(),
+  cached_price: z.number().optional(),
+  context_window: z.number().optional(),
+  max_output_tokens: z.number().optional(),
+  supports_caching: z.boolean().optional(),
+  supports_vision: z.boolean().optional(),
+  supports_reasoning: z.boolean().optional(),
+  supports_tool_calling: z.boolean().optional(),
+  supports_image_generation: z.boolean().optional(),
+  supports_output_json_schema: z.boolean().optional(),
+}).passthrough();
+
+export const RequestyResponse = z.object({
+  data: z.array(RequestyModel),
+}).passthrough();
+
+export type RequestyModel = z.infer<typeof RequestyModel>;
+
+export const requesty = {
+  id: "requesty",
+  name: "Requesty",
+  modelsDir: "providers/requesty/models",
+  // Requesty proxies a large, frequently-changing catalog (including many
+  // re-proxied sub-provider variants). Only sync models that resolve to a
+  // canonical models.dev base model, and never delete hand-curated entries.
+  deleteMissing: false,
+  // Requesty's live API doesn't carry every field curated entries may have
+  // (e.g. cache_write tiers, pdf modality). Treat any existing entry as
+  // authoritative so the sync is purely additive: it creates newly-available
+  // models but never rewrites hand-curated ones.
+  sameModel() {
+    return true;
+  },
+  async fetchModels() {
+    const headers = process.env.REQUESTY_API_KEY
+      ? { Authorization: `Bearer ${process.env.REQUESTY_API_KEY}` }
+      : undefined;
+    const response = await fetch(API_ENDPOINT, { headers });
+    if (!response.ok) {
+      throw new Error(`Requesty request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return RequestyResponse.parse(raw).data.filter((model) => {
+      // Skip routing-policy aliases and non-chat surfaces.
+      if ((model.api ?? "chat") !== "chat") return false;
+      if (!model.id.includes("/")) return false;
+      if (model.id.startsWith("policy/")) return false;
+      // Only keep models that map onto an existing canonical models.dev model,
+      // so synced entries stay factored via base_model and the catalog stays
+      // curated rather than mirroring every proxied sub-provider variant.
+      return resolveCanonicalBaseModel(model.id) !== undefined;
+    });
+  },
+  translateModel(model, context) {
+    return {
+      id: model.id,
+      model: buildRequestyModel(model, context.existing(model.id)),
+    };
+  },
+} satisfies SyncProvider<RequestyModel>;
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+// Requesty reports prices in USD per token. models.dev stores USD per million tokens.
+function price(value: number | undefined) {
+  if (value === undefined) return undefined;
+  return Number.isFinite(value) && value >= 0
+    ? Math.round(value * 1_000_000_000_000) / 1_000_000
+    : undefined;
+}
+
+export function buildRequestyModel(
+  model: RequestyModel,
+  existing: ExistingModel | undefined,
+): SyncedModel {
+  const input: Modality[] = model.supports_vision ? ["text", "image"] : ["text"];
+  const output: Modality[] = ["text"];
+  const inputPrice = price(model.input_price);
+  const outputPrice = price(model.output_price);
+  const reasoning = Boolean(model.supports_reasoning);
+  const attachment = input.some((value) => value !== "text");
+  const toolCall = Boolean(model.supports_tool_calling);
+  const structuredOutput = Boolean(model.supports_output_json_schema);
+  const cost = inputPrice !== undefined && outputPrice !== undefined
+    ? {
+        input: inputPrice,
+        output: outputPrice,
+        cache_read: price(model.cached_price),
+        tiers: existing?.cost?.tiers,
+      }
+    : existing?.cost;
+
+  // parseModels only admits models that resolve to a canonical base model, so
+  // these entries stay factored via base_model (provider-agnostic facts are
+  // inherited from models/<provider>/<id>.toml). An existing authored
+  // base_model wins so curated overrides are preserved.
+  const canonical = existing?.base_model ?? resolveCanonicalBaseModel(model.id)!;
+  const context = model.context_window ?? existing?.limit?.context ?? 0;
+  const limit = {
+    context,
+    input: existing?.limit?.input,
+    output: model.max_output_tokens || existing?.limit?.output || context,
+  };
+
+  return factorBaseModel(
+    canonical,
+    {
+      attachment,
+      reasoning,
+      temperature: true,
+      tool_call: toolCall,
+      structured_output: structuredOutput,
+      status: existing?.status,
+      interleaved: existing?.interleaved,
+      limit,
+      modalities: { input, output },
+      cost,
+    },
+    limit,
+    existing?.base_model === canonical ? existing.base_model_omit : undefined,
+  );
+}

--- a/providers/requesty/models/alibaba/qwen-max.toml
+++ b/providers/requesty/models/alibaba/qwen-max.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen-max"
+structured_output = true
+
+[cost]
+input = 1.6
+output = 6.4
+cache_read = 1.6
+
+[limit]
+output = 32_768

--- a/providers/requesty/models/alibaba/qwen-plus.toml
+++ b/providers/requesty/models/alibaba/qwen-plus.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen-plus"
+reasoning = false
+structured_output = true
+
+[cost]
+input = 0.4
+output = 1.2
+cache_read = 0.4
+
+[limit]
+context = 131_072
+output = 131_072

--- a/providers/requesty/models/alibaba/qwen-turbo.toml
+++ b/providers/requesty/models/alibaba/qwen-turbo.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen-turbo"
+reasoning = false
+structured_output = true
+
+[cost]
+input = 0.05
+output = 0.2
+cache_read = 0.05
+
+[limit]
+output = 1_000_000

--- a/providers/requesty/models/alibaba/qwen3-coder-flash.toml
+++ b/providers/requesty/models/alibaba/qwen3-coder-flash.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3-coder-flash"
+attachment = true
+structured_output = true
+
+[cost]
+input = 0.3
+output = 1.5
+cache_read = 0.08
+
+[limit]
+context = 1_048_576
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/alibaba/qwen3-coder-plus.toml
+++ b/providers/requesty/models/alibaba/qwen3-coder-plus.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3-coder-plus"
+attachment = true
+structured_output = true
+
+[cost]
+input = 1
+output = 5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/alibaba/qwen3-max.toml
+++ b/providers/requesty/models/alibaba/qwen3-max.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3-max"
+attachment = true
+structured_output = true
+
+[cost]
+input = 0.861
+output = 3.441
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/alibaba/qwen3.6-plus.toml
+++ b/providers/requesty/models/alibaba/qwen3.6-plus.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.6-plus"
+structured_output = true
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+
+[modalities]
+input = ["text"]

--- a/providers/requesty/models/alibaba/qwen3.7-max.toml
+++ b/providers/requesty/models/alibaba/qwen3.7-max.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.7-max"
+reasoning = false
+structured_output = true
+
+[cost]
+input = 2.5
+output = 7.5
+cache_read = 0.25
+
+[limit]
+context = 1_048_576

--- a/providers/requesty/models/alibaba/qwen3.7-plus.toml
+++ b/providers/requesty/models/alibaba/qwen3.7-plus.toml
@@ -1,0 +1,13 @@
+base_model = "alibaba/qwen3.7-plus"
+attachment = true
+reasoning = false
+structured_output = true
+
+[cost]
+input = 0.32
+output = 1.28
+cache_read = 0.032
+
+[limit]
+context = 1_048_576
+output = 65_536

--- a/providers/requesty/models/anthropic/claude-fable-5.toml
+++ b/providers/requesty/models/anthropic/claude-fable-5.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-fable-5"
+temperature = true
+structured_output = true
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/anthropic/claude-opus-4-7.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-7"
+temperature = true
+structured_output = true
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/anthropic/claude-opus-4-8.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-8.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-8"
+temperature = true
+structured_output = true
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/deepseek/deepseek-chat.toml
+++ b/providers/requesty/models/deepseek/deepseek-chat.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-chat"
+attachment = false
+structured_output = false
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028

--- a/providers/requesty/models/deepseek/deepseek-reasoner.toml
+++ b/providers/requesty/models/deepseek/deepseek-reasoner.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-reasoner"
+attachment = false
+reasoning = false
+structured_output = false
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028

--- a/providers/requesty/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/requesty/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning = false
+structured_output = false
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028

--- a/providers/requesty/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/requesty/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-pro"
+reasoning = false
+structured_output = false
+
+[cost]
+input = 0.435
+output = 0.87
+cache_read = 0.0145

--- a/providers/requesty/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/requesty/models/google/gemini-2.5-flash-lite.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-2.5-flash-lite"
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01
+
+[limit]
+output = 65_535
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/requesty/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,16 @@
+base_model = "google/gemini-3.1-flash-image-preview"
+tool_call = true
+structured_output = false
+
+[cost]
+input = 0.5
+output = 2
+cache_read = 0
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/requesty/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/requesty/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning = false
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+
+[limit]
+output = 65_535
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/requesty/models/google/gemini-3.1-pro-preview.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[limit]
+output = 65_535
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/google/gemma-4-31b-it.toml
+++ b/providers/requesty/models/google/gemma-4-31b-it.toml
@@ -1,0 +1,10 @@
+base_model = "google/gemma-4-31b-it"
+structured_output = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+output = 8_192

--- a/providers/requesty/models/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/requesty/models/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -1,0 +1,7 @@
+base_model = "nvidia/nemotron-3-nano-30b-a3b"
+structured_output = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/requesty/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/providers/requesty/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -1,0 +1,14 @@
+base_model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+structured_output = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 131_072
+output = 20_480
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/requesty/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,11 @@
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+structured_output = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 1_048_576
+output = 65_536

--- a/providers/requesty/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/requesty/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,11 @@
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+structured_output = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 1_048_576
+output = 65_536

--- a/providers/requesty/models/nvidia/nemotron-3.5-content-safety.toml
+++ b/providers/requesty/models/nvidia/nemotron-3.5-content-safety.toml
@@ -1,0 +1,10 @@
+base_model = "nvidia/nemotron-3.5-content-safety"
+structured_output = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 131_072

--- a/providers/requesty/models/openai/gpt-4.1-nano.toml
+++ b/providers/requesty/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-4.1-nano"
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.025

--- a/providers/requesty/models/openai/gpt-4o-2024-05-13.toml
+++ b/providers/requesty/models/openai/gpt-4o-2024-05-13.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-4o-2024-05-13"
+structured_output = false
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 2.5

--- a/providers/requesty/models/openai/gpt-4o-2024-08-06.toml
+++ b/providers/requesty/models/openai/gpt-4o-2024-08-06.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-4o-2024-08-06"
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25

--- a/providers/requesty/models/openai/gpt-4o-2024-11-20.toml
+++ b/providers/requesty/models/openai/gpt-4o-2024-11-20.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-4o-2024-11-20"
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25

--- a/providers/requesty/models/openai/gpt-4o.toml
+++ b/providers/requesty/models/openai/gpt-4o.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-4o"
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/openai/gpt-5.4-mini.toml
+++ b/providers/requesty/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.4-mini"
+temperature = true
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075

--- a/providers/requesty/models/openai/gpt-5.4-nano.toml
+++ b/providers/requesty/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.4-nano"
+temperature = true
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02

--- a/providers/requesty/models/openai/gpt-5.5.toml
+++ b/providers/requesty/models/openai/gpt-5.5.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-5.5"
+temperature = true
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/openai/o1.toml
+++ b/providers/requesty/models/openai/o1.toml
@@ -1,0 +1,10 @@
+base_model = "openai/o1"
+temperature = true
+
+[cost]
+input = 15
+output = 60
+cache_read = 7.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/openai/o3-mini.toml
+++ b/providers/requesty/models/openai/o3-mini.toml
@@ -1,0 +1,7 @@
+base_model = "openai/o3-mini"
+temperature = true
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.55

--- a/providers/requesty/models/openai/o3.toml
+++ b/providers/requesty/models/openai/o3.toml
@@ -1,0 +1,10 @@
+base_model = "openai/o3"
+temperature = true
+
+[cost]
+input = 2
+output = 8
+cache_read = 0.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/xai/grok-4.3.toml
+++ b/providers/requesty/models/xai/grok-4.3.toml
@@ -1,0 +1,12 @@
+base_model = "xai/grok-4.3"
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[limit]
+output = 1_000_000
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/xai/grok-build-0.1.toml
+++ b/providers/requesty/models/xai/grok-build-0.1.toml
@@ -1,0 +1,11 @@
+base_model = "xai/grok-build-0.1"
+attachment = false
+reasoning = false
+
+[cost]
+input = 1
+output = 2
+cache_read = 0.1
+
+[modalities]
+input = ["text"]

--- a/providers/requesty/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/requesty/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,0 +1,8 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+reasoning = false
+structured_output = false
+
+[cost]
+input = 0.435
+output = 0.87
+cache_read = 0.0036

--- a/providers/requesty/models/xiaomi/mimo-v2.5.toml
+++ b/providers/requesty/models/xiaomi/mimo-v2.5.toml
@@ -1,0 +1,11 @@
+base_model = "xiaomi/mimo-v2.5"
+reasoning = false
+structured_output = false
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/zai/glm-5.1.toml
+++ b/providers/requesty/models/zai/glm-5.1.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.1"
+attachment = true
+structured_output = false
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+output = 128_000
+
+[modalities]
+input = ["text", "image"]

--- a/providers/requesty/models/zai/glm-5.2.toml
+++ b/providers/requesty/models/zai/glm-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+attachment = true
+structured_output = false
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+output = 128_000
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
### What

Adds a Requesty sync provider so the Requesty catalog stays up to date through the existing per-provider sync automation, mirroring the OpenRouter aggregator. Today Requesty's entries are hand-maintained (38 models); this lets `bun models:sync requesty` (and the scheduled automation) keep it current.

### How

Requesty (https://requesty.ai) is an OpenAI-compatible LLM gateway. Its `/v1/models` endpoint reports per-model `input_price`/`output_price`/`cached_price` (USD per token), `context_window`, `max_output_tokens`, and capability flags.

- New `packages/core/src/sync/providers/requesty.ts` — a `SyncProvider` that fetches `https://router.requesty.ai/v1/models`, translates pricing to USD-per-million, and reuses the OpenRouter aggregator's `resolveCanonicalBaseModel`/`factorBaseModel` (Requesty uses the same `provider/model` id convention).
- Registered in `packages/core/src/sync/index.ts` (providers registry, type, and the `aggregators` group).

Curation / safety choices:
- `parseModels` only admits models that resolve to an existing canonical models.dev base model, so entries stay factored via `base_model` and the catalog isn't flooded with every proxied sub-provider variant (Requesty serves 500+ ids, many re-proxied). It also drops Requesty routing-policy aliases (`policy/*`).
- `deleteMissing: false` and `sameModel: () => true` make the sync **additive**: it creates newly-served models but never overwrites or removes the hand-curated entries (Requesty's API doesn't carry every field a curated TOML may have, e.g. `cache_write` tiers or pdf modality).

### Testing

- `bun models:sync requesty` runs against the live API and adds 43 currently-served models (alibaba/anthropic/deepseek/google/nvidia/openai/xai/xiaomi/zai), all factored via `base_model`. Re-running is idempotent (0 changes).
- `bun validate` passes on the generated catalog.
- `bun test` — the sync tests pass; the one failing test (`open-weight model metadata includes weights links`) also fails on a clean `dev` checkout, i.e. it's pre-existing and unrelated to this change.

I work at Requesty. This mirrors the existing OpenRouter aggregator sync as closely as possible. Happy to adjust the curation rules (e.g. which model families to include) or close it if it's not a fit.