### PR TITLE
[zenmux] Fix reasoning options metadata

### DIFF
--- a/providers/zenmux/models/moonshotai/kimi-k2.7-code-free.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2.7-code-free.toml
@@ -1,4 +1,5 @@
 base_model="moonshotai/kimi-k2.7-code"
+reasoning_options = []
 name = "Kimi K2.7 Code (Free)"
 
 [cost]

--- a/providers/zenmux/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2.7-code.toml
@@ -1,4 +1,5 @@
 base_model="moonshotai/kimi-k2.7-code"
+reasoning_options = []
 
 [cost]
 input = 0.95


### PR DESCRIPTION
## Summary

- Fixed `providers/zenmux/models/moonshotai/kimi-k2.7-code.toml`.
- Fixed `providers/zenmux/models/moonshotai/kimi-k2.7-code-free.toml`.
- Both models inherit `reasoning = true`, so this adds `reasoning_options = []` to satisfy the reasoning metadata invariant without claiming a selectable provider control.

## Reasoning options audit

- No `toggle`, `effort`, or `budget_tokens` option is claimed for these two Kimi K2.7 Code entries.
- `reasoning_options = []` means the models reason, but no ZenMux-exposed user-selectable control was verified for these exact model IDs.
- ZenMux documents OpenAI-compatible Chat Completions at `https://zenmux.ai/api/v1` and says model slugs are used in requests, establishing the provider request surface used for these ZenMux models: https://docs.zenmux.ai/guide/quickstart.html#supported-api-protocols
- ZenMux's reasoning guide documents generic OpenAI Chat reasoning fields, including `reasoning_effort` and `reasoning.enabled`, but this page is generic and does not document Kimi K2.7 Code-specific accepted controls: https://docs.zenmux.ai/guide/advanced/reasoning.html#openai-chat-completion-api
- Moonshot's Kimi thinking-model guide says `kimi-k2.7-code` thinking is always on, `thinking.type` only accepts `"enabled"`, passing `"disabled"` errors, and users should not pass the `thinking` parameter for this model: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
- The Kimi K2.7 Code Hugging Face model card likewise says Kimi-K2.7-Code forces thinking and preserve_thinking, and that preserve_thinking is enabled by default and cannot be disabled: https://huggingface.co/moonshotai/Kimi-K2.7-Code#6-model-usage

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true` completed.
- `bun validate` passed; it generated provider JSON without Zod validation errors.
- `git diff --check` passed with no output.
- Focused invariant check passed: `zenmux reasoning invariant ok`.
