### PR TITLE
[aihubmix/claude] Add Claude Opus 4.8

### DIFF
--- a/providers/aihubmix/models/claude-opus-4-8-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-8-think.toml
@@ -1,0 +1,19 @@
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/claude-opus-4-8.toml
+++ b/providers/aihubmix/models/claude-opus-4-8.toml
@@ -1,0 +1,18 @@
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+
+interleaved = true
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/kimi-k2.7-code-highspeed.toml
+++ b/providers/aihubmix/models/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,19 @@
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
+reasoning_options = [{ type = "toggle" }]
+temperature = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.9
+output = 7.999
+cache_read = 0.32167
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/aihubmix/models/kimi-k2.7-code.toml
+++ b/providers/aihubmix/models/kimi-k2.7-code.toml
@@ -1,0 +1,19 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = [{ type = "toggle" }]
+temperature = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 3.9995
+cache_read = 0.160835
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Add AIHubMix provider TOML entries for Claude Opus 4.8 and Claude Opus 4.8 Thinking.
- Reuse existing read-only base models and override AIHubMix service-side cost, limits, modalities, interleaved reasoning fields, and reasoning options.

## Changes

- `providers/aihubmix/models/claude-opus-4-8.toml`
- `providers/aihubmix/models/claude-opus-4-8-think.toml`

## Validation

- `bun run validate`
- AIHubMix OpenCode validator for:
  - `claude-opus-4-8`
  - `claude-opus-4-8-think`

Superseded by https://github.com/anomalyco/models.dev/pull/2925.