### PR TITLE
feat(opencode): add Hy3 Free model

### DIFF
--- a/providers/opencode/models/hy3-free.toml
+++ b/providers/opencode/models/hy3-free.toml
@@ -1,0 +1,24 @@
+name = "Hy3 Free"
+description = "Tencent Hy reasoning model for coding, instruction following, and agent tasks"
+family = "hy3-free"
+release_date = "2026-06-26"
+last_updated = "2026-06-26"
+attachment = false
+reasoning = true
+reasoning_options = []
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 256_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary
- add the Hy3 Free model to the OpenCode provider
- configure free pricing, 256K context, and 64K output limits
- declare reasoning support with no exposed reasoning controls

## Validation
- `bun validate`
- `git diff --check`