### PR TITLE
Add MiniMax-M3 to NVIDIA provider

### DIFF
--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -1,0 +1,22 @@
+name = "MiniMax-M3"
+family = "minimax"
+release_date = "2026-06-07"
+last_updated = "2026-06-12"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.0
+output = 0.0
+
+[limit]
+context = 1_000_000
+output = 16_384
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
Adds `minimaxai/minimax-m3` to NVIDIA provider catalog. 

- Build page: https://build.nvidia.com/minimaxai/minimax-m3
- Already tested and working via integrate.api.nvidia.com