### PR TITLE
Fix OpenRouter reasoning option sync

### DIFF
--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -57,6 +57,17 @@ export const OpenRouterModel = z.object({
     max_completion_tokens: z.number().nullable(),
   }),
   supported_parameters: z.array(z.string()),
+  reasoning: z
+    .object({
+      mandatory: z.boolean(),
+      supported_efforts: z
+        .array(z.enum(["max", "xhigh", "high", "medium", "low", "minimal", "none"]))
+        .nullable()
+        .optional(),
+      supports_max_tokens: z.boolean().optional(),
+    })
+    .passthrough()
+    .optional(),
 });
 
 export const OpenRouterResponse = z.object({
@@ -144,6 +155,9 @@ export function buildOpenRouterModel(
   const prompt = price(model.pricing.prompt);
   const completion = price(model.pricing.completion);
   const reasoning = params.has("reasoning") || params.has("include_reasoning");
+  const reasoning_options = existing?.reasoning_options?.length
+    ? existing.reasoning_options
+    : openRouterReasoningOptions(model.reasoning) ?? existing?.reasoning_options;
   const context = model.top_provider.context_length ?? model.context_length;
   const family = inferFamily(model, name);
   const releaseDate = dateFromTimestamp(model.created);
@@ -179,6 +193,7 @@ export function buildOpenRouterModel(
         name: baseModel !== undefined || model.id.endsWith(":free") ? name : undefined,
         attachment,
         reasoning,
+        reasoning_options,
         temperature: params.has("temperature"),
         tool_call: toolCall,
         structured_output: structuredOutput,
@@ -200,6 +215,7 @@ export function buildOpenRouterModel(
     last_updated: releaseDate,
     attachment,
     reasoning,
+    reasoning_options,
     temperature: params.has("temperature"),
     tool_call: toolCall,
     structured_output: structuredOutput,
@@ -211,6 +227,28 @@ export function buildOpenRouterModel(
     limit,
     modalities: { input, output },
   } satisfies SyncedFullModel;
+}
+
+function openRouterReasoningOptions(reasoning: OpenRouterModel["reasoning"]): SyncedFullModel["reasoning_options"] {
+  if (reasoning === undefined) return undefined;
+
+  const options: NonNullable<SyncedFullModel["reasoning_options"]> = [];
+  const efforts = reasoning.supported_efforts === null
+    ? ["max", "xhigh", "high", "medium", "low", "minimal", "none"] as const
+    : reasoning.supported_efforts;
+
+  if (efforts !== undefined) {
+    options.push({
+      type: "effort",
+      values: reasoning.mandatory ? efforts.filter((value) => value !== "none") : [...efforts],
+    });
+  }
+
+  if (reasoning.supports_max_tokens === true) {
+    options.push({ type: "budget_tokens" });
+  }
+
+  return options.length > 0 ? options : undefined;
 }
 
 export function resolveCanonicalBaseModel(openrouterID: string) {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 
 import { formatToml, preserveReasoningOptions } from "../src/sync/index.js";
+import { buildOpenRouterModel, type OpenRouterModel } from "../src/sync/providers/openrouter.js";
 
 test("formats interleaved as a root field before reasoning option tables", () => {
   const content = formatToml({
@@ -54,3 +55,98 @@ test("defaults new reasoning models to empty reasoning options", () => {
     reasoning_options: [],
   });
 });
+
+test("syncs OpenRouter reasoning efforts from model metadata", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    reasoning: {
+      mandatory: false,
+      supported_efforts: ["max", "xhigh", "high", "medium", "low"],
+    },
+  }), undefined);
+
+  expect(model).toMatchObject({
+    base_model: "anthropic/claude-sonnet-5",
+    reasoning_options: [
+      { type: "effort", values: ["max", "xhigh", "high", "medium", "low"] },
+    ],
+  });
+});
+
+test("preserves authored OpenRouter reasoning options over model metadata", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    reasoning: {
+      mandatory: false,
+      supported_efforts: ["max", "xhigh", "high", "medium", "low"],
+    },
+  }), {
+    name: "Claude Sonnet 5",
+    release_date: "2026-06-30",
+    last_updated: "2026-06-30",
+    attachment: true,
+    reasoning: true,
+    reasoning_options: [{ type: "toggle" }],
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 2, output: 10 },
+    limit: { context: 1_000_000, output: 128_000 },
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    reasoning_options: [{ type: "toggle" }],
+  });
+});
+
+test("upgrades empty OpenRouter reasoning options from model metadata", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    reasoning: {
+      mandatory: false,
+      supported_efforts: ["high", "medium", "low"],
+    },
+  }), {
+    name: "Claude Sonnet 5",
+    release_date: "2026-06-30",
+    last_updated: "2026-06-30",
+    attachment: true,
+    reasoning: true,
+    reasoning_options: [],
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 2, output: 10 },
+    limit: { context: 1_000_000, output: 128_000 },
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    reasoning_options: [
+      { type: "effort", values: ["high", "medium", "low"] },
+    ],
+  });
+});
+
+function openRouterModel(overrides: Partial<OpenRouterModel> = {}): OpenRouterModel {
+  return {
+    id: "anthropic/claude-sonnet-5",
+    name: "Anthropic: Claude Sonnet 5",
+    created: 1_782_777_600,
+    hugging_face_id: null,
+    knowledge_cutoff: "2026-01-31",
+    context_length: 1_000_000,
+    architecture: {
+      input_modalities: ["text", "image", "file"],
+      output_modalities: ["text"],
+    },
+    pricing: {
+      prompt: "0.000002",
+      completion: "0.00001",
+      input_cache_read: "0.0000002",
+      input_cache_write: "0.0000025",
+    },
+    top_provider: {
+      context_length: 1_000_000,
+      max_completion_tokens: 128_000,
+    },
+    supported_parameters: ["include_reasoning", "reasoning", "structured_outputs", "tools"],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- Parse OpenRouter model.reasoning metadata from GET /api/v1/models.
- Sync supported_efforts into reasoning_options for new OpenRouter reasoning models.
- Preserve non-empty authored reasoning_options, but allow empty fallback options to be upgraded when OpenRouter provides concrete metadata.
- Add regression tests for new, authored, and empty-option OpenRouter sync cases.

## Verification
- Verified live OpenRouter API reports reasoning.supported_efforts for anthropic/claude-sonnet-5: max, xhigh, high, medium, low.
- Verified Vercel model API does not expose a reasoning metadata object, only tags.
- bun test packages/core/test/sync.test.ts
- bun validate
- OpenRouter dry-run sync
- git diff --check

## Notes
OpenRouter dry-run now reports broader updates because several existing OpenRouter models with reasoning_options = [] have concrete reasoning metadata in the live API.