### PR TITLE
fix(siliconflow): correct GLM-5.2 limits

### DIFF
--- a/providers/siliconflow-cn/models/zai-org/GLM-5.2.toml
+++ b/providers/siliconflow-cn/models/zai-org/GLM-5.2.toml
@@ -10,5 +10,5 @@ cache_input = 0.26
 cache_write = 0
 
 [limit]
-context = 205_000
-output = 205_000
+context = 1_049_000
+output = 262_000

--- a/providers/siliconflow/models/zai-org/GLM-5.2.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.2.toml
@@ -10,5 +10,5 @@ cache_input = 0.26
 cache_write = 0
 
 [limit]
-context = 205_000
-output = 205_000
+context = 1_049_000
+output = 262_000


### PR DESCRIPTION
This PR updates the provider-specific limits for `zai-org/GLM-5.2` on both SiliconFlow providers.

SiliconFlow’s official GLM-5.2 model page lists the model as having a 1049K context length and 262K max tokens, but the current provider TOMLs still report 205K / 205K. Since these provider-specific limits override the inherited `zhipuai/glm-5.2` metadata, consumers such as OpenCode can compact context much earlier than expected.

Changes:

* `providers/siliconflow/models/zai-org/GLM-5.2.toml`: `205_000 / 205_000` → `1_049_000 / 262_000`
* `providers/siliconflow-cn/models/zai-org/GLM-5.2.toml`: `205_000 / 205_000` → `1_049_000 / 262_000`

Closes #2771.
