### PR TITLE
[stepfun] Fix reasoning options metadata

### DIFF
--- a/providers/stepfun/models/step-1-32k.toml
+++ b/providers/stepfun/models/step-1-32k.toml
@@ -3,6 +3,7 @@ release_date = "2025-01-01"
 last_updated = "2026-02-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-06"

--- a/providers/stepfun/models/step-2-16k.toml
+++ b/providers/stepfun/models/step-2-16k.toml
@@ -3,6 +3,7 @@ release_date = "2025-01-01"
 last_updated = "2026-02-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-06"

--- a/providers/stepfun/models/step-3.5-flash.toml
+++ b/providers/stepfun/models/step-3.5-flash.toml
@@ -3,6 +3,7 @@ release_date = "2026-01-29"
 last_updated = "2026-06-15"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"


### PR DESCRIPTION
## Summary

- Fixed StepFun models from the audit: `step-1-32k`, `step-2-16k`, and `step-3.5-flash`.
- Added `reasoning_options = []` for each fixed model.
- No provider-exposed user control was verified for these fixed models, so this records reasoning support without claiming selectable `toggle`, `effort`, or `budget_tokens` controls.

## Request Surface

- This PR does not add any selectable option type for the fixed models.
- StepFun's documented effort request fields are `reasoning_effort` for Chat Completions, `output_config.effort` for Messages, and `reasoning.effort` for Responses.
- Documented effort values are `low`, `medium`, and `high` for models that support three tiers; `step-3.5-flash-2603` is documented with `low` and `high` on Chat/Messages; Responses is documented as supporting only `step-3.7-flash`.
- No StepFun `toggle` or `budget_tokens` request field was verified.

## Evidence

- [Chat Completions API](https://platform.stepfun.com/docs/zh/api-reference/chat/chat-completion-create) documents top-level `reasoning_effort`, its `low`/`medium`/`high` values for three-tier models, and `low`/`high` compatibility for `step-3.5-flash-2603`; it also documents returned `reasoning` content for Step reasoning models.
- [Messages API](https://platform.stepfun.com/docs/zh/api-reference/chat/messages-create) documents `output_config.effort` as the Anthropic-compatible request path with the same model-specific effort values, and states undocumented fields should not be sent.
- [Responses API](https://platform.stepfun.com/docs/zh/api-reference/responses/responses-create) documents `reasoning.effort` with `low`/`medium`/`high` and states the Responses endpoint currently supports only `step-3.7-flash`.
- [Step 3.5 Flash model page](https://platform.stepfun.com/docs/zh/guides/models/step-3.5-flash) documents `step-3.5-flash` as StepFun's language reasoning model and separately documents only `step-3.5-flash-2603` as supporting `reasoning_effort` values `low` and `high`.
- [Reasoning model best practices](https://platform.stepfun.com/docs/zh/guides/developer/reasoning) documents that `step-3.5-flash` is a reasoning model and that reasoning output is exposed through the response `reasoning` field, while effort-control examples point to `step-3.7-flash`.
- [Model migration](https://platform.stepfun.com/docs/zh/guides/model-migration) lists `step-1-32k` and `step-2-16k` as legacy models to migrate away from and does not expose any reasoning-control request field for them.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: passed
- `bun validate`: passed
- `git diff --check`: passed
- StepFun invariant check with `bun validate 2>/dev/null | jq -e ...`: `"stepfun invariant ok"`
