### PR TITLE
Fix opencode non-toggle reasoning options

### DIFF
--- a/providers/opencode-go/models/glm-5.2.toml
+++ b/providers/opencode-go/models/glm-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/opencode-go/models/qwen3.5-plus.toml
+++ b/providers/opencode-go/models/qwen3.5-plus.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode-go/models/qwen3.6-plus.toml
+++ b/providers/opencode-go/models/qwen3.6-plus.toml
@@ -4,7 +4,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"

--- a/providers/opencode-go/models/qwen3.7-max.toml
+++ b/providers/opencode-go/models/qwen3.7-max.toml
@@ -4,7 +4,7 @@ release_date = "2026-05-21"
 last_updated = "2026-05-21"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/opencode-go/models/qwen3.7-plus.toml
+++ b/providers/opencode-go/models/qwen3.7-plus.toml
@@ -4,7 +4,7 @@ release_date = "2026-06-02"
 last_updated = "2026-06-02"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
 temperature = true
 tool_call = true
 open_weights = false

--- a/providers/opencode/models/claude-haiku-4-5.toml
+++ b/providers/opencode/models/claude-haiku-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/opencode/models/claude-opus-4-1.toml
+++ b/providers/opencode/models/claude-opus-4-1.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 31_999 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/claude-opus-4-5.toml
+++ b/providers/opencode/models/claude-opus-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/claude-opus-4-6.toml
+++ b/providers/opencode/models/claude-opus-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 
 [cost]
 input = 5

--- a/providers/opencode/models/claude-sonnet-4-5.toml
+++ b/providers/opencode/models/claude-sonnet-4-5.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/opencode/models/claude-sonnet-4-6.toml
+++ b/providers/opencode/models/claude-sonnet-4-6.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/opencode/models/claude-sonnet-4.toml
+++ b/providers/opencode/models/claude-sonnet-4.toml
@@ -4,7 +4,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024, max = 63_999 }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/opencode/models/glm-5.2.toml
+++ b/providers/opencode/models/glm-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/opencode/models/gpt-5.3-codex.toml
+++ b/providers/opencode/models/gpt-5.3-codex.toml
@@ -4,7 +4,7 @@ release_date = "2026-02-24"
 last_updated = "2026-02-24"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true


### PR DESCRIPTION
## Summary
- Add GLM-5.2 effort reasoning options to opencode and opencode-go.
- Add Qwen budget-token reasoning options to affected opencode-go models.
- Remove unverified Anthropic budget max bounds from opencode models to match native Anthropic records.
- Add the missing `none` effort value to opencode GPT-5.3 Codex.

Fixes #2888

## Notes
- Toggle-only mismatches were intentionally left unchanged.
- Follow-up comparison found no remaining non-toggle reasoning-option mismatches among matched opencode/opencode-go records.

## Validation
- `bun validate`
- `git diff --check`