### PR TITLE
feat(zenmux): add Claude Sonnet 5 and free variant

### DIFF
--- a/providers/zenmux/models/anthropic/claude-sonnet-5-free.toml
+++ b/providers/zenmux/models/anthropic/claude-sonnet-5-free.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (Free)"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.00
+output = 0.00
+cache_read = 0.00
+cache_write = 0.00
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"

--- a/providers/zenmux/models/anthropic/claude-sonnet-5.toml
+++ b/providers/zenmux/models/anthropic/claude-sonnet-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 2.00
+output = 10.00
+cache_read = 0.20
+cache_write = 4.00
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"


### PR DESCRIPTION
Add Claude Sonnet 5 and Claude Sonnet 5 (Free) to the ZenMux provider.

Data sourced from https://zenmux.ai/api/anthropic/v1/models

**Files added:**
- `providers/zenmux/models/anthropic/claude-sonnet-5.toml` (paid)
- `providers/zenmux/models/anthropic/claude-sonnet-5-free.toml` (free variant)

Both use `base_model` inheritance from `anthropic/claude-sonnet-5`.