### PR TITLE
Fix Sonnet 5 provider metadata

### DIFF
--- a/providers/llmgateway/models/claude-sonnet-5.toml
+++ b/providers/llmgateway/models/claude-sonnet-5.toml
@@ -1,14 +1,8 @@
-name = "Claude Sonnet 5"
-family = "claude-sonnet"
-release_date = "2026-06-30"
-last_updated = "2026-06-30"
-attachment = true
-reasoning = true
+base_model = "anthropic/claude-sonnet-5"
 temperature = true
 tool_call = false
 structured_output = true
-open_weights = false
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 3
@@ -17,9 +11,7 @@ cache_read = 0.3
 cache_write = 3.75
 
 [limit]
-context = 1_000_000
 output = 1_000_000
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/vercel/models/anthropic/claude-sonnet-5.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-5.toml
@@ -1,7 +1,7 @@
 base_model = "anthropic/claude-sonnet-5"
 release_date = "2026-06-29"
 temperature = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2


### PR DESCRIPTION
## Summary
- Use base_model inheritance for LLM Gateway Claude Sonnet 5 instead of duplicating base model fields
- Set Vercel Claude Sonnet 5 reasoning options to match Vercel Claude Opus 4.8
- Set LLM Gateway Claude Sonnet 5 reasoning options to match LLM Gateway Claude Opus 4.8

## Validation
- bun validate
- git diff --check