### PR TITLE
feat(openai): add GPT-5.6 Sol, Terra, and Luna models

### DIFF
--- a/models/openai/gpt-5.6-luna.toml
+++ b/models/openai/gpt-5.6-luna.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.6 Luna"
+description = "Fast, cost-efficient GPT-5.6 for high-volume chat, classification, and lightweight agents"
+family = "gpt"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2026-02-01"
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/models/openai/gpt-5.6-sol.toml
+++ b/models/openai/gpt-5.6-sol.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.6 Sol"
+description = "Flagship GPT-5.6 for complex reasoning, coding, and long-horizon agentic workflows"
+family = "gpt"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2026-02-01"
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/models/openai/gpt-5.6-terra.toml
+++ b/models/openai/gpt-5.6-terra.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.6 Terra"
+description = "Balanced GPT-5.6 for everyday coding, reasoning, and agentic tasks"
+family = "gpt"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2026-02-01"
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/openai/models/gpt-5.6-luna.toml
+++ b/providers/openai/models/gpt-5.6-luna.toml
@@ -1,0 +1,30 @@
+name = "GPT-5.6 Luna"
+description = "Fast, cost-efficient GPT-5.6 for high-volume chat, classification, and lightweight agents"
+family = "gpt"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+temperature = false
+knowledge = "2026-02-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 1.00
+output = 6.00
+cache_read = 0.10
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }

--- a/providers/openai/models/gpt-5.6-sol.toml
+++ b/providers/openai/models/gpt-5.6-sol.toml
@@ -1,0 +1,30 @@
+name = "GPT-5.6 Sol"
+description = "Flagship GPT-5.6 for complex reasoning, coding, and long-horizon agentic workflows"
+family = "gpt"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+temperature = false
+knowledge = "2026-02-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }

--- a/providers/openai/models/gpt-5.6-terra.toml
+++ b/providers/openai/models/gpt-5.6-terra.toml
@@ -1,0 +1,30 @@
+name = "GPT-5.6 Terra"
+description = "Balanced GPT-5.6 for everyday coding, reasoning, and agentic tasks"
+family = "gpt"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+temperature = false
+knowledge = "2026-02-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }


### PR DESCRIPTION
## Summary

Adds the three new GPT-5.6 tier models to the OpenAI provider, with matching provider-agnostic metadata in `models/openai/` (mirroring the gpt-5.5 / gpt-5.4 layout so other providers can inherit via `base_model`).

| Model | Slug | Tier | In / Out / Cache (per 1M) |
|---|---|---|---|
| GPT-5.6 Sol | `gpt-5.6-sol` | Flagship | $5 / $30 / $0.50 |
| GPT-5.6 Terra | `gpt-5.6-terra` | Balanced | $2.50 / $15 / $0.25 |
| GPT-5.6 Luna | `gpt-5.6-luna` | Cost-efficient | $1 / $6 / $0.10 |

All three: `reasoning = true`, knowledge `2026-02-01`, released `2026-07-09`, 1M context.

## Pro variants

OpenRouter also lists `*-pro` slugs ("same underlying model, served with `reasoning.mode` set to `pro`"). The OpenAI provider does not carry separate entries for reasoning-flag convenience variants (cf. no `o4-mini-high` entry), so I modeled Pro as an `experimental.modes.pro` serving mode on each base model that only overrides the request body:

```toml
[experimental.modes.pro]
provider = { body = { reasoning = { mode = "pro" } } }
```

No `cost` override is declared (mode `cost` is optional in the schema), so Pro inherits the base per-token price. Rationale: like `o4-mini-high`, Pro is the same underlying model whose extra reasoning is already billed as output tokens — there is no separate per-token price change implied by the source. **If Pro is in fact a separately-priced tier, a `cost` override should be added.**

## Evidence

- [OpenRouter – GPT-5.6 Luna](https://openrouter.ai/openai/gpt-5.6-luna) — in/out \$1/\$6, cache \$0.10, context 1M, released 2026-07-09, knowledge Feb 2026.
- [OpenRouter – GPT-5.6 Terra](https://openrouter.ai/openai/gpt-5.6-terra) — in/out \$2.50/\$15, cache \$0.25, context 1M.
- [OpenRouter – GPT-5.6 Sol](https://openrouter.ai/openai/gpt-5.6-sol) — in/out \$5/\$30, cache \$0.50, context 1M.
- Provider pricing tables on each page supply the cache-read column (\$0.10 / \$0.25 / \$0.50).

## Assumptions worth verifying before merge

These follow the GPT-5.x series precedent but are not fully pinned by the OpenRouter source; happy to adjust:

1. **`reasoning_options`** — used the series-standard `effort` dial (`none`/`low`/`medium`/`high`/`xhigh`). The Pro copy hints at a `reasoning.mode` control (captured above as an experimental mode, not a reasoning option, since the schema has no `mode` option type). If the canonical 5.6 reasoning API differs, this should change.
2. **Context split** — OpenRouter reports "1M"; I used `1,050,000 / 922,000 / 128,000` from gpt-5.5/5.4.
3. **Modalities** — `["text", "image", "pdf"]` in / `["text"]` out, matching the flagship series.
4. **Omitted unverified fields** — no `cost.tiers` (>200K pricing) and no `experimental.modes.fast`, since the source does not surface them (gpt-5.5/5.4 have both).

## Validation

`bun validate` passes (exit 0, no errors); all three models resolve with expected cost, limits, modalities, and the `pro` mode.