### PR TITLE
poe: add/update official provider model metadata

### DIFF
--- a/providers/poe/models/empiriolabs/deepseek-v4-flash-e.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-flash-e.toml
@@ -1,4 +1,5 @@
 name = "DeepSeek-V4-Flash-E"
+description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
 family = "deepseek-flash"
 release_date = "2026-04-24"
 last_updated = "2026-04-24"

--- a/providers/poe/models/empiriolabs/deepseek-v4-flash-e.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-flash-e.toml
@@ -1,23 +1,21 @@
-name = "DeepSeek-V4-Flash-EL"
-description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
+name = "DeepSeek-V4-Flash-E"
 family = "deepseek-flash"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 393_216 }]
 temperature = true
-tool_call = true
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
 knowledge = "2025-05"
 open_weights = true
+tool_call = true
 
 [cost]
-input = 0.1394
-output = 0.2778
+input = 0.202
+output = 0.404
 
 [limit]
 context = 1_000_000
-input = 1_000_000
 output = 384_000
 
 [modalities]

--- a/providers/poe/models/empiriolabs/deepseek-v4-flash-e.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-flash-e.toml
@@ -1,24 +1,11 @@
+base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek-V4-Flash-E"
-description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
-family = "deepseek-flash"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 393_216 }]
-temperature = true
-knowledge = "2025-05"
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.202
 output = 0.404
 
-[limit]
-context = 1_000_000
-output = 384_000
-
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/deepseek-v4-flash-el.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-flash-el.toml
@@ -1,25 +1,14 @@
+base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek-V4-Flash-EL"
-description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
-family = "deepseek-flash"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 393_216 }]
-temperature = true
-tool_call = true
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-knowledge = "2025-05"
-open_weights = true
 
 [cost]
 input = 0.1394
 output = 0.2778
 
 [limit]
-context = 1_000_000
 input = 1_000_000
-output = 384_000
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/deepseek-v4-pro-e.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-pro-e.toml
@@ -1,24 +1,11 @@
+base_model = "deepseek/deepseek-v4-pro"
 name = "DeepSeek-V4-Pro-E"
-description = "Flagship DeepSeek model for coding, reasoning, and agentic work"
-family = "deepseek-thinking"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 393_216 }]
-temperature = true
-knowledge = "2025-05"
-open_weights = true
-tool_call = true
 
 [cost]
 input = 2.4242
 output = 4.8485
 
-[limit]
-context = 1_000_000
-output = 384_000
-
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/deepseek-v4-pro-e.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-pro-e.toml
@@ -1,4 +1,5 @@
 name = "DeepSeek-V4-Pro-E"
+description = "Flagship DeepSeek model for coding, reasoning, and agentic work"
 family = "deepseek-thinking"
 release_date = "2026-04-24"
 last_updated = "2026-04-24"

--- a/providers/poe/models/empiriolabs/deepseek-v4-pro-e.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-pro-e.toml
@@ -1,23 +1,21 @@
-name = "DeepSeek-V4-Flash-EL"
-description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
-family = "deepseek-flash"
+name = "DeepSeek-V4-Pro-E"
+family = "deepseek-thinking"
+release_date = "2026-04-24"
+last_updated = "2026-04-24"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 393_216 }]
 temperature = true
-tool_call = true
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
 knowledge = "2025-05"
 open_weights = true
+tool_call = true
 
 [cost]
-input = 0.1394
-output = 0.2778
+input = 2.4242
+output = 4.8485
 
 [limit]
 context = 1_000_000
-input = 1_000_000
 output = 384_000
 
 [modalities]

--- a/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
@@ -1,16 +1,19 @@
 name = "DeepSeek-V4-Pro-EL"
 description = "Flagship DeepSeek model for coding, reasoning, and agentic work"
+family = "deepseek-thinking"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 393_216 }]
+temperature = true
 tool_call = true
 release_date = "2026-04-24"
-last_updated = "2026-05-02"
+last_updated = "2026-04-24"
+knowledge = "2025-05"
 open_weights = true
 
 [cost]
-input = 1.67
-output = 3.33
+input = 1.6667
+output = 3.3343
 
 [limit]
 context = 1_000_000
@@ -18,5 +21,5 @@ input = 1_000_000
 output = 384_000
 
 [modalities]
-input = ["text"]
+input = ["text", "pdf"]
 output = ["text"]

--- a/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
+++ b/providers/poe/models/empiriolabs/deepseek-v4-pro-el.toml
@@ -1,25 +1,14 @@
+base_model = "deepseek/deepseek-v4-pro"
 name = "DeepSeek-V4-Pro-EL"
-description = "Flagship DeepSeek model for coding, reasoning, and agentic work"
-family = "deepseek-thinking"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 393_216 }]
-temperature = true
-tool_call = true
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-knowledge = "2025-05"
-open_weights = true
 
 [cost]
 input = 1.6667
 output = 3.3343
 
 [limit]
-context = 1_000_000
 input = 1_000_000
-output = 384_000
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/glm-5.2-el.toml
+++ b/providers/poe/models/empiriolabs/glm-5.2-el.toml
@@ -1,0 +1,25 @@
+name = "GLM-5.2-EL"
+family = "glm"
+release_date = "2026-06-13"
+last_updated = "2026-06-13"
+attachment = true
+reasoning = true
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["minimal", "low", "medium", "high", "xhigh", "max"] },
+]
+temperature = true
+open_weights = true
+tool_call = true
+
+[cost]
+input = 1.4141
+output = 4.4444
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/glm-5.2-el.toml
+++ b/providers/poe/models/empiriolabs/glm-5.2-el.toml
@@ -1,4 +1,5 @@
 name = "GLM-5.2-EL"
+description = "Open flagship GLM for long-horizon coding agents and million-token context work"
 family = "glm"
 release_date = "2026-06-13"
 last_updated = "2026-06-13"

--- a/providers/poe/models/empiriolabs/glm-5.2-el.toml
+++ b/providers/poe/models/empiriolabs/glm-5.2-el.toml
@@ -1,26 +1,11 @@
+base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2-EL"
-description = "Open flagship GLM for long-horizon coding agents and million-token context work"
-family = "glm"
-release_date = "2026-06-13"
-last_updated = "2026-06-13"
 attachment = true
-reasoning = true
-reasoning_options = [
-  { type = "toggle" },
-  { type = "effort", values = ["minimal", "low", "medium", "high", "xhigh", "max"] },
-]
-temperature = true
-open_weights = true
-tool_call = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 1.4141
 output = 4.4444
 
-[limit]
-context = 1_000_000
-output = 131_072
-
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/kimi-k2.7-code-el.toml
+++ b/providers/poe/models/empiriolabs/kimi-k2.7-code-el.toml
@@ -1,4 +1,5 @@
 name = "Kimi-K2.7-Code-EL"
+description = "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking"
 family = "kimi-k2"
 release_date = "2026-06-12"
 last_updated = "2026-06-12"

--- a/providers/poe/models/empiriolabs/kimi-k2.7-code-el.toml
+++ b/providers/poe/models/empiriolabs/kimi-k2.7-code-el.toml
@@ -1,24 +1,11 @@
+base_model = "moonshotai/kimi-k2.7-code"
 name = "Kimi-K2.7-Code-EL"
-description = "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking"
-family = "kimi-k2"
-release_date = "2026-06-12"
-last_updated = "2026-06-12"
-attachment = true
-reasoning = true
-reasoning_options = []
 temperature = true
-knowledge = "2025-01"
-open_weights = true
-tool_call = true
+reasoning_options = []
 
 [cost]
 input = 0.9596
 output = 4.0404
 
-[limit]
-context = 262_144
-output = 262_144
-
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/kimi-k2.7-code-el.toml
+++ b/providers/poe/models/empiriolabs/kimi-k2.7-code-el.toml
@@ -1,8 +1,7 @@
-name = "Kimi-K2.5-FW"
-description = "Kimi multimodal agent model for visual understanding, coding, and planning"
+name = "Kimi-K2.7-Code-EL"
 family = "kimi-k2"
-release_date = "2026-01-27"
-last_updated = "2026-01-27"
+release_date = "2026-06-12"
+last_updated = "2026-06-12"
 attachment = true
 reasoning = true
 reasoning_options = []
@@ -11,10 +10,14 @@ knowledge = "2025-01"
 open_weights = true
 tool_call = true
 
+[cost]
+input = 0.9596
+output = 4.0404
+
 [limit]
 context = 262_144
 output = 262_144
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video", "pdf"]
 output = ["text"]

--- a/providers/poe/models/empiriolabs/mimo-v2.5-pro.toml
+++ b/providers/poe/models/empiriolabs/mimo-v2.5-pro.toml
@@ -1,0 +1,28 @@
+name = "MiMo-V2.5-Pro"
+family = "mimo"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+knowledge = "2024-12"
+open_weights = true
+tool_call = true
+
+[cost]
+input = 1.0101
+output = 3.0303
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 2.0202
+output = 6.0606
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/mimo-v2.5-pro.toml
+++ b/providers/poe/models/empiriolabs/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 name = "MiMo-V2.5-Pro"
+description = "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution"
 family = "mimo"
 release_date = "2026-04-22"
 last_updated = "2026-04-22"

--- a/providers/poe/models/empiriolabs/mimo-v2.5-pro.toml
+++ b/providers/poe/models/empiriolabs/mimo-v2.5-pro.toml
@@ -1,15 +1,6 @@
-name = "MiMo-V2.5-Pro"
-description = "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution"
-family = "mimo"
-release_date = "2026-04-22"
-last_updated = "2026-04-22"
+base_model = "xiaomi/mimo-v2.5-pro"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-knowledge = "2024-12"
-open_weights = true
-tool_call = true
 
 [cost]
 input = 1.0101
@@ -22,8 +13,6 @@ output = 6.0606
 
 [limit]
 context = 1_000_000
-output = 131_072
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/minimax-m3-el.toml
+++ b/providers/poe/models/empiriolabs/minimax-m3-el.toml
@@ -1,14 +1,6 @@
+base_model = "minimax/MiniMax-M3"
 name = "MiniMax-M3-EL"
-description = "MiniMax multimodal model for long-context coding, perception, and agent planning"
-family = "minimax"
-release_date = "2026-06-01"
-last_updated = "2026-06-01"
-attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.303
@@ -17,8 +9,6 @@ cache_read = 0.0606
 
 [limit]
 context = 524_288
-output = 128_000
 
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/minimax-m3-el.toml
+++ b/providers/poe/models/empiriolabs/minimax-m3-el.toml
@@ -1,8 +1,7 @@
-name = "Minimax-M2.1"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
+name = "MiniMax-M3-EL"
 family = "minimax"
-release_date = "2025-12-26"
-last_updated = "2025-12-26"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
@@ -13,12 +12,12 @@ tool_call = true
 [cost]
 input = 0.303
 output = 1.2121
-cache_read = 0.0303
+cache_read = 0.0606
 
 [limit]
-context = 205_000
-output = 131_072
+context = 524_288
+output = 128_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "video", "pdf"]
 output = ["text"]

--- a/providers/poe/models/empiriolabs/minimax-m3-el.toml
+++ b/providers/poe/models/empiriolabs/minimax-m3-el.toml
@@ -1,4 +1,5 @@
 name = "MiniMax-M3-EL"
+description = "MiniMax multimodal model for long-context coding, perception, and agent planning"
 family = "minimax"
 release_date = "2026-06-01"
 last_updated = "2026-06-01"

--- a/providers/poe/models/empiriolabs/qwen3-max-preview.toml
+++ b/providers/poe/models/empiriolabs/qwen3-max-preview.toml
@@ -1,0 +1,23 @@
+name = "Qwen3-Max-Preview"
+family = "qwen"
+release_date = "2025-09-05"
+last_updated = "2025-09-23"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+knowledge = "2025-04"
+open_weights = false
+tool_call = false
+
+[cost]
+input = 1.0909
+output = 4.8485
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3-max-preview.toml
+++ b/providers/poe/models/empiriolabs/qwen3-max-preview.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-Max-Preview"
+description = "Flagship Qwen model for complex reasoning, coding, and agentic workflows"
 family = "qwen"
 release_date = "2025-09-05"
 last_updated = "2025-09-23"

--- a/providers/poe/models/empiriolabs/qwen3-max-thinking.toml
+++ b/providers/poe/models/empiriolabs/qwen3-max-thinking.toml
@@ -1,0 +1,33 @@
+name = "Qwen3-Max-Thinking"
+family = "qwen"
+release_date = "2026-02-09"
+last_updated = "2026-02-09"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+knowledge = "2025-04"
+open_weights = false
+tool_call = true
+
+[cost]
+input = 1.0909
+output = 5.5758
+
+[[cost.tiers]]
+tier = { type = "context", size = 32_000 }
+input = 2.1818
+output = 11.1516
+
+[[cost.tiers]]
+tier = { type = "context", size = 128_000 }
+input = 2.72725
+output = 13.9395
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3-max-thinking.toml
+++ b/providers/poe/models/empiriolabs/qwen3-max-thinking.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-Max-Thinking"
+description = "Qwen reasoning model for deliberate problem solving, math, and coding"
 family = "qwen"
 release_date = "2026-02-09"
 last_updated = "2026-02-09"

--- a/providers/poe/models/empiriolabs/qwen3-max.toml
+++ b/providers/poe/models/empiriolabs/qwen3-max.toml
@@ -1,0 +1,32 @@
+name = "Qwen3-Max"
+family = "qwen"
+release_date = "2025-09-23"
+last_updated = "2025-09-23"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+open_weights = false
+tool_call = true
+
+[cost]
+input = 1.0909
+output = 5.5758
+
+[[cost.tiers]]
+tier = { type = "context", size = 32_000 }
+input = 2.1818
+output = 11.1516
+
+[[cost.tiers]]
+tier = { type = "context", size = 128_000 }
+input = 2.72725
+output = 13.9395
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3-max.toml
+++ b/providers/poe/models/empiriolabs/qwen3-max.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-Max"
+description = "Flagship Qwen3 model for coding agents, complex reasoning, and tool use"
 family = "qwen"
 release_date = "2025-09-23"
 last_updated = "2025-09-23"

--- a/providers/poe/models/empiriolabs/qwen3-max.toml
+++ b/providers/poe/models/empiriolabs/qwen3-max.toml
@@ -1,14 +1,6 @@
+base_model = "alibaba/qwen3-max"
 name = "Qwen3-Max"
-description = "Flagship Qwen3 model for coding agents, complex reasoning, and tool use"
-family = "qwen"
-release_date = "2025-09-23"
-last_updated = "2025-09-23"
 attachment = true
-reasoning = false
-temperature = true
-knowledge = "2025-04"
-open_weights = false
-tool_call = true
 
 [cost]
 input = 1.0909
@@ -24,10 +16,5 @@ tier = { type = "context", size = 128_000 }
 input = 2.72725
 output = 13.9395
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.5-4b-el.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-4b-el.toml
@@ -1,0 +1,24 @@
+name = "Qwen3.5-4B-EL"
+family = "qwen"
+release_date = "2026-03-03"
+last_updated = "2026-03-03"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 32_768 }]
+temperature = true
+knowledge = "2025-04"
+open_weights = true
+tool_call = true
+
+[cost]
+input = 0.0404
+output = 0.0707
+cache_read = 0.0202
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.5-4b-el.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-4b-el.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.5-4B-EL"
+description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
 family = "qwen"
 release_date = "2026-03-03"
 last_updated = "2026-03-03"

--- a/providers/poe/models/empiriolabs/qwen3.5-9b-el.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-9b-el.toml
@@ -1,0 +1,23 @@
+name = "Qwen3.5-9B-EL"
+family = "qwen"
+release_date = "2026-02-23"
+last_updated = "2026-02-23"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 32_768 }]
+temperature = true
+open_weights = true
+tool_call = true
+
+[cost]
+input = 0.0909
+output = 0.1313
+cache_read = 0.0455
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.5-9b-el.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-9b-el.toml
@@ -1,24 +1,12 @@
+base_model = "alibaba/qwen3.5-9b"
 name = "Qwen3.5-9B-EL"
-description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
-family = "qwen"
-release_date = "2026-02-23"
-last_updated = "2026-02-23"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 32_768 }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.0909
 output = 0.1313
 cache_read = 0.0455
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.5-9b-el.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-9b-el.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.5-9B-EL"
+description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
 family = "qwen"
 release_date = "2026-02-23"
 last_updated = "2026-02-23"

--- a/providers/poe/models/empiriolabs/qwen3.5-flash.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-flash.toml
@@ -1,0 +1,23 @@
+name = "Qwen3.5-Flash"
+family = "qwen"
+release_date = "2026-02-23"
+last_updated = "2026-02-23"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+knowledge = "2025-04"
+open_weights = false
+tool_call = true
+
+[cost]
+input = 0.0909
+output = 0.3717
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.5-flash.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-flash.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.5-Flash"
+description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
 family = "qwen"
 release_date = "2026-02-23"
 last_updated = "2026-02-23"

--- a/providers/poe/models/empiriolabs/qwen3.5-plus.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-plus.toml
@@ -1,0 +1,28 @@
+name = "Qwen3.5-Plus"
+family = "qwen"
+release_date = "2026-02-16"
+last_updated = "2026-02-16"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+knowledge = "2025-04"
+open_weights = false
+tool_call = true
+
+[cost]
+input = 0.3636
+output = 2.2303
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 1.0908
+output = 6.6909
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.5-plus.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-plus.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.5-Plus"
+description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
 family = "qwen"
 release_date = "2026-02-16"
 last_updated = "2026-02-16"

--- a/providers/poe/models/empiriolabs/qwen3.5-plus.toml
+++ b/providers/poe/models/empiriolabs/qwen3.5-plus.toml
@@ -1,15 +1,7 @@
+base_model = "alibaba/qwen3.5-plus"
 name = "Qwen3.5-Plus"
-description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
-family = "qwen"
-release_date = "2026-02-16"
-last_updated = "2026-02-16"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-knowledge = "2025-04"
-open_weights = false
-tool_call = true
 
 [cost]
 input = 0.3636
@@ -20,10 +12,5 @@ tier = { type = "context", size = 256_000 }
 input = 1.0908
 output = 6.6909
 
-[limit]
-context = 1_000_000
-output = 65_536
-
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.6-max-preview.toml
+++ b/providers/poe/models/empiriolabs/qwen3.6-max-preview.toml
@@ -1,0 +1,28 @@
+name = "Qwen3.6-Max-Preview"
+family = "qwen"
+release_date = "2026-04-20"
+last_updated = "2026-04-20"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 32_768 }]
+temperature = true
+knowledge = "2025-04"
+open_weights = false
+tool_call = true
+
+[cost]
+input = 1.3131
+output = 7.8788
+
+[[cost.tiers]]
+tier = { type = "context", size = 128_000 }
+input = 1.96965
+output = 11.8182
+
+[limit]
+context = 256_000
+output = 65_536
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.6-max-preview.toml
+++ b/providers/poe/models/empiriolabs/qwen3.6-max-preview.toml
@@ -1,15 +1,7 @@
+base_model = "alibaba/qwen3.6-max-preview"
 name = "Qwen3.6-Max-Preview"
-description = "Flagship Qwen model for long-context agents, coding, and complex reasoning"
-family = "qwen"
-release_date = "2026-04-20"
-last_updated = "2026-04-20"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1, max = 32_768 }]
-temperature = true
-knowledge = "2025-04"
-open_weights = false
-tool_call = true
 
 [cost]
 input = 1.3131
@@ -22,8 +14,6 @@ output = 11.8182
 
 [limit]
 context = 256_000
-output = 65_536
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.6-max-preview.toml
+++ b/providers/poe/models/empiriolabs/qwen3.6-max-preview.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.6-Max-Preview"
+description = "Flagship Qwen model for long-context agents, coding, and complex reasoning"
 family = "qwen"
 release_date = "2026-04-20"
 last_updated = "2026-04-20"

--- a/providers/poe/models/empiriolabs/qwen3.6-plus.toml
+++ b/providers/poe/models/empiriolabs/qwen3.6-plus.toml
@@ -1,0 +1,28 @@
+name = "Qwen3.6-Plus"
+family = "qwen"
+release_date = "2026-04-02"
+last_updated = "2026-04-02"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+knowledge = "2025-04"
+open_weights = false
+tool_call = true
+
+[cost]
+input = 0.5051
+output = 3.0303
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 2.0204
+output = 6.0606
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.6-plus.toml
+++ b/providers/poe/models/empiriolabs/qwen3.6-plus.toml
@@ -1,15 +1,7 @@
+base_model = "alibaba/qwen3.6-plus"
 name = "Qwen3.6-Plus"
-description = "Earlier Qwen multimodal workhorse for million-token agent and document tasks"
-family = "qwen"
-release_date = "2026-04-02"
-last_updated = "2026-04-02"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-knowledge = "2025-04"
-open_weights = false
-tool_call = true
 
 [cost]
 input = 0.5051
@@ -20,10 +12,5 @@ tier = { type = "context", size = 256_000 }
 input = 2.0204
 output = 6.0606
 
-[limit]
-context = 1_000_000
-output = 65_536
-
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.6-plus.toml
+++ b/providers/poe/models/empiriolabs/qwen3.6-plus.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.6-Plus"
+description = "Earlier Qwen multimodal workhorse for million-token agent and document tasks"
 family = "qwen"
 release_date = "2026-04-02"
 last_updated = "2026-04-02"

--- a/providers/poe/models/empiriolabs/qwen3.7-max.toml
+++ b/providers/poe/models/empiriolabs/qwen3.7-max.toml
@@ -1,23 +1,11 @@
+base_model = "alibaba/qwen3.7-max"
 name = "Qwen3.7-Max"
-description = "Flagship Qwen model for long-context agents, coding, and complex reasoning"
-family = "qwen"
-release_date = "2026-05-21"
-last_updated = "2026-05-21"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = false
-tool_call = true
 
 [cost]
 input = 2.5253
 output = 7.5758
 
-[limit]
-context = 1_000_000
-output = 65_536
-
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.7-max.toml
+++ b/providers/poe/models/empiriolabs/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.7-Max"
+description = "Flagship Qwen model for long-context agents, coding, and complex reasoning"
 family = "qwen"
 release_date = "2026-05-21"
 last_updated = "2026-05-21"

--- a/providers/poe/models/empiriolabs/qwen3.7-max.toml
+++ b/providers/poe/models/empiriolabs/qwen3.7-max.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.7-Max"
+family = "qwen"
+release_date = "2026-05-21"
+last_updated = "2026-05-21"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+open_weights = false
+tool_call = true
+
+[cost]
+input = 2.5253
+output = 7.5758
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.7-plus.toml
+++ b/providers/poe/models/empiriolabs/qwen3.7-plus.toml
@@ -1,0 +1,28 @@
+name = "Qwen3.7-Plus"
+family = "qwen"
+release_date = "2026-06-02"
+last_updated = "2026-06-02"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+knowledge = "2025-04"
+open_weights = false
+tool_call = true
+
+[cost]
+input = 0.404
+output = 1.6162
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 1.212
+output = 4.8486
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.7-plus.toml
+++ b/providers/poe/models/empiriolabs/qwen3.7-plus.toml
@@ -1,15 +1,7 @@
+base_model = "alibaba/qwen3.7-plus"
 name = "Qwen3.7-Plus"
-description = "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding"
-family = "qwen"
-release_date = "2026-06-02"
-last_updated = "2026-06-02"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-knowledge = "2025-04"
-open_weights = false
-tool_call = true
 
 [cost]
 input = 0.404
@@ -20,10 +12,5 @@ tier = { type = "context", size = 256_000 }
 input = 1.212
 output = 4.8486
 
-[limit]
-context = 1_000_000
-output = 64_000
-
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/empiriolabs/qwen3.7-plus.toml
+++ b/providers/poe/models/empiriolabs/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.7-Plus"
+description = "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding"
 family = "qwen"
 release_date = "2026-06-02"
 last_updated = "2026-06-02"

--- a/providers/poe/models/fireworks-ai/glm-5.1-fw.toml
+++ b/providers/poe/models/fireworks-ai/glm-5.1-fw.toml
@@ -1,0 +1,18 @@
+name = "GLM-5.1-FW"
+family = "glm"
+release_date = "2026-04-07"
+last_updated = "2026-04-07"
+attachment = false
+reasoning = true
+reasoning_options = []
+temperature = true
+open_weights = true
+tool_call = true
+
+[limit]
+context = 202_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/poe/models/fireworks-ai/glm-5.1-fw.toml
+++ b/providers/poe/models/fireworks-ai/glm-5.1-fw.toml
@@ -1,19 +1,6 @@
+base_model = "zhipuai/glm-5.1"
 name = "GLM-5.1-FW"
-description = "Strong GLM coding model for agentic engineering, terminals, and repository generation"
-family = "glm"
-release_date = "2026-04-07"
-last_updated = "2026-04-07"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-open_weights = true
-tool_call = true
 
 [limit]
 context = 202_800
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/poe/models/fireworks-ai/glm-5.1-fw.toml
+++ b/providers/poe/models/fireworks-ai/glm-5.1-fw.toml
@@ -1,4 +1,5 @@
 name = "GLM-5.1-FW"
+description = "Strong GLM coding model for agentic engineering, terminals, and repository generation"
 family = "glm"
 release_date = "2026-04-07"
 last_updated = "2026-04-07"

--- a/providers/poe/models/fireworks-ai/kimi-k2.5-fw.toml
+++ b/providers/poe/models/fireworks-ai/kimi-k2.5-fw.toml
@@ -7,6 +7,7 @@ reasoning = false
 temperature = false
 open_weights = false
 tool_call = true
+status = "deprecated"
 
 [cost]
 input = 0

--- a/providers/poe/models/fireworks-ai/kimi-k2.5-fw.toml
+++ b/providers/poe/models/fireworks-ai/kimi-k2.5-fw.toml
@@ -1,19 +1,21 @@
 name = "Kimi-K2.5-FW"
 description = "Kimi multimodal agent model for visual understanding, coding, and planning"
-family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
-reasoning = true
-reasoning_options = []
-temperature = true
-knowledge = "2025-01"
-open_weights = true
+reasoning = false
+temperature = false
+open_weights = false
 tool_call = true
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 262_144
-output = 262_144
+input = 245_760
+output = 16_384
 
 [modalities]
 input = ["text", "image"]

--- a/providers/poe/models/fireworks-ai/minimax-m2.7-fw.toml
+++ b/providers/poe/models/fireworks-ai/minimax-m2.7-fw.toml
@@ -1,0 +1,18 @@
+name = "Minimax-M2.7-FW"
+family = "minimax"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
+attachment = false
+reasoning = true
+reasoning_options = []
+temperature = true
+open_weights = true
+tool_call = true
+
+[limit]
+context = 196_608
+output = 196_608
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/poe/models/fireworks-ai/minimax-m2.7-fw.toml
+++ b/providers/poe/models/fireworks-ai/minimax-m2.7-fw.toml
@@ -1,4 +1,5 @@
 name = "Minimax-M2.7-FW"
+description = "Open MiniMax flagship for coding agents, office automation, and complex environments"
 family = "minimax"
 release_date = "2026-03-18"
 last_updated = "2026-03-18"

--- a/providers/poe/models/fireworks-ai/minimax-m2.7-fw.toml
+++ b/providers/poe/models/fireworks-ai/minimax-m2.7-fw.toml
@@ -1,19 +1,7 @@
+base_model = "minimax/MiniMax-M2.7"
 name = "Minimax-M2.7-FW"
-description = "Open MiniMax flagship for coding agents, office automation, and complex environments"
-family = "minimax"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-open_weights = true
-tool_call = true
 
 [limit]
 context = 196_608
 output = 196_608
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/poe/models/novita/deepseek-v3.2.toml
+++ b/providers/poe/models/novita/deepseek-v3.2.toml
@@ -1,5 +1,6 @@
 name = "DeepSeek-V3.2"
 description = "DeepSeek chat model for instruction following, coding, and analysis"
+family = "deepseek"
 release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = true
@@ -10,14 +11,14 @@ open_weights = true
 tool_call = true
 
 [cost]
-input = 0.27
-output = 0.4
-cache_read = 0.13
+input = 0.2717
+output = 0.404
+cache_read = 0.1359
 
 [limit]
 context = 128_000
-output = 0
+output = 65_536
 
 [modalities]
-input = ["text"]
+input = ["text", "pdf"]
 output = ["text"]

--- a/providers/poe/models/novita/glm-4.6.toml
+++ b/providers/poe/models/novita/glm-4.6.toml
@@ -4,15 +4,21 @@ family = "glm"
 release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
-reasoning = false
-temperature = false
-open_weights = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+open_weights = true
 tool_call = true
 
+[cost]
+input = 0.5556
+output = 2.2222
+cache_read = 0.1111
+
 [limit]
-context = 0
-output = 0
+context = 205_000
+output = 131_072
 
 [modalities]
-input = ["text"]
+input = ["text", "pdf"]
 output = ["text"]

--- a/providers/poe/models/novita/glm-4.6.toml
+++ b/providers/poe/models/novita/glm-4.6.toml
@@ -1,14 +1,6 @@
-name = "GLM-4.6"
-description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
-release_date = "2025-09-30"
-last_updated = "2025-09-30"
+base_model = "zhipuai/glm-4.6"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.5556
@@ -17,8 +9,6 @@ cache_read = 0.1111
 
 [limit]
 context = 205_000
-output = 131_072
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/glm-4.6v.toml
+++ b/providers/poe/models/novita/glm-4.6v.toml
@@ -1,15 +1,7 @@
-name = "GLM-4.6V"
-description = "GLM vision model for visual reasoning, documents, and multimodal agents"
-family = "glm"
+base_model = "zhipuai/glm-4.6v"
 release_date = "2025-12-09"
 last_updated = "2025-12-09"
-attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-knowledge = "2025-04"
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.303
@@ -18,8 +10,6 @@ cache_read = 0.0556
 
 [limit]
 context = 131_000
-output = 32_768
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/glm-4.6v.toml
+++ b/providers/poe/models/novita/glm-4.6v.toml
@@ -1,18 +1,25 @@
-name = "glm-4.6v"
+name = "GLM-4.6V"
 description = "GLM vision model for visual reasoning, documents, and multimodal agents"
+family = "glm"
 release_date = "2025-12-09"
 last_updated = "2025-12-09"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = false
-open_weights = false
+temperature = true
+knowledge = "2025-04"
+open_weights = true
 tool_call = true
+
+[cost]
+input = 0.303
+output = 0.9091
+cache_read = 0.0556
 
 [limit]
 context = 131_000
 output = 32_768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/poe/models/novita/glm-4.7-flash.toml
+++ b/providers/poe/models/novita/glm-4.7-flash.toml
@@ -1,13 +1,20 @@
-name = "glm-4.7-flash"
+name = "GLM-4.7-Flash"
 description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
+family = "glm-flash"
 release_date = "2026-01-19"
 last_updated = "2026-01-19"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = false
-open_weights = false
+temperature = true
+knowledge = "2025-04"
+open_weights = true
 tool_call = true
+
+[cost]
+input = 0.0707
+output = 0.404
+cache_read = 0.0101
 
 [limit]
 context = 200_000

--- a/providers/poe/models/novita/glm-4.7-flash.toml
+++ b/providers/poe/models/novita/glm-4.7-flash.toml
@@ -1,15 +1,6 @@
-name = "GLM-4.7-Flash"
-description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
-family = "glm-flash"
-release_date = "2026-01-19"
-last_updated = "2026-01-19"
+base_model = "zhipuai/glm-4.7-flash"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-knowledge = "2025-04"
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.0707
@@ -17,9 +8,4 @@ output = 0.404
 cache_read = 0.0101
 
 [limit]
-context = 200_000
 output = 65_500
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/poe/models/novita/glm-4.7-n.toml
+++ b/providers/poe/models/novita/glm-4.7-n.toml
@@ -1,14 +1,7 @@
+base_model = "zhipuai/glm-4.7"
 name = "GLM-4.7-N"
-description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.6061
@@ -16,8 +9,6 @@ output = 2.2222
 
 [limit]
 context = 205_000
-output = 131_072
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/glm-5.2.toml
+++ b/providers/poe/models/novita/glm-5.2.toml
@@ -1,8 +1,7 @@
-name = "GLM-4.7-N"
-description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+name = "GLM-5.2"
 family = "glm"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
+release_date = "2026-06-13"
+last_updated = "2026-06-13"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
@@ -11,11 +10,12 @@ open_weights = true
 tool_call = true
 
 [cost]
-input = 0.6061
-output = 2.2222
+input = 1.4141
+output = 4.4444
+cache_read = 0.2626
 
 [limit]
-context = 205_000
+context = 1_048_576
 output = 131_072
 
 [modalities]

--- a/providers/poe/models/novita/glm-5.2.toml
+++ b/providers/poe/models/novita/glm-5.2.toml
@@ -1,14 +1,6 @@
-name = "GLM-5.2"
-description = "Open flagship GLM for long-horizon coding agents and million-token context work"
-family = "glm"
-release_date = "2026-06-13"
-last_updated = "2026-06-13"
+base_model = "zhipuai/glm-5.2"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 1.4141
@@ -17,8 +9,6 @@ cache_read = 0.2626
 
 [limit]
 context = 1_048_576
-output = 131_072
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/glm-5.2.toml
+++ b/providers/poe/models/novita/glm-5.2.toml
@@ -1,4 +1,5 @@
 name = "GLM-5.2"
+description = "Open flagship GLM for long-horizon coding agents and million-token context work"
 family = "glm"
 release_date = "2026-06-13"
 last_updated = "2026-06-13"

--- a/providers/poe/models/novita/glm-5.toml
+++ b/providers/poe/models/novita/glm-5.toml
@@ -1,18 +1,19 @@
 name = "GLM-5"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+family = "glm"
 release_date = "2026-02-15"
 last_updated = "2026-02-15"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
 temperature = true
-open_weights = false
+open_weights = true
 tool_call = true
 
 [cost]
-input = 1
-output = 3.2
-cache_read = 0.2
+input = 1.0101
+output = 3.2323
+cache_read = 0.202
 
 [limit]
 context = 205_000

--- a/providers/poe/models/novita/glm-5.toml
+++ b/providers/poe/models/novita/glm-5.toml
@@ -1,14 +1,8 @@
-name = "GLM-5"
-description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
+base_model = "zhipuai/glm-5"
 release_date = "2026-02-15"
 last_updated = "2026-02-15"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 1.0101
@@ -17,8 +11,3 @@ cache_read = 0.202
 
 [limit]
 context = 205_000
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/poe/models/novita/kimi-k2-thinking.toml
+++ b/providers/poe/models/novita/kimi-k2-thinking.toml
@@ -1,14 +1,9 @@
+base_model = "moonshotai/kimi-k2-thinking"
 name = "Kimi-K2-Thinking"
-description = "Kimi reasoning model for long-horizon research, planning, and tool use"
-family = "kimi-thinking"
 release_date = "2025-11-07"
 last_updated = "2025-11-07"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.6061
@@ -18,7 +13,3 @@ cache_read = 0.1515
 [limit]
 context = 256_000
 output = 100_352
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/poe/models/novita/kimi-k2-thinking.toml
+++ b/providers/poe/models/novita/kimi-k2-thinking.toml
@@ -1,4 +1,4 @@
-name = "kimi-k2-thinking"
+name = "Kimi-K2-Thinking"
 description = "Kimi reasoning model for long-horizon research, planning, and tool use"
 family = "kimi-thinking"
 release_date = "2025-11-07"
@@ -6,13 +6,18 @@ last_updated = "2025-11-07"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = false
-open_weights = false
+temperature = true
+open_weights = true
 tool_call = true
+
+[cost]
+input = 0.6061
+output = 2.5253
+cache_read = 0.1515
 
 [limit]
 context = 256_000
-output = 0
+output = 100_352
 
 [modalities]
 input = ["text"]

--- a/providers/poe/models/novita/kimi-k2.5.toml
+++ b/providers/poe/models/novita/kimi-k2.5.toml
@@ -1,15 +1,10 @@
+base_model = "moonshotai/kimi-k2.5"
 name = "Kimi-K2.5"
-description = "Kimi multimodal agent model for visual understanding, coding, and planning"
-family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
-reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = true
-knowledge = "2025-01"
-open_weights = true
-tool_call = true
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.6061
@@ -18,8 +13,3 @@ cache_read = 0.101
 
 [limit]
 context = 128_000
-output = 262_144
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]

--- a/providers/poe/models/novita/kimi-k2.5.toml
+++ b/providers/poe/models/novita/kimi-k2.5.toml
@@ -1,18 +1,20 @@
 name = "Kimi-K2.5"
 description = "Kimi multimodal agent model for visual understanding, coding, and planning"
+family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
 temperature = true
-open_weights = false
+knowledge = "2025-01"
+open_weights = true
 tool_call = true
 
 [cost]
-input = 0.6
-output = 3
-cache_read = 0.1
+input = 0.6061
+output = 3.0303
+cache_read = 0.101
 
 [limit]
 context = 128_000

--- a/providers/poe/models/novita/kimi-k2.6.toml
+++ b/providers/poe/models/novita/kimi-k2.6.toml
@@ -1,15 +1,8 @@
+base_model = "moonshotai/kimi-k2.6"
 name = "Kimi-K2.6"
-description = "Kimi multimodal agent model for visual understanding, coding, and planning"
-family = "kimi-k2"
-attachment = true
-reasoning = true
-reasoning_options = [{ type = "toggle" }]
-tool_call = true
-temperature = true
-knowledge = "2025-04"
 release_date = "2026-04-20"
 last_updated = "2026-05-02"
-open_weights = true
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.9596
@@ -17,10 +10,7 @@ output = 4.0404
 cache_read = 0.1616
 
 [limit]
-context = 262_144
 input = 262_144
-output = 262_144
 
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/kimi-k2.7-code.toml
+++ b/providers/poe/models/novita/kimi-k2.7-code.toml
@@ -1,15 +1,7 @@
+base_model = "moonshotai/kimi-k2.7-code"
 name = "Kimi-K2.7-Code"
-description = "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking"
-family = "kimi-k2"
-attachment = true
-reasoning = true
-reasoning_options = [{ type = "toggle" }]
-tool_call = true
 temperature = true
-knowledge = "2025-01"
-release_date = "2026-06-12"
-last_updated = "2026-06-12"
-open_weights = true
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.9596
@@ -17,10 +9,7 @@ output = 4.0404
 cache_read = 0.1919
 
 [limit]
-context = 262_144
 input = 262_144
-output = 262_144
 
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/kimi-k2.7-code.toml
+++ b/providers/poe/models/novita/kimi-k2.7-code.toml
@@ -1,20 +1,19 @@
-name = "Kimi-K2.6"
-description = "Kimi multimodal agent model for visual understanding, coding, and planning"
+name = "Kimi-K2.7-Code"
 family = "kimi-k2"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
 tool_call = true
 temperature = true
-knowledge = "2025-04"
-release_date = "2026-04-20"
-last_updated = "2026-05-02"
+knowledge = "2025-01"
+release_date = "2026-06-12"
+last_updated = "2026-06-12"
 open_weights = true
 
 [cost]
 input = 0.9596
 output = 4.0404
-cache_read = 0.1616
+cache_read = 0.1919
 
 [limit]
 context = 262_144

--- a/providers/poe/models/novita/kimi-k2.7-code.toml
+++ b/providers/poe/models/novita/kimi-k2.7-code.toml
@@ -1,4 +1,5 @@
 name = "Kimi-K2.7-Code"
+description = "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking"
 family = "kimi-k2"
 attachment = true
 reasoning = true

--- a/providers/poe/models/novita/minimax-m2.1.toml
+++ b/providers/poe/models/novita/minimax-m2.1.toml
@@ -1,14 +1,9 @@
+base_model = "minimax/MiniMax-M2.1"
 name = "Minimax-M2.1"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
-family = "minimax"
 release_date = "2025-12-26"
 last_updated = "2025-12-26"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.303
@@ -17,8 +12,3 @@ cache_read = 0.0303
 
 [limit]
 context = 205_000
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/poe/models/novita/minimax-m2.5.toml
+++ b/providers/poe/models/novita/minimax-m2.5.toml
@@ -1,14 +1,7 @@
+base_model = "minimax/MiniMax-M2.5"
 name = "Minimax-M2.5"
-description = "Prior MiniMax coding model for agent workflows, office edits, and automation"
-family = "minimax"
-release_date = "2026-02-12"
-last_updated = "2026-02-12"
 attachment = true
-reasoning = true
 reasoning_options = []
-temperature = true
-open_weights = false
-tool_call = true
 
 [cost]
 input = 0.303
@@ -18,7 +11,3 @@ cache_read = 0.0303
 [limit]
 context = 205_000
 output = 131_100
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/poe/models/novita/minimax-m2.5.toml
+++ b/providers/poe/models/novita/minimax-m2.5.toml
@@ -1,0 +1,23 @@
+name = "Minimax-M2.5"
+family = "minimax"
+release_date = "2026-02-12"
+last_updated = "2026-02-12"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = true
+open_weights = false
+tool_call = true
+
+[cost]
+input = 0.303
+output = 1.2121
+cache_read = 0.0303
+
+[limit]
+context = 205_000
+output = 131_100
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/poe/models/novita/minimax-m2.5.toml
+++ b/providers/poe/models/novita/minimax-m2.5.toml
@@ -1,4 +1,5 @@
 name = "Minimax-M2.5"
+description = "Prior MiniMax coding model for agent workflows, office edits, and automation"
 family = "minimax"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"

--- a/providers/poe/models/novita/minimax-m2.7.toml
+++ b/providers/poe/models/novita/minimax-m2.7.toml
@@ -1,11 +1,10 @@
-name = "Minimax-M2.1"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
+name = "Minimax-M2.7"
 family = "minimax"
-release_date = "2025-12-26"
-last_updated = "2025-12-26"
+release_date = "2026-03-18"
+last_updated = "2026-03-18"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 temperature = true
 open_weights = true
 tool_call = true
@@ -13,7 +12,7 @@ tool_call = true
 [cost]
 input = 0.303
 output = 1.2121
-cache_read = 0.0303
+cache_read = 0.0606
 
 [limit]
 context = 205_000

--- a/providers/poe/models/novita/minimax-m2.7.toml
+++ b/providers/poe/models/novita/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 name = "Minimax-M2.7"
+description = "Open MiniMax flagship for coding agents, office automation, and complex environments"
 family = "minimax"
 release_date = "2026-03-18"
 last_updated = "2026-03-18"

--- a/providers/poe/models/novita/minimax-m2.7.toml
+++ b/providers/poe/models/novita/minimax-m2.7.toml
@@ -1,14 +1,7 @@
+base_model = "minimax/MiniMax-M2.7"
 name = "Minimax-M2.7"
-description = "Open MiniMax flagship for coding agents, office automation, and complex environments"
-family = "minimax"
-release_date = "2026-03-18"
-last_updated = "2026-03-18"
 attachment = true
-reasoning = true
 reasoning_options = []
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.303
@@ -17,8 +10,3 @@ cache_read = 0.0606
 
 [limit]
 context = 205_000
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/poe/models/novita/minimax-m3-n.toml
+++ b/providers/poe/models/novita/minimax-m3-n.toml
@@ -1,4 +1,5 @@
 name = "Minimax-M3-N"
+description = "MiniMax multimodal model for long-context coding, perception, and agent planning"
 family = "minimax"
 release_date = "2026-06-01"
 last_updated = "2026-06-25"

--- a/providers/poe/models/novita/minimax-m3-n.toml
+++ b/providers/poe/models/novita/minimax-m3-n.toml
@@ -1,8 +1,7 @@
-name = "Minimax-M2.1"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
+name = "Minimax-M3-N"
 family = "minimax"
-release_date = "2025-12-26"
-last_updated = "2025-12-26"
+release_date = "2026-06-01"
+last_updated = "2026-06-25"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
@@ -13,12 +12,12 @@ tool_call = true
 [cost]
 input = 0.303
 output = 1.2121
-cache_read = 0.0303
+cache_read = 0.0606
 
 [limit]
-context = 205_000
+context = 1_048_576
 output = 131_072
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "video", "pdf"]
 output = ["text"]

--- a/providers/poe/models/novita/minimax-m3-n.toml
+++ b/providers/poe/models/novita/minimax-m3-n.toml
@@ -1,14 +1,7 @@
+base_model = "minimax/MiniMax-M3"
 name = "Minimax-M3-N"
-description = "MiniMax multimodal model for long-context coding, perception, and agent planning"
-family = "minimax"
-release_date = "2026-06-01"
 last_updated = "2026-06-25"
-attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.303
@@ -21,4 +14,3 @@ output = 131_072
 
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/qwen3-235b-a22b-n.toml
+++ b/providers/poe/models/novita/qwen3-235b-a22b-n.toml
@@ -1,0 +1,18 @@
+name = "Qwen3-235B-A22B-N"
+family = "qwen"
+release_date = "2025-04"
+last_updated = "2025-04"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+open_weights = true
+tool_call = true
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/novita/qwen3-235b-a22b-n.toml
+++ b/providers/poe/models/novita/qwen3-235b-a22b-n.toml
@@ -1,19 +1,7 @@
+base_model = "alibaba/qwen3-235b-a22b"
 name = "Qwen3-235B-A22B-N"
-description = "Open Qwen reasoning model for multilingual chat, math, coding, and tool use"
-family = "qwen"
-release_date = "2025-04"
-last_updated = "2025-04"
 attachment = true
 reasoning = false
-temperature = true
-knowledge = "2025-04"
-open_weights = true
-tool_call = true
-
-[limit]
-context = 131_072
-output = 16_384
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/qwen3-235b-a22b-n.toml
+++ b/providers/poe/models/novita/qwen3-235b-a22b-n.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-235B-A22B-N"
+description = "Open Qwen reasoning model for multilingual chat, math, coding, and tool use"
 family = "qwen"
 release_date = "2025-04"
 last_updated = "2025-04"

--- a/providers/poe/models/novita/qwen3-coder-480b-n.toml
+++ b/providers/poe/models/novita/qwen3-coder-480b-n.toml
@@ -1,0 +1,18 @@
+name = "Qwen3-Coder-480B-N"
+family = "qwen"
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+open_weights = true
+tool_call = true
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/novita/qwen3-coder-480b-n.toml
+++ b/providers/poe/models/novita/qwen3-coder-480b-n.toml
@@ -1,19 +1,8 @@
+base_model = "alibaba/qwen3-coder-480b-a35b-instruct"
 name = "Qwen3-Coder-480B-N"
-description = "Qwen coding model for software agents, repository edits, and code reasoning"
-family = "qwen"
 release_date = "2025-07-23"
 last_updated = "2025-07-23"
 attachment = true
-reasoning = false
-temperature = true
-knowledge = "2025-04"
-open_weights = true
-tool_call = true
-
-[limit]
-context = 262_144
-output = 65_536
 
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/qwen3-coder-480b-n.toml
+++ b/providers/poe/models/novita/qwen3-coder-480b-n.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-Coder-480B-N"
+description = "Qwen coding model for software agents, repository edits, and code reasoning"
 family = "qwen"
 release_date = "2025-07-23"
 last_updated = "2025-07-23"

--- a/providers/poe/models/novita/qwen3-coder-next.toml
+++ b/providers/poe/models/novita/qwen3-coder-next.toml
@@ -1,0 +1,21 @@
+name = "Qwen3-Coder-Next"
+family = "qwen"
+release_date = "2026-02-03"
+last_updated = "2026-02-03"
+attachment = false
+reasoning = false
+temperature = true
+open_weights = true
+tool_call = true
+
+[cost]
+input = 0.202
+output = 1.5152
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/poe/models/novita/qwen3-coder-next.toml
+++ b/providers/poe/models/novita/qwen3-coder-next.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-Coder-Next"
+description = "Qwen coding model for software agents, repository edits, and code reasoning"
 family = "qwen"
 release_date = "2026-02-03"
 last_updated = "2026-02-03"

--- a/providers/poe/models/novita/qwen3-max-n.toml
+++ b/providers/poe/models/novita/qwen3-max-n.toml
@@ -1,0 +1,23 @@
+name = "Qwen3-Max-N"
+family = "qwen"
+release_date = "2025-09-24"
+last_updated = "2025-09-24"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = true
+knowledge = "2025-04"
+open_weights = false
+tool_call = true
+
+[cost]
+input = 2.1313
+output = 8.5354
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/novita/qwen3-max-n.toml
+++ b/providers/poe/models/novita/qwen3-max-n.toml
@@ -1,24 +1,14 @@
+base_model = "alibaba/qwen3-max"
 name = "Qwen3-Max-N"
-description = "Flagship Qwen3 model for coding agents, complex reasoning, and tool use"
-family = "qwen"
 release_date = "2025-09-24"
 last_updated = "2025-09-24"
 attachment = true
 reasoning = true
 reasoning_options = []
-temperature = true
-knowledge = "2025-04"
-open_weights = false
-tool_call = true
 
 [cost]
 input = 2.1313
 output = 8.5354
 
-[limit]
-context = 262_144
-output = 65_536
-
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/qwen3-max-n.toml
+++ b/providers/poe/models/novita/qwen3-max-n.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-Max-N"
+description = "Flagship Qwen3 model for coding agents, complex reasoning, and tool use"
 family = "qwen"
 release_date = "2025-09-24"
 last_updated = "2025-09-24"

--- a/providers/poe/models/novita/qwen3-next-80b-think.toml
+++ b/providers/poe/models/novita/qwen3-next-80b-think.toml
@@ -1,0 +1,26 @@
+name = "Qwen3-Next-80B-Think"
+family = "qwen"
+release_date = "2025-09-10"
+last_updated = "2025-09-10"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = true
+knowledge = "2025-04"
+open_weights = true
+tool_call = true
+
+[cost]
+input = 0.1515
+output = 1.5152
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]
+
+[provider]
+body = { enable_thinking = true }

--- a/providers/poe/models/novita/qwen3-next-80b-think.toml
+++ b/providers/poe/models/novita/qwen3-next-80b-think.toml
@@ -1,27 +1,16 @@
+base_model = "alibaba/qwen3-next-80b-a3b-thinking"
 name = "Qwen3-Next-80B-Think"
-description = "Qwen reasoning model for deliberate problem solving, math, and coding"
-family = "qwen"
 release_date = "2025-09-10"
 last_updated = "2025-09-10"
 attachment = true
-reasoning = true
 reasoning_options = []
-temperature = true
-knowledge = "2025-04"
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.1515
 output = 1.5152
 
-[limit]
-context = 131_072
-output = 32_768
-
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]
 
 [provider]
 body = { enable_thinking = true }

--- a/providers/poe/models/novita/qwen3-next-80b-think.toml
+++ b/providers/poe/models/novita/qwen3-next-80b-think.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-Next-80B-Think"
+description = "Qwen reasoning model for deliberate problem solving, math, and coding"
 family = "qwen"
 release_date = "2025-09-10"
 last_updated = "2025-09-10"

--- a/providers/poe/models/novita/qwen3-next-80b.toml
+++ b/providers/poe/models/novita/qwen3-next-80b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3-Next-80B"
+family = "qwen"
+release_date = "2025-09-10"
+last_updated = "2025-09-10"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+open_weights = true
+tool_call = true
+
+[cost]
+input = 0.1515
+output = 1.5152
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text", "pdf"]
+output = ["text"]

--- a/providers/poe/models/novita/qwen3-next-80b.toml
+++ b/providers/poe/models/novita/qwen3-next-80b.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-Next-80B"
+description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
 family = "qwen"
 release_date = "2025-09-10"
 last_updated = "2025-09-10"

--- a/providers/poe/models/novita/qwen3-next-80b.toml
+++ b/providers/poe/models/novita/qwen3-next-80b.toml
@@ -1,23 +1,12 @@
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
 name = "Qwen3-Next-80B"
-description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
-family = "qwen"
 release_date = "2025-09-10"
 last_updated = "2025-09-10"
 attachment = true
-reasoning = false
-temperature = true
-knowledge = "2025-04"
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.1515
 output = 1.5152
 
-[limit]
-context = 131_072
-output = 32_768
-
 [modalities]
 input = ["text", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/qwen3-vl-235b-a22b-i.toml
+++ b/providers/poe/models/novita/qwen3-vl-235b-a22b-i.toml
@@ -1,0 +1,21 @@
+name = "Qwen3-VL-235B-A22B-I"
+family = "qwen"
+release_date = "2025-09-24"
+last_updated = "2025-09-24"
+attachment = true
+reasoning = false
+temperature = true
+open_weights = true
+tool_call = true
+
+[cost]
+input = 0.303
+output = 1.5152
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/poe/models/novita/qwen3-vl-235b-a22b-i.toml
+++ b/providers/poe/models/novita/qwen3-vl-235b-a22b-i.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-VL-235B-A22B-I"
+description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
 family = "qwen"
 release_date = "2025-09-24"
 last_updated = "2025-09-24"

--- a/providers/poe/models/novita/qwen3-vl-235b-a22b-t.toml
+++ b/providers/poe/models/novita/qwen3-vl-235b-a22b-t.toml
@@ -1,0 +1,22 @@
+name = "Qwen3-VL-235B-A22B-T"
+family = "qwen"
+release_date = "2025-09-24"
+last_updated = "2025-09-24"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = true
+open_weights = true
+tool_call = true
+
+[cost]
+input = 0.9899
+output = 3.9899
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/poe/models/novita/qwen3-vl-235b-a22b-t.toml
+++ b/providers/poe/models/novita/qwen3-vl-235b-a22b-t.toml
@@ -1,4 +1,5 @@
 name = "Qwen3-VL-235B-A22B-T"
+description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
 family = "qwen"
 release_date = "2025-09-24"
 last_updated = "2025-09-24"

--- a/providers/poe/models/novita/qwen3.5-397b-a17b.toml
+++ b/providers/poe/models/novita/qwen3.5-397b-a17b.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.5-397B-A17B"
+description = "Large open Qwen multimodal MoE for visual agents and long technical tasks"
 family = "qwen"
 release_date = "2026-02-17"
 last_updated = "2026-02-17"

--- a/providers/poe/models/novita/qwen3.5-397b-a17b.toml
+++ b/providers/poe/models/novita/qwen3.5-397b-a17b.toml
@@ -1,23 +1,15 @@
+base_model = "alibaba/qwen3.5-397b-a17b"
 name = "Qwen3.5-397B-A17B"
-description = "Large open Qwen multimodal MoE for visual agents and long technical tasks"
-family = "qwen"
 release_date = "2026-02-17"
 last_updated = "2026-02-17"
-attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-temperature = true
-open_weights = true
-tool_call = true
 
 [cost]
 input = 0.6061
 output = 3.6364
 
 [limit]
-context = 262_144
 output = 64_000
 
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/poe/models/novita/qwen3.5-397b-a17b.toml
+++ b/providers/poe/models/novita/qwen3.5-397b-a17b.toml
@@ -1,0 +1,22 @@
+name = "Qwen3.5-397B-A17B"
+family = "qwen"
+release_date = "2026-02-17"
+last_updated = "2026-02-17"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+open_weights = true
+tool_call = true
+
+[cost]
+input = 0.6061
+output = 3.6364
+
+[limit]
+context = 262_144
+output = 64_000
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/providers/poe/models/openai/gpt-image-1.5.toml
+++ b/providers/poe/models/openai/gpt-image-1.5.toml
@@ -1,4 +1,4 @@
-name = "gpt-image-1.5"
+name = "GPT-Image-1.5"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 release_date = "2025-12-16"
 last_updated = "2025-12-16"


### PR DESCRIPTION
## Summary

- Add and update Poe model metadata for Novita AI, EmpirioLabs AI, and Fireworks AI.
- Align model names, pricing, tool support, modalities, and reasoning controls with Poe `/v1/models`.
- Keep request-only Poe models without `[cost]`.
- Fix `GPT-Image-1.5` display name casing.

## Verification

- Live-tested selected Poe chat completions
- Live-tested PDF upload/read support where `pdf` is declared
- Verified thinking controls for models with Poe live calls

## Notes

- `qwen3-next-80b-think` requires `enable_thinking = true`, so it is set via provider body.
- Request-only models intentionally omit `[cost]`.
- Note on `base_model`: Poe models can use `base_model` where there is a clean canonical model match and only small provider-specific differences. I kept these entries expanded because the pricing, modalities, PDF support, and reasoning controls are Poe-bot-specific and were verified against Poe's API/catalog rather than inherited from an upstream provider.