### PR TITLE
feat: add Claude Sonnet 5

### DIFF
--- a/models/anthropic/claude-sonnet-5.toml
+++ b/models/anthropic/claude-sonnet-5.toml
@@ -1,0 +1,18 @@
+name = "Claude Sonnet 5"
+family = "claude-sonnet"
+release_date = "2026-06-30"
+last_updated = "2026-06-30"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2026-01-31"
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/anthropic.claude-sonnet-5.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-sonnet-5.toml
@@ -1,0 +1,9 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+structured_output = true
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-5.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+name = "Claude Sonnet 5 (AU)"
+structured_output = true
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-5.toml
+++ b/providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+name = "Claude Sonnet 5 (EU)"
+structured_output = true
+
+[cost]
+input = 2.2
+output = 11
+cache_read = 0.22
+cache_write = 2.75

--- a/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-5.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+name = "Claude Sonnet 5 (Global)"
+structured_output = true
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-5.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+name = "Claude Sonnet 5 (JP)"
+structured_output = true
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-5.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+name = "Claude Sonnet 5 (US)"
+structured_output = true
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/anthropic/models/claude-sonnet-5.toml
+++ b/providers/anthropic/models/claude-sonnet-5.toml
@@ -1,0 +1,31 @@
+name = "Claude Sonnet 5"
+family = "claude-sonnet"
+release_date = "2026-06-30"
+last_updated = "2026-06-30"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+knowledge = "2026-01-31"
+open_weights = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2.00
+output = 10.00
+cache_read = 0.20
+cache_write = 2.50
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/azure/models/claude-sonnet-5.toml
+++ b/providers/azure/models/claude-sonnet-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+structured_output = true
+status = "beta"
+
+[cost]
+input = 2.00
+output = 10.00
+cache_read = 0.20
+cache_write = 2.50
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/anthropic/v1"

--- a/providers/google-vertex-anthropic/models/claude-sonnet-5@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-sonnet-5@default.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+output = 128_000

--- a/providers/google-vertex/models/claude-sonnet-5@default.toml
+++ b/providers/google-vertex/models/claude-sonnet-5@default.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+output = 128_000
+
+[provider]
+npm = "@ai-sdk/google-vertex/anthropic"


### PR DESCRIPTION
## Summary

- Add provider-agnostic metadata for `anthropic/claude-sonnet-5`.
- Add first-party Anthropic API pricing/capabilities for `claude-sonnet-5`.
- Add official cloud provider entries for Amazon Bedrock, Google Vertex Anthropic, Google Vertex, and Microsoft Foundry/Azure.
- Mark Microsoft Foundry/Azure entry as `beta` because Foundry lists Sonnet 5 as preview.

## Evidence

- [Anthropic models overview](https://platform.claude.com/docs/en/about-claude/models/overview) documents `claude-sonnet-5`, Bedrock ID `anthropic.claude-sonnet-5`, Google Cloud ID `claude-sonnet-5`, 1M context, 128k max output, Jan 2026 reliable knowledge cutoff, adaptive thinking, and $3/$15 standard pricing.
- [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing) documents active introductory pricing through August 31, 2026 at $2/$10 per MTok, cache read/write rates of $0.20/$2.50 per MTok, and no long-context premium for Sonnet 5.
- [Anthropic effort docs](https://platform.claude.com/docs/en/build-with-claude/effort) document Sonnet 5 effort values `low`, `medium`, `high`, `xhigh`, and `max`, plus `thinking: { type: "disabled" }` to turn adaptive thinking off.
- [Claude in Amazon Bedrock](https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock) documents the Bedrock Messages API model ID, feature support including structured outputs, and global/regional endpoint availability.
- [Claude on Google Cloud](https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai) documents the Vertex model ID, 1M context availability, and Anthropic-compatible request shape.
- [Claude in Microsoft Foundry](https://platform.claude.com/docs/en/build-with-claude/claude-in-microsoft-foundry) documents `claude-sonnet-5` as preview on Foundry, 1M context, Anthropic-compatible endpoint, and CCU billing from Claude token rates.

## Validation

- `bun validate`
- `git diff --check`
