### PR TITLE
chore(togetherai): 20260702 update pricing

### DIFF
--- a/providers/togetherai/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/togetherai/models/Qwen/Qwen3.7-Max.toml
@@ -2,7 +2,7 @@ name = "Qwen3.7 Max"
 description = "Flagship Qwen model for complex reasoning, coding, and agentic workflows"
 family = "qwen"
 release_date = "2026-05-21"
-last_updated = "2026-06-15"
+last_updated = "2026-07-02"
 attachment = false
 reasoning = false
 temperature = true
@@ -12,7 +12,7 @@ open_weights = false
 [cost]
 input = 1.25
 output = 3.75
-cached_input = 0.13
+cached_input = 0.125
 
 [limit]
 context = 1_000_000

--- a/providers/togetherai/models/meta-llama/Llama-3.3-70B-Instruct-Turbo.toml
+++ b/providers/togetherai/models/meta-llama/Llama-3.3-70B-Instruct-Turbo.toml
@@ -2,7 +2,7 @@ name = "Llama 3.3 70B"
 description = "Compact Llama instruction model for fast chat and local deployment"
 family = "llama"
 release_date = "2024-12-06"
-last_updated = "2024-12-06"
+last_updated = "2026-07-02"
 attachment = false
 reasoning = false
 temperature = true
@@ -11,8 +11,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.88
-output = 0.88
+input = 1.04
+output = 1.04
 
 [limit]
 context = 131_072

--- a/providers/togetherai/models/zai-org/GLM-5.1.toml
+++ b/providers/togetherai/models/zai-org/GLM-5.1.toml
@@ -6,7 +6,7 @@ name = "GLM-5.1"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
 family = "glm"
 release_date = "2026-04-07"
-last_updated = "2026-04-07"
+last_updated = "2026-07-02"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
@@ -17,8 +17,9 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 1.40
-output = 4.40
+input = 1.4
+output = 4.4
+cached_input = 0.26
 
 [limit]
 context = 202_752


### PR DESCRIPTION
Run a diff on togetherai pricing. The following models drifted:

- meta-llama/Llama-3.3-70B-Instruct-Turbo: input/output 0.88 → 1.04
- zai-org/GLM-5.1: add cached_input 0.26
- Qwen/Qwen3.7-Max: cached_input 0.13 → 0.125

Based on rates in [Narev MCP](https://narev.ai/)