### PR TITLE
Add Model Oracle AI provider

### DIFF
--- a/providers/model-oracle-ai/logo.svg
+++ b/providers/model-oracle-ai/logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M4.55 10.3a7.7 7.7 0 0 1 14.9 0M19.45 13.7a7.7 7.7 0 0 1-14.9 0" stroke="currentColor" stroke-width="1.55" stroke-linecap="round"/>
+  <circle cx="3.35" cy="12" r="1.45" fill="currentColor"/>
+  <circle cx="20.65" cy="12" r="1.45" fill="currentColor"/>
+  <circle cx="12" cy="20.65" r="1.45" fill="currentColor"/>
+  <path d="M12 4.85 17.05 7.8 12 10.75 6.95 7.8 12 4.85Z" fill="currentColor"/>
+  <path d="M6.65 8.95 11.25 11.65v6.1l-4.6-2.7v-6.1Z" fill="currentColor"/>
+  <path d="M17.35 8.95 12.75 11.65v6.1l4.6-2.7v-6.1Z" fill="currentColor"/>
+  <path d="M3.35 12h3.3M17.35 12h3.3M12 17.75v2.9" stroke="currentColor" stroke-width="1.05" stroke-linecap="round"/>
+  <circle cx="12" cy="12" r=".95" fill="currentColor"/>
+</svg>

--- a/providers/model-oracle-ai/models/auto.toml
+++ b/providers/model-oracle-ai/models/auto.toml
@@ -1,0 +1,19 @@
+name = "Auto"
+description = "Model Oracle AI decision engine that selects and routes among configured coding-agent models"
+release_date = "2026-06-29"
+last_updated = "2026-07-07"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/model-oracle-ai/models/claude-fable-5.toml
+++ b/providers/model-oracle-ai/models/claude-fable-5.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/model-oracle-ai/models/claude-haiku-4.5.toml
+++ b/providers/model-oracle-ai/models/claude-haiku-4.5.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/model-oracle-ai/models/claude-opus-4.8.toml
+++ b/providers/model-oracle-ai/models/claude-opus-4.8.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/model-oracle-ai/models/claude-sonnet-5.toml
+++ b/providers/model-oracle-ai/models/claude-sonnet-5.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/model-oracle-ai/models/deepseek-v4-pro.toml
+++ b/providers/model-oracle-ai/models/deepseek-v4-pro.toml
@@ -1,0 +1,5 @@
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/model-oracle-ai/models/glm-5.2.toml
+++ b/providers/model-oracle-ai/models/glm-5.2.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "high", "xhigh"] }]
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/model-oracle-ai/models/gpt-4.1-mini.toml
+++ b/providers/model-oracle-ai/models/gpt-4.1-mini.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4.1-mini"

--- a/providers/model-oracle-ai/models/gpt-4.1.toml
+++ b/providers/model-oracle-ai/models/gpt-4.1.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4.1"

--- a/providers/model-oracle-ai/models/gpt-5.4-mini.toml
+++ b/providers/model-oracle-ai/models/gpt-5.4-mini.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]

--- a/providers/model-oracle-ai/models/gpt-5.4-nano.toml
+++ b/providers/model-oracle-ai/models/gpt-5.4-nano.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]

--- a/providers/model-oracle-ai/models/gpt-5.4.toml
+++ b/providers/model-oracle-ai/models/gpt-5.4.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]

--- a/providers/model-oracle-ai/models/gpt-5.5.toml
+++ b/providers/model-oracle-ai/models/gpt-5.5.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]

--- a/providers/model-oracle-ai/models/gpt-5.toml
+++ b/providers/model-oracle-ai/models/gpt-5.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]

--- a/providers/model-oracle-ai/models/o4-mini.toml
+++ b/providers/model-oracle-ai/models/o4-mini.toml
@@ -1,0 +1,2 @@
+base_model = "openai/o4-mini"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-oracle-ai/provider.toml
+++ b/providers/model-oracle-ai/provider.toml
@@ -1,0 +1,9 @@
+# OpenAI-compatible endpoint and public model aliases:
+# https://modeloracle.com/setup/ (accessed 2026-07-07)
+# API contract and routing behavior:
+# https://github.com/anomalyco/ai-control-plane/blob/main/docs/api.md
+name = "Model Oracle AI"
+env = ["MODEL_ORACLE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.modeloracle.com/api/v1"
+doc = "https://modeloracle.com/setup/"


### PR DESCRIPTION
## Summary
- Add Model Oracle AI as an OpenAI-compatible provider using the `model-oracle-ai` ID
- Add a monochrome SVG provider logo based on the Model Oracle AI marketing mark
- Add the documented Model Oracle AI model aliases, including `auto` for the decision engine

## Sources
- https://modeloracle.com/setup/
- https://github.com/anomalyco/ai-control-plane/blob/main/docs/api.md

## Validation
- `npx --yes bun validate`