### PR TITLE
fix(sync): factor new LLM Gateway models against canonical base_model

### DIFF
--- a/packages/core/src/sync/providers/llmgateway.ts
+++ b/packages/core/src/sync/providers/llmgateway.ts
@@ -3,9 +3,32 @@ import { z } from "zod";
 import { describeModel } from "../../describe.js";
 import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
-import { factorBaseModel } from "./openrouter.js";
+import { factorBaseModel, findCanonicalBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://api.llmgateway.io/v1/models";
+
+// LLM Gateway reports the originating lab in `family`. Map those labs onto the
+// canonical `models/` metadata namespaces so brand-new models can inherit the
+// reviewed capability/modality facts through `base_model` instead of shipping a
+// noisy standalone definition. `provider` selects the ID normalization rules,
+// `metadata` names the directory the base entry lives in.
+const CANONICAL_FAMILIES: Record<string, { provider: string; metadata: string }> = {
+  alibaba: { provider: "alibaba", metadata: "alibaba" },
+  anthropic: { provider: "anthropic", metadata: "anthropic" },
+  deepseek: { provider: "deepseek", metadata: "deepseek" },
+  google: { provider: "google", metadata: "google" },
+  meta: { provider: "llama", metadata: "meta" },
+  minimax: { provider: "minimax", metadata: "minimax" },
+  mistral: { provider: "mistral", metadata: "mistral" },
+  moonshot: { provider: "moonshotai", metadata: "moonshotai" },
+  nvidia: { provider: "nvidia", metadata: "nvidia" },
+  openai: { provider: "openai", metadata: "openai" },
+  perplexity: { provider: "perplexity", metadata: "perplexity" },
+  sakana: { provider: "sakana", metadata: "sakana" },
+  xai: { provider: "xai", metadata: "xai" },
+  xiaomi: { provider: "xiaomi", metadata: "xiaomi" },
+  zai: { provider: "zai", metadata: "zhipuai" },
+};
 
 const Pricing = z.object({
   prompt: z.string().optional(),
@@ -94,6 +117,12 @@ function modalities(values: string[], fallback: Modality[]): Modality[] {
   return [...new Set(result.length > 0 ? result : fallback)];
 }
 
+function resolveCanonicalBaseModel(model: LLMGatewayModel) {
+  const canonical = model.family === undefined ? undefined : CANONICAL_FAMILIES[model.family];
+  if (canonical === undefined) return undefined;
+  return findCanonicalBaseModel(canonical.provider, canonical.metadata, model.id);
+}
+
 function inferFamily(model: LLMGatewayModel, name: string) {
   const kimiFamily = inferKimiFamily(model.id, name);
   if (kimiFamily !== undefined) return kimiFamily;
@@ -110,7 +139,7 @@ function inferFamily(model: LLMGatewayModel, name: string) {
     });
 }
 
-function buildLLMGatewayModel(
+export function buildLLMGatewayModel(
   model: LLMGatewayModel,
   existing: ExistingModel | undefined,
 ): SyncedModel {
@@ -209,6 +238,17 @@ function buildLLMGatewayModel(
       limit,
       modalities: existing.modalities ?? defaultModalities(model),
     } satisfies SyncedFullModel;
+  }
+
+  // Brand-new model with a reviewed metadata entry: factor it against the
+  // canonical base so capability, modality, and description facts inherit from
+  // the curated `models/` file. Only the gateway-authoritative cost and served
+  // context are overridden; the gateway's capability/modality data is too noisy
+  // to author standalone.
+  const canonical = resolveCanonicalBaseModel(model);
+  if (canonical !== undefined) {
+    const factoredLimit = { context, input: undefined, output: undefined };
+    return factorBaseModel(canonical, { limit: factoredLimit, cost }, factoredLimit);
   }
 
   // Brand-new model: best-effort translation from the gateway. Capability and

--- a/packages/core/src/sync/providers/llmgateway.ts
+++ b/packages/core/src/sync/providers/llmgateway.ts
@@ -3,31 +3,16 @@ import { z } from "zod";
 import { describeModel } from "../../describe.js";
 import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
-import { factorBaseModel, findCanonicalBaseModel } from "./openrouter.js";
+import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://api.llmgateway.io/v1/models";
 
-// LLM Gateway reports the originating lab in `family`. Map those labs onto the
-// canonical `models/` metadata namespaces so brand-new models can inherit the
-// reviewed capability/modality facts through `base_model` instead of shipping a
-// noisy standalone definition. `provider` selects the ID normalization rules,
-// `metadata` names the directory the base entry lives in.
-const CANONICAL_FAMILIES: Record<string, { provider: string; metadata: string }> = {
-  alibaba: { provider: "alibaba", metadata: "alibaba" },
-  anthropic: { provider: "anthropic", metadata: "anthropic" },
-  deepseek: { provider: "deepseek", metadata: "deepseek" },
-  google: { provider: "google", metadata: "google" },
-  meta: { provider: "llama", metadata: "meta" },
-  minimax: { provider: "minimax", metadata: "minimax" },
-  mistral: { provider: "mistral", metadata: "mistral" },
-  moonshot: { provider: "moonshotai", metadata: "moonshotai" },
-  nvidia: { provider: "nvidia", metadata: "nvidia" },
-  openai: { provider: "openai", metadata: "openai" },
-  perplexity: { provider: "perplexity", metadata: "perplexity" },
-  sakana: { provider: "sakana", metadata: "sakana" },
-  xai: { provider: "xai", metadata: "xai" },
-  xiaomi: { provider: "xiaomi", metadata: "xiaomi" },
-  zai: { provider: "zai", metadata: "zhipuai" },
+// LLM Gateway names the originating lab in `family`; most already match the
+// canonical prefixes understood by resolveCanonicalBaseModel. Alias the few that
+// spell the lab differently. (Mirrors huggingface's CANONICAL_ORG_PREFIXES.)
+const CANONICAL_FAMILY_ALIASES: Record<string, string> = {
+  mistral: "mistralai",
+  moonshot: "moonshotai",
 };
 
 const Pricing = z.object({
@@ -117,10 +102,10 @@ function modalities(values: string[], fallback: Modality[]): Modality[] {
   return [...new Set(result.length > 0 ? result : fallback)];
 }
 
-function resolveCanonicalBaseModel(model: LLMGatewayModel) {
-  const canonical = model.family === undefined ? undefined : CANONICAL_FAMILIES[model.family];
-  if (canonical === undefined) return undefined;
-  return findCanonicalBaseModel(canonical.provider, canonical.metadata, model.id);
+function resolveLLMGatewayBaseModel(model: LLMGatewayModel) {
+  if (model.family === undefined) return undefined;
+  const prefix = CANONICAL_FAMILY_ALIASES[model.family] ?? model.family;
+  return resolveCanonicalBaseModel(`${prefix}/${model.id}`);
 }
 
 function inferFamily(model: LLMGatewayModel, name: string) {
@@ -242,10 +227,11 @@ export function buildLLMGatewayModel(
 
   // Brand-new model with a reviewed metadata entry: factor it against the
   // canonical base so capability, modality, and description facts inherit from
-  // the curated `models/` file. Only the gateway-authoritative cost and served
-  // context are overridden; the gateway's capability/modality data is too noisy
-  // to author standalone.
-  const canonical = resolveCanonicalBaseModel(model);
+  // the curated `models/` file. The gateway serves bare IDs and names the lab in
+  // `family`, so glue them into the prefixed form the shared resolver expects.
+  // Only the gateway-authoritative cost and served context are overridden; the
+  // gateway's capability/modality data is too noisy to author standalone.
+  const canonical = resolveLLMGatewayBaseModel(model);
   if (canonical !== undefined) {
     const factoredLimit = { context, input: undefined, output: undefined };
     return factorBaseModel(canonical, { limit: factoredLimit, cost }, factoredLimit);

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -296,16 +296,12 @@ export function resolveCanonicalBaseModel(openrouterID: string) {
   if (canonical === undefined) return undefined;
 
   const modelID = modelParts.join("/").replace(/:free$/, "");
-  return findCanonicalBaseModel(canonical.provider, canonical.metadata, modelID);
-}
+  const candidates = canonicalCandidates(canonical.provider, modelID);
+  const match = candidates.find((candidate) => {
+    return modelMetadataExists(canonical.metadata, candidate);
+  });
 
-// Resolve the `models/<metadata>/<model>.toml` base entry for a bare model ID by
-// probing the naming variants each canonical provider is known to use. `provider`
-// selects the candidate transforms; `metadata` names the directory to look in.
-export function findCanonicalBaseModel(provider: string, metadata: string, modelID: string) {
-  const candidates = canonicalCandidates(provider, modelID);
-  const match = candidates.find((candidate) => modelMetadataExists(metadata, candidate));
-  return match === undefined ? undefined : `${metadata}/${match}`;
+  return match === undefined ? undefined : `${canonical.metadata}/${match}`;
 }
 
 function modelMetadataExists(provider: string, modelID: string) {

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -296,12 +296,16 @@ export function resolveCanonicalBaseModel(openrouterID: string) {
   if (canonical === undefined) return undefined;
 
   const modelID = modelParts.join("/").replace(/:free$/, "");
-  const candidates = canonicalCandidates(canonical.provider, modelID);
-  const match = candidates.find((candidate) => {
-    return modelMetadataExists(canonical.metadata, candidate);
-  });
+  return findCanonicalBaseModel(canonical.provider, canonical.metadata, modelID);
+}
 
-  return match === undefined ? undefined : `${canonical.metadata}/${match}`;
+// Resolve the `models/<metadata>/<model>.toml` base entry for a bare model ID by
+// probing the naming variants each canonical provider is known to use. `provider`
+// selects the candidate transforms; `metadata` names the directory to look in.
+export function findCanonicalBaseModel(provider: string, metadata: string, modelID: string) {
+  const candidates = canonicalCandidates(provider, modelID);
+  const match = candidates.find((candidate) => modelMetadataExists(metadata, candidate));
+  return match === undefined ? undefined : `${metadata}/${match}`;
 }
 
 function modelMetadataExists(provider: string, modelID: string) {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { formatToml, preserveReasoningOptions, syncProvider, type SyncProvider } from "../src/sync/index.js";
 import { buildOpenRouterModel, openrouter, type OpenRouterModel } from "../src/sync/providers/openrouter.js";
+import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
 
 test("formats interleaved as a root field before reasoning option tables", () => {
   const content = formatToml({
@@ -156,6 +157,32 @@ test("upgrades empty OpenRouter reasoning options from model metadata", () => {
   });
 });
 
+test("factors new LLM Gateway models against the canonical base metadata", () => {
+  const model = buildLLMGatewayModel(llmGatewayModel(), undefined);
+
+  expect(model).toEqual({
+    base_model: "anthropic/claude-fable-5",
+    cost: {
+      input: 10,
+      output: 50,
+      cache_read: 1,
+      cache_write: 12.5,
+    },
+  });
+  expect("name" in model).toBe(false);
+  expect("modalities" in model).toBe(false);
+});
+
+test("skips LLM Gateway base_model factoring when no metadata entry exists", () => {
+  const model = buildLLMGatewayModel(
+    llmGatewayModel({ id: "claude-fable-does-not-exist" }),
+    undefined,
+  );
+
+  expect("base_model" in model).toBe(false);
+  expect(model).toMatchObject({ name: "Claude Fable 5" });
+});
+
 test("preserves the authored header comment block when rewriting a changed model", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "sync-header-"));
   const modelsDir = path.join(dir, "providers", "example", "models");
@@ -262,6 +289,30 @@ function unavailableStub(): OpenRouterModel {
     reasoning: { mandatory: true },
     top_provider: { context_length: null, max_completion_tokens: null },
   });
+}
+
+function llmGatewayModel(overrides: Partial<LLMGatewayModel> = {}): LLMGatewayModel {
+  return {
+    id: "claude-fable-5",
+    name: "Claude Fable 5",
+    created: 1_780_963_200,
+    family: "anthropic",
+    architecture: {
+      input_modalities: ["text", "image"],
+      output_modalities: ["text"],
+    },
+    pricing: {
+      prompt: "10.0e-6",
+      completion: "50.0e-6",
+      input_cache_read: "1.0e-6",
+      input_cache_write: "12.5e-6",
+      internal_reasoning: "0",
+    },
+    context_length: 1_000_000,
+    supported_parameters: ["temperature", "max_tokens", "top_p", "effort", "reasoning"],
+    structured_outputs: true,
+    ...overrides,
+  };
 }
 
 function openRouterModel(overrides: Partial<OpenRouterModel> = {}): OpenRouterModel {

--- a/providers/llmgateway/models/claude-fable-5.toml
+++ b/providers/llmgateway/models/claude-fable-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-fable-5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 10

--- a/providers/llmgateway/models/claude-fable-5.toml
+++ b/providers/llmgateway/models/claude-fable-5.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-fable-5"
+reasoning_options = []
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5


### PR DESCRIPTION
## Problem

The daily LLM Gateway sync (PR #2976) created `providers/llmgateway/models/claude-fable-5.toml` as a **full standalone definition** instead of using `base_model`, even though `models/anthropic/claude-fable-5.toml` already exists. The standalone output was also **wrong** — derived from the gateway's noisy `supported_parameters`/modality data: `tool_call = false` (should be `true`), missing the `pdf` modality, and `output = 1_000_000` instead of the curated `128_000`.

## Root cause

Every other aggregator (`openrouter`, `vercel`, `huggingface`, `baseten`) resolves a canonical `models/` entry and factors new models to `base_model` via the shared `resolveCanonicalBaseModel`. The `llmgateway` provider only *preserved* `base_model` on files that already used it, and always emitted a full definition for brand-new models.

## Fix

Do exactly what the other aggregators do. LLM Gateway serves bare ids (`claude-fable-5`) and names the lab in a separate `family` field (`"anthropic"`), so glue them into the prefixed form the shared resolver already understands — with a tiny alias map for the two labs whose family label differs (`mistral`->`mistralai`, `moonshot`->`moonshotai`), mirroring `huggingface`'s `CANONICAL_ORG_PREFIXES`.

The entire change is contained in `llmgateway.ts`; `openrouter.ts` and the shared prefix map are untouched, so there is **no cross-provider churn**.

Regenerated output:

```toml
base_model = "anthropic/claude-fable-5"
reasoning_options = []

[cost]
input = 10
output = 50
cache_read = 1
cache_write = 12.5
```

The resolved model now correctly inherits `tool_call: true`, the `pdf` modality, and `output: 128000` from the base metadata, overriding only the gateway-authoritative cost.

## Tests

- Added regression tests: factoring against the canonical base, and falling back to a full definition when no metadata entry exists.
- `bun validate` passes; dry-run syncs for openrouter/vercel/huggingface/baseten show zero churn.