### PR TITLE
feat(fireworks-ai): add GLM 5.2 Fast and fix GLM 5.2 context limit

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p2-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p2-fast.toml
@@ -1,7 +1,7 @@
-name = "GLM 5.2"
+name = "GLM 5.2 Fast"
 family = "glm"
-release_date = "2026-06-16"
-last_updated = "2026-06-16"
+release_date = "2026-06-26"
+last_updated = "2026-06-26"
 attachment = false
 reasoning = true
 temperature = true
@@ -16,9 +16,9 @@ type = "effort"
 values = ["high", "max"]
 
 [cost]
-input = 1.40
-output = 4.40
-cache_read = 0.26
+input = 2.10
+output = 6.60
+cache_read = 0.21
 
 [limit]
 context = 1_048_575


### PR DESCRIPTION
This commit:
- adds GLM 5.2 Fast router model for Fireworks AI
- corrects the GLM 5.2 context window size from `1,048,576` to `1,048,575`

For the context window reference, an API request can be made for verification:

```
curl -s \
  -H "Authorization: Bearer $FIREWORKS_API_KEY" \
  -H "Content-Type: application/json" \
  --data-binary @/tmp/glm_payload.json \
  https://api.fireworks.ai/inference/v1/chat/completions
```

A test payload can be generated using the following:

```
#!/usr/bin/env bash
python3 -c "
import json
words = 'the quick brown fox jumps over lazy dog hello world this is a test of context window artificial intelligence machine learning deep neural network language model token embedding attention transformer architecture training inference generation '
text = words * 35000
payload = json.dumps({
  'model': 'accounts/fireworks/models/glm-5p2',
  'messages': [{'role': 'user', 'content': text + '\n\nSay ok.'}],
  'max_tokens': 1
})
with open('/tmp/glm_payload.json', 'w') as f:
    f.write(payload)
print('Payload written to /tmp/glm_payload.json')
"
```

<img width="1576" height="119" alt="image" src="https://github.com/user-attachments/assets/8a1f6639-1df3-47d4-9e51-159cb9a1e0d0" />