### PR TITLE
[nano-gpt] Fix reasoning options metadata

### DIFF
--- a/providers/nano-gpt/models/deepseek/deepseek-v3.2-speciale.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v3.2-speciale.toml
@@ -4,6 +4,7 @@ release_date = "2025-12-02"
 last_updated = "2025-12-02"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.2-pro.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.2-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-01-01"
 last_updated = "2026-01-01"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/openai/gpt-5.4-pro.toml
+++ b/providers/nano-gpt/models/openai/gpt-5.4-pro.toml
@@ -4,6 +4,7 @@ release_date = "2026-03-05"
 last_updated = "2026-03-05"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
+++ b/providers/nano-gpt/models/qwen/Qwen3.6-35B-A3B:thinking.toml
@@ -4,6 +4,7 @@ release_date = "2026-04-19"
 last_updated = "2026-04-19"
 attachment = true
 reasoning = true
+reasoning_options = []
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
## Summary

- Fixed NanoGPT reasoning metadata consistency for `openai/gpt-5.4-pro`, `openai/gpt-5.2-pro`, `deepseek/deepseek-v3.2-speciale`, and `qwen/Qwen3.6-35B-A3B:thinking`.
- Added NanoGPT `effort` reasoning options to the two GPT Pro models using the documented Chat Completions request fields `reasoning_effort` or `reasoning.effort` with values `none`, `low`, `medium`, `high`, and `xhigh`.
- Added `reasoning_options = []` for `deepseek/deepseek-v3.2-speciale` and `qwen/Qwen3.6-35B-A3B:thinking` because no provider-exposed user-selectable control was verified for those exact models, so this records reasoning support without claiming selectable controls.

## Evidence

- [NanoGPT Extended Thinking](https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking) documents Chat Completions reasoning controls: `reasoning_effort` or `reasoning.effort` controls reasoning depth, `none` explicitly disables reasoning behavior, and valid values include `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
- [NanoGPT Chat Completion](https://docs.nano-gpt.com/api-reference/endpoint/chat-completion) documents the OpenAI-compatible `POST /api/v1/chat/completions` endpoint used for these request-body controls.
- [NanoGPT Model Suffixes](https://docs.nano-gpt.com/api-reference/miscellaneous/model-suffixes) documents that `:thinking` is a model-specific thinking/reasoning variant when that exact ID exists, and that model identity suffixes are preserved rather than stripped as routing controls; this does not by itself prove a same-ID toggle or budget control.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true` completed.
- `bun validate` passed.
- `git diff --check` passed.
- Local resolved NanoGPT invariant check using `generate("./providers")` passed: no NanoGPT model has `reasoning = true` without `reasoning_options`, and no NanoGPT model has `reasoning = false` with `reasoning_options`.

## Limitations

- `NANO_GPT_API_KEY` was not available, so no authenticated live completion requests were made.
