### PR TITLE
feat(providers): add byNara router

### DIFF
--- a/providers/bynara/logo.svg
+++ b/providers/bynara/logo.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg viewBox="0 0 473 473" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-3070.817135,-2716)">
+        <g id="Artboard4" transform="matrix(1.079611,0,0,1.028581,-965.884905,-72.932771)">
+            <rect x="3739.035" y="2711.438" width="437.603" height="459.313" style="fill:none;"/>
+            <clipPath id="_clip1">
+                <rect x="3739.035" y="2711.438" width="437.603" height="459.313"/>
+            </clipPath>
+            <g clip-path="url(#_clip1)">
+                <g id="shape-logo-light" serif:id="shape logo light" transform="matrix(1.013818,0,0,1.064116,3509.768502,2365.934293)">
+                    <g transform="matrix(0.998275,0,0,1.884605,1.333891,-407.618686)">
+                        <path d="M309.838,459.551L309.838,575.795L225.197,607.189L225.197,429.444C225.197,429.444 237.642,421.233 254.161,427.814L309.838,459.551Z" fill="currentColor"/>
+                    </g>
+                    <g transform="matrix(0.896457,0,0,2.115238,380.024228,-579.593284)">
+                        <path d="M225.197,570.014L225.197,453.454L309.838,428.337L309.838,608.616L225.197,570.014Z" fill="currentColor"/>
+                    </g>
+                    <g transform="matrix(0.896457,0,0,1.412823,284.610478,-231.401617)">
+                        <path d="M225.197,534.369L225.197,479.736L309.838,442.13L309.838,592.076L270.199,565.01L270.131,565.051L225.197,534.369Z" fill="currentColor"/>
+                    </g>
+                    <g transform="matrix(0.73128,-0.679547,1.864373,2.006305,-718.524466,-318.806393)">
+                        <path d="M225.28,607.88C225.225,607.627 225.197,607.37 225.197,607.111L225.197,433.872C221.552,426.456 201.884,427.507 201.884,427.507C208.076,425.233 209.419,425.696 222.023,425.22C222.023,425.22 238.812,424.558 251.435,424.308L283.599,424.308C298.081,424.308 309.838,428.593 309.838,433.872L309.838,546.413L309.922,546.413L309.922,616.65L249.531,616.65C236.635,616.312 226.307,612.571 225.28,607.88Z" fill="currentColor"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/providers/bynara/models/claude-fable-5.toml
+++ b/providers/bynara/models/claude-fable-5.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-fable-5"
+reasoning = false
+
+[cost]
+input = 10
+output = 50

--- a/providers/bynara/models/claude-opus-4.7.toml
+++ b/providers/bynara/models/claude-opus-4.7.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-opus-4-7"
+reasoning = false
+
+[cost]
+input = 0
+output = 25

--- a/providers/bynara/models/claude-opus-4.8.toml
+++ b/providers/bynara/models/claude-opus-4.8.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-opus-4-8"
+reasoning = false
+
+[cost]
+input = 4
+output = 25

--- a/providers/bynara/models/claude-sonnet-4.5.toml
+++ b/providers/bynara/models/claude-sonnet-4.5.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-sonnet-4-5"
+reasoning = false
+
+[cost]
+input = 3
+output = 15

--- a/providers/bynara/models/claude-sonnet-5.toml
+++ b/providers/bynara/models/claude-sonnet-5.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning = false
+
+[cost]
+input = 2
+output = 10

--- a/providers/bynara/models/deepseek-v4-flash.toml
+++ b/providers/bynara/models/deepseek-v4-flash.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 1000000 }]
+
+[cost]
+input = 0.09
+output = 0.18
+reasoning = 0.18

--- a/providers/bynara/models/deepseek-v4-pro.toml
+++ b/providers/bynara/models/deepseek-v4-pro.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-pro"
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 1000000 }]
+
+[cost]
+input = 0.435
+output = 0.87
+reasoning = 0.87

--- a/providers/bynara/models/glm-5.1.toml
+++ b/providers/bynara/models/glm-5.1.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5.1"
+reasoning = false
+
+[cost]
+input = 0.98
+output = 3.08

--- a/providers/bynara/models/glm-5.2.toml
+++ b/providers/bynara/models/glm-5.2.toml
@@ -1,0 +1,8 @@
+base_model = "zhipuai/glm-5.2"
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 1000000 }]
+
+[cost]
+input = 0.98
+output = 3.08
+reasoning = 3.08

--- a/providers/bynara/models/gpt-5.4.toml
+++ b/providers/bynara/models/gpt-5.4.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4"
+reasoning = false
+
+[cost]
+input = 2.5
+output = 15

--- a/providers/bynara/models/gpt-5.5.toml
+++ b/providers/bynara/models/gpt-5.5.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.5"
+reasoning = false
+
+[cost]
+input = 5
+output = 30

--- a/providers/bynara/models/kimi-k2.6.toml
+++ b/providers/bynara/models/kimi-k2.6.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.6"
+reasoning = false
+
+[cost]
+input = 0.66
+output = 3.41

--- a/providers/bynara/models/kimi-k2.7-code.toml
+++ b/providers/bynara/models/kimi-k2.7-code.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 262000 }]
+
+[cost]
+input = 0.68
+output = 3.41
+reasoning = 3.41

--- a/providers/bynara/models/mimo-v2.5-pro-ultraspeed.toml
+++ b/providers/bynara/models/mimo-v2.5-pro-ultraspeed.toml
@@ -1,0 +1,8 @@
+base_model = "xiaomi/mimo-v2.5-pro-ultraspeed"
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 1000000 }]
+
+[cost]
+input = 0.435
+output = 0.87
+reasoning = 0.87

--- a/providers/bynara/models/mimo-v2.5-pro.toml
+++ b/providers/bynara/models/mimo-v2.5-pro.toml
@@ -1,0 +1,8 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 1000000 }]
+
+[cost]
+input = 0.435
+output = 0.87
+reasoning = 0.87

--- a/providers/bynara/models/mimo-v2.5.toml
+++ b/providers/bynara/models/mimo-v2.5.toml
@@ -1,0 +1,8 @@
+base_model = "xiaomi/mimo-v2.5"
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 1000000 }]
+
+[cost]
+input = 0.14
+output = 0.28
+reasoning = 0.28

--- a/providers/bynara/models/minimax-m3.toml
+++ b/providers/bynara/models/minimax-m3.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M3"
+reasoning = false
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/bynara/models/mistral-large.toml
+++ b/providers/bynara/models/mistral-large.toml
@@ -1,0 +1,6 @@
+base_model = "mistral/mistral-large-latest"
+reasoning = false
+
+[cost]
+input = 0.5
+output = 1.5

--- a/providers/bynara/models/mistral-medium-3-5.toml
+++ b/providers/bynara/models/mistral-medium-3-5.toml
@@ -1,0 +1,6 @@
+base_model = "mistral/mistral-medium-2604"
+reasoning = false
+
+[cost]
+input = 1.5
+output = 7.5

--- a/providers/bynara/provider.toml
+++ b/providers/bynara/provider.toml
@@ -1,0 +1,6 @@
+name = "byNara"
+# OpenAI-compatible router gateway. Use a byNara API key.
+npm = "@ai-sdk/openai-compatible"
+env = ["BYNARA_API_KEY"]
+api = "https://router.bynara.id/v1"
+doc = "https://bynara.id/products"


### PR DESCRIPTION
Add byNara as an OpenAI-compatible provider served by https://router.bynara.id/v1.

Includes 19 public model aliases sourced from the live pricing endpoint (router.bynara.id/api/pricing), mapped to existing canonical model metadata where available, with byNara-specific costs from the endpoint.'\''s OpenRouter USD reference fields.

- Provider TOML + logo.svg (currentColor)
- 19 model TOMLs using base_model inheritance

Co-authored-by: ByNara <admin@bynara.id>