### PR TITLE
chore(ci): restrict workflows to main repo

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   close-stale-pull-requests:
+    if: github.repository == 'anomalyco/models.dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v8

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -7,10 +7,13 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      github.repository == 'anomalyco/models.dev' &&
+      (
+        contains(github.event.comment.body, ' /oc') ||
+        startsWith(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, ' /opencode') ||
+        startsWith(github.event.comment.body, '/opencode')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   validate:
+    if: github.repository == 'anomalyco/models.dev'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Add repository guards to validate, stale PR cleanup, and opencode workflows
- Ensure workflow jobs skip outside anomalyco/models.dev

## Validation
- git diff --check
- Parsed all .github/workflows/*.yml as YAML