### PR TITLE
feat(zenmux): add Grok 4.5/Free, Ring-2.6-1T, KAT-Coder-Pro/Air-V2.5

### DIFF
--- a/models/kuaishou/kat-coder-air-v2.5.toml
+++ b/models/kuaishou/kat-coder-air-v2.5.toml
@@ -1,0 +1,18 @@
+name = "KAT-Coder-Air-V2.5"
+description = "KAT-Coder-Air-V2.5 model"
+family = "kat-coder"
+release_date = "2026-07-08"
+last_updated = "2026-07-08"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 256_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/kuaishou/kat-coder-pro-v2.5.toml
+++ b/models/kuaishou/kat-coder-pro-v2.5.toml
@@ -1,0 +1,18 @@
+name = "KAT-Coder-Pro-V2.5"
+description = "KAT-Coder-Pro-V2.5 model"
+family = "kat-coder"
+release_date = "2026-07-08"
+last_updated = "2026-07-08"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 256_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/x-ai/grok-4.5.toml
+++ b/models/x-ai/grok-4.5.toml
@@ -1,0 +1,18 @@
+name = "Grok 4.5"
+description = "Grok 4.5 model"
+family = "grok"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 500_000
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zenmux/models/inclusionai/ring-2.6-1t.toml
+++ b/providers/zenmux/models/inclusionai/ring-2.6-1t.toml
@@ -1,0 +1,11 @@
+base_model = "inclusionai/ring-2.6-1t"
+reasoning_options = []
+
+[cost]
+input = 0.1318155
+output = 1.0984625
+cache_read = 0.0263631
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"

--- a/providers/zenmux/models/kuaishou/kat-coder-air-v2.5.toml
+++ b/providers/zenmux/models/kuaishou/kat-coder-air-v2.5.toml
@@ -1,0 +1,10 @@
+base_model = "kuaishou/kat-coder-air-v2.5"
+
+[cost]
+input = 0.135
+output = 0.54
+cache_read = 0.027
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"

--- a/providers/zenmux/models/kuaishou/kat-coder-pro-v2.5.toml
+++ b/providers/zenmux/models/kuaishou/kat-coder-pro-v2.5.toml
@@ -1,0 +1,10 @@
+base_model = "kuaishou/kat-coder-pro-v2.5"
+
+[cost]
+input = 0.444
+output = 1.776
+cache_read = 0.09
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"

--- a/providers/zenmux/models/x-ai/grok-4.5-free.toml
+++ b/providers/zenmux/models/x-ai/grok-4.5-free.toml
@@ -1,0 +1,12 @@
+base_model = "x-ai/grok-4.5"
+name = "Grok 4.5 (Free)"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"

--- a/providers/zenmux/models/x-ai/grok-4.5.toml
+++ b/providers/zenmux/models/x-ai/grok-4.5.toml
@@ -1,0 +1,11 @@
+base_model = "x-ai/grok-4.5"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"


### PR DESCRIPTION
Add the following models to ZenMux provider:

- xAI: Grok 4.5
- xAI: Grok 4.5 (Free)
- inclusionAI: Ring-2.6-1T
- KwaiKAT: KAT-Coder-Pro-V2.5
- KwaiKAT: KAT-Coder-Air-V2.5

Note: Meituan LongCat-2.0 already exists, skipped.

Data sourced from https://zenmux.ai/api/anthropic/v1/models