### PR TITLE
[poe] Fix reasoning options metadata

### DIFF
--- a/providers/poe/models/anthropic/claude-opus-4.toml
+++ b/providers/poe/models/anthropic/claude-opus-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-21"
 last_updated = "2025-05-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-sonnet-3.7.toml
+++ b/providers/poe/models/anthropic/claude-sonnet-3.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/anthropic/claude-sonnet-4.toml
+++ b/providers/poe/models/anthropic/claude-sonnet-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-21"
 last_updated = "2025-05-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/google/gemini-3-pro.toml
+++ b/providers/poe/models/google/gemini-3-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-22"
 last_updated = "2025-10-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/google/gemini-deep-research.toml
+++ b/providers/poe/models/google/gemini-deep-research.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true

--- a/providers/poe/models/novita/glm-4.7.toml
+++ b/providers/poe/models/novita/glm-4.7.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 open_weights = false
 tool_call = true

--- a/providers/poe/models/openai/gpt-5.3-codex-spark.toml
+++ b/providers/poe/models/openai/gpt-5.3-codex-spark.toml
@@ -3,6 +3,7 @@ release_date = "2026-03-04"
 last_updated = "2026-03-04"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 open_weights = false
 tool_call = true


### PR DESCRIPTION
## Summary

Fixed Poe reasoning metadata for seven models by adding `reasoning_options = []`:

- `openai/gpt-5.3-codex-spark`
- `anthropic/claude-sonnet-3.7`
- `anthropic/claude-opus-4`
- `anthropic/claude-sonnet-4`
- `novita/glm-4.7`
- `google/gemini-3-pro`
- `google/gemini-deep-research`

These models already had `reasoning = true`; this PR records reasoning support while not claiming selectable controls.

## Reasoning Options

No `toggle`, `effort`, or `budget_tokens` option is claimed for these seven models. Poe documents `POST /v1/responses` with an optional `reasoning` object and gives an example of `reasoning.effort`, but I did not verify exact selectable controls for these specific Poe bot IDs. Poe also documents that Chat Completions ignores top-level `reasoning_effort`, that custom bot parameters such as `reasoning_effort` or `thinking_budget` are passed through `extra_body`, and that parameter passing is best-effort with unsupported fields generally ignored. Because of that, `reasoning_options = []` is the least-claim metadata for these failures.

## Evidence

- https://creator.poe.com/docs/external-applications/openai-compatible-api documents that Poe supports `POST /v1/responses` and that the Responses API adds reasoning support through a `reasoning` object.
- https://creator.poe.com/docs/external-applications/openai-compatible-api#reasoning shows Poe's Responses API request field `reasoning` with `reasoning.effort` in the request body, proving the documented provider request path for reasoning examples.
- https://creator.poe.com/docs/external-applications/openai-compatible-api#request-fields documents that Chat Completions top-level `reasoning_effort` is ignored and that custom bot parameters such as `reasoning_effort` and `thinking_budget` must be passed through `extra_body`.
- https://creator.poe.com/docs/external-applications/openai-compatible-api#parameter-handling documents best-effort parameter passing across bots, which is why this PR does not claim user-selectable controls for the seven model IDs without model-specific verification.
- https://creator.poe.com/api-reference/createResponse documents the provider endpoint `POST https://api.poe.com/v1/responses` and the optional `reasoning` request body object.

## Validation

- `bun validate` passed.
- `git diff --check` passed.
- Resolved Poe invariant scan passed: no Poe model has `reasoning = true` without `reasoning_options`, and no Poe model has `reasoning = false` with `reasoning_options`.
