### PR TITLE
feat: add DeepInfra Kimi K2.7 Code

### DIFF
--- a/providers/deepinfra/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/deepinfra/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.74
+output = 3.50
+cache_read = 0.15


### PR DESCRIPTION
Add MoonshotAI Kimi K2.7 Code model for DeepInfra provider.

Data sourced from <https://api.deepinfra.com/v1/openai/models>.