### PR TITLE
Add CoderPlan provider

### DIFF
--- a/providers/coderplan/logo.svg
+++ b/providers/coderplan/logo.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none" style="background-color: transparent;">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e1e2e"/>
+      <stop offset="100%" stop-color="#181825"/>
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="28" fill="url(#bg)"/>
+  <rect x="16" y="18" width="88" height="10" rx="5" fill="#313244"/>
+  <circle cx="26" cy="23" r="3" fill="#f38ba8"/>
+  <circle cx="36" cy="23" r="3" fill="#f9e2af"/>
+  <circle cx="46" cy="23" r="3" fill="#a6e3a1"/>
+  <text x="30" y="76" font-family="'SF Mono','Fira Code','Cascadia Code',monospace" font-size="42" font-weight="700" fill="#cba6f7">$</text>
+  <rect x="68" y="64" width="20" height="5" rx="2.5" fill="#cdd6f4"/>
+</svg>

--- a/providers/coderplan/logo.svg
+++ b/providers/coderplan/logo.svg
@@ -1,15 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none" style="background-color: transparent;">
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1e1e2e"/>
-      <stop offset="100%" stop-color="#181825"/>
-    </linearGradient>
-  </defs>
-  <rect width="120" height="120" rx="28" fill="url(#bg)"/>
-  <rect x="16" y="18" width="88" height="10" rx="5" fill="#313244"/>
-  <circle cx="26" cy="23" r="3" fill="#f38ba8"/>
-  <circle cx="36" cy="23" r="3" fill="#f9e2af"/>
-  <circle cx="46" cy="23" r="3" fill="#a6e3a1"/>
-  <text x="30" y="76" font-family="'SF Mono','Fira Code','Cascadia Code',monospace" font-size="42" font-weight="700" fill="#cba6f7">$</text>
-  <rect x="68" y="64" width="20" height="5" rx="2.5" fill="#cdd6f4"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect x="16" y="18" width="88" height="10" rx="5" fill="currentColor"/>
+  <circle cx="26" cy="23" r="3" fill="currentColor"/>
+  <circle cx="36" cy="23" r="3" fill="currentColor"/>
+  <circle cx="46" cy="23" r="3" fill="currentColor"/>
+  <text x="30" y="76" font-family="'SF Mono','Fira Code','Cascadia Code',monospace" font-size="42" font-weight="700" fill="currentColor">$</text>
+  <rect x="68" y="64" width="20" height="5" rx="2.5" fill="currentColor"/>
 </svg>

--- a/providers/coderplan/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/coderplan/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+max = 63_999
+
+[cost]
+input = 0.14
+output = 0.68

--- a/providers/coderplan/models/anthropic/claude-opus-4-7.toml
+++ b/providers/coderplan/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+max = 63_999
+
+[cost]
+input = 0.68
+output = 3.42

--- a/providers/coderplan/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/coderplan/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+max = 63_999
+
+[cost]
+input = 0.41
+output = 2.05

--- a/providers/coderplan/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/coderplan/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "xhigh"]
+
+[cost]
+input = 0.02
+output = 0.04

--- a/providers/coderplan/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/coderplan/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "xhigh"]
+
+[cost]
+input = 0.19
+output = 0.38

--- a/providers/coderplan/models/openai/gpt-5.4.toml
+++ b/providers/coderplan/models/openai/gpt-5.4.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-5.4"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.17
+output = 1.03

--- a/providers/coderplan/models/openai/gpt-5.5.toml
+++ b/providers/coderplan/models/openai/gpt-5.5.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-5.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.34
+output = 2.05

--- a/providers/coderplan/provider.toml
+++ b/providers/coderplan/provider.toml
@@ -1,0 +1,5 @@
+name = "CoderPlan"
+env = ["CODERPLAN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.coderplan.ai/v1"
+doc = "https://coderplan.ai/docs/setup"


### PR DESCRIPTION
Resubmits #1973, which was closed by the stale bot (not rejected on merits) after the logo was added too late. This refreshes it against current `dev` with the logo included and pricing updated to current published rates.

**CoderPlan** — an OpenAI-compatible LLM API relay for the China market (Alipay/WeChat payment, ¥10 minimum top-up, Hong Kong/Singapore nodes). API at `https://api.coderplan.ai/v1`.

**7 models** with current per-token pricing (USD/M input/output, sourced from coderplan.ai/pricing on 2026-07-02):

| Model | Input | Output |
|---|---|---|
| anthropic/claude-opus-4-7 | 0.68 | 3.42 |
| anthropic/claude-sonnet-4-6 | 0.41 | 2.05 |
| anthropic/claude-haiku-4-5 | 0.14 | 0.68 |
| openai/gpt-5.5 | 0.34 | 2.05 |
| openai/gpt-5.4 | 0.17 | 1.03 |
| deepseek/deepseek-v4-pro | 0.19 | 0.38 |
| deepseek/deepseek-v4-flash | 0.02 | 0.04 |

Each model uses `base_model` to inherit capabilities from the canonical entry, with CoderPlan-specific `[cost]` and `reasoning_options` mirroring the upstream providers (Claude toggle + budget_tokens; GPT-5 effort; DeepSeek toggle + effort). `logo.svg` is included.

`bun validate` passes locally. Open to any schema/positioning feedback — happy to adjust model selection, reasoning_options granularity, or add cache pricing if you can point me at how other relays publish it (CoderPlan's pricing page lists only input/output today).