### PR TITLE
Add ClinePass provider

### DIFF
--- a/providers/cline-pass/models/cline-pass/deepseek-v4-flash.toml
+++ b/providers/cline-pass/models/cline-pass/deepseek-v4-flash.toml
@@ -1,0 +1,7 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028

--- a/providers/cline-pass/models/cline-pass/deepseek-v4-flash.toml
+++ b/providers/cline-pass/models/cline-pass/deepseek-v4-flash.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.14

--- a/providers/cline-pass/models/cline-pass/deepseek-v4-pro.toml
+++ b/providers/cline-pass/models/cline-pass/deepseek-v4-pro.toml
@@ -1,0 +1,7 @@
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.0145

--- a/providers/cline-pass/models/cline-pass/deepseek-v4-pro.toml
+++ b/providers/cline-pass/models/cline-pass/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.74

--- a/providers/cline-pass/models/cline-pass/glm-5.2.toml
+++ b/providers/cline-pass/models/cline-pass/glm-5.2.toml
@@ -1,0 +1,7 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = []
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26

--- a/providers/cline-pass/models/cline-pass/glm-5.2.toml
+++ b/providers/cline-pass/models/cline-pass/glm-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.4

--- a/providers/cline-pass/models/cline-pass/kimi-k2.6.toml
+++ b/providers/cline-pass/models/cline-pass/kimi-k2.6.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.16

--- a/providers/cline-pass/models/cline-pass/kimi-k2.6.toml
+++ b/providers/cline-pass/models/cline-pass/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.95

--- a/providers/cline-pass/models/cline-pass/kimi-k2.7-code.toml
+++ b/providers/cline-pass/models/cline-pass/kimi-k2.7-code.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19

--- a/providers/cline-pass/models/cline-pass/kimi-k2.7-code.toml
+++ b/providers/cline-pass/models/cline-pass/kimi-k2.7-code.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.95

--- a/providers/cline-pass/models/cline-pass/mimo-v2.5-pro.toml
+++ b/providers/cline-pass/models/cline-pass/mimo-v2.5-pro.toml
@@ -1,0 +1,7 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.0145

--- a/providers/cline-pass/models/cline-pass/mimo-v2.5-pro.toml
+++ b/providers/cline-pass/models/cline-pass/mimo-v2.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.74

--- a/providers/cline-pass/models/cline-pass/mimo-v2.5.toml
+++ b/providers/cline-pass/models/cline-pass/mimo-v2.5.toml
@@ -1,0 +1,7 @@
+base_model = "xiaomi/mimo-v2.5"
+reasoning_options = []
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028

--- a/providers/cline-pass/models/cline-pass/mimo-v2.5.toml
+++ b/providers/cline-pass/models/cline-pass/mimo-v2.5.toml
@@ -1,5 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.14

--- a/providers/cline-pass/models/cline-pass/minimax-m3.toml
+++ b/providers/cline-pass/models/cline-pass/minimax-m3.toml
@@ -1,0 +1,7 @@
+base_model = "minimax/MiniMax-M3"
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06

--- a/providers/cline-pass/models/cline-pass/minimax-m3.toml
+++ b/providers/cline-pass/models/cline-pass/minimax-m3.toml
@@ -1,5 +1,5 @@
 base_model = "minimax/MiniMax-M3"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.3

--- a/providers/cline-pass/models/cline-pass/qwen3.7-max.toml
+++ b/providers/cline-pass/models/cline-pass/qwen3.7-max.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3.7-max"
+reasoning_options = []
+
+[cost]
+input = 2.5
+output = 7.5
+cache_read = 0.5
+cache_write = 3.125

--- a/providers/cline-pass/models/cline-pass/qwen3.7-max.toml
+++ b/providers/cline-pass/models/cline-pass/qwen3.7-max.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5

--- a/providers/cline-pass/models/cline-pass/qwen3.7-plus.toml
+++ b/providers/cline-pass/models/cline-pass/qwen3.7-plus.toml
@@ -1,0 +1,15 @@
+base_model = "alibaba/qwen3.7-plus"
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.04
+cache_write = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 1.2
+output = 4.8
+cache_read = 0.12
+cache_write = 1.5

--- a/providers/cline-pass/models/cline-pass/qwen3.7-plus.toml
+++ b/providers/cline-pass/models/cline-pass/qwen3.7-plus.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.4

--- a/providers/cline-pass/provider.toml
+++ b/providers/cline-pass/provider.toml
@@ -1,0 +1,10 @@
+name = "ClinePass"
+env = ["CLINE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# ClinePass uses the Cline API's OpenAI-compatible Chat Completions endpoint.
+# The model IDs below are the full ClinePass slugs documented for the `model`
+# request field. ClinePass is subscription-based; model TOML costs are the
+# reference per-1M-token rates Cline documents for quota accounting.
+# https://docs.cline.bot/getting-started/clinepass (accessed 2026-06-30)
+api = "https://api.cline.bot/api/v1"
+doc = "https://docs.cline.bot/getting-started/clinepass"


### PR DESCRIPTION
## Summary
- add ClinePass as an OpenAI-compatible provider using the Cline API base URL
- add the ten documented ClinePass model slugs
- use existing base model metadata and Cline's documented reference per-1M-token prices

## Notes
- ClinePass is subscription-based; the costs here are the reference rates Cline documents for quota accounting.
- Reasoning controls are marked as `reasoning_options = []` because the ClinePass docs do not document a toggle, effort, or token-budget parameter.

## Validation
- `bun validate`

Source: https://docs.cline.bot/getting-started/clinepass