### PR TITLE
fix(xai): preserve curated model dates in sync

### DIFF
--- a/packages/core/src/sync/providers/xai.ts
+++ b/packages/core/src/sync/providers/xai.ts
@@ -119,10 +119,6 @@ async function fetchTypedModels(key: string, endpoint: string) {
   return XAIModelList.parse(await response.json()).models;
 }
 
-function dateFromTimestamp(timestamp: number) {
-  return new Date(timestamp * 1000).toISOString().slice(0, 10);
-}
-
 type Modality = "text" | "audio" | "image" | "video" | "pdf";
 
 function modalities(values: string[] | undefined, fallback: Modality[]) {
@@ -179,15 +175,14 @@ export function buildXAIModel(model: XAIModel, existing: ExistingModel): SyncedM
     || toolCall === undefined
     || openWeights === undefined
     || limit === undefined
-    || (model.canonical_id !== undefined && releaseDate === undefined)
-    || (model.canonical_id !== undefined && lastUpdated === undefined)
+    || releaseDate === undefined
+    || lastUpdated === undefined
   ) {
     throw new Error(`xAI model ${model.id} has incomplete local TOML metadata required for sync`);
   }
 
   const input = modalities(model.input_modalities, existing.modalities?.input ?? ["text"]);
   const output = modalities(model.output_modalities, existing.modalities?.output ?? ["text"]);
-  const created = dateFromTimestamp(model.created);
 
   const values = {
     name,
@@ -207,8 +202,8 @@ export function buildXAIModel(model: XAIModel, existing: ExistingModel): SyncedM
       modalities: { input, output },
     }),
     family: existing.family,
-    release_date: model.canonical_id === undefined ? created : releaseDate!,
-    last_updated: model.canonical_id === undefined ? created : lastUpdated!,
+    release_date: releaseDate,
+    last_updated: lastUpdated,
     attachment: input.some((value) => value !== "text"),
     reasoning,
     reasoning_options: existing.reasoning_options,

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -389,7 +389,7 @@ test("xAI sync factors inherited base model fields", () => {
   const model = buildXAIModel(
     {
       id: "grok-4.5",
-      created: Date.parse("2026-07-08T00:00:00Z") / 1000,
+      created: Date.parse("2026-06-29T00:00:00Z") / 1000,
       input_modalities: ["text", "image"],
       output_modalities: ["text"],
       prompt_text_token_price: 20_000,
@@ -434,6 +434,8 @@ test("xAI sync factors inherited base model fields", () => {
   });
   expect(model).not.toHaveProperty("name");
   expect(model).not.toHaveProperty("family");
+  expect(model).not.toHaveProperty("release_date");
+  expect(model).not.toHaveProperty("last_updated");
   expect(model).not.toHaveProperty("limit");
 });
 


### PR DESCRIPTION
## Summary

- stop treating the xAI Models API internal `created` timestamp as the public release date
- preserve curated `release_date` and `last_updated` values for update-only xAI sync entries
- extend the Grok 4.5 regression test with the mismatching June 29 API timestamp from #3118

## Validation

- `bun test packages/core/test/sync.test.ts`
- `bun validate`
- `git diff --check`

Fixes the date overrides demonstrated by #3118.