### PR TITLE
[aihubmix/claude] Add Claude Opus 4.8

### DIFF
--- a/providers/aihubmix/models/claude-opus-4-8-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-8-think.toml
@@ -1,5 +1,4 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/aihubmix/models/claude-opus-4-8-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-8-think.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "toggle" }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/aihubmix/models/claude-opus-4-8-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-8-think.toml
@@ -1,0 +1,19 @@
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/claude-opus-4-8-think.toml
+++ b/providers/aihubmix/models/claude-opus-4-8-think.toml
@@ -1,5 +1,6 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+# Anthropic-compatible /v1/messages: $.thinking.type = "enabled"|"disabled"|"adaptive" (disabled turns reasoning off = toggle) and $.output_config.effort = "low"|"medium"|"high"|"xhigh"|"max"; manual budget_tokens is rejected on this Opus tier. https://docs.aihubmix.com/cn/api-reference/anthropic-compatible/create-a-message (accessed 2026-07-02)
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/aihubmix/models/claude-opus-4-8.toml
+++ b/providers/aihubmix/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "toggle" }]
 
 interleaved = true
 

--- a/providers/aihubmix/models/claude-opus-4-8.toml
+++ b/providers/aihubmix/models/claude-opus-4-8.toml
@@ -1,0 +1,18 @@
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+
+interleaved = true
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/claude-opus-4-8.toml
+++ b/providers/aihubmix/models/claude-opus-4-8.toml
@@ -1,5 +1,4 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 
 interleaved = true
 

--- a/providers/aihubmix/models/claude-opus-4-8.toml
+++ b/providers/aihubmix/models/claude-opus-4-8.toml
@@ -1,5 +1,6 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+# Anthropic-compatible /v1/messages: $.thinking.type = "enabled"|"disabled"|"adaptive" (disabled turns reasoning off = toggle) and $.output_config.effort = "low"|"medium"|"high"|"xhigh"|"max"; manual budget_tokens is rejected on this Opus tier. https://docs.aihubmix.com/cn/api-reference/anthropic-compatible/create-a-message (accessed 2026-07-02)
 
 interleaved = true
 


### PR DESCRIPTION
## Summary

- Add AIHubMix provider TOML entries for Claude Opus 4.8 and Claude Opus 4.8 Thinking.
- Reuse existing read-only base models and override AIHubMix service-side cost, limits, modalities, interleaved reasoning fields, and reasoning options.

## Changes

- `providers/aihubmix/models/claude-opus-4-8.toml`
- `providers/aihubmix/models/claude-opus-4-8-think.toml`

## Validation

- `bun run validate`
- AIHubMix OpenCode validator for:
  - `claude-opus-4-8`
  - `claude-opus-4-8-think`