### PR TITLE
[openai] Fix reasoning options metadata

### DIFF
--- a/providers/openai/models/gpt-image-1.5.toml
+++ b/providers/openai/models/gpt-image-1.5.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-image-1.5"
-reasoning_options = []
 name = "gpt-image-1.5"
 
 [limit]

--- a/providers/openai/models/gpt-image-1.toml
+++ b/providers/openai/models/gpt-image-1.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-image-1"
-reasoning_options = []
 name = "gpt-image-1"
 
 [limit]

--- a/providers/openai/models/gpt-image-2.toml
+++ b/providers/openai/models/gpt-image-2.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-image-2"
-reasoning_options = []
 name = "gpt-image-2"
 
 [cost]


### PR DESCRIPTION
## Summary

- Fixed OpenAI `gpt-image-1`, `gpt-image-1.5`, and `gpt-image-2`.
- Removed `reasoning_options = []` from these `reasoning = false` image-generation models so they satisfy the PR #2828 invariant.
- No `toggle`, `effort`, or `budget_tokens` option type is claimed for these models.

## Evidence

- [OpenAI image generation guide](https://platform.openai.com/docs/guides/image-generation) says GPT Image models, including `gpt-image-2`, `gpt-image-1.5`, and `gpt-image-1`, are used through the Image API for image generation/editing and customize image output with fields such as quality, size, format, and compression.
- [OpenAI Images API reference](https://platform.openai.com/docs/api-reference/images/create) documents the image generation endpoint `/v1/images/generations` and image request/response surface, including image model selection and image output controls, without defining `reasoning`, `reasoning.effort`, or reasoning-token budget fields for image generation.
- [OpenAI reasoning models guide](https://platform.openai.com/docs/guides/reasoning) documents `reasoning: { effort: ... }` on Responses API requests for reasoning models and says supported effort values are model-dependent, which keeps reasoning controls separate from these GPT Image model entries.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: passed
- `bun validate`: passed
- `git diff --check`: passed
- OpenAI-specific generated metadata invariant check: passed (`openai reasoning_options invariant passed`)
