### PR TITLE
[frogbot] Fix reasoning options metadata

### DIFF
--- a/providers/frogbot/models/gpt-4o.toml
+++ b/providers/frogbot/models/gpt-4o.toml
@@ -4,7 +4,6 @@ release_date = "2024-05-13"
 last_updated = "2024-08-06"
 attachment = true
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2023-09"
 tool_call = true

--- a/providers/frogbot/models/grok-4-1-fast-non-reasoning.toml
+++ b/providers/frogbot/models/grok-4-1-fast-non-reasoning.toml
@@ -4,7 +4,6 @@ release_date = "2025-11-25"
 last_updated = "2025-11-25"
 attachment = true
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2025-11"
 tool_call = true


### PR DESCRIPTION
## Summary

- Fixed `providers/frogbot/models/gpt-4o.toml` by removing `reasoning_options` because `reasoning = false`.
- Fixed `providers/frogbot/models/grok-4-1-fast-non-reasoning.toml` by removing `reasoning_options` because `reasoning = false`.

## Reasoning Options

- This PR does not claim any new `toggle`, `effort`, or `budget_tokens` options.
- No `reasoning_options = []` entries were added. The two changed models are recorded as non-reasoning models, so they must not expose selectable reasoning controls.

## Evidence

- [FrogBot models catalog](https://docs.frogbot.ai/api-reference/models) lists `gpt-4o` as an OpenAI chat model and lists `grok-4-1-fast-non-reasoning` as the xAI chat model ID for Grok 4.1 Fast Non-Reasoning.
- [FrogBot intro model list](https://docs.frogbot.ai/) marks specific OpenAI models such as `gpt-5-5` and `gpt-5-3-codex` as `(reasoning)` while listing `gpt-4o` without that marker, and it lists `grok-4-1-fast-non-reasoning` as Grok 4.1 Fast Non-Reasoning.
- [FrogBot chat completions API](https://docs.frogbot.ai/api-reference/chat-completions) documents `reasoning_effort` only as a control for supported reasoning models, with accepted values `low`, `medium`, and `high`; this PR removes reasoning controls from the two models FrogBot documents as non-reasoning.

## Validation

- `bun validate` passed.
- `git diff --check` passed.
- Local resolved-provider invariant check passed for FrogBot: `reasoning = true` models have `reasoning_options`, and `reasoning = false` models do not have `reasoning_options`.