### PR TITLE
Add OpenPaths provider

### DIFF
--- a/providers/openpaths/models/auto-code.toml
+++ b/providers/openpaths/models/auto-code.toml
@@ -1,0 +1,22 @@
+name = "Auto Code"
+release_date = "2026-07-01"
+last_updated = "2026-07-01"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream coding models; pricing is variable. Values below are
+# representative, not a fixed per-token rate.
+[cost]
+input = 1.50
+output = 6.00
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openpaths/models/auto-easy-task.toml
+++ b/providers/openpaths/models/auto-easy-task.toml
@@ -1,0 +1,22 @@
+name = "Auto Easy Task"
+release_date = "2026-07-01"
+last_updated = "2026-07-01"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to lower-cost upstream models for simple tasks; pricing is variable.
+# Values below are representative, not a fixed per-token rate.
+[cost]
+input = 0.20
+output = 0.60
+
+[limit]
+context = 128_000
+output = 16_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openpaths/models/auto-hard-task.toml
+++ b/providers/openpaths/models/auto-hard-task.toml
@@ -1,0 +1,23 @@
+name = "Auto Hard Task"
+release_date = "2026-07-01"
+last_updated = "2026-07-01"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to stronger upstream models for difficult tasks; pricing is variable.
+# Values below are representative, not a fixed per-token rate.
+[cost]
+input = 3.00
+output = 12.00
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openpaths/models/auto-medium-task.toml
+++ b/providers/openpaths/models/auto-medium-task.toml
@@ -1,0 +1,22 @@
+name = "Auto Medium Task"
+release_date = "2026-07-01"
+last_updated = "2026-07-01"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to balanced upstream models for general tasks; pricing is variable.
+# Values below are representative, not a fixed per-token rate.
+[cost]
+input = 1.00
+output = 3.00
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openpaths/models/auto-think.toml
+++ b/providers/openpaths/models/auto-think.toml
@@ -1,0 +1,23 @@
+name = "Auto Think"
+release_date = "2026-07-01"
+last_updated = "2026-07-01"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream reasoning models; pricing is variable. Values below
+# are representative, not a fixed per-token rate.
+[cost]
+input = 2.00
+output = 8.00
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openpaths/models/auto.toml
+++ b/providers/openpaths/models/auto.toml
@@ -1,0 +1,23 @@
+name = "Auto"
+release_date = "2026-07-01"
+last_updated = "2026-07-01"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# OpenPaths is an aggregating router; requests are routed to mixed upstream
+# models, so pricing is variable. Values below are representative, not a fixed
+# per-token rate.
+[cost]
+input = 1.00
+output = 3.00
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openpaths/provider.toml
+++ b/providers/openpaths/provider.toml
@@ -1,0 +1,5 @@
+name = "OpenPaths"
+env = ["OPENPATHS_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://openpaths.io/v1"
+doc = "https://openpaths.io"


### PR DESCRIPTION
Adds OpenPaths as an OpenAI-compatible model router provider with the text-oriented auto/task aliases:

- auto
- auto-code
- auto-easy-task
- auto-medium-task
- auto-hard-task
- auto-think

The public site describes OpenPaths as an open source model router across 400+ models; the live /v1/models endpoint requires an API key, so this PR keeps the catalog narrow to the documented router aliases rather than enumerating upstream models.

Validation:

```bash
bun validate
# passed
```