### PR TITLE
fix: correct nanogpt gemini reasoning options

### DIFF
--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -3,7 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 512, max = 24_576 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
@@ -3,7 +3,7 @@ release_date = "2025-04-17"
 last_updated = "2025-04-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
@@ -3,7 +3,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-exp-03-25.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-exp-03-25.toml
@@ -3,7 +3,7 @@ release_date = "2025-03-25"
 last_updated = "2025-03-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-03-25.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-03-25.toml
@@ -3,7 +3,7 @@ release_date = "2025-03-25"
 last_updated = "2025-03-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-05-06.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-05-06.toml
@@ -3,7 +3,7 @@ release_date = "2025-05-06"
 last_updated = "2025-05-06"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro-preview-06-05.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro-preview-06-05.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-pro.toml
+++ b/providers/nano-gpt/models/gemini-2.5-pro.toml
@@ -3,7 +3,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 128, max = 32_768 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
## Summary
- Removed inaccurate `budget_tokens` reasoning options from NanoGPT Gemini 2.5 entries.
- Kept `effort` because NanoGPT docs support `reasoning_effort` / `reasoning.effort` for Chat Completions.
- Left other audited provider dual controls unchanged where provider docs support both effort and token-budget controls.

## Validation
- `bun validate > /dev/null`
- `git diff --check`
- Targeted Bun scan for Gemini 2.5 entries with both `effort` and `budget_tokens` across audited providers; NanoGPT no longer reports dual controls, with remaining dual entries only in providers where retained intentionally.