### PR TITLE
feat: add default field to reasoning_options schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ Models must conform to the following schema, as defined in `packages/core/src/sc
 - `open_weights`: Boolean - Indicate the model's trained weights are publicly available
 - `interleaved` _(optional)_: Boolean or Object — Supports interleaved reasoning. Use `true` for general support or an object with `field` to specify the format
 - `interleaved.field`: String — Name of the interleaved field (`"reasoning_content"` or `"reasoning_details"`)
+- `reasoning_options` _(optional, provider-specific)_: Array of objects — How the model's reasoning can be configured. Each entry is one of:
+  - `{ type = "toggle", default? = <bool> }` — reasoning can be turned on/off. `default` is the value applied when the request omits it.
+  - `{ type = "effort", values = [...], default? = <value> }` — reasoning effort selectable from `values` (a subset of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`). `default`, when present, must be one of `values` and is the effort the provider applies when the request omits it.
+  - `{ type = "budget_tokens", min? = <n>, max? = <n>, default? = <n> }` — reasoning controlled by a token budget. `default`, when present, must fall within `[min, max]`, or be `-1` to denote the provider's dynamic-thinking default.
 - `cost.input`: Number — Cost per million input tokens (USD)
 - `cost.output`: Number — Cost per million output tokens (USD)
 - `cost.reasoning` _(optional)_: Number — Cost per million reasoning tokens (USD)

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -34,12 +34,14 @@ const ReasoningOption = z
     z
       .object({
         type: z.literal("toggle"),
+        default: z.boolean().optional(),
       })
       .strict(),
     z
       .object({
         type: z.literal("effort"),
         values: z.array(ReasoningEffortValue),
+        default: ReasoningEffortValue.optional(),
       })
       .strict(),
     z
@@ -52,6 +54,10 @@ const ReasoningOption = z
         max: z
           .number()
           .min(0, "Maximum reasoning budget cannot be negative")
+          .optional(),
+        default: z
+          .number()
+          .min(-1, "Default reasoning budget cannot be less than -1")
           .optional(),
       })
       .strict(),
@@ -66,6 +72,30 @@ const ReasoningOption = z
       message:
         "Minimum reasoning budget cannot exceed maximum reasoning budget",
       path: ["min"],
+    },
+  )
+  .refine(
+    (data) =>
+      data.type !== "effort" ||
+      data.default === undefined ||
+      data.values.includes(data.default),
+    {
+      message: "Default reasoning effort must be one of the allowed values",
+      path: ["default"],
+    },
+  )
+  .refine(
+    (data) =>
+      data.type !== "budget_tokens" ||
+      data.default === undefined ||
+      // -1 is the dynamic-thinking sentinel and is always allowed
+      data.default === -1 ||
+      ((data.min === undefined || data.default >= data.min) &&
+        (data.max === undefined || data.default <= data.max)),
+    {
+      message:
+        "Default reasoning budget must be within [min, max] or -1 for dynamic",
+      path: ["default"],
     },
   );
 

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -296,6 +296,87 @@ input = ["text"]
   });
 });
 
+describe("reasoning_options default", () => {
+  test("carries an effort default through to provider JSON", async () => {
+    await withFixture(async (root) => {
+      await write(root, "providers/provider/provider.toml", providerToml("Provider"));
+      await write(
+        root,
+        "providers/provider/models/model.toml",
+        reasoningModelToml(
+          `[{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]`,
+        ),
+      );
+
+      const providers = await generate(path.join(root, "providers"));
+
+      expect(providers.provider?.models.model?.reasoning_options).toEqual([
+        { type: "effort", values: ["low", "medium", "high"], default: "medium" },
+      ]);
+    });
+  });
+
+  test("rejects an effort default that is not an allowed value", async () => {
+    await withFixture(async (root) => {
+      await write(root, "providers/provider/provider.toml", providerToml("Provider"));
+      await write(
+        root,
+        "providers/provider/models/model.toml",
+        reasoningModelToml(
+          `[{ type = "effort", values = ["low", "high"], default = "medium" }]`,
+        ),
+      );
+
+      expect(generate(path.join(root, "providers"))).rejects.toThrow();
+    });
+  });
+
+  test("rejects a budget default outside [min, max]", async () => {
+    await withFixture(async (root) => {
+      await write(root, "providers/provider/provider.toml", providerToml("Provider"));
+      await write(
+        root,
+        "providers/provider/models/model.toml",
+        reasoningModelToml(
+          `[{ type = "budget_tokens", min = 128, max = 32_768, default = 1_000_000 }]`,
+        ),
+      );
+
+      expect(generate(path.join(root, "providers"))).rejects.toThrow();
+    });
+  });
+
+  test("allows a budget default of -1 for dynamic thinking", async () => {
+    await withFixture(async (root) => {
+      await write(root, "providers/provider/provider.toml", providerToml("Provider"));
+      await write(
+        root,
+        "providers/provider/models/model.toml",
+        reasoningModelToml(
+          `[{ type = "budget_tokens", min = 128, max = 32_768, default = -1 }]`,
+        ),
+      );
+
+      const providers = await generate(path.join(root, "providers"));
+
+      expect(providers.provider?.models.model?.reasoning_options).toEqual([
+        { type: "budget_tokens", min: 128, max: 32_768, default: -1 },
+      ]);
+    });
+  });
+});
+
+function reasoningModelToml(optionsInline: string) {
+  return `${providerFieldsToml().replace(
+    "reasoning = true\n",
+    `reasoning = true\nreasoning_options = ${optionsInline}\n`,
+  )}
+[cost]
+input = 1.25
+output = 2.50
+`;
+}
+
 function providerToml(name: string) {
   return `name = "${name}"
 npm = "@ai-sdk/openai"

--- a/providers/google-vertex/models/gemini-2.5-flash.toml
+++ b/providers/google-vertex/models/gemini-2.5-flash.toml
@@ -4,7 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576, default = -1 }]
 temperature = true
 knowledge = "2025-01"
 tool_call = true

--- a/providers/google-vertex/models/gemini-2.5-pro.toml
+++ b/providers/google-vertex/models/gemini-2.5-pro.toml
@@ -1,6 +1,6 @@
 base_model = "google/gemini-2.5-pro"
 base_model_omit = ["structured_output"]
-reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "budget_tokens", min = 128, max = 32_768, default = -1 }]
 
 [cost]
 input = 1.25

--- a/providers/google/models/gemini-2.5-flash.toml
+++ b/providers/google/models/gemini-2.5-flash.toml
@@ -17,6 +17,7 @@ type = "toggle"
 type = "budget_tokens"
 min = 0
 max = 24_576
+default = -1
 
 [cost]
 input = 0.30

--- a/providers/google/models/gemini-2.5-pro.toml
+++ b/providers/google/models/gemini-2.5-pro.toml
@@ -14,6 +14,7 @@ open_weights = false
 type = "budget_tokens"
 min = 128
 max = 32_768
+default = -1
 
 [cost]
 input = 1.25

--- a/providers/openai/models/gpt-5-codex.toml
+++ b/providers/openai/models/gpt-5-codex.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-15"
 last_updated = "2025-09-15"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/openai/models/gpt-5-mini.toml
+++ b/providers/openai/models/gpt-5-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/openai/models/gpt-5-nano.toml
+++ b/providers/openai/models/gpt-5-nano.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-07"
 last_updated = "2025-08-07"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2024-05-30"
 tool_call = true

--- a/providers/openai/models/gpt-5-pro.toml
+++ b/providers/openai/models/gpt-5-pro.toml
@@ -4,7 +4,7 @@ release_date = "2025-10-06"
 last_updated = "2025-10-06"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high"] }]
+reasoning_options = [{ type = "effort", values = ["high"], default = "high" }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/openai/models/gpt-5.1-chat-latest.toml
+++ b/providers/openai/models/gpt-5.1-chat-latest.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium"] }]
+reasoning_options = [{ type = "effort", values = ["medium"], default = "medium" }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/openai/models/gpt-5.1-codex-mini.toml
+++ b/providers/openai/models/gpt-5.1-codex-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/openai/models/gpt-5.1-codex.toml
+++ b/providers/openai/models/gpt-5.1-codex.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/openai/models/gpt-5.1.toml
+++ b/providers/openai/models/gpt-5.1.toml
@@ -4,7 +4,7 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"], default = "none" }]
 temperature = false
 knowledge = "2024-09-30"
 tool_call = true

--- a/providers/openai/models/gpt-5.2-chat-latest.toml
+++ b/providers/openai/models/gpt-5.2-chat-latest.toml
@@ -4,7 +4,7 @@ release_date = "2025-12-11"
 last_updated = "2025-12-11"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium"] }]
+reasoning_options = [{ type = "effort", values = ["medium"], default = "medium" }]
 temperature = false
 knowledge = "2025-08-31"
 tool_call = true

--- a/providers/openai/models/gpt-5.toml
+++ b/providers/openai/models/gpt-5.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5"
 
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"], default = "medium" }]
 
 [cost]
 input = 1.25

--- a/providers/openai/models/o1-pro.toml
+++ b/providers/openai/models/o1-pro.toml
@@ -5,7 +5,7 @@ last_updated = "2025-03-19"
 
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2023-09"
 tool_call = true

--- a/providers/openai/models/o1.toml
+++ b/providers/openai/models/o1.toml
@@ -4,7 +4,7 @@ release_date = "2024-12-05"
 last_updated = "2024-12-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2023-09"
 tool_call = true

--- a/providers/openai/models/o3-deep-research.toml
+++ b/providers/openai/models/o3-deep-research.toml
@@ -4,7 +4,7 @@ release_date = "2024-06-26"
 last_updated = "2024-06-26"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium"] }]
+reasoning_options = [{ type = "effort", values = ["medium"], default = "medium" }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/openai/models/o3-mini.toml
+++ b/providers/openai/models/o3-mini.toml
@@ -4,7 +4,7 @@ release_date = "2024-12-20"
 last_updated = "2025-01-29"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/openai/models/o3-pro.toml
+++ b/providers/openai/models/o3-pro.toml
@@ -4,7 +4,7 @@ release_date = "2025-06-10"
 last_updated = "2025-06-10"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/openai/models/o3.toml
+++ b/providers/openai/models/o3.toml
@@ -4,7 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/openai/models/o4-mini-deep-research.toml
+++ b/providers/openai/models/o4-mini-deep-research.toml
@@ -4,7 +4,7 @@ release_date = "2024-06-26"
 last_updated = "2024-06-26"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["medium"] }]
+reasoning_options = [{ type = "effort", values = ["medium"], default = "medium" }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true

--- a/providers/openai/models/o4-mini.toml
+++ b/providers/openai/models/o4-mini.toml
@@ -4,7 +4,7 @@ release_date = "2025-04-16"
 last_updated = "2025-04-16"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"], default = "medium" }]
 temperature = false
 knowledge = "2024-05"
 tool_call = true


### PR DESCRIPTION
Refs #314

## What

Adds an optional `default` field to each variant of the existing `reasoning_options` discriminated union, so consumers can know the value a provider applies when the reasoning option is omitted from a request (e.g. `gpt-5` runs at `medium` effort by default; `gemini-2.5-pro` thinks dynamically).

This **extends the existing nested `reasoning_options` shape** rather than introducing the flat keys sketched earlier in #314. The nested discriminated union is the shape under active development in this repo and already encodes the "required reasoning" and "single allowed value" cases cleanly.

## Schema (`packages/core/src/schema.ts`)

- `toggle`  → `default?: boolean`
- `effort`  → `default?: <effort value>`, refined to be a member of `values`
- `budget_tokens` → `default?: number`, refined to be within `[min, max]` **or** `-1` (the dynamic-thinking sentinel, matching the Gemini API convention)

## Docs

`reasoning_options` was previously undocumented in the README schema reference; this PR adds an entry covering all three variants and `default`.

## Backfill

Only values I could ground in provider docs are included:

| Provider | Models | default | Source |
|---|---|---|---|
| OpenAI | `gpt-5`, `gpt-5-mini`, `gpt-5-nano` | `medium` | [reasoning guide](https://developers.openai.com/api/docs/guides/reasoning), [AI SDK provider](https://ai-sdk.dev/providers/ai-sdk-providers/openai) ("Defaults to medium") |
| OpenAI | `gpt-5-pro` | `high` (only value) | [Azure reasoning matrix](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/reasoning) |
| OpenAI | `o1`, `o1-pro`, `o3`, `o3-mini`, `o3-pro`, `o4-mini` | `medium` | [API ref: `reasoning_effort`](https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort) |
| OpenAI | `o3-deep-research`, `o4-mini-deep-research`, `gpt-5.1-chat-latest`, `gpt-5.2-chat-latest` | single-value (default == only value) | n/a |
| OpenAI | `gpt-5.1` | `none` | [Azure reasoning matrix](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/reasoning) (5.1 adaptive/none default) ⚠️ |
| OpenAI | `gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-mini` | `medium` | family convention ⚠️ |
| Google | `gemini-2.5-pro`, `gemini-2.5-flash` (in `google` + `google-vertex`) | `-1` (dynamic) | [Gemini thinking docs](https://ai.google.dev/gemini-api/docs/thinking#set-budget) |

⚠️ The codex rows and `gpt-5.1`'s `none` follow the documented family convention but aren't individually stated per model. Happy to drop them if you'd prefer only the fully-explicit ones.

## Question: surface this in the web UI too?

Right now the UI only shows `reasoning` as a yes/no boolean; the whole `reasoning_options` structure (allowed values, budget ranges, and now `default`) is API-only and not rendered anywhere. Would you want a follow-up PR to display it on the model page / detail view? If so, any preference on presentation (e.g. a chip list of allowed efforts with the default marked)?

## Out of scope (follow-ups)

- Speculative `gpt-5.2`–`5.5` + `gpt-5.1-codex-max` defaults (couldn't verify; omitting beats guessing in a source-of-truth dataset).
- xAI grok and Anthropic Claude 4.6+ effort defaults (need a docs pass).
- Non-reasoning options (`verbosity`, `service_tier`, etc.).

`bun validate` passes; both new refines verified to reject out-of-set / out-of-range defaults.
