### PR TITLE
[claudinio] Fix reasoning options metadata

### DIFF
--- a/providers/claudinio/models/claudinio.toml
+++ b/providers/claudinio/models/claudinio.toml
@@ -1,4 +1,7 @@
 name = "Claudinio"
+# The configured OpenAI effort shape is `reasoning_effort = low|medium|high`,
+# but the published request list documents no reasoning control or budget.
+# https://claudin.io/docs/api-reference/ (accessed 2026-06-25)
 release_date = "2026-05-12"
 last_updated = "2026-06-02"
 attachment = true

--- a/providers/claudinio/models/claudinio.toml
+++ b/providers/claudinio/models/claudinio.toml
@@ -1,12 +1,9 @@
 name = "Claudinio"
-# The configured OpenAI effort shape is `reasoning_effort = low|medium|high`,
-# but the published request list documents no reasoning control or budget.
-# https://claudin.io/docs/api-reference/ (accessed 2026-06-25)
 release_date = "2026-05-12"
 last_updated = "2026-06-02"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 tool_call = true
 open_weights = false
 knowledge = "2026-05"

--- a/providers/claudinio/models/claudius.toml
+++ b/providers/claudinio/models/claudius.toml
@@ -3,6 +3,7 @@ release_date = "2026-05-12"
 last_updated = "2026-05-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = true
 open_weights = false
 knowledge = "2026-05"

--- a/providers/claudinio/provider.toml
+++ b/providers/claudinio/provider.toml
@@ -1,9 +1,5 @@
 name = "Claudinio"
 env = ["CLAUDINIO_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-# Raw HTTP routes are POST `/v1/chat/completions`, `/v1/responses`, and
-# `/v1/messages`. The documented request fields do not include a reasoning
-# toggle, effort, or token-budget field.
-# https://claudin.io/docs/api-reference/ (accessed 2026-06-25)
 doc = "https://claudin.io"
 api = "https://api.claudin.io/v1"

--- a/providers/claudinio/provider.toml
+++ b/providers/claudinio/provider.toml
@@ -1,5 +1,9 @@
 name = "Claudinio"
 env = ["CLAUDINIO_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
+# Raw HTTP routes are POST `/v1/chat/completions`, `/v1/responses`, and
+# `/v1/messages`. The documented request fields do not include a reasoning
+# toggle, effort, or token-budget field.
+# https://claudin.io/docs/api-reference/ (accessed 2026-06-25)
 doc = "https://claudin.io"
 api = "https://api.claudin.io/v1"


### PR DESCRIPTION
## Summary

- Fixed `providers/claudinio/models/claudius.toml` by adding `reasoning_options = []` for a reasoning model.
- Corrected `providers/claudinio/models/claudinio.toml` from an unsupported `effort` claim to `reasoning_options = []`.
- Removed provider-scoped TOML citation comments so evidence stays in the PR body.

## Reasoning Options

- No `toggle`, `effort`, or `budget_tokens` option is claimed for Claudinio models in this PR.
- `reasoning_options = []` is used for `claudinio` and `claudius` because reasoning support is recorded, but no provider-exposed user-selectable reasoning control was verified for these models.

## Evidence

- [Claudin.io API reference](https://claudin.io/docs/api-reference/) documents the provider base URL, OpenAI-style routes including `/v1/chat/completions`, `/v1/messages`, and `/v1/responses`, and the supported chat request parameters such as `messages`, `temperature`, `top_p`, `max_tokens`, `stream`, `stop`, `tools` / `tool_choice`, and `response_format`; it does not document a raw reasoning toggle, effort field, or reasoning-token budget field.
- [Claudin.io OpenAI-compatible client guide](https://claudin.io/docs/clients/openai-compatible/) documents the OpenAI-compatible base URL, model setting, authentication, and supported endpoints; it provides provider-specific compatibility evidence without documenting any reasoning request control.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: completed.
- `bun validate > /var/folders/wp/p9bq_z410fl2zmv767k8w0zw0000gn/T/opencode/fix-reasoning-options-claudinio-validate.json`: passed.
- `git diff --check`: passed.
- `bun --eval 'import { generate } from "./packages/core/src/generate.js"; const providers = await generate("./providers"); const failures = Object.entries(providers["claudinio"].models).flatMap(([id, model]) => (model.reasoning === true && model.reasoning_options === undefined) || (model.reasoning === false && model.reasoning_options !== undefined) ? [{ id, reasoning: model.reasoning, hasReasoningOptions: model.reasoning_options !== undefined }] : []); if (failures.length > 0) { console.error(JSON.stringify(failures, null, 2)); process.exit(1); } console.log("claudinio invariant ok");'`: passed (`claudinio invariant ok`).
