### PR TITLE
Fix sync defaults for new reasoning models

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -351,7 +351,12 @@ export function preserveReasoningOptions(
     const { reasoning_options: _reasoningOptions, ...withoutReasoningOptions } = model;
     return withoutReasoningOptions as SyncedModel;
   }
-  if (model.reasoning_options !== undefined || existing?.reasoning_options === undefined) return model;
+  if (model.reasoning_options !== undefined) return model;
+  if (existing?.reasoning_options === undefined) {
+    return (model.reasoning ?? resolvedReasoning) === true
+      ? { ...model, reasoning_options: [] }
+      : model;
+  }
   return {
     ...model,
     reasoning_options: existing.reasoning_options,

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { formatToml } from "../src/sync/index.js";
+import { formatToml, preserveReasoningOptions } from "../src/sync/index.js";
 
 test("formats interleaved as a root field before reasoning option tables", () => {
   const content = formatToml({
@@ -44,6 +44,13 @@ test("formats empty reasoning options outside the interleaved table", () => {
 
   expect(Bun.TOML.parse(content)).toMatchObject({
     interleaved: { field: "reasoning_content" },
+    reasoning_options: [],
+  });
+});
+
+test("defaults new reasoning models to empty reasoning options", () => {
+  expect(preserveReasoningOptions({ reasoning: true }, undefined)).toEqual({
+    reasoning: true,
     reasoning_options: [],
   });
 });


### PR DESCRIPTION
## Summary
- Default newly synced reasoning models to reasoning_options = [] when no provider-specific controls have been audited yet.
- Preserve existing behavior for authored reasoning options and continue stripping options when reasoning is false.
- Add a regression test for the default.

## Context
The scheduled sync run failed for OpenRouter and Vercel when a new google/gemini-3.1-flash-lite-image model synced with reasoning = true but no reasoning_options. An empty options list is the least-permissive metadata: it records that the model reasons without claiming toggle, effort, or budget controls.

## Verification
- bun test packages/core/test/sync.test.ts
- bun validate
- bun --eval import syncTargets from packages/core/src/sync/index.js for openrouter dry run
- bun --eval import syncTargets from packages/core/src/sync/index.js for vercel dry run
- git diff --check