### PR TITLE
chore: fix 7 novita-ai models with stale pricing

### DIFF
--- a/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/novita-ai/models/deepseek/deepseek-v4-pro.toml
@@ -5,9 +5,9 @@ reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "m
 field = "reasoning_content"
 
 [cost]
-input = 1.69
-output = 3.38
-cache_read = 0.13
+input = 1.6
+output = 3.2
+cache_read = 0.135
 
 [limit]
 context = 1_048_576

--- a/providers/novita-ai/models/moonshotai/kimi-k2.6.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2.6.toml
@@ -5,6 +5,6 @@ reasoning_options = [{ type = "toggle" }]
 field = "reasoning_content"
 
 [cost]
-input = 0.95
-output = 4
+input = 0.8
+output = 3.4
 cache_read = 0.16

--- a/providers/novita-ai/models/qwen/qwen3-coder-480b-a35b-instruct.toml
+++ b/providers/novita-ai/models/qwen/qwen3-coder-480b-a35b-instruct.toml
@@ -12,8 +12,8 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 0.3
-output = 1.3
+input = 0.38
+output = 1.55
 
 [limit]
 context = 262_144

--- a/providers/novita-ai/models/qwen/qwen3.7-max.toml
+++ b/providers/novita-ai/models/qwen/qwen3.7-max.toml
@@ -14,7 +14,7 @@ open_weights = false
 [cost]
 input = 1.25
 output = 3.75
-cache_read = 0.125
+cache_read = 0.25
 cache_write = 1.5625
 
 [limit]

--- a/providers/novita-ai/models/xiaomimimo/mimo-v2.5-pro.toml
+++ b/providers/novita-ai/models/xiaomimimo/mimo-v2.5-pro.toml
@@ -7,12 +7,12 @@ structured_output = true
 field = "reasoning_content"
 
 [cost]
-input = 2
-output = 6
-cache_read = 0.4
+input = 0.522
+output = 1.044
+cache_read = 0.0043
 
 [[cost.tiers]]
 tier = { type = "context", size = 256_000 }
-input = 2
-output = 6
-cache_read = 0.4
+input = 0.522
+output = 1.044
+cache_read = 0.0043

--- a/providers/novita-ai/models/zai-org/glm-4.5-air.toml
+++ b/providers/novita-ai/models/zai-org/glm-4.5-air.toml
@@ -14,6 +14,7 @@ open_weights = true
 [cost]
 input = 0.13
 output = 0.85
+cache_read = 0.025
 
 [limit]
 context = 131_072

--- a/providers/novita-ai/models/zai-org/glm-5.1.toml
+++ b/providers/novita-ai/models/zai-org/glm-5.1.toml
@@ -12,7 +12,7 @@ structured_output = true
 open_weights = true
 
 [cost]
-input = 1.4
+input = 1.38
 output = 4.4
 cache_read = 0.26
 


### PR DESCRIPTION
- upstream already matches Novita API rates for 96/105 models when using price_per_m / 10_000 (USD per million tokens)
- only these seven had real drift from the live catalog
- based on [Narev Github App](https://narev.ai)