### PR TITLE
feat(google-vertex-anthropic): add Anthropic Vertex SDK env vars

### DIFF
--- a/providers/google-vertex-anthropic/provider.toml
+++ b/providers/google-vertex-anthropic/provider.toml
@@ -1,4 +1,4 @@
 name = "Vertex (Anthropic)"
-env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]
+env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS", "ANTHROPIC_VERTEX_PROJECT_ID", "CLOUD_ML_REGION"]
 npm = "@ai-sdk/google-vertex/anthropic"
 doc = "https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude"


### PR DESCRIPTION
Add `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` to the `google-vertex-anthropic` provider env detection.

These are the environment variables used by [Claude Code](https://code.claude.com/docs/en/google-vertex-ai) and the Anthropic Vertex SDK to configure the GCP project and region. Users who already have these set (e.g. from running Claude Code) currently don't get the `google-vertex-anthropic` provider auto-detected because the env list only includes the generic Google Cloud variables (`GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION`, `GOOGLE_APPLICATION_CREDENTIALS`).

Source: [Claude Code - Google Vertex AI setup](https://code.claude.com/docs/en/google-vertex-ai)
