### PR TITLE
Sort synced reasoning effort values

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -687,6 +687,26 @@ function formatReasoningValue(value: string | null) {
   return value === null ? quote("null") : quote(value);
 }
 
+const ReasoningEffortOrder = new Map<string | null, number>([
+  ["none", 0],
+  ["minimal", 1],
+  ["low", 2],
+  ["medium", 3],
+  ["high", 4],
+  ["xhigh", 5],
+  ["max", 6],
+  ["default", 7],
+  [null, 8],
+]);
+
+function sortReasoningValues(values: Array<string | null>) {
+  return [...values].sort((a, b) => {
+    const order = (ReasoningEffortOrder.get(a) ?? Number.MAX_SAFE_INTEGER)
+      - (ReasoningEffortOrder.get(b) ?? Number.MAX_SAFE_INTEGER);
+    return order || formatReasoningValue(a).localeCompare(formatReasoningValue(b));
+  });
+}
+
 export function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
   const lines: string[] = [];
 
@@ -724,7 +744,8 @@ export function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
     lines.push("", "[[reasoning_options]]");
     lines.push(`type = ${quote(option.type)}`);
     if (option.type === "effort") {
-      lines.push(`values = [${option.values.map(formatReasoningValue).join(", ")}]`);
+      const values = sortReasoningValues(option.values).map(formatReasoningValue).join(", ");
+      lines.push(`values = [${values}]`);
     }
     if (option.type === "budget_tokens") {
       if (option.min !== undefined) lines.push(`min = ${formatInteger(option.min)}`);

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -49,6 +49,30 @@ test("formats empty reasoning options outside the interleaved table", () => {
   });
 });
 
+test("formats reasoning efforts from lowest to highest", () => {
+  const content = formatToml({
+    id: "example/model",
+    name: "Example Model",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: false,
+    reasoning: true,
+    reasoning_options: [{
+      type: "effort",
+      values: ["max", "xhigh", "high", "medium", "low", "minimal", "none", "default"],
+    }],
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 1, output: 2 },
+    limit: { context: 1_000, output: 100 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(content).toContain(
+    'values = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "default"]',
+  );
+});
+
 test("defaults new reasoning models to empty reasoning options", () => {
   expect(preserveReasoningOptions({ reasoning: true }, undefined)).toEqual({
     reasoning: true,


### PR DESCRIPTION
## Summary
- Sort formatted reasoning effort values in a canonical low-to-high order.
- Use none, minimal, low, medium, high, xhigh, max, then sentinel values default and null.
- Add a regression test for high-to-low input being emitted low-to-high.

## Verification
- bun test packages/core/test/sync.test.ts
- bun validate
- OpenRouter dry-run sync
- git diff --check