### PR TITLE
feat(alibaba-cn): add GLM-5.2

### DIFF
--- a/providers/alibaba-cn/models/glm-5.2.toml
+++ b/providers/alibaba-cn/models/glm-5.2.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.2"
+
+# Alibaba Cloud Model Studio lists this as the Alibaba-supplied glm-5.2 model.
+# https://bailian.console.aliyun.com/cn-beijing/?tab=model#/model-market/detail/glm-5.2?serviceSite=asia-pacific-china
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.1
+output = 3.851
+cache_read = 0.275
+cache_write = 0


### PR DESCRIPTION
## Summary

Adds the Alibaba Cloud Model Studio supplied `glm-5.2` model to the `alibaba-cn` provider.

This is the Alibaba-supplied model listed in Model Studio as `glm-5.2`, not the third-party direct `ZHIPU/GLM-5.2` listing.

## Details

- Reuses canonical GLM-5.2 metadata through `base_model = "zhipuai/glm-5.2"`
- Uses `reasoning_options = []` because Alibaba-specific GLM-5.2 reasoning controls have not been provider-audited yet
- Keeps `interleaved.field = "reasoning_content"`
- Sets pricing from the Alibaba Cloud Model Studio detail page

First-party reference:
https://bailian.console.aliyun.com/cn-beijing/?tab=model#/model-market/detail/glm-5.2?serviceSite=asia-pacific-china

Related blocked PR: #2676
Related OpenCode request: anomalyco/opencode#34889

## Validation

- Parsed the added TOML with Python `tomllib`
- `git diff --check`
- Did not run `bun validate` locally because Bun is not installed in this environment; GitHub Actions should run the repository validation
