### PR TITLE
fix: Add base model file + PDF modality for Claude Fable 5 on Bedrock

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-fable-5.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-fable-5.toml
@@ -1,9 +1,8 @@
 base_model = "anthropic/claude-fable-5"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
-name = "Claude Fable 5 (EU)"
 
 [cost]
-input = 11
-output = 55
-cache_read = 1.1
-cache_write = 13.75
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/amazon-bedrock/models/global.anthropic.claude-fable-5.toml
+++ b/providers/amazon-bedrock/models/global.anthropic.claude-fable-5.toml
@@ -2,9 +2,6 @@ base_model = "anthropic/claude-fable-5"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 name = "Claude Fable 5 (Global)"
 
-[modalities]
-input = ["text", "image"]
-
 [cost]
 input = 10
 output = 50

--- a/providers/amazon-bedrock/models/us.anthropic.claude-fable-5.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-fable-5.toml
@@ -2,9 +2,6 @@ base_model = "anthropic/claude-fable-5"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 name = "Claude Fable 5 (US)"
 
-[modalities]
-input = ["text", "image"]
-
 [cost]
 input = 10
 output = 50


### PR DESCRIPTION
Adds the missing non-region-prefixed `anthropic.claude-fable-5` entry for Amazon Bedrock. 

Also removes the modalities override on all of the Bedrock Fable 5 entries, so they correctly inherit PDF input support from the base model. (PDF isn't officially noted as a supported format on the [model's AWS docs page](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html), but I manually verified working that it's working via document blocks submitted to Converse API. Plus the existing Bedrock Claude 4.x files don't have this restriction.)
