### PR TITLE
fix: add Muse Spark pricing

### DIFF
--- a/providers/meta/models/muse-spark-1.1.toml
+++ b/providers/meta/models/muse-spark-1.1.toml
@@ -1,3 +1,10 @@
+# Sources:
+# https://developer.meta.com/ai/resources/blog/build-with-muse-spark/
+
 base_model = "meta/muse-spark-1.1"
 
 reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.25
+output = 4.25


### PR DESCRIPTION
## Summary

- add Meta Muse Spark 1.1 input pricing at $1.25 per million tokens
- add output pricing at $4.25 per million tokens
- cite Meta's Model API launch announcement

## Source

- https://developer.meta.com/ai/resources/blog/build-with-muse-spark/

Meta states that reasoning tokens are billed as output. No separate cache rate is published, so this change does not infer one.

## Validation

- `bun validate`