### PR TITLE
feat(xai): add Grok 4.5

### DIFF
--- a/models/xai/grok-4.5.toml
+++ b/models/xai/grok-4.5.toml
@@ -1,0 +1,19 @@
+name = "Grok 4.5"
+description = "xAI's latest Grok for chat, coding, agentic tools, and lower hallucination risk"
+family = "grok"
+release_date = "2026-07-08"
+last_updated = "2026-07-08"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 500_000
+output = 500_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/models/xai/grok-4.5.toml
+++ b/models/xai/grok-4.5.toml
@@ -15,5 +15,5 @@ context = 500_000
 output = 500_000
 
 [modalities]
-input = ["text", "image", "pdf"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/xai/models/grok-4.3.toml
+++ b/providers/xai/models/grok-4.3.toml
@@ -1,5 +1,5 @@
 name = "Grok 4.3"
-description = "xAI's default Grok for chat, coding, agentic tools, and lower hallucination risk"
+description = "xAI's Grok for chat, coding, agentic tools, and lower hallucination risk"
 family = "grok"
 release_date = "2026-04-17"
 last_updated = "2026-04-17"

--- a/providers/xai/models/grok-4.5.toml
+++ b/providers/xai/models/grok-4.5.toml
@@ -8,3 +8,9 @@ values = ["low", "medium", "high"]
 input = 2.0
 output = 6.0
 cache_read = 0.5
+
+[[cost.tiers]]
+tier = { size = 200_000 }
+input = 4.0
+output = 12.0
+cache_read = 1.0

--- a/providers/xai/models/grok-4.5.toml
+++ b/providers/xai/models/grok-4.5.toml
@@ -1,0 +1,10 @@
+base_model = "xai/grok-4.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2.0
+output = 6.0
+cache_read = 0.5


### PR DESCRIPTION
## Summary

- add canonical Grok 4.5 model metadata
- add xAI pricing and supported reasoning effort controls
- remove the obsolete default designation from Grok 4.3

## Evidence

- [xAI Grok 4.5 model card](https://docs.x.ai/developers/models/grok-4.5) documents the 500K context window, text/image input, function calling, structured outputs, reasoning support, and $2.00 input / $0.50 cached input / $6.00 output pricing.
- [xAI reasoning documentation](https://docs.x.ai/developers/model-capabilities/text/reasoning) documents `low`, `medium`, and `high` reasoning effort for `grok-4.5` and states that reasoning cannot be disabled.

## Validation

- `bun validate`
- `git diff --check`