### PR TITLE
[vivgrid] Fix reasoning options metadata

### DIFF
--- a/providers/vivgrid/models/deepseek-v3.2.toml
+++ b/providers/vivgrid/models/deepseek-v3.2.toml
@@ -1,13 +1,10 @@
 name = "DeepSeek-V3.2"
-# Raw POST /v1/chat/completions is documented for this model, but no reasoning
-# request field is specified; /v1/responses limits reasoning to GPT-5/o-series.
-# https://docs.vivgrid.com/models/deepseek-v3.2 (accessed 2026-06-25)
-# https://docs.vivgrid.com/api/model-api (accessed 2026-06-25)
 family = "deepseek"
 release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 knowledge = "2024-07"
 tool_call = true

--- a/providers/vivgrid/models/deepseek-v4-pro.toml
+++ b/providers/vivgrid/models/deepseek-v4-pro.toml
@@ -1,8 +1,5 @@
-# Raw POST /v1/chat/completions is documented for this model, but no reasoning
-# request field is specified; /v1/responses limits reasoning to GPT-5/o-series.
-# https://docs.vivgrid.com/models/deepseek-v4-pro (accessed 2026-06-25)
-# https://docs.vivgrid.com/api/model-api (accessed 2026-06-25)
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/vivgrid/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/vivgrid/models/gemini-3.1-flash-lite-preview.toml
@@ -1,13 +1,10 @@
 name = "Gemini 3.1 Flash Lite Preview"
-# Raw POST /v1/chat/completions is documented for this model, but no reasoning
-# request field is specified; /v1/responses limits reasoning to GPT-5/o-series.
-# https://docs.vivgrid.com/models/gemini-3.1-flash-lite-preview (accessed 2026-06-25)
-# https://docs.vivgrid.com/api/model-api (accessed 2026-06-25)
 family = "gemini-flash-lite"
 release_date = "2026-03-03"
 last_updated = "2026-03-03"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/vivgrid/models/gemini-3.1-pro-preview.toml
+++ b/providers/vivgrid/models/gemini-3.1-pro-preview.toml
@@ -1,13 +1,10 @@
 name = "Gemini 3.1 Pro Preview"
-# Raw POST /v1/chat/completions is documented for this model, but no reasoning
-# request field is specified; /v1/responses limits reasoning to GPT-5/o-series.
-# https://docs.vivgrid.com/models/gemini-3.1-pro-preview (accessed 2026-06-25)
-# https://docs.vivgrid.com/api/model-api (accessed 2026-06-25)
 family = "gemini-pro"
 release_date = "2026-02-19"
 last_updated = "2026-02-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/vivgrid/models/gpt-5-mini.toml
+++ b/providers/vivgrid/models/gpt-5-mini.toml
@@ -1,14 +1,10 @@
 name = "GPT-5 Mini"
-# Raw POST /v1/chat/completions is documented for this ID without a reasoning
-# field. POST /v1/responses has an opaque reasoning object for GPT-5/o-series,
-# but its documented model list excludes this ID, so no control is verified.
-# https://docs.vivgrid.com/models/gpt-5-mini (accessed 2026-06-25)
-# https://docs.vivgrid.com/api/model-api (accessed 2026-06-25)
 family = "gpt-mini"
 release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/vivgrid/models/gpt-5.1-codex-max.toml
+++ b/providers/vivgrid/models/gpt-5.1-codex-max.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/vivgrid/models/gpt-5.1-codex.toml
+++ b/providers/vivgrid/models/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/vivgrid/models/gpt-5.2-codex.toml
+++ b/providers/vivgrid/models/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/vivgrid/models/gpt-5.3-codex.toml
+++ b/providers/vivgrid/models/gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/vivgrid/models/gpt-5.4-mini.toml
+++ b/providers/vivgrid/models/gpt-5.4-mini.toml
@@ -1,14 +1,10 @@
 name = "GPT-5.4 Mini"
-# Raw POST /v1/chat/completions is documented for this ID without a reasoning
-# field. POST /v1/responses has an opaque reasoning object for GPT-5/o-series,
-# but its documented model list excludes this ID, so no control is verified.
-# https://docs.vivgrid.com/models/gpt-5.4-mini (accessed 2026-06-25)
-# https://docs.vivgrid.com/api/model-api (accessed 2026-06-25)
 family = "gpt-mini"
 release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/vivgrid/models/gpt-5.4-nano.toml
+++ b/providers/vivgrid/models/gpt-5.4-nano.toml
@@ -1,14 +1,10 @@
 name = "GPT-5.4 Nano"
-# Raw POST /v1/chat/completions is documented for this ID without a reasoning
-# field. POST /v1/responses has an opaque reasoning object for GPT-5/o-series,
-# but its documented model list excludes this ID, so no control is verified.
-# https://docs.vivgrid.com/models/gpt-5.4-nano (accessed 2026-06-25)
-# https://docs.vivgrid.com/api/model-api (accessed 2026-06-25)
 family = "gpt-nano"
 release_date = "2026-03-17"
 last_updated = "2026-03-17"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/vivgrid/models/gpt-5.4.toml
+++ b/providers/vivgrid/models/gpt-5.4.toml
@@ -1,14 +1,10 @@
 name = "GPT-5.4"
-# Raw POST /v1/chat/completions is documented for this ID without a reasoning
-# field. POST /v1/responses has an opaque reasoning object for GPT-5/o-series,
-# but its documented model list excludes this ID, so no control is verified.
-# https://docs.vivgrid.com/models/gpt-5.4 (accessed 2026-06-25)
-# https://docs.vivgrid.com/api/model-api (accessed 2026-06-25)
 family = "gpt"
 release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/vivgrid/models/gpt-5.5.toml
+++ b/providers/vivgrid/models/gpt-5.5.toml
@@ -1,9 +1,5 @@
-# Raw POST /v1/chat/completions is documented for this ID without a reasoning
-# field. POST /v1/responses has an opaque reasoning object for GPT-5/o-series,
-# but its documented model list excludes this ID, so no control is verified.
-# https://docs.vivgrid.com/models/gpt-5.5 (accessed 2026-06-25)
-# https://docs.vivgrid.com/api/model-api (accessed 2026-06-25)
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 5


### PR DESCRIPTION
## Summary

Fixes all 13 Vivgrid reasoning metadata failures from the PR #2828 invariant audit.

Fixed models:

- `deepseek-v3.2`
- `deepseek-v4-pro`
- `gemini-3.1-flash-lite-preview`
- `gemini-3.1-pro-preview`
- `gpt-5-mini`
- `gpt-5.1-codex`
- `gpt-5.1-codex-max`
- `gpt-5.2-codex`
- `gpt-5.3-codex`
- `gpt-5.4`
- `gpt-5.4-mini`
- `gpt-5.4-nano`
- `gpt-5.5`

## Reasoning Options

- Effort: Vivgrid Chat Completions accepts the top-level request field `reasoning_effort` with values `none`, `low`, `medium`, and `high`.
- Applied effort to Chat Completions models: `deepseek-v3.2`, `deepseek-v4-pro`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview`, `gpt-5-mini`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, and `gpt-5.5`.
- No toggle or `budget_tokens` option is claimed because Vivgrid docs do not document a raw toggle field or a reasoning-token budget field for these models.
- `reasoning_options = []` is used for `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.2-codex`, and `gpt-5.3-codex` because they are documented on the Responses API, but Vivgrid only documents an opaque `reasoning` object there and no provider-exposed selectable controls or accepted values were verified.

## Evidence

- [Vivgrid Chat Completions API](https://vivgrid.com/docs/api/agent/completions) documents raw `POST /chat/completions` and the request field `reasoning_effort` with enum values `none`, `low`, `medium`, and `high`, described as controlling reasoning depth.
- [Vivgrid gpt-5.4 model page](https://vivgrid.com/docs/models/gpt-5.4) shows `gpt-5.4` called through `https://api.vivgrid.com/v1/chat/completions`, establishing the Chat Completions surface for the GPT-5.4 family.
- [Vivgrid gpt-5-mini model page](https://vivgrid.com/docs/models/gpt-5-mini) shows `gpt-5-mini` called through `https://api.vivgrid.com/v1/chat/completions`, establishing the Chat Completions surface for that model.
- [Vivgrid gpt-5.5 model page](https://vivgrid.com/docs/models/gpt-5.5) documents `gpt-5.5` as available through Vivgrid's unified OpenAI-compatible API, and Vivgrid's Chat Completions schema above provides the raw effort field and values for that surface.
- [Vivgrid Gemini 3.1 Pro Preview model page](https://vivgrid.com/docs/models/gemini-3.1-pro-preview) shows `gemini-3.1-pro-preview` called through `https://api.vivgrid.com/v1/chat/completions`, establishing the Chat Completions surface for the Gemini 3.1 entries.
- [Vivgrid DeepSeek V4 Pro model page](https://vivgrid.com/docs/models/deepseek-v4-pro) shows `deepseek-v4-pro` called through `https://api.vivgrid.com/v1/chat/completions`, establishing the Chat Completions surface for the DeepSeek entries.
- [Vivgrid Vibe Coding API](https://vivgrid.com/docs/api/model-api/vibe-coding) documents raw `POST /v1/responses`, limits the model list to the Codex-style Responses models, and exposes only an opaque `reasoning` object without accepted subfields or values.
- [Vivgrid gpt-5.3-codex model page](https://vivgrid.com/docs/models/gpt-5.3-codex) documents `gpt-5.3-codex` as a Codex-tuned model served on the Responses API, supporting the empty options treatment when no selectable Responses control is verified.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: passed
- `bun validate`: passed
- `git diff --check`: passed
- Provider invariant check: `vivgrid invariant ok (13 models checked)`
