### PR TITLE
Add app.nz provider (OpenAI-compatible auto-router gateway)

### DIFF
--- a/providers/app-nz/models/app/auto-cheap.toml
+++ b/providers/app-nz/models/app/auto-cheap.toml
@@ -1,0 +1,22 @@
+name = "Auto Cheap"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream low-cost models; pricing is variable. Values below
+# are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 0.20
+output = 0.60
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto-code.toml
+++ b/providers/app-nz/models/app/auto-code.toml
@@ -1,0 +1,22 @@
+name = "Auto Code"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream coding models; pricing is variable. Values below
+# are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 1.50
+output = 6.00
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto-fast.toml
+++ b/providers/app-nz/models/app/auto-fast.toml
@@ -1,0 +1,22 @@
+name = "Auto Fast"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream low-latency models; pricing is variable. Values
+# below are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 0.50
+output = 1.50
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto-reasoning.toml
+++ b/providers/app-nz/models/app/auto-reasoning.toml
@@ -1,0 +1,23 @@
+name = "Auto Reasoning"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream reasoning models; pricing is variable. Values below
+# are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 2.00
+output = 8.00
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto-vision.toml
+++ b/providers/app-nz/models/app/auto-vision.toml
@@ -1,0 +1,22 @@
+name = "Auto Vision"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream vision models; pricing is variable. Values below
+# are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 1.50
+output = 5.00
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto.toml
+++ b/providers/app-nz/models/app/auto.toml
@@ -1,0 +1,23 @@
+name = "Auto"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# app.nz is an aggregating gateway; requests are routed to mixed upstream
+# models, so pricing is variable. Values below are modest representative
+# numbers, not a fixed per-token rate.
+[cost]
+input = 1.00
+output = 3.00
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/provider.toml
+++ b/providers/app-nz/provider.toml
@@ -1,0 +1,5 @@
+name = "app.nz"
+env = ["APP_NZ_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://app.nz/v1"
+doc = "https://app.nz/docs"


### PR DESCRIPTION
Adds the **app.nz** provider — a hosted, OpenAI-compatible LLM gateway/aggregator (base URL `https://app.nz/v1`, auth via `APP_NZ_API_KEY`).

app.nz has no public npm SDK, so it uses `@ai-sdk/openai-compatible` with an explicit `api` base URL, matching existing aggregators like `302ai` and `aihubmix`.

### Models (auto-router family)
- `app/auto` — default auto-router
- `app/auto-code` — coding-optimized routing
- `app/auto-reasoning` — reasoning routing (toggle + low/medium/high effort)
- `app/auto-fast` — low-latency routing
- `app/auto-cheap` — low-cost routing
- `app/auto-vision` — image-input routing

### Notes
- `id` is auto-derived from filenames; slash ids encoded as `models/app/<name>.toml`.
- `family` is intentionally omitted: the gateway routes across mixed upstreams with no single matching `ModelFamily`.
- `[cost]` values are representative with an inline note that pricing is routed/variable (upstream-dependent).

Validated with `bun validate` (passes).
