### PR TITLE
[siliconflow] Fix reasoning options metadata

### DIFF
--- a/providers/siliconflow/models/zai-org/GLM-5.2.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/siliconflow/models/zai-org/GLM-5.2.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/siliconflow/models/zai-org/GLM-5.2.toml
+++ b/providers/siliconflow/models/zai-org/GLM-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/siliconflow/provider.toml
+++ b/providers/siliconflow/provider.toml
@@ -5,8 +5,11 @@ api = "https://api.siliconflow.com/v1"
 # Reasoning HTTP format (accessed 2026-06-25):
 # POST /v1/chat/completions uses top-level enable_thinking = true|false only
 # for the schema's enumerated models (default true), and thinking_budget =
-# 128..32768 for all reasoning models. No zero/negative disable sentinel or
-# reasoning_effort field is documented by the global endpoint schema.
+# 128..32768 for all reasoning models. No zero/negative disable sentinel is
+# documented by the global endpoint schema. Model-specific launch posts may
+# document additional controls; GLM-5.2 documents reasoning effort High/Max on
+# SiliconFlow.
 # Source:
 # https://docs.siliconflow.com/en/api-reference/chat-completions/chat-completions
+# https://www.siliconflow.com/blog/glm-5.2-now-on-siliconflow-1m-context-long-horizon-engineering-near-opus-coding
 doc = "https://cloud.siliconflow.com/models"


### PR DESCRIPTION
## Summary

- Fixes `providers/siliconflow/models/zai-org/GLM-5.2.toml`.
- Adds `reasoning_options = [{ type = "effort", values = ["high", "max"] }]` for GLM-5.2.
- Does not claim `toggle` or `budget_tokens`: SiliconFlow's GLM-5.2 material verifies High/Max reasoning effort, but does not document a disabled value or numeric reasoning budget for this exact provider model ID.

## Evidence

- [SiliconFlow GLM-5.2 launch post](https://www.siliconflow.com/blog/glm-5.2-now-on-siliconflow-1m-context-long-horizon-engineering-near-opus-coding) documents exact provider model ID `zai-org/GLM-5.2`, says GLM-5.2 has `Thinking · Dual Reasoning effort`, and states High and Max reasoning modes / reasoning effort can be used on SiliconFlow.
- [SiliconFlow Chat Completions API](https://docs.siliconflow.com/en/api-reference/chat-completions/chat-completions) documents the raw `POST /v1/chat/completions` surface and related thinking fields. The global schema is less current than the GLM-5.2 launch post, so this PR only records the model-specific High/Max effort values.
- [SiliconFlow GLM-5.2 model page](https://www.siliconflow.com/models/glm-5-2) documents the exact provider model ID `zai-org/GLM-5.2` and links it to SiliconFlow's Chat Completions API.

## Validation

- `bun validate`
- `git diff --check`
- Provider-scoped invariant check passed.
