### PR TITLE
[ollama-cloud] Fix reasoning options metadata

### DIFF
--- a/providers/ollama-cloud/models/devstral-2:123b.toml
+++ b/providers/ollama-cloud/models/devstral-2:123b.toml
@@ -2,7 +2,6 @@ name = "devstral-2:123b"
 family = "devstral"
 attachment = false
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2025-12-09"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/devstral-small-2:24b.toml
+++ b/providers/ollama-cloud/models/devstral-small-2:24b.toml
@@ -2,7 +2,6 @@ name = "devstral-small-2:24b"
 family = "devstral"
 attachment = true
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2025-12-09"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/gemma3:12b.toml
+++ b/providers/ollama-cloud/models/gemma3:12b.toml
@@ -2,7 +2,6 @@ name = "gemma3:12b"
 family = "gemma"
 attachment = true
 reasoning = false
-reasoning_options = []
 tool_call = false
 release_date = "2024-12-01"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/gemma3:27b.toml
+++ b/providers/ollama-cloud/models/gemma3:27b.toml
@@ -2,7 +2,6 @@ name = "gemma3:27b"
 family = "gemma"
 attachment = true
 reasoning = false
-reasoning_options = []
 tool_call = false
 release_date = "2025-07-27"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/gemma3:4b.toml
+++ b/providers/ollama-cloud/models/gemma3:4b.toml
@@ -2,7 +2,6 @@ name = "gemma3:4b"
 family = "gemma"
 attachment = true
 reasoning = false
-reasoning_options = []
 tool_call = false
 release_date = "2024-12-01"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/kimi-k2:1t.toml
+++ b/providers/ollama-cloud/models/kimi-k2:1t.toml
@@ -2,7 +2,6 @@ name = "kimi-k2:1t"
 family = "kimi-k2"
 attachment = false
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2025-07-11"
 knowledge = "2024-10"

--- a/providers/ollama-cloud/models/ministral-3:14b.toml
+++ b/providers/ollama-cloud/models/ministral-3:14b.toml
@@ -2,7 +2,6 @@ name = "ministral-3:14b"
 family = "ministral"
 attachment = true
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2024-12-01"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/ministral-3:3b.toml
+++ b/providers/ollama-cloud/models/ministral-3:3b.toml
@@ -2,7 +2,6 @@ name = "ministral-3:3b"
 family = "ministral"
 attachment = true
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2024-10-22"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/ministral-3:8b.toml
+++ b/providers/ollama-cloud/models/ministral-3:8b.toml
@@ -2,7 +2,6 @@ name = "ministral-3:8b"
 family = "ministral"
 attachment = true
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2024-12-01"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/mistral-large-3:675b.toml
+++ b/providers/ollama-cloud/models/mistral-large-3:675b.toml
@@ -2,7 +2,6 @@ name = "mistral-large-3:675b"
 family = "mistral-large"
 attachment = true
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2025-12-02"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/qwen3-coder-next.toml
+++ b/providers/ollama-cloud/models/qwen3-coder-next.toml
@@ -2,7 +2,6 @@ name = "qwen3-coder-next"
 family = "qwen"
 attachment = false
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2026-02-02"
 last_updated = "2026-02-08"

--- a/providers/ollama-cloud/models/qwen3-coder:480b.toml
+++ b/providers/ollama-cloud/models/qwen3-coder:480b.toml
@@ -2,7 +2,6 @@ name = "qwen3-coder:480b"
 family = "qwen"
 attachment = false
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2025-07-22"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/qwen3-vl:235b-instruct.toml
+++ b/providers/ollama-cloud/models/qwen3-vl:235b-instruct.toml
@@ -2,7 +2,6 @@ name = "qwen3-vl:235b-instruct"
 family = "qwen"
 attachment = true
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2025-09-22"
 last_updated = "2026-01-19"

--- a/providers/ollama-cloud/models/rnj-1:8b.toml
+++ b/providers/ollama-cloud/models/rnj-1:8b.toml
@@ -2,7 +2,6 @@ name = "rnj-1:8b"
 family = "rnj"
 attachment = false
 reasoning = false
-reasoning_options = []
 tool_call = true
 release_date = "2025-12-06"
 last_updated = "2026-01-19"


### PR DESCRIPTION
## Summary

Fixes the ollama-cloud reasoning metadata invariant failures by removing direct `reasoning_options = []` from 14 models that are already marked `reasoning = false`.

Fixed models:

- `devstral-small-2:24b`
- `ministral-3:3b`
- `gemma3:4b`
- `gemma3:12b`
- `rnj-1:8b`
- `qwen3-vl:235b-instruct`
- `gemma3:27b`
- `devstral-2:123b`
- `ministral-3:8b`
- `qwen3-coder-next`
- `kimi-k2:1t`
- `ministral-3:14b`
- `qwen3-coder:480b`
- `mistral-large-3:675b`

## Reasoning Options

No option type is claimed for the fixed models. Because each fixed file has `reasoning = false`, the direct `reasoning_options = []` entries were removed rather than converted into `toggle`, `effort`, or `budget_tokens` claims.

This PR does not add `reasoning_options = []`; it removes invalid reasoning option declarations from non-reasoning models.

## Evidence

- [Ollama Cloud docs](https://docs.ollama.com/cloud) document that direct Cloud API access uses Ollama's `https://ollama.com/api/chat` endpoint with the selected model in the request body, proving the provider-specific request surface used by ollama-cloud.
- [Ollama thinking docs](https://docs.ollama.com/capabilities/thinking) document that thinking controls apply to thinking-capable models and use the native `think` request field with booleans or levels, so non-reasoning model entries should not claim user-selectable reasoning controls.
- [Ollama OpenAI compatibility docs](https://docs.ollama.com/openai) document that `/v1/chat/completions` supports reasoning/thinking control for thinking models and lists `reasoning_effort` plus `reasoning.effort` values; this PR does not claim those controls for the fixed non-reasoning models.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`
- `bun validate` passed.
- `git diff --check` passed.
- Provider invariant checks passed for authored TOML and generated `ollama-cloud` provider data: no `reasoning = false` model has `reasoning_options`, and no `reasoning = true` model is missing `reasoning_options`.
