### PR TITLE
feat(openai): add GPT-5.6 models

### DIFF
--- a/models/openai/gpt-5.6-luna.toml
+++ b/models/openai/gpt-5.6-luna.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.6 Luna"
+description = "Cost-efficient GPT-5.6 model for fast, high-volume workloads"
+family = "gpt-nano"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2026-02-16"
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/models/openai/gpt-5.6-sol.toml
+++ b/models/openai/gpt-5.6-sol.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.6 Sol"
+description = "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows"
+family = "gpt"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2026-02-16"
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/models/openai/gpt-5.6-terra.toml
+++ b/models/openai/gpt-5.6-terra.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.6 Terra"
+description = "Balanced GPT-5.6 model for capable, cost-efficient everyday work"
+family = "gpt-mini"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2026-02-16"
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/openai/models/gpt-5.6-luna.toml
+++ b/providers/openai/models/gpt-5.6-luna.toml
@@ -1,0 +1,22 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 1.00
+output = 6.00
+cache_read = 0.10
+cache_write = 1.25
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 2.00
+output = 9.00
+cache_read = 0.20
+cache_write = 2.50
+
+[experimental.modes.fast]
+cost = { input = 2.00, output = 12.00, cache_read = 0.20, cache_write = 2.50 }
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }

--- a/providers/openai/models/gpt-5.6-sol.toml
+++ b/providers/openai/models/gpt-5.6-sol.toml
@@ -1,0 +1,22 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 10.00
+output = 45.00
+cache_read = 1.00
+cache_write = 12.50
+
+[experimental.modes.fast]
+cost = { input = 10.00, output = 60.00, cache_read = 1.00, cache_write = 12.50 }
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }

--- a/providers/openai/models/gpt-5.6-terra.toml
+++ b/providers/openai/models/gpt-5.6-terra.toml
@@ -1,0 +1,22 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+cache_write = 3.125
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 5.00
+output = 22.50
+cache_read = 0.50
+cache_write = 6.25
+
+[experimental.modes.fast]
+cost = { input = 5.00, output = 30.00, cache_read = 0.50, cache_write = 6.25 }
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }

--- a/providers/openai/models/gpt-5.6.toml
+++ b/providers/openai/models/gpt-5.6.toml
@@ -1,0 +1,22 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 10.00
+output = 45.00
+cache_read = 1.00
+cache_write = 12.50
+
+[experimental.modes.fast]
+cost = { input = 10.00, output = 60.00, cache_read = 1.00, cache_write = 12.50 }
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }


### PR DESCRIPTION
## Summary

- add provider-agnostic metadata for GPT-5.6 Sol, Terra, and Luna
- add OpenAI offerings for all three API IDs and the documented `gpt-5.6` Sol alias
- include standard, long-context, cache read/write, and Priority pricing
- expose the documented `none`, `low`, `medium`, `high`, `xhigh`, and `max` reasoning efforts
- expose Priority as `fast` and `reasoning.mode = "pro"` as `pro` experimental modes

## Evidence

- [GPT-5.6 launch](https://openai.com/index/gpt-5-6/) documents the July 9 release, API availability, model tiers, and headline pricing.
- [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol), [Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra), and [Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna) document model IDs, context/output limits, knowledge cutoff, modalities, features, and per-model pricing.
- [GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model) documents the `gpt-5.6` alias, all six reasoning effort values, and cache-write behavior.
- [OpenAI reasoning mode](https://developers.openai.com/api/docs/guides/reasoning#reasoning-mode) documents `reasoning.mode = "pro"` and states that its aggregated model-work tokens are billed at the selected model's standard token rates. It therefore needs no per-token cost override; higher total cost comes from increased token usage.
- [OpenAI pricing](https://developers.openai.com/api/docs/pricing) documents standard, long-context, cache read/write, and Priority rates.
- Authenticated API checks on 2026-07-09 returned all three concrete IDs from `GET /v1/models`; each concrete `GET /v1/models/{id}` returned HTTP 200.

## Reasoning options audit

All four provider entries expose only the model-specific effort values documented by OpenAI: `none`, `low`, `medium`, `high`, `xhigh`, and `max`. No toggle or token-budget control is claimed. Pro execution is represented separately as an experimental provider mode using `reasoning.mode = "pro"`.

## Validation

- `bun validate`
- `bun models:sync openai --dry-run`
- `git diff --cached --check`
