### PR TITLE
Add Agnes AI provider and agnes-2.0-flash model

### DIFF
--- a/providers/agnes/models/agnes-2.0-flash.toml
+++ b/providers/agnes/models/agnes-2.0-flash.toml
@@ -1,0 +1,20 @@
+name = "Agnes 2.0 Flash"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+release_date = "2025-06"
+last_updated = "2025-06"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 512000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/agnes/provider.toml
+++ b/providers/agnes/provider.toml
@@ -1,0 +1,3 @@
+name = "Agnes AI"
+npm = "@ai-sdk/openai-compatible"
+api = "https://apihub.agnes-ai.com/v1"


### PR DESCRIPTION
Add Agnes AI as a new provider with the agnes-2.0-flash model.

Provider: Agnes AI (apihub.agnes-ai.com)
Model: agnes-2.0-flash
- 512K context window
- 65K max output
- Supports text + image input
- Free pricing (currently /1M tokens)