### PR TITLE
fix(meituan): correct LongCat-2.0 open_weights and structured_output

### DIFF
--- a/models/meituan/longcat-2.0.toml
+++ b/models/meituan/longcat-2.0.toml
@@ -6,8 +6,8 @@ reasoning = true
 temperature = true
 tool_call = true
 release_date = "2026-06-30"
-last_updated = "2026-06-30"
-open_weights = false
+last_updated = "2026-07-06"
+open_weights = true
 
 [limit]
 context = 1_000_000

--- a/providers/longcat/models/LongCat-2.0.toml
+++ b/providers/longcat/models/LongCat-2.0.toml
@@ -1,6 +1,7 @@
 # API: {"thinking": {"type": "enabled"}} / {"thinking": {"type": "disabled"}}
 base_model = "meituan/longcat-2.0"
 reasoning_options = [{ type = "toggle" }]
+structured_output = true
 
 [cost]
 input = 0.75


### PR DESCRIPTION
## Summary

Two corrections to the LongCat-2.0 entry:

1. **`open_weights`: `false` → `true`** on `models/meituan/longcat-2.0.toml` — Meituan open-sourced LongCat-2.0 under the MIT license on 2026-07-06. The original value was accurate when the model was added on 2026-06-30. `last_updated` bumped accordingly.
2. **`structured_output = true`** on `providers/longcat/models/LongCat-2.0.toml` — the provider supports it, but the field was absent so the site rendered it as unsupported.

`structured_output` is recorded at the provider level rather than on the shared `meituan/longcat-2.0` model, because constrained decoding is a property of the serving stack, not of the weights — the repo already reflects this (e.g. `openai/gpt-oss-20b` is `true` at model level but `false` under `stackit`). Only the LongCat provider's own API was tested, and now that the weights are open, other providers may serve the model without grammar support.

## Sources

- Weights: https://huggingface.co/meituan-longcat/LongCat-2.0 (MIT license, 1.6T-param MoE)
- Coverage: https://venturebeat.com/technology/meituan-open-sources-longcat-2-0-the-1-6t-near-frontier-agentic-coding-model-thats-been-leading-openrouter-trained-entirely-on-chinese-chips

## Verification

`bun run validate` passes (exit 0), and `structured_output` surfaces on the generated `longcat/LongCat-2.0` entry.

The provider's API docs document neither `tools` nor `response_format`, so both capability fields were verified empirically against the live API. Every observation below was reproduced first-hand.

**Tool calling — supported.** Requests carrying `tools` return `finish_reason: "tool_calls"` with a well-formed `tool_calls` array. A `tool_choice: "none"` control returns ordinary assistant text and no `tool_calls`, confirming the tool path is real rather than text that merely resembles a tool call.

**Structured output — supported, and enforced server-side.** A naive test cannot distinguish real enforcement from "the schema was injected into the prompt and the model chose to comply", so that hypothesis was ruled out directly:

- *The server compiles the schema into a decoding grammar.* A schema with an unsatisfiable numeric range (`minimum: 100, maximum: 1`) returns **HTTP 400 `Grammar compilation failed for the provided schema`** — the server names the mechanism itself.
- *The grammar drives decoding.* A self-referential `{"child": {"$ref": "#"}}` schema returns HTTP 200 and decodes into unbounded nesting — `{"child": {"child": {"child": …` until `max_tokens` — with `finish_reason: "length"`. A prompt-level instruction would not trap the decoder this way.
- *The schema never enters the prompt.* Holding the message fixed, `usage.prompt_tokens` is invariant across no `response_format`, a one-property schema, and a schema whose JSON body is 13 KB. (Weaker on its own — usage accounting could simply exclude injected text — but consistent with the above.)
- *Output the model would never produce.* Given an enum of a single nonsense value and the prompt *"What color is the sky on a clear day? Answer honestly"*, it returns that value 3/3 at `temperature: 1`; the unconstrained control returns prose about Rayleigh scattering and the color blue, 3/3.
- *Type coercion against the model's intent.* Asked *"What is the capital of France? Reply with the city name"* under a schema requiring `{"answer": integer}`, it emits `{"answer": 42}` — it cannot emit `"Paris"`.

Caveat worth recording: enforcement is grammar-level, not full JSON Schema validation. A self-contradictory schema (`type: "integer"` with `enum: ["banana"]`) returns HTTP 200 and `{"n": "banana"}`, invalid against its own declared type. This does not change the boolean, but consumers should not assume strict schema validation.

**Reasoning** (existing fields, re-confirmed): `thinking: {"type": "enabled"}` populates `reasoning_content`; `"disabled"` omits it, matching the current `reasoning_options` / `interleaved` config.

Remaining fields — 1M context, 131072 max output, text-only I/O, and $0.75 / $2.95 / $0.015 pricing — match the official English docs (the Chinese docs carry a separate CNY price list).