### PR TITLE
Add TrustedRouter provider catalog

### DIFF
--- a/providers/trustedrouter/logo.svg
+++ b/providers/trustedrouter/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M3 4h18v4h-7v12h-4V8H3V4Z"/>
+  <path d="M15 10h2.75C20.65 10 23 12.35 23 15.25S20.65 20.5 17.75 20.5H15v-4h2.75c.69 0 1.25-.56 1.25-1.25S18.44 14 17.75 14H15v-4Z"/>
+</svg>

--- a/providers/trustedrouter/models/auto.toml
+++ b/providers/trustedrouter/models/auto.toml
@@ -1,0 +1,19 @@
+name = "Auto"
+description = "TrustedRouter automatic routing alias that chooses a healthy supported model endpoint for the request."
+release_date = "2026-05-01"
+last_updated = "2026-06-27"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/trustedrouter/models/cheap.toml
+++ b/providers/trustedrouter/models/cheap.toml
@@ -1,0 +1,19 @@
+name = "Cheap"
+description = "TrustedRouter low-cost routing alias that prefers inexpensive healthy model endpoints."
+release_date = "2026-05-01"
+last_updated = "2026-06-27"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/trustedrouter/models/e2e.toml
+++ b/providers/trustedrouter/models/e2e.toml
@@ -1,0 +1,19 @@
+name = "End-to-End Encrypted"
+description = "TrustedRouter privacy routing alias for end-to-end encrypted provider routes where available."
+release_date = "2026-06-01"
+last_updated = "2026-06-27"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/trustedrouter/models/fast.toml
+++ b/providers/trustedrouter/models/fast.toml
@@ -1,0 +1,19 @@
+name = "Fast"
+description = "TrustedRouter speed routing alias that prefers low-latency healthy model endpoints."
+release_date = "2026-06-01"
+last_updated = "2026-06-27"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/trustedrouter/models/synth-code.toml
+++ b/providers/trustedrouter/models/synth-code.toml
@@ -1,0 +1,19 @@
+name = "Synth Code"
+description = "TrustedRouter code synthesis orchestration alias that combines multiple model responses into one answer."
+release_date = "2026-06-20"
+last_updated = "2026-06-27"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/trustedrouter/models/synth.toml
+++ b/providers/trustedrouter/models/synth.toml
@@ -1,0 +1,19 @@
+name = "Synth"
+description = "TrustedRouter synthesis orchestration alias that combines multiple model responses into one answer."
+release_date = "2026-06-20"
+last_updated = "2026-06-27"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/trustedrouter/models/zdr.toml
+++ b/providers/trustedrouter/models/zdr.toml
@@ -1,0 +1,19 @@
+name = "Zero Data Retention"
+description = "TrustedRouter privacy routing alias that prefers zero data retention model endpoints."
+release_date = "2026-06-01"
+last_updated = "2026-06-27"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/trustedrouter/provider.toml
+++ b/providers/trustedrouter/provider.toml
@@ -1,0 +1,5 @@
+name = "TrustedRouter"
+env = ["TRUSTEDROUTER_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.trustedrouter.com/v1"
+doc = "https://trustedrouter.com/docs"


### PR DESCRIPTION
## Summary
- Add TrustedRouter as an OpenAI-compatible provider catalog entry.
- Include public router aliases for auto, cheap, fast, ZDR, E2E, Synth, and Synth Code.
- Omit static pricing because these aliases route dynamically and cost depends on the selected downstream model/provider.

## Context
This follows the redirect from the closed Opencode provider PR: https://github.com/anomalyco/opencode/pull/32115

## Validation
- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun ./packages/core/script/validate.ts`
