### PR TITLE
Add DeepReinforce Ornith 1.0 model family

### DIFF
--- a/models/deepreinforce/ornith-1.0-31b.toml
+++ b/models/deepreinforce/ornith-1.0-31b.toml
@@ -1,0 +1,27 @@
+# Announced in the Ornith 1.0 family but not yet published on Hugging Face as
+# of 2026-06-28 — no weights URL or benchmark scores available yet. Modalities
+# and context window are provisional, assumed consistent with the rest of the
+# family pending the public release.
+# https://deep-reinforce.com/ornith_1_0.html
+name = "Ornith 1.0 31B"
+family = "ornith"
+release_date = "2026-06-25"
+last_updated = "2026-06-25"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+license = "MIT"
+
+[limit]
+context = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[links]]
+label = "Announcement"
+url = "https://deep-reinforce.com/ornith_1_0.html"
+type = "announcement"

--- a/models/deepreinforce/ornith-1.0-35b.toml
+++ b/models/deepreinforce/ornith-1.0-35b.toml
@@ -1,0 +1,75 @@
+name = "Ornith 1.0 35B"
+family = "ornith"
+release_date = "2026-06-25"
+last_updated = "2026-06-25"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+license = "MIT"
+
+[limit]
+context = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B"
+
+[[links]]
+label = "Model card"
+url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B"
+type = "model_card"
+
+[[links]]
+label = "Announcement"
+url = "https://deep-reinforce.com/ornith_1_0.html"
+type = "announcement"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 75.6
+metric = "percent resolved"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B"
+
+[[benchmarks]]
+name = "SWE-Bench Pro"
+score = 50.4
+metric = "percent resolved"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B"
+
+[[benchmarks]]
+name = "SWE-Bench Multilingual"
+score = 69.3
+metric = "percent resolved"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1"
+score = 64.2
+metric = "percent"
+variant = "Terminus-2"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1"
+score = 62.8
+metric = "percent"
+variant = "Claude Code"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B"
+
+[[benchmarks]]
+name = "NL2Repo"
+score = 34.6
+metric = "percent"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B"
+
+[[benchmarks]]
+name = "Claw-eval"
+score = 69.8
+metric = "percent"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B"

--- a/models/deepreinforce/ornith-1.0-397b.toml
+++ b/models/deepreinforce/ornith-1.0-397b.toml
@@ -1,0 +1,80 @@
+name = "Ornith 1.0 397B"
+family = "ornith"
+release_date = "2026-06-25"
+last_updated = "2026-06-25"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+license = "MIT"
+
+[limit]
+context = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B"
+
+[[weights]]
+label = "Hugging Face (FP8)"
+url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B-FP8"
+quantization = "fp8"
+
+[[links]]
+label = "Model card"
+url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B"
+type = "model_card"
+
+[[links]]
+label = "Announcement"
+url = "https://deep-reinforce.com/ornith_1_0.html"
+type = "announcement"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 82.4
+metric = "percent resolved"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B"
+
+[[benchmarks]]
+name = "SWE-Bench Pro"
+score = 62.2
+metric = "percent resolved"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B"
+
+[[benchmarks]]
+name = "SWE-Bench Multilingual"
+score = 78.9
+metric = "percent resolved"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1"
+score = 77.5
+metric = "percent"
+variant = "Terminus-2"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1"
+score = 78.2
+metric = "percent"
+variant = "Claude Code"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B"
+
+[[benchmarks]]
+name = "NL2Repo"
+score = 48.2
+metric = "percent"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B"
+
+[[benchmarks]]
+name = "Claw-eval"
+score = 77.1
+metric = "percent"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B"

--- a/models/deepreinforce/ornith-1.0-9b.toml
+++ b/models/deepreinforce/ornith-1.0-9b.toml
@@ -1,0 +1,75 @@
+name = "Ornith 1.0 9B"
+family = "ornith"
+release_date = "2026-06-25"
+last_updated = "2026-06-25"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+license = "MIT"
+
+[limit]
+context = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B"
+
+[[links]]
+label = "Model card"
+url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B"
+type = "model_card"
+
+[[links]]
+label = "Announcement"
+url = "https://deep-reinforce.com/ornith_1_0.html"
+type = "announcement"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 69.4
+metric = "percent resolved"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B"
+
+[[benchmarks]]
+name = "SWE-Bench Pro"
+score = 42.9
+metric = "percent resolved"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B"
+
+[[benchmarks]]
+name = "SWE-Bench Multilingual"
+score = 52
+metric = "percent resolved"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1"
+score = 43.1
+metric = "percent"
+variant = "Terminus-2"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B"
+
+[[benchmarks]]
+name = "Terminal-Bench 2.1"
+score = 40.6
+metric = "percent"
+variant = "Claude Code"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B"
+
+[[benchmarks]]
+name = "NL2Repo"
+score = 27.2
+metric = "percent"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B"
+
+[[benchmarks]]
+name = "Claw-eval"
+score = 63.1
+metric = "percent"
+source = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B"

--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -54,6 +54,9 @@ export const ModelFamilyValues = [
   "qwen3.7-max",
   "qwen-free",
 
+  // DeepReinforce
+  "ornith",
+
   // DeepSeek
   "deepseek",
   "deepseek-thinking",


### PR DESCRIPTION
## Summary

Adds provider-agnostic metadata for the **Ornith 1.0** open-weights agentic-coding family from [DeepReinforce](https://deep-reinforce.com/ornith_1_0.html):

| Model | Type | Weights | Context | License |
|---|---|---|---|---|
| `deepreinforce/ornith-1.0-9b` | 9B Dense | [HF](https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B) | 262K | MIT |
| `deepreinforce/ornith-1.0-31b` | 31B Dense | — (unreleased) | 262K | MIT |
| `deepreinforce/ornith-1.0-35b` | 35B MoE | [HF](https://huggingface.co/deepreinforce-ai/Ornith-1.0-35B) | 262K | MIT |
| `deepreinforce/ornith-1.0-397b` | 397B MoE | [HF](https://huggingface.co/deepreinforce-ai/Ornith-1.0-397B) (+ FP8) | 262K | MIT |

All variants share reasoning (`<think>` blocks), tool calling, multimodal text+image input, and a 262,144-token context window. Facts and benchmark scores are sourced from each model's Hugging Face card and the DeepReinforce announcement.

Also introduces an `ornith` value in `ModelFamily` (`packages/core/src/family.ts`) and groups all four entries under it.

## Notes for reviewers

- **Metadata-only, no serving provider.** Ornith 1.0 has no hosted API or pricing yet, so these are `models/` entries (surface in `models.json` / `catalog.json`) with no `providers/` counterpart. They're ready for any inference provider to inherit via `base_model = "deepreinforce/ornith-1.0-<size>"` once one lists the model.
- **31B Dense is a provisional stub.** It's named in the announcement but not yet published on Hugging Face, so it has no `weights` URL and no benchmark scores. A header comment in the file flags this; specs (modalities, context) are assumed consistent with the rest of the family pending release.
- **Multimodal inference.** The 9B/35B/397B repos are tagged `image-text-to-text` with `Qwen3_5(Moe)ForConditionalGeneration` architectures and image-aware chat templates, so `modalities.input = ["text", "image"]`. (The 9B README prose says "text-only", but the model config contradicts it.)

## Validation

`bun validate` passes locally (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
