### PR TITLE
Add TensorX provider

### DIFF
--- a/providers/tensorx/models/deepseek/deepseek-chat-v3.1.toml
+++ b/providers/tensorx/models/deepseek/deepseek-chat-v3.1.toml
@@ -1,0 +1,23 @@
+name = "DeepSeek Chat V3.1"
+family = "deepseek"
+release_date = "2025-08"
+last_updated = "2025-08"
+knowledge = "2024-07"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.20
+output = 0.80
+cache_read = 0.05
+
+[limit]
+context = 164_000
+output = 164_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorx/models/deepseek/deepseek-r1-0528.toml
+++ b/providers/tensorx/models/deepseek/deepseek-r1-0528.toml
@@ -1,0 +1,24 @@
+name = "DeepSeek R1 0528"
+family = "deepseek-thinking"
+release_date = "2025-05-28"
+last_updated = "2025-05-28"
+knowledge = "2024-07"
+attachment = false
+reasoning = true
+reasoning_options = []
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.66
+output = 2.60
+cache_read = 0.17
+
+[limit]
+context = 164_000
+output = 164_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorx/models/deepseek/deepseek-v3.2.toml
+++ b/providers/tensorx/models/deepseek/deepseek-v3.2.toml
@@ -1,0 +1,24 @@
+name = "DeepSeek V3.2"
+family = "deepseek"
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+knowledge = "2024-07"
+attachment = false
+reasoning = true
+reasoning_options = []
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.30
+output = 0.50
+cache_read = 0.08
+
+[limit]
+context = 160_000
+output = 160_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorx/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/tensorx/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,18 @@
+base_model = "deepseek/deepseek-v4-flash"
+# Chat reasoning: POST /v1/chat/completions defaults to non-thinking; toggle via
+# `extra_body.chat_template_kwargs.thinking` (true|false) and set budget with
+# `extra_body.reasoning_effort` (verified value: "max"). Reasoning returns
+# `message.reasoning_content`. Verified on DeepSeek V4 models.
+# https://docs.tensorx.ai/api-reference/chat-completions (accessed 2026-07-01)
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.30
+cache_read = 0.04

--- a/providers/tensorx/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/tensorx/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,18 @@
+base_model = "deepseek/deepseek-v4-pro"
+# Chat reasoning: POST /v1/chat/completions defaults to non-thinking; toggle via
+# `extra_body.chat_template_kwargs.thinking` (true|false) and set budget with
+# `extra_body.reasoning_effort` (verified value: "max"). Reasoning returns
+# `message.reasoning_content`. Verified on DeepSeek V4 models.
+# https://docs.tensorx.ai/api-reference/chat-completions (accessed 2026-07-01)
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.75
+output = 3.50
+cache_read = 0.44

--- a/providers/tensorx/models/minimax/minimax-m2.5.toml
+++ b/providers/tensorx/models/minimax/minimax-m2.5.toml
@@ -1,0 +1,10 @@
+base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
+
+[limit]
+context = 192_000
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.08

--- a/providers/tensorx/models/minimax/minimax-m3.toml
+++ b/providers/tensorx/models/minimax/minimax-m3.toml
@@ -1,0 +1,10 @@
+base_model = "minimax/MiniMax-M3"
+reasoning_options = []
+
+[limit]
+context = 1_000_000
+
+[cost]
+input = 0.40
+output = 2.00
+cache_read = 0.10

--- a/providers/tensorx/models/moonshotai/kimi-k2.5.toml
+++ b/providers/tensorx/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.5"
+reasoning_options = []
+
+[cost]
+input = 0.50
+output = 2.80
+cache_read = 0.13

--- a/providers/tensorx/models/moonshotai/kimi-k2.6.toml
+++ b/providers/tensorx/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
+
+[cost]
+input = 1.00
+output = 4.00
+cache_read = 0.25

--- a/providers/tensorx/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/tensorx/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 4.50
+cache_read = 0.31

--- a/providers/tensorx/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/tensorx/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,7 @@
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+reasoning_options = []
+
+[cost]
+input = 0.30
+output = 0.90
+cache_read = 0.08

--- a/providers/tensorx/models/openai/gpt-oss-120b.toml
+++ b/providers/tensorx/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-oss-120b"
+reasoning_options = []
+
+[cost]
+input = 0.04
+output = 0.20
+cache_read = 0.01

--- a/providers/tensorx/models/qwen/qwen3-235b-a22b-2507.toml
+++ b/providers/tensorx/models/qwen/qwen3-235b-a22b-2507.toml
@@ -1,0 +1,24 @@
+name = "Qwen3 235B A22B 2507"
+family = "qwen"
+release_date = "2025-07-23"
+last_updated = "2025-07-23"
+knowledge = "2025-04"
+attachment = false
+reasoning = true
+reasoning_options = []
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.07
+output = 0.46
+cache_read = 0.02
+
+[limit]
+context = 131_000
+output = 131_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorx/models/qwen/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/tensorx/models/qwen/qwen3-coder-30b-a3b-instruct.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
+
+[cost]
+input = 0.06
+output = 0.25
+cache_read = 0.02

--- a/providers/tensorx/models/qwen/qwen3-embedding-8b.toml
+++ b/providers/tensorx/models/qwen/qwen3-embedding-8b.toml
@@ -1,0 +1,21 @@
+name = "Qwen3 Embedding 8B"
+family = "text-embedding"
+release_date = "2025-06-03"
+last_updated = "2025-06-03"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+
+[cost]
+input = 0.01
+output = 0.00
+
+[limit]
+context = 32_000
+output = 1_024
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tensorx/models/qwen/qwen3-vl-235b-a22b-instruct.toml
+++ b/providers/tensorx/models/qwen/qwen3-vl-235b-a22b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Qwen3-VL 235B A22B Instruct"
+family = "qwen"
+release_date = "2025-09"
+last_updated = "2025-09"
+knowledge = "2025-04"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.21
+output = 1.90
+cache_read = 0.05
+
+[limit]
+context = 131_000
+output = 131_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/tensorx/models/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/tensorx/models/qwen/qwen3.5-122b-a10b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.5-122b-a10b"
+reasoning_options = []
+
+[cost]
+input = 0.50
+output = 3.50
+cache_read = 0.13

--- a/providers/tensorx/models/qwen/qwen3.5-9b.toml
+++ b/providers/tensorx/models/qwen/qwen3.5-9b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.5-9b"
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 0.20
+cache_read = 0.04

--- a/providers/tensorx/models/z-ai/glm-4.7.toml
+++ b/providers/tensorx/models/z-ai/glm-4.7.toml
@@ -1,0 +1,7 @@
+base_model = "zhipuai/glm-4.7"
+reasoning_options = []
+
+[cost]
+input = 0.60
+output = 2.20
+cache_read = 0.15

--- a/providers/tensorx/models/z-ai/glm-5-turbo.toml
+++ b/providers/tensorx/models/z-ai/glm-5-turbo.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5-turbo"
+reasoning_options = []
+
+[limit]
+context = 198_000
+
+[cost]
+input = 1.20
+output = 4.00
+cache_read = 0.30

--- a/providers/tensorx/models/z-ai/glm-5.1.toml
+++ b/providers/tensorx/models/z-ai/glm-5.1.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.1"
+reasoning_options = []
+
+[limit]
+context = 198_000
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.35

--- a/providers/tensorx/models/z-ai/glm-5.2.toml
+++ b/providers/tensorx/models/z-ai/glm-5.2.toml
@@ -1,0 +1,7 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = []
+
+[cost]
+input = 1.50
+output = 4.50
+cache_read = 0.38

--- a/providers/tensorx/models/z-ai/glm-5.toml
+++ b/providers/tensorx/models/z-ai/glm-5.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5"
+reasoning_options = []
+
+[limit]
+context = 198_000
+
+[cost]
+input = 1.00
+output = 3.20
+cache_read = 0.25

--- a/providers/tensorx/models/z-ai/glm-5v-turbo.toml
+++ b/providers/tensorx/models/z-ai/glm-5v-turbo.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5v-turbo"
+reasoning_options = []
+
+[limit]
+context = 198_000
+
+[cost]
+input = 1.20
+output = 4.00
+cache_read = 0.30

--- a/providers/tensorx/provider.toml
+++ b/providers/tensorx/provider.toml
@@ -1,0 +1,5 @@
+name = "TensorX"
+env = ["TENSORX_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.tensorx.ai/v1"
+doc = "https://tensorx.ai/pricing/"


### PR DESCRIPTION
## Summary
- Adds the `tensorx` provider (EU-sovereign inference, OpenAI-compatible API at `https://api.tensorx.ai/v1`).
- Adds 24 models with pricing (input/cache_read/output per 1M tokens) sourced from the TensorX pricing page.
- Reuses provider-agnostic model metadata via `base_model` for 18 models; full definitions for the 5 without existing metadata (`deepseek-v3.2`, `deepseek-chat-v3.1`, `deepseek-r1-0528`, `qwen3-235b-a22b-2507`, `qwen3-vl-235b-a22b-instruct`) plus the `qwen3-embedding-8b` embedding model.

## Reasoning options
- `deepseek-v4-pro` / `deepseek-v4-flash`: `toggle` + `effort` (`"max"`) + `interleaved` (`reasoning_content`), per the TensorX Chat Completions docs which document `extra_body.chat_template_kwargs.thinking` and `extra_body.reasoning_effort`.
- All other reasoning models: `reasoning_options = []` — the docs note \"Behaviour on other models may differ,\" so no control is claimed without verification.

## Notes
- Context overrides applied where TensorX publishes a different window than upstream metadata (e.g. minimax-m3 → 1M, minimax-m2.5 → 192K, GLM-5 family → 198K).
- `qwen3-vl-235b-a22b-instruct`: `attachment = true` (vision), `reasoning = false` per repo convention for instruct variants.
- `deepseek-chat-v3.1`: `reasoning = false` (non-thinking chat variant).

## Validation
- `bun validate` (exit 0)
- `cd packages/web && bun run build` (exit 0)
- Generated output confirms 24 models resolve with correct pricing, limits, and reasoning options.