### PR TITLE
feat(provider) add Runware

### DIFF
--- a/providers/runware/models/anthropic-claude-fable-5.toml
+++ b/providers/runware/models/anthropic-claude-fable-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-fable-5"
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/runware/models/anthropic-claude-fable-5.toml
+++ b/providers/runware/models/anthropic-claude-fable-5.toml
@@ -1,5 +1,9 @@
 base_model = "anthropic/claude-fable-5"
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 10
 output = 50

--- a/providers/runware/models/anthropic-claude-haiku-4-5.toml
+++ b/providers/runware/models/anthropic-claude-haiku-4-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25

--- a/providers/runware/models/anthropic-claude-haiku-4-5.toml
+++ b/providers/runware/models/anthropic-claude-haiku-4-5.toml
@@ -1,5 +1,9 @@
 base_model = "anthropic/claude-haiku-4-5"
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1024
+
 [cost]
 input = 1
 output = 5

--- a/providers/runware/models/anthropic-claude-opus-4-7.toml
+++ b/providers/runware/models/anthropic-claude-opus-4-7.toml
@@ -1,5 +1,9 @@
 base_model = "anthropic/claude-opus-4-7"
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 5
 output = 25

--- a/providers/runware/models/anthropic-claude-opus-4-7.toml
+++ b/providers/runware/models/anthropic-claude-opus-4-7.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/runware/models/anthropic-claude-opus-4-8.toml
+++ b/providers/runware/models/anthropic-claude-opus-4-8.toml
@@ -1,5 +1,9 @@
 base_model = "anthropic/claude-opus-4-8"
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 5
 output = 25

--- a/providers/runware/models/anthropic-claude-opus-4-8.toml
+++ b/providers/runware/models/anthropic-claude-opus-4-8.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/runware/models/anthropic-claude-sonnet-4-6.toml
+++ b/providers/runware/models/anthropic-claude-sonnet-4-6.toml
@@ -1,5 +1,13 @@
 base_model = "anthropic/claude-sonnet-4-6"
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1024
+
 [cost]
 input = 3
 output = 15

--- a/providers/runware/models/anthropic-claude-sonnet-4-6.toml
+++ b/providers/runware/models/anthropic-claude-sonnet-4-6.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+output = 128000

--- a/providers/runware/models/deepseek-v4-flash.toml
+++ b/providers/runware/models/deepseek-v4-flash.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [cost]
 input = 0.076
 output = 0.153

--- a/providers/runware/models/deepseek-v4-flash.toml
+++ b/providers/runware/models/deepseek-v4-flash.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[cost]
+input = 0.076
+output = 0.153
+cache_read = 0.014
+
+[limit]
+context = 1048576

--- a/providers/runware/models/deepseek-v4-pro.toml
+++ b/providers/runware/models/deepseek-v4-pro.toml
@@ -1,5 +1,12 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [cost]
 input = 0.961
 output = 1.922

--- a/providers/runware/models/deepseek-v4-pro.toml
+++ b/providers/runware/models/deepseek-v4-pro.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 0.961
+output = 1.922
+cache_read = 0.079
+
+[limit]
+context = 1048576

--- a/providers/runware/models/google-gemini-3-1-flash-lite.toml
+++ b/providers/runware/models/google-gemini-3-1-flash-lite.toml
@@ -1,5 +1,9 @@
 base_model = "google/gemini-3.1-flash-lite"
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 0.25
 output = 1.5

--- a/providers/runware/models/google-gemini-3-1-flash-lite.toml
+++ b/providers/runware/models/google-gemini-3-1-flash-lite.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.1-flash-lite"
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025

--- a/providers/runware/models/google-gemini-3-1-pro.toml
+++ b/providers/runware/models/google-gemini-3-1-pro.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2

--- a/providers/runware/models/google-gemini-3-1-pro.toml
+++ b/providers/runware/models/google-gemini-3-1-pro.toml
@@ -1,5 +1,9 @@
 base_model = "google/gemini-3.1-pro-preview"
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
 [cost]
 input = 2
 output = 12

--- a/providers/runware/models/google-gemini-3-5-flash.toml
+++ b/providers/runware/models/google-gemini-3-5-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.5-flash"
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15

--- a/providers/runware/models/google-gemini-3-5-flash.toml
+++ b/providers/runware/models/google-gemini-3-5-flash.toml
@@ -1,5 +1,9 @@
 base_model = "google/gemini-3.5-flash"
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 1.5
 output = 9

--- a/providers/runware/models/google-gemini-3-flash.toml
+++ b/providers/runware/models/google-gemini-3-flash.toml
@@ -1,5 +1,9 @@
 base_model = "google/gemini-3-flash-preview"
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 0.5
 output = 3

--- a/providers/runware/models/google-gemini-3-flash.toml
+++ b/providers/runware/models/google-gemini-3-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3-flash-preview"
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05

--- a/providers/runware/models/google-gemma-4-31b.toml
+++ b/providers/runware/models/google-gemma-4-31b.toml
@@ -1,0 +1,9 @@
+base_model = "google/gemma-4-31b-it"
+
+[cost]
+input = 0.102
+output = 0.297
+cache_read = 0.012
+
+[limit]
+output = 65536

--- a/providers/runware/models/google-gemma-4-31b.toml
+++ b/providers/runware/models/google-gemma-4-31b.toml
@@ -1,5 +1,8 @@
 base_model = "google/gemma-4-31b-it"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.102
 output = 0.297

--- a/providers/runware/models/minimax-m2-5.toml
+++ b/providers/runware/models/minimax-m2-5.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
 
 [cost]
 input = 0.127

--- a/providers/runware/models/minimax-m2-5.toml
+++ b/providers/runware/models/minimax-m2-5.toml
@@ -1,0 +1,9 @@
+base_model = "minimax/MiniMax-M2.5"
+
+[cost]
+input = 0.127
+output = 0.765
+cache_read = 0.025
+
+[limit]
+output = 196608

--- a/providers/runware/models/minimax-m2-7-highspeed.toml
+++ b/providers/runware/models/minimax-m2-7-highspeed.toml
@@ -1,0 +1,7 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
+
+[cost]
+input = 0.6
+output = 2.4
+cache_read = 0.06
+cache_write = 0.375

--- a/providers/runware/models/minimax-m2-7-highspeed.toml
+++ b/providers/runware/models/minimax-m2-7-highspeed.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/runware/models/minimax-m2-7.toml
+++ b/providers/runware/models/minimax-m2-7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/runware/models/minimax-m2-7.toml
+++ b/providers/runware/models/minimax-m2-7.toml
@@ -1,0 +1,7 @@
+base_model = "minimax/MiniMax-M2.7"
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+cache_write = 0.375

--- a/providers/runware/models/minimax-m3.toml
+++ b/providers/runware/models/minimax-m3.toml
@@ -1,5 +1,8 @@
 base_model = "minimax/MiniMax-M3"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.3
 output = 1.2

--- a/providers/runware/models/minimax-m3.toml
+++ b/providers/runware/models/minimax-m3.toml
@@ -1,0 +1,10 @@
+base_model = "minimax/MiniMax-M3"
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+
+[limit]
+context = 1000000
+output = 512000

--- a/providers/runware/models/moonshotai-kimi-k2-6.toml
+++ b/providers/runware/models/moonshotai-kimi-k2-6.toml
@@ -1,5 +1,8 @@
 base_model = "moonshotai/kimi-k2.6"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.9
 output = 4.2

--- a/providers/runware/models/moonshotai-kimi-k2-6.toml
+++ b/providers/runware/models/moonshotai-kimi-k2-6.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.9
+output = 4.2
+cache_read = 0.18
+
+[limit]
+output = 49152
+
+[modalities]
+input = ["text", "image"]

--- a/providers/runware/models/openai-gpt-5-4-mini.toml
+++ b/providers/runware/models/openai-gpt-5-4-mini.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.4-mini"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
 [cost]
 input = 0.75
 output = 4.5

--- a/providers/runware/models/openai-gpt-5-4-mini.toml
+++ b/providers/runware/models/openai-gpt-5-4-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4-mini"
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075

--- a/providers/runware/models/openai-gpt-5-4-nano.toml
+++ b/providers/runware/models/openai-gpt-5-4-nano.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.4-nano"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
 [cost]
 input = 0.2
 output = 1.25

--- a/providers/runware/models/openai-gpt-5-4-nano.toml
+++ b/providers/runware/models/openai-gpt-5-4-nano.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4-nano"
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02

--- a/providers/runware/models/openai-gpt-5-4-pro.toml
+++ b/providers/runware/models/openai-gpt-5-4-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-pro"
+
+[cost]
+input = 30
+output = 180

--- a/providers/runware/models/openai-gpt-5-4-pro.toml
+++ b/providers/runware/models/openai-gpt-5-4-pro.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.4-pro"
 
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high", "xhigh"]
+
 [cost]
 input = 30
 output = 180

--- a/providers/runware/models/openai-gpt-5-4.toml
+++ b/providers/runware/models/openai-gpt-5-4.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-5.4"
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[modalities]
+input = ["text", "image"]

--- a/providers/runware/models/openai-gpt-5-4.toml
+++ b/providers/runware/models/openai-gpt-5-4.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.4"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
 [cost]
 input = 2.5
 output = 15

--- a/providers/runware/models/openai-gpt-5-5.toml
+++ b/providers/runware/models/openai-gpt-5-5.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5.5"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
 [cost]
 input = 5
 output = 30

--- a/providers/runware/models/openai-gpt-5-5.toml
+++ b/providers/runware/models/openai-gpt-5-5.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-5.5"
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/runware/models/openai-gpt-5-mini.toml
+++ b/providers/runware/models/openai-gpt-5-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5-mini"
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025

--- a/providers/runware/models/openai-gpt-5-mini.toml
+++ b/providers/runware/models/openai-gpt-5-mini.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5-mini"
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 0.25
 output = 2

--- a/providers/runware/models/openai-gpt-5-nano.toml
+++ b/providers/runware/models/openai-gpt-5-nano.toml
@@ -1,5 +1,9 @@
 base_model = "openai/gpt-5-nano"
 
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
 input = 0.05
 output = 0.4

--- a/providers/runware/models/openai-gpt-5-nano.toml
+++ b/providers/runware/models/openai-gpt-5-nano.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5-nano"
+
+[cost]
+input = 0.05
+output = 0.4
+cache_read = 0.005

--- a/providers/runware/models/qwen35_27b_fp8.toml
+++ b/providers/runware/models/qwen35_27b_fp8.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen3.5-27b"
+
+[cost]
+input = 0.165
+output = 1.326
+cache_read = 0.024
+
+[limit]
+output = 128000
+
+[modalities]
+input = ["text", "image"]

--- a/providers/runware/models/qwen35_27b_fp8.toml
+++ b/providers/runware/models/qwen35_27b_fp8.toml
@@ -1,5 +1,11 @@
 base_model = "alibaba/qwen3.5-27b"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.165
 output = 1.326

--- a/providers/runware/models/qwen35_397b_a17b_fp8.toml
+++ b/providers/runware/models/qwen35_397b_a17b_fp8.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen3.5-397b-a17b"
+
+[cost]
+input = 0.327
+output = 1.989
+cache_read = 0.05
+
+[limit]
+output = 128000
+
+[modalities]
+input = ["text", "image"]

--- a/providers/runware/models/qwen35_397b_a17b_fp8.toml
+++ b/providers/runware/models/qwen35_397b_a17b_fp8.toml
@@ -1,5 +1,11 @@
 base_model = "alibaba/qwen3.5-397b-a17b"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
 input = 0.327
 output = 1.989

--- a/providers/runware/models/xai-grok-4-3.toml
+++ b/providers/runware/models/xai-grok-4-3.toml
@@ -1,5 +1,9 @@
 base_model = "xai/grok-4.3"
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
 [cost]
 input = 1.25
 output = 2.5

--- a/providers/runware/models/xai-grok-4-3.toml
+++ b/providers/runware/models/xai-grok-4-3.toml
@@ -1,0 +1,13 @@
+base_model = "xai/grok-4.3"
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[limit]
+context = 1048576
+output = 131072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/runware/models/zai-glm-4-7.toml
+++ b/providers/runware/models/zai-glm-4-7.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-4.7"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.34
 output = 1.487

--- a/providers/runware/models/zai-glm-4-7.toml
+++ b/providers/runware/models/zai-glm-4-7.toml
@@ -1,0 +1,9 @@
+base_model = "zhipuai/glm-4.7"
+
+[cost]
+input = 0.34
+output = 1.487
+cache_read = 0.04
+
+[limit]
+context = 200000

--- a/providers/runware/models/zai-glm-5-1.toml
+++ b/providers/runware/models/zai-glm-5-1.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5.1"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26

--- a/providers/runware/models/zai-glm-5-1.toml
+++ b/providers/runware/models/zai-glm-5-1.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-5.1"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 1.4
 output = 4.4

--- a/providers/runware/provider.toml
+++ b/providers/runware/provider.toml
@@ -1,0 +1,5 @@
+name = "Runware"
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.runware.ai/v1"
+env = ["RUNWARE_API_KEY"]
+doc = "https://runware.ai/docs"


### PR DESCRIPTION
Adds Runware (OpenAI-compatible inference gateway) as a provider, with 29 models.

Models are factored via `base_model` against existing canonical metadata. 
`cost` is always overridden; `limit` and `modalities` are overridden only where they diverge from the canonical model.