### PR TITLE
Add GitHub Copilot MAI-Code-1-Flash

### DIFF
--- a/models/microsoft/mai-code-1-flash.toml
+++ b/models/microsoft/mai-code-1-flash.toml
@@ -1,0 +1,30 @@
+name = "MAI-Code-1-Flash"
+description = "Microsoft coding model built for fast, efficient assistance in everyday developer workflows"
+family = "mai"
+release_date = "2026-06-02"
+last_updated = "2026-06-08"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-12"
+open_weights = false
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[links]]
+label = "Model card"
+url = "https://microsoft.ai/pdf/MAI-Code-1-Flash-Model-Card.PDF"
+type = "model_card"
+
+[[links]]
+label = "Announcement"
+url = "https://microsoft.ai/news/introducingmai-code-1-flash/"
+type = "announcement"

--- a/providers/github-copilot/models/mai-code-1-flash-picker.toml
+++ b/providers/github-copilot/models/mai-code-1-flash-picker.toml
@@ -1,0 +1,12 @@
+base_model = "microsoft/mai-code-1-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+
+[limit]
+context = 256_000
+input = 128_000
+output = 128_000


### PR DESCRIPTION
## Summary

- Add base metadata for Microsoft `MAI-Code-1-Flash`.
- Add the GitHub Copilot provider model `mai-code-1-flash-picker`.
- Add Copilot pricing, reasoning effort controls, and context limits from GitHub Copilot docs/API metadata.

## Sources

- https://docs.github.com/en/copilot/reference/ai-models/supported-models
- https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
- https://microsoft.ai/models/mai-code-1-flash/
- https://microsoft.ai/pdf/MAI-Code-1-Flash-Model-Card.PDF
- https://github.blog/changelog/2026-06-02-mai-code-1-flash-is-now-available-for-github-copilot/

## Validation

- `bun validate`