### PR TITLE
[snowflake-cortex] Fix reasoning options metadata

### DIFF
--- a/providers/snowflake-cortex/models/claude-fable-5.toml
+++ b/providers/snowflake-cortex/models/claude-fable-5.toml
@@ -1,3 +1,3 @@
 base_model = "anthropic/claude-fable-5"
 
-reasoning_options = [{ type = "budget_tokens" }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]

--- a/providers/snowflake-cortex/models/claude-fable-5.toml
+++ b/providers/snowflake-cortex/models/claude-fable-5.toml
@@ -1,3 +1,3 @@
 base_model = "anthropic/claude-fable-5"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []

--- a/providers/snowflake-cortex/models/claude-fable-5.toml
+++ b/providers/snowflake-cortex/models/claude-fable-5.toml
@@ -1,3 +1,3 @@
 base_model = "anthropic/claude-fable-5"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/snowflake-cortex/models/claude-fable-5.toml
+++ b/providers/snowflake-cortex/models/claude-fable-5.toml
@@ -1,1 +1,3 @@
 base_model = "anthropic/claude-fable-5"
+
+reasoning_options = [{ type = "budget_tokens" }]

--- a/providers/snowflake-cortex/models/claude-haiku-4-5.toml
+++ b/providers/snowflake-cortex/models/claude-haiku-4-5.toml
@@ -1,4 +1,6 @@
 base_model = "anthropic/claude-haiku-4-5"
 
+reasoning_options = [{ type = "budget_tokens" }]
+
 [limit]
 output = 16_384

--- a/providers/snowflake-cortex/models/claude-opus-4-7.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-7.toml
@@ -1,7 +1,7 @@
 base_model = "anthropic/claude-opus-4-7"
 status = "beta"
 
-reasoning_options = [{ type = "budget_tokens" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [experimental.modes.fast]
 cost = { input = 30, output = 150, cache_read = 3, cache_write = 37.5 }

--- a/providers/snowflake-cortex/models/claude-opus-4-7.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-7.toml
@@ -1,7 +1,7 @@
 base_model = "anthropic/claude-opus-4-7"
 status = "beta"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [experimental.modes.fast]
 cost = { input = 30, output = 150, cache_read = 3, cache_write = 37.5 }

--- a/providers/snowflake-cortex/models/claude-opus-4-7.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-7.toml
@@ -1,6 +1,8 @@
 base_model = "anthropic/claude-opus-4-7"
 status = "beta"
 
+reasoning_options = [{ type = "budget_tokens" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+
 [experimental.modes.fast]
 cost = { input = 30, output = 150, cache_read = 3, cache_write = 37.5 }
 provider = { body = { speed = "fast" }, headers = { anthropic-beta = "fast-mode-2026-02-01" } }

--- a/providers/snowflake-cortex/models/claude-opus-4-7.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-7.toml
@@ -1,7 +1,7 @@
 base_model = "anthropic/claude-opus-4-7"
 status = "beta"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 
 [experimental.modes.fast]
 cost = { input = 30, output = 150, cache_read = 3, cache_write = 37.5 }

--- a/providers/snowflake-cortex/models/claude-opus-4-8.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-8.toml
@@ -1,3 +1,3 @@
 base_model = "anthropic/claude-opus-4-8"
 
-reasoning_options = [{ type = "budget_tokens" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]

--- a/providers/snowflake-cortex/models/claude-opus-4-8.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-8.toml
@@ -1,3 +1,3 @@
 base_model = "anthropic/claude-opus-4-8"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/snowflake-cortex/models/claude-opus-4-8.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-8.toml
@@ -1,1 +1,3 @@
 base_model = "anthropic/claude-opus-4-8"
+
+reasoning_options = [{ type = "budget_tokens" }, { type = "effort", values = ["low", "medium", "high", "max"] }]

--- a/providers/snowflake-cortex/models/claude-opus-4-8.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-8.toml
@@ -1,3 +1,3 @@
 base_model = "anthropic/claude-opus-4-8"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []

--- a/providers/snowflake-cortex/models/claude-sonnet-4-5.toml
+++ b/providers/snowflake-cortex/models/claude-sonnet-4-5.toml
@@ -1,4 +1,6 @@
 base_model = "anthropic/claude-sonnet-4-5"
 
+reasoning_options = [{ type = "budget_tokens" }]
+
 [limit]
 output = 16_384

--- a/providers/snowflake-cortex/models/claude-sonnet-4-6.toml
+++ b/providers/snowflake-cortex/models/claude-sonnet-4-6.toml
@@ -1,6 +1,6 @@
 base_model = "anthropic/claude-sonnet-4-6"
 
-reasoning_options = [{ type = "budget_tokens" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "budget_tokens" }]
 
 [limit]
 output = 16_384

--- a/providers/snowflake-cortex/models/claude-sonnet-4-6.toml
+++ b/providers/snowflake-cortex/models/claude-sonnet-4-6.toml
@@ -1,4 +1,6 @@
 base_model = "anthropic/claude-sonnet-4-6"
 
+reasoning_options = [{ type = "budget_tokens" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+
 [limit]
 output = 16_384

--- a/providers/snowflake-cortex/models/deepseek-r1.toml
+++ b/providers/snowflake-cortex/models/deepseek-r1.toml
@@ -1,1 +1,3 @@
 base_model = "deepseek/deepseek-r1"
+
+reasoning_options = []

--- a/providers/snowflake-cortex/models/gemini-3.1-pro.toml
+++ b/providers/snowflake-cortex/models/gemini-3.1-pro.toml
@@ -1,1 +1,3 @@
 base_model = "google/gemini-3.1-pro-preview"
+
+reasoning_options = []

--- a/providers/snowflake-cortex/models/openai-gpt-5-mini.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5-mini.toml
@@ -1,6 +1,8 @@
 base_model = "openai/gpt-5-mini"
 status = "beta"
 
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
+
 [limit]
 context = 272_000
 output = 8_192

--- a/providers/snowflake-cortex/models/openai-gpt-5-nano.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5-nano.toml
@@ -1,2 +1,4 @@
 base_model = "openai/gpt-5-nano"
 status = "beta"
+
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]

--- a/providers/snowflake-cortex/models/openai-gpt-5.1.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5.1.toml
@@ -1,1 +1,3 @@
 base_model = "openai/gpt-5.1"
+
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]

--- a/providers/snowflake-cortex/models/openai-gpt-5.2.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5.2.toml
@@ -1,1 +1,3 @@
 base_model = "openai/gpt-5.2"
+
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]

--- a/providers/snowflake-cortex/models/openai-gpt-5.4.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5.4.toml
@@ -1,6 +1,8 @@
 base_model = "openai/gpt-5.4"
 status = "beta"
 
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
+
 [experimental.modes.fast]
 cost = { input = 5, output = 30, cache_read = 0.5 }
 provider = { body = { service_tier = "priority" } }

--- a/providers/snowflake-cortex/models/openai-gpt-5.5.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5.5.toml
@@ -1,2 +1,4 @@
 base_model = "openai/gpt-5.5"
 status = "beta"
+
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]

--- a/providers/snowflake-cortex/models/openai-gpt-5.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5.toml
@@ -1,2 +1,4 @@
 base_model = "openai/gpt-5"
 status = "beta"
+
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]

--- a/providers/snowflake-cortex/provider.toml
+++ b/providers/snowflake-cortex/provider.toml
@@ -10,8 +10,9 @@ env = ["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_CORTEX_PAT"]
 # max_tokens is the native budget. Adaptive-only Claude models use effort, not a
 # manual thinking-token budget. Other model families ignore all three controls.
 # Anthropic-compatible POST /api/v2/cortex/v1/messages (Claude only): adaptive
-# thinking uses thinking.type = "adaptive" and output_config.effort =
-# "low"|"medium"|"high"|"max" for claude-opus-4-6+ and claude-sonnet-4-6.
+# thinking uses thinking.type = "adaptive" and output_config.effort. Snowflake
+# documents "low"|"medium"|"high"|"max"; Anthropic documents xhigh for
+# Claude Fable 5, Claude Opus 4.7, and Claude Opus 4.8 on this routed surface.
 # Source:
 # https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api
 doc = "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api"

--- a/providers/snowflake-cortex/provider.toml
+++ b/providers/snowflake-cortex/provider.toml
@@ -5,14 +5,11 @@ env = ["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_CORTEX_PAT"]
 # Reasoning HTTP format (accessed 2026-06-25):
 # OpenAI-compatible POST /api/v2/cortex/v1/chat/completions: OpenAI models use
 # top-level reasoning_effort = "none"|"minimal"|"low"|"medium"|"high".
-# Claude budget-capable models use reasoning.effort or reasoning.max_tokens;
-# reasoning_effort is ignored, reasoning.effort is converted to max_tokens, and
-# max_tokens is the native budget. Adaptive-only Claude models use effort, not a
-# manual thinking-token budget. Other model families ignore all three controls.
-# Anthropic-compatible POST /api/v2/cortex/v1/messages (Claude only): adaptive
-# thinking uses thinking.type = "adaptive" and output_config.effort. Snowflake
-# documents "low"|"medium"|"high"|"max"; Anthropic documents xhigh for
-# Claude Fable 5, Claude Opus 4.7, and Claude Opus 4.8 on this routed surface.
+# Claude models use reasoning.max_tokens for manual thinking budgets;
+# reasoning_effort is ignored, and reasoning.effort is converted to max_tokens.
+# Adaptive-only Claude controls are exposed on Snowflake's Messages API, not on
+# this OpenAI-compatible provider surface. Other model families ignore all three
+# reasoning controls.
 # Source:
 # https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api
 doc = "https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api"

--- a/providers/snowflake-cortex/provider.toml
+++ b/providers/snowflake-cortex/provider.toml
@@ -5,9 +5,10 @@ env = ["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_CORTEX_PAT"]
 # Reasoning HTTP format (accessed 2026-06-25):
 # OpenAI-compatible POST /api/v2/cortex/v1/chat/completions: OpenAI models use
 # top-level reasoning_effort = "none"|"minimal"|"low"|"medium"|"high".
-# Claude models use reasoning.effort or reasoning.max_tokens; reasoning_effort
-# is ignored, reasoning.effort is converted to max_tokens, and max_tokens is
-# the native budget. Other model families ignore all three controls.
+# Claude budget-capable models use reasoning.effort or reasoning.max_tokens;
+# reasoning_effort is ignored, reasoning.effort is converted to max_tokens, and
+# max_tokens is the native budget. Adaptive-only Claude models use effort, not a
+# manual thinking-token budget. Other model families ignore all three controls.
 # Anthropic-compatible POST /api/v2/cortex/v1/messages (Claude only): adaptive
 # thinking uses thinking.type = "adaptive" and output_config.effort =
 # "low"|"medium"|"high"|"max" for claude-opus-4-6+ and claude-sonnet-4-6.


### PR DESCRIPTION
## Fixed Models

- OpenAI reasoning models: `openai-gpt-5`, `openai-gpt-5.1`, `openai-gpt-5.2`, `openai-gpt-5.4`, `openai-gpt-5.5`, `openai-gpt-5-mini`, `openai-gpt-5-nano`.
- Claude Chat Completions budget-capable models: `claude-haiku-4-5`, `claude-sonnet-4-5`, `claude-sonnet-4-6`.
- Claude adaptive-only models without a verified Chat Completions control: `claude-fable-5`, `claude-opus-4-7`, `claude-opus-4-8`.
- Other reasoning models with no verified Snowflake Chat Completions control: `deepseek-r1`, `gemini-3.1-pro`.

## Re-Audit Matrix

| Models | Claim | Verdict | Why |
| --- | --- | --- | --- |
| OpenAI GPT-5 family | `effort = [none, minimal, low, medium, high]` | Kept | Snowflake Chat Completions documents top-level `reasoning_effort` for OpenAI reasoning models with these values. |
| `claude-haiku-4-5`, `claude-sonnet-4-5`, `claude-sonnet-4-6` | `budget_tokens` | Kept | Snowflake Chat Completions documents Claude `reasoning.max_tokens`; Sonnet 4.6 still accepts manual thinking budgets upstream, although deprecated. |
| `claude-fable-5`, `claude-opus-4-7`, `claude-opus-4-8` | `[]` | Changed | These are adaptive-only or always-adaptive Claude models. Snowflake documents adaptive `thinking.type = "adaptive"` and `output_config.effort` on the Anthropic Messages API, not the OpenAI-compatible Chat Completions surface represented by this provider entry. |
| `deepseek-r1`, `gemini-3.1-pro` | `[]` | Kept | Snowflake compatibility chart says reasoning fields are ignored for other model families. |

## Evidence

- Snowflake Cortex REST API docs document two separate surfaces: Chat Completions (`/api/v2/cortex/v1/chat/completions`) and Messages (`/api/v2/cortex/v1/messages`). This provider entry is `@ai-sdk/openai-compatible`, so these TOMLs represent the Chat Completions surface: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api#choose-your-api
- Snowflake Chat Completions reasoning docs say Claude models use the `reasoning` object, while OpenAI reasoning models use top-level `reasoning_effort`: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api#thinking-and-reasoning
- Snowflake Chat Completions field docs say `reasoning.max_tokens` is supported for Claude and `reasoning.effort` is converted to `reasoning.max_tokens`; `reasoning_effort` is ignored for Claude: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api#label-cortex-openai-sdk-compatibility
- Snowflake Messages API docs separately document adaptive thinking with `thinking.type = "adaptive"` and `output_config.effort`. Those controls are not recorded in this OpenAI-compatible provider TOML: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api#thinking-and-reasoning
- Anthropic docs state Opus 4.7/4.8 reject manual `budget_tokens`, and Fable 5 is adaptive-only / always-on, so no Chat Completions budget-token claim is made for those models: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking

## Validation

- `bun validate`
- `git diff --check`
- Snowflake Cortex generated-output invariant check passed.
