### PR TITLE
feat: add gitlab duo-chat-sonnet-5 model

### DIFF
--- a/providers/gitlab/models/duo-chat-sonnet-5.toml
+++ b/providers/gitlab/models/duo-chat-sonnet-5.toml
@@ -1,0 +1,25 @@
+name = "Agentic Chat (Claude Sonnet 5)"
+family = "claude-sonnet"
+release_date = "2026-07-01"
+last_updated = "2026-07-01"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = false
+tool_call = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1000000
+output = 64000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/gitlab/models/duo-chat-sonnet-5.toml
+++ b/providers/gitlab/models/duo-chat-sonnet-5.toml
@@ -1,14 +1,9 @@
+base_model = "anthropic/claude-sonnet-5"
 name = "Agentic Chat (Claude Sonnet 5)"
-family = "claude-sonnet"
-release_date = "2026-07-01"
-last_updated = "2026-07-01"
-attachment = true
-reasoning = true
-reasoning_options = []
-temperature = false
-tool_call = true
-knowledge = "2025-08-31"
-open_weights = false
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
+]
 
 [cost]
 input = 0
@@ -17,9 +12,5 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 1000000
-output = 64000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]
+context = 1_000_000
+output = 64_000


### PR DESCRIPTION
## Summary

Adds Claude Sonnet 5 to the `gitlab` provider so it appears in opencode's model picker as **Agentic Chat (Claude Sonnet 5)**.

## Details

Uses the `base_model` syntax (matching the amazon-bedrock definitions) to inherit from `anthropic/claude-sonnet-5`:

```toml
base_model = "anthropic/claude-sonnet-5"
name = "Agentic Chat (Claude Sonnet 5)"
reasoning_options = [
  { type = "toggle" },
  { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
]

[cost]
input = 0
output = 0
cache_read = 0
cache_write = 0

[limit]
context = 1_000_000
output = 64_000
```

Inherits description, family, modalities, and capabilities from the anthropic base, overriding only:
- `name` — the gitlab picker label
- `reasoning_options` — required because `reasoning = true` is inherited (not carried through base_model)
- `cost` — 0, since GitLab proxy models are billed upstream
- `limit.output` — 64k, the max GitLab's ai-assist model selection enforces (vs the anthropic base's 128k)

## Validation

`bun validate` passes and confirms `duo-chat-sonnet-5` is present in the generated models.json.