### PR TITLE
[openrouter] Fix reasoning options metadata

### DIFF
--- a/providers/openrouter/models/cohere/north-mini-code:free.toml
+++ b/providers/openrouter/models/cohere/north-mini-code:free.toml
@@ -1,4 +1,5 @@
 name = "North Mini Code (free)"
+reasoning_options = []
 family = "north"
 release_date = "2026-06-17"
 last_updated = "2026-06-17"

--- a/providers/openrouter/models/google/gemini-3-pro-image.toml
+++ b/providers/openrouter/models/google/gemini-3-pro-image.toml
@@ -1,4 +1,5 @@
 name = "Nano Banana Pro (Gemini 3 Pro Image)"
+reasoning_options = []
 family = "gemini"
 release_date = "2026-06-18"
 last_updated = "2026-06-18"

--- a/providers/openrouter/models/google/gemini-3.1-flash-image.toml
+++ b/providers/openrouter/models/google/gemini-3.1-flash-image.toml
@@ -1,4 +1,5 @@
 name = "Nano Banana 2 (Gemini 3.1 Flash Image)"
+reasoning_options = [{ type = "effort", values = ["high", "minimal"] }]
 family = "gemini"
 release_date = "2026-06-18"
 last_updated = "2026-06-18"

--- a/providers/openrouter/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/openrouter/models/moonshotai/kimi-k2.7-code.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
 temperature = true
 
 [cost]

--- a/providers/openrouter/models/nex-agi/nex-n2-pro.toml
+++ b/providers/openrouter/models/nex-agi/nex-n2-pro.toml
@@ -1,4 +1,5 @@
 name = "Nex-N2-Pro"
+reasoning_options = []
 family = "agi"
 release_date = "2026-06-08"
 last_updated = "2026-06-08"

--- a/providers/openrouter/models/poolside/laguna-m.1.toml
+++ b/providers/openrouter/models/poolside/laguna-m.1.toml
@@ -1,4 +1,5 @@
 name = "Laguna M.1"
+reasoning_options = []
 release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = false

--- a/providers/openrouter/models/poolside/laguna-xs.2.toml
+++ b/providers/openrouter/models/poolside/laguna-xs.2.toml
@@ -1,4 +1,5 @@
 name = "Laguna XS.2"
+reasoning_options = []
 release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = false

--- a/providers/openrouter/models/sakana/fugu-ultra.toml
+++ b/providers/openrouter/models/sakana/fugu-ultra.toml
@@ -1,4 +1,5 @@
 name = "Fugu Ultra"
+reasoning_options = [{ type = "effort", values = ["max", "xhigh", "high"] }]
 release_date = "2026-06-24"
 last_updated = "2026-06-24"
 attachment = true

--- a/providers/openrouter/models/z-ai/glm-5v-turbo.toml
+++ b/providers/openrouter/models/z-ai/glm-5v-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5v-turbo"
+reasoning_options = []
 structured_output = false
 
 [cost]


### PR DESCRIPTION
## Summary

Fixes the OpenRouter reasoning metadata invariant failures for:

- `nex-agi/nex-n2-pro`
- `sakana/fugu-ultra`
- `z-ai/glm-5v-turbo`
- `poolside/laguna-xs.2`
- `poolside/laguna-m.1`
- `google/gemini-3-pro-image`
- `google/gemini-3.1-flash-image`
- `moonshotai/kimi-k2.7-code`
- `cohere/north-mini-code:free`

## Reasoning Options

- Effort: OpenRouter request field is `reasoning.effort`.
- `sakana/fugu-ultra`: accepted effort values are `max`, `xhigh`, and `high`.
- `google/gemini-3.1-flash-image`: accepted effort values are `high` and `minimal`.
- Toggle: no toggle option is claimed in this PR.
- Budget tokens: no `reasoning.max_tokens` / `budget_tokens` option is claimed in this PR.
- `reasoning_options = []` is used for `nex-agi/nex-n2-pro`, `z-ai/glm-5v-turbo`, `poolside/laguna-xs.2`, `poolside/laguna-m.1`, `google/gemini-3-pro-image`, `moonshotai/kimi-k2.7-code`, and `cohere/north-mini-code:free` because OpenRouter verifies reasoning support for those models but I did not verify a provider-exposed selectable effort, toggle, or reasoning-token budget control for them.

## Evidence

- [OpenRouter Reasoning Tokens](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens) documents the unified `reasoning` request object, `reasoning.effort`, `reasoning.max_tokens`, and the per-model `reasoning` metadata semantics, including that omitted `supported_efforts` means the model does not expose effort selection and omitted `supports_max_tokens` means no token-budget control should be shown.
- [OpenRouter List Models API](https://openrouter.ai/docs/api/api-reference/models/get-models) documents `GET /api/v1/models`, the `ModelReasoning` fields `supported_efforts`, `supports_max_tokens`, and `mandatory`, and the gateway `ReasoningEffort` enum.
- `GET https://openrouter.ai/api/v1/models` queried on 2026-06-27 returned `sakana/fugu-ultra.reasoning.supported_efforts = ["max", "xhigh", "high"]`, proving the exact `reasoning.effort` values added for that model.
- `GET https://openrouter.ai/api/v1/models` queried on 2026-06-27 returned `google/gemini-3.1-flash-image.reasoning.supported_efforts = ["high", "minimal"]`, proving the exact `reasoning.effort` values added for that model.
- `GET https://openrouter.ai/api/v1/models` queried on 2026-06-27 returned `reasoning` metadata for the other fixed models but did not return `supported_efforts` or `supports_max_tokens` for them, so this PR records reasoning support without claiming selectable controls.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true` completed.
- `bun validate` passed.
- `git diff --check` passed.
- OpenRouter-only PR #2828 invariant check passed: every OpenRouter model with `reasoning = true` has `reasoning_options`, and no OpenRouter model with `reasoning = false` has `reasoning_options`.
