### PR TITLE
[synthetic] Fix reasoning options metadata

### DIFF
--- a/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M3.toml
+++ b/providers/synthetic/models/hf:MiniMaxAI/MiniMax-M3.toml
@@ -2,9 +2,7 @@ base_model = "minimax/MiniMax-M3"
 release_date = "2026-06-12"
 last_updated = "2026-06-12"
 structured_output = true
-
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/synthetic/models/hf:Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/synthetic/models/hf:Qwen/Qwen3.5-397B-A17B.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/synthetic/models/hf:Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/synthetic/models/hf:Qwen/Qwen3.5-397B-A17B.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/synthetic/models/hf:moonshotai/Kimi-K2.6.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K2.6.toml
@@ -1,7 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
-
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/synthetic/models/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4.toml
+++ b/providers/synthetic/models/hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4.toml
@@ -1,7 +1,5 @@
 base_model = "nvidia/nemotron-3-super-120b-a12b"
-
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/synthetic/models/hf:openai/gpt-oss-120b.toml
+++ b/providers/synthetic/models/hf:openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 open_weights = true

--- a/providers/synthetic/models/hf:zai-org/GLM-4.7-Flash.toml
+++ b/providers/synthetic/models/hf:zai-org/GLM-4.7-Flash.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-18"
 last_updated = "2026-01-18"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/synthetic/models/hf:zai-org/GLM-4.7.toml
+++ b/providers/synthetic/models/hf:zai-org/GLM-4.7.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/synthetic/models/hf:zai-org/GLM-5.1.toml
+++ b/providers/synthetic/models/hf:zai-org/GLM-5.1.toml
@@ -2,6 +2,7 @@ name = "GLM 5.1"
 family = "glm"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 temperature = true

--- a/providers/synthetic/provider.toml
+++ b/providers/synthetic/provider.toml
@@ -1,5 +1,13 @@
 name = "Synthetic"
 env = ["SYNTHETIC_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
+# Reasoning HTTP metadata (accessed 2026-06-25):
+# GET https://api.synthetic.new/openai/v1/models is the live model surface.
+# Entries expose `supported_features` (including `reasoning`), context/output
+# limits, modalities, pricing, and serving provider, but no reasoning request
+# field, accepted values, budget bounds, or disable sentinel.
+# Sources:
+# https://api.synthetic.new/openai/v1/models
+# https://synthetic.new/pricing
 doc = "https://synthetic.new/pricing"
 api = "https://api.synthetic.new/openai/v1"

--- a/providers/synthetic/provider.toml
+++ b/providers/synthetic/provider.toml
@@ -1,13 +1,5 @@
 name = "Synthetic"
 env = ["SYNTHETIC_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-# Reasoning HTTP metadata (accessed 2026-06-25):
-# GET https://api.synthetic.new/openai/v1/models is the live model surface.
-# Entries expose `supported_features` (including `reasoning`), context/output
-# limits, modalities, pricing, and serving provider, but no reasoning request
-# field, accepted values, budget bounds, or disable sentinel.
-# Sources:
-# https://api.synthetic.new/openai/v1/models
-# https://synthetic.new/pricing
 doc = "https://synthetic.new/pricing"
 api = "https://api.synthetic.new/openai/v1"


### PR DESCRIPTION
## Summary
- Fixed the five audited Synthetic failures by adding `reasoning_options` to `hf:zai-org/GLM-5.1`, `hf:zai-org/GLM-4.7-Flash`, `hf:zai-org/GLM-4.7`, `hf:Qwen/Qwen3.5-397B-A17B`, and `hf:openai/gpt-oss-120b`.
- Corrected existing Synthetic `toggle` claims on `hf:moonshotai/Kimi-K2.6`, `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4`, and `hf:MiniMaxAI/MiniMax-M3`.
- Restored the pre-existing `providers/synthetic/provider.toml` reasoning HTTP metadata comment block from `origin/dev`.

## Reasoning Options
- Kept `effort` for `hf:zai-org/GLM-5.1`, `hf:zai-org/GLM-4.7-Flash`, `hf:zai-org/GLM-4.7`, `hf:openai/gpt-oss-120b`, `hf:moonshotai/Kimi-K2.6`, `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4`, and `hf:MiniMaxAI/MiniMax-M3`.
- Provider request field: `reasoning_effort` on Synthetic OpenAI-compatible `/openai/v1/chat/completions` and `/openai/v1/completions` requests.
- Accepted values: `low`, `medium`, and `high`.
- Narrowed `hf:Qwen/Qwen3.5-397B-A17B` to `reasoning_options = []`: it reasons according to repo metadata, but Synthetic's live `/openai/v1/models` entry is routed via Together and does not expose `supported_features.reasoning` or model-level selectable-effort metadata.
- No `toggle` or `budget_tokens` option is claimed because I did not find a Synthetic API field for enabling/disabling thinking or setting a reasoning-token budget.

## Evidence
- [Synthetic chat completions request body](https://dev.synthetic.new/docs/openai/chat-completions#request-body) documents `reasoning_effort` as a string parameter that controls reasoning effort for thinking models with values `low`, `medium`, or `high`.
- [Synthetic completions request body](https://dev.synthetic.new/docs/openai/completions#request-body) documents the same `reasoning_effort` field and values for the text completions endpoint.
- [Synthetic models documentation](https://dev.synthetic.new/docs/api/models#always-on-models) lists the affected `hf:` model IDs as available Synthetic models and says model details are available from `/openai/v1/models`.
- [`GET https://api.synthetic.new/openai/v1/models`](https://api.synthetic.new/openai/v1/models), accessed 2026-06-27, reports `supported_features` including `reasoning` for the seven kept effort models; the `hf:Qwen/Qwen3.5-397B-A17B` entry does not report that feature metadata, so its selectable effort claim was removed.

## Validation
- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true` succeeded.
- `bun validate` passed.
- `git diff --check` passed.
- Synthetic invariant check passed: all generated Synthetic models with `reasoning = true` have `reasoning_options`, and no generated Synthetic `reasoning = false` model has `reasoning_options`.