### PR TITLE
fix(sap-ai-core, models/anthropic): align Claude Opus wrappers with upstream reasoning surface

### DIFF
--- a/models/anthropic/claude-opus-4-8.toml
+++ b/models/anthropic/claude-opus-4-8.toml
@@ -8,6 +8,7 @@ reasoning = true
 temperature = false
 tool_call = true
 open_weights = false
+knowledge = "2026-01"
 
 [limit]
 context = 1_000_000

--- a/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.5-opus.toml
@@ -5,7 +5,7 @@ release_date = "2025-11-24"
 last_updated = "2025-11-24"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-05"

--- a/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.6-sonnet.toml
@@ -6,7 +6,7 @@ last_updated = "2026-03-13"
 attachment = true
 reasoning = true
 # Bedrock Claude 4.6 prefers $.thinking.type = "adaptive" plus $.output_config.effort = "low"|"medium"|"high"; manual enabled budget_tokens >= 1024 is deprecated. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-08"

--- a/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.7-opus.toml
@@ -6,7 +6,7 @@ last_updated = "2026-04-16"
 attachment = true
 reasoning = true
 # Bedrock Claude 4.7 uses $.thinking.type = "adaptive" and $.output_config.effort; manual budget_tokens is rejected. Converse prefixes both paths with $.additionalModelRequestFields. https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking (accessed 2026-06-25)
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/sap-ai-core/models/anthropic--claude-4.8-opus.toml
+++ b/providers/sap-ai-core/models/anthropic--claude-4.8-opus.toml
@@ -1,29 +1,12 @@
-name = "anthropic--claude-4.8-opus"
-description = "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents"
-family = "claude-opus"
-release_date = "2026-05-28"
-last_updated = "2026-05-28"
-attachment = true
-reasoning = true
-temperature = false
-tool_call = true
-structured_output = true
-open_weights = false
+base_model = "anthropic/claude-opus-4-8"
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+name = "anthropic--claude-4.8-opus"
+structured_output = true
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5.00
 output = 25.00
 cache_read = 0.50
 cache_write = 6.25
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]


### PR DESCRIPTION
Follow-up to #3121 addressing findings from post-merge cross-validation.

**Metadata fix**
- `models/anthropic/claude-opus-4-8.toml`: add `knowledge = "2026-01"` — [Anthropic docs officially publish Jan 2026](https://docs.anthropic.com/en/docs/about-claude/models/overview) as reliable knowledge cutoff. Propagates to 28 downstream `base_model` consumers; 2 Azure providers keep their explicit `"2025-12-31"` override.

**Wrapper refactor**
- `providers/sap-ai-core/models/anthropic--claude-4.8-opus.toml`: convert flat declaration to `base_model = "anthropic/claude-opus-4-8"` per AGENTS.md L47-49 (*"Must use `base_model` when a `models/` metadata entry exists"*). Wrapper reduced 29 → 12 lines; declares only provider-specific fields (`name` override, `structured_output`, `reasoning_options`, `[cost]`). Generated JSON zero-delta verified via `bun run compare:migrations`.

**Reasoning options alignment**
Restore full upstream effort values to match the [Anthropic effort surface](https://docs.anthropic.com/en/build-with-claude/effort) and the existing [`providers/amazon-bedrock/models/anthropic.claude-opus-4-*.toml`](../blob/dev/providers/amazon-bedrock/models/anthropic.claude-opus-4-8.toml) declarations:

- `anthropic--claude-4.5-opus`: restore `effort ["low","medium","high"]` alongside `budget_tokens` — matches [`anthropic.claude-opus-4-5-20251101-v1:0.toml`](../blob/dev/providers/amazon-bedrock/models/anthropic.claude-opus-4-5-20251101-v1:0.toml)
- `anthropic--claude-4.6-sonnet`: add `"max"` — matches Anthropic effort table for Sonnet 4.6
- `anthropic--claude-4.7-opus`: add `"xhigh"`, `"max"` — matches Anthropic effort table for Opus 4.7

SAP AI Core routes to Anthropic Claude via Bedrock; the wrapper should expose the same effort surface as the underlying route. `amazon-bedrock/` canonical files have carried these full sets in `main` throughout and route through the same backend without runtime errors.

**Validation**: `bun validate` PASS. `bun run compare:migrations` produces zero non-intentional diffs.