### PR TITLE
[xpersona] Fix reasoning options metadata

### DIFF
--- a/providers/xpersona/models/xpersona-frieren-coder.toml
+++ b/providers/xpersona/models/xpersona-frieren-coder.toml
@@ -3,7 +3,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-25"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low"] }]
 temperature = false
 knowledge = "2025-12-30"
 tool_call = true

--- a/providers/xpersona/models/xpersona-frieren-coder.toml
+++ b/providers/xpersona/models/xpersona-frieren-coder.toml
@@ -3,7 +3,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-25"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 knowledge = "2025-12-30"
 tool_call = true

--- a/providers/xpersona/models/xpersona-frieren-coder.toml
+++ b/providers/xpersona/models/xpersona-frieren-coder.toml
@@ -3,6 +3,7 @@ release_date = "2026-05-01"
 last_updated = "2026-05-25"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 knowledge = "2025-12-30"
 tool_call = true

--- a/providers/xpersona/models/xpersona-gpt-5.5.toml
+++ b/providers/xpersona/models/xpersona-gpt-5.5.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.5"
 base_model_omit = ["limit.input"]
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 release_date = "2026-05-29"
 last_updated = "2026-05-29"
 attachment = false

--- a/providers/xpersona/models/xpersona-gpt-5.5.toml
+++ b/providers/xpersona/models/xpersona-gpt-5.5.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.5"
 base_model_omit = ["limit.input"]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 release_date = "2026-05-29"
 last_updated = "2026-05-29"
 attachment = false

--- a/providers/xpersona/models/xpersona-gpt-5.5.toml
+++ b/providers/xpersona/models/xpersona-gpt-5.5.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.5"
 base_model_omit = ["limit.input"]
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 release_date = "2026-05-29"
 last_updated = "2026-05-29"
 attachment = false

--- a/providers/xpersona/provider.toml
+++ b/providers/xpersona/provider.toml
@@ -1,4 +1,7 @@
 name = "Xpersona"
+# POST /v1/chat/completions accepts reasoning.effort set to "low", "medium",
+# "high", "xhigh", or "max"; no disable sentinel or token budget is documented.
+# https://www.xpersona.co/api/v1/openapi/ai-public (accessed 2026-06-25)
 env = ["XPERSONA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
 api = "https://www.xpersona.co/v1"

--- a/providers/xpersona/provider.toml
+++ b/providers/xpersona/provider.toml
@@ -1,7 +1,4 @@
 name = "Xpersona"
-# POST /v1/chat/completions accepts reasoning.effort set to "low", "medium",
-# "high", "xhigh", or "max"; no disable sentinel or token budget is documented.
-# https://www.xpersona.co/api/v1/openapi/ai-public (accessed 2026-06-25)
 env = ["XPERSONA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
 api = "https://www.xpersona.co/v1"


### PR DESCRIPTION
## Fixed models

- `xpersona-frieren-coder`
- `xpersona-gpt-5.5`

## Reasoning options

- Claimed option type: `effort`.
- Provider request field/path: `reasoning.effort` in `POST /v1/chat/completions`.
- Accepted values: `low`, `medium`, `high`, `xhigh`, `max`.
- No `toggle` or `budget_tokens` option is claimed because the provider OpenAPI does not document a disable sentinel or reasoning-token budget field.

## Evidence

- https://www.xpersona.co/api/v1/openapi/ai-public documents the OpenAI-compatible Xpersona `POST /v1/chat/completions` request body and the `reasoning.effort` enum values `low`, `medium`, `high`, `xhigh`, and `max`.
- https://www.xpersona.co/v1/models documents current Xpersona inference model metadata, including `xpersona-frieren-coder`.
- https://www.xpersona.co/v1/pricing documents Xpersona inference pricing entries with `reasoningEffort`, confirming reasoning is part of the Xpersona inference product surface.

## Validation

- `bun validate`
- `git diff --check`
- Focused xpersona invariant check passed.
