### PR TITLE
fix(sync): move inline comments to file top so they survive sync rewrites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,11 @@ items are **hard blockers**; the last two are **strongly recommended** but not b
   model docs, or API reference that justifies the change in the PR body. This is highly
   recommended, not a blocker, but PRs without any sourcing should be treated with more
   scrutiny and verified before merge.
+- **In-file comments must live at the top of the file.** The daily model sync rewrites
+  synced provider TOMLs by parsing and re-serializing them, which discards every comment
+  except a leading header block. Put source citations and rationale as a comment block at
+  the very top of the file (above the first key); comments placed between sections or
+  above individual keys are silently deleted on the next sync run.
 
 ### Logo guidelines
 - File lives at `providers/<provider-id>/logo.svg`, SVG format.

--- a/providers/baseten/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/baseten/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,3 +1,7 @@
+# This deprecated model is absent from Baseten's current reasoning support table;
+# no toggle, effort, or budget request field is documented for it.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 name = "MiniMax-M2.5"
 description = "Legacy model retained for compatibility with older integrations"
 family = "minimax"
@@ -6,9 +10,6 @@ release_date = "2026-02-12"
 last_updated = "2026-02-12"
 attachment = false
 reasoning = true
-# This deprecated model is absent from Baseten's current reasoning support table;
-# no toggle, effort, or budget request field is documented for it.
-# https://docs.baseten.co/inference/model-apis/reasoning
 reasoning_options = []
 temperature = true
 tool_call = true

--- a/providers/baseten/models/deepseek-ai/DeepSeek-V3.1.toml
+++ b/providers/baseten/models/deepseek-ai/DeepSeek-V3.1.toml
@@ -1,3 +1,7 @@
+# This deprecated model is absent from Baseten's current reasoning support table;
+# no toggle, effort, or budget request field is documented for it.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 name = "DeepSeek V3.1"
 description = "Legacy model retained for compatibility with older integrations"
 family = "deepseek"
@@ -6,9 +10,6 @@ release_date = "2025-08-25"
 last_updated = "2025-08-25"
 attachment = false
 reasoning = true
-# This deprecated model is absent from Baseten's current reasoning support table;
-# no toggle, effort, or budget request field is documented for it.
-# https://docs.baseten.co/inference/model-apis/reasoning
 reasoning_options = []
 temperature = true
 tool_call = true

--- a/providers/baseten/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/baseten/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -1,12 +1,13 @@
+# Baseten documents top-level reasoning_effort = low | medium | high | xhigh
+# for DeepSeek V4 Pro; no toggle or reasoning-token budget field is documented.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 base_model = "deepseek/deepseek-v4-pro"
 name = "Deepseek V4 Pro"
 
 [interleaved]
 field = "reasoning_content"
 
-# Baseten documents top-level reasoning_effort = low | medium | high | xhigh
-# for DeepSeek V4 Pro; no toggle or reasoning-token budget field is documented.
-# https://docs.baseten.co/inference/model-apis/reasoning
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high", "xhigh"]

--- a/providers/baseten/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.5.toml
@@ -1,3 +1,7 @@
+# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
+# explicit false behavior, effort values, or reasoning-token budget.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 name = "Kimi K2.5"
 description = "Kimi multimodal agent model for visual understanding, coding, and planning"
 family = "kimi-k2"
@@ -11,9 +15,6 @@ structured_output = true
 knowledge = "2025-12"
 open_weights = true
 
-# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
-# explicit false behavior, effort values, or reasoning-token budget.
-# https://docs.baseten.co/inference/model-apis/reasoning
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/baseten/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.6.toml
@@ -1,3 +1,7 @@
+# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
+# explicit false behavior, effort values, or reasoning-token budget.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 name = "Kimi K2.6"
 description = "Kimi multimodal agent model for visual understanding, coding, and planning"
 family = "kimi-k2"
@@ -11,9 +15,6 @@ structured_output = true
 knowledge = "2025-01"
 open_weights = true
 
-# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
-# explicit false behavior, effort values, or reasoning-token budget.
-# https://docs.baseten.co/inference/model-apis/reasoning
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/baseten/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,8 +1,9 @@
-base_model = "moonshotai/kimi-k2.7-code"
-temperature = true
 # Baseten documents opt-in via chat_template_args.enable_thinking=true, but no
 # explicit false behavior, effort values, or reasoning-token budget.
 # https://docs.baseten.co/inference/model-apis/reasoning
+
+base_model = "moonshotai/kimi-k2.7-code"
+temperature = true
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/baseten/models/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B.toml
+++ b/providers/baseten/models/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B.toml
@@ -1,10 +1,11 @@
+# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
+# explicit false behavior, effort values, or reasoning-token budget.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 name = "Nemotron Ultra"
 structured_output = true
 
-# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
-# explicit false behavior, effort values, or reasoning-token budget.
-# https://docs.baseten.co/inference/model-apis/reasoning
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
+++ b/providers/baseten/models/nvidia/Nemotron-120B-A12B.toml
@@ -1,11 +1,12 @@
+# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
+# explicit false behavior, effort values, or reasoning-token budget.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 base_model = "nvidia/nemotron-3-super-120b-a12b"
 name = "Nemotron Super"
 structured_output = true
 knowledge = "2026-02"
 
-# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
-# explicit false behavior, effort values, or reasoning-token budget.
-# https://docs.baseten.co/inference/model-apis/reasoning
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/baseten/models/openai/gpt-oss-120b.toml
+++ b/providers/baseten/models/openai/gpt-oss-120b.toml
@@ -1,3 +1,7 @@
+# Baseten documents top-level reasoning_effort = low | medium | high for GPT OSS
+# 120B; reasoning is otherwise enabled by default. No toggle or budget exists.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 name = "OpenAI GPT 120B"
 description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
 family = "gpt-oss"
@@ -11,9 +15,6 @@ structured_output = true
 knowledge = "2025-08"
 open_weights = true
 
-# Baseten documents top-level reasoning_effort = low | medium | high for GPT OSS
-# 120B; reasoning is otherwise enabled by default. No toggle or budget exists.
-# https://docs.baseten.co/inference/model-apis/reasoning
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/baseten/models/zai-org/GLM-4.7.toml
+++ b/providers/baseten/models/zai-org/GLM-4.7.toml
@@ -1,3 +1,7 @@
+# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
+# explicit false behavior, effort values, or reasoning-token budget.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 name = "GLM 4.7"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
 family = "glm"
@@ -11,9 +15,6 @@ structured_output = true
 knowledge = "2025-04"
 open_weights = true
 
-# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
-# explicit false behavior, effort values, or reasoning-token budget.
-# https://docs.baseten.co/inference/model-apis/reasoning
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/baseten/models/zai-org/GLM-5.1.toml
+++ b/providers/baseten/models/zai-org/GLM-5.1.toml
@@ -1,9 +1,10 @@
-base_model = "zhipuai/glm-5.1"
-name = "GLM 5.1"
-
 # Opt in with chat_template_args.enable_thinking=true. Baseten documents no
 # explicit false behavior, effort values, or reasoning-token budget.
 # https://docs.baseten.co/inference/model-apis/reasoning
+
+base_model = "zhipuai/glm-5.1"
+name = "GLM 5.1"
+
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/baseten/models/zai-org/GLM-5.2.toml
+++ b/providers/baseten/models/zai-org/GLM-5.2.toml
@@ -1,9 +1,10 @@
-base_model = "zhipuai/glm-5.2"
-name = "GLM 5.2"
-
 # Opt in with chat_template_args.enable_thinking=true. Baseten documents no
 # explicit false behavior, effort values, or reasoning-token budget.
 # https://docs.baseten.co/inference/model-apis/reasoning
+
+base_model = "zhipuai/glm-5.2"
+name = "GLM 5.2"
+
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/baseten/models/zai-org/GLM-5.toml
+++ b/providers/baseten/models/zai-org/GLM-5.toml
@@ -1,3 +1,7 @@
+# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
+# explicit false behavior, effort values, or reasoning-token budget.
+# https://docs.baseten.co/inference/model-apis/reasoning
+
 name = "GLM 5"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
 family = "glm"
@@ -11,9 +15,6 @@ structured_output = true
 knowledge = "2026-01"
 open_weights = true
 
-# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
-# explicit false behavior, effort values, or reasoning-token budget.
-# https://docs.baseten.co/inference/model-apis/reasoning
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/cloudflare-workers-ai/models/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b.toml
@@ -1,7 +1,8 @@
-base_model = "deepseek/deepseek-r1"
 # Native `/ai/run` schema documents no reasoning toggle, effort, or token
 # budget for this reasoning-only model.
 # https://developers.cloudflare.com/workers-ai/models/deepseek-r1-distill-qwen-32b/sync-input.json (accessed 2026-06-25)
+
+base_model = "deepseek/deepseek-r1"
 name = "Deepseek R1 Distill Qwen 32B"
 reasoning_options = []
 tool_call = false

--- a/providers/cloudflare-workers-ai/models/@cf/google/gemma-4-26b-a4b-it.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/google/gemma-4-26b-a4b-it.toml
@@ -1,7 +1,8 @@
-base_model = "google/gemma-4-26b-a4b-it"
 # Native `/ai/run` accepts `reasoning_effort = low|medium|high` and
 # `chat_template_kwargs.enable_thinking = true|false`; no budget is documented.
 # https://developers.cloudflare.com/workers-ai/models/gemma-4-26b-a4b-it/sync-input.json (accessed 2026-06-25)
+
+base_model = "google/gemma-4-26b-a4b-it"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 interleaved = true
 

--- a/providers/cloudflare-workers-ai/models/@cf/moonshotai/kimi-k2.6.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/moonshotai/kimi-k2.6.toml
@@ -1,7 +1,8 @@
-base_model = "moonshotai/kimi-k2.6"
 # Native `/ai/run` accepts `reasoning_effort = low|medium|high` and
 # `chat_template_kwargs.thinking = true|false`; no budget is documented.
 # https://developers.cloudflare.com/workers-ai/models/kimi-k2.6/sync-input.json (accessed 2026-06-25)
+
+base_model = "moonshotai/kimi-k2.6"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]

--- a/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/nvidia/nemotron-3-120b-a12b.toml
@@ -1,7 +1,8 @@
-base_model = "nvidia/nemotron-3-super-120b-a12b"
 # Native `/ai/run` accepts `reasoning_effort = low|medium|high` and
 # `chat_template_kwargs.enable_thinking = true|false`; no budget is documented.
 # https://developers.cloudflare.com/workers-ai/models/nemotron-3-120b-a12b/sync-input.json (accessed 2026-06-25)
+
+base_model = "nvidia/nemotron-3-super-120b-a12b"
 name = "Nemotron 3 Super 120B"
 structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-120b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-120b.toml
@@ -1,7 +1,8 @@
-base_model = "openai/gpt-oss-120b"
 # Native `/ai/run` schema has no reasoning control, and no model-specific
 # OpenAI-compatible reasoning field was verified. No token budget is documented.
 # https://developers.cloudflare.com/workers-ai/models/gpt-oss-120b/sync-input.json (accessed 2026-06-25)
+
+base_model = "openai/gpt-oss-120b"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-20b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/openai/gpt-oss-20b.toml
@@ -1,8 +1,9 @@
-name = "GPT OSS 20B"
-description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
 # Native `/ai/run` schema has no reasoning control, and no model-specific
 # OpenAI-compatible reasoning field was verified. No token budget is documented.
 # https://developers.cloudflare.com/workers-ai/models/gpt-oss-20b/sync-input.json (accessed 2026-06-25)
+
+name = "GPT OSS 20B"
+description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
 family = "gpt-oss"
 release_date = "2025-08-05"
 last_updated = "2025-08-05"

--- a/providers/cloudflare-workers-ai/models/@cf/qwen/qwen3-30b-a3b-fp8.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/qwen/qwen3-30b-a3b-fp8.toml
@@ -1,8 +1,9 @@
-name = "Qwen3 30B A3b fp8"
-description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
 # Native `/ai/run` schema does not document a selectable reasoning control.
 # No model-specific OpenAI-compatible reasoning field or token budget was verified.
 # https://developers.cloudflare.com/workers-ai/models/qwen3-30b-a3b-fp8/sync-input.json (accessed 2026-06-25)
+
+name = "Qwen3 30B A3b fp8"
+description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
 family = "qwen"
 release_date = "2025-04-30"
 last_updated = "2025-04-30"

--- a/providers/cloudflare-workers-ai/models/@cf/qwen/qwq-32b.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/qwen/qwq-32b.toml
@@ -1,8 +1,9 @@
-name = "Qwq 32B"
-description = "Qwen reasoning model for deliberate problem solving, math, and coding"
 # Native `/ai/run` schema documents no reasoning toggle, effort, or token
 # budget for this reasoning-only model.
 # https://developers.cloudflare.com/workers-ai/models/qwq-32b/sync-input.json (accessed 2026-06-25)
+
+name = "Qwq 32B"
+description = "Qwen reasoning model for deliberate problem solving, math, and coding"
 family = "qwen"
 release_date = "2025-03-05"
 last_updated = "2025-03-05"

--- a/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-4.7-flash.toml
@@ -1,8 +1,9 @@
-name = "GLM-4.7-Flash"
-description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
 # Native `/ai/run` accepts `reasoning_effort = low|medium|high` and
 # `chat_template_kwargs.enable_thinking = true|false`; no budget is documented.
 # https://developers.cloudflare.com/workers-ai/models/glm-4.7-flash/sync-input.json (accessed 2026-06-25)
+
+name = "GLM-4.7-Flash"
+description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
 family = "glm-flash"
 release_date = "2026-01-19"
 last_updated = "2026-01-19"

--- a/providers/ovhcloud/models/gpt-oss-120b.toml
+++ b/providers/ovhcloud/models/gpt-oss-120b.toml
@@ -1,11 +1,12 @@
+# Chat: `reasoning_effort = low|medium|high`; Responses: `reasoning.effort`.
+# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/gpt-oss-120b/
+
 name = "gpt-oss-120b"
 description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
 release_date = "2025-08-28"
 last_updated = "2025-08-28"
 attachment = false
 reasoning = true
-# Chat: `reasoning_effort = low|medium|high`; Responses: `reasoning.effort`.
-# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/gpt-oss-120b/
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true

--- a/providers/ovhcloud/models/gpt-oss-20b.toml
+++ b/providers/ovhcloud/models/gpt-oss-20b.toml
@@ -1,11 +1,12 @@
+# Chat: `reasoning_effort = low|medium|high`; Responses: `reasoning.effort`.
+# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/gpt-oss-20b/
+
 name = "gpt-oss-20b"
 description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
 release_date = "2025-08-28"
 last_updated = "2025-08-28"
 attachment = false
 reasoning = true
-# Chat: `reasoning_effort = low|medium|high`; Responses: `reasoning.effort`.
-# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/gpt-oss-20b/
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 tool_call = true
 structured_output = true

--- a/providers/ovhcloud/models/qwen3-32b.toml
+++ b/providers/ovhcloud/models/qwen3-32b.toml
@@ -1,11 +1,12 @@
+# Put `/no_think` in prompt content to disable the model's default reasoning.
+# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/qwen-3-32b/
+
 name = "Qwen3-32B"
 description = "Reasoning model for deliberate analysis, multi-step problem solving, and tool use"
 release_date = "2025-07-16"
 last_updated = "2025-07-16"
 attachment = false
 reasoning = true
-# Put `/no_think` in prompt content to disable the model's default reasoning.
-# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/qwen-3-32b/
 reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true

--- a/providers/ovhcloud/models/qwen3.5-397b-a17b.toml
+++ b/providers/ovhcloud/models/qwen3.5-397b-a17b.toml
@@ -1,11 +1,12 @@
+# Chat `reasoning_effort` supports none|low|medium|high; `none` disables it.
+# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/qwen-3-5-397b/
+
 name = "Qwen3.5-397B-A17B"
 description = "Multimodal reasoning model for visual analysis, planning, and tool use"
 release_date = "2026-05-18"
 last_updated = "2026-05-18"
 attachment = true
 reasoning = true
-# Chat `reasoning_effort` supports none|low|medium|high; `none` disables it.
-# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/qwen-3-5-397b/
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/ovhcloud/models/qwen3.5-9b.toml
+++ b/providers/ovhcloud/models/qwen3.5-9b.toml
@@ -1,11 +1,12 @@
+# Chat `reasoning_effort` supports none|low|medium|high; `none` disables it.
+# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/qwen-3-5-9b/
+
 name = "Qwen3.5-9B"
 description = "Multimodal reasoning model for visual analysis, planning, and tool use"
 release_date = "2026-04-22"
 last_updated = "2026-04-22"
 attachment = true
 reasoning = true
-# Chat `reasoning_effort` supports none|low|medium|high; `none` disables it.
-# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/qwen-3-5-9b/
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/ovhcloud/models/qwen3.6-27b.toml
+++ b/providers/ovhcloud/models/qwen3.6-27b.toml
@@ -1,11 +1,12 @@
+# Chat `reasoning_effort` supports none|minimal|low|medium|high; `none` disables it.
+# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/qwen-3-6-27b/
+
 name = "Qwen3.6-27B"
 description = "Multimodal reasoning model for visual analysis, planning, and tool use"
 release_date = "2026-06-01"
 last_updated = "2026-06-01"
 attachment = true
 reasoning = true
-# Chat `reasoning_effort` supports none|minimal|low|medium|high; `none` disables it.
-# https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/qwen-3-6-27b/
 reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true

--- a/providers/venice/models/aion-labs-aion-2-0.toml
+++ b/providers/venice/models/aion-labs-aion-2-0.toml
@@ -1,3 +1,6 @@
+# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 name = "Aion 2.0"
 description = "Reasoning model for deliberate analysis, multi-step problem solving, and tool use"
 release_date = "2026-03-24"
@@ -7,8 +10,6 @@ reasoning = true
 tool_call = false
 open_weights = false
 
-# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/venice/models/claude-fable-5.toml
+++ b/providers/venice/models/claude-fable-5.toml
@@ -1,9 +1,10 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-fable-5"
 release_date = "2026-06-10"
 last_updated = "2026-06-11"
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/claude-opus-4-5.toml
+++ b/providers/venice/models/claude-opus-4-5.toml
@@ -1,10 +1,11 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-opus-4-5"
 name = "Claude Opus 4.5"
 release_date = "2025-12-06"
 last_updated = "2026-06-11"
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/claude-opus-4-6.toml
+++ b/providers/venice/models/claude-opus-4-6.toml
@@ -1,8 +1,9 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-opus-4-6"
 last_updated = "2026-06-11"
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/claude-opus-4-7-fast.toml
+++ b/providers/venice/models/claude-opus-4-7-fast.toml
@@ -1,10 +1,11 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-opus-4-7"
 name = "Claude Opus 4.7 Fast"
 release_date = "2026-05-14"
 last_updated = "2026-06-11"
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/claude-opus-4-7.toml
+++ b/providers/venice/models/claude-opus-4-7.toml
@@ -1,8 +1,9 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-opus-4-7"
 last_updated = "2026-06-11"
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/claude-opus-4-8-fast.toml
+++ b/providers/venice/models/claude-opus-4-8-fast.toml
@@ -1,9 +1,10 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-opus-4-8"
 name = "Claude Opus 4.8 Fast"
 last_updated = "2026-06-11"
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/claude-opus-4-8.toml
+++ b/providers/venice/models/claude-opus-4-8.toml
@@ -1,8 +1,9 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-opus-4-8"
 last_updated = "2026-06-11"
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/claude-sonnet-4-5.toml
+++ b/providers/venice/models/claude-sonnet-4-5.toml
@@ -1,10 +1,11 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-sonnet-4-5"
 name = "Claude Sonnet 4.5"
 release_date = "2025-01-15"
 last_updated = "2026-06-11"
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/claude-sonnet-4-6.toml
+++ b/providers/venice/models/claude-sonnet-4-6.toml
@@ -1,8 +1,9 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-sonnet-4-6"
 last_updated = "2026-06-11"
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/claude-sonnet-5.toml
+++ b/providers/venice/models/claude-sonnet-5.toml
@@ -1,11 +1,12 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-07-01).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "anthropic/claude-sonnet-5"
 description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
 release_date = "2026-06-29"
 last_updated = "2026-07-01"
 structured_output = true
 
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-07-01).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/deepseek-v3.2.toml
+++ b/providers/venice/models/deepseek-v3.2.toml
@@ -1,3 +1,6 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 name = "DeepSeek V3.2"
 description = "DeepSeek chat model for instruction following, coding, and analysis"
 family = "deepseek"
@@ -9,8 +12,6 @@ tool_call = true
 structured_output = true
 open_weights = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/gemini-3-1-pro-preview.toml
+++ b/providers/venice/models/gemini-3-1-pro-preview.toml
@@ -1,9 +1,10 @@
+# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "google/gemini-3.1-pro-preview"
 family = "gemini"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/venice/models/gemini-3-5-flash.toml
+++ b/providers/venice/models/gemini-3-5-flash.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "google/gemini-3.5-flash"
 family = "gemini"
 release_date = "2026-05-22"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/venice/models/google-gemma-4-26b-a4b-it.toml
+++ b/providers/venice/models/google-gemma-4-26b-a4b-it.toml
@@ -1,9 +1,10 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "google/gemma-4-26b-a4b-it"
 name = "Google Gemma 4 26B A4B Instruct"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/google-gemma-4-31b-it.toml
+++ b/providers/venice/models/google-gemma-4-31b-it.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "google/gemma-4-31b-it"
 name = "Google Gemma 4 31B Instruct"
 release_date = "2026-04-03"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/grok-4-20-multi-agent.toml
+++ b/providers/venice/models/grok-4-20-multi-agent.toml
@@ -1,3 +1,6 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 name = "Grok 4.20 Multi-Agent"
 description = "Grok model for agentic tool use, reasoning, coding, and live assistance"
 family = "grok"
@@ -8,8 +11,6 @@ reasoning = true
 tool_call = false
 structured_output = true
 open_weights = false
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/grok-4-20.toml
+++ b/providers/venice/models/grok-4-20.toml
@@ -1,3 +1,6 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 name = "Grok 4.20"
 description = "Grok model for agentic tool use, reasoning, coding, and live assistance"
 family = "grok"
@@ -8,8 +11,6 @@ reasoning = true
 tool_call = true
 structured_output = true
 open_weights = false
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/grok-build-0-1.toml
+++ b/providers/venice/models/grok-build-0-1.toml
@@ -1,8 +1,9 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "xai/grok-build-0.1"
 release_date = "2026-05-21"
 last_updated = "2026-06-11"
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/kimi-k2-5.toml
+++ b/providers/venice/models/kimi-k2-5.toml
@@ -1,3 +1,6 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "moonshotai/kimi-k2.5"
 release_date = "2026-01-27"
 last_updated = "2026-06-11"
@@ -5,8 +8,6 @@ attachment = true
 knowledge = "2024-04"
 open_weights = false
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/kimi-k2-6.toml
+++ b/providers/venice/models/kimi-k2-6.toml
@@ -1,8 +1,9 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "moonshotai/kimi-k2.6"
 release_date = "2026-04-20"
 last_updated = "2026-06-11"
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [interleaved]

--- a/providers/venice/models/kimi-k2-7-code.toml
+++ b/providers/venice/models/kimi-k2-7-code.toml
@@ -1,9 +1,10 @@
+# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "moonshotai/kimi-k2.7-code"
 release_date = "2026-06-13"
 last_updated = "2026-06-16"
 
-# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/venice/models/mercury-2.toml
+++ b/providers/venice/models/mercury-2.toml
@@ -1,3 +1,6 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 name = "Mercury 2"
 description = "Reasoning model for deliberate analysis, multi-step problem solving, and tool use"
 family = "mercury"
@@ -9,8 +12,6 @@ tool_call = true
 structured_output = true
 open_weights = false
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/minimax-m25.toml
+++ b/providers/venice/models/minimax-m25.toml
@@ -1,9 +1,10 @@
+# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "minimax/MiniMax-M2.5"
 name = "MiniMax M2.5"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/venice/models/minimax-m3-preview.toml
+++ b/providers/venice/models/minimax-m3-preview.toml
@@ -1,3 +1,6 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 name = "MiniMax M3 Preview"
 description = "MiniMax multimodal coding model for long-context reasoning and agent tasks"
 family = "minimax-m3"
@@ -7,8 +10,6 @@ attachment = false
 reasoning = true
 tool_call = true
 open_weights = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/mistral-small-2603.toml
+++ b/providers/venice/models/mistral-small-2603.toml
@@ -1,9 +1,10 @@
+# Live /models (2026-06-25): none|high only; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "mistral/mistral-small-2603"
 last_updated = "2026-06-11"
 structured_output = true
 
-# Live /models (2026-06-25): none|high only; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "high"]

--- a/providers/venice/models/nvidia-nemotron-3-ultra-550b-a55b.toml
+++ b/providers/venice/models/nvidia-nemotron-3-ultra-550b-a55b.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 name = "NVIDIA Nemotron 3 Ultra"
 last_updated = "2026-06-11"
 structured_output = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/nvidia-nemotron-cascade-2-30b-a3b.toml
+++ b/providers/venice/models/nvidia-nemotron-cascade-2-30b-a3b.toml
@@ -1,9 +1,10 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "nvidia/nemotron-cascade-2-30b-a3b"
 last_updated = "2026-06-11"
 structured_output = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/olafangensan-glm-4.7-flash-heretic.toml
+++ b/providers/venice/models/olafangensan-glm-4.7-flash-heretic.toml
@@ -1,3 +1,6 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 name = "GLM 4.7 Flash Heretic"
 description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
 family = "glm"
@@ -9,8 +12,6 @@ tool_call = true
 structured_output = true
 open_weights = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/openai-gpt-52-codex.toml
+++ b/providers/venice/models/openai-gpt-52-codex.toml
@@ -1,11 +1,12 @@
+# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "openai/gpt-5.2-codex"
 family = "gpt"
 release_date = "2025-01-15"
 last_updated = "2026-06-11"
 knowledge = "2025-08"
 
-# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "minimal", "low", "medium", "high"]

--- a/providers/venice/models/openai-gpt-52.toml
+++ b/providers/venice/models/openai-gpt-52.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "openai/gpt-5.2"
 release_date = "2025-12-13"
 last_updated = "2026-06-11"
 attachment = false
 
-# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "minimal", "low", "medium", "high"]

--- a/providers/venice/models/openai-gpt-53-codex.toml
+++ b/providers/venice/models/openai-gpt-53-codex.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "openai/gpt-5.3-codex"
 family = "gpt"
 release_date = "2026-02-24"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "minimal", "low", "medium", "high"]

--- a/providers/venice/models/openai-gpt-54-mini.toml
+++ b/providers/venice/models/openai-gpt-54-mini.toml
@@ -1,11 +1,12 @@
+# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "openai/gpt-5.4-mini"
 name = "GPT-5.4 Mini"
 family = "gpt"
 release_date = "2026-03-27"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "minimal", "low", "medium", "high"]

--- a/providers/venice/models/openai-gpt-54-pro.toml
+++ b/providers/venice/models/openai-gpt-54-pro.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "openai/gpt-5.4-pro"
 family = "gpt"
 last_updated = "2026-06-11"
 structured_output = true
 
-# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "minimal", "low", "medium", "high"]

--- a/providers/venice/models/openai-gpt-54.toml
+++ b/providers/venice/models/openai-gpt-54.toml
@@ -1,8 +1,9 @@
+# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "openai/gpt-5.4"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "minimal", "low", "medium", "high"]

--- a/providers/venice/models/openai-gpt-55-pro.toml
+++ b/providers/venice/models/openai-gpt-55-pro.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "openai/gpt-5.5-pro"
 family = "gpt"
 release_date = "2026-04-24"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "minimal", "low", "medium", "high"]

--- a/providers/venice/models/openai-gpt-55.toml
+++ b/providers/venice/models/openai-gpt-55.toml
@@ -1,8 +1,9 @@
+# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "openai/gpt-5.5"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|minimal|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "minimal", "low", "medium", "high"]

--- a/providers/venice/models/qwen-3-6-plus.toml
+++ b/providers/venice/models/qwen-3-6-plus.toml
@@ -1,11 +1,12 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "alibaba/qwen3.6-plus"
 name = "Qwen 3.6 Plus Uncensored"
 release_date = "2026-04-06"
 last_updated = "2026-06-11"
 attachment = true
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/qwen-3-7-max.toml
+++ b/providers/venice/models/qwen-3-7-max.toml
@@ -1,10 +1,11 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "alibaba/qwen3.7-max"
 name = "Qwen 3.7 Max"
 release_date = "2026-05-22"
 last_updated = "2026-06-11"
 attachment = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/qwen-3-7-plus.toml
+++ b/providers/venice/models/qwen-3-7-plus.toml
@@ -1,10 +1,11 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "alibaba/qwen3.7-plus"
 name = "Qwen 3.7 Plus"
 last_updated = "2026-06-11"
 attachment = true
 structured_output = true
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/qwen3-235b-a22b-thinking-2507.toml
+++ b/providers/venice/models/qwen3-235b-a22b-thinking-2507.toml
@@ -1,3 +1,6 @@
+# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 name = "Qwen 3 235B A22B Thinking 2507"
 description = "Qwen reasoning model for deliberate problem solving, math, and coding"
 family = "qwen"
@@ -9,8 +12,6 @@ tool_call = true
 structured_output = true
 open_weights = true
 
-# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/venice/models/qwen3-5-35b-a3b.toml
+++ b/providers/venice/models/qwen3-5-35b-a3b.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "alibaba/qwen3.5-35b-a3b"
 name = "Qwen 3.5 35B A3B"
 release_date = "2026-02-25"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/qwen3-5-397b-a17b.toml
+++ b/providers/venice/models/qwen3-5-397b-a17b.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "alibaba/qwen3.5-397b-a17b"
 name = "Qwen 3.5 397B"
 release_date = "2026-02-16"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/qwen3-5-9b.toml
+++ b/providers/venice/models/qwen3-5-9b.toml
@@ -1,11 +1,12 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "alibaba/qwen3.5-9b"
 name = "Qwen 3.5 9B"
 release_date = "2026-03-05"
 last_updated = "2026-06-11"
 attachment = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/qwen3-6-27b.toml
+++ b/providers/venice/models/qwen3-6-27b.toml
@@ -1,11 +1,12 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "alibaba/qwen3.6-27b"
 name = "Qwen 3.6 27B"
 release_date = "2026-04-24"
 last_updated = "2026-06-11"
 open_weights = false
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/xiaomi-mimo-v2-5.toml
+++ b/providers/venice/models/xiaomi-mimo-v2-5.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "xiaomi/mimo-v2.5"
 release_date = "2026-06-11"
 last_updated = "2026-06-11"
 structured_output = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/z-ai-glm-5-turbo.toml
+++ b/providers/venice/models/z-ai-glm-5-turbo.toml
@@ -1,11 +1,12 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "zhipuai/glm-5-turbo"
 name = "GLM 5 Turbo"
 release_date = "2026-03-15"
 last_updated = "2026-06-11"
 open_weights = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/z-ai-glm-5v-turbo.toml
+++ b/providers/venice/models/z-ai-glm-5v-turbo.toml
@@ -1,10 +1,11 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "zhipuai/glm-5v-turbo"
 name = "GLM 5V Turbo"
 last_updated = "2026-06-11"
 structured_output = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/zai-org-glm-4.6.toml
+++ b/providers/venice/models/zai-org-glm-4.6.toml
@@ -1,3 +1,6 @@
+# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "zhipuai/glm-4.6"
 name = "GLM 4.6"
 release_date = "2024-04-01"
@@ -7,8 +10,6 @@ structured_output = true
 [interleaved]
 field = "reasoning_content"
 
-# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/venice/models/zai-org-glm-4.7-flash.toml
+++ b/providers/venice/models/zai-org-glm-4.7-flash.toml
@@ -1,3 +1,6 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "zhipuai/glm-4.7-flash"
 name = "GLM 4.7 Flash"
 family = "glm"
@@ -5,8 +8,6 @@ release_date = "2026-01-29"
 last_updated = "2026-06-11"
 structured_output = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/zai-org-glm-4.7.toml
+++ b/providers/venice/models/zai-org-glm-4.7.toml
@@ -1,11 +1,12 @@
+# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "zhipuai/glm-4.7"
 name = "GLM 4.7"
 release_date = "2025-12-24"
 last_updated = "2026-06-11"
 structured_output = true
 
-# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/venice/models/zai-org-glm-5-1.toml
+++ b/providers/venice/models/zai-org-glm-5-1.toml
@@ -1,9 +1,10 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "zhipuai/glm-5.1"
 name = "GLM 5.1"
 last_updated = "2026-06-11"
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]

--- a/providers/venice/models/zai-org-glm-5-2.toml
+++ b/providers/venice/models/zai-org-glm-5-2.toml
@@ -1,9 +1,10 @@
+# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
+# https://api.venice.ai/api/v1/models?type=text
+
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
 release_date = "2026-06-16"
 last_updated = "2026-06-16"
-# Live metadata: reasoning only; no effort control or dedicated budget (2026-06-25).
-# https://api.venice.ai/api/v1/models?type=text
 reasoning_options = []
 
 [cost]

--- a/providers/venice/models/zai-org-glm-5.toml
+++ b/providers/venice/models/zai-org-glm-5.toml
@@ -1,11 +1,12 @@
+# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
+# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
+
 base_model = "zhipuai/glm-5"
 name = "GLM 5"
 release_date = "2026-02-11"
 last_updated = "2026-06-11"
 structured_output = true
 
-# Live /models (2026-06-25): none|low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
 values = ["none", "low", "medium", "high"]


### PR DESCRIPTION
## Problem

Sync PRs such as #3004 (Venice) silently deleted hand-authored comments that live **between** sections — e.g. the `# Live /models ...` citation block authored right before `[[reasoning_options]]`:

```
 base_model = "minimax/MiniMax-M2.5"
 name = "MiniMax M2.5"
 last_updated = "2026-06-11"

-# Live /models (2026-06-25): low|medium|high; no dedicated reasoning budget.
-# https://api.venice.ai/api/v1/models?type=text (accessed 2026-06-25)
 [[reasoning_options]]
 type = "effort"
```

The prior comment-preservation fix (#2973 / f07ac11f) only re-attaches the **leading** comment block at the very top of a file. The daily sync rewrites synced provider TOMLs by parsing (`Bun.TOML.parse`, which discards all comments) and re-serializing via `formatToml`, so any comment authored **inline** — before a top-level key or a table/array header — was lost on every rewrite that touched the file. This hit every synced provider that authors inline citations: Venice, Baseten, OVHcloud, Cloudflare Workers AI.

## Fix

Simpler than teaching the serializer to track inline comments: **move every existing inline comment to the top of its file** (one-time data migration) and document the rule in AGENTS.md. The existing leading-header preservation then keeps them across rewrites — no code change needed.

- Migrated **82** model files across Venice, Baseten, OVHcloud, and Cloudflare Workers AI: every comment run that appeared after the first key was moved into a single leading header block.
- Added a rule to `AGENTS.md` (Citations section): *"In-file comments must live at the top of the file ... comments placed between sections or above individual keys are silently deleted on the next sync run."*
- **No code change.** The existing `leadingComments()` preservation already handles top-of-file comments.

## Verification
- Every migrated file parses to **identical data** before and after (0 data mismatches) — only comment placement changed.
- Round-tripped all **1000** synced provider model files through the existing `formatToml` + `leadingComments` preservation: **0 comments lost**.
- `bun validate` passes; sync test suite passes.

## Sources
- Symptom: #3004 (Venice sync stripping `# Live /models ...` citations).
- Prior partial fix: #2973 (leading header only).
