### PR TITLE
Fix Copilot Sonnet 5 metadata

### DIFF
--- a/providers/github-copilot/models/claude-sonnet-5.toml
+++ b/providers/github-copilot/models/claude-sonnet-5.toml
@@ -1,2 +1,12 @@
 base_model = "anthropic/claude-sonnet-5"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+context = 1_000_000
+output = 128_000


### PR DESCRIPTION
Messed up in https://github.com/anomalyco/models.dev/pull/2960, this metadata is not inherited so we need it explicitly.