### PR TITLE
[llmgateway] Fix reasoning options metadata

### DIFF
--- a/providers/llmgateway/models/claude-haiku-4-5-20251001.toml
+++ b/providers/llmgateway/models/claude-haiku-4-5-20251001.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5-20251001"
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/llmgateway/models/claude-haiku-4-5.toml
+++ b/providers/llmgateway/models/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/llmgateway/models/deepseek-v4-flash.toml
+++ b/providers/llmgateway/models/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/deepseek-v4-pro.toml
+++ b/providers/llmgateway/models/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/fugu-ultra.toml
+++ b/providers/llmgateway/models/fugu-ultra.toml
@@ -3,6 +3,7 @@ release_date = "2026-06-22"
 last_updated = "2026-06-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/llmgateway/models/gemini-2.5-flash-lite.toml
+++ b/providers/llmgateway/models/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/llmgateway/models/gemma-4-26b-a4b-it.toml
+++ b/providers/llmgateway/models/gemma-4-26b-a4b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = []
 
 [cost]
 input = 0.07

--- a/providers/llmgateway/models/gemma-4-31b-it.toml
+++ b/providers/llmgateway/models/gemma-4-31b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = []
 
 [cost]
 input = 0.13

--- a/providers/llmgateway/models/glm-4.7-flash-free.toml
+++ b/providers/llmgateway/models/glm-4.7-flash-free.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/llmgateway/models/glm-5.2.toml
+++ b/providers/llmgateway/models/glm-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/glm-5.2.toml
+++ b/providers/llmgateway/models/glm-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/llmgateway/models/qwen-flash.toml
+++ b/providers/llmgateway/models/qwen-flash.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen-flash"
+reasoning_options = []
 
 [cost]
 input = 0.05

--- a/providers/llmgateway/models/qwen-plus.toml
+++ b/providers/llmgateway/models/qwen-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen-plus"
+reasoning_options = []
 
 [cost]
 input = 0.4

--- a/providers/llmgateway/models/qwen-turbo.toml
+++ b/providers/llmgateway/models/qwen-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen-turbo"
+reasoning_options = []
 
 [cost]
 input = 0.05

--- a/providers/llmgateway/models/qwen3-235b-a22b-fp8.toml
+++ b/providers/llmgateway/models/qwen3-235b-a22b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-28"
 last_updated = "2025-04-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/llmgateway/models/qwen3-235b-a22b-thinking-2507.toml
@@ -4,6 +4,7 @@ release_date = "2025-07-08"
 last_updated = "2025-07-08"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-32b.toml
+++ b/providers/llmgateway/models/qwen3-32b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-32b"
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/llmgateway/models/qwen3-4b-fp8.toml
+++ b/providers/llmgateway/models/qwen3-4b-fp8.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-28"
 last_updated = "2025-04-28"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-coder-next.toml
+++ b/providers/llmgateway/models/qwen3-coder-next.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-max-2026-01-23.toml
+++ b/providers/llmgateway/models/qwen3-max-2026-01-23.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-23"
 last_updated = "2026-01-23"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/llmgateway/models/qwen3-next-80b-a3b-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-next-80b-a3b-thinking"
+reasoning_options = []
 
 [cost]
 input = 0.15

--- a/providers/llmgateway/models/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/llmgateway/models/qwen3-vl-235b-a22b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-vl-30b-a3b-thinking.toml
+++ b/providers/llmgateway/models/qwen3-vl-30b-a3b-thinking.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-02"
 last_updated = "2025-10-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/llmgateway/models/qwen3-vl-plus.toml
+++ b/providers/llmgateway/models/qwen3-vl-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-vl-plus"
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/llmgateway/models/qwen3.5-9b.toml
+++ b/providers/llmgateway/models/qwen3.5-9b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-9b"
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/llmgateway/models/qwen3.6-35b-a3b.toml
+++ b/providers/llmgateway/models/qwen3.6-35b-a3b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = []
 
 [cost]
 input = 0.248

--- a/providers/llmgateway/models/qwen3.6-max-preview.toml
+++ b/providers/llmgateway/models/qwen3.6-max-preview.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-max-preview"
+reasoning_options = []
 
 [cost]
 input = 1.3

--- a/providers/llmgateway/models/qwen3.6-plus.toml
+++ b/providers/llmgateway/models/qwen3.6-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-plus"
+reasoning_options = []
 
 [cost]
 input = 0.5

--- a/providers/llmgateway/models/qwen3.7-max.toml
+++ b/providers/llmgateway/models/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/llmgateway/models/qwen3.7-plus.toml
+++ b/providers/llmgateway/models/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+reasoning_options = []
 
 [cost]
 input = 0.4

--- a/providers/llmgateway/models/qwen35-397b-a17b.toml
+++ b/providers/llmgateway/models/qwen35-397b-a17b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-397b-a17b"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/llmgateway/models/qwq-plus.toml
+++ b/providers/llmgateway/models/qwq-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwq-plus"
+reasoning_options = []
 
 [cost]
 input = 0.8


### PR DESCRIPTION
## Summary

Fixes the LLM Gateway reasoning metadata invariant for all audited failures from PR #2828.

## Reasoning Options

For `glm-5.2`, this PR now claims `effort` values rather than `toggle` only.

- Request field/path: top-level JSON `reasoning_effort` on `POST /v1/chat/completions`.
- Values: `none`, `low`, `medium`, `high`, `xhigh`, `max`.
- `none` disables reasoning for non-OpenAI providers according to LLM Gateway docs.
- `minimal` is not claimed for GLM-5.2 because LLM Gateway docs reserve it for GPT-5 models.

For the other fixed models, this PR uses `reasoning_options = []`. Exact selectable controls were not verified for those model IDs, so the PR records reasoning support without claiming controls.

## Evidence

- [LLM Gateway reasoning docs](https://docs.llmgateway.io/features/reasoning) document reasoning-capable models, top-level `reasoning_effort`, Z.AI reasoning models, and that `reasoning_effort: "none"` disables reasoning for non-OpenAI providers.
- [LLM Gateway chat completions API](https://docs.llmgateway.io/v1_chat_completions) documents `POST /v1/chat/completions`, `reasoning_effort`, and accepted enum values `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
- [LLM Gateway GLM-5.2 page](https://llmgateway.io/models/glm-5.2) documents exact provider model ID `glm-5.2` as a reasoning-capable model.
- [LLM Gateway models API](https://docs.llmgateway.io/v1_models) documents per-model metadata including `supported_parameters`; public `/v1/models` metadata includes `reasoning_effort` for GLM-5.2 provider mappings.

## Validation

- `bun validate`
- `git diff --check`
- LLM Gateway invariant check passed.
