### PR TITLE
[alibaba-cn] Fix reasoning options metadata

### DIFF
--- a/providers/alibaba-cn/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-cn/models/MiniMax-M2.5.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = true
+reasoning_options = []
 
 [cost]
 input = 0.30

--- a/providers/alibaba-cn/models/MiniMax/MiniMax-M2.7.toml
+++ b/providers/alibaba-cn/models/MiniMax/MiniMax-M2.7.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = true
+reasoning_options = []
 
 [cost]
 input = 0.30

--- a/providers/alibaba-cn/models/deepseek-r1-0528.toml
+++ b/providers/alibaba-cn/models/deepseek-r1-0528.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.574

--- a/providers/alibaba-cn/models/deepseek-r1-distill-llama-70b.toml
+++ b/providers/alibaba-cn/models/deepseek-r1-distill-llama-70b.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.287

--- a/providers/alibaba-cn/models/deepseek-r1-distill-llama-8b.toml
+++ b/providers/alibaba-cn/models/deepseek-r1-distill-llama-8b.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.0

--- a/providers/alibaba-cn/models/deepseek-r1-distill-qwen-1-5b.toml
+++ b/providers/alibaba-cn/models/deepseek-r1-distill-qwen-1-5b.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.0

--- a/providers/alibaba-cn/models/deepseek-r1-distill-qwen-14b.toml
+++ b/providers/alibaba-cn/models/deepseek-r1-distill-qwen-14b.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.144

--- a/providers/alibaba-cn/models/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/alibaba-cn/models/deepseek-r1-distill-qwen-32b.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.287

--- a/providers/alibaba-cn/models/deepseek-r1-distill-qwen-7b.toml
+++ b/providers/alibaba-cn/models/deepseek-r1-distill-qwen-7b.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.072

--- a/providers/alibaba-cn/models/deepseek-r1.toml
+++ b/providers/alibaba-cn/models/deepseek-r1.toml
@@ -7,6 +7,7 @@ reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.574

--- a/providers/alibaba-cn/models/kimi-k2-thinking.toml
+++ b/providers/alibaba-cn/models/kimi-k2-thinking.toml
@@ -9,6 +9,9 @@ tool_call = true
 open_weights = true
 structured_output = true
 
+[[reasoning_options]]
+type = "budget_tokens"
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/alibaba-cn/models/qvq-max.toml
+++ b/providers/alibaba-cn/models/qvq-max.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-04"
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 1.147

--- a/providers/alibaba-cn/models/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/alibaba-cn/models/qwen3-next-80b-a3b-thinking.toml
@@ -9,6 +9,9 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.144
 output = 1.434

--- a/providers/alibaba-cn/models/qwen3-vl-235b-a22b.toml
+++ b/providers/alibaba-cn/models/qwen3-vl-235b-a22b.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2025-04"
 tool_call = true
 open_weights = true
+reasoning_options = []
 
 [cost]
 input = 0.286705

--- a/providers/alibaba-cn/models/qwen3-vl-30b-a3b.toml
+++ b/providers/alibaba-cn/models/qwen3-vl-30b-a3b.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2025-04"
 tool_call = true
 open_weights = true
+reasoning_options = []
 
 [cost]
 input = 0.108

--- a/providers/alibaba-cn/models/qwq-32b.toml
+++ b/providers/alibaba-cn/models/qwq-32b.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-04"
 tool_call = true
 open_weights = true
+reasoning_options = []
 
 [cost]
 input = 0.287

--- a/providers/alibaba-cn/models/qwq-plus.toml
+++ b/providers/alibaba-cn/models/qwq-plus.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-04"
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.230

--- a/providers/alibaba-cn/models/siliconflow/deepseek-r1-0528.toml
+++ b/providers/alibaba-cn/models/siliconflow/deepseek-r1-0528.toml
@@ -8,6 +8,7 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.5


### PR DESCRIPTION
## Summary

Fixes all 18 `alibaba-cn` reasoning metadata consistency failures from the PR #2828 audit.

- Added `budget_tokens` only for `qwen3-next-80b-a3b-thinking` and `kimi-k2-thinking`.
- Added `reasoning_options = []` for fixed-thinking models where no provider-exposed user control was verified: `qwq-plus`, `qwq-32b`, `qvq-max`, `deepseek-r1`, `deepseek-r1-0528`, all listed DeepSeek R1 distill models, `siliconflow/deepseek-r1-0528`, `qwen3-vl-235b-a22b`, `qwen3-vl-30b-a3b`, `MiniMax-M2.5`, and `MiniMax/MiniMax-M2.7`.

## Claimed Options

- `budget_tokens`: DashScope documents `thinking_budget` as the request field for limiting reasoning tokens on the OpenAI-compatible Chat Completions API (`POST /compatible-mode/v1/chat/completions`) and the native DashScope API (`parameters.thinking_budget`). This PR records budget support for `qwen3-next-80b-a3b-thinking` and `kimi-k2-thinking`; no `min` or `max` is recorded because the cited docs direct readers to model cards/model lists for per-model maximums rather than publishing exact bounds on the API page.
- No `toggle` or `effort` options are claimed in this PR.

## Evidence

- [DashScope deep-thinking API docs](https://www.alibabacloud.com/help/en/model-studio/deep-thinking) document `enable_thinking` as the hybrid thinking switch and `thinking_budget` as the reasoning-token cap, and state that `thinking_budget` is supported for Qwen3 thinking mode and Kimi models.
- [DashScope deep-thinking model list](https://help.aliyun.com/zh/model-studio/deep-thinking) classifies `qwen3-next-80b-a3b-thinking`, QwQ, DeepSeek R1/Distill, Kimi thinking, and MiniMax entries as thinking-only where applicable, which supports recording reasoning without claiming a toggle for fixed-thinking models.
- [DashScope vision reasoning docs](https://www.alibabacloud.com/help/en/model-studio/vision) document that `qwen3-vl-plus`/`qwen3-vl-flash` are the Qwen-VL families with a toggleable `enable_thinking`, while `thinking`-suffix Qwen-VL models are mandatory-thinking and `enable_thinking` does not apply to other Qwen-VL models; therefore the two audited Qwen3-VL open-weight entries are recorded without a selectable control.

## Empty Options

For models changed to `reasoning_options = []`, no provider-exposed user control was verified for the exact model family or model ID. The PR records reasoning support to satisfy the invariant without claiming a selectable provider API control.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: completed.
- `bun validate`: passed.
- `git diff --check`: passed.
- Local provider invariant check against generated `alibaba-cn` output: passed.
