### PR TITLE
[perplexity-agent] Fix reasoning options metadata

### DIFF
--- a/providers/perplexity-agent/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-haiku-4-5.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-02-28"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 1.00
 output = 5.00

--- a/providers/perplexity-agent/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-haiku-4-5.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-02-28"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 1.00

--- a/providers/perplexity-agent/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-haiku-4-5.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-02-28"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 1.00

--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-5.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-5.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 5.00

--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-5.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-5.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 5.00
 output = 25.00

--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-5.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-5.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-03-31"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5.00

--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-6.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-6.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-05-31"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5.00

--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-6.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-6.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-05-31"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 5.00

--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-6.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-6.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-05-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 5.00
 output = 25.00

--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-7.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-7.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2026-01-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 5.00
 output = 25.00

--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-7.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-7.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2026-01-31"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 5.00

--- a/providers/perplexity-agent/models/anthropic/claude-opus-4-7.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-opus-4-7.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2026-01-31"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5.00

--- a/providers/perplexity-agent/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-sonnet-4-5.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-07-31"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 3.00

--- a/providers/perplexity-agent/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-sonnet-4-5.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-07-31"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 3.00

--- a/providers/perplexity-agent/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-sonnet-4-5.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-07-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/perplexity-agent/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-sonnet-4-6.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 3.00

--- a/providers/perplexity-agent/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-sonnet-4-6.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/perplexity-agent/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/perplexity-agent/models/anthropic/claude-sonnet-4-6.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 3.00

--- a/providers/perplexity-agent/models/google/gemini-2.5-flash.toml
+++ b/providers/perplexity-agent/models/google/gemini-2.5-flash.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.30

--- a/providers/perplexity-agent/models/google/gemini-2.5-flash.toml
+++ b/providers/perplexity-agent/models/google/gemini-2.5-flash.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 0.30

--- a/providers/perplexity-agent/models/google/gemini-2.5-flash.toml
+++ b/providers/perplexity-agent/models/google/gemini-2.5-flash.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 0.30
 output = 2.50

--- a/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
+++ b/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 1.25
 output = 10.00

--- a/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
+++ b/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 1.25

--- a/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
+++ b/providers/perplexity-agent/models/google/gemini-2.5-pro.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.50

--- a/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 0.50
 output = 3.00

--- a/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3-flash-preview.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 0.50

--- a/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 2.00

--- a/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 2.00

--- a/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/perplexity-agent/models/google/gemini-3.1-pro-preview.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 2.00
 output = 12.00

--- a/providers/perplexity-agent/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/perplexity-agent/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -10,9 +10,7 @@ tool_call = true
 knowledge = "2026-02"
 open_weights = true
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/perplexity-agent/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/perplexity-agent/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -10,7 +10,9 @@ tool_call = true
 knowledge = "2026-02"
 open_weights = true
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.25

--- a/providers/perplexity-agent/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/perplexity-agent/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -10,6 +10,10 @@ tool_call = true
 knowledge = "2026-02"
 open_weights = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 0.25
 output = 2.50

--- a/providers/perplexity-agent/models/openai/gpt-5-mini.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5-mini.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2024-05-30"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 0.25
 output = 2.00

--- a/providers/perplexity-agent/models/openai/gpt-5-mini.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5-mini.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2024-05-30"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.25

--- a/providers/perplexity-agent/models/openai/gpt-5-mini.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5-mini.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2024-05-30"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/perplexity-agent/models/openai/gpt-5.1.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.1.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2024-09-30"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 1.25
 output = 10.00

--- a/providers/perplexity-agent/models/openai/gpt-5.1.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.1.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2024-09-30"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/perplexity-agent/models/openai/gpt-5.1.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.1.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2024-09-30"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 1.25

--- a/providers/perplexity-agent/models/openai/gpt-5.2.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.2.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 1.75
 output = 14.00

--- a/providers/perplexity-agent/models/openai/gpt-5.2.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.2.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 1.75

--- a/providers/perplexity-agent/models/openai/gpt-5.2.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.2.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/perplexity-agent/models/openai/gpt-5.4.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.4.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 2.50

--- a/providers/perplexity-agent/models/openai/gpt-5.4.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.4.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 2.50
 output = 15.00

--- a/providers/perplexity-agent/models/openai/gpt-5.4.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.4.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-08-31"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 2.50

--- a/providers/perplexity-agent/models/openai/gpt-5.5.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.5.toml
@@ -9,7 +9,9 @@ tool_call = true
 knowledge = "2025-12-01"
 open_weights = false
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5.00

--- a/providers/perplexity-agent/models/openai/gpt-5.5.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.5.toml
@@ -9,6 +9,10 @@ tool_call = true
 knowledge = "2025-12-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 5.00
 output = 30.00

--- a/providers/perplexity-agent/models/openai/gpt-5.5.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.5.toml
@@ -9,9 +9,7 @@ tool_call = true
 knowledge = "2025-12-01"
 open_weights = false
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []
 
 [cost]
 input = 5.00


### PR DESCRIPTION
## Summary

Fixed all 16 `perplexity-agent` audit failures by adding provider-level `effort` reasoning options to reasoning-capable third-party models served through the Perplexity Agent API:

- `openai/gpt-5.2`, `openai/gpt-5.4`, `openai/gpt-5-mini`, `openai/gpt-5.5`, `openai/gpt-5.1`
- `anthropic/claude-haiku-4-5`, `anthropic/claude-sonnet-4-5`, `anthropic/claude-opus-4-5`, `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-opus-4-7`
- `nvidia/nemotron-3-super-120b-a12b`
- `google/gemini-2.5-pro`, `google/gemini-2.5-flash`, `google/gemini-3-flash-preview`, `google/gemini-3.1-pro-preview`

## Kept / Removed Matrix

| Claim | Models | Verdict | Why |
| --- | --- | --- | --- |
| `effort` values `low`, `medium`, `high`, `xhigh`, `max` via request path `reasoning.effort` | All 16 reasoning-capable `perplexity-agent` models listed above | Kept / restored | Perplexity documents a shared `POST /v1/agent` request contract with `ResponsesRequest.reasoning` and `ReasoningConfig.effort` enum values `low`, `medium`, `high`, `xhigh`, and `max`. The same Agent API accepts third-party `provider/model` IDs through the `model` field, and these TOMLs mark the listed models as reasoning-capable. |
| `toggle` | None | Not claimed | The Perplexity Agent request schema does not document a raw request field or values that explicitly enable and disable reasoning for the same model ID. |
| `budget_tokens` | None | Not claimed | The Perplexity Agent request schema does not document a numeric reasoning-token budget field or supported range. |
| `reasoning_options = []` | None of the 16 changed reasoning-capable models | Removed | The provider-level Agent API contract supports selectable `reasoning.effort`, so these models should not be recorded as always-on/no-control under the corrected audit standard. |

## Evidence

- [Perplexity Create Agent Response API](https://docs.perplexity.ai/api-reference/agent-post.md) documents the raw endpoint `POST /v1/agent`, the request `model` field using `provider/model` IDs such as `openai/gpt-5`, `anthropic/claude-sonnet-4-6`, and the `reasoning` field pointing to `ReasoningConfig`.
- [Perplexity Create Agent Response API](https://docs.perplexity.ai/api-reference/agent-post.md) defines `ReasoningConfig.effort` as the provider request path for reasoning effort and enumerates accepted values `low`, `medium`, `high`, `xhigh`, and `max`.
- [Perplexity Agent API quickstart](https://docs.perplexity.ai/docs/agent-api/quickstart.md) describes the Agent API as a multi-provider interface with reasoning control and shows third-party model calls sent to `https://api.perplexity.ai/v1/agent`.
- [Perplexity Agent API Models](https://docs.perplexity.ai/docs/agent-api/models.md) documents the Agent API's third-party model namespaces for OpenAI, Anthropic, Google, and NVIDIA, and lists the same provider/model ID pattern used by the changed TOMLs.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: passed
- `bun validate`: passed
- `git diff --check`: passed
- Custom generated-catalog invariant check for `perplexity-agent`: passed; no `reasoning = true` models lack `reasoning_options`, and no `reasoning = false` models have `reasoning_options`.
