### PR TITLE
fix: declare Wafer GLM-5.2 reasoning_content interleaving

### DIFF
--- a/providers/wafer.ai/models/GLM-5.2.toml
+++ b/providers/wafer.ai/models/GLM-5.2.toml
@@ -2,6 +2,9 @@ base_model = "zhipuai/glm-5.2"
 last_updated = "2026-06-22"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
+[interleaved]
+field = "reasoning_content"
+
 [cost]
 input = 1.20
 output = 4.10


### PR DESCRIPTION
`wafer.ai`'s `GLM-5.2` returns its reasoning trace in the non-standard `reasoning_content` field, so a client has to be told where the reasoning lives — to surface it and to send it back on follow-up turns. The base `zhipuai/glm-5.2` doesn't declare this, so the provider entry sets it, matching the other GLM-5.2 OpenAI-compatible providers (`opencode-go`, `alibaba-token-plan`).

## Proof

With reasoning enabled the model puts the whole trace in `reasoning_content`, not the OpenAI-standard `reasoning` field:

```bash
curl -sS https://pass.wafer.ai/v1/chat/completions \
  -H "Authorization: Bearer $WAFER_API_KEY" -H "Content-Type: application/json" \
  -d '{
    "model": "GLM-5.2",
    "messages": [{"role": "user", "content": "What is 17 * 23? Think it through."}],
    "thinking": {"type": "enabled"},
    "max_tokens": 1500
  }' | jq '.choices[0].message | {keys: keys, has_reasoning_content: has("reasoning_content"), has_reasoning: has("reasoning")}'
```

```json
{
  "keys": ["content", "reasoning_content", "role", "tool_calls"],
  "has_reasoning_content": true,
  "has_reasoning": false
}
```
