### PR TITLE
Add Claude Fable 5 model for Xpersona

### DIFF
--- a/providers/xpersona/models/claude-fable-5.toml
+++ b/providers/xpersona/models/claude-fable-5.toml
@@ -1,9 +1,6 @@
 base_model = "anthropic/claude-fable-5"
 base_model_omit = ["cost.cache_write"]
-release_date = "2026-07-05"
-last_updated = "2026-07-05"
 attachment = false
-knowledge = "2025-12-30"
 interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
@@ -15,10 +12,6 @@ input = 3.00
 output = 18.00
 reasoning = 18.00
 cache_read = 0.30
-
-[limit]
-context = 1_000_000
-output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/xpersona/models/claude-fable-5.toml
+++ b/providers/xpersona/models/claude-fable-5.toml
@@ -6,6 +6,10 @@ attachment = false
 knowledge = "2025-12-30"
 interleaved = { field = "reasoning_content" }
 
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
 [cost]
 input = 3.00
 output = 18.00

--- a/providers/xpersona/models/claude-fable-5.toml
+++ b/providers/xpersona/models/claude-fable-5.toml
@@ -1,0 +1,27 @@
+name = "Claude Fable 5"
+description = "Premium coding model alias for deep repository work with extra-high reasoning"
+release_date = "2026-07-05"
+last_updated = "2026-07-05"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+temperature = false
+knowledge = "2025-12-30"
+tool_call = true
+structured_output = true
+open_weights = false
+interleaved = { field = "reasoning_content" }
+
+[cost]
+input = 3.00
+output = 18.00
+reasoning = 18.00
+cache_read = 0.30
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/xpersona/models/claude-fable-5.toml
+++ b/providers/xpersona/models/claude-fable-5.toml
@@ -1,6 +1,4 @@
 base_model = "anthropic/claude-fable-5"
-base_model_omit = ["cost.cache_write"]
-attachment = false
 interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]

--- a/providers/xpersona/models/claude-fable-5.toml
+++ b/providers/xpersona/models/claude-fable-5.toml
@@ -1,15 +1,9 @@
-name = "Claude Fable 5"
-description = "Premium coding model alias for deep repository work with extra-high reasoning"
+base_model = "anthropic/claude-fable-5"
+base_model_omit = ["cost.cache_write"]
 release_date = "2026-07-05"
 last_updated = "2026-07-05"
 attachment = false
-reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
-temperature = false
 knowledge = "2025-12-30"
-tool_call = true
-structured_output = true
-open_weights = false
 interleaved = { field = "reasoning_content" }
 
 [cost]


### PR DESCRIPTION
## Summary
- add providers/xpersona/models/claude-fable-5.toml
- expose Xpersona's new premium model alias as Claude Fable 5
- keep pricing and limits aligned with the live Xpersona premium route

## Notes
- This is a provider-specific Xpersona model entry, not a change to the existing Frieren or GPT-5.5 entries.
- Live Xpersona currently exposes claude-fable-5 on /v1/pricing with input=3.00, cache_read=0.30, and output=18.00.