### PR TITLE
fix: update Xiaomi MiMo PAYG pricing

### DIFF
--- a/providers/xiaomi/models/mimo-v2-flash.toml
+++ b/providers/xiaomi/models/mimo-v2-flash.toml
@@ -1,7 +1,7 @@
 name = "MiMo-V2-Flash"
 family = "mimo"
 release_date = "2025-12-16"
-last_updated = "2026-02-04"
+last_updated = "2026-06-24"
 attachment = false
 reasoning = true
 temperature = true
@@ -14,9 +14,9 @@ status = "deprecated"
 type = "toggle"
 
 [cost]
-input = 0.10
-output = 0.30
-cache_read = 0.01
+input = 0.14
+output = 0.28
+cache_read = 0.0028
 
 [limit]
 context = 262_144

--- a/providers/xiaomi/models/mimo-v2-omni.toml
+++ b/providers/xiaomi/models/mimo-v2-omni.toml
@@ -1,7 +1,7 @@
 name = "MiMo-V2-Omni"
 family = "mimo"
 release_date = "2026-03-18"
-last_updated = "2026-03-18"
+last_updated = "2026-06-24"
 attachment = true
 reasoning = true
 temperature = true
@@ -17,9 +17,9 @@ type = "toggle"
 field = "reasoning_content"
 
 [cost]
-input = 0.40
-output = 2.00
-cache_read = 0.08
+input = 0.14
+output = 0.28
+cache_read = 0.0028
 
 [limit]
 context = 262_144

--- a/providers/xiaomi/models/mimo-v2-pro.toml
+++ b/providers/xiaomi/models/mimo-v2-pro.toml
@@ -1,7 +1,7 @@
 name = "MiMo-V2-Pro"
 family = "mimo"
 release_date = "2026-03-18"
-last_updated = "2026-03-18"
+last_updated = "2026-06-24"
 attachment = false
 reasoning = true
 temperature = true
@@ -17,15 +17,9 @@ type = "toggle"
 field = "reasoning_content"
 
 [cost]
-input = 1.00
-output = 3.00
-cache_read = 0.20
-
-[[cost.tiers]]
-tier = { size = 256_000 }
-input = 2.00
-output = 6.00
-cache_read = 0.40
+input = 0.435
+output = 0.87
+cache_read = 0.0036
 
 [limit]
 context = 1_048_576

--- a/providers/xiaomi/models/mimo-v2.5-pro.toml
+++ b/providers/xiaomi/models/mimo-v2.5-pro.toml
@@ -1,7 +1,7 @@
 name = "MiMo-V2.5-Pro"
 family = "mimo"
 release_date = "2026-04-22"
-last_updated = "2026-04-22"
+last_updated = "2026-06-24"
 attachment = false
 reasoning = true
 temperature = true
@@ -13,15 +13,9 @@ open_weights = true
 type = "toggle"
 
 [cost]
-input = 1
-output = 3
-cache_read = 0.2
-
-[[cost.tiers]]
-tier = { size = 256_000 }
-input = 2.00
-output = 6.00
-cache_read = 0.40
+input = 0.435
+output = 0.87
+cache_read = 0.0036
 
 [limit]
 context = 1_048_576

--- a/providers/xiaomi/models/mimo-v2.5.toml
+++ b/providers/xiaomi/models/mimo-v2.5.toml
@@ -1,7 +1,7 @@
 name = "MiMo-V2.5"
 family = "mimo"
 release_date = "2026-04-22"
-last_updated = "2026-04-22"
+last_updated = "2026-06-24"
 attachment = true
 reasoning = true
 temperature = true
@@ -13,15 +13,9 @@ open_weights = true
 type = "toggle"
 
 [cost]
-input = 0.4
-output = 2
-cache_read = 0.08
-
-[[cost.tiers]]
-tier = { size = 256_000 }
-input = 0.80
-output = 4.00
-cache_read = 0.16
+input = 0.14
+output = 0.28
+cache_read = 0.0028
 
 [limit]
 context = 1_048_576


### PR DESCRIPTION
Updates Xiami MiMo pay as you go model prices to match current pricing: https://mimo.mi.com/docs/en-US/price/pay-as-you-go

Removes the `[[cost.tiers]]` sections as well, as this distinction has been removed. See earlier state from Wayback Machine: https://web.archive.org/web/20260526190944/https://platform.xiaomimimo.com/docs/en-US/price/pay-as-you-go

Ref https://github.com/earendil-works/pi/issues/6138