### PR TITLE
deprecate: nvdia glm5.1, fix: kenari gpt-oss-20b

### DIFF
--- a/providers/kenari/models/gpt-oss-20b.toml
+++ b/providers/kenari/models/gpt-oss-20b.toml
@@ -1,4 +1,5 @@
 name = "GPT OSS 20B"
+description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
 family = "gpt-oss"
 attachment = false
 reasoning = true

--- a/providers/nvidia/models/z-ai/glm-5.1.toml
+++ b/providers/nvidia/models/z-ai/glm-5.1.toml
@@ -10,6 +10,7 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
+status = "deprecated"
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## 1. Deprecate: nvidia nim glm 5.1
<img width="1144" height="123" alt="image" src="https://github.com/user-attachments/assets/68cc80c9-4894-4a55-839f-850a9b80d07d" />

```sh
HTTP/2 410 
date: Thu, 02 Jul 2026 17:35:20 GMT
content-type: application/problem+json
content-length: 167
vary: Origin

{"type":"about:blank","title":"Gone","status":410,"detail":"The model 'z-ai/glm-5.1' has reached its end of life on 2026-07-02T00:00:00Z and is no longer available."}
```

## 2. Fix: missing description at kenari gpt-oss-20b causing `packages/web bun run build` to fail
```sh
$ ./script/build.ts
582 |         return {
583 |             success: false,
584 |             get error() {
585 |                 if (this._error)
586 |                     return this._error;
587 |                 const error = new ZodError(ctx.common.issues);
                                    ^
ZodError: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "description"
    ],
    "message": "Required"
  }
]
    issues: [
  [Object ...]
],
  addIssue: [Function],
 addIssues: [Function],
     cause: {
  modelPath: "models.dev/providers/kenari/models/gpt-oss-20b.toml",
  toml: [Object ...],
},
```