### PR TITLE
add new model support

### DIFF
--- a/providers/hpc-ai/models/anthropic/claude-opus-4.7.toml
+++ b/providers/hpc-ai/models/anthropic/claude-opus-4.7.toml
@@ -5,3 +5,7 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 input = 5.00
 output = 25.00
 cache_read = 0.50
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/hpc-ai/models/anthropic/claude-opus-4.7.toml
+++ b/providers/hpc-ai/models/anthropic/claude-opus-4.7.toml
@@ -1,5 +1,6 @@
 base_model = "anthropic/claude-opus-4-7"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+temperature = true
 
 [cost]
 input = 5.00

--- a/providers/hpc-ai/models/anthropic/claude-opus-4.7.toml
+++ b/providers/hpc-ai/models/anthropic/claude-opus-4.7.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50

--- a/providers/hpc-ai/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/hpc-ai/models/deepseek/deepseek-v4-flash.toml
@@ -3,6 +3,10 @@ base_model = "deepseek/deepseek-v4-flash"
 [[reasoning_options]]
 type = "toggle"
 
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 
@@ -10,3 +14,6 @@ field = "reasoning_content"
 input = 0.14
 output = 0.28
 cache_read = 0.028
+
+[limit]
+context = 1_048_576

--- a/providers/hpc-ai/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/hpc-ai/models/deepseek/deepseek-v4-flash.toml
@@ -1,9 +1,6 @@
 base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
 values = ["high", "max"]
 
@@ -17,3 +14,4 @@ cache_read = 0.028
 
 [limit]
 context = 1_048_576
+output = 128_000

--- a/providers/hpc-ai/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/hpc-ai/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028

--- a/providers/hpc-ai/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/hpc-ai/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.145

--- a/providers/hpc-ai/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/hpc-ai/models/deepseek/deepseek-v4-pro.toml
@@ -3,6 +3,10 @@ base_model = "deepseek/deepseek-v4-pro"
 [[reasoning_options]]
 type = "toggle"
 
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 
@@ -10,3 +14,6 @@ field = "reasoning_content"
 input = 1.74
 output = 3.48
 cache_read = 0.145
+
+[limit]
+context = 1_002_000

--- a/providers/hpc-ai/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/hpc-ai/models/deepseek/deepseek-v4-pro.toml
@@ -1,9 +1,6 @@
 base_model = "deepseek/deepseek-v4-pro"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
 values = ["high", "max"]
 
@@ -17,3 +14,4 @@ cache_read = 0.145
 
 [limit]
 context = 1_002_000
+output = 128_000

--- a/providers/hpc-ai/models/minimax/minimax-m2.5.toml
+++ b/providers/hpc-ai/models/minimax/minimax-m2.5.toml
@@ -1,15 +1,6 @@
-name = "MiniMax M2.5"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
-family = "minimax-m2.5"
-release_date = "2026-02-12"
-last_updated = "2026-06-01"
-attachment = false
-reasoning = true
+base_model = "minimax/MiniMax-M2.5"
 reasoning_options = []
-temperature = true
-tool_call = true
-structured_output = false
-open_weights = true
+structured_output = true
 
 [cost]
 input = 0.30
@@ -18,8 +9,4 @@ cache_read = 0.03
 
 [limit]
 context = 196_000
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 195_000

--- a/providers/hpc-ai/models/minimax/minimax-m2.5.toml
+++ b/providers/hpc-ai/models/minimax/minimax-m2.5.toml
@@ -17,7 +17,7 @@ output = 1.20
 cache_read = 0.03
 
 [limit]
-context = 1_000_000
+context = 196_000
 output = 131_072
 
 [modalities]

--- a/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
+++ b/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
@@ -1,28 +1,19 @@
-name = "Kimi K2.5"
-description = "Kimi multimodal agent model for visual understanding, coding, and planning"
-family = "kimi-k2"
-release_date = "2026-01-01"
-last_updated = "2026-06-01"
+base_model = "moonshotai/kimi-k2.5"
 attachment = true
-reasoning = true
 reasoning_options = [{ type = "toggle" }]
-structured_output = true
-temperature = false
-tool_call = true
-knowledge = "2025-01-01"
-open_weights = true
+temperature = true
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.30
-output = 1.50
-cache_read = 0.05
+input = 0.60
+output = 3.00
+cache_read = 0.10
 
 [limit]
 context = 256_000
-output = 262_144
+output = 256_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
+++ b/providers/hpc-ai/models/moonshotai/kimi-k2.5.toml
@@ -3,7 +3,7 @@ description = "Kimi multimodal agent model for visual understanding, coding, and
 family = "kimi-k2"
 release_date = "2026-01-01"
 last_updated = "2026-06-01"
-attachment = false
+attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }]
 structured_output = true
@@ -21,9 +21,9 @@ output = 1.50
 cache_read = 0.05
 
 [limit]
-context = 262_144
+context = 256_000
 output = 262_144
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/hpc-ai/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/hpc-ai/models/moonshotai/kimi-k2.7-code.toml
@@ -1,7 +1,16 @@
 base_model = "moonshotai/kimi-k2.7-code"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 0.95
 output = 4.00
 cache_read = 0.19
+
+[limit]
+context = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/hpc-ai/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/hpc-ai/models/moonshotai/kimi-k2.7-code.toml
@@ -1,7 +1,6 @@
 base_model = "moonshotai/kimi-k2.7-code"
-
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = []
+temperature = true
 
 [cost]
 input = 0.95
@@ -10,6 +9,7 @@ cache_read = 0.19
 
 [limit]
 context = 256_000
+output = 256_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/hpc-ai/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/hpc-ai/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4.00
+cache_read = 0.19

--- a/providers/hpc-ai/models/openai/gpt-5.5.toml
+++ b/providers/hpc-ai/models/openai/gpt-5.5.toml
@@ -11,3 +11,7 @@ tier = { type = "context", size = 272_000 }
 input = 10.00
 output = 45.00
 cache_read = 1.00
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/hpc-ai/models/openai/gpt-5.5.toml
+++ b/providers/hpc-ai/models/openai/gpt-5.5.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10.00
+output = 45.00
+cache_read = 1.00

--- a/providers/hpc-ai/models/openai/gpt-5.5.toml
+++ b/providers/hpc-ai/models/openai/gpt-5.5.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.5"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
 
 [cost]
 input = 5.00

--- a/providers/hpc-ai/models/zai-org/glm-5.2.toml
+++ b/providers/hpc-ai/models/zai-org/glm-5.2.toml
@@ -14,3 +14,4 @@ cache_read = 0.26
 
 [limit]
 context = 1_048_576
+output = 131_072

--- a/providers/hpc-ai/models/zai-org/glm-5.2.toml
+++ b/providers/hpc-ai/models/zai-org/glm-5.2.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.26

--- a/providers/hpc-ai/models/zai-org/glm-5.2.toml
+++ b/providers/hpc-ai/models/zai-org/glm-5.2.toml
@@ -1,7 +1,8 @@
 base_model = "zhipuai/glm-5.2"
 
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["high", "max"]
 
 [interleaved]
 field = "reasoning_content"
@@ -10,3 +11,6 @@ field = "reasoning_content"
 input = 1.40
 output = 4.40
 cache_read = 0.26
+
+[limit]
+context = 1_048_576


### PR DESCRIPTION
### Summary

Adds six new HPC-AI models and updates two existing entries. Provider-agnostic metadata is inherited with `base_model`; HPC-AI-specific pricing, limits, modalities, capabilities, and reasoning controls remain local.

| Model | Input ($/M) | Output ($/M) | Cache Read ($/M) |
|---|---:|---:|---:|
| `anthropic/claude-opus-4.7` | 5.00 | 25.00 | 0.50 |
| `deepseek/deepseek-v4-flash` | 0.14 | 0.28 | 0.028 |
| `deepseek/deepseek-v4-pro` | 1.74 | 3.48 | 0.145 |
| `minimax/minimax-m2.5` | 0.30 | 1.20 | 0.03 |
| `moonshotai/kimi-k2.5` | 0.60 | 3.00 | 0.10 |
| `moonshotai/kimi-k2.7-code` | 0.95 | 4.00 | 0.19 |
| `openai/gpt-5.5` | 5.00 / 10.00 (>272K) | 30.00 / 45.00 (>272K) | 0.50 / 1.00 (>272K) |
| `zai-org/glm-5.2` | 1.40 | 4.40 | 0.26 |

### Evidence

- [HPC-AI model catalog](https://www.hpc-ai.com/model-apis) lists current model availability and pricing.
- [Chat Completions API](https://www.hpc-ai.com/doc/docs/Model-APIs/API-Reference/OpenAI-Compatible-API/Create-Chat-Completions/) documents the OpenAI-compatible request surface and `reasoning_effort`.
- [Claude Opus 4.7](https://www.hpc-ai.com/api/maas/v1/model?model_id=anthropic%2Fclaude-opus-4.7), [DeepSeek V4 Flash](https://www.hpc-ai.com/api/maas/v1/model?model_id=deepseek%2Fdeepseek-v4-flash), and [DeepSeek V4 Pro](https://www.hpc-ai.com/api/maas/v1/model?model_id=deepseek%2Fdeepseek-v4-pro) provide provider-specific pricing, limits, modalities, and capabilities.
- [MiniMax M2.5](https://www.hpc-ai.com/api/maas/v1/model?model_id=minimax%2Fminimax-m2.5), [Kimi K2.5](https://www.hpc-ai.com/api/maas/v1/model?model_id=moonshotai%2Fkimi-k2.5), and [Kimi K2.7 Code](https://www.hpc-ai.com/api/maas/v1/model?model_id=moonshotai%2Fkimi-k2.7-code) provide provider-specific pricing, limits, modalities, and capabilities.
- [GPT-5.5](https://www.hpc-ai.com/api/maas/v1/model?model_id=openai%2Fgpt-5.5) documents the 272K pricing tier; [GLM-5.2](https://www.hpc-ai.com/api/maas/v1/model?model_id=zai-org%2Fglm-5.2) documents its pricing and limits.

### Validation

- `bun validate`
- `git diff --check`