### PR TITLE
feat: add Volcengine Agent Plan provider with 13 models

### DIFF
--- a/providers/volcengine-agent-plan/models/ark-code-latest.toml
+++ b/providers/volcengine-agent-plan/models/ark-code-latest.toml
@@ -1,0 +1,24 @@
+name = "ARK Code Latest"
+family = "ark"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/deepseek-v4-flash.toml
+++ b/providers/volcengine-agent-plan/models/deepseek-v4-flash.toml
@@ -1,0 +1,14 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 1_024_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/deepseek-v4-pro.toml
+++ b/providers/volcengine-agent-plan/models/deepseek-v4-pro.toml
@@ -1,0 +1,14 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 1_024_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/doubao-seed-2.0-code.toml
+++ b/providers/volcengine-agent-plan/models/doubao-seed-2.0-code.toml
@@ -1,0 +1,24 @@
+name = "Doubao Seed 2.0 Code"
+family = "doubao"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/doubao-seed-2.0-lite.toml
+++ b/providers/volcengine-agent-plan/models/doubao-seed-2.0-lite.toml
@@ -1,0 +1,24 @@
+name = "Doubao Seed 2.0 Lite"
+family = "doubao"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/doubao-seed-2.0-mini.toml
+++ b/providers/volcengine-agent-plan/models/doubao-seed-2.0-mini.toml
@@ -1,0 +1,24 @@
+name = "Doubao Seed 2.0 Mini"
+family = "doubao"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/doubao-seed-2.0-pro.toml
+++ b/providers/volcengine-agent-plan/models/doubao-seed-2.0-pro.toml
@@ -1,0 +1,24 @@
+name = "Doubao Seed 2.0 Pro"
+family = "doubao"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/glm-5.2.toml
+++ b/providers/volcengine-agent-plan/models/glm-5.2.toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5.2"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_024_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/glm-latest.toml
+++ b/providers/volcengine-agent-plan/models/glm-latest.toml
@@ -1,0 +1,24 @@
+name = "GLM Latest"
+family = "glm"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_024_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/kimi-k2.6.toml
+++ b/providers/volcengine-agent-plan/models/kimi-k2.6.toml
@@ -1,0 +1,16 @@
+base_model = "moonshotai/kimi-k2.6"
+base_model_omit = ["video"]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/kimi-k2.7-code.toml
+++ b/providers/volcengine-agent-plan/models/kimi-k2.7-code.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/minimax-m2.7.toml
+++ b/providers/volcengine-agent-plan/models/minimax-m2.7.toml
@@ -1,0 +1,15 @@
+base_model = "minimax/MiniMax-M2.7"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/minimax-m3.toml
+++ b/providers/volcengine-agent-plan/models/minimax-m3.toml
@@ -1,0 +1,15 @@
+base_model = "minimax/MiniMax-M3"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 512_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/provider.toml
+++ b/providers/volcengine-agent-plan/provider.toml
@@ -1,0 +1,5 @@
+name = "Volcengine Agent Plan"
+npm = "@ai-sdk/openai-compatible"
+env = ["VOLC_AGENT_PLAN_API_KEY"]
+api = "https://ark.cn-beijing.volces.com/api/plan/v3"
+doc = "https://www.volcengine.com/docs/82379"


### PR DESCRIPTION
## Summary

Add the **Volcengine Agent Plan** provider with 13 supported models.

Volcengine Agent Plan is a subscription-based AI service that provides access to a curated set of models through an OpenAI-compatible API at `https://ark.cn-beijing.volces.com/api/plan/v3`.

## Changes

- `providers/volcengine-agent-plan/provider.toml` — Provider metadata (name, API, env, docs)
- `providers/volcengine-agent-plan/models/` — 13 model definitions:

### Proprietary Volcengine models (full metadata)
| Model | Context | Modalities |
|-------|---------|------------|
| `ark-code-latest` | 256K | text, image → text |
| `glm-latest` | 1M | text → text |
| `doubao-seed-2.0-code` | 256K | text, image → text |
| `doubao-seed-2.0-pro` | 256K | text, image → text |
| `doubao-seed-2.0-lite` | 256K | text, image → text |
| `doubao-seed-2.0-mini` | 256K | text, image → text |

### Third-party models (inherit upstream metadata via `base_model`)
| Model | Base | Context | Modalities |
|-------|------|---------|------------|
| `glm-5.2` | `zhipuai/glm-5.2` | 1M | text → text |
| `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 1M | text → text |
| `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | 1M | text → text |
| `minimax-m2.7` | `minimax/MiniMax-M2.7` | 200K | text → text |
| `minimax-m3` | `minimax/MiniMax-M3` | 512K | text, image → text |
| `kimi-k2.6` | `moonshotai/kimi-k2.6` | 256K | text, image → text |
| `kimi-k2.7-code` | `moonshotai/kimi-k2.7-code` | 256K | text → text |

## Notes

- All models have `cost = 0` as the Agent Plan is subscription-based (same pattern as Alibaba Coding Plan, Z.AI Coding Plan, etc.)
- `kimi-k2.6` uses `base_model_omit = ["video"]` since Volcengine's plan does not support video input for this model
- The provider uses `@ai-sdk/openai-compatible` with the standard `/v1/chat/completions` endpoint