### PR TITLE
[302ai] Fix reasoning options metadata

### DIFF
--- a/providers/302ai/models/glm-for-coding.toml
+++ b/providers/302ai/models/glm-for-coding.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
## Summary
- Fixed `302ai/glm-for-coding`.
- Added `reasoning_options = []` because the model has `reasoning = true`, but no provider-exposed selectable reasoning control was verified.

## Reasoning option claims
- No `toggle`, `effort`, or `budget_tokens` option is claimed for `glm-for-coding`.
- `reasoning_options = []` records reasoning support without claiming selectable controls.

## Evidence
- [302.AI glm-for-coding OpenAPI](https://doc-en.302.ai/394326369e0) documents the provider request surface for `glm-for-coding` on the `https://api.302.ai` `/messages` endpoint; its request schema lists `model`, `messages`, `temperature`, `top_p`, `stream`, `max_tokens`, `system`, `stop_sequences`, and `top_k`, but no reasoning toggle, effort, or reasoning-token budget field.

## Validation
- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: completed.
- `bun validate`: passed.
- `git diff --check`: passed.
- Provider invariant check: passed (`302ai reasoning invariant OK`).