### PR TITLE
Correct Amazon EU pricing for Haiku 4.5 and Opus 4.5

### DIFF
--- a/providers/amazon-bedrock/models/eu.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -12,10 +12,10 @@ knowledge = "2025-02-28"
 open_weights = false
 
 [cost]
-input = 1.00
-output = 5.00
-cache_read = 0.10
-cache_write = 1.25
+input = 1.10
+output = 5.50
+cache_read = 0.11
+cache_write = 1.375
 
 [limit]
 context = 200_000

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-5-20251101-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-opus-4-5-20251101-v1:0.toml
@@ -12,10 +12,10 @@ knowledge = "2025-03-31"
 open_weights = false
 
 [cost]
-input = 5.00
-output = 25.00
-cache_read = 0.50
-cache_write = 6.25
+input = 5.50
+output = 27.50
+cache_read = 0.55
+cache_write = 6.875
 
 [limit]
 context = 200_000


### PR DESCRIPTION
The pricing for the models `eu.anthropic.claude-haiku-4-5-20251001-v1:0` and `eu.anthropic.claude-opus-4-5-20251101-v1:0` were incorrect.

<img width="573" height="322" alt="image" src="https://github.com/user-attachments/assets/2ee42c09-008e-4f17-bc23-414146ad5135" />
