### PR TITLE
[orcarouter] Fix reasoning options metadata

### DIFF
--- a/providers/orcarouter/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/orcarouter/models/anthropic/claude-haiku-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 1

--- a/providers/orcarouter/models/anthropic/claude-haiku-4.5.toml
+++ b/providers/orcarouter/models/anthropic/claude-haiku-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/orcarouter/models/anthropic/claude-opus-4.1.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 15

--- a/providers/orcarouter/models/anthropic/claude-opus-4.1.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.1.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-1"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 15

--- a/providers/orcarouter/models/anthropic/claude-opus-4.5.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/anthropic/claude-opus-4.5.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/anthropic/claude-opus-4.6.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/anthropic/claude-opus-4.6.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/anthropic/claude-opus-4.6.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/anthropic/claude-opus-4.7.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/anthropic/claude-opus-4.7.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/anthropic/claude-opus-4.7.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.7.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/anthropic/claude-opus-4.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-0"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 15

--- a/providers/orcarouter/models/anthropic/claude-opus-4.toml
+++ b/providers/orcarouter/models/anthropic/claude-opus-4.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-0"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 15

--- a/providers/orcarouter/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/orcarouter/models/anthropic/claude-sonnet-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 3

--- a/providers/orcarouter/models/anthropic/claude-sonnet-4.5.toml
+++ b/providers/orcarouter/models/anthropic/claude-sonnet-4.5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/orcarouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/orcarouter/models/anthropic/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 3

--- a/providers/orcarouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/orcarouter/models/anthropic/claude-sonnet-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 3

--- a/providers/orcarouter/models/anthropic/claude-sonnet-4.6.toml
+++ b/providers/orcarouter/models/anthropic/claude-sonnet-4.6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/orcarouter/models/anthropic/claude-sonnet-4.toml
+++ b/providers/orcarouter/models/anthropic/claude-sonnet-4.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-0"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 3

--- a/providers/orcarouter/models/anthropic/claude-sonnet-4.toml
+++ b/providers/orcarouter/models/anthropic/claude-sonnet-4.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-0"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/orcarouter/models/deepseek/deepseek-reasoner.toml
+++ b/providers/orcarouter/models/deepseek/deepseek-reasoner.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-reasoner"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/orcarouter/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/orcarouter/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/orcarouter/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/orcarouter/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/orcarouter/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/orcarouter/models/google/gemini-2.5-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/orcarouter/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/orcarouter/models/google/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 0.1

--- a/providers/orcarouter/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/orcarouter/models/google/gemini-2.5-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.1

--- a/providers/orcarouter/models/google/gemini-2.5-flash.toml
+++ b/providers/orcarouter/models/google/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 0.3

--- a/providers/orcarouter/models/google/gemini-2.5-flash.toml
+++ b/providers/orcarouter/models/google/gemini-2.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/orcarouter/models/google/gemini-2.5-flash.toml
+++ b/providers/orcarouter/models/google/gemini-2.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/orcarouter/models/google/gemini-2.5-pro.toml
+++ b/providers/orcarouter/models/google/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 2.5

--- a/providers/orcarouter/models/google/gemini-2.5-pro.toml
+++ b/providers/orcarouter/models/google/gemini-2.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 2.5

--- a/providers/orcarouter/models/google/gemini-2.5-pro.toml
+++ b/providers/orcarouter/models/google/gemini-2.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-pro"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 2.5

--- a/providers/orcarouter/models/google/gemini-3-flash-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3-flash-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.5

--- a/providers/orcarouter/models/google/gemini-3-flash-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 0.5

--- a/providers/orcarouter/models/google/gemini-3-flash-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3-flash-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 0.5

--- a/providers/orcarouter/models/google/gemini-3-pro-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3-pro-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 4

--- a/providers/orcarouter/models/google/gemini-3-pro-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 4

--- a/providers/orcarouter/models/google/gemini-3-pro-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3-pro-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-pro-preview"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 4

--- a/providers/orcarouter/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/orcarouter/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/orcarouter/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 0.25

--- a/providers/orcarouter/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/orcarouter/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview-customtools"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 4

--- a/providers/orcarouter/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/orcarouter/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview-customtools"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 4

--- a/providers/orcarouter/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/orcarouter/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview-customtools"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 4

--- a/providers/orcarouter/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3.1-pro-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 4

--- a/providers/orcarouter/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3.1-pro-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 4

--- a/providers/orcarouter/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/orcarouter/models/google/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 4

--- a/providers/orcarouter/models/google/gemini-flash-latest.toml
+++ b/providers/orcarouter/models/google/gemini-flash-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-flash-latest"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 0.5

--- a/providers/orcarouter/models/google/gemini-flash-latest.toml
+++ b/providers/orcarouter/models/google/gemini-flash-latest.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-flash-latest"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 0.5

--- a/providers/orcarouter/models/google/gemini-flash-lite-latest.toml
+++ b/providers/orcarouter/models/google/gemini-flash-lite-latest.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-flash-lite-latest"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/orcarouter/models/google/gemini-flash-lite-latest.toml
+++ b/providers/orcarouter/models/google/gemini-flash-lite-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-flash-lite-latest"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 0.25

--- a/providers/orcarouter/models/google/gemma-4-26b-a4b-it.toml
+++ b/providers/orcarouter/models/google/gemma-4-26b-a4b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = []
 
 [cost]
 input = 0.06

--- a/providers/orcarouter/models/google/gemma-4-31b-it.toml
+++ b/providers/orcarouter/models/google/gemma-4-31b-it.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemma-4-31b-it"
+reasoning_options = []
 
 [cost]
 input = 0.13

--- a/providers/orcarouter/models/grok/grok-4.3.toml
+++ b/providers/orcarouter/models/grok/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/kimi/kimi-k2.5.toml
+++ b/providers/orcarouter/models/kimi/kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/orcarouter/models/kimi/kimi-k2.6.toml
+++ b/providers/orcarouter/models/kimi/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/orcarouter/models/minimax/minimax-m2.5-highspeed.toml
+++ b/providers/orcarouter/models/minimax/minimax-m2.5-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5-highspeed"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/orcarouter/models/minimax/minimax-m2.5.toml
+++ b/providers/orcarouter/models/minimax/minimax-m2.5.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/orcarouter/models/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/orcarouter/models/minimax/minimax-m2.7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/orcarouter/models/minimax/minimax-m2.7.toml
+++ b/providers/orcarouter/models/minimax/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/orcarouter/models/openai/gpt-5-chat-latest.toml
+++ b/providers/orcarouter/models/openai/gpt-5-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-chat-latest"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5-chat-latest.toml
+++ b/providers/orcarouter/models/openai/gpt-5-chat-latest.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-chat-latest"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5-codex.toml
+++ b/providers/orcarouter/models/openai/gpt-5-codex.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-codex"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5-codex.toml
+++ b/providers/orcarouter/models/openai/gpt-5-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5-mini.toml
+++ b/providers/orcarouter/models/openai/gpt-5-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-mini"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/orcarouter/models/openai/gpt-5-mini.toml
+++ b/providers/orcarouter/models/openai/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/orcarouter/models/openai/gpt-5-nano.toml
+++ b/providers/orcarouter/models/openai/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/orcarouter/models/openai/gpt-5-nano.toml
+++ b/providers/orcarouter/models/openai/gpt-5-nano.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-nano"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 0.05

--- a/providers/orcarouter/models/openai/gpt-5-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 15

--- a/providers/orcarouter/models/openai/gpt-5-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 15

--- a/providers/orcarouter/models/openai/gpt-5-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-pro"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 15

--- a/providers/orcarouter/models/openai/gpt-5.1-chat-latest.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-chat-latest"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5.1-chat-latest.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1-chat-latest.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.1-chat-latest"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1-codex-max.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.1-codex-max"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1-codex-max.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex-max"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1-codex-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/orcarouter/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1-codex-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.1-codex-mini"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 0.25

--- a/providers/orcarouter/models/openai/gpt-5.1-codex.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5.1-codex.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1-codex.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.1-codex"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5.1.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.1"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5.1.toml
+++ b/providers/orcarouter/models/openai/gpt-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.1"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5.2-chat-latest.toml
+++ b/providers/orcarouter/models/openai/gpt-5.2-chat-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-chat-latest"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.75

--- a/providers/orcarouter/models/openai/gpt-5.2-chat-latest.toml
+++ b/providers/orcarouter/models/openai/gpt-5.2-chat-latest.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.2-chat-latest"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/orcarouter/models/openai/gpt-5.2-codex.toml
+++ b/providers/orcarouter/models/openai/gpt-5.2-codex.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.2-codex"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/orcarouter/models/openai/gpt-5.2-codex.toml
+++ b/providers/orcarouter/models/openai/gpt-5.2-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.75

--- a/providers/orcarouter/models/openai/gpt-5.2-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5.2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 21

--- a/providers/orcarouter/models/openai/gpt-5.2-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5.2-pro.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.2-pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 21

--- a/providers/orcarouter/models/openai/gpt-5.2-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5.2-pro.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.2-pro"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 21

--- a/providers/orcarouter/models/openai/gpt-5.2.toml
+++ b/providers/orcarouter/models/openai/gpt-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.75

--- a/providers/orcarouter/models/openai/gpt-5.2.toml
+++ b/providers/orcarouter/models/openai/gpt-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.2"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/orcarouter/models/openai/gpt-5.3-codex.toml
+++ b/providers/orcarouter/models/openai/gpt-5.3-codex.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.75

--- a/providers/orcarouter/models/openai/gpt-5.3-codex.toml
+++ b/providers/orcarouter/models/openai/gpt-5.3-codex.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.3-codex"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/orcarouter/models/openai/gpt-5.4-mini.toml
+++ b/providers/orcarouter/models/openai/gpt-5.4-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 0.75

--- a/providers/orcarouter/models/openai/gpt-5.4-mini.toml
+++ b/providers/orcarouter/models/openai/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.75

--- a/providers/orcarouter/models/openai/gpt-5.4-nano.toml
+++ b/providers/orcarouter/models/openai/gpt-5.4-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.2

--- a/providers/orcarouter/models/openai/gpt-5.4-nano.toml
+++ b/providers/orcarouter/models/openai/gpt-5.4-nano.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-nano"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/orcarouter/models/openai/gpt-5.4-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5.4-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 60

--- a/providers/orcarouter/models/openai/gpt-5.4-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5.4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-pro"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 60

--- a/providers/orcarouter/models/openai/gpt-5.4-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5.4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 60

--- a/providers/orcarouter/models/openai/gpt-5.4.toml
+++ b/providers/orcarouter/models/openai/gpt-5.4.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/openai/gpt-5.4.toml
+++ b/providers/orcarouter/models/openai/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/openai/gpt-5.5-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 30

--- a/providers/orcarouter/models/openai/gpt-5.5-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 30

--- a/providers/orcarouter/models/openai/gpt-5.5-pro.toml
+++ b/providers/orcarouter/models/openai/gpt-5.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 30

--- a/providers/orcarouter/models/openai/gpt-5.5.toml
+++ b/providers/orcarouter/models/openai/gpt-5.5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/openai/gpt-5.5.toml
+++ b/providers/orcarouter/models/openai/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/orcarouter/models/openai/gpt-5.toml
+++ b/providers/orcarouter/models/openai/gpt-5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/openai/gpt-5.toml
+++ b/providers/orcarouter/models/openai/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/orcarouter/models/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/orcarouter/models/qwen/qwen3.5-122b-a10b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-122b-a10b"
+reasoning_options = []
 
 [cost]
 input = 0.115

--- a/providers/orcarouter/models/qwen/qwen3.5-27b.toml
+++ b/providers/orcarouter/models/qwen/qwen3.5-27b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-27b"
+reasoning_options = []
 
 [cost]
 input = 0.086

--- a/providers/orcarouter/models/qwen/qwen3.5-35b-a3b.toml
+++ b/providers/orcarouter/models/qwen/qwen3.5-35b-a3b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-35b-a3b"
+reasoning_options = []
 
 [cost]
 input = 0.057

--- a/providers/orcarouter/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/orcarouter/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-397b-a17b"
+reasoning_options = []
 
 [cost]
 input = 0.172

--- a/providers/orcarouter/models/qwen/qwen3.5-plus.toml
+++ b/providers/orcarouter/models/qwen/qwen3.5-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.5-plus"
+reasoning_options = []
 
 [cost]
 input = 0.115

--- a/providers/orcarouter/models/qwen/qwen3.6-35b-a3b.toml
+++ b/providers/orcarouter/models/qwen/qwen3.6-35b-a3b.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = []
 
 [cost]
 input = 0.248

--- a/providers/orcarouter/models/qwen/qwen3.6-plus.toml
+++ b/providers/orcarouter/models/qwen/qwen3.6-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-plus"
+reasoning_options = []
 
 [cost]
 input = 0.5

--- a/providers/orcarouter/models/z-ai/glm-4.5-air.toml
+++ b/providers/orcarouter/models/z-ai/glm-4.5-air.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5-air"
+reasoning_options = []
 
 [cost]
 input = 0.2

--- a/providers/orcarouter/models/z-ai/glm-4.5.toml
+++ b/providers/orcarouter/models/z-ai/glm-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.5"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/orcarouter/models/z-ai/glm-4.6.toml
+++ b/providers/orcarouter/models/z-ai/glm-4.6.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.6"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/orcarouter/models/z-ai/glm-4.7.toml
+++ b/providers/orcarouter/models/z-ai/glm-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/orcarouter/models/z-ai/glm-5.1.toml
+++ b/providers/orcarouter/models/z-ai/glm-5.1.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.1"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/orcarouter/models/z-ai/glm-5.toml
+++ b/providers/orcarouter/models/z-ai/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Summary

Fixes OrcaRouter reasoning metadata while keeping selectable controls limited to the model families that OrcaRouter documents for its raw request surface.

## Changes

- Adds `reasoning_options = []` for reasoning-capable models where no provider-exposed selectable control was verified.
- Adds `effort = ["low", "medium", "high"]` for documented OrcaRouter `reasoning_effort` support on:
  - OpenAI `gpt-5-pro` / `gpt-5.x-pro` family entries.
  - Exact documented Anthropic Claude 4.6 / 4.7 entries.
  - Google Gemini 2.5 / 3.x entries.
- Does not claim `toggle` or `budget_tokens` in this PR. OrcaRouter exposes Anthropic `thinking` and Gemini native `thinkingConfig`, but the exact model/endpoint support was not tight enough here to claim those controls for the affected catalog entries.
- Leaves DeepSeek reasoner/V4 and other reasoning-by-design models as `reasoning_options = []`; OrcaRouter documents DeepSeek `reasoning_effort` as a no-op.

## Evidence

- [OrcaRouter reasoning docs](https://docs.orcarouter.ai/advanced/reasoning) document top-level Chat Completions `reasoning_effort` values `low`, `medium`, and `high`, with provider translation for OpenAI pro-family, Anthropic Claude, and Google Gemini reasoning models.
- The same page lists `openai/gpt-5-pro` and `gpt-5.x-pro`, Anthropic Claude 4.6/4.7 examples, and Gemini 2.5/3.x examples as reasoning model families in the deployment.
- The same page documents DeepSeek reasoner as reasoner-by-design where `reasoning_effort` is a no-op, so no selectable control is claimed for DeepSeek models.
- [OrcaRouter Chat Completions OpenAPI](https://docs.orcarouter.ai/api-reference/chat/create-a-chat-completion) documents `reasoning_effort = low | medium | high` on the raw OpenAI-compatible chat request.
- [OrcaRouter Messages OpenAPI](https://docs.orcarouter.ai/api-reference/messages/create-a-message) and [Gemini native docs](https://docs.orcarouter.ai/native-formats/gemini) document provider-native thinking surfaces, but this PR avoids broad `toggle`/`budget_tokens` claims without tighter per-model support.

Sources accessed 2026-06-27.

## Validation

- `bun validate`
- `git diff --check`
- Local OrcaRouter invariant check passed.
