### PR TITLE
fix(kenari): add required description to gpt-oss-20b

### DIFF
--- a/providers/kenari/models/gpt-oss-20b.toml
+++ b/providers/kenari/models/gpt-oss-20b.toml
@@ -1,4 +1,5 @@
 name = "GPT OSS 20B"
+description = "Open-weight GPT reasoning model for self-hosted agents and controllable deployments"
 family = "gpt-oss"
 attachment = false
 reasoning = true


### PR DESCRIPTION
## Problem

The `dev` CI `Validate models` job is failing on every sync matrix job:

```
Validation error: [
  { code: "invalid_type", expected: "string", received: "undefined", path: [ "description" ], message: "Required" }
]
When parsing: providers/kenari/models/gpt-oss-20b.toml
```

The schema (`ModelBase` in `packages/core/src/schema.ts:217`) requires a non-empty `description`. Every other Kenari model file inherits its description via `base_model`, but `gpt-oss-20b.toml` has no matching `models/openai/gpt-oss-20b.toml` metadata entry to inherit from, so it needs the field inline. It was merged in #2959 without one, which broke CI.

## Fix

Add an inline `description` to `providers/kenari/models/gpt-oss-20b.toml`, consistent with how other providers (e.g. ovhcloud) define this model inline.

`bun validate` now passes locally.