### PR TITLE
[alibaba-coding-plan-cn] Fix reasoning options metadata

### DIFF
--- a/providers/alibaba-coding-plan-cn/models/qwen3-coder-next.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3-coder-next.toml
@@ -4,7 +4,6 @@ release_date = "2026-02-03"
 last_updated = "2026-02-03"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/alibaba-coding-plan-cn/models/qwen3-coder-plus.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3-coder-plus.toml
@@ -9,7 +9,6 @@ release_date = "2025-07-23"
 last_updated = "2025-07-23"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 knowledge = "2025-04"
 tool_call = true

--- a/providers/alibaba-coding-plan-cn/models/qwen3-max-2026-01-23.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3-max-2026-01-23.toml
@@ -4,7 +4,6 @@ release_date = "2026-01-23"
 last_updated = "2026-01-23"
 attachment = false
 reasoning = false
-reasoning_options = [{ type = "toggle" }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true


### PR DESCRIPTION
## Summary

- Fixed `alibaba-coding-plan-cn` reasoning metadata for `qwen3-max-2026-01-23`, `qwen3-coder-next`, and `qwen3-coder-plus`.
- Removed direct `reasoning_options` from models that are currently marked `reasoning = false`, satisfying the PR #2828 invariant without adding unverified selectable controls.

## Evidence

- [Alibaba Coding Plan overview](https://help.aliyun.com/zh/model-studio/coding-plan) documents that Coding Plan has its own API key and base URLs, including the OpenAI-compatible `https://coding.dashscope.aliyuncs.com/v1`, and lists the fixed model IDs in its exact-string supported model allowlist.
- [Alibaba Qwen Code Coding Plan configuration](https://help.aliyun.com/zh/model-studio/qwen-code) documents the China Coding Plan OpenAI-compatible request surface at `https://coding.dashscope.aliyuncs.com/v1`; its model-specific examples use `generationConfig.extra_body.enable_thinking` where Coding Plan exposes thinking controls, but the fixed model entries do not document a reasoning request control.
- [Alibaba OpenCode Coding Plan configuration](https://help.aliyun.com/zh/model-studio/opencode) documents the Coding Plan Anthropic-compatible base URL and model-specific `thinking` options for some models; the fixed model entries are present without a documented selectable reasoning option.

## Reasoning Options Audit

- This PR does not claim any new `reasoning_options` type for the fixed models.
- For the fixed models, no provider-exposed user control was verified, so the PR removes `reasoning_options` instead of claiming `toggle`, `effort`, or `budget_tokens`.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: passed
- `bun validate`: passed
- `git diff --check`: passed
- One-off generated-data invariant check for `alibaba-coding-plan-cn`: passed
