### PR TITLE
[requesty] Fix reasoning options metadata

### DIFF
--- a/providers/requesty/models/anthropic/claude-3-7-sonnet.toml
+++ b/providers/requesty/models/anthropic/claude-3-7-sonnet.toml
@@ -22,3 +22,10 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-3-7-sonnet.toml
+++ b/providers/requesty/models/anthropic/claude-3-7-sonnet.toml
@@ -4,7 +4,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 tool_call = true
 knowledge = "2024-01"

--- a/providers/requesty/models/anthropic/claude-3-7-sonnet.toml
+++ b/providers/requesty/models/anthropic/claude-3-7-sonnet.toml
@@ -4,6 +4,7 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-01"
@@ -22,10 +23,3 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-haiku-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-01"

--- a/providers/requesty/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-haiku-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-02-01"
@@ -22,10 +23,3 @@ output = 62_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-haiku-4-5.toml
@@ -22,3 +22,10 @@ output = 62_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-opus-4-1.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-1.toml
@@ -1,11 +1,6 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
 
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 15

--- a/providers/requesty/models/anthropic/claude-opus-4-1.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-1.toml
@@ -1,5 +1,12 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 15
 output = 75

--- a/providers/requesty/models/anthropic/claude-opus-4-1.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-1.toml
@@ -1,6 +1,6 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
 
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 15

--- a/providers/requesty/models/anthropic/claude-opus-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-5.toml
@@ -22,3 +22,10 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-opus-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/requesty/models/anthropic/claude-opus-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"
@@ -22,10 +23,3 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-opus-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true
@@ -30,10 +31,3 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-opus-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/requesty/models/anthropic/claude-opus-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-6.toml
@@ -30,3 +30,10 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-opus-4.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"
@@ -22,10 +23,3 @@ output = 32_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-opus-4.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4.toml
@@ -4,7 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/requesty/models/anthropic/claude-opus-4.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4.toml
@@ -22,3 +22,10 @@ output = 32_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4-5.toml
@@ -1,5 +1,12 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 3
 output = 15

--- a/providers/requesty/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4-5.toml
@@ -1,6 +1,6 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
 
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 3

--- a/providers/requesty/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4-5.toml
@@ -1,11 +1,6 @@
 base_model = "anthropic/claude-sonnet-4-5-20250929"
 
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
@@ -30,3 +30,10 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4-6.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true
@@ -30,10 +31,3 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/anthropic/claude-sonnet-4.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4.toml
@@ -1,6 +1,6 @@
 base_model = "anthropic/claude-sonnet-4-20250514"
 
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 3

--- a/providers/requesty/models/anthropic/claude-sonnet-4.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4.toml
@@ -1,11 +1,6 @@
 base_model = "anthropic/claude-sonnet-4-20250514"
 
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/requesty/models/anthropic/claude-sonnet-4.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-4.toml
@@ -1,5 +1,12 @@
 base_model = "anthropic/claude-sonnet-4-20250514"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 3
 output = 15

--- a/providers/requesty/models/google/gemini-2.5-flash.toml
+++ b/providers/requesty/models/google/gemini-2.5-flash.toml
@@ -22,3 +22,10 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/google/gemini-2.5-flash.toml
+++ b/providers/requesty/models/google/gemini-2.5-flash.toml
@@ -4,7 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/requesty/models/google/gemini-2.5-flash.toml
+++ b/providers/requesty/models/google/gemini-2.5-flash.toml
@@ -4,6 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true
@@ -22,10 +23,3 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/google/gemini-2.5-pro.toml
+++ b/providers/requesty/models/google/gemini-2.5-pro.toml
@@ -1,7 +1,7 @@
 base_model = "google/gemini-2.5-pro"
 base_model_omit = ["structured_output"]
 
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 1.25

--- a/providers/requesty/models/google/gemini-2.5-pro.toml
+++ b/providers/requesty/models/google/gemini-2.5-pro.toml
@@ -1,6 +1,13 @@
 base_model = "google/gemini-2.5-pro"
 base_model_omit = ["structured_output"]
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 1.25
 output = 10

--- a/providers/requesty/models/google/gemini-2.5-pro.toml
+++ b/providers/requesty/models/google/gemini-2.5-pro.toml
@@ -1,12 +1,7 @@
 base_model = "google/gemini-2.5-pro"
 base_model_omit = ["structured_output"]
 
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/requesty/models/google/gemini-3-flash-preview.toml
+++ b/providers/requesty/models/google/gemini-3-flash-preview.toml
@@ -3,6 +3,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true
@@ -21,10 +22,3 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/google/gemini-3-flash-preview.toml
+++ b/providers/requesty/models/google/gemini-3-flash-preview.toml
@@ -3,7 +3,7 @@ release_date = "2025-12-17"
 last_updated = "2025-12-17"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/requesty/models/google/gemini-3-flash-preview.toml
+++ b/providers/requesty/models/google/gemini-3-flash-preview.toml
@@ -21,3 +21,10 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/google/gemini-3-pro-preview.toml
+++ b/providers/requesty/models/google/gemini-3-pro-preview.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/requesty/models/google/gemini-3-pro-preview.toml
+++ b/providers/requesty/models/google/gemini-3-pro-preview.toml
@@ -22,3 +22,10 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/google/gemini-3-pro-preview.toml
+++ b/providers/requesty/models/google/gemini-3-pro-preview.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-18"
 last_updated = "2025-11-18"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-01"
 tool_call = true
@@ -22,10 +23,3 @@ output = 65_536
 [modalities]
 input = ["text", "image", "audio", "video", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-chat.toml
+++ b/providers/requesty/models/openai/gpt-5-chat.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2024-09-30"
 tool_call = false

--- a/providers/requesty/models/openai/gpt-5-chat.toml
+++ b/providers/requesty/models/openai/gpt-5-chat.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09-30"
 tool_call = false
@@ -21,10 +22,3 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-chat.toml
+++ b/providers/requesty/models/openai/gpt-5-chat.toml
@@ -21,3 +21,10 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-codex.toml
+++ b/providers/requesty/models/openai/gpt-5-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true
@@ -22,10 +23,3 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-codex.toml
+++ b/providers/requesty/models/openai/gpt-5-codex.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5-codex.toml
+++ b/providers/requesty/models/openai/gpt-5-codex.toml
@@ -22,3 +22,10 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-image.toml
+++ b/providers/requesty/models/openai/gpt-5-image.toml
@@ -22,3 +22,10 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text", "image"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-image.toml
+++ b/providers/requesty/models/openai/gpt-5-image.toml
@@ -4,7 +4,7 @@ release_date = "2025-10-14"
 last_updated = "2025-10-14"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5-image.toml
+++ b/providers/requesty/models/openai/gpt-5-image.toml
@@ -4,6 +4,7 @@ release_date = "2025-10-14"
 last_updated = "2025-10-14"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-10-01"
 tool_call = true
@@ -22,10 +23,3 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text", "image"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-mini.toml
+++ b/providers/requesty/models/openai/gpt-5-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true
@@ -21,10 +22,3 @@ output = 32_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-mini.toml
+++ b/providers/requesty/models/openai/gpt-5-mini.toml
@@ -21,3 +21,10 @@ output = 32_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-mini.toml
+++ b/providers/requesty/models/openai/gpt-5-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5-nano.toml
+++ b/providers/requesty/models/openai/gpt-5-nano.toml
@@ -21,3 +21,10 @@ output = 4_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-nano.toml
+++ b/providers/requesty/models/openai/gpt-5-nano.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true
@@ -21,10 +22,3 @@ output = 4_000
 [modalities]
 input = ["text"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5-nano.toml
+++ b/providers/requesty/models/openai/gpt-5-nano.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5-pro.toml
+++ b/providers/requesty/models/openai/gpt-5-pro.toml
@@ -1,12 +1,7 @@
 base_model = "openai/gpt-5-pro"
 base_model_omit = ["limit.input"]
 
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 15

--- a/providers/requesty/models/openai/gpt-5-pro.toml
+++ b/providers/requesty/models/openai/gpt-5-pro.toml
@@ -1,7 +1,7 @@
 base_model = "openai/gpt-5-pro"
 base_model_omit = ["limit.input"]
 
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 15

--- a/providers/requesty/models/openai/gpt-5-pro.toml
+++ b/providers/requesty/models/openai/gpt-5-pro.toml
@@ -1,6 +1,13 @@
 base_model = "openai/gpt-5-pro"
 base_model_omit = ["limit.input"]
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 15
 output = 120

--- a/providers/requesty/models/openai/gpt-5.1-chat.toml
+++ b/providers/requesty/models/openai/gpt-5.1-chat.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.1-chat.toml
+++ b/providers/requesty/models/openai/gpt-5.1-chat.toml
@@ -22,3 +22,10 @@ output = 16_384
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.1-chat.toml
+++ b/providers/requesty/models/openai/gpt-5.1-chat.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true
@@ -22,10 +23,3 @@ output = 16_384
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex-max.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex-max.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true
@@ -22,10 +23,3 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.1-codex-max.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex-max.toml
@@ -22,3 +22,10 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true
@@ -22,10 +23,3 @@ output = 100_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.1-codex-mini.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex-mini.toml
@@ -22,3 +22,10 @@ output = 100_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.1-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.1-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true
@@ -22,10 +23,3 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.1-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.1-codex.toml
@@ -22,3 +22,10 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.1.toml
+++ b/providers/requesty/models/openai/gpt-5.1.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.1.toml
+++ b/providers/requesty/models/openai/gpt-5.1.toml
@@ -4,6 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2024-09-30"
 tool_call = true
@@ -22,10 +23,3 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.1.toml
+++ b/providers/requesty/models/openai/gpt-5.1.toml
@@ -22,3 +22,10 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.2-chat.toml
+++ b/providers/requesty/models/openai/gpt-5.2-chat.toml
@@ -1,11 +1,6 @@
 base_model = "openai/gpt-5.2-chat-latest"
 
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/requesty/models/openai/gpt-5.2-chat.toml
+++ b/providers/requesty/models/openai/gpt-5.2-chat.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.2-chat-latest"
 
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 1.75

--- a/providers/requesty/models/openai/gpt-5.2-chat.toml
+++ b/providers/requesty/models/openai/gpt-5.2-chat.toml
@@ -1,5 +1,12 @@
 base_model = "openai/gpt-5.2-chat-latest"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 1.75
 output = 14

--- a/providers/requesty/models/openai/gpt-5.2-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.2-codex.toml
@@ -4,7 +4,7 @@ release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.2-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.2-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-14"
 last_updated = "2026-01-14"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 knowledge = "2025-08-31"
 tool_call = true
@@ -22,10 +23,3 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.2-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.2-codex.toml
@@ -22,3 +22,10 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.2-pro.toml
+++ b/providers/requesty/models/openai/gpt-5.2-pro.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true
@@ -21,10 +22,3 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.2-pro.toml
+++ b/providers/requesty/models/openai/gpt-5.2-pro.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.2-pro.toml
+++ b/providers/requesty/models/openai/gpt-5.2-pro.toml
@@ -21,3 +21,10 @@ output = 128_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.2.toml
+++ b/providers/requesty/models/openai/gpt-5.2.toml
@@ -1,12 +1,7 @@
 base_model = "openai/gpt-5.2"
 base_model_omit = ["limit.input"]
 
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 1.75

--- a/providers/requesty/models/openai/gpt-5.2.toml
+++ b/providers/requesty/models/openai/gpt-5.2.toml
@@ -1,6 +1,13 @@
 base_model = "openai/gpt-5.2"
 base_model_omit = ["limit.input"]
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 1.75
 output = 14

--- a/providers/requesty/models/openai/gpt-5.2.toml
+++ b/providers/requesty/models/openai/gpt-5.2.toml
@@ -1,7 +1,7 @@
 base_model = "openai/gpt-5.2"
 base_model_omit = ["limit.input"]
 
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 1.75

--- a/providers/requesty/models/openai/gpt-5.3-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.3-codex.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.3-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.3-codex.toml
@@ -4,6 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true
@@ -22,10 +23,3 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.3-codex.toml
+++ b/providers/requesty/models/openai/gpt-5.3-codex.toml
@@ -22,3 +22,10 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.4-pro.toml
+++ b/providers/requesty/models/openai/gpt-5.4-pro.toml
@@ -23,3 +23,10 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.4-pro.toml
+++ b/providers/requesty/models/openai/gpt-5.4-pro.toml
@@ -4,7 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.4-pro.toml
+++ b/providers/requesty/models/openai/gpt-5.4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true
@@ -23,10 +24,3 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.4.toml
+++ b/providers/requesty/models/openai/gpt-5.4.toml
@@ -1,5 +1,12 @@
 base_model = "openai/gpt-5.4"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 2.5
 output = 15

--- a/providers/requesty/models/openai/gpt-5.4.toml
+++ b/providers/requesty/models/openai/gpt-5.4.toml
@@ -1,11 +1,6 @@
 base_model = "openai/gpt-5.4"
 
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 2.5

--- a/providers/requesty/models/openai/gpt-5.4.toml
+++ b/providers/requesty/models/openai/gpt-5.4.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.4"
 
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 2.5

--- a/providers/requesty/models/openai/gpt-5.toml
+++ b/providers/requesty/models/openai/gpt-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/requesty/models/openai/gpt-5.toml
+++ b/providers/requesty/models/openai/gpt-5.toml
@@ -4,6 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true
@@ -21,10 +22,3 @@ output = 128_000
 [modalities]
 input = ["text", "audio", "image", "video"]
 output = ["text", "audio", "image"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/gpt-5.toml
+++ b/providers/requesty/models/openai/gpt-5.toml
@@ -21,3 +21,10 @@ output = 128_000
 [modalities]
 input = ["text", "audio", "image", "video"]
 output = ["text", "audio", "image"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/o4-mini.toml
+++ b/providers/requesty/models/openai/o4-mini.toml
@@ -4,6 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2024-06"
@@ -21,10 +22,3 @@ output = 100_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/openai/o4-mini.toml
+++ b/providers/requesty/models/openai/o4-mini.toml
@@ -21,3 +21,10 @@ output = 100_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/openai/o4-mini.toml
+++ b/providers/requesty/models/openai/o4-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
 temperature = true
 tool_call = true
 knowledge = "2024-06"

--- a/providers/requesty/models/xai/grok-4-fast.toml
+++ b/providers/requesty/models/xai/grok-4-fast.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-19"
 last_updated = "2025-09-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"
@@ -22,10 +23,3 @@ output = 64_000
 [modalities]
 input = ["text"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"

--- a/providers/requesty/models/xai/grok-4-fast.toml
+++ b/providers/requesty/models/xai/grok-4-fast.toml
@@ -22,3 +22,10 @@ output = 64_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/xai/grok-4.toml
+++ b/providers/requesty/models/xai/grok-4.toml
@@ -22,3 +22,10 @@ output = 64_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/requesty/models/xai/grok-4.toml
+++ b/providers/requesty/models/xai/grok-4.toml
@@ -4,6 +4,7 @@ release_date = "2025-09-09"
 last_updated = "2025-09-09"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01"
@@ -22,10 +23,3 @@ output = 64_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
-
-[[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"


### PR DESCRIPTION
## Summary

- Fixes 35 Requesty models where `reasoning = true` had no `reasoning_options`.
- Restores Requesty's shared `reasoning_effort` controls for OpenAI, Anthropic, and Google routes.
- Keeps xAI Grok models as `reasoning_options = []` because Requesty's reasoning docs do not describe xAI reasoning control mapping.
- Does not claim `toggle`: Requesty's `none`/`min` behavior is route-dependent and not a consistent on/off control.

## Request Fields

- `effort`: Requesty `POST /v1/chat/completions` accepts top-level `reasoning_effort` as an effort string.
- Values recorded: `none`, `low`, `medium`, `high`, and `max`.
- `min` is documented by Requesty but not represented because models.dev has no `min` effort enum.
- `budget_tokens`: the same top-level `reasoning_effort` field accepts decimal budget strings such as `"10000"`; no bounds are recorded because Requesty converts or caps budgets differently by route.

## Route Behavior

- OpenAI via Requesty: `low`, `medium`, and `high` pass through; `max` maps to `high`; `none`/`min` map to the lowest supported reasoning; decimal budget strings map to `low`/`medium`/`high` by threshold.
- Anthropic via Requesty: effort strings map to thinking-token budgets; decimal budget strings are accepted and capped to model output limits.
- Vertex/Gemini via Requesty: effort strings map to thinking budgets; decimal budget strings are accepted and capped to model output limits.
- Google AI Studio via Requesty: documented as same behavior as OpenAI-compatible path.

## Evidence

- [Requesty reasoning docs](https://docs.requesty.ai/features/reasoning) state that reasoning is enabled by specifying top-level `reasoning_effort` in the API request.
- [Requesty reasoning effort values](https://docs.requesty.ai/features/reasoning#reasoning-effort-values) document `low`, `medium`, `high`, `max`, `min`, and `none`; this PR records the values supported by the models.dev schema.
- [Requesty OpenAI routing behavior](https://docs.requesty.ai/features/reasoning#when-using-openai-via-requesty) documents effort forwarding/mapping and decimal budget string conversion.
- [Requesty Anthropic routing behavior](https://docs.requesty.ai/features/reasoning#when-using-anthropic-via-requesty) documents converting effort strings to budgets and accepting budget strings.
- [Requesty Vertex AI routing behavior](https://docs.requesty.ai/features/reasoning#when-using-vertex-ai-via-requesty) documents converting effort strings to budgets and accepting budget strings.
- [Requesty Google AI Studio routing behavior](https://docs.requesty.ai/features/reasoning#when-using-google-ai-studio-via-requesty) states it uses the same behavior as the OpenAI-compatible path.

## Validation

- `bun validate`
- `git diff --check`
- Requesty-only invariant check passed.
