### PR TITLE
[friendli] Fix reasoning options metadata

### DIFF
--- a/providers/friendli/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
+++ b/providers/friendli/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
@@ -3,6 +3,7 @@ name = "Qwen3 235B A22B Instruct 2507"
 release_date = "2025-07-29"
 last_updated = "2026-01-29"
 structured_output = true
+reasoning_options = []
 
 [cost]
 input = 0.2


### PR DESCRIPTION
## Fixed Models

- `Qwen/Qwen3-235B-A22B-Instruct-2507`: added `reasoning_options = []` because the model inherits `reasoning = true`, but no Friendli-exposed user-selectable reasoning control was verified for this model.

## Reasoning Options

- No `toggle`, `effort`, or `budget_tokens` option is claimed in this PR.
- Friendli documents the controllable reasoning request path as `chat_template_kwargs.enable_thinking = true | false`, but says support is model-specific and only shows `zai-org/GLM-5.2` as the controllable example. I did not verify that this field is accepted for `Qwen/Qwen3-235B-A22B-Instruct-2507`, so this PR records reasoning support without claiming selectable controls.

## Evidence

- [Friendli Reasoning guide](https://friendli.ai/docs/guides/reasoning) documents the Model APIs Chat Completions endpoint and the only provider-specific controllable reasoning request field I found: `chat_template_kwargs.enable_thinking = true | false`; it also states support for that parameter is model-specific.
- [Friendli public Model APIs metadata](https://friendli.ai/api/public/model-apis) lists `Qwen/Qwen3-235B-A22B-Instruct-2507` as a Friendli Model API with text input/output and pricing, but does not expose any model-specific `enable_thinking`, effort, or reasoning-token budget metadata for that model.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true` passed.
- `bun validate` passed.
- `git diff --check` passed.
- Provider invariant check passed: `friendli reasoning_options invariant passed`.
