### PR TITLE
chore: update groq pricing

### DIFF
--- a/providers/groq/models/openai/gpt-oss-safeguard-20b.toml
+++ b/providers/groq/models/openai/gpt-oss-safeguard-20b.toml
@@ -9,7 +9,7 @@
 name = "Safety GPT OSS 20B"
 family = "gpt-oss"
 release_date = "2025-10-29"
-last_updated = "2025-10-29"
+last_updated = "2026-06-29"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
@@ -22,7 +22,6 @@ status = "beta"
 [cost]
 input = 0.075
 output = 0.30
-cache_read = 0.037
 
 [limit]
 context = 131_072


### PR DESCRIPTION
- updating groq pricing
- GPT OSS Safeguard 20B doesn't charge for cache anymore on Groq
- updated with [opencode agent + Narev MCP](https://github.com/oskarkocol/models.dev-contrib/blob/dev/.github/workflows/pricing-updater.yml), sources in the comments