### PR TITLE
[ambient] Fix reasoning options metadata

### DIFF
--- a/providers/ambient/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/ambient/models/moonshotai/kimi-k2.7-code.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
 temperature = true
 
 [cost]


### PR DESCRIPTION
## Summary

- Fixed `moonshotai/kimi-k2.7-code` by adding `reasoning_options = []`.
- This records reasoning support without claiming any Ambient user-selectable reasoning controls.

## Reasoning option audit

- Claimed option types: none.
- No Ambient `toggle`, `effort`, or `budget_tokens` request field/path was verified, so no accepted values or ranges are claimed.
- `reasoning_options = []` is used because the model is reasoning-capable, but no provider-exposed user control was verified for this model.

## Evidence

- [Ambient Models & API pricing](https://ambient.xyz/models) lists Ambient as `OpenAI-compatible` and includes `moonshotai/kimi-k2.7-code` with the `Reasoning` capability, proving Ambient exposes this model through its API and marks it as reasoning-capable.
- [Ambient Developers](https://ambient.xyz/developers) is Ambient's developer entry point; accessed 2026-06-27, it did not document any raw `reasoning`, `reasoning_effort`, `thinking`, or reasoning-budget request parameter for user-controlled reasoning.
- [Ambient Docs](https://docs.ambient.xyz) is the API docs target linked from Ambient's model page; accessed 2026-06-27, the public landing page did not expose a readable API schema or request-surface documentation for selectable reasoning controls.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: completed.
- `bun validate`: passed.
- `git diff --check`: passed.
- Ambient-only PR #2828 invariant check via repository `generate("./providers")`: passed.