### PR TITLE
[siliconflow-cn] Fix reasoning options metadata

### DIFF
--- a/providers/siliconflow-cn/models/zai-org/GLM-5.2.toml
+++ b/providers/siliconflow-cn/models/zai-org/GLM-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/siliconflow-cn/models/zai-org/GLM-5.2.toml
+++ b/providers/siliconflow-cn/models/zai-org/GLM-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/siliconflow-cn/provider.toml
+++ b/providers/siliconflow-cn/provider.toml
@@ -8,6 +8,9 @@ api = "https://api.siliconflow.cn/v1"
 # most reasoning models. No zero/negative disable sentinel is documented.
 # reasoning_effort is only for deepseek-ai/DeepSeek-V4-Flash: "high"|"max";
 # low|medium map to high and xhigh maps to max for compatibility.
+# Model-specific listings may document additional controls; GLM-5.2 documents
+# multiple thinking effort levels on SiliconFlow CN.
 # Source:
 # https://docs.siliconflow.cn/cn/api-reference/chat-completions/chat-completions
+# https://cloud.siliconflow.cn/open/models?target=zai-org%2FGLM-5.2
 doc = "https://cloud.siliconflow.com/models"


### PR DESCRIPTION
## Summary

- Fixes `siliconflow-cn` model `zai-org/GLM-5.2`.
- Adds `reasoning_options = [{ type = "effort", values = ["high", "max"] }]`.
- Does not claim `toggle` or `budget_tokens`; the verified provider/model evidence is for High/Max thinking effort only.

## Evidence

- [SiliconFlow CN model listing](https://cloud.siliconflow.cn/open/models?target=zai-org%2FGLM-5.2) lists exact provider model ID `zai-org/GLM-5.2`, marks it as a reasoning model, and says GLM-5.2 supports multiple `thinking effort levels`.
- [SiliconFlow GLM-5.2 launch post](https://www.siliconflow.com/blog/glm-5.2-now-on-siliconflow-1m-context-long-horizon-engineering-near-opus-coding) documents the exact model ID `zai-org/GLM-5.2` and says High and Max reasoning modes / reasoning effort can be used on SiliconFlow.
- [SiliconFlow CN Chat Completions API](https://docs.siliconflow.cn/cn/api-reference/chat-completions/chat-completions) documents the raw `POST /v1/chat/completions` surface and related thinking fields. The global schema is less current than the GLM-5.2 model listing, so this PR only records the model-specific High/Max effort values.

## Validation

- `bun validate`
- `git diff --check`
- SiliconFlow CN invariant check passed.
