### PR TITLE
chore(nvidia): mark kimi-k2.6 and kimi-k2-instruct-0905 as deprecated

### DIFF
--- a/providers/nvidia/models/moonshotai/kimi-k2-instruct-0905.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k2-instruct-0905.toml
@@ -1,4 +1,5 @@
 name = "Kimi K2 0905"
+status = "deprecated"
 description = "Kimi model for long-context chat, coding, and agentic reasoning"
 family = "kimi-k2"
 release_date = "2025-09-05"

--- a/providers/nvidia/models/moonshotai/kimi-k2.6.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 name = "Kimi K2.6"
+status = "deprecated"
 description = "Kimi multimodal agent model for visual understanding, coding, and planning"
 family = "kimi-k2"
 release_date = "2026-04-21"


### PR DESCRIPTION
This PR updates the NVIDIA provider configuration for Kimi K2.6 (moonshotai/kimi-k2.6) and Kimi K2 Instruct (moonshotai/kimi-k2-instruct) by changing their status to deprecated. As of July 7, 2026, NVIDIA has officially reached end-of-life for these models on their API catalog and they are no longer actively served. Instead of deleting the provider's TOML files—which would break historical cost auditing and cause sudden failures for routing applications—this update preserves the pricing and usage metadata while correctly flagging them as inactive for developer tools.

For reference, the official NVIDIA model card is located at:
https://build.nvidia.com/moonshotai/kimi-k2.6/modelcard
https://build.nvidia.com/moonshotai/kimi-k2-instruct-0905

