### PR TITLE
chore: add stepfun stt/tts models

### DIFF
--- a/providers/stepfun-ai/models/step-tts-2.toml
+++ b/providers/stepfun-ai/models/step-tts-2.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/step-tts-2.toml

--- a/providers/stepfun-ai/models/stepaudio-2.5-asr.toml
+++ b/providers/stepfun-ai/models/stepaudio-2.5-asr.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/stepaudio-2.5-asr.toml

--- a/providers/stepfun-ai/models/stepaudio-2.5-tts.toml
+++ b/providers/stepfun-ai/models/stepaudio-2.5-tts.toml
@@ -1,0 +1,1 @@
+../../stepfun/models/stepaudio-2.5-tts.toml

--- a/providers/stepfun/models/step-tts-2.toml
+++ b/providers/stepfun/models/step-tts-2.toml
@@ -1,0 +1,18 @@
+name = "Step TTS 2"
+description = "Speech generation model for controllable voice, narration, and audio delivery"
+family = "step"
+release_date = "2026-03-01"
+last_updated = "2026-07-02"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/stepfun/models/stepaudio-2.5-asr.toml
+++ b/providers/stepfun/models/stepaudio-2.5-asr.toml
@@ -1,7 +1,7 @@
 name = "StepAudio 2.5 ASR"
 description = "Speech transcription model for accurate audio-to-text and captioning workflows"
 family = "step"
-release_date = "2026-05-22"
+release_date = "2026-04-24"
 last_updated = "2026-07-02"
 attachment = false
 reasoning = false

--- a/providers/stepfun/models/stepaudio-2.5-asr.toml
+++ b/providers/stepfun/models/stepaudio-2.5-asr.toml
@@ -1,0 +1,18 @@
+name = "StepAudio 2.5 ASR"
+description = "Speech transcription model for accurate audio-to-text and captioning workflows"
+family = "step"
+release_date = "2026-05-22"
+last_updated = "2026-07-02"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["audio"]
+output = ["text"]

--- a/providers/stepfun/models/stepaudio-2.5-tts.toml
+++ b/providers/stepfun/models/stepaudio-2.5-tts.toml
@@ -1,0 +1,18 @@
+name = "StepAudio 2.5 TTS"
+description = "Speech generation model for controllable voice, narration, and audio delivery"
+family = "step"
+release_date = "2026-04-16"
+last_updated = "2026-07-02"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]


### PR DESCRIPTION
- adding stt/tts models for stepfun
- skipping cost - they charge per character and not token. I checked some other stt models and it's consistent
- release dates based on news articles

Created symlinks for these models just like in: https://github.com/anomalyco/models.dev/pull/2980