### PR TITLE
[cortecs] Fix reasoning options metadata

### DIFF
--- a/providers/cortecs/models/glm-5-turbo.toml
+++ b/providers/cortecs/models/glm-5-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5-turbo"
+reasoning_options = []
 
 [cost]
 input = 1.235

--- a/providers/cortecs/models/glm-5v-turbo.toml
+++ b/providers/cortecs/models/glm-5v-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5v-turbo"
+reasoning_options = []
 
 [cost]
 input = 1.235

--- a/providers/cortecs/models/gpt-oss-120b.toml
+++ b/providers/cortecs/models/gpt-oss-120b.toml
@@ -1,4 +1,6 @@
 name = "GPT Oss 120b"
+# Cortecs Chat maps `reasoning_effort = low|medium|high`; no budget is exposed.
+# https://api.cortecs.ai/v1/models (accessed 2026-06-25)
 family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"

--- a/providers/cortecs/models/gpt-oss-120b.toml
+++ b/providers/cortecs/models/gpt-oss-120b.toml
@@ -1,13 +1,10 @@
 name = "GPT Oss 120b"
-# Cortecs Chat maps `reasoning_effort = low|medium|high`; no budget is exposed.
-# https://api.cortecs.ai/v1/models (accessed 2026-06-25)
 family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"
 knowledge = "2024-01"
 attachment = false
 reasoning = false
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/gpt-oss-120b.toml
+++ b/providers/cortecs/models/gpt-oss-120b.toml
@@ -4,7 +4,8 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 knowledge = "2024-01"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 temperature = true
 open_weights = true

--- a/providers/cortecs/models/minimax-m3.toml
+++ b/providers/cortecs/models/minimax-m3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = []
 
 [cost]
 input = 0.355


### PR DESCRIPTION
## Summary

- Fixed `minimax-m3`, `glm-5v-turbo`, and `glm-5-turbo` by adding `reasoning_options = []` so they record reasoning support without claiming unverified selectable controls.
- Fixed `gpt-oss-120b` by marking it reasoning-enabled and keeping only the verified Cortecs `reasoning_effort` control with values `low`, `medium`, and `high`.

## Evidence

- [Cortecs reasoning documentation](https://docs.cortecs.ai/usage/reasoning) documents the request field `reasoning_effort` and accepted values `low`, `medium`, and `high`, and says unsupported adjustable reasoning controls may be ignored by providers.
- [Cortecs `gpt-oss-120b` model page](https://cortecs.ai/detailedServerlessView/gpt-oss-120b) marks the model as `Reasoning` and says it allows configurable effort levels, so the PR claims the Cortecs `reasoning_effort` effort option only for `gpt-oss-120b`.
- [Cortecs public model endpoint](https://api.cortecs.ai/v1/models) lists `minimax-m3`, `glm-5v-turbo`, and `glm-5-turbo` with `Reasoning` tags but does not expose model-specific request controls or accepted values; no provider-exposed user control was verified for those models, so the PR uses `reasoning_options = []`.
- [Cortecs chat completions OpenAPI page](https://docs.cortecs.ai/api-overview/chat-completions) documents the OpenAI-compatible `POST /v1/chat/completions` endpoint and response `reasoning_content`, but its request schema does not add model-specific budget or toggle fields for the empty-options models.

## Validation

- `bun validate >/dev/null` passed.
- `git diff --check` passed.
- Provider-only generated invariant check passed for `cortecs`: no `reasoning = true` model is missing `reasoning_options`, and no `reasoning = false` model has `reasoning_options`.

No credentials were used.