### PR TITLE
fix(sync): allow zero limits for DigitalOcean image models

### DIFF
--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -211,10 +211,7 @@ export function parseDigitalOceanModels(raw: unknown): DigitalOceanSourceModel[]
 
 function isManagedTextModel(model: DigitalOceanModel) {
   const output = normalizeModalities(model.modalities?.output ?? [], []);
-  return output.length === 1
-    && output[0] === "text"
-    && model.type !== "embedding"
-    && model.type !== "reranking";
+  return output.includes("text") && model.type !== "embedding" && model.type !== "reranking";
 }
 
 function pricingName(value: string) {
@@ -409,7 +406,7 @@ export function buildDigitalOceanModel(
     tool_call: z.boolean(),
     open_weights: z.boolean(),
     cost: z.object({ input: z.number(), output: z.number() }),
-    limit: z.object({ context: z.number().positive(), output: z.number().positive() }),
+    limit: z.object({ context: z.number().nonnegative(), output: z.number().nonnegative() }),
     modalities: z.object({ input: z.array(z.string()).min(1), output: z.array(z.string()).min(1) }),
   }).safeParse(values);
   if (!required.success) {

--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -211,7 +211,10 @@ export function parseDigitalOceanModels(raw: unknown): DigitalOceanSourceModel[]
 
 function isManagedTextModel(model: DigitalOceanModel) {
   const output = normalizeModalities(model.modalities?.output ?? [], []);
-  return output.includes("text") && model.type !== "embedding" && model.type !== "reranking";
+  return output.length === 1
+    && output[0] === "text"
+    && model.type !== "embedding"
+    && model.type !== "reranking";
 }
 
 function pricingName(value: string) {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -232,16 +232,44 @@ test("skips existing dedicated-only DigitalOcean models without token pricing", 
   expect(translated).toBeUndefined();
 });
 
+test("syncs existing DigitalOcean image models with zero token limits", () => {
+  const existing = {
+    name: "GPT Image 1.5",
+    description: "Image generation model",
+    family: "gpt-image" as const,
+    release_date: "2025-11-25",
+    last_updated: "2025-11-25",
+    attachment: true,
+    reasoning: false,
+    temperature: false,
+    tool_call: false,
+    open_weights: false,
+    cost: { input: 5, output: 10 },
+    limit: { context: 0, output: 0 },
+    modalities: { input: ["text" as const, "image" as const], output: ["image" as const] },
+  };
+  const translated = digitalocean.translateModel(digitalOceanModel({
+    id: "openai-gpt-image-1.5",
+    name: "GPT Image 1.5",
+    context_window: undefined,
+    modalities: { input: ["text", "image"], output: ["text", "image"] },
+    settings: [],
+    pricing: { input: 6, output: 12 },
+  }), {
+    existing: () => existing,
+    authored: () => existing,
+  });
+
+  expect(translated?.model).toMatchObject({
+    cost: { input: 6, output: 12 },
+    limit: { context: 0, output: 0 },
+  });
+});
+
 test("filters unmanaged DigitalOcean models and joins pricing names", () => {
   const models = parseDigitalOceanModels({
     models: [
       digitalOceanModel({ id: "kimi-k2.5", name: "Kimi K2", pricing: undefined }),
-      digitalOceanModel({
-        id: "openai-gpt-image-1.5",
-        name: "GPT Image 1.5",
-        modalities: { input: ["text", "image"], output: ["text", "image"] },
-        pricing: undefined,
-      }),
       digitalOceanModel({
         id: "bge-m3",
         name: "BGE M3",

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -237,6 +237,12 @@ test("filters unmanaged DigitalOcean models and joins pricing names", () => {
     models: [
       digitalOceanModel({ id: "kimi-k2.5", name: "Kimi K2", pricing: undefined }),
       digitalOceanModel({
+        id: "openai-gpt-image-1.5",
+        name: "GPT Image 1.5",
+        modalities: { input: ["text", "image"], output: ["text", "image"] },
+        pricing: undefined,
+      }),
+      digitalOceanModel({
         id: "bge-m3",
         name: "BGE M3",
         type: "embedding",


### PR DESCRIPTION
## Summary
- allow existing DigitalOcean image models to retain valid zero token limits
- continue syncing their API pricing and metadata
- keep the positive-limit requirement for newly discovered models in `translateModel`
- add regression coverage for `openai-gpt-image-1.5`

## Verification
- `bun test packages/core/test/sync.test.ts` (28 pass)
- `bun validate`
- `git diff --check`

## Context
Fresh post-merge sync exposed `openai-gpt-image-1.5` as the next failure: https://github.com/anomalyco/models.dev/actions/runs/28821893392/job/85475415677