### PR TITLE
[scaleway] Fix reasoning options metadata

### DIFF
--- a/providers/scaleway/models/glm-5.2.toml
+++ b/providers/scaleway/models/glm-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 1.8

--- a/providers/scaleway/models/glm-5.2.toml
+++ b/providers/scaleway/models/glm-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.8

--- a/providers/scaleway/models/gpt-oss-120b.toml
+++ b/providers/scaleway/models/gpt-oss-120b.toml
@@ -3,10 +3,7 @@ family = "gpt-oss"
 release_date = "2024-01-01"
 last_updated = "2026-03-17"
 attachment = true
-reasoning = false
-# Scaleway excludes gpt-oss-120b from reasoning_effort = "none"; documented
-# effort values are "low"|"medium"|"high" (accessed 2026-06-25).
-# https://www.scaleway.com/en/docs/generative-apis/how-to/query-reasoning-models/
+reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/scaleway/models/gpt-oss-120b.toml
+++ b/providers/scaleway/models/gpt-oss-120b.toml
@@ -4,6 +4,9 @@ release_date = "2024-01-01"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+# Scaleway excludes gpt-oss-120b from reasoning_effort = "none"; documented
+# effort values are "low"|"medium"|"high" (accessed 2026-06-25).
+# https://www.scaleway.com/en/docs/generative-apis/how-to/query-reasoning-models/
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/scaleway/models/mistral-medium-3.5-128b.toml
+++ b/providers/scaleway/models/mistral-medium-3.5-128b.toml
@@ -1,5 +1,6 @@
 base_model = "mistral/mistral-medium-2604"
 name = "Mistral Medium 3.5 128B"
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
 
 [cost]
 input = 1.5


### PR DESCRIPTION
## Fixed models

| Model | Change | Verdict |
| --- | --- | --- |
| `gpt-oss-120b` | Set `reasoning = true`; keep `effort` values `low`, `medium`, `high` | Kept. Scaleway documents GPT-OSS 120B as reasoning-capable and explicitly says `reasoning_effort = none` is not supported for this model. |
| `mistral-medium-3.5-128b` | Add `effort` values `none`, `high` | Kept. Scaleway's supported-model page lists exactly these reasoning efforts for this model. |
| `glm-5.2` | Restore `effort` values `none`, `low`, `medium`, `high` | Kept under the shared Chat Completions contract. The Scaleway API reference documents the top-level `reasoning_effort` enum and lists model-specific exceptions for Qwen, Mistral Medium, and GPT-OSS only; GLM-5.2 is a reasoning-capable chat model and is not listed as an exception. |
| `gemma-4-26b-a4b-it` | Existing `effort` values `none`, `low`, `medium`, `high` | Kept. Scaleway's supported-model page lists exactly these reasoning efforts. |
| `qwen3.6-35b-a3b` | Existing `effort` values `none`, `low`, `medium`, `high` | Kept. Scaleway's supported-model page and API reference support these values, with the API reference noting `low` and `high` behave similarly to `medium`. |
| `qwen3.5-397b-a17b` | Existing `effort` values `none`, `low`, `medium`, `high` | Kept. Scaleway's supported-model page and API reference support these values, with the API reference noting `low` and `high` behave similarly to `medium`. |

## Reasoning options

- Option type claimed: `effort` only.
- Chat Completions request field/path: top-level `reasoning_effort` on Scaleway Generative APIs requests to `/v1/chat/completions`.
- Responses request field/path, for GPT-OSS 120B only: `reasoning.effort` on `/v1/responses`.
- Generic Chat Completions enum: `none`, `low`, `medium`, `high`.
- No `toggle` or `budget_tokens` option is claimed.

## Evidence

- https://www.scaleway.com/en/developers/api/generative-apis/chat-completions documents the `/v1/chat/completions` top-level `reasoning_effort` request field, enum values `none`, `low`, `medium`, and `high`, and model-specific exceptions for Qwen, Mistral Medium, and GPT-OSS.
- https://www.scaleway.com/en/docs/generative-apis/how-to/query-reasoning-models/ documents that reasoning-capable Scaleway models have reasoning enabled by default, that `reasoning_effort=none` disables reasoning for most models except `gpt-oss-120b`, and that supported `reasoning_effort` values differ by model.
- https://www.scaleway.com/en/developers/api/generative-apis/responses documents the `/v1/responses` `reasoning.effort` field and states the Responses API currently only supports `gpt-oss-120b`.
- https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/#gemma-4-26b-a4b-it documents Gemma-4-26b-a4b-it as a Scaleway model with supported reasoning efforts `none`, `low`, `medium`, and `high`.
- https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/#mistral-medium-35-128b documents Mistral-medium-3.5-128b as a reasoning-capable Scaleway model with supported reasoning efforts `none` and `high`.
- https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/#qwen36-35b-a3b documents Qwen3.6-35b-a3b as a Scaleway model with supported reasoning efforts `none`, `low`, `medium`, and `high`.
- https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/#qwen35-397b-a17b documents Qwen3.5-397b-a17b as a Scaleway model with supported reasoning efforts `none`, `low`, `medium`, and `high`.
- https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/#gpt-oss-120b documents GPT-OSS 120B as a reasoning-capable Scaleway model with supported reasoning efforts `low`, `medium`, and `high`.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: passed
- `bun validate`: passed
- `git diff --check`: passed
