### PR TITLE
Add Claude Sonnet 5 for GitHub Copilot

### DIFF
--- a/providers/github-copilot/models/claude-sonnet-5.toml
+++ b/providers/github-copilot/models/claude-sonnet-5.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]


### PR DESCRIPTION
GitHub’s announcement says Claude Sonnet 5 in Copilot is "billed at provider list pricing under Usage Based Billing." https://github.blog/changelog/2026-06-30-claude-sonnet-5-is-generally-available-for-github-copilot/

Ref https://github.com/earendil-works/pi/issues/6200