### PR TITLE
[vercel] Fix reasoning options metadata

### DIFF
--- a/providers/vercel/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/vercel/models/google/gemma-4-26b-a4b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = []
 open_weights = false
 
 [cost]

--- a/providers/vercel/models/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/providers/vercel/models/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code-highspeed"
+reasoning_options = []
 name = "Kimi K2.7 Code High Speed"
 release_date = "2026-06-15"
 temperature = true

--- a/providers/vercel/models/sakana/fugu-ultra.toml
+++ b/providers/vercel/models/sakana/fugu-ultra.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-21"
 last_updated = "2026-06-21"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = false


### PR DESCRIPTION
## Summary

Fixes the three Vercel reasoning metadata invariant failures by adding `reasoning_options = []` for:

- `sakana/fugu-ultra`
- `google/gemma-4-26b-a4b-it`
- `moonshotai/kimi-k2.7-code-highspeed`

These models are recorded as reasoning-capable, but this PR does not claim any user-selectable `toggle`, `effort`, or `budget_tokens` option. No provider-exposed, model-specific selectable control was verified for these models, so `reasoning_options = []` records reasoning support without claiming selectable controls.

## Option Evidence

No option types are claimed in this PR.

- `toggle`: not claimed. Vercel's generic raw field is `reasoning.enabled`, but I did not verify route-safe disable semantics for these three model IDs.
- `effort`: not claimed. No model-specific accepted `reasoning.effort` values were verified for these three model IDs.
- `budget_tokens`: not claimed. No model-specific accepted `reasoning.max_tokens` range was verified for these three model IDs.

## Citations

- https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/advanced#reasoning-configuration proves Vercel's raw Chat Completions request surface uses a top-level `reasoning` object with `enabled`, `max_tokens`, `effort`, and `exclude`, and lists generic effort values.
- https://ai-gateway.vercel.sh/v1/models/sakana/fugu-ultra/endpoints proves Vercel endpoint metadata marks `sakana/fugu-ultra` as reasoning-capable and lists generic `reasoning`/`include_reasoning` support, but does not provide model-specific effort values or budget ranges.
- https://ai-gateway.vercel.sh/v1/models/google/gemma-4-26b-a4b-it/endpoints proves Vercel endpoint metadata marks `google/gemma-4-26b-a4b-it` as reasoning-capable on some routes while another route lacks the raw `reasoning` parameter, so this PR does not claim a route-safe selectable toggle.
- https://ai-gateway.vercel.sh/v1/models/moonshotai/kimi-k2.7-code-highspeed/endpoints proves Vercel endpoint metadata marks `moonshotai/kimi-k2.7-code-highspeed` as reasoning-capable and lists generic `reasoning`/`include_reasoning` support, but does not provide model-specific effort values or budget ranges.
- https://vercel.com/docs/ai-gateway/models-and-providers/reasoning/google proves Vercel documents Gemma reasoning through provider-specific `chat_template_kwargs.enable_thinking`, not a route-safe raw Gateway `toggle`, `effort`, or `budget_tokens` control for `google/gemma-4-26b-a4b-it`.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: ok
- `bun validate`: ok
- `git diff --check`: ok
- Vercel-only local PR #2828 invariant check: ok
