### PR TITLE
fix(xai): preserve factored model metadata in sync

### DIFF
--- a/packages/core/src/sync/providers/xai.ts
+++ b/packages/core/src/sync/providers/xai.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 import { describeModel } from "../../describe.js";
-import type { ExistingModel, SyncProvider, SyncedModel } from "../index.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel } from "./openrouter.js";
 
 const API_BASE = "https://api.x.ai/v1";
 
@@ -188,9 +189,7 @@ export function buildXAIModel(model: XAIModel, existing: ExistingModel): SyncedM
   const output = modalities(model.output_modalities, existing.modalities?.output ?? ["text"]);
   const created = dateFromTimestamp(model.created);
 
-  return {
-    base_model: existing.base_model,
-    base_model_omit: existing.base_model_omit,
+  const values = {
     name,
     description: description ?? describeModel({
       id: model.id,
@@ -227,5 +226,9 @@ export function buildXAIModel(model: XAIModel, existing: ExistingModel): SyncedM
       output: limit.output,
     },
     modalities: { input, output },
-  };
+  } satisfies SyncedFullModel;
+
+  return existing.base_model === undefined
+    ? values
+    : factorBaseModel(existing.base_model, values, values.limit, existing.base_model_omit);
 }

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -21,6 +21,7 @@ import {
 import { buildOpenRouterModel, openrouter, type OpenRouterModel } from "../src/sync/providers/openrouter.js";
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
 import { openai, parseOpenAIModels } from "../src/sync/providers/openai.js";
+import { buildXAIModel } from "../src/sync/providers/xai.js";
 
 function anthropicModel(overrides: Partial<AnthropicModel> = {}): AnthropicModel {
   return {
@@ -382,6 +383,58 @@ test("new DigitalOcean base models inherit intrinsic capabilities", () => {
   expect(model).not.toHaveProperty("knowledge");
   expect(model).not.toHaveProperty("reasoning");
   expect(model).not.toHaveProperty("temperature");
+});
+
+test("xAI sync factors inherited base model fields", () => {
+  const model = buildXAIModel(
+    {
+      id: "grok-4.5",
+      created: Date.parse("2026-07-08T00:00:00Z") / 1000,
+      input_modalities: ["text", "image"],
+      output_modalities: ["text"],
+      prompt_text_token_price: 20_000,
+      cached_prompt_text_token_price: 5_000,
+      completion_text_token_price: 60_000,
+      max_prompt_length: 500_000,
+    },
+    {
+      base_model: "xai/grok-4.5",
+      name: "Grok 4.5",
+      description: "xAI's latest Grok for chat, coding, agentic tools, and lower hallucination risk",
+      family: "grok",
+      release_date: "2026-07-08",
+      last_updated: "2026-07-08",
+      attachment: true,
+      reasoning: true,
+      reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+      temperature: true,
+      tool_call: true,
+      structured_output: true,
+      open_weights: false,
+      cost: {
+        input: 2,
+        output: 6,
+        cache_read: 0.5,
+        tiers: [{ tier: { size: 200_000 }, input: 4, output: 12, cache_read: 1 }],
+      },
+      limit: { context: 500_000, output: 500_000 },
+      modalities: { input: ["text", "image"], output: ["text"] },
+    },
+  );
+
+  expect(model).toMatchObject({
+    base_model: "xai/grok-4.5",
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+    cost: {
+      input: 2,
+      output: 6,
+      cache_read: 0.5,
+      tiers: [{ tier: { size: 200_000 }, input: 4, output: 12, cache_read: 1 }],
+    },
+  });
+  expect(model).not.toHaveProperty("name");
+  expect(model).not.toHaveProperty("family");
+  expect(model).not.toHaveProperty("limit");
 });
 
 test("skips new DigitalOcean models with incomplete pricing or limits", () => {


### PR DESCRIPTION
## Summary

- factor xAI sync output against existing `base_model` metadata
- retain only provider-specific and API-authoritative overrides in synced TOML
- add a Grok 4.5 regression test covering the expansion seen in #3114

## Validation

- `bun test packages/core/test/sync.test.ts`
- `bun validate`
- `git diff --check`

Fixes the sync output demonstrated by #3114.