### PR TITLE
[azure] Fix reasoning options metadata

### DIFF
--- a/providers/azure/models/gpt-image-1.5.toml
+++ b/providers/azure/models/gpt-image-1.5.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-image-1.5"
-reasoning_options = []
 
 [cost]
 input = 5.00

--- a/providers/azure/models/gpt-image-1.toml
+++ b/providers/azure/models/gpt-image-1.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-image-1"
-reasoning_options = []
 
 [cost]
 input = 5.00

--- a/providers/azure/models/gpt-image-2.toml
+++ b/providers/azure/models/gpt-image-2.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-image-2"
-reasoning_options = []
 
 [cost]
 input = 5.00


### PR DESCRIPTION
## Summary

- Removed direct `reasoning_options = []` from Azure `gpt-image-1.5`, `gpt-image-1`, and `gpt-image-2`.
- These models resolve to `reasoning = false`, so the provider output must not include `reasoning_options`.
- This PR claims no `toggle`, `effort`, or `budget_tokens` option for these image generation models.

## Request fields

- No Azure reasoning request field/path or accepted values are claimed for `gpt-image-1.5`, `gpt-image-1`, or `gpt-image-2`.
- The change only removes invalid reasoning option metadata from non-reasoning Azure image models.

## Evidence

- [Azure OpenAI image generation how-to](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/dall-e) documents `gpt-image-2`, `gpt-image-1.5`, and `gpt-image-1` as Azure OpenAI image generation models and lists image-generation controls such as size, quality, and image count.
- [Azure OpenAI image and audio REST API reference](https://learn.microsoft.com/en-us/azure/foundry/openai/reference-preview#image-generations---create) documents the `/openai/deployments/{deployment-id}/images/generations` request body fields, including `prompt`, `n`, `quality`, `size`, `background`, `output_format`, and related image options, without a reasoning control for that image endpoint.
- [Azure OpenAI reasoning models guide](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/reasoning) documents Azure's provider-exposed reasoning controls, including `reasoning_effort`, for GPT-5 and o-series reasoning models, separately from the `gpt-image-*` image generation endpoint.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true && bun validate && git diff --check` passed. `bun validate` emitted generated provider JSON and returned without validation errors; `git diff --check` returned no issues.
- Azure-only invariant check passed: `Azure reasoning_options invariant passed`.
