### PR TITLE
feat(cerebras): add Gemma 4 31B

### DIFF
--- a/providers/cerebras/models/gemma-4-31b.toml
+++ b/providers/cerebras/models/gemma-4-31b.toml
@@ -1,0 +1,17 @@
+base_model = "google/gemma-4-31b-it"
+last_updated = "2026-07-01"
+status = "beta"
+# Model-specific reasoning HTTP values (accessed 2026-07-01):
+# reasoning_effort = "none" (default) | "low"|"medium"|"high" (enable reasoning).
+# Sources:
+# https://inference-docs.cerebras.ai/capabilities/reasoning#gemma-4-31b-reasoning_effort
+# https://inference-docs.cerebras.ai/models/gemma-4-31b
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 0.99
+output = 1.49
+
+[limit]
+context = 131_072
+output = 40_960


### PR DESCRIPTION
## Summary
- add Cerebras entry for Gemma 4 31B, inherits shared metadata from `google/gemma-4-31b-it` via `base_model`
- pricing: $0.99/$1.49 (input/output)
- reasoning effort options: none, low, medium, high (disabled by default, enabled via `reasoning_effort`)
- limits: 131,072 context / 40,960 output tokens

## Validation
- `bun validate`