### PR TITLE
[huggingface] Fix reasoning options metadata

### DIFF
--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M2.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M2.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/huggingface/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/huggingface/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = []
 structured_output = true
 
 [cost]

--- a/providers/huggingface/models/Qwen/Qwen3-235B-A22B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-235B-A22B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-235b-a22b"
+reasoning_options = []
 structured_output = true
 
 [cost]

--- a/providers/huggingface/models/Qwen/Qwen3-32B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-32B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-32b"
+reasoning_options = []
 structured_output = true
 
 [cost]

--- a/providers/huggingface/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.toml
@@ -4,7 +4,6 @@ release_date = "2025-07-23"
 last_updated = "2025-07-23"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/Qwen/Qwen3-Coder-Next.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Coder-Next.toml
@@ -4,7 +4,6 @@ release_date = "2026-02-03"
 last_updated = "2026-02-03"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/Qwen/Qwen3-Embedding-4B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Embedding-4B.toml
@@ -4,7 +4,6 @@ release_date = "2025-01-01"
 last_updated = "2025-01-01"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = false
 knowledge = "2024-12"
 tool_call = false

--- a/providers/huggingface/models/Qwen/Qwen3-Embedding-8B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Embedding-8B.toml
@@ -4,7 +4,6 @@ release_date = "2025-01-01"
 last_updated = "2025-01-01"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = false
 knowledge = "2024-12"
 tool_call = false

--- a/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
@@ -4,7 +4,6 @@ release_date = "2025-09-11"
 last_updated = "2025-09-11"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
+++ b/providers/huggingface/models/Qwen/Qwen3-Next-80B-A3B-Thinking.toml
@@ -4,7 +4,6 @@ release_date = "2025-09-11"
 last_updated = "2025-09-11"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-122B-A10B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-122b-a10b"
+reasoning_options = []
 
 [cost]
 input = 0.4

--- a/providers/huggingface/models/Qwen/Qwen3.5-27B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-27B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-27b"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/huggingface/models/Qwen/Qwen3.5-35B-A3B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-35B-A3B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-35b-a3b"
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/huggingface/models/Qwen/Qwen3.5-9B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.5-9B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-9b"
+reasoning_options = []
 attachment = true
 
 [cost]

--- a/providers/huggingface/models/Qwen/Qwen3.6-27B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.6-27B.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.6-27b"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 0.47

--- a/providers/huggingface/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/huggingface/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = []
 
 [cost]
 input = 0.15

--- a/providers/huggingface/models/XiaomiMiMo/MiMo-V2.5-Pro.toml
+++ b/providers/huggingface/models/XiaomiMiMo/MiMo-V2.5-Pro.toml
@@ -1,5 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 structured_output = true
 
 [cost]

--- a/providers/huggingface/models/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/huggingface/models/deepseek-ai/DeepSeek-R1.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-r1"
+reasoning_options = []
 structured_output = true
 
 [cost]

--- a/providers/huggingface/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/huggingface/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
 
 [cost]
 input = 0.14

--- a/providers/huggingface/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/huggingface/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/huggingface/models/google/gemma-4-26B-A4B-it.toml
+++ b/providers/huggingface/models/google/gemma-4-26B-A4B-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = []
 
 [cost]
 input = 0.13

--- a/providers/huggingface/models/google/gemma-4-31B-it.toml
+++ b/providers/huggingface/models/google/gemma-4-31B-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = []
 
 [cost]
 input = 0.14

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Instruct-0905.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Instruct-0905.toml
@@ -4,7 +4,6 @@ release_date = "2025-09-04"
 last_updated = "2025-09-04"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/huggingface/models/moonshotai/Kimi-K2-Instruct.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2-Instruct.toml
@@ -4,7 +4,6 @@ release_date = "2025-07-14"
 last_updated = "2025-07-14"
 attachment = false
 reasoning = false
-reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-10"

--- a/providers/huggingface/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/huggingface/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
 
 [cost]
 input = 0.95

--- a/providers/huggingface/models/stepfun-ai/Step-3.5-Flash.toml
+++ b/providers/huggingface/models/stepfun-ai/Step-3.5-Flash.toml
@@ -1,5 +1,6 @@
 base_model = "stepfun/step-3.5-flash"
 base_model_omit = ["limit.input"]
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/huggingface/models/zai-org/GLM-4.5-Air.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.5-Air.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
+reasoning_options = []
 
 [cost]
 input = 0.13

--- a/providers/huggingface/models/zai-org/GLM-4.5.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/huggingface/models/zai-org/GLM-4.5V.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.5V.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5v"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/huggingface/models/zai-org/GLM-4.6.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6"
+reasoning_options = []
 
 [cost]
 input = 0.55

--- a/providers/huggingface/models/zai-org/GLM-4.7.toml
+++ b/providers/huggingface/models/zai-org/GLM-4.7.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/huggingface/models/zai-org/GLM-5.2.toml
+++ b/providers/huggingface/models/zai-org/GLM-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+reasoning_options = []
 
 [cost]
 input = 1.4


### PR DESCRIPTION
## Summary

- Fixes the audited Hugging Face `reasoning` / `reasoning_options` consistency failures.
- Adds `reasoning_options = []` to reasoning models where no model-specific Hugging Face user control was verified.
- Removes `reasoning_options` from models marked `reasoning = false`.
- Corrects related provider-scoped claims by removing unverified toggle controls and dropping the undocumented `max` effort value.

## Fixed models

Added `reasoning_options = []`:

- `MiniMaxAI/MiniMax-M2`
- `MiniMaxAI/MiniMax-M3`
- `zai-org/GLM-4.5`
- `zai-org/GLM-4.5-Air`
- `zai-org/GLM-4.5V`
- `zai-org/GLM-5.2`
- `zai-org/GLM-4.6`
- `Qwen/Qwen3.5-122B-A10B`
- `Qwen/Qwen3.5-35B-A3B`
- `Qwen/Qwen3-32B`
- `Qwen/Qwen3-235B-A22B`
- `Qwen/Qwen3.5-9B`
- `Qwen/Qwen3.5-27B`
- `Qwen/Qwen3.6-35B-A3B`
- `deepseek-ai/DeepSeek-R1`
- `deepseek-ai/DeepSeek-V4-Flash`
- `google/gemma-4-31B-it`
- `google/gemma-4-26B-A4B-it`
- `stepfun-ai/Step-3.5-Flash`
- `moonshotai/Kimi-K2.7-Code`

Removed `reasoning_options` because `reasoning = false`:

- `Qwen/Qwen3-Next-80B-A3B-Instruct`
- `Qwen/Qwen3-Next-80B-A3B-Thinking`
- `Qwen/Qwen3-Embedding-4B`
- `Qwen/Qwen3-Embedding-8B`
- `Qwen/Qwen3-Coder-Next`
- `Qwen/Qwen3-Coder-480B-A35B-Instruct`
- `moonshotai/Kimi-K2-Instruct-0905`
- `moonshotai/Kimi-K2-Instruct`

Corrected related option claims:

- `zai-org/GLM-4.7`: removed unverified `toggle`.
- `Qwen/Qwen3.6-27B`: removed unverified `toggle`.
- `XiaomiMiMo/MiMo-V2.5-Pro`: removed unverified `toggle`.
- `deepseek-ai/DeepSeek-V4-Pro`: removed undocumented `max`, retaining only documented `high` effort.

## Request Surface

- `effort`: Hugging Face Chat Completion accepts top-level `reasoning_effort`. The documented common values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`; current Hugging Face metadata only claims documented values already present for retained effort entries: `none`, `low`, `medium`, and `high`.
- `toggle`: no Hugging Face toggle option is claimed after this change; no shared Hugging Face raw request field for enabling and disabling reasoning was verified.
- `budget_tokens`: no Hugging Face budget-token option is claimed; no shared Hugging Face numeric reasoning-budget field was verified.
- For models changed to `reasoning_options = []`, no provider-exposed model-specific user control was verified, so this records reasoning support without claiming selectable controls.

## Evidence

- [Hugging Face Chat Completion docs](https://huggingface.co/docs/inference-providers/en/tasks/chat-completion) document the OpenAI-compatible chat payload, including top-level `reasoning_effort`, its common values, and that support/defaults are provider- and model-dependent. Accessed 2026-06-27.
- [Hugging Face Inference Providers overview](https://huggingface.co/docs/inference-providers/en/index) documents the router `https://router.huggingface.co/v1` and server-side provider selection for OpenAI-compatible chat completions, so reasoning controls must be verified as Hugging Face router request-surface capabilities rather than copied from upstream model facts. Accessed 2026-06-27.
- [Hugging Face Hub API docs](https://huggingface.co/docs/inference-providers/main/en/hub-api) document provider routing metadata for models, but do not expose per-model toggle or numeric reasoning-budget controls; this supports using empty `reasoning_options` where no model-specific control was verified. Accessed 2026-06-27.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: completed.
- `bun validate`: passed.
- `git diff --check`: passed.
- Local invariant check: `huggingface invariant ok: 49 models`.
