### PR TITLE
feat(amazon-bedrock): add JP Claude Haiku 4.5 model

### DIFF
--- a/providers/amazon-bedrock/models/jp.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/amazon-bedrock/models/jp.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-haiku-4-5-20251001"
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+name = "Claude Haiku 4.5 (JP)"
+structured_output = true
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25


### PR DESCRIPTION
## Summary

- Adds `jp.anthropic.claude-haiku-4-5-20251001-v1:0.toml` — the JP-region Claude Haiku 4.5 variant, which was missing while all other JP Claude models (`jp.anthropic.claude-sonnet-4-5`, `jp.anthropic.claude-sonnet-4-6`, `jp.anthropic.claude-opus-4-7`, `jp.anthropic.claude-opus-4-8`, `jp.anthropic.claude-sonnet-5`) were already present.

## Validation

- Inherits via `base_model = "anthropic/claude-haiku-4-5-20251001"` — consistent with `au.*` and `us.*` variants.
- `bun validate` → exit 0, new entry resolves correctly.

## Evidence

- [AWS Bedrock supported models — JP region (ap-northeast-1)](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html): `jp.anthropic.claude-haiku-4-5-20251001-v1:0` listed as a supported cross-region inference profile.