### PR TITLE
feat(sap-ai-core): add Gemini 3.1 Flash Lite and Gemini 3.5 Flash

### DIFF
--- a/providers/sap-ai-core/models/gemini-3.1-flash-lite.toml
+++ b/providers/sap-ai-core/models/gemini-3.1-flash-lite.toml
@@ -1,0 +1,13 @@
+# Vertex Gemini 3.x adapter: $.generationConfig.thinkingConfig.thinkingLevel accepts "minimal", "low", "medium", or "high"; mutually exclusive with the legacy $.generationConfig.thinkingConfig.thinkingBudget. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-07-09)
+
+base_model = "google/gemini-3.1-flash-lite"
+
+name = "gemini-3.1-flash-lite"
+description = "Low-latency Gemini model for high-volume multimodal and agent workloads"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+input_audio = 0.5

--- a/providers/sap-ai-core/models/gemini-3.5-flash.toml
+++ b/providers/sap-ai-core/models/gemini-3.5-flash.toml
@@ -1,0 +1,13 @@
+# Vertex Gemini 3.x adapter: $.generationConfig.thinkingConfig.thinkingLevel accepts "minimal", "low", "medium", or "high"; mutually exclusive with the legacy $.generationConfig.thinkingConfig.thinkingBudget. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-07-09)
+
+base_model = "google/gemini-3.5-flash"
+
+name = "gemini-3.5-flash"
+description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+input_audio = 1.5


### PR DESCRIPTION
## What

Two new SAP AI Core wrappers routed to Google via the `gcp-vertexai`
foundation-models scenario:

- `providers/sap-ai-core/models/gemini-3.1-flash-lite.toml`
- `providers/sap-ai-core/models/gemini-3.5-flash.toml`

Both inherit provider-agnostic facts (release date, knowledge cutoff,
context/output limits, modalities, family, boolean capabilities) from
`models/google/gemini-3.{1-flash-lite,5-flash}.toml` via `base_model`.
Local overrides mirror the existing sap-ai-core Gemini 2.5 wrapper
convention:

- `name` uses SAP AI Core's lowercase identifier (`gemini-3.x-flash-*`)
- `description` mirrors metadata for consistency across catalogs
- `reasoning_options` exposes the Vertex 3.x effort surface
  (`minimal / low / medium / high`)
- `[cost]` tracks the corresponding `providers/google-vertex/` entries

## Why

SAP AI Core Generative AI Hub officially offers both models via the
Google Vertex AI foundation-model scenario. The SAP AI Core service
guide lists "Gemini 3.5 flash" and "Gemini 3.1 Flash Lite" among the
available models.

## Sources

- Availability: SAP AI Core service guide (Metering and Pricing for
  Generative AI section) —
  `help.sap.com/doc/c31b38b32a5d4e07a4488cb0f8bb55d9/CLOUD/en-US/f17fa8568d0448c685f2a0301061a6ee.pdf`
- Routing: SAP AI Launchpad user guide, `gcp-vertexai` foundation-models
  scenario — `help.sap.com/docs/ai-launchpad`
- Reasoning API surface (Vertex Gemini 3.x uses `thinkingLevel`, not the
  legacy `thinkingBudget`) —
  https://cloud.google.com/vertex-ai/generative-ai/docs/thinking
- Pricing reference: `providers/google-vertex/models/gemini-3.{1-flash-lite,5-flash}.toml`
  (aligned with GCP Vertex generative-ai pricing page)

## Verification

- `bun validate` → exit 0
- `base_model` resolution via `generateCatalog()` yields the expected
  merged output (metadata inherited, sap-ai-core overrides applied):
  - `gemini-3.1-flash-lite` — reasoning_options `[effort=["minimal","low","medium","high"]]`, cost `{input:0.25, output:1.5, cache_read:0.025, input_audio:0.5}`
  - `gemini-3.5-flash` — reasoning_options `[effort=["minimal","low","medium","high"]]`, cost `{input:1.5, output:9, cache_read:0.15, input_audio:1.5}`
- Cross-validation against 14 providers exposing the same models:
  release date, effort values and pricing are consensus (`google-vertex`,
  `aihubmix`, `llmgateway`, `merge-gateway`, `nano-gpt`, `nearai`,
  `vercel`, `github-copilot` for 3.5-flash, `opencode` for 3.5-flash).