### PR TITLE
feat: add Voyage AI provider with embedding and reranker models

### DIFF
--- a/models/voyageai/voyage-4-nano.toml
+++ b/models/voyageai/voyage-4-nano.toml
@@ -1,0 +1,25 @@
+name = "voyage-4-nano"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2026-01-15"
+last_updated = "2026-01-15"
+# Open-weight member of the Voyage 4 family (available on Hugging Face).
+open_weights = true
+license = "Apache-2.0"
+
+[limit]
+context = 32_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "voyage-4-nano"
+url = "https://huggingface.co/voyageai/voyage-4-nano"
+format = "safetensors"

--- a/providers/voyageai/models/rerank-2-lite.toml
+++ b/providers/voyageai/models/rerank-2-lite.toml
@@ -1,0 +1,22 @@
+name = "rerank-2-lite"
+# Reranker: scores query/document pairs; emits no generated or embedding tokens.
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-09-30"
+last_updated = "2024-09-30"
+open_weights = false
+
+[cost]
+input = 0.02
+output = 0.00
+
+[limit]
+# Max query + single-document context; query alone up to 2K tokens.
+context = 8_000
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/rerank-2.5-lite.toml
+++ b/providers/voyageai/models/rerank-2.5-lite.toml
@@ -1,0 +1,22 @@
+name = "rerank-2.5-lite"
+# Reranker: scores query/document pairs; emits no generated or embedding tokens.
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2025-08-11"
+last_updated = "2025-08-11"
+open_weights = false
+
+[cost]
+input = 0.02
+output = 0.00
+
+[limit]
+# Max query + single-document context; query alone up to 8K tokens.
+context = 32_000
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/rerank-2.5.toml
+++ b/providers/voyageai/models/rerank-2.5.toml
@@ -1,0 +1,23 @@
+name = "rerank-2.5"
+# Reranker: scores query/document pairs; emits no generated or embedding tokens.
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2025-08-11"
+last_updated = "2025-08-11"
+open_weights = false
+
+[cost]
+input = 0.05
+output = 0.00
+
+[limit]
+# Max query + single-document context; query alone up to 8K tokens.
+context = 32_000
+# Rerankers return relevance scores, not output tokens.
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/rerank-2.toml
+++ b/providers/voyageai/models/rerank-2.toml
@@ -1,0 +1,22 @@
+name = "rerank-2"
+# Reranker: scores query/document pairs; emits no generated or embedding tokens.
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-09-30"
+last_updated = "2024-09-30"
+open_weights = false
+
+[cost]
+input = 0.05
+output = 0.00
+
+[limit]
+# Max query + single-document context; query alone up to 4K tokens.
+context = 16_000
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-3-large.toml
+++ b/providers/voyageai/models/voyage-3-large.toml
@@ -1,0 +1,22 @@
+name = "voyage-3-large"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2025-01-07"
+last_updated = "2025-01-07"
+open_weights = false
+
+[cost]
+input = 0.18
+output = 0.00
+
+[limit]
+context = 32_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-3-lite.toml
+++ b/providers/voyageai/models/voyage-3-lite.toml
@@ -1,0 +1,21 @@
+name = "voyage-3-lite"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-09-18"
+last_updated = "2024-09-18"
+open_weights = false
+
+[cost]
+input = 0.02
+output = 0.00
+
+[limit]
+context = 32_000
+output = 512
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-3.5-lite.toml
+++ b/providers/voyageai/models/voyage-3.5-lite.toml
@@ -1,0 +1,22 @@
+name = "voyage-3.5-lite"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+open_weights = false
+
+[cost]
+input = 0.02
+output = 0.00
+
+[limit]
+context = 32_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-3.5.toml
+++ b/providers/voyageai/models/voyage-3.5.toml
@@ -1,0 +1,22 @@
+name = "voyage-3.5"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2025-05-20"
+last_updated = "2025-05-20"
+open_weights = false
+
+[cost]
+input = 0.06
+output = 0.00
+
+[limit]
+context = 32_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-3.toml
+++ b/providers/voyageai/models/voyage-3.toml
@@ -1,0 +1,21 @@
+name = "voyage-3"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-09-18"
+last_updated = "2024-09-18"
+open_weights = false
+
+[cost]
+input = 0.06
+output = 0.00
+
+[limit]
+context = 32_000
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-4-large.toml
+++ b/providers/voyageai/models/voyage-4-large.toml
@@ -1,0 +1,22 @@
+name = "voyage-4-large"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2026-03-03"
+last_updated = "2026-03-03"
+open_weights = false
+
+[cost]
+input = 0.12
+output = 0.00
+
+[limit]
+context = 32_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-4-lite.toml
+++ b/providers/voyageai/models/voyage-4-lite.toml
@@ -1,0 +1,22 @@
+name = "voyage-4-lite"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2026-01-15"
+last_updated = "2026-01-15"
+open_weights = false
+
+[cost]
+input = 0.02
+output = 0.00
+
+[limit]
+context = 32_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-4-nano.toml
+++ b/providers/voyageai/models/voyage-4-nano.toml
@@ -1,0 +1,4 @@
+# Open-weight model; Voyage does not publish a hosted per-token price, so no
+# [cost] table. Provider-agnostic facts (incl. weights) live in
+# models/voyageai/voyage-4-nano.toml.
+base_model = "voyageai/voyage-4-nano"

--- a/providers/voyageai/models/voyage-4.toml
+++ b/providers/voyageai/models/voyage-4.toml
@@ -1,0 +1,22 @@
+name = "voyage-4"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2026-01-15"
+last_updated = "2026-01-15"
+open_weights = false
+
+[cost]
+input = 0.06
+output = 0.00
+
+[limit]
+context = 32_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-code-2.toml
+++ b/providers/voyageai/models/voyage-code-2.toml
@@ -1,0 +1,21 @@
+name = "voyage-code-2"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-01-23"
+last_updated = "2024-01-23"
+open_weights = false
+
+[cost]
+input = 0.12
+output = 0.00
+
+[limit]
+context = 16_000
+output = 1_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-code-3.toml
+++ b/providers/voyageai/models/voyage-code-3.toml
@@ -1,0 +1,22 @@
+name = "voyage-code-3"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-12-04"
+last_updated = "2024-12-04"
+open_weights = false
+
+[cost]
+input = 0.18
+output = 0.00
+
+[limit]
+context = 32_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-context-3.toml
+++ b/providers/voyageai/models/voyage-context-3.toml
@@ -1,0 +1,23 @@
+name = "voyage-context-3"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+open_weights = false
+
+[cost]
+input = 0.18
+output = 0.00
+
+[limit]
+# 120K tokens total per request; up to 32K tokens per chunk.
+context = 120_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-context-4.toml
+++ b/providers/voyageai/models/voyage-context-4.toml
@@ -1,0 +1,25 @@
+name = "voyage-context-4"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2026-06-29"
+last_updated = "2026-06-29"
+open_weights = false
+
+[cost]
+# Contextualized chunk embeddings; per-token price not yet listed on the
+# Voyage pricing page as of this entry (voyage-context-3 is $0.18 / 1M).
+input = 0.18
+output = 0.00
+
+[limit]
+# 120K tokens total per request; up to 32K tokens per chunk.
+context = 120_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-finance-2.toml
+++ b/providers/voyageai/models/voyage-finance-2.toml
@@ -1,0 +1,21 @@
+name = "voyage-finance-2"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-06-03"
+last_updated = "2024-06-03"
+open_weights = false
+
+[cost]
+input = 0.12
+output = 0.00
+
+[limit]
+context = 32_000
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-large-2-instruct.toml
+++ b/providers/voyageai/models/voyage-large-2-instruct.toml
@@ -1,0 +1,21 @@
+name = "voyage-large-2-instruct"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-05-05"
+last_updated = "2024-05-05"
+open_weights = false
+
+[cost]
+input = 0.12
+output = 0.00
+
+[limit]
+context = 16_000
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-law-2.toml
+++ b/providers/voyageai/models/voyage-law-2.toml
@@ -1,0 +1,21 @@
+name = "voyage-law-2"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-04-15"
+last_updated = "2024-04-15"
+open_weights = false
+
+[cost]
+input = 0.12
+output = 0.00
+
+[limit]
+context = 16_000
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-multilingual-2.toml
+++ b/providers/voyageai/models/voyage-multilingual-2.toml
@@ -1,0 +1,21 @@
+name = "voyage-multilingual-2"
+family = "voyage"
+attachment = false
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-06-10"
+last_updated = "2024-06-10"
+open_weights = false
+
+[cost]
+input = 0.12
+output = 0.00
+
+[limit]
+context = 32_000
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-multimodal-3.5.toml
+++ b/providers/voyageai/models/voyage-multimodal-3.5.toml
@@ -1,0 +1,23 @@
+name = "voyage-multimodal-3.5"
+family = "voyage"
+# Accepts interleaved text, images, and video as input.
+attachment = true
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2026-01-15"
+last_updated = "2026-01-15"
+open_weights = false
+
+[cost]
+input = 0.12
+output = 0.00
+
+[limit]
+context = 32_000
+# output holds the default embedding dimension (also supports 256, 512, 2048)
+output = 1_024
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/voyageai/models/voyage-multimodal-3.toml
+++ b/providers/voyageai/models/voyage-multimodal-3.toml
@@ -1,0 +1,22 @@
+name = "voyage-multimodal-3"
+family = "voyage"
+# Accepts interleaved text and images as input.
+attachment = true
+reasoning = false
+tool_call = false
+temperature = false
+release_date = "2024-11-12"
+last_updated = "2024-11-12"
+open_weights = false
+
+[cost]
+input = 0.12
+output = 0.00
+
+[limit]
+context = 32_000
+output = 1_024
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/voyageai/provider.toml
+++ b/providers/voyageai/provider.toml
@@ -1,0 +1,4 @@
+name = "Voyage AI"
+env = ["VOYAGE_API_KEY"]
+npm = "voyage-ai-provider"
+doc = "https://docs.voyageai.com/docs/embeddings"


### PR DESCRIPTION
Add the Voyage AI provider (voyage-ai-provider, VOYAGE_API_KEY) with 23 models sourced from docs.voyageai.com:

- Text embeddings: voyage-4-large/4/4-lite/4-nano, voyage-code-3/2, voyage-finance-2, voyage-law-2, voyage-3-large, voyage-3.5/3.5-lite, voyage-3/3-lite, voyage-multilingual-2, voyage-large-2-instruct
- Contextualized chunk embeddings: voyage-context-4/3
- Multimodal embeddings: voyage-multimodal-3.5/3
- Rerankers: rerank-2.5/2.5-lite, rerank-2/2-lite

Pricing, context windows, default embedding dimensions and release dates follow the official Voyage docs and pricing page. Rerankers carry output=0 (no generated tokens). voyage-4-nano is open-weight (Apache-2.0); its provider entry uses base_model to inherit model-only metadata from models/voyageai/voyage-4-nano.toml, which carries the Hugging Face weights link.