### PR TITLE
[stepfun-ai] Fix reasoning options metadata

### DIFF
--- a/providers/stepfun-ai/models/step-3.5-flash.toml
+++ b/providers/stepfun-ai/models/step-3.5-flash.toml
@@ -1,1 +1,24 @@
-../../stepfun/models/step-3.5-flash.toml
+name = "Step 3.5 Flash"
+release_date = "2026-01-29"
+last_updated = "2026-06-15"
+attachment = false
+reasoning = true
+reasoning_options = []
+temperature = true
+tool_call = true
+knowledge = "2025-01"
+open_weights = true
+
+[cost]
+input = 0.1
+output = 0.3
+cache_read = 0.02
+
+[limit]
+context = 256_000
+input = 256_000
+output = 256_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- Fixed `stepfun-ai/step-3.5-flash` by making its model TOML provider-local and adding `reasoning_options = []`.
- No selectable `toggle`, `effort`, or `budget_tokens` control is claimed for `step-3.5-flash`; this records reasoning support without claiming provider-exposed controls.
- Provider scan: `step-3.5-flash-2603` already has effort metadata and was left unchanged.

## Evidence
- [Step Plan reasoning integration](https://platform.stepfun.ai/docs/en/step-plan/integrations/reasoning-api) lists `step-3.5-flash`, `step-3.5-flash-2603`, and `step-3.7-flash` as supported Step Plan reasoning models, and documents raw request endpoints `POST /step_plan/v1/chat/completions` and `POST /step_plan/v1/messages`.
- [Step Plan reasoning integration](https://platform.stepfun.ai/docs/en/step-plan/integrations/reasoning-api) documents the effort request fields for supported effort models: Chat Completions uses top-level `reasoning_effort`; Messages uses `output_config.effort`.
- [Step 3.5 Flash model page](https://platform.stepfun.ai/docs/en/guides/models/step-3.5-flash) describes `step-3.5-flash` as a reasoning model and documents `reasoning_effort` (`low` / `high`) only for `step-3.5-flash-2603`, so no provider-exposed user control was verified for base `step-3.5-flash`.

## Audit conclusion
- `step-3.5-flash`: corrected to `reasoning = true` with `reasoning_options = []`.
- `step-3.5-flash-2603`: existing effort claim remains `low` / `high` via provider request field `reasoning_effort` on Chat Completions and `output_config.effort` on Messages.

## Validation
- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: completed
- `bun validate`: passed
- `git diff --check`: passed
- `bun -e ... stepfun-ai invariant check`: passed
