### PR TITLE
[gmicloud] add latest model ids

### DIFF
--- a/providers/gmicloud/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/gmicloud/models/Qwen/Qwen3.7-Max.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3.7-max"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 2.50
+output = 7.50
+cache_read = 0.25
+cache_write = 3.125

--- a/providers/gmicloud/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/gmicloud/models/Qwen/Qwen3.7-Max.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 2.50

--- a/providers/gmicloud/models/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/providers/gmicloud/models/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,13 @@
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.90
+output = 8.00
+cache_read = 0.38
+
+[modalities]
+input = ["text"]

--- a/providers/gmicloud/models/zai-org/GLM-5.2-FP8.toml
+++ b/providers/gmicloud/models/zai-org/GLM-5.2-FP8.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.979
+output = 3.08
+cache_read = 0.182

--- a/providers/gmicloud/models/zai-org/GLM-5.2-FP8.toml
+++ b/providers/gmicloud/models/zai-org/GLM-5.2-FP8.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Summary
- Add GMI Cloud model entries for `moonshotai/kimi-k2.7-code-highspeed`, `zai-org/GLM-5.2-FP8`, and `Qwen/Qwen3.7-Max`.
- Place the model definitions under the matching GMI model ID directories and reuse shared metadata with `base_model`.
- Add GMI Cloud pricing and cache pricing overrides from the GMI catalog data.

## Tests
- `python` TOML parse check for the three added files
- `git cat-file -e` check for the referenced base models
- `git diff --check origin/dev..HEAD`

bun run validate.