### PR TITLE
fix(neuralwatt): add reasoning_options to kimi-k2.7-code-flex

### DIFF
--- a/providers/neuralwatt/models/kimi-k2.7-code-flex.toml
+++ b/providers/neuralwatt/models/kimi-k2.7-code-flex.toml
@@ -1,5 +1,6 @@
 base_model = "moonshotai/kimi-k2.7-code"
 name = "Kimi K2.7 Code Flex"
+reasoning_options = []
 
 [cost]
 input = 0.475


### PR DESCRIPTION
Validation was failing because reasoning=true (inherited from base_model moonshotai/kimi-k2.7-code) requires reasoning_options to be set in provider TOML files.

This fixes the CI deploy failure introduced in #2730.

Validation now passes: bun validate