### PR TITLE
feat(amazon-bedrock): add xAI Grok 4.3

### DIFF
--- a/providers/amazon-bedrock/models/xai.grok-4.3.toml
+++ b/providers/amazon-bedrock/models/xai.grok-4.3.toml
@@ -1,0 +1,20 @@
+base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+last_updated = "2026-06-28"
+
+[cost]
+input = 1.25
+output = 2.50
+cache_read = 0.20
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"


### PR DESCRIPTION
## Summary
- add Amazon Bedrock Mantle entry for xAI Grok 4.3
- routes through `bedrock-mantle` on the `/openai/v1` path with `shape = "responses"`
- pricing: \$1.25/\$2.50/\$0.20 (input/output/cache) per AWS Bedrock pricing page
- reasoning effort options: none, low, medium, high (always-on, configurable per AWS docs)
- modalities: text + image input (PDF dropped — not supported on Bedrock)
- output limit: 131,072 tokens (per AWS docs `max_completion_tokens` default)

## Validation
- `bun validate`

Closes #2667