### PR TITLE
Re-add GitLab Duo Chat Fable 5 model

### DIFF
--- a/providers/gitlab/models/duo-chat-fable-5.toml
+++ b/providers/gitlab/models/duo-chat-fable-5.toml
@@ -1,26 +1,9 @@
+base_model = "anthropic/claude-fable-5"
 name = "Agentic Chat (Claude Fable 5)"
-description = "Claude Fable model for coding, reasoning, and agentic workflows"
-family = "claude-fable"
-release_date = "2026-06-09"
-last_updated = "2026-06-09"
-attachment = true
-reasoning = true
-reasoning_options = []
-temperature = false
-tool_call = true
-knowledge = "2026-01-31"
-open_weights = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 0
 output = 0
 cache_read = 0
 cache_write = 0
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/gitlab/models/duo-chat-fable-5.toml
+++ b/providers/gitlab/models/duo-chat-fable-5.toml
@@ -1,0 +1,26 @@
+name = "Agentic Chat (Claude Fable 5)"
+description = "Claude Fable model for coding, reasoning, and agentic workflows"
+family = "claude-fable"
+release_date = "2026-06-09"
+last_updated = "2026-06-09"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = false
+tool_call = true
+knowledge = "2026-01-31"
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Reverts #2591, which removed `providers/gitlab/models/duo-chat-fable-5.toml`. This re-adds the **Agentic Chat (Claude Fable 5)** model to the `gitlab` provider so it appears in opencode's model picker again.

## Details

Rather than duplicating the full metadata, the entry uses the `base_model` syntax (matching the amazon-bedrock fable definitions) to inherit from `anthropic/claude-fable-5`:

```toml
base_model = "anthropic/claude-fable-5"
name = "Agentic Chat (Claude Fable 5)"
reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

[cost]
input = 0
output = 0
cache_read = 0
cache_write = 0
```

This inherits description, family, limits (1M context / 128k output), modalities, and capabilities from the anthropic base, overriding only:
- `name` — the gitlab picker label
- `reasoning_options` — required because `reasoning = true` is inherited (not carried through base_model)
- `cost` — set to 0, since GitLab proxy models are billed upstream

## Validation

`bun validate` passes and confirms `duo-chat-fable-5` is present in the generated models.json.