### PR TITLE
[vercel] Correct raw gateway reasoning options

### DIFF
--- a/providers/vercel/models/alibaba/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/vercel/models/alibaba/qwen3-next-80b-a3b-thinking.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3-next-80b-a3b-thinking"
-reasoning_options = []
+reasoning_options = [{ type = "budget_tokens", min = 1 }]
 name = "Qwen3 Next 80B A3B Thinking"
 release_date = "2025-09-11"
 knowledge = "2025-09"

--- a/providers/vercel/models/bytedance/seed-1.8.toml
+++ b/providers/vercel/models/bytedance/seed-1.8.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-01"
 last_updated = "2025-10"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/deepseek/deepseek-v3.2.toml
+++ b/providers/vercel/models/deepseek/deepseek-v3.2.toml
@@ -3,14 +3,11 @@ family = "deepseek"
 release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
-reasoning = true
+reasoning = false
 temperature = true
 tool_call = false
 knowledge = "2024-07"
 open_weights = false
-
-[[reasoning_options]]
-type = "toggle"
 
 [cost]
 input = 0.28

--- a/providers/vercel/models/interfaze/interfaze-beta.toml
+++ b/providers/vercel/models/interfaze/interfaze-beta.toml
@@ -6,7 +6,7 @@ reasoning = true
 temperature = true
 tool_call = false
 open_weights = false
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.5

--- a/providers/vercel/models/meituan/longcat-flash-thinking-2601.toml
+++ b/providers/vercel/models/meituan/longcat-flash-thinking-2601.toml
@@ -7,7 +7,7 @@ reasoning = true
 temperature = true
 tool_call = false
 open_weights = false
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [limit]
 context = 32_768

--- a/providers/vercel/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/vercel/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -2,7 +2,7 @@ base_model = "nvidia/nemotron-3-super-120b-a12b"
 name = "NVIDIA Nemotron 3 Super 120B A12B"
 tool_call = false
 open_weights = false
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.15

--- a/providers/vercel/models/openai/gpt-5.1-instant.toml
+++ b/providers/vercel/models/openai/gpt-5.1-instant.toml
@@ -3,8 +3,7 @@ family = "gpt"
 release_date = "2025-11-12"
 last_updated = "2025-08-07"
 attachment = true
-reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium"] }]
+reasoning = false
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.2-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.2-chat.toml
@@ -3,8 +3,7 @@ family = "gpt"
 release_date = "2025-12-11"
 last_updated = "2025-08-07"
 attachment = true
-reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium"] }]
+reasoning = false
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/vercel/models/openai/gpt-5.3-chat.toml
+++ b/providers/vercel/models/openai/gpt-5.3-chat.toml
@@ -1,8 +1,7 @@
 name = "GPT-5.3 Chat"
 family = "gpt"
 attachment = true
-reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium"] }]
+reasoning = false
 tool_call = true
 temperature = true
 release_date = "2026-03-03"

--- a/providers/vercel/models/openai/gpt-5.3-codex.toml
+++ b/providers/vercel/models/openai/gpt-5.3-codex.toml
@@ -5,7 +5,7 @@ temperature = true
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "xhigh"]
+values = ["low", "medium", "high", "xhigh"]
 
 [cost]
 input = 1.75

--- a/providers/vercel/models/openai/gpt-5.5.toml
+++ b/providers/vercel/models/openai/gpt-5.5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 name = "GPT 5.5"
 release_date = "2026-04-24"
 temperature = true

--- a/providers/vercel/models/stepfun/step-3.5-flash.toml
+++ b/providers/vercel/models/stepfun/step-3.5-flash.toml
@@ -6,7 +6,7 @@ open_weights = false
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high"]
+values = ["low", "medium", "high"]
 
 [cost]
 input = 0.09

--- a/providers/vercel/models/xai/grok-4.20-multi-agent-beta.toml
+++ b/providers/vercel/models/xai/grok-4.20-multi-agent-beta.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-11"
 last_updated = "2026-03-13"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/xai/grok-4.20-multi-agent.toml
+++ b/providers/vercel/models/xai/grok-4.20-multi-agent.toml
@@ -10,7 +10,7 @@ open_weights = false
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high"]
+values = ["low", "medium", "high", "xhigh"]
 
 [cost]
 input = 1.25

--- a/providers/vercel/models/xai/grok-4.3.toml
+++ b/providers/vercel/models/xai/grok-4.3.toml
@@ -1,5 +1,5 @@
 base_model = "xai/grok-4.3"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 release_date = "2026-04-30"
 
 [cost]

--- a/providers/vercel/models/zai/glm-5.2-fast.toml
+++ b/providers/vercel/models/zai/glm-5.2-fast.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-16"
 last_updated = "2026-06-16"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/vercel/models/zai/glm-5.2.toml
+++ b/providers/vercel/models/zai/glm-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
 name = "GLM 5.2"
 release_date = "2026-06-16"
 


### PR DESCRIPTION
## Summary

- correct current Vercel metadata against the raw Gateway `POST /v1/chat/completions` `reasoning` surface
- remove unsupported OpenAI chat/instant reasoning claims where endpoint metadata exposes no raw `reasoning`
- remove unsupported OpenAI model-specific efforts: `none` for `gpt-5.3-codex`, `minimal` for `gpt-5.5`
- remove unsupported DeepSeek V3.2 toggle where Vercel endpoints expose no raw `reasoning`
- add verified controls for stale empty entries: Interfaze, Nemotron Super, LongCat Thinking, GLM-5.2, and Qwen3 Next Thinking
- correct StepFun, xAI, and Seed 1.8 effort sets from provider docs plus Vercel endpoint metadata

## Evidence

- Vercel raw Gateway reasoning object: https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/advanced#reasoning-configuration
- Vercel endpoint metadata: `https://ai-gateway.vercel.sh/v1/models/{id}/endpoints`
- Provider docs checked for value-level semantics after endpoint metadata exposed raw `reasoning`.

## Not Changed

- Qwen budget max values remain for now where prior PRs claimed tested/provider-specific bounds; public Vercel endpoint metadata alone does not enumerate nested bounds.
- Route-partial `alibaba/qwen-3-235b` remains conservative because only one current route exposes raw `reasoning`.
- `kwaipilot/kat-coder-pro-v2` remains unchanged because public evidence is conflicting and no Gateway POST probe was available.

## Validation

- `bun validate`
- `git diff --check`

No `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` was available, so no authenticated positive/negative POST probes were run.