### PR TITLE
chore: add citations to issue fixer PRs

### DIFF
--- a/.github/workflows/issue-fixer.yml
+++ b/.github/workflows/issue-fixer.yml
@@ -35,11 +35,12 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENCODE_PERMISSION: '{"bash":"deny"}'
         run: |
-          set -o pipefail
+          set -euo pipefail
+          EVENTS_FILE="$RUNNER_TEMP/issue-fixer-events.jsonl"
           RESPONSE_FILE="$RUNNER_TEMP/issue-fixer-response.md"
           echo "RESPONSE_FILE=$RESPONSE_FILE" >> "$GITHUB_ENV"
 
-          opencode run --agent issue-fixer -m opencode/glm-5.2 <<EOF | tee "$RESPONSE_FILE"
+          opencode run --agent issue-fixer -m opencode/glm-5.2 --format json <<EOF | tee "$EVENTS_FILE"
           A new GitHub issue was opened in anomalyco/models.dev.
 
           Issue #$ISSUE_NUMBER: $ISSUE_TITLE
@@ -53,6 +54,11 @@ jobs:
 
           If it is a feature request, a request to track a new kind of information, a question, or any miscellaneous non-catalog-data request, do not edit files. Respond briefly that it needs maintainer review and no automated fix was opened.
           EOF
+
+          if ! jq -ers 'map(select(.type == "text") | .part.text) | last | select(length > 0)' "$EVENTS_FILE" > "$RESPONSE_FILE"; then
+            echo "Issue fixer did not produce a final response." >&2
+            exit 1
+          fi
 
       - name: Check changed paths
         if: success()
@@ -69,8 +75,9 @@ jobs:
         if: success()
         env:
           BRANCH: issue-${{ github.event.issue.number }}
-          TITLE: "fix: #${{ github.event.issue.number }}"
         run: |
+          set -euo pipefail
+
           if [ -z "$(git status --porcelain)" ]; then
             if [ -s "$RESPONSE_FILE" ]; then
               gh issue comment "$ISSUE_NUMBER" --body-file "$RESPONSE_FILE"
@@ -82,7 +89,17 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$BRANCH"
           git add -A
+          TITLE="fix: ${ISSUE_TITLE:0:200}"
           git commit -m "$TITLE"
           git push origin "$BRANCH"
 
-          gh pr create --base dev --head "$BRANCH" --title "$TITLE" --body "Closes #$ISSUE_NUMBER"
+          PR_BODY="$RUNNER_TEMP/issue-fixer-pr-body.md"
+          {
+            cat "$RESPONSE_FILE"
+            echo
+            echo "Closes #$ISSUE_NUMBER"
+            echo
+            echo "Automated by the issue fixer: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          } > "$PR_BODY"
+
+          gh pr create --base dev --head "$BRANCH" --title "$TITLE" --body-file "$PR_BODY"

--- a/.opencode/agent/issue-fixer.md
+++ b/.opencode/agent/issue-fixer.md
@@ -27,12 +27,22 @@ When you do make a fix:
 
 - Follow `AGENTS.md` and the existing TOML conventions exactly.
 - Prefer the smallest correct change.
+- Verify every changed factual value against authoritative sources. Prefer first-party provider documentation, pricing pages, API references, model cards, or live provider catalog responses. Treat the issue as a lead, not sufficient verification by itself.
+- Do not broaden the issue's scope unless the additional changes are required for internal consistency and each one is independently verified.
 - Edit only `models/` and `providers/` TOML files.
 - Use `base_model` when appropriate instead of duplicating provider-agnostic metadata.
 - Preserve provider-specific fields in provider TOMLs.
-- Include source URLs in metadata fields when the schema/conventions require citations.
-- Do not run shell commands or use Bash. The workflow handles validation, commits, and pull request creation after you finish.
+- Put durable source URLs in a leading TOML comment block when adding or changing factual data. Never put source comments between TOML sections because sync serialization removes them.
+- Do not run shell commands or use Bash. The workflow handles commits and pull request creation after you finish. Do not claim validation unless you actually performed it.
 
 If the issue lacks enough source information to make a safe factual correction, do not guess and do not edit files. Reply with the specific missing information needed.
 
-Your final response should be concise. If you edited files, summarize the data changes and mention that the workflow will validate and open a pull request. If you did not edit files, explain why in one or two sentences.
+If you edited files, your final response becomes the pull request description. Write review-ready Markdown with these sections:
+
+- `## Summary`: explain the correction and why it is needed.
+- `## Changes`: list each material field change, including old and new values where applicable.
+- `## Evidence`: map each material claim or group of claims to a direct source URL and briefly state what that source establishes. Prefer first-party sources; clearly label any fallback source. Do not cite a search-results page or invent a URL.
+- `## Validation`: state what you actually verified. Do not claim commands or live API tests you did not run.
+- `## Review notes`: disclose ambiguities, assumptions, related changes intentionally left out, or write `None`.
+
+Make the evidence specific enough that a maintainer can review the diff without repeating the entire investigation. If you did not edit files, explain why in one or two sentences.


### PR DESCRIPTION
## Summary
- require the issue-fixer agent to verify changed facts against authoritative sources
- structure the agent final response as a citation-rich, review-ready PR description
- extract only the final OpenCode response from JSON events and use it as the PR body
- use descriptive issue-derived commit and PR titles

## Why
The agent run for #3025 produced a detailed report with first-party citations, but the workflow discarded it and opened #3026 with only `Closes #3025`. This preserves that research for reviewers.

## Validation
- workflow YAML parsed successfully
- issue-fixer agent definition loaded successfully
- `git diff --check`