### PR TITLE
feat(digitalocean): add GLM 5.1 and GLM 5.2

### DIFF
--- a/providers/digitalocean/models/glm-5.1.toml
+++ b/providers/digitalocean/models/glm-5.1.toml
@@ -1,5 +1,15 @@
-base_model = "zhipuai/glm-5.1"
+name = "GLM 5.1"
+description = "Strong GLM coding model for agentic engineering, terminals, and repository generation"
+family = "glm"
+release_date = "2026-04-07"
+last_updated = "2026-04-07"
+attachment = false
+reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -7,4 +17,11 @@ field = "reasoning_content"
 [cost]
 input = 0.975
 output = 4.30
-cache_read = 0.26
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/digitalocean/models/glm-5.1.toml
+++ b/providers/digitalocean/models/glm-5.1.toml
@@ -17,6 +17,7 @@ field = "reasoning_content"
 [cost]
 input = 0.975
 output = 4.30
+cache_read = 0.26
 
 [limit]
 context = 200_000

--- a/providers/digitalocean/models/glm-5.1.toml
+++ b/providers/digitalocean/models/glm-5.1.toml
@@ -1,15 +1,5 @@
-name = "GLM 5.1"
-description = "Strong GLM coding model for agentic engineering, terminals, and repository generation"
-family = "glm"
-release_date = "2026-04-07"
-last_updated = "2026-04-07"
-attachment = false
-reasoning = true
+base_model = "zhipuai/glm-5.1"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -18,11 +8,3 @@ field = "reasoning_content"
 input = 0.975
 output = 4.30
 cache_read = 0.26
-
-[limit]
-context = 200_000
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/digitalocean/models/glm-5.1.toml
+++ b/providers/digitalocean/models/glm-5.1.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.975
+output = 4.30
+cache_read = 0.26

--- a/providers/digitalocean/models/glm-5.1.toml
+++ b/providers/digitalocean/models/glm-5.1.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.1"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/digitalocean/models/glm-5.2.toml
+++ b/providers/digitalocean/models/glm-5.2.toml
@@ -1,15 +1,5 @@
-name = "GLM 5.2"
-description = "Open flagship GLM for long-horizon coding agents and million-token context work"
-family = "glm"
-release_date = "2026-06-13"
-last_updated = "2026-06-13"
-attachment = false
-reasoning = true
+base_model = "zhipuai/glm-5.2"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -18,11 +8,3 @@ field = "reasoning_content"
 input = 1.05
 output = 4.40
 cache_read = 0.21
-
-[limit]
-context = 1_000_000
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/digitalocean/models/glm-5.2.toml
+++ b/providers/digitalocean/models/glm-5.2.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.05
+output = 4.40
+cache_read = 0.21

--- a/providers/digitalocean/models/glm-5.2.toml
+++ b/providers/digitalocean/models/glm-5.2.toml
@@ -1,5 +1,15 @@
-base_model = "zhipuai/glm-5.2"
+name = "GLM 5.2"
+description = "Open flagship GLM for long-horizon coding agents and million-token context work"
+family = "glm"
+release_date = "2026-06-13"
+last_updated = "2026-06-13"
+attachment = false
+reasoning = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
 
 [interleaved]
 field = "reasoning_content"
@@ -7,4 +17,11 @@ field = "reasoning_content"
 [cost]
 input = 1.05
 output = 4.40
-cache_read = 0.21
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/digitalocean/models/glm-5.2.toml
+++ b/providers/digitalocean/models/glm-5.2.toml
@@ -17,6 +17,7 @@ field = "reasoning_content"
 [cost]
 input = 1.05
 output = 4.40
+cache_read = 0.21
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
## Summary

- Adds `glm-5.1` and `glm-5.2` to the DigitalOcean provider
- Both models use `base_model` to inherit from `zhipuai/glm-5.1` and `zhipuai/glm-5.2` respectively
- Reasoning options follow the DigitalOcean effort scale (`none|low|medium|high|max`) consistent with other reasoning models on this provider

## Pricing sources

- https://docs.digitalocean.com/products/inference/details/pricing/

| Model | Input | Output | Cache Read |
|-------|-------|--------|------------|
| GLM 5.1 | $0.975/1M | $4.30/1M | $0.26/1M |
| GLM 5.2 | $1.05/1M | $4.40/1M | $0.21/1M |

## Test plan

- [x] `bun validate` passes (verified locally — no errors)