### PR TITLE
[alibaba] Narrow reasoning budget metadata

### DIFF
--- a/providers/alibaba/models/qwen-flash.toml
+++ b/providers/alibaba/models/qwen-flash.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 81_920
 
 [cost]
 input = 0.05

--- a/providers/alibaba/models/qwen-plus.toml
+++ b/providers/alibaba/models/qwen-plus.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 81_920
 
 [cost]
 input = 0.4

--- a/providers/alibaba/models/qwen-turbo.toml
+++ b/providers/alibaba/models/qwen-turbo.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 38_912
 
 [cost]
 input = 0.05

--- a/providers/alibaba/models/qwen3-14b.toml
+++ b/providers/alibaba/models/qwen3-14b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 38_912
 
 [cost]
 input = 0.35

--- a/providers/alibaba/models/qwen3-235b-a22b.toml
+++ b/providers/alibaba/models/qwen3-235b-a22b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 38_912
 
 [cost]
 input = 0.7

--- a/providers/alibaba/models/qwen3-32b.toml
+++ b/providers/alibaba/models/qwen3-32b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 38_912
 
 [cost]
 input = 0.7

--- a/providers/alibaba/models/qwen3-8b.toml
+++ b/providers/alibaba/models/qwen3-8b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 38_912
 
 [cost]
 input = 0.18

--- a/providers/alibaba/models/qwen3-vl-plus.toml
+++ b/providers/alibaba/models/qwen3-vl-plus.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 81_920
 
 [cost]
 input = 0.2

--- a/providers/alibaba/models/qwen3.5-122b-a10b.toml
+++ b/providers/alibaba/models/qwen3.5-122b-a10b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 81_920
 
 [cost]
 input = 0.4

--- a/providers/alibaba/models/qwen3.5-27b.toml
+++ b/providers/alibaba/models/qwen3.5-27b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 81_920
 
 [cost]
 input = 0.3

--- a/providers/alibaba/models/qwen3.5-35b-a3b.toml
+++ b/providers/alibaba/models/qwen3.5-35b-a3b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 81_920
 
 [cost]
 input = 0.25

--- a/providers/alibaba/models/qwen3.5-397b-a17b.toml
+++ b/providers/alibaba/models/qwen3.5-397b-a17b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 81_920
 
 [cost]
 input = 0.6

--- a/providers/alibaba/models/qwen3.5-plus.toml
+++ b/providers/alibaba/models/qwen3.5-plus.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 81_920
 
 [cost]
 input = 0.4

--- a/providers/alibaba/models/qwen3.6-27b.toml
+++ b/providers/alibaba/models/qwen3.6-27b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 131_072
 
 [cost]
 input = 0.6

--- a/providers/alibaba/models/qwen3.6-35b-a3b.toml
+++ b/providers/alibaba/models/qwen3.6-35b-a3b.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 131_072
 
 [cost]
 input = 0.248

--- a/providers/alibaba/models/qwen3.6-flash.toml
+++ b/providers/alibaba/models/qwen3.6-flash.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 131_072
 
 [cost]
 input = 0.1875

--- a/providers/alibaba/models/qwen3.6-max-preview.toml
+++ b/providers/alibaba/models/qwen3.6-max-preview.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 131_072
 
 [cost]
 input = 1.3

--- a/providers/alibaba/models/qwen3.6-plus.toml
+++ b/providers/alibaba/models/qwen3.6-plus.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 81_920
 
 [cost]
 input = 0.50

--- a/providers/alibaba/models/qwen3.7-max.toml
+++ b/providers/alibaba/models/qwen3.7-max.toml
@@ -13,7 +13,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 262_144
 
 [cost]
 input = 2.50

--- a/providers/alibaba/models/qwen3.7-plus.toml
+++ b/providers/alibaba/models/qwen3.7-plus.toml
@@ -14,7 +14,6 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-max = 262_144
 
 [cost]
 input = 0.50

--- a/providers/alibaba/provider.toml
+++ b/providers/alibaba/provider.toml
@@ -4,7 +4,8 @@ npm = "@ai-sdk/openai-compatible"
 # Reasoning HTTP format (accessed 2026-06-25):
 # OpenAI Chat: POST /compatible-mode/v1/chat/completions; top-level
 # `enable_thinking` is true or false and `thinking_budget` is an integer token
-# cap (Qwen3 in thinking mode and Kimi only; default is the model maximum).
+# cap (Qwen3/Qwen3.5/Qwen3.6/Qwen3.7/Qwen3-VL thinking mode and Kimi;
+# public docs say the default is the model maximum but do not publish bounds).
 # Responses: POST /compatible-mode/v1/responses; `reasoning.effort` is none,
 # minimal, low, medium (default), or high; no numeric thinking budget is accepted.
 # Anthropic: POST /apps/anthropic/v1/messages; `thinking.type` is enabled or
@@ -17,4 +18,4 @@ npm = "@ai-sdk/openai-compatible"
 # https://www.alibabacloud.com/help/en/model-studio/compatibility-with-openai-responses-api
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
 doc = "https://www.alibabacloud.com/help/en/model-studio/models"
-api = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1" 
+api = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"


### PR DESCRIPTION
## Summary

Follow-up to #2867. Re-audited Alibaba selectable reasoning claims against provider-specific raw request-surface documentation.

- Kept Alibaba `toggle` claims where `enable_thinking` is documented for the same hybrid-thinking model families.
- Kept Alibaba `budget_tokens` claims where `thinking_budget` is documented as the provider request field for supported Qwen/Qwen-VL thinking modes.
- Removed model-specific `budget_tokens.max` values because the public Alibaba docs state the default is the model maximum but do not publish exact accepted bounds for these model IDs.

## Evidence

- [Alibaba Model Studio Deep thinking](https://www.alibabacloud.com/help/en/model-studio/deep-thinking) documents the OpenAI-compatible Chat `enable_thinking` field with `true` and `false` values for hybrid thinking models, lists the relevant Qwen hybrid-thinking model families, and documents `thinking_budget` as a numeric reasoning-token cap.
- [Alibaba Model Studio Visual reasoning](https://www.alibabacloud.com/help/en/model-studio/visual-reasoning) documents Qwen3.5, Qwen3.6, Qwen3-VL, and Kimi visual reasoning behavior, states that `enable_thinking` controls hybrid-thinking models, and states that `thinking_budget` limits thinking-process token length for Qwen3.6, Qwen3.5, Qwen3-VL thinking mode, and Kimi thinking mode.
- [Alibaba OpenAI-compatible Chat API reference](https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-chat-completions) documents the raw Alibaba endpoint `POST /compatible-mode/v1/chat/completions`, `enable_thinking`, and `thinking_budget`; it says `thinking_budget` defaults to the model maximum and to check the console for that maximum, so this PR does not claim TOML `max` bounds.

## Validation

- `ln -s "/Users/aidencline/development/modelsdev2/node_modules" node_modules 2>/dev/null || true`: completed.
- `bun validate`: passed.
- Alibaba-only generated invariant check for `reasoning === true` requiring `reasoning_options` and `reasoning === false` forbidding `reasoning_options`: passed.
- `git diff --check`: passed.
