### PR TITLE
[neuralwatt] Fix reasoning options metadata

### DIFF
--- a/providers/neuralwatt/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/neuralwatt/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 0.95

--- a/providers/neuralwatt/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/neuralwatt/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.95


### PR DESCRIPTION
## Summary
- Fixed `providers/neuralwatt/models/moonshotai/Kimi-K2.7-Code.toml`.
- Re-audit corrected the original selectable `toggle` claim to `reasoning_options = []`; Kimi K2.7 Code reasons, but no verified provider-exposed selectable control can disable reasoning for that same model ID.

## Re-audit verdict
- Removed/narrowed: `moonshotai/Kimi-K2.7-Code` no longer claims `toggle`. NeuralWatt `/v1/models` advertises `kimi-k2.7-code` as `metadata.capabilities.reasoning: true` and `metadata.capabilities.reasoning_effort: false`, while Moonshot Kimi documentation says Kimi K2.7 Code thinking is always on and passing disabled thinking errors. NeuralWatt documentation does not document a Kimi K2.7 Code-specific override that changes that constraint.
- Kept: existing NeuralWatt `toggle` claims for Kimi K2.5, Kimi K2.6, GLM-5.1, Qwen3.5, and Qwen3.6 models. NeuralWatt Chat Completions documents raw `POST /v1/chat/completions` and the provider request field `chat_template_kwargs: {"enable_thinking": false}` for disabling thinking; NeuralWatt docs identify Kimi K2.5, Kimi K2.6, GLM-5.1, and Qwen3.x as reasoning model families using chat-template kwargs.
- Kept: existing GLM-5.2 `effort` claims for `glm-5.2` and `glm-5.2-short`. NeuralWatt documents request field `reasoning_effort` and the claimed accepted values `minimal`, `low`, `medium`, `high`, and `xhigh` in the GLM-5.2 reasoning-effort table. No `budget_tokens` claim is made.

## Evidence
- [NeuralWatt Models API docs](https://portal.neuralwatt.com/docs/api/models) document `GET /v1/models`, including `metadata.capabilities.reasoning` and `metadata.capabilities.reasoning_effort`, and list `kimi-k2.7-code` as a featured reasoning model.
- [NeuralWatt public `/v1/models`](https://api.neuralwatt.com/v1/models) returned `kimi-k2.7-code` with `metadata.capabilities.reasoning: true` and `metadata.capabilities.reasoning_effort: false` on 2026-06-27.
- [NeuralWatt Chat Completions docs](https://portal.neuralwatt.com/docs/api/chat-completions) document raw `POST /v1/chat/completions`, `chat_template_kwargs: {"enable_thinking": false}` for disabling thinking, and `reasoning_effort` support for GLM-5.2 with the accepted values table.
- [Moonshot Kimi thinking docs](https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model) document that Kimi K2.7 Code thinking is always on, `disabled` errors, and Kimi K2.6/K2.5 are the Kimi models with a disable switch.

## Validation
- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true && bun validate` passed.
- Focused NeuralWatt invariant check passed: no generated NeuralWatt model has `reasoning = true` without `reasoning_options`, and no `reasoning = false` model has `reasoning_options`.
- `git diff --check` passed.