### PR TITLE
fix(sync): skip unpriced DigitalOcean models

### DIFF
--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -406,7 +406,6 @@ export function buildDigitalOceanModel(
     reasoning: z.boolean(),
     tool_call: z.boolean(),
     open_weights: z.boolean(),
-    cost: z.object({ input: z.number(), output: z.number() }),
     limit: z.object({ context: z.number().positive(), output: z.number().positive() }),
     modalities: z.object({ input: z.array(z.string()).min(1), output: z.array(z.string()).min(1) }),
   }).safeParse(values);

--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -141,12 +141,11 @@ export const digitalocean = {
     const existing = context.existing(model.id);
     const contextWindow = number(model.context_window);
     const outputLimit = model.settings?.find((setting) => setting.name === "max_tokens")?.max;
+    if (model.pricing?.input === undefined || model.pricing.output === undefined) return undefined;
     if (
       existing === undefined
       && (
-        model.pricing?.input === undefined
-        || model.pricing.output === undefined
-        || contextWindow === undefined
+        contextWindow === undefined
         || contextWindow <= 0
         || outputLimit === undefined
         || outputLimit <= 0
@@ -406,6 +405,7 @@ export function buildDigitalOceanModel(
     reasoning: z.boolean(),
     tool_call: z.boolean(),
     open_weights: z.boolean(),
+    cost: z.object({ input: z.number(), output: z.number() }),
     limit: z.object({ context: z.number().positive(), output: z.number().positive() }),
     modalities: z.object({ input: z.array(z.string()).min(1), output: z.array(z.string()).min(1) }),
   }).safeParse(values);

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -201,19 +201,11 @@ test("syncs DigitalOcean pricing and preserves curated cache tiers", () => {
   });
 });
 
-test("preserves dedicated-only DigitalOcean models without token pricing", () => {
-  const model = buildDigitalOceanModel(digitalOceanModel({
-    id: "mistral-7b-instruct-v0.3",
-    name: "Mistral 7B Instruct v0.3",
-    thinking: false,
-    context_window: 32_768,
-    modalities: { input: ["text"], output: ["text"] },
-    settings: [{ name: "max_tokens", max: 8_192 }],
-    pricing: undefined,
-  }), {
+test("skips existing dedicated-only DigitalOcean models without token pricing", () => {
+  const existing = {
     name: "Mistral 7B Instruct v0.3",
     description: "Mistral model for multilingual chat and dedicated inference",
-    family: "mistral",
+    family: "mistral" as const,
     release_date: "2024-05-22",
     last_updated: "2024-05-22",
     attachment: false,
@@ -222,13 +214,22 @@ test("preserves dedicated-only DigitalOcean models without token pricing", () =>
     tool_call: true,
     open_weights: true,
     limit: { context: 32_768, output: 32_768 },
+    modalities: { input: ["text" as const], output: ["text" as const] },
+  };
+  const translated = digitalocean.translateModel(digitalOceanModel({
+    id: "mistral-7b-instruct-v0.3",
+    name: "Mistral 7B Instruct v0.3",
+    thinking: false,
+    context_window: 32_768,
     modalities: { input: ["text"], output: ["text"] },
+    settings: [{ name: "max_tokens", max: 8_192 }],
+    pricing: undefined,
+  }), {
+    existing: () => existing,
+    authored: () => existing,
   });
 
-  expect("cost" in model ? model.cost : undefined).toBeUndefined();
-  expect(model).toMatchObject({
-    limit: { context: 32_768, output: 8_192 },
-  });
+  expect(translated).toBeUndefined();
 });
 
 test("filters unmanaged DigitalOcean models and joins pricing names", () => {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -201,6 +201,36 @@ test("syncs DigitalOcean pricing and preserves curated cache tiers", () => {
   });
 });
 
+test("preserves dedicated-only DigitalOcean models without token pricing", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    id: "mistral-7b-instruct-v0.3",
+    name: "Mistral 7B Instruct v0.3",
+    thinking: false,
+    context_window: 32_768,
+    modalities: { input: ["text"], output: ["text"] },
+    settings: [{ name: "max_tokens", max: 8_192 }],
+    pricing: undefined,
+  }), {
+    name: "Mistral 7B Instruct v0.3",
+    description: "Mistral model for multilingual chat and dedicated inference",
+    family: "mistral",
+    release_date: "2024-05-22",
+    last_updated: "2024-05-22",
+    attachment: false,
+    reasoning: false,
+    temperature: true,
+    tool_call: true,
+    open_weights: true,
+    limit: { context: 32_768, output: 32_768 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect("cost" in model ? model.cost : undefined).toBeUndefined();
+  expect(model).toMatchObject({
+    limit: { context: 32_768, output: 8_192 },
+  });
+});
+
 test("filters unmanaged DigitalOcean models and joins pricing names", () => {
   const models = parseDigitalOceanModels({
     models: [


### PR DESCRIPTION
## Summary
- skip DigitalOcean models when the authoritative pricing feed has no input/output token rates
- retain existing skipped models unchanged because DigitalOcean sync uses `deleteMissing: false`
- continue requiring complete pricing before translating or creating any model
- cover the dedicated-only Mistral 7B case that broke scheduled sync

DigitalOcean lists `mistral-7b-instruct-v0.3` for dedicated inference only. Dedicated deployments are billed per GPU-hour, so it is absent from the serverless token pricing feed and should remain outside sync management.

Priced models continue to be translated normally, so pricing changes are still tracked.

## Testing
- `bun test packages/core/test/sync.test.ts` (27 pass)
- `bun validate`
- `git diff --check`

## References
- Failed run: https://github.com/anomalyco/models.dev/actions/runs/28815668368/job/85454376010
- Model availability: https://docs.digitalocean.com/products/inference/details/models/
- Pricing: https://docs.digitalocean.com/products/inference/details/pricing/