### PR TITLE
[alibaba] Fix reasoning options metadata

### DIFF
--- a/providers/alibaba/models/qvq-max.toml
+++ b/providers/alibaba/models/qvq-max.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-04"
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 1.2

--- a/providers/alibaba/models/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/alibaba/models/qwen3-next-80b-a3b-thinking.toml
@@ -9,6 +9,9 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.5
 output = 6

--- a/providers/alibaba/models/qwen3-vl-235b-a22b.toml
+++ b/providers/alibaba/models/qwen3-vl-235b-a22b.toml
@@ -9,6 +9,9 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.7
 output = 2.8

--- a/providers/alibaba/models/qwen3-vl-30b-a3b.toml
+++ b/providers/alibaba/models/qwen3-vl-30b-a3b.toml
@@ -9,6 +9,9 @@ knowledge = "2025-04"
 tool_call = true
 open_weights = true
 
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.2
 output = 0.8

--- a/providers/alibaba/models/qwq-plus.toml
+++ b/providers/alibaba/models/qwq-plus.toml
@@ -8,6 +8,7 @@ temperature = true
 knowledge = "2024-04"
 tool_call = true
 open_weights = false
+reasoning_options = []
 
 [cost]
 input = 0.8


### PR DESCRIPTION
## Summary

Fixes Alibaba reasoning metadata for the five audited PR #2828 invariant failures:

- `qwq-plus`: adds `reasoning_options = []`.
- `qvq-max`: adds `reasoning_options = []`.
- `qwen3-next-80b-a3b-thinking`: adds `budget_tokens`.
- `qwen3-vl-235b-a22b`: adds `budget_tokens`.
- `qwen3-vl-30b-a3b`: adds `budget_tokens`.

## Request Surface

- `budget_tokens` maps to Alibaba Model Studio's OpenAI-compatible Chat request field `thinking_budget`, an integer cap for reasoning tokens. The docs state that when this cap is reached, reasoning is stopped/truncated and the model generates the final answer. I did not encode `min` or `max` because the public docs point readers to per-model defaults/maximums in the model list or console rather than publishing verified bounds for these exact model IDs.
- No `toggle` is claimed for the five fixed models. Alibaba documents `qwq-plus`, QVQ, `qwen3-next-80b-a3b-thinking`, and the Qwen3-VL thinking variants as thinking-only models or as models where `enable_thinking` cannot disable thinking.
- For `qwq-plus` and `qvq-max`, no provider-exposed user control was verified, so this PR records reasoning support with `reasoning_options = []` without claiming selectable controls.

## Evidence

- [Alibaba Model Studio Deep thinking](https://www.alibabacloud.com/help/en/model-studio/deep-thinking) documents hybrid `enable_thinking` behavior, thinking-only mode, lists `qwq-plus` and `qwen3-next-80b-a3b-thinking` as thinking-only models, and documents `thinking_budget` support for Qwen3 in thinking mode.
- [Alibaba Model Studio Visual reasoning](https://www.alibabacloud.com/help/en/model-studio/visual-reasoning) documents QVQ as thinking-only, lists Qwen3-VL thinking-only models, states that `enable_thinking` can only be true for Qwen3-VL `-thinking` models, and documents `thinking_budget` for Qwen3-VL thinking mode.
- [Alibaba OpenAI-compatible Chat API reference](https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-chat-completions) documents the raw Alibaba endpoint `POST /compatible-mode/v1/chat/completions` and the non-standard request parameters `enable_thinking` and `thinking_budget` on Alibaba's OpenAI-compatible request surface.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true && bun validate && git diff --check`: passed.
- `bun validate > /var/folders/wp/p9bq_z410fl2zmv767k8w0zw0000gn/T/opencode/fix-reasoning-options-alibaba/validate-alibaba.log && git diff --check`: passed.
- Alibaba-only generated invariant check for `reasoning === true` requiring `reasoning_options` and `reasoning === false` forbidding `reasoning_options`: passed.
