### PR TITLE
fix(ci): preserve PRs updated after review

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -45,14 +45,57 @@ jobs:
             }
 
             for (const pull of pulls) {
-              const updatedAt = Date.parse(pull.updated_at)
+              let feedbackAt = 0
+              if (feedbackPulls.has(pull.number)) {
+                const [comments, reviews, reviewComments] = await Promise.all([
+                  github.paginate(github.rest.issues.listComments, {
+                    owner,
+                    repo,
+                    issue_number: pull.number,
+                    per_page: 100,
+                  }),
+                  github.paginate(github.rest.pulls.listReviews, {
+                    owner,
+                    repo,
+                    pull_number: pull.number,
+                    per_page: 100,
+                  }),
+                  github.paginate(github.rest.pulls.listReviewComments, {
+                    owner,
+                    repo,
+                    pull_number: pull.number,
+                    per_page: 100,
+                  }),
+                ])
+
+                const feedbackTimes = [
+                  ...comments
+                    .filter((comment) => comment.user?.login === process.env.REVIEWER)
+                    .map((comment) => Date.parse(comment.updated_at)),
+                  ...reviews
+                    .filter((review) => review.user?.login === process.env.REVIEWER && review.submitted_at)
+                    .map((review) => Date.parse(review.submitted_at)),
+                  ...reviewComments
+                    .filter((comment) => comment.user?.login === process.env.REVIEWER)
+                    .map((comment) => Date.parse(comment.updated_at)),
+                ]
+                feedbackAt = Math.max(0, ...feedbackTimes)
+              }
+
+              // Refetch after loading feedback so activity during this run cannot be missed.
+              const { data: currentPull } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pull.number,
+              })
+              const updatedAt = Date.parse(currentPull.updated_at)
               const monthStale = updatedAt < monthAgo
-              const feedbackStale = updatedAt < weekAgo && feedbackPulls.has(pull.number)
+              const feedbackStale = feedbackAt > 0 && feedbackAt < weekAgo && updatedAt <= feedbackAt
               if (!monthStale && !feedbackStale) continue
 
               const reason = monthStale
                 ? "it has not been updated in 30 days"
-                : `it has not been updated in 7 days after feedback from @${process.env.REVIEWER}`
+                : `it has not been updated since feedback from @${process.env.REVIEWER} was left 7 days ago`
 
               await github.rest.issues.createComment({
                 owner,


### PR DESCRIPTION
## Summary
- resolve the latest maintainer feedback timestamp from PR comments, reviews, and inline review comments
- only apply the 7-day feedback timeout when no PR activity happened after that feedback
- re-fetch each PR before closing to avoid racing concurrent contributor updates

## Incident
The July 4 stale run closed PRs based on whether they had ever received feedback and whether their overall update was older than seven days. This incorrectly closed #2798, #2696, #2677, #2674, #2616, and #2588 even though contributors had responded or pushed commits after the latest review. Those PRs have been reopened.

## Validation
- `bun validate`
- YAML parse validation
- `git diff --check`