### PR TITLE
[github-models] Fix reasoning options metadata

### DIFF
--- a/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-08-2024.toml
@@ -4,7 +4,6 @@ release_date = "2024-08-01"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus-08-2024.toml
@@ -4,7 +4,6 @@ release_date = "2024-08-01"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/cohere/cohere-command-r-plus.toml
+++ b/providers/github-models/models/cohere/cohere-command-r-plus.toml
@@ -4,7 +4,6 @@ release_date = "2024-04-04"
 last_updated = "2024-08-01"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2024-03"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4.1-mini.toml
+++ b/providers/github-models/models/openai/gpt-4.1-mini.toml
@@ -4,7 +4,6 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = true
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4.1-nano.toml
+++ b/providers/github-models/models/openai/gpt-4.1-nano.toml
@@ -4,7 +4,6 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = true
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4.1.toml
+++ b/providers/github-models/models/openai/gpt-4.1.toml
@@ -4,7 +4,6 @@ release_date = "2025-04-14"
 last_updated = "2025-04-14"
 attachment = true
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2024-04"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4o-mini.toml
+++ b/providers/github-models/models/openai/gpt-4o-mini.toml
@@ -4,7 +4,6 @@ release_date = "2024-07-18"
 last_updated = "2024-07-18"
 attachment = true
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/openai/gpt-4o.toml
+++ b/providers/github-models/models/openai/gpt-4o.toml
@@ -4,7 +4,6 @@ release_date = "2024-05-13"
 last_updated = "2024-05-13"
 attachment = true
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2023-10"
 tool_call = true

--- a/providers/github-models/models/openai/o1-mini.toml
+++ b/providers/github-models/models/openai/o1-mini.toml
@@ -4,7 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o1.toml
+++ b/providers/github-models/models/openai/o1.toml
@@ -4,7 +4,7 @@ release_date = "2024-09-12"
 last_updated = "2024-12-17"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 temperature = false
 knowledge = "2023-10"
 tool_call = false

--- a/providers/github-models/models/openai/o3-mini.toml
+++ b/providers/github-models/models/openai/o3-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/openai/o3.toml
+++ b/providers/github-models/models/openai/o3.toml
@@ -4,7 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/models/openai/o4-mini.toml
+++ b/providers/github-models/models/openai/o4-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-01-31"
 last_updated = "2025-01-31"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
 temperature = false
 knowledge = "2024-04"
 tool_call = false

--- a/providers/github-models/provider.toml
+++ b/providers/github-models/provider.toml
@@ -1,4 +1,8 @@
 name = "GitHub Models"
+# Reasoning HTTP format (accessed 2026-06-25): POST /inference/chat/completions.
+# GitHub's request schema has no toggle, effort, or budget property; therefore
+# the raw reasoning-control format for listed reasoning models is undocumented.
+# https://docs.github.com/en/rest/models/inference
 env = ["GITHUB_TOKEN"]
 npm = "@ai-sdk/openai-compatible"
 doc = "https://docs.github.com/en/github-models"

--- a/providers/github-models/provider.toml
+++ b/providers/github-models/provider.toml
@@ -1,8 +1,4 @@
 name = "GitHub Models"
-# Reasoning HTTP format (accessed 2026-06-25): POST /inference/chat/completions.
-# GitHub's request schema has no toggle, effort, or budget property; therefore
-# the raw reasoning-control format for listed reasoning models is undocumented.
-# https://docs.github.com/en/rest/models/inference
 env = ["GITHUB_TOKEN"]
 npm = "@ai-sdk/openai-compatible"
 doc = "https://docs.github.com/en/github-models"


### PR DESCRIPTION
## Summary

- Removed invalid `reasoning_options` from non-reasoning GitHub Models entries: `openai/gpt-4.1`, `openai/gpt-4.1-mini`, `openai/gpt-4.1-nano`, `openai/gpt-4o`, `openai/gpt-4o-mini`, `cohere/cohere-command-r-08-2024`, `cohere/cohere-command-r-plus-08-2024`, and `cohere/cohere-command-r-plus`.
- Changed `openai/o1`, `openai/o1-mini`, `openai/o3`, `openai/o3-mini`, and `openai/o4-mini` from an unverified `effort` claim to `reasoning_options = []`.
- Removed the provider TOML citation comment; citations are recorded here instead.

## Reasoning Options

- No `toggle`, `effort`, or `budget_tokens` option is claimed for GitHub Models in this PR.
- GitHub Models reasoning-capable entries use `reasoning_options = []` because no provider-exposed user control was verified for those models, so the metadata records reasoning support without claiming selectable controls.

## Evidence

- [GitHub Models prototyping docs](https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models#experimenting-with-ai-models-using-the-api) say the playground Code tab can emit REST requests and links those requests to the GitHub Models REST API, which identifies the provider-specific raw API surface used for this audit.
- [GitHub Models REST inference docs](https://docs.github.com/en/rest/models/inference#run-an-inference-request) document `POST /inference/chat/completions` request body parameters including `model`, `messages`, sampling fields, response format, streaming, and tools, but no reasoning toggle, effort, or reasoning-token budget field.
- [GitHub Models rate limits](https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models#rate-limits) list separate rate-limit tiers for `Azure OpenAI o1`, `o3`, `o1-mini`, `o3-mini`, and `o4-mini`, which supports keeping those GitHub Models entries marked as reasoning-capable while not proving any selectable reasoning control.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true && bun validate && git diff --check` passed.
- `rg --pcre2 -n -U 'reasoning = false\nreasoning_options|reasoning = true\n(?!reasoning_options)' 'providers/github-models'` returned no matches.
