### PR TITLE
[sap-ai-core] Fix reasoning options metadata

### DIFF
--- a/providers/sap-ai-core/models/anthropic--claude-3.7-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-3.7-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-24"
 last_updated = "2025-02-24"
 attachment = true
 reasoning = true
+# Bedrock Invoke body: $.thinking = {"type":"enabled","budget_tokens":N} or {"type":"disabled"}, with N >= 1024 and N < $.max_tokens. Bedrock Converse nests that object at $.additionalModelRequestFields.thinking. https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#converse-additional-model-request-fields (accessed 2026-06-25)
 reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true

--- a/providers/sap-ai-core/models/anthropic--claude-3.7-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-3.7-sonnet.toml
@@ -4,7 +4,7 @@ release_date = "2025-02-24"
 last_updated = "2025-02-24"
 attachment = true
 reasoning = true
-# Bedrock Invoke body: $.thinking = {"type":"enabled","budget_tokens":N} or {"type":"disabled"}, with N >= 1024 and N < $.max_tokens. Bedrock Converse nests that object at $.additionalModelRequestFields.thinking. https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#converse-additional-model-request-fields (accessed 2026-06-25)
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2024-10-31"

--- a/providers/sap-ai-core/models/anthropic--claude-4-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4-opus.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/sap-ai-core/models/anthropic--claude-4-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/sap-ai-core/models/anthropic--claude-4.5-haiku.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.5-haiku.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 knowledge = "2025-02-28"
 tool_call = true

--- a/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-05"

--- a/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-05"

--- a/providers/sap-ai-core/models/anthropic--claude-4.5-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.5-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-07-31"

--- a/providers/sap-ai-core/models/anthropic--claude-4.6-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-opus.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+# Bedrock Claude 4.6 prefers $.thinking.type = "adaptive" plus $.output_config.effort = "low"|"medium"|"high"|"max"; manual enabled budget_tokens >= 1024 is deprecated. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true

--- a/providers/sap-ai-core/models/anthropic--claude-4.6-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-opus.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
-# Bedrock Claude 4.6 prefers $.thinking.type = "adaptive" plus $.output_config.effort = "low"|"medium"|"high"|"max"; manual enabled budget_tokens >= 1024 is deprecated. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-05"

--- a/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
+# Bedrock Claude 4.6 prefers $.thinking.type = "adaptive" plus $.output_config.effort = "low"|"medium"|"high"; manual enabled budget_tokens >= 1024 is deprecated. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true

--- a/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
@@ -5,7 +5,7 @@ last_updated = "2026-03-13"
 attachment = true
 reasoning = true
 # Bedrock Claude 4.6 prefers $.thinking.type = "adaptive" plus $.output_config.effort = "low"|"medium"|"high"; manual enabled budget_tokens >= 1024 is deprecated. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-08"

--- a/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-03-13"
 attachment = true
 reasoning = true
-# Bedrock Claude 4.6 prefers $.thinking.type = "adaptive" plus $.output_config.effort = "low"|"medium"|"high"; manual enabled budget_tokens >= 1024 is deprecated. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-08"

--- a/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
-# Bedrock Claude 4.7 uses $.thinking.type = "adaptive" and $.output_config.effort = "low"|"medium"|"high"|"xhigh"|"max"; manual budget_tokens is rejected. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
@@ -4,8 +4,8 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
-# Bedrock Claude 4.7 uses $.thinking.type = "adaptive" and $.output_config.effort = "low"|"medium"|"high"|"xhigh"|"max"; manual budget_tokens is rejected. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+# Bedrock Claude 4.7 uses $.thinking.type = "adaptive" and $.output_config.effort; manual budget_tokens is rejected. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-16"
 last_updated = "2026-04-16"
 attachment = true
 reasoning = true
+# Bedrock Claude 4.7 uses $.thinking.type = "adaptive" and $.output_config.effort = "low"|"medium"|"high"|"xhigh"|"max"; manual budget_tokens is rejected. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true

--- a/providers/sap-ai-core/models/gemini-2.5-flash-lite.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-flash-lite.toml
@@ -4,7 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-# Vertex Gemini adapter: $.generationConfig.thinkingConfig.thinkingBudget is 0 (off), -1 (dynamic), or 512..24576. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-06-25)
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 512, max = 24_576 }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/sap-ai-core/models/gemini-2.5-flash-lite.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-flash-lite.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+# Vertex Gemini adapter: $.generationConfig.thinkingConfig.thinkingBudget is 0 (off), -1 (dynamic), or 512..24576. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-06-25)
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 512, max = 24_576 }]
 temperature = true
 knowledge = "2025-01"

--- a/providers/sap-ai-core/models/gemini-2.5-flash.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-flash.toml
@@ -4,7 +4,7 @@ release_date = "2025-04-17"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-# Vertex Gemini adapter: $.generationConfig.thinkingConfig.thinkingBudget is 0 (off), -1 (dynamic), or 1..24576. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-06-25)
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/sap-ai-core/models/gemini-2.5-flash.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-17"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+# Vertex Gemini adapter: $.generationConfig.thinkingConfig.thinkingBudget is 0 (off), -1 (dynamic), or 1..24576. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-06-25)
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
 temperature = true
 knowledge = "2025-01"

--- a/providers/sap-ai-core/models/gemini-2.5-pro.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-03-25"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
+# Vertex Gemini adapter: $.generationConfig.thinkingConfig.thinkingBudget is -1 (dynamic) or 128..32768; 0/off is unsupported. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-06-25)
 reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 knowledge = "2025-01"

--- a/providers/sap-ai-core/models/gemini-2.5-pro.toml
+++ b/providers/sap-ai-core/models/gemini-2.5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2025-03-25"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-# Vertex Gemini adapter: $.generationConfig.thinkingConfig.thinkingBudget is -1 (dynamic) or 128..32768; 0/off is unsupported. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-06-25)
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/sap-ai-core/models/gpt-5-mini.toml
+++ b/providers/sap-ai-core/models/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/sap-ai-core/models/gpt-5-nano.toml
+++ b/providers/sap-ai-core/models/gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/sap-ai-core/models/gpt-5.4.toml
+++ b/providers/sap-ai-core/models/gpt-5.4.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+# Azure OpenAI deployment adapter: raw Chat uses top-level $.reasoning_effort = "none"|"low"|"medium"|"high"|"xhigh"; "none" is off. https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning (accessed 2026-06-25)
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"

--- a/providers/sap-ai-core/models/gpt-5.4.toml
+++ b/providers/sap-ai-core/models/gpt-5.4.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
-# Azure OpenAI deployment adapter: raw Chat uses top-level $.reasoning_effort = "none"|"low"|"medium"|"high"|"xhigh"; "none" is off. https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning (accessed 2026-06-25)
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/sap-ai-core/models/gpt-5.5.toml
+++ b/providers/sap-ai-core/models/gpt-5.5.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-23"
 attachment = true
 reasoning = true
-# Azure OpenAI deployment adapter: raw Chat uses top-level $.reasoning_effort = "none"|"low"|"medium"|"high"|"xhigh"; "none" is off. https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning (accessed 2026-06-25)
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-12-01"
 tool_call = true

--- a/providers/sap-ai-core/models/gpt-5.5.toml
+++ b/providers/sap-ai-core/models/gpt-5.5.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-23"
 last_updated = "2026-04-23"
 attachment = true
 reasoning = true
+# Azure OpenAI deployment adapter: raw Chat uses top-level $.reasoning_effort = "none"|"low"|"medium"|"high"|"xhigh"; "none" is off. https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning (accessed 2026-06-25)
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-12-01"

--- a/providers/sap-ai-core/models/gpt-5.toml
+++ b/providers/sap-ai-core/models/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+# Azure OpenAI deployment adapter: raw Chat uses top-level $.reasoning_effort = "minimal"|"low"|"medium"|"high"; there is no explicit off value for original gpt-5. https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning (accessed 2026-06-25)
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"

--- a/providers/sap-ai-core/models/gpt-5.toml
+++ b/providers/sap-ai-core/models/gpt-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-# Azure OpenAI deployment adapter: raw Chat uses top-level $.reasoning_effort = "minimal"|"low"|"medium"|"high"; there is no explicit off value for original gpt-5. https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning (accessed 2026-06-25)
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/sap-ai-core/models/sonar-deep-research.toml
+++ b/providers/sap-ai-core/models/sonar-deep-research.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-01"
 last_updated = "2025-09-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = false
 tool_call = false
 knowledge = "2025-01"

--- a/providers/sap-ai-core/provider.toml
+++ b/providers/sap-ai-core/provider.toml
@@ -1,4 +1,5 @@
 name = "SAP AI Core"
 env = ["AICORE_SERVICE_KEY"]
 npm = "@jerome-benoit/sap-ai-provider-v2"
+# Raw orchestration v2 nests routed controls at $.config.modules.prompt_templating.model.params.<field>; for example, reasoning_effort stays under params rather than at request root. https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/orchestration-workflow-v2 (accessed 2026-06-25)
 doc = "https://help.sap.com/docs/sap-ai-core"

--- a/providers/sap-ai-core/provider.toml
+++ b/providers/sap-ai-core/provider.toml
@@ -1,5 +1,4 @@
 name = "SAP AI Core"
 env = ["AICORE_SERVICE_KEY"]
 npm = "@jerome-benoit/sap-ai-provider-v2"
-# Raw orchestration v2 nests routed controls at $.config.modules.prompt_templating.model.params.<field>; for example, reasoning_effort stays under params rather than at request root. https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/orchestration-workflow-v2 (accessed 2026-06-25)
 doc = "https://help.sap.com/docs/sap-ai-core"


### PR DESCRIPTION
## Summary

Fixes all 18 `sap-ai-core` reasoning metadata failures by adding `reasoning_options` to every `reasoning = true` model listed in the PR #2828 audit, then re-audits the selectable claims against SAP AI Core request-surface evidence.

Fixed models: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.4`, `gpt-5.5`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `sonar-deep-research`, `anthropic--claude-3.7-sonnet`, `anthropic--claude-4-opus`, `anthropic--claude-4-sonnet`, `anthropic--claude-4.5-haiku`, `anthropic--claude-4.5-opus`, `anthropic--claude-4.5-sonnet`, `anthropic--claude-4.6-opus`, `anthropic--claude-4.6-sonnet`, and `anthropic--claude-4.7-opus`.

## Request Fields

- SAP AI Core orchestration exposes routed model request controls under `config.modules.prompt_templating.model.params.<field>` through `promptTemplating.model.params` custom settings.
- Azure OpenAI GPT models use `params.reasoning_effort`.
- Gemini models use `params.generationConfig.thinkingConfig.thinkingBudget`.
- Anthropic Claude models use `params.thinking` and, for adaptive-effort models, `params.output_config.effort`.
- Perplexity Sonar Deep Research uses `params.reasoning_effort`.

## Options

- `gpt-5`, `gpt-5-mini`, `gpt-5-nano`: `effort` values `minimal`, `low`, `medium`, `high`.
- `gpt-5.4`, `gpt-5.5`: `effort` values `none`, `low`, `medium`, `high`, `xhigh`.
- `gemini-2.5-pro`: `budget_tokens` range `128..32768`.
- `gemini-2.5-flash`: `toggle` via `thinkingBudget = 0`; `budget_tokens` range `0..24576`.
- `gemini-2.5-flash-lite`: `toggle` via `thinkingBudget = 0`; `budget_tokens` range `512..24576`.
- `sonar-deep-research`: `effort` values `minimal`, `low`, `medium`, `high`.
- Claude 3.7/4/4.5 manual-thinking models: `budget_tokens` minimum `1024`.
- `anthropic--claude-4.6-opus`: `effort` values `low`, `medium`, `high`, `max`, plus deprecated-but-supported `budget_tokens` minimum `1024`.
- `anthropic--claude-4.6-sonnet`: `effort` values `low`, `medium`, `high`, plus deprecated-but-supported `budget_tokens` minimum `1024`.
- `anthropic--claude-4.7-opus`: `effort` values `low`, `medium`, `high`.

No `reasoning_options = []` entries were used because provider-exposed controls were verified for every fixed reasoning model.

## Re-audit Corrections

- Removed the `effort` claim from `anthropic--claude-4.5-opus` because the re-audit did not find official SAP/Bedrock request-surface evidence for `output_config.effort` on that SAP-routed model; the Bedrock-documented `thinking.budget_tokens` claim remains.
- Removed `max` from `anthropic--claude-4.6-sonnet` because Bedrock documents `max` as Opus 4.6-only.
- Removed `xhigh` and `max` from `anthropic--claude-4.7-opus` because Bedrock-specific adaptive-thinking docs only verify `low`, `medium`, and `high` for the relevant SAP-routed request surface.

## Evidence

- [SAP Cloud SDK for AI orchestration chat completion](https://sap.github.io/ai-sdk/docs/js/orchestration/chat-completion) documents SAP AI Core orchestration, `promptTemplating.model.params` custom model settings, and harmonized access to Azure OpenAI, AWS Anthropic Claude, GCP Gemini, and Perplexity Sonar models.
- [Azure OpenAI reasoning guide](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/reasoning) documents Chat Completions `reasoning_effort` and GPT-5 reasoning-model behavior.
- [Azure `ReasoningEffort` type](https://learn.microsoft.com/en-us/javascript/api/@azure/ai-projects/reasoningeffort?view=azure-node-preview) documents Azure reasoning effort values `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`, with model-family restrictions.
- [Vertex AI Gemini thinking](https://cloud.google.com/vertex-ai/generative-ai/docs/thinking) documents `generationConfig.thinkingConfig.thinkingBudget`, including `0` to disable thinking on supported Flash models and model-specific budget ranges.
- [Amazon Bedrock extended thinking](https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html) documents Bedrock Claude `thinking.type = "enabled"` with `budget_tokens`, supported Claude 3.7/4/4.5/4.6 model IDs, and the manual-thinking deprecation on Claude 4.6.
- [Amazon Bedrock adaptive thinking](https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html) documents Bedrock `thinking.type = "adaptive"`, `output_config.effort`, the `additionalModelRequestFields` path for Converse, `low|medium|high`, and `max` as Claude Opus 4.6-only.
- [Perplexity Sonar API reference](https://docs.perplexity.ai/api-reference/sonar-post.md) documents `sonar-deep-research`, `reasoning_effort` values `minimal`, `low`, `medium`, `high`, and `usage.reasoning_tokens`.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: passed.
- `bun validate`: passed.
- `git diff --check`: passed.
- Focused Bun TOML scan for `sap-ai-core` PR #2828 invariants: passed (`reasoning=true` models have `reasoning_options`; `reasoning=false` models do not).
