### PR TITLE
[gmicloud] add Opus 4.8 and GPT-5.5

### DIFF
--- a/providers/gmicloud/models/anthropic/claude-opus-4.8.toml
+++ b/providers/gmicloud/models/anthropic/claude-opus-4.8.toml
@@ -1,0 +1,9 @@
+base_model = "anthropic/claude-opus-4-8"
+# GMI documents Opus 4.8 as defaulting to high effort, with xhigh for Claude Code
+# and max via API parameters.
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5

--- a/providers/gmicloud/models/openai/gpt-5.5.toml
+++ b/providers/gmicloud/models/openai/gpt-5.5.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.5"
+# GMI's Responses endpoint sends reasoning effort as reasoning = { effort = "low" }.
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5


### PR DESCRIPTION
## Summary
- Add GMI Cloud model entries for `anthropic/claude-opus-4.8` and `openai/gpt-5.5`.
- Reuse shared base model metadata through `base_model`.
- Add GMI pricing and reasoning option comments based on the documented API behavior.

## Tests
- Parsed added TOML files with Python `tomllib`
- Verified referenced base model files exist in upstream `dev`
- `git diff --check` for the added files