### PR TITLE
fix: restore opencode go minimax m3 pricing

### DIFF
--- a/providers/opencode-go/models/minimax-m3.toml
+++ b/providers/opencode-go/models/minimax-m3.toml
@@ -11,15 +11,15 @@ knowledge = "2025-01"
 open_weights = true
 
 [cost]
-input = 0.1
-output = 0.4
-cache_read = 0.02
+input = 0.3
+output = 1.2
+cache_read = 0.06
 
 [[cost.tiers]]
 tier = { size = 512_000 }
-input = 0.2
-output = 0.8
-cache_read = 0.04
+input = 0.6
+output = 2.4
+cache_read = 0.12
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
## Summary
- restore opencode-go MiniMax M3 pricing to 3x the promotional values
- keep metadata fields unchanged

## Validation
- bun validate