### PR TITLE
docs(agents): add contribution review checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,59 @@
 - Handle undefined values explicitly in comparisons and sorting
 - Use optional chaining (`?.`) and nullish coalescing (`??`) for safe property access
 
+## Contribution Review Checklist
+
+Use this checklist when reviewing PRs that add providers or models. The first two
+items are **hard blockers**; the last two are **strongly recommended** but not blockers.
+
+### New providers (blocker)
+- **Must ship a logo.** Every new provider needs a `providers/<id>/logo.svg` that follows
+  the logo guidelines below. A PR that adds a provider without a compliant logo is not
+  mergeable as-is.
+- **Should add a sync module when the source is context-rich.** If the provider exposes an
+  API/catalog that can populate full model data (or at least authoritatively delete models
+  it no longer serves), add a sync module like OpenRouter's (see `sync.md`). Only add sync
+  when the source is rich enough to be authoritative; a thin endpoint that cannot populate
+  required fields should stay hand-authored. This is highly recommended, not a blocker.
+
+### New models (blocker)
+- **Must use `base_model` when a `models/` metadata entry exists** for the underlying model.
+  Do not duplicate provider-agnostic facts inline when they can be inherited. Only write a
+  full inline definition when no matching `models/<provider>/<model>.toml` exists.
+- **Reasoning models must declare `reasoning_options`.** Any model with `reasoning = true`
+  needs a `reasoning_options` array reflecting the provider's actual API surface (see the
+  audit-reasoning-options skill). For niche providers that document a budget or toggle
+  control, express the exact API request syntax the provider expects as a TOML comment next
+  to the option, e.g.:
+  ```toml
+  [[reasoning_options]]
+  type = "toggle" # API: {"chat_template_kwargs": {"enable_thinking": false}}
+
+  [[reasoning_options]]
+  type = "budget_tokens" # API: {"thinking": {"budget_tokens": <n>}}
+  min = 1_024
+  max = 32_000
+  ```
+  Use `reasoning_options = []` when the model reasons but exposes no verified control.
+
+### Citations (recommended)
+- **PRs that change data should cite their sources.** Link to the provider's pricing page,
+  model docs, or API reference that justifies the change in the PR body. This is highly
+  recommended, not a blocker, but PRs without any sourcing should be treated with more
+  scrutiny and verified before merge.
+
+### Logo guidelines
+- File lives at `providers/<provider-id>/logo.svg`, SVG format.
+- No fixed size or hardcoded colors — use `currentColor` for fills/strokes so the logo
+  adapts to light/dark themes.
+- Prefer a square `viewBox` (e.g. `0 0 24 24`).
+- Example:
+  ```svg
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <!-- Logo paths here -->
+  </svg>
+  ```
+
 ## Model Configuration
 
 - Model `id` is **auto-injected** from filename (minus `.toml`) — never put `id` in TOML files


### PR DESCRIPTION
## Summary

Adds a **Contribution Review Checklist** section to `AGENTS.md` so provider/model PR reviews apply consistent standards. Splits requirements into hard blockers and strongly-recommended items.

### Blockers
- **New providers must ship a compliant `logo.svg`.** Logo guidelines are documented inline (SVG, `currentColor`, square `viewBox`, no fixed size/colors).
- **New models must use `base_model`** when a `models/<provider>/<model>.toml` metadata entry exists, instead of duplicating provider-agnostic facts inline.
- **Reasoning models must declare `reasoning_options`** reflecting the provider's real API surface. For niche providers, the exact API request syntax (budget/toggle) is expressed as a TOML comment next to the option. `reasoning_options = []` when the model reasons but exposes no verified control.

### Recommended (not blockers)
- **New providers should add a sync module** (like OpenRouter's, see `sync.md`) **when the source is context-rich** enough to populate full model data or authoritatively delete removed models. Thin endpoints stay hand-authored.
- **PRs that change data should cite their sources** (pricing page, model docs, API reference) in the PR body. PRs without sourcing get more scrutiny before merge.

## Testing
- `bun validate` passes (exit 0).