### PR TITLE
Add Claude Sonnet 5 to GitHub Copilot

### DIFF
--- a/providers/github-copilot/models/claude-sonnet-5.toml
+++ b/providers/github-copilot/models/claude-sonnet-5.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, { type = "budget_tokens", min = 1_024, max = 32_000 }]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+context = 200_000
+input = 168_000
+output = 32_000


### PR DESCRIPTION
Claude Sonnet 5 is now available on GitHub Copilot but was missing from the database. This adds it.

## Changes
- New `providers/github-copilot/models/claude-sonnet-5.toml`

## Details
Follows the repo's conventions and the existing GitHub Copilot Anthropic entries (`claude-sonnet-4.6`, `claude-opus-4.8`):

- Inherits provider-agnostic facts via `base_model = "anthropic/claude-sonnet-5"`
- **Cost** (2 / 10 / 0.2 / 2.5 in/out/cache-read/cache-write) — matches the cross-provider consensus for Sonnet 5 (anthropic, azure, openrouter, vercel, opencode, vertex)
- **Reasoning options** — `effort` (low/medium/high/xhigh/max) plus Copilot's `budget_tokens` control (1024–32000), consistent with sibling Copilot models
- **Limits** — 200K context / 168K input / 32K output, matching Copilot's caps for Anthropic Sonnet models

Validated with `bun ./packages/core/script/validate.ts` (exit 0, no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)