### PR TITLE
feat(zenmux): add Claude Fable 5 (Free)

### DIFF
--- a/providers/zenmux/models/anthropic/claude-fable-5-free.toml
+++ b/providers/zenmux/models/anthropic/claude-fable-5-free.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-fable-5"
+name = "Claude Fable 5 (Free)"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"
+


### PR DESCRIPTION
Add Claude Fable 5 (Free) variant to ZenMux provider. Data sourced from https://zenmux.ai/api/anthropic/v1/models