### PR TITLE
fix(sync): use DigitalOcean model catalog

### DIFF
--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -72,6 +72,11 @@ const DigitalOceanCatalogResponse = z.object({
       next: z.string().nullable().optional(),
     }).passthrough().optional(),
   }).passthrough().optional(),
+  meta: z.object({
+    page: z.number().int().positive(),
+    pages: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  }).passthrough().optional(),
 }).passthrough();
 
 const DigitalOceanCatalogDetailResponse = z.object({
@@ -91,10 +96,13 @@ interface ModelPricing {
   output?: number;
   cacheRead?: number;
   cacheWrite?: number;
-  inputOver200k?: number;
-  outputOver200k?: number;
-  cacheReadOver200k?: number;
-  cacheWriteOver200k?: number;
+  extended?: {
+    context: number;
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
 }
 
 type ReasoningEffort =
@@ -221,7 +229,15 @@ async function fetchAllDigitalOceanCatalog(fetcher: typeof fetch) {
     const page = DigitalOceanCatalogResponse.parse(await response.json());
     catalog.push(...page.data);
     const next = page.links?.pages?.next;
-    url = next ? new URL(next, url).toString() : undefined;
+    if (next) {
+      url = new URL(next, url).toString();
+    } else if (page.meta !== undefined && page.meta.page < page.meta.pages) {
+      const nextPage = new URL(url);
+      nextPage.searchParams.set("page", String(page.meta.page + 1));
+      url = nextPage.toString();
+    } else {
+      url = undefined;
+    }
   }
 
   return Promise.all(catalog.map(async (model) => {
@@ -232,7 +248,12 @@ async function fetchAllDigitalOceanCatalog(fetcher: typeof fetch) {
     if (!response.ok) {
       throw new Error(`DigitalOcean catalog detail request failed: ${response.status} ${response.statusText}`);
     }
-    return DigitalOceanCatalogDetailResponse.parse(await response.json()).data;
+    const detail = DigitalOceanCatalogDetailResponse.parse(await response.json()).data;
+    return {
+      ...model,
+      modalities: detail.modalities ?? model.modalities,
+      pricing_detail: detail.pricing_detail ?? model.pricing_detail,
+    };
   }));
 }
 
@@ -276,17 +297,30 @@ function catalogPricing(model: DigitalOceanCatalogModel | undefined): ModelPrici
   const extended = model.pricing_detail?.variants.find((variant) =>
     variant.mode === "MODEL_BILLING_MODE_INTERACTIVE"
     && variant.tier?.startsWith("MODEL_PRICING_TIER_EXTENDED_") === true
-  )?.prices;
+  );
+  const extendedContext = pricingTierContext(extended?.tier);
   return {
     input: perMillion(model.pricing.input_price_per_million),
     output: perMillion(model.pricing.output_price_per_million),
     cacheRead: perMillion(model.pricing.cache_read_input_price_per_million),
     cacheWrite: perMillion(standard?.cache_write_5m_input_price_per_million),
-    inputOver200k: perMillion(extended?.input_price_per_million),
-    outputOver200k: perMillion(extended?.output_price_per_million),
-    cacheReadOver200k: perMillion(extended?.cache_read_input_price_per_million),
-    cacheWriteOver200k: perMillion(extended?.cache_write_5m_input_price_per_million),
+    extended: extendedContext === undefined || extended?.prices == null
+      ? undefined
+      : {
+          context: extendedContext,
+          input: perMillion(extended.prices.input_price_per_million),
+          output: perMillion(extended.prices.output_price_per_million),
+          cacheRead: perMillion(extended.prices.cache_read_input_price_per_million),
+          cacheWrite: perMillion(extended.prices.cache_write_5m_input_price_per_million),
+        },
   };
+}
+
+function pricingTierContext(tier: string | undefined) {
+  // Tier names describe capacity; Anthropic's 1M surcharge starts above 200K.
+  if (tier === "MODEL_PRICING_TIER_EXTENDED_1M") return 200_000;
+  if (tier === "MODEL_PRICING_TIER_EXTENDED_272K") return 272_000;
+  return undefined;
 }
 
 function perMillion(value: number | undefined) {
@@ -365,18 +399,18 @@ function cost(model: DigitalOceanSourceModel, existing: ExistingModel | undefine
   const longContext = existingTiers.find((tier) =>
     (tier.tier.type === undefined || tier.tier.type === "context") && tier.tier.size >= 200_000
   );
-  const hasLongContextPricing = model.pricing?.inputOver200k !== undefined
-    && model.pricing.outputOver200k !== undefined;
+  const extended = model.pricing?.extended;
+  const hasLongContextPricing = extended?.input !== undefined && extended.output !== undefined;
   const tiers = hasLongContextPricing
     ? [
         ...existingTiers.filter((tier) => tier !== longContext),
         {
-          tier: { type: "context" as const, size: longContext?.tier.size ?? 200_000 },
-          input: model.pricing!.inputOver200k!,
-          output: model.pricing!.outputOver200k!,
+          tier: { type: "context" as const, size: extended.context },
+          input: extended.input!,
+          output: extended.output!,
           reasoning: longContext?.reasoning,
-          cache_read: model.pricing?.cacheReadOver200k ?? longContext?.cache_read,
-          cache_write: model.pricing?.cacheWriteOver200k ?? longContext?.cache_write,
+          cache_read: extended.cacheRead ?? longContext?.cache_read,
+          cache_write: extended.cacheWrite ?? longContext?.cache_write,
         },
       ]
     : existingTiers;
@@ -414,8 +448,10 @@ export function buildDigitalOceanModel(
     output: maxTokens ?? existing?.limit?.output ?? 0,
   };
   const textOutput = output.includes("text") && !output.includes("image") && !output.includes("video");
-  const reasoning = existing?.reasoning
-    ?? (textOutput && ((model.thinking ?? false) || (model.reasoning_efforts?.length ?? 0) > 0));
+  const remoteReasoning = textOutput
+    && ((model.thinking ?? false) || (model.reasoning_efforts?.length ?? 0) > 0);
+  const providerReasoning = remoteReasoning ? true : existing?.reasoning;
+  const reasoning = providerReasoning ?? false;
   const reasoningOptions = reasoning ? reasoningOptionsFor(model, existing) : undefined;
   const modelStatus = status(model.lifecycle_status, existing?.status);
   const releaseDate = existing?.release_date ?? model.created_at?.slice(0, 10) ?? new Date().toISOString().slice(0, 10);
@@ -457,7 +493,7 @@ export function buildDigitalOceanModel(
       name: model.name,
       description: existing?.description,
       attachment: input.some((value) => value !== "text"),
-      reasoning: model.thinking ?? existing?.reasoning,
+      reasoning: providerReasoning,
       reasoning_options: reasoningOptions,
       temperature: existing?.temperature,
       tool_call: existing?.tool_call,

--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -6,7 +6,7 @@ import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "
 import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
 
 const MODELS_API = "https://api.digitalocean.com/v2/gen-ai/models?per_page=200";
-const PRICING_API = "https://www.digitalocean.com/api/static-content/v1/products";
+const CATALOG_API = "https://api.digitalocean.com/v2/gen-ai/models/catalog?limit=200";
 
 export const DigitalOceanModel = z.object({
   id: z.string().min(1),
@@ -14,6 +14,7 @@ export const DigitalOceanModel = z.object({
   lifecycle_status: z.string(),
   type: z.string().optional(),
   thinking: z.boolean().optional(),
+  reasoning_efforts: z.array(z.string()).optional(),
   context_window: z.union([z.number(), z.string()]).optional(),
   modalities: z.object({
     input: z.array(z.string()).optional(),
@@ -36,74 +37,82 @@ const DigitalOceanModelsResponse = z.object({
   }).passthrough().optional(),
 }).passthrough();
 
-const PricingEntry = z.object({
-  name: z.string(),
-  slug: z.string(),
-  model: z.string(),
-  prompt_tokens: z.string().optional(),
-  price: z.object({ rate: z.number() }),
+const DigitalOceanCatalogPricing = z.object({
+  input_price_per_million: z.number().optional(),
+  output_price_per_million: z.number().optional(),
+  cache_read_input_price_per_million: z.number().optional(),
+  cache_write_5m_input_price_per_million: z.number().optional(),
 }).passthrough();
 
-const DigitalOceanPricingResponse = z.object({
-  gradient: z.object({ models: z.array(PricingEntry) }),
+const DigitalOceanCatalogModel = z.object({
+  id: z.string().min(1).optional(),
+  model_id: z.string().min(1),
+  name: z.string().min(1),
+  context_window: z.union([z.number(), z.string()]).nullish(),
+  max_output_tokens: z.union([z.number(), z.string()]).nullish(),
+  availability: z.array(z.string()).optional(),
+  modalities: z.object({
+    input: z.array(z.string()).optional(),
+    output: z.array(z.string()).optional(),
+  }).nullish(),
+  pricing: DigitalOceanCatalogPricing.nullish(),
+  pricing_detail: z.object({
+    variants: z.array(z.object({
+      tier: z.string().optional(),
+      mode: z.string().optional(),
+      prices: DigitalOceanCatalogPricing.nullish(),
+    }).passthrough()),
+  }).nullish(),
+}).passthrough();
+
+const DigitalOceanCatalogResponse = z.object({
+  data: z.array(DigitalOceanCatalogModel),
+  links: z.object({
+    pages: z.object({
+      next: z.string().nullable().optional(),
+    }).passthrough().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+const DigitalOceanCatalogDetailResponse = z.object({
+  data: DigitalOceanCatalogModel,
 }).passthrough();
 
 const DigitalOceanResponse = z.object({
   models: z.array(DigitalOceanModel),
-  pricing: z.array(PricingEntry),
+  catalog: z.array(DigitalOceanCatalogModel),
 });
 
 export type DigitalOceanModel = z.infer<typeof DigitalOceanModel>;
-type PricingEntry = z.infer<typeof PricingEntry>;
+type DigitalOceanCatalogModel = z.infer<typeof DigitalOceanCatalogModel>;
 
 interface ModelPricing {
   input?: number;
   output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
   inputOver200k?: number;
   outputOver200k?: number;
+  cacheReadOver200k?: number;
+  cacheWriteOver200k?: number;
 }
+
+type ReasoningEffort =
+  | null
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "default";
 
 export interface DigitalOceanSourceModel extends DigitalOceanModel {
+  max_output_tokens?: string | number | null;
+  availability?: string[];
   pricing?: ModelPricing;
 }
-
-const PRICING_NAME_OVERRIDES: Record<string, string> = {
-  "claude sonnet 4.6": "anthropic-claude-4.6-sonnet",
-  "claude sonnet 4.5": "anthropic-claude-4.5-sonnet",
-  "claude sonnet 4": "anthropic-claude-sonnet-4",
-  "claude haiku 4.5": "anthropic-claude-haiku-4.5",
-  "claude opus 4.6": "anthropic-claude-opus-4.6",
-  "claude opus 4.5": "anthropic-claude-opus-4.5",
-  "claude opus 4.1": "anthropic-claude-4.1-opus",
-  "claude opus 4": "anthropic-claude-opus-4",
-  "gpt-5.4": "openai-gpt-5.4",
-  "gpt-5.4 mini": "openai-gpt-5.4-mini",
-  "gpt-5.4 nano": "openai-gpt-5.4-nano",
-  "gpt-5.4 pro": "openai-gpt-5.4-pro",
-  "gpt-5.3-codex": "openai-gpt-5.3-codex",
-  "gpt-5.2": "openai-gpt-5.2",
-  "gpt-5.2 pro": "openai-gpt-5.2-pro",
-  "gpt-5.1-codex-max": "openai-gpt-5.1-codex-max",
-  "gpt-5": "openai-gpt-5",
-  "gpt-5 mini": "openai-gpt-5-mini",
-  "gpt-5 nano": "openai-gpt-5-nano",
-  "gpt-4.1": "openai-gpt-4.1",
-  "gpt image 1": "openai-gpt-image-1",
-  "gpt image 1.5": "openai-gpt-image-1.5",
-  "gpt-oss-120b": "openai-gpt-oss-120b",
-  "gpt-oss-20b": "openai-gpt-oss-20b",
-  "gpt-4o": "openai-gpt-4o",
-  "gpt-4o mini": "openai-gpt-4o-mini",
-  o1: "openai-o1",
-  "o3-mini": "openai-o3-mini",
-  "deepseek r1 distill llama 70b": "deepseek-r1-distill-llama-70b",
-  "llama 3.3 70b": "llama3.3-70b-instruct",
-  "qwen3-32b": "alibaba-qwen3-32b",
-  "minimax m2.5": "minimax-m2.5",
-  "kimi k2.5": "kimi-k2.5",
-  "nvidia nemotron 3 super 120b": "nvidia-nemotron-3-super-120b",
-  "glm 5": "glm-5",
-};
 
 export const digitalocean = {
   id: "digitalocean",
@@ -140,7 +149,7 @@ export const digitalocean = {
   translateModel(model, context) {
     const existing = context.existing(model.id);
     const contextWindow = number(model.context_window);
-    const outputLimit = model.settings?.find((setting) => setting.name === "max_tokens")?.max;
+    const outputLimit = number(model.max_output_tokens ?? undefined);
     if (model.pricing?.input === undefined || model.pricing.output === undefined) return undefined;
     if (
       existing === undefined
@@ -162,19 +171,11 @@ export const digitalocean = {
 } satisfies SyncProvider<DigitalOceanSourceModel>;
 
 export async function fetchDigitalOceanModels(key: string, fetcher: typeof fetch = fetch) {
-  const [models, pricingResponse] = await Promise.all([
+  const [models, catalog] = await Promise.all([
     fetchAllDigitalOceanModels(key, fetcher),
-    fetcher(PRICING_API, {
-      headers: { "User-Agent": "models.dev/digitalocean-sync" },
-    }),
+    fetchAllDigitalOceanCatalog(fetcher),
   ]);
-
-  if (!pricingResponse.ok) {
-    throw new Error(`DigitalOcean pricing request failed: ${pricingResponse.status} ${pricingResponse.statusText}`);
-  }
-
-  const pricing = DigitalOceanPricingResponse.parse(await pricingResponse.json()).gradient.models;
-  return { models, pricing };
+  return { models, catalog };
 }
 
 async function fetchAllDigitalOceanModels(key: string, fetcher: typeof fetch) {
@@ -201,56 +202,98 @@ async function fetchAllDigitalOceanModels(key: string, fetcher: typeof fetch) {
   return models;
 }
 
+async function fetchAllDigitalOceanCatalog(fetcher: typeof fetch) {
+  const catalog: DigitalOceanCatalogModel[] = [];
+  const visited = new Set<string>();
+  let url: string | undefined = CATALOG_API;
+
+  while (url !== undefined) {
+    if (visited.has(url)) throw new Error(`DigitalOcean catalog pagination repeated URL: ${url}`);
+    visited.add(url);
+
+    const response = await fetcher(url, {
+      headers: { "Content-Type": "application/json", "User-Agent": "models.dev/digitalocean-sync" },
+    });
+    if (!response.ok) {
+      throw new Error(`DigitalOcean catalog request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const page = DigitalOceanCatalogResponse.parse(await response.json());
+    catalog.push(...page.data);
+    const next = page.links?.pages?.next;
+    url = next ? new URL(next, url).toString() : undefined;
+  }
+
+  return Promise.all(catalog.map(async (model) => {
+    if (model.id === undefined || model.availability?.includes("serverless") !== true) return model;
+    const response = await fetcher(`https://api.digitalocean.com/v2/gen-ai/models/catalog/${model.id}`, {
+      headers: { "Content-Type": "application/json", "User-Agent": "models.dev/digitalocean-sync" },
+    });
+    if (!response.ok) {
+      throw new Error(`DigitalOcean catalog detail request failed: ${response.status} ${response.statusText}`);
+    }
+    return DigitalOceanCatalogDetailResponse.parse(await response.json()).data;
+  }));
+}
+
 export function parseDigitalOceanModels(raw: unknown): DigitalOceanSourceModel[] {
   const response = DigitalOceanResponse.parse(raw);
-  const pricing = buildPricingMap(response.pricing, response.models);
+  const catalog = new Map(response.catalog.map((model) => [model.model_id, model]));
   return response.models
-    .filter(isManagedTextModel)
-    .map((model) => ({ ...model, pricing: pricing.get(model.id) }));
+    .map((model) => mergeCatalogModel(model, catalog.get(model.id)))
+    .filter(isManagedTextModel);
 }
 
-function isManagedTextModel(model: DigitalOceanModel) {
+function mergeCatalogModel(
+  model: DigitalOceanModel,
+  catalog: DigitalOceanCatalogModel | undefined,
+): DigitalOceanSourceModel {
+  return {
+    ...model,
+    name: catalog?.name ?? model.name,
+    context_window: catalog?.context_window ?? model.context_window,
+    max_output_tokens: catalog?.max_output_tokens,
+    modalities: catalog?.modalities ?? model.modalities,
+    availability: catalog?.availability,
+    pricing: catalogPricing(catalog),
+  };
+}
+
+function isManagedTextModel(model: DigitalOceanSourceModel) {
   const output = normalizeModalities(model.modalities?.output ?? [], []);
-  return output.includes("text") && model.type !== "embedding" && model.type !== "reranking";
+  return model.availability?.includes("serverless") === true
+    && output.includes("text")
+    && model.type !== "embedding"
+    && model.type !== "reranking";
 }
 
-function pricingName(value: string) {
-  return value
-    .replace(/\s+(input|output)\s+tokens$/i, "")
-    .replace(/\s*\(public preview\)\s*/i, " ")
-    .trim()
-    .toLowerCase();
+function catalogPricing(model: DigitalOceanCatalogModel | undefined): ModelPricing | undefined {
+  if (model?.pricing == null) return undefined;
+  const standard = model.pricing_detail?.variants.find((variant) =>
+    variant.mode === "MODEL_BILLING_MODE_INTERACTIVE"
+    && variant.tier === "MODEL_PRICING_TIER_STANDARD"
+  )?.prices;
+  const extended = model.pricing_detail?.variants.find((variant) =>
+    variant.mode === "MODEL_BILLING_MODE_INTERACTIVE"
+    && variant.tier?.startsWith("MODEL_PRICING_TIER_EXTENDED_") === true
+  )?.prices;
+  return {
+    input: perMillion(model.pricing.input_price_per_million),
+    output: perMillion(model.pricing.output_price_per_million),
+    cacheRead: perMillion(model.pricing.cache_read_input_price_per_million),
+    cacheWrite: perMillion(standard?.cache_write_5m_input_price_per_million),
+    inputOver200k: perMillion(extended?.input_price_per_million),
+    outputOver200k: perMillion(extended?.output_price_per_million),
+    cacheReadOver200k: perMillion(extended?.cache_read_input_price_per_million),
+    cacheWriteOver200k: perMillion(extended?.cache_write_5m_input_price_per_million),
+  };
 }
 
-function normalizedName(value: string) {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
-}
-
-export function buildPricingMap(entries: PricingEntry[], models: DigitalOceanModel[]) {
-  const names = new Map<string, string[]>();
-  for (const model of models) {
-    const key = normalizedName(model.name);
-    names.set(key, [...names.get(key) ?? [], model.id]);
-  }
-
-  const result = new Map<string, ModelPricing>();
-  for (const entry of entries) {
-    const name = pricingName(entry.name);
-    const matches = names.get(normalizedName(name)) ?? [];
-    const id = PRICING_NAME_OVERRIDES[name] ?? (matches.length === 1 ? matches[0] : undefined);
-    if (id === undefined) continue;
-
-    const price = Math.round(entry.price.rate * 10_000) / 10_000;
-    const current = result.get(id) ?? {};
-    const input = /\sinput\s+tokens$/i.test(entry.name);
-    const over200k = entry.prompt_tokens === ">200k";
-    if (input && over200k) current.inputOver200k = price;
-    else if (!input && over200k) current.outputOver200k = price;
-    else if (input) current.input = price;
-    else current.output = price;
-    result.set(id, current);
-  }
-  return result;
+function perMillion(value: number | undefined) {
+  if (value === undefined) return undefined;
+  // The live catalog currently returns per-token rates despite the field names.
+  const normalized = value < 0.001 ? value * 1_000_000 : value;
+  return Math.round(normalized * 10_000) / 10_000;
 }
 
 type Modality = "text" | "audio" | "image" | "video" | "pdf";
@@ -279,6 +322,40 @@ function inferFamily(id: string, name: string) {
     .find((family) => target.includes(family.toLowerCase()));
 }
 
+function reasoningOptionsFor(
+  model: DigitalOceanSourceModel,
+  existing: ExistingModel | undefined,
+): ExistingModel["reasoning_options"] {
+  if (model.reasoning_efforts === undefined) return existing?.reasoning_options;
+  const values = model.reasoning_efforts
+    .map((value) => value === "null" ? null : value)
+    .filter(isReasoningEffort);
+  const preserved = existing?.reasoning_options?.filter((option) => option.type !== "effort") ?? [];
+  return values.length > 0 ? [...preserved, { type: "effort", values }] : preserved;
+}
+
+function isReasoningEffort(value: string | null): value is ReasoningEffort {
+  return value === null
+    || value === "none"
+    || value === "minimal"
+    || value === "low"
+    || value === "medium"
+    || value === "high"
+    || value === "xhigh"
+    || value === "max"
+    || value === "default";
+}
+
+function status(
+  lifecycleStatus: string,
+  existing: ExistingModel["status"],
+): ExistingModel["status"] {
+  const lifecycle = lifecycleStatus.toLowerCase().replaceAll("_", "-");
+  if (lifecycle === "deprecated" || lifecycle === "end-of-life") return "deprecated";
+  if (lifecycle === "public-preview") return "beta";
+  return existing === "deprecated" || existing === "beta" ? undefined : existing;
+}
+
 function cost(model: DigitalOceanSourceModel, existing: ExistingModel | undefined) {
   const input = model.pricing?.input ?? existing?.cost?.input;
   const output = model.pricing?.output ?? existing?.cost?.output;
@@ -298,8 +375,8 @@ function cost(model: DigitalOceanSourceModel, existing: ExistingModel | undefine
           input: model.pricing!.inputOver200k!,
           output: model.pricing!.outputOver200k!,
           reasoning: longContext?.reasoning,
-          cache_read: longContext?.cache_read,
-          cache_write: longContext?.cache_write,
+          cache_read: model.pricing?.cacheReadOver200k ?? longContext?.cache_read,
+          cache_write: model.pricing?.cacheWriteOver200k ?? longContext?.cache_write,
         },
       ]
     : existingTiers;
@@ -308,8 +385,8 @@ function cost(model: DigitalOceanSourceModel, existing: ExistingModel | undefine
     input,
     output,
     reasoning: existing?.cost?.reasoning,
-    cache_read: existing?.cost?.cache_read,
-    cache_write: existing?.cost?.cache_write,
+    cache_read: model.pricing?.cacheRead ?? existing?.cost?.cache_read,
+    cache_write: model.pricing?.cacheWrite ?? existing?.cost?.cache_write,
     input_audio: existing?.cost?.input_audio,
     output_audio: existing?.cost?.output_audio,
     tiers: tiers.length > 0 ? tiers : undefined,
@@ -330,14 +407,17 @@ export function buildDigitalOceanModel(
     existing?.modalities?.output ?? ["text"],
   );
   const context = number(model.context_window) ?? existing?.limit?.context ?? 0;
-  const maxTokens = model.settings?.find((setting) => setting.name === "max_tokens")?.max;
+  const maxTokens = number(model.max_output_tokens ?? undefined);
   const limit = {
     context,
     input: existing?.limit?.input,
     output: maxTokens ?? existing?.limit?.output ?? 0,
   };
   const textOutput = output.includes("text") && !output.includes("image") && !output.includes("video");
-  const reasoning = existing?.reasoning ?? (textOutput && (model.thinking ?? false));
+  const reasoning = existing?.reasoning
+    ?? (textOutput && ((model.thinking ?? false) || (model.reasoning_efforts?.length ?? 0) > 0));
+  const reasoningOptions = reasoning ? reasoningOptionsFor(model, existing) : undefined;
+  const modelStatus = status(model.lifecycle_status, existing?.status);
   const releaseDate = existing?.release_date ?? model.created_at?.slice(0, 10) ?? new Date().toISOString().slice(0, 10);
   const values: Partial<SyncedFullModel> = {
     name: model.name,
@@ -357,15 +437,13 @@ export function buildDigitalOceanModel(
     last_updated: existing?.last_updated ?? releaseDate,
     attachment: existing?.attachment ?? input.some((value) => value !== "text"),
     reasoning,
-    reasoning_options: existing?.reasoning_options,
+    reasoning_options: reasoningOptions,
     temperature: existing?.temperature ?? true,
     tool_call: existing?.tool_call ?? textOutput,
     structured_output: existing?.structured_output,
     knowledge: existing?.knowledge,
     open_weights: existing?.open_weights ?? false,
-    status: model.lifecycle_status === "end_of_life"
-      ? "deprecated"
-      : existing?.status === "deprecated" ? undefined : existing?.status,
+    status: modelStatus,
     interleaved: existing?.interleaved,
     cost: cost(model, existing),
     limit,
@@ -380,13 +458,11 @@ export function buildDigitalOceanModel(
       description: existing?.description,
       attachment: input.some((value) => value !== "text"),
       reasoning: model.thinking ?? existing?.reasoning,
-      reasoning_options: existing?.reasoning_options,
+      reasoning_options: reasoningOptions,
       temperature: existing?.temperature,
       tool_call: existing?.tool_call,
       structured_output: existing?.structured_output,
-      status: model.lifecycle_status === "end_of_life"
-        ? "deprecated"
-        : existing?.status === "deprecated" ? undefined : existing?.status,
+      status: modelStatus,
       interleaved: existing?.interleaved,
       cost: cost(model, existing),
       limit,

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -239,24 +239,26 @@ function digitalOceanModel(overrides: Partial<DigitalOceanSourceModel> = {}): Di
   return {
     id: "anthropic-claude-4.6-sonnet",
     name: "Claude Sonnet 4.6",
-    lifecycle_status: "available",
+    lifecycle_status: "active",
     type: "chat",
     thinking: true,
+    reasoning_efforts: ["low", "medium", "high"],
     context_window: 1_000_000,
+    max_output_tokens: 8_192,
+    availability: ["serverless"],
     modalities: { input: ["text", "image", "pdf"], output: ["text"] },
     settings: [{ name: "max_tokens", max: 64_000 }],
     created_at: "2026-02-17T00:00:00Z",
     pricing: {
       input: 3,
       output: 15,
-      inputOver200k: 6,
-      outputOver200k: 22.5,
+      cacheRead: 0.3,
     },
     ...overrides,
   };
 }
 
-test("syncs DigitalOcean pricing and preserves curated cache tiers", () => {
+test("syncs DigitalOcean catalog limits and pricing while preserving curated tiers", () => {
   const model = buildDigitalOceanModel(digitalOceanModel(), {
     name: "Claude Sonnet 4.6",
     description: "Curated DigitalOcean description",
@@ -269,7 +271,6 @@ test("syncs DigitalOcean pricing and preserves curated cache tiers", () => {
     temperature: true,
     tool_call: true,
     open_weights: false,
-    status: "beta",
     cost: {
       input: 2,
       output: 10,
@@ -290,7 +291,6 @@ test("syncs DigitalOcean pricing and preserves curated cache tiers", () => {
   expect(model).toMatchObject({
     description: "Curated DigitalOcean description",
     last_updated: "2026-03-13",
-    status: "beta",
     cost: {
       input: 3,
       output: 15,
@@ -298,13 +298,13 @@ test("syncs DigitalOcean pricing and preserves curated cache tiers", () => {
       cache_write: 3.75,
       tiers: [{
         tier: { type: "context", size: 200_000 },
-        input: 6,
-        output: 22.5,
+        input: 4,
+        output: 15,
         cache_read: 0.6,
         cache_write: 7.5,
       }],
     },
-    limit: { context: 1_000_000, output: 64_000 },
+    limit: { context: 1_000_000, output: 8_192 },
   });
 });
 
@@ -339,7 +339,7 @@ test("skips existing dedicated-only DigitalOcean models without token pricing", 
   expect(translated).toBeUndefined();
 });
 
-test("syncs existing DigitalOcean image models with zero token limits", () => {
+test("syncs existing DigitalOcean image models with catalog output limits", () => {
   const existing = {
     name: "GPT Image 1.5",
     description: "Image generation model",
@@ -359,6 +359,7 @@ test("syncs existing DigitalOcean image models with zero token limits", () => {
     id: "openai-gpt-image-1.5",
     name: "GPT Image 1.5",
     context_window: undefined,
+    max_output_tokens: 16_384,
     modalities: { input: ["text", "image"], output: ["text", "image"] },
     settings: [],
     pricing: { input: 6, output: 12 },
@@ -369,11 +370,11 @@ test("syncs existing DigitalOcean image models with zero token limits", () => {
 
   expect(translated?.model).toMatchObject({
     cost: { input: 6, output: 12 },
-    limit: { context: 0, output: 0 },
+    limit: { context: 0, output: 16_384 },
   });
 });
 
-test("filters unmanaged DigitalOcean models and joins pricing names", () => {
+test("filters unmanaged DigitalOcean models and joins catalog data by ID", () => {
   const models = parseDigitalOceanModels({
     models: [
       digitalOceanModel({ id: "kimi-k2.5", name: "Kimi K2", pricing: undefined }),
@@ -385,16 +386,77 @@ test("filters unmanaged DigitalOcean models and joins pricing names", () => {
         pricing: undefined,
       }),
     ],
-    pricing: [
-      { name: "Kimi K2.5 Input Tokens", slug: "input", model: "DigitalOcean-Hosted Models", price: { rate: 0.5 } },
-      { name: "Kimi K2.5 Output Tokens", slug: "output", model: "DigitalOcean-Hosted Models", price: { rate: 2.4 } },
+    catalog: [
+      {
+        model_id: "kimi-k2.5",
+        name: "Kimi K2.5",
+        context_window: "256000",
+        max_output_tokens: "32768",
+        availability: ["serverless", "dedicated"],
+        pricing: {
+          input_price_per_million: 0.000000375,
+          output_price_per_million: 0.000002025,
+          cache_read_input_price_per_million: 0.000000203,
+        },
+        pricing_detail: {
+          variants: [{
+            tier: "MODEL_PRICING_TIER_EXTENDED_1M",
+            mode: "MODEL_BILLING_MODE_INTERACTIVE",
+            prices: {
+              input_price_per_million: 0.00000075,
+              output_price_per_million: 0.000003,
+            },
+          }],
+        },
+      },
+      {
+        model_id: "bge-m3",
+        name: "BGE M3",
+        availability: ["serverless"],
+      },
     ],
   });
 
   expect(models).toHaveLength(1);
   expect(models[0]).toMatchObject({
     id: "kimi-k2.5",
-    pricing: { input: 0.5, output: 2.4 },
+    context_window: "256000",
+    max_output_tokens: "32768",
+    pricing: {
+      input: 0.375,
+      output: 2.025,
+      cacheRead: 0.203,
+      inputOver200k: 0.75,
+      outputOver200k: 3,
+    },
+  });
+});
+
+test("syncs DigitalOcean reasoning efforts and lifecycle status", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    lifecycle_status: "deprecated",
+    reasoning_efforts: ["none", "low", "medium", "high", "max", "unsupported"],
+  }), {
+    name: "Claude Sonnet 4.6",
+    description: "Curated DigitalOcean description",
+    family: "claude-sonnet",
+    release_date: "2026-02-17",
+    last_updated: "2026-03-13",
+    attachment: true,
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+    temperature: true,
+    tool_call: true,
+    open_weights: false,
+    status: "beta",
+    cost: { input: 3, output: 15 },
+    limit: { context: 200_000, output: 64_000 },
+    modalities: { input: ["text", "image"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    status: "deprecated",
+    reasoning_options: [{ type: "effort", values: ["none", "low", "medium", "high", "max"] }],
   });
 });
 
@@ -492,8 +554,26 @@ test("fetches every page of the DigitalOcean catalog", async () => {
   const fetcher = ((input: string | URL | Request) => {
     const url = String(input);
     requests.push(url);
-    if (url.includes("static-content")) {
-      return Promise.resolve(new Response(JSON.stringify({ gradient: { models: [] } })));
+    if (url.includes("/catalog/first-catalog-id")) {
+      return Promise.resolve(new Response(JSON.stringify({
+        data: { id: "first-catalog-id", model_id: "first", name: "First", availability: ["serverless"] },
+      })));
+    }
+    if (url.includes("/catalog/second-catalog-id")) {
+      return Promise.resolve(new Response(JSON.stringify({
+        data: { id: "second-catalog-id", model_id: "second", name: "Second", availability: ["serverless"] },
+      })));
+    }
+    if (url.includes("/catalog") && url.includes("?page=2")) {
+      return Promise.resolve(new Response(JSON.stringify({
+        data: [{ id: "second-catalog-id", model_id: "second", name: "Second", availability: ["serverless"] }],
+      })));
+    }
+    if (url.includes("/catalog")) {
+      return Promise.resolve(new Response(JSON.stringify({
+        data: [{ id: "first-catalog-id", model_id: "first", name: "First", availability: ["serverless"] }],
+        links: { pages: { next: "https://api.digitalocean.com/v2/gen-ai/models/catalog?page=2" } },
+      })));
     }
     if (url.includes("?page=2")) {
       return Promise.resolve(new Response(JSON.stringify({ models: [second] })));
@@ -506,7 +586,8 @@ test("fetches every page of the DigitalOcean catalog", async () => {
 
   const result = await fetchDigitalOceanModels("test-key", fetcher);
   expect(result.models.map((model) => model.id)).toEqual(["first", "second"]);
-  expect(requests).toHaveLength(3);
+  expect(result.catalog.map((model) => model.model_id)).toEqual(["first", "second"]);
+  expect(requests).toHaveLength(6);
 });
 
 function deepInfraModel(model_name: string, tags: string[]): DeepInfraModel {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -258,8 +258,21 @@ function digitalOceanModel(overrides: Partial<DigitalOceanSourceModel> = {}): Di
   };
 }
 
-test("syncs DigitalOcean catalog limits and pricing while preserving curated tiers", () => {
-  const model = buildDigitalOceanModel(digitalOceanModel(), {
+test("syncs DigitalOcean catalog limits and extended pricing thresholds", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    pricing: {
+      input: 3,
+      output: 15,
+      cacheRead: 0.3,
+      extended: {
+        context: 272_000,
+        input: 6,
+        output: 22.5,
+        cacheRead: 0.6,
+        cacheWrite: 7.5,
+      },
+    },
+  }), {
     name: "Claude Sonnet 4.6",
     description: "Curated DigitalOcean description",
     family: "claude-sonnet",
@@ -297,9 +310,9 @@ test("syncs DigitalOcean catalog limits and pricing while preserving curated tie
       cache_read: 0.3,
       cache_write: 3.75,
       tiers: [{
-        tier: { type: "context", size: 200_000 },
-        input: 4,
-        output: 15,
+        tier: { type: "context", size: 272_000 },
+        input: 6,
+        output: 22.5,
         cache_read: 0.6,
         cache_write: 7.5,
       }],
@@ -400,7 +413,7 @@ test("filters unmanaged DigitalOcean models and joins catalog data by ID", () =>
         },
         pricing_detail: {
           variants: [{
-            tier: "MODEL_PRICING_TIER_EXTENDED_1M",
+            tier: "MODEL_PRICING_TIER_EXTENDED_272K",
             mode: "MODEL_BILLING_MODE_INTERACTIVE",
             prices: {
               input_price_per_million: 0.00000075,
@@ -426,15 +439,55 @@ test("filters unmanaged DigitalOcean models and joins catalog data by ID", () =>
       input: 0.375,
       output: 2.025,
       cacheRead: 0.203,
-      inputOver200k: 0.75,
-      outputOver200k: 3,
+      extended: {
+        context: 272_000,
+        input: 0.75,
+        output: 3,
+      },
     },
   });
 });
 
-test("syncs DigitalOcean reasoning efforts and lifecycle status", () => {
+test("maps DigitalOcean 1M catalog pricing to its 200K threshold", () => {
+  const models = parseDigitalOceanModels({
+    models: [digitalOceanModel({ pricing: undefined })],
+    catalog: [{
+      model_id: "anthropic-claude-4.6-sonnet",
+      name: "Claude Sonnet 4.6",
+      context_window: "1000000",
+      max_output_tokens: "64000",
+      availability: ["serverless"],
+      modalities: { input: ["text", "image"], output: ["text"] },
+      pricing: {
+        input_price_per_million: 0.000003,
+        output_price_per_million: 0.000015,
+      },
+      pricing_detail: {
+        variants: [{
+          tier: "MODEL_PRICING_TIER_EXTENDED_1M",
+          mode: "MODEL_BILLING_MODE_INTERACTIVE",
+          prices: {
+            input_price_per_million: 0.000006,
+            output_price_per_million: 0.0000225,
+          },
+        }],
+      },
+    }],
+  });
+
+  expect(models[0]?.pricing?.extended).toEqual({
+    context: 200_000,
+    input: 6,
+    output: 22.5,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  });
+});
+
+test("syncs DigitalOcean reasoning capability, efforts, and lifecycle status", () => {
   const model = buildDigitalOceanModel(digitalOceanModel({
     lifecycle_status: "deprecated",
+    thinking: false,
     reasoning_efforts: ["none", "low", "medium", "high", "max", "unsupported"],
   }), {
     name: "Claude Sonnet 4.6",
@@ -443,7 +496,7 @@ test("syncs DigitalOcean reasoning efforts and lifecycle status", () => {
     release_date: "2026-02-17",
     last_updated: "2026-03-13",
     attachment: true,
-    reasoning: true,
+    reasoning: false,
     reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
     temperature: true,
     tool_call: true,
@@ -456,6 +509,7 @@ test("syncs DigitalOcean reasoning efforts and lifecycle status", () => {
 
   expect(model).toMatchObject({
     status: "deprecated",
+    reasoning: true,
     reasoning_options: [{ type: "effort", values: ["none", "low", "medium", "high", "max"] }],
   });
 });
@@ -471,6 +525,7 @@ test("new DigitalOcean base models inherit intrinsic capabilities", () => {
       id: "openai-gpt-5.5",
       name: "GPT-5.5",
       thinking: undefined,
+      reasoning_efforts: undefined,
     }),
     undefined,
     "openai/gpt-5.5",
@@ -556,7 +611,17 @@ test("fetches every page of the DigitalOcean catalog", async () => {
     requests.push(url);
     if (url.includes("/catalog/first-catalog-id")) {
       return Promise.resolve(new Response(JSON.stringify({
-        data: { id: "first-catalog-id", model_id: "first", name: "First", availability: ["serverless"] },
+        data: {
+          id: "first-catalog-id",
+          model_id: "first",
+          name: "Stale First Detail",
+          context_window: "50",
+          max_output_tokens: "10",
+          availability: ["dedicated"],
+          modalities: { input: ["text", "image"], output: ["text"] },
+          pricing: { input_price_per_million: 0.000009, output_price_per_million: 0.000009 },
+          pricing_detail: { variants: [] },
+        },
       })));
     }
     if (url.includes("/catalog/second-catalog-id")) {
@@ -564,15 +629,24 @@ test("fetches every page of the DigitalOcean catalog", async () => {
         data: { id: "second-catalog-id", model_id: "second", name: "Second", availability: ["serverless"] },
       })));
     }
-    if (url.includes("/catalog") && url.includes("?page=2")) {
+    if (url.includes("/catalog") && url.includes("page=2")) {
       return Promise.resolve(new Response(JSON.stringify({
         data: [{ id: "second-catalog-id", model_id: "second", name: "Second", availability: ["serverless"] }],
+        meta: { total: 2, page: 2, pages: 2 },
       })));
     }
     if (url.includes("/catalog")) {
       return Promise.resolve(new Response(JSON.stringify({
-        data: [{ id: "first-catalog-id", model_id: "first", name: "First", availability: ["serverless"] }],
-        links: { pages: { next: "https://api.digitalocean.com/v2/gen-ai/models/catalog?page=2" } },
+        data: [{
+          id: "first-catalog-id",
+          model_id: "first",
+          name: "First",
+          context_window: "100",
+          max_output_tokens: "90",
+          availability: ["serverless"],
+          pricing: { input_price_per_million: 0.000001, output_price_per_million: 0.000002 },
+        }],
+        meta: { total: 2, page: 1, pages: 2 },
       })));
     }
     if (url.includes("?page=2")) {
@@ -587,6 +661,15 @@ test("fetches every page of the DigitalOcean catalog", async () => {
   const result = await fetchDigitalOceanModels("test-key", fetcher);
   expect(result.models.map((model) => model.id)).toEqual(["first", "second"]);
   expect(result.catalog.map((model) => model.model_id)).toEqual(["first", "second"]);
+  expect(result.catalog[0]).toMatchObject({
+    name: "First",
+    context_window: "100",
+    max_output_tokens: "90",
+    availability: ["serverless"],
+    pricing: { input_price_per_million: 0.000001, output_price_per_million: 0.000002 },
+    modalities: { input: ["text", "image"], output: ["text"] },
+    pricing_detail: { variants: [] },
+  });
   expect(requests).toHaveLength(6);
 });
 

--- a/sync.md
+++ b/sync.md
@@ -181,10 +181,10 @@ OVHcloud AI Endpoints is implemented in `packages/core/src/sync/providers/ovhclo
 ## DigitalOcean Notes
 
 - DigitalOcean is implemented in `packages/core/src/sync/providers/digitalocean.ts`.
-- Source endpoints: `https://api.digitalocean.com/v2/gen-ai/models` for catalog metadata and `https://www.digitalocean.com/api/static-content/v1/products` for pricing.
-- Required auth: `DIGITALOCEAN_API_TOKEN` or `DIGITALOCEAN_ACCESS_TOKEN`; the pricing endpoint is public.
-- The sync manages text-output models. Other model types and local models absent from the API are retained for manual lifecycle review.
-- Catalog metadata updates names, modalities, limits, and end-of-life status. Pricing updates input/output and long-context rates while preserving cache, reasoning, and audio prices that the pricing API does not expose.
+- Source endpoints: `https://api.digitalocean.com/v2/gen-ai/models` for lifecycle and reasoning metadata, and the public `https://api.digitalocean.com/v2/gen-ai/models/catalog` for availability, modalities, limits, and pricing.
+- Required auth: `DIGITALOCEAN_API_TOKEN` or `DIGITALOCEAN_ACCESS_TOKEN` for the control-plane model endpoint; the model catalog is public.
+- The sync manages serverless text-output models. Other model types, dedicated-only models, and local models absent from the API are retained for manual lifecycle review.
+- Catalog pricing updates standard, cache-read, cache-write, and extended-context rates while preserving authored reasoning and audio prices.
 
 ## Vercel Status
 


### PR DESCRIPTION
## Summary

- use DigitalOcean's public model catalog for serverless availability, model-ID pricing, modalities, context, and `max_output_tokens`
- paginate the live catalog through `meta.page/pages` while retaining link-based pagination support
- keep list metadata authoritative when detail cards disagree, using details only for modalities and pricing variants
- map `EXTENDED_272K` to 272K pricing and Anthropic `EXTENDED_1M` to its actual 200K surcharge boundary
- retain the authenticated control-plane feed for lifecycle and model-specific `reasoning_efforts`, including positive reasoning capability corrections
- stop treating the Playground `settings.max_tokens` bound as model output capacity
- filter dedicated-only models from the serverless provider catalog

## Context

The generated changes in #3077 exposed that `settings.max_tokens.max` is not the model's output limit. For example, it produced Qwen3 output `131072` instead of `32768`, o1 output `16000` instead of `100000`, and Claude Opus 4.6 output `128000` instead of `8192`.

The previous static pricing feed also required a fragile marketing-name join and lagged the model catalog, causing models with complete metadata and pricing to be skipped.

## Sources

- [List Model Catalog](https://docs.digitalocean.com/reference/api/reference/gradientai-platform/index.html.md#genai_list_model_catalog) documents pagination, `max_output_tokens`, availability, and standard pricing.
- [Get Model Catalog Card](https://docs.digitalocean.com/reference/api/reference/gradientai-platform/index.html.md#genai_get_model_catalog_card) documents modalities and complete pricing variants.
- [List Available Models](https://docs.digitalocean.com/reference/pydo/reference/genai/list_models/) documents lifecycle and `reasoning_efforts`.
- [Available Models for Inference](https://docs.digitalocean.com/products/inference/details/models/index.html.md) provides the published model limits and extended-context pricing used to cross-check the live responses.

## Testing

- `bun test packages/core/test/sync.test.ts` (37 pass)
- `bun validate`
- `git diff --check`
- parsed all 81 live public catalog detail responses successfully
- cross-checked live pagination and pricing variants (`EXTENDED_1M` and `EXTENDED_272K`)
- independent follow-up review found no remaining correctness issues

`bun test` was also run repository-wide. The DigitalOcean tests pass; unrelated existing failures remain in open-weight metadata checks and SDK snapshot/effect tests that require generated or unavailable dependencies.