### PR TITLE
[stackit] Fix reasoning options metadata

### DIFF
--- a/providers/stackit/models/openai/gpt-oss-120b.toml
+++ b/providers/stackit/models/openai/gpt-oss-120b.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/stackit/models/openai/gpt-oss-120b.toml
+++ b/providers/stackit/models/openai/gpt-oss-120b.toml
@@ -4,11 +4,14 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = false
 reasoning = true
-reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false
 open_weights = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
 
 [cost]
 input = 0.49


### PR DESCRIPTION
# Summary

- Fixed `providers/stackit/models/openai/gpt-oss-120b.toml`.
- Replaced `reasoning_options = []` with a narrow `effort` option for `low`, `medium`, and `high`.

# Reasoning Options Audit

- Kept `reasoning = true`: Stackit documents `openai/gpt-oss-120b` as reasoning-enabled.
- Added `effort`: Stackit exposes the model through an OpenAI-compatible `POST /chat/completions` endpoint and tells users to consult OpenAI API parameters; GPT-OSS 120B is documented by OpenAI as Chat Completions-capable with configurable reasoning effort values `low`, `medium`, and `high`. The Chat Completions request field is the OpenAI-compatible `reasoning_effort` control.
- Did not add `toggle`: no Stackit documentation or endpoint metadata was found for disabling reasoning on the same model ID.
- Did not add `budget_tokens`: no Stackit documentation or endpoint metadata was found for a reasoning-token budget or bounds.

# Evidence

- [Stackit available shared models](https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models/#gpt-oss-120b) documents `openai/gpt-oss-120b` as a Stackit chat model at `https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1`, lists OpenAI-compatible `POST /chat/completions`, and marks `Tool calling & Reasoning enabled`.
- [Stackit use-the-models documentation](https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/how-tos/use-the-models/#use-the-models) states that Stackit AI Model Serving provides an OpenAI-compatible API and directs callers to the OpenAI API documentation for additional parameters.
- [OpenAI GPT-OSS 120B model page](https://platform.openai.com/docs/models/gpt-oss-120b) documents `gpt-oss-120b` as supporting Chat Completions and configurable reasoning effort values `low`, `medium`, and `high`.
- [OpenAI GPT-OSS 120B Hugging Face model card](https://huggingface.co/openai/gpt-oss-120b#highlights) documents configurable reasoning effort values `low`, `medium`, and `high` for the GPT-OSS model family.

# Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true` completed.
- `bun validate` passed.
- `git diff --check` passed.
- Stackit-only invariant check passed and generated `openai/gpt-oss-120b` with `reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]`.
