### PR TITLE
fix(sync): normalize Windows path separators in the sync runner

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -238,7 +238,7 @@ export async function syncProvider<SourceModel>(
     }
     const namespaceDir = path.join(metadataDir, provider.metadataNamespace);
     for (const { file } of await tomlFiles(namespaceDir)) {
-      const relativePath = path.join(provider.metadataNamespace, file);
+      const relativePath = path.join(provider.metadataNamespace, file).split(path.sep).join("/");
       if (desiredMetadata.has(relativePath) || provider.deleteMissing === false) continue;
       if (options.newOnly) {
         console.log(`Skipping metadata removal in new-only mode: ${relativePath}`);
@@ -444,7 +444,7 @@ async function readModelMetadata(modelsDir: string) {
     absolute: true,
     followSymlinks: true,
   })) {
-    const modelID = path.relative(metadataDir, modelPath).slice(0, -5);
+    const modelID = path.relative(metadataDir, modelPath).split(path.sep).join("/").slice(0, -5);
     const toml = Bun.TOML.parse(
       await Bun.file(modelPath).text(),
     ) as Record<string, unknown>;
@@ -553,7 +553,7 @@ async function tomlFiles(root: string, dir = "") {
   const result: Array<{ file: string; symlink: boolean }> = [];
 
   for (const entry of await readdir(path.join(root, dir), { withFileTypes: true })) {
-    const file = path.join(dir, entry.name);
+    const file = path.join(dir, entry.name).split(path.sep).join("/");
     if (entry.isDirectory()) {
       result.push(...await tomlFiles(root, file));
     } else if (entry.name.endsWith(".toml") && (entry.isFile() || entry.isSymbolicLink())) {


### PR DESCRIPTION
## Summary

Makes `bun models:sync <provider>` runnable on Windows. The sync runner `packages/core/src/sync/index.ts` builds map keys from `path.relative` (`readModelMetadata`) and `path.join` (`tomlFiles`, plus the metadata-namespace cleanup). On Windows these return backslash-separated paths, which are then compared against forward-slash `base_model` references, `${id}.toml` model ids, and `desiredMetadata` keys — so base_model resolution and existing-file diffing both break, and a local sync throws `Unable to resolve base_model: ...`. CI runs on Linux (`path.sep === "/"`), so this only affects local Windows runs.

## Fix

Normalize the three keys with `.split(path.sep).join("/")` (a no-op on POSIX), the same approach #2711 used for `src/generate.ts` and the standalone generators. Surfaced while wiring the Chutes sync provider (#2709).

## Validation

On Windows, `bun models:sync chutes --dry-run` now reports `13 unchanged` (previously threw `Unable to resolve base_model`); `bun validate` passes.
