### PR TITLE
[togetherai] Fix reasoning options metadata

### DIFF
--- a/providers/togetherai/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/togetherai/models/MiniMaxAI/MiniMax-M3.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-12"
 last_updated = "2026-06-12"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/togetherai/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/togetherai/models/moonshotai/Kimi-K2.7-Code.toml
@@ -4,6 +4,7 @@ release_date = "2026-06-14"
 last_updated = "2026-06-14"
 attachment = false
 reasoning = true
+reasoning_options = []
 structured_output = true
 temperature = true
 tool_call = true


### PR DESCRIPTION
## Summary

Fixed Together AI reasoning metadata for:

- `MiniMaxAI/MiniMax-M3`
- `moonshotai/Kimi-K2.7-Code`

Both models now set `reasoning_options = []`. No `toggle`, `effort`, or `budget_tokens` option is claimed for these fixed models.

## Reasoning options audit

No provider-exposed user control meeting the evidence standard was verified for these models, so this PR records reasoning support without claiming selectable controls.

- `MiniMaxAI/MiniMax-M3`: Together's model page identifies MiniMax M3 as a reasoning model with toggleable thinking, but it does not document the exact raw request field and accepted values for this model ID, so this PR does not claim a `toggle` option.
- `moonshotai/Kimi-K2.7-Code`: Together's model page says thinking and preserve_thinking are always enabled, so this PR does not claim a `toggle` option.

## Evidence

- [Together MiniMax M3 model page](https://www.together.ai/models/minimax-m3) proves Together serves `MiniMaxAI/MiniMax-M3` as a reasoning model and describes toggleable thinking, but it does not identify an exact request field or accepted values for that control.
- [Together Kimi K2.7 Code model page](https://www.together.ai/models/kimi-k27-code) proves Together serves `moonshotai/Kimi-K2.7-Code` and states that thinking and preserve_thinking are always enabled.
- [Together serverless model catalog](https://docs.together.ai/docs/serverless/models) proves both fixed model IDs are available through Together serverless chat/vision inference.
- [Together chat completions API reference](https://docs.together.ai/reference/chat-completions) documents generic request fields `reasoning.enabled` and `reasoning_effort`, but does not establish either field for these exact fixed model IDs.
- [Together reasoning guide](https://docs.together.ai/docs/inference/chat/reasoning) documents reasoning model categories and selectable controls for listed models; the two fixed model IDs are not listed there with a verified selectable control.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: passed
- `bun validate`: passed
- `git diff --check`: passed
- Provider invariant check: `togetherai reasoning invariant OK`
