### PR TITLE
Add GitHub Copilot Kimi K2.7 Code

### DIFF
--- a/providers/github-copilot/models/kimi-k2.7-code.toml
+++ b/providers/github-copilot/models/kimi-k2.7-code.toml
@@ -1,0 +1,16 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4.0
+cache_read = 0.19
+
+[limit]
+context = 256_000
+input = 224_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- Add `kimi-k2.7-code` to the GitHub Copilot provider.
- Inherit the existing Moonshot AI base model metadata.
- Add Copilot pricing and context limits from GitHub Copilot docs/API metadata.

## Sources

- https://docs.github.com/en/copilot/reference/ai-models/supported-models
- https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
- https://github.blog/changelog/2026-07-01-kimi-k2-7-is-now-available-in-github-copilot/

## Validation

- `bun validate`