### PR TITLE
[routing-run] Fix reasoning options metadata

### DIFF
--- a/providers/routing-run/models/route/deepseek-v3.2.toml
+++ b/providers/routing-run/models/route/deepseek-v3.2.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/routing-run/models/route/deepseek-v4-flash-6bit.toml
+++ b/providers/routing-run/models/route/deepseek-v4-flash-6bit.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
 name = "DeepSeek V4 Flash 6bit"
 
 [interleaved]

--- a/providers/routing-run/models/route/deepseek-v4-flash.toml
+++ b/providers/routing-run/models/route/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/routing-run/models/route/deepseek-v4-pro-6bit.toml
+++ b/providers/routing-run/models/route/deepseek-v4-pro-6bit.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
 name = "DeepSeek V4 Pro 6bit"
 
 [interleaved]

--- a/providers/routing-run/models/route/deepseek-v4-pro.toml
+++ b/providers/routing-run/models/route/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/routing-run/models/route/glm-5.1-6bit.toml
+++ b/providers/routing-run/models/route/glm-5.1-6bit.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = []
 name = "GLM 5.1 6bit"
 
 [interleaved]

--- a/providers/routing-run/models/route/glm-5.1.toml
+++ b/providers/routing-run/models/route/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = []
 name = "GLM 5.1"
 
 [interleaved]

--- a/providers/routing-run/models/route/kimi-k2.6-6bit.toml
+++ b/providers/routing-run/models/route/kimi-k2.6-6bit.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
 name = "Kimi K2.6 6bit"
 
 [interleaved]

--- a/providers/routing-run/models/route/kimi-k2.6.toml
+++ b/providers/routing-run/models/route/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/routing-run/models/route/minimax-m2.7-highspeed.toml
+++ b/providers/routing-run/models/route/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
 name = "MiniMax M2.7 Highspeed"
 
 [interleaved]

--- a/providers/routing-run/models/route/minimax-m2.7.toml
+++ b/providers/routing-run/models/route/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
 name = "MiniMax M2.7"
 
 [interleaved]

--- a/providers/routing-run/models/route/step-3.5-flash-2603.toml
+++ b/providers/routing-run/models/route/step-3.5-flash-2603.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.5-flash-2603"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/routing-run/models/route/step-3.5-flash.toml
+++ b/providers/routing-run/models/route/step-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.5-flash"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/routing-run/models/route/stepfun-3.5-flash.toml
+++ b/providers/routing-run/models/route/stepfun-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "stepfun/step-3.5-flash"
+reasoning_options = []
 name = "StepFun 3.5 Flash"
 
 [interleaved]


### PR DESCRIPTION
## Summary

Fixes Routing.run reasoning metadata for 14 models that had `reasoning = true` after base-model resolution but no `reasoning_options` field:

- `route/glm-5.1-6bit`
- `route/glm-5.1`
- `route/kimi-k2.6`
- `route/deepseek-v4-pro-6bit`
- `route/minimax-m2.7-highspeed`
- `route/deepseek-v3.2`
- `route/step-3.5-flash-2603`
- `route/kimi-k2.6-6bit`
- `route/step-3.5-flash`
- `route/deepseek-v4-flash-6bit`
- `route/stepfun-3.5-flash`
- `route/minimax-m2.7`
- `route/deepseek-v4-flash`
- `route/deepseek-v4-pro`

Each model now has `reasoning_options = []`. This records that the model can return reasoning content through Routing.run without claiming a caller-selectable reasoning control.

## Re-audit Verdict

I re-audited Routing.run using the corrected shared-contract standard: a documented shared OpenAI-compatible Chat Completions reasoning request contract may apply across reasoning-capable models without exact per-model docs. I did not restore `toggle`, `effort`, or `budget_tokens` because I could not verify a shared Routing.run request contract for any of the checked fields.

Checked request controls:

- `reasoning_effort`: not verified in current Routing.run docs or public model metadata.
- `reasoning.effort`: not verified in current Routing.run docs or public model metadata.
- `thinking`: not verified as a request control; some model metadata has top-level `thinking = true`, but the corresponding `options` object is still `{}`.
- `enable_thinking`: not verified in current Routing.run docs or public model metadata.
- `thinking_budget` / reasoning-token budgets: not verified in current Routing.run docs or public model metadata.

## Kept/Removed Matrix

| Models | Current metadata | PR metadata | Why |
| --- | --- | --- | --- |
| `route/deepseek-v3.2` | Public model list has `reasoning: true`, `thinking: false`, `labels: ["reasoning"]`, `options: {}`. | Kept `reasoning_options = []`. | Reasoning support is verified, but no selectable request control is exposed. |
| `route/deepseek-v4-pro`, `route/deepseek-v4-flash` | Public model list has `reasoning: true`, `thinking: false`, `labels: ["reasoning"]`, `options: {}`. | Kept `reasoning_options = []`. | Reasoning support is verified, but no selectable request control is exposed. |
| `route/deepseek-v4-pro-6bit`, `route/deepseek-v4-flash-6bit` | These exact IDs are not in the public unauthenticated list; their non-6bit counterparts have `options: {}`. | Kept `reasoning_options = []`. | No shared Routing.run contract or model metadata proves extra controls for the 6bit variants. |
| `route/glm-5.1` | Public model list has `reasoning: true`, `thinking: true`, `labels: ["reasoning", "thinking"]`, `options: {}`. | Kept `reasoning_options = []`. | Top-level `thinking` marks capability, but no request field/values are exposed in `options`. |
| `route/glm-5.1-6bit` | Exact ID is not in the public unauthenticated list; `route/glm-5.1` has `options: {}`. | Kept `reasoning_options = []`. | No shared Routing.run contract or model metadata proves extra controls for the 6bit variant. |
| `route/kimi-k2.6` | Public model list has `reasoning: true`, `thinking: true`, `labels: ["reasoning", "thinking"]`, `options: {}`. | Kept `reasoning_options = []`. | Top-level `thinking` marks capability, but no request field/values are exposed in `options`. |
| `route/kimi-k2.6-6bit` | Exact ID is not in the public unauthenticated list; `route/kimi-k2.6` has `options: {}`. | Kept `reasoning_options = []`. | No shared Routing.run contract or model metadata proves extra controls for the 6bit variant. |
| `route/minimax-m2.7`, `route/minimax-m2.7-highspeed` | Public model list has `reasoning: true`, `thinking: false`, `labels: ["reasoning"]`, `options: {}`. | Kept `reasoning_options = []`. | Reasoning support is verified, but no selectable request control is exposed. |
| `route/step-3.5-flash`, `route/stepfun-3.5-flash`, `route/step-3.5-flash-2603` | Public model list has `reasoning: true`, `thinking: false`, `labels: ["reasoning"]`, `options: {}`. | Kept `reasoning_options = []`. | Reasoning support is verified, but no selectable request control is exposed. |

No options were removed in this re-audit because the PR already used empty `reasoning_options`; no options were restored because no shared provider request contract was verified.

## Evidence

- [Routing.run docs](https://docs.routing.run/) document Routing.run as a gateway using stable `route/...` model IDs and list the public inference surface as `POST /v1/chat/completions`, `POST /v1/messages`, `POST /v1/embeddings`, `POST /v1/rerank`, and `GET /v1/status`; this establishes the provider-specific API surface audited here.
- [Routing.run model API docs](https://docs.routing.run/api-reference/models) document `GET /v1/models` as OpenAI-list shaped and `GET /v1/models/{model_id}` metadata with `id`, `object`, `created`, `owned_by`, `tier`, and `allowed`; the documented model metadata does not expose per-model reasoning controls or supported reasoning effort/budget values.
- [Routing.run public model endpoint](https://api.routing.run/v1/models) currently returns per-model `reasoning`, `thinking`, `labels`, and `options`; for the exact audited IDs present in the public list, `options` is `{}`, and the 6bit variants are absent from the unauthenticated list.
- The repo's Routing.run provider metadata already records `POST /v1/chat/completions` may return `message.reasoning_content`, while the documented request body has no reasoning toggle, effort, or token budget. This supports keeping `reasoning = true`/`interleaved.field = "reasoning_content"` without adding selectable `reasoning_options`.

Limitations: `GET /v1/models/{model_id}` requires authentication, no `ROUTING_RUN_API_KEY` was available locally, and live docs access was partially degraded during re-audit (`docs.routing.run` did not resolve from the shell while `routing.run` served a maintenance page). I therefore used the public `GET /v1/models` metadata as the current provider-specific endpoint evidence and did not claim controls beyond it.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: completed
- `bun validate`: passed
- `git diff --check`: passed
- Throwaway resolved-provider invariant check for Routing.run: passed
