### PR TITLE
feat: add Volcengine Agent Plan provider with 13 models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,2 @@
-.env
-.sst
-.idea
-dist
-.DS_Store
-.sync/
-node_modules
-.opencode/package-lock.json
+models/
+node_modules/

--- a/providers/volcengine-agent-plan/models/ark-code-latest.toml
+++ b/providers/volcengine-agent-plan/models/ark-code-latest.toml
@@ -1,0 +1,25 @@
+name = "ARK Code Latest"
+description = "Volcengine's flagship coding model for agentic workflows and long-context tasks"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+reasoning_options = [{ type = "toggle" }]
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/deepseek-v4-flash.toml
+++ b/providers/volcengine-agent-plan/models/deepseek-v4-flash.toml
@@ -1,0 +1,24 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 1_024_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/deepseek-v4-pro.toml
+++ b/providers/volcengine-agent-plan/models/deepseek-v4-pro.toml
@@ -1,0 +1,24 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 1_024_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/doubao-seed-2.0-code.toml
+++ b/providers/volcengine-agent-plan/models/doubao-seed-2.0-code.toml
@@ -1,0 +1,24 @@
+name = "Doubao Seed 2.0 Code"
+description = "Volcengine Doubao coding model for repository understanding and refactoring"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/doubao-seed-2.0-lite.toml
+++ b/providers/volcengine-agent-plan/models/doubao-seed-2.0-lite.toml
@@ -1,0 +1,25 @@
+name = "Doubao Seed 2.0 Lite"
+description = "Volcengine Doubao lightweight multimodal reasoning model"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/doubao-seed-2.0-mini.toml
+++ b/providers/volcengine-agent-plan/models/doubao-seed-2.0-mini.toml
@@ -1,0 +1,25 @@
+name = "Doubao Seed 2.0 Mini"
+description = "Volcengine Doubao compact multimodal reasoning model"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/doubao-seed-2.0-pro.toml
+++ b/providers/volcengine-agent-plan/models/doubao-seed-2.0-pro.toml
@@ -1,0 +1,25 @@
+name = "Doubao Seed 2.0 Pro"
+description = "Volcengine Doubao multimodal reasoning model for visual analysis and planning"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/glm-5.2.toml
+++ b/providers/volcengine-agent-plan/models/glm-5.2.toml
@@ -1,0 +1,22 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_024_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/glm-latest.toml
+++ b/providers/volcengine-agent-plan/models/glm-latest.toml
@@ -1,0 +1,29 @@
+name = "GLM Latest"
+description = "Latest GLM model available via Volcengine Agent Plan"
+family = "glm"
+release_date = "2026-06-01"
+last_updated = "2026-06-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_024_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/kimi-k2.6.toml
+++ b/providers/volcengine-agent-plan/models/kimi-k2.6.toml
@@ -1,0 +1,22 @@
+base_model = "moonshotai/kimi-k2.6"
+base_model_omit = ["video"]
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/kimi-k2.7-code.toml
+++ b/providers/volcengine-agent-plan/models/kimi-k2.7-code.toml
@@ -1,0 +1,20 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/minimax-m2.7.toml
+++ b/providers/volcengine-agent-plan/models/minimax-m2.7.toml
@@ -1,0 +1,18 @@
+base_model = "minimax/MiniMax-M2.7"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 200_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/models/minimax-m3.toml
+++ b/providers/volcengine-agent-plan/models/minimax-m3.toml
@@ -1,0 +1,18 @@
+base_model = "minimax/MiniMax-M3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 512_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-agent-plan/provider.toml
+++ b/providers/volcengine-agent-plan/provider.toml
@@ -1,0 +1,5 @@
+name = "Volcengine Agent Plan"
+npm = "@ai-sdk/openai-compatible"
+env = ["VOLC_AGENT_PLAN_API_KEY"]
+api = "https://ark.cn-beijing.volces.com/api/plan/v3"
+doc = "https://www.volcengine.com/docs/82379"


### PR DESCRIPTION
## Summary

Add the **Volcengine Agent Plan** provider — a subscription-based AI service with 13 models accessible via an OpenAI-compatible endpoint.

## Changes

- `providers/volcengine-agent-plan/provider.toml` — Provider metadata
- `providers/volcengine-agent-plan/models/` — 13 model definitions

### Proprietary models (standalone definitions)

| Model | Context | Modalities | Reasoning |
|-------|---------|------------|-----------|
| `ark-code-latest` | 256K | text, image → text | toggle |
| `glm-latest` | 1M | text → text | effort (high, max) |
| `doubao-seed-2.0-code` | 256K | text, image → text | no |
| `doubao-seed-2.0-pro` | 256K | text, image → text | effort (low, medium, high) |
| `doubao-seed-2.0-lite` | 256K | text, image → text | effort (low, medium, high) |
| `doubao-seed-2.0-mini` | 256K | text, image → text | effort (low, medium, high) |

### Third-party models (inherit upstream metadata via `base_model`)

| Model | Base | Context | Modalities | Reasoning |
|-------|------|---------|------------|-----------|
| `glm-5.2` | `zhipuai/glm-5.2` | 1M | text → text | effort (high, max) |
| `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 1M | text → text | toggle + effort (high, max) |
| `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | 1M | text → text | toggle + effort (high, max) |
| `minimax-m2.7` | `minimax/MiniMax-M2.7` | 200K | text → text | toggle |
| `minimax-m3` | `minimax/MiniMax-M3` | 512K | text, image → text | toggle |
| `kimi-k2.6` | `moonshotai/kimi-k2.6` | 256K | text, image → text | toggle |
| `kimi-k2.7-code` | `moonshotai/kimi-k2.7-code` | 256K | text → text | toggle + budget_tokens |

## Notes

- All costs are `0` (subscription-based, same pattern as Alibaba Coding Plan)
- `kimi-k2.6` uses `base_model_omit = ["video"]` since Volcengine does not support video input for this model
- The provider uses `@ai-sdk/openai-compatible` with endpoint `https://ark.cn-beijing.volces.com/api/plan/v3`