### PR TITLE
feat(sap-ai-core): add Claude Opus 4.8

### DIFF
--- a/providers/sap-ai-core/models/anthropic--claude-4.8-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.8-opus.toml
@@ -1,0 +1,29 @@
+name = "anthropic--claude-4.8-opus"
+description = "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents"
+family = "claude-opus"
+release_date = "2026-05-28"
+last_updated = "2026-05-28"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]


### PR DESCRIPTION
**Add** `anthropic--claude-4.8-opus` ([Anthropic announcement 2026-05-28](https://www.anthropic.com/news/claude-opus-4-8), [SAP Java SDK v1.21.0 - 2026-07-02](https://sap.github.io/ai-sdk/docs/java/release-notes) — `CLAUDE_4_8_OPUS = new OrchestrationAiModel("anthropic--claude-4.8-opus")`).

Uses [`base_model = "anthropic/claude-opus-4-8"`](../blob/dev/models/anthropic/claude-opus-4-8.toml) per AGENTS.md guidance to inherit provider-agnostic facts (name/description/family/dates/limits/modalities/benchmarks); declares only provider-specific fields:

- `name` override (SAP identifier: `anthropic--claude-4.8-opus`)
- `structured_output = true` (mirrors [`anthropic/claude-opus-4-8`](../blob/dev/providers/anthropic/models/claude-opus-4-8.toml) canonical provider)
- `reasoning_options` — full Anthropic effort set `["low", "medium", "high", "xhigh", "max"]`; routing/effort mapping handled by consumers
- `[cost]` — provider-specific USD pricing

`[experimental.modes.fast]` intentionally omitted (SAP AI Core does not advertise fast-mode routing for Bedrock-Anthropic).

Cross-validated: `bun validate` PASS, generated JSON zero-delta vs prior flat declaration.