### PR TITLE
fix(openrouter): factor OpenAI Pro variants

### DIFF
--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -11,6 +11,12 @@ const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", 
 const modelMetadataByID = new Map<string, Record<string, unknown>>();
 const modelMetadataFilesByProvider = new Map<string, Set<string>>();
 
+const CANONICAL_BASE_MODEL_OVERRIDES = {
+  "openai/gpt-5.6-luna-pro": "openai/gpt-5.6-luna",
+  "openai/gpt-5.6-sol-pro": "openai/gpt-5.6-sol",
+  "openai/gpt-5.6-terra-pro": "openai/gpt-5.6-terra",
+} as const;
+
 const CANONICAL_PROVIDER_PREFIXES = {
   alibaba: { provider: "alibaba", metadata: "alibaba" },
   anthropic: { provider: "anthropic", metadata: "anthropic" },
@@ -201,15 +207,11 @@ export function buildOpenRouterModel(
   const canonical = existing?.base_model ?? baseModel ?? resolveCanonicalBaseModel(model.id);
 
   if (canonical !== undefined) {
-    const sourceModelID = model.id.split("/").slice(1).join("/").replace(/:free$/, "");
-    const canonicalModelID = canonical.split("/").slice(1).join("/");
-    const openAIProVariant = model.id.startsWith("openai/")
-      && sourceModelID.endsWith("-pro")
-      && sourceModelID.replace(/-pro$/, "") === canonicalModelID;
+    const canonicalOverride = canonicalBaseModelOverride(model.id);
     return factorBaseModel(
       canonical,
       {
-        name: baseModel !== undefined || model.id.endsWith(":free") || openAIProVariant
+        name: baseModel !== undefined || model.id.endsWith(":free") || canonicalOverride === canonical
           ? name
           : undefined,
         description: existing?.description ?? describeModel({
@@ -295,6 +297,9 @@ function openRouterReasoningOptions(reasoning: OpenRouterModel["reasoning"]): Sy
 }
 
 export function resolveCanonicalBaseModel(openrouterID: string) {
+  const override = canonicalBaseModelOverride(openrouterID);
+  if (override !== undefined) return override;
+
   const [prefix, ...modelParts] = openrouterID.split("/");
   if (prefix === undefined || modelParts.length === 0) return undefined;
   if (openrouterID.startsWith("~/") || prefix.startsWith("~")) return undefined;
@@ -322,6 +327,12 @@ function modelMetadataExists(provider: string, modelID: string) {
     modelMetadataFilesByProvider.set(provider, files);
   }
   return files.has(`${modelID}.toml`);
+}
+
+function canonicalBaseModelOverride(openrouterID: string) {
+  return CANONICAL_BASE_MODEL_OVERRIDES[
+    openrouterID as keyof typeof CANONICAL_BASE_MODEL_OVERRIDES
+  ];
 }
 
 export function factorBaseModel(
@@ -452,10 +463,6 @@ function canonicalCandidates(provider: string, modelID: string) {
 
   if (provider === "minimax") {
     candidates.push(modelID.replace(/^minimax-m/, "MiniMax-M"));
-  }
-
-  if (provider === "openai") {
-    candidates.push(modelID.replace(/-pro$/, ""));
   }
 
   return [...new Set(candidates)];

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -201,10 +201,17 @@ export function buildOpenRouterModel(
   const canonical = existing?.base_model ?? baseModel ?? resolveCanonicalBaseModel(model.id);
 
   if (canonical !== undefined) {
+    const sourceModelID = model.id.split("/").slice(1).join("/").replace(/:free$/, "");
+    const canonicalModelID = canonical.split("/").slice(1).join("/");
+    const openAIProVariant = model.id.startsWith("openai/")
+      && sourceModelID.endsWith("-pro")
+      && sourceModelID.replace(/-pro$/, "") === canonicalModelID;
     return factorBaseModel(
       canonical,
       {
-        name: baseModel !== undefined || model.id.endsWith(":free") ? name : undefined,
+        name: baseModel !== undefined || model.id.endsWith(":free") || openAIProVariant
+          ? name
+          : undefined,
         description: existing?.description ?? describeModel({
           id: model.id,
           name,
@@ -445,6 +452,10 @@ function canonicalCandidates(provider: string, modelID: string) {
 
   if (provider === "minimax") {
     candidates.push(modelID.replace(/^minimax-m/, "MiniMax-M"));
+  }
+
+  if (provider === "openai") {
+    candidates.push(modelID.replace(/-pro$/, ""));
   }
 
   return [...new Set(candidates)];

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -748,7 +748,15 @@ test("factors OpenRouter Pro routes against canonical OpenAI metadata", () => {
     },
   }), undefined);
 
-  expect(resolveCanonicalBaseModel("openai/gpt-5.6-sol-pro")).toBe("openai/gpt-5.6-sol");
+  expect([
+    resolveCanonicalBaseModel("openai/gpt-5.6-luna-pro"),
+    resolveCanonicalBaseModel("openai/gpt-5.6-sol-pro"),
+    resolveCanonicalBaseModel("openai/gpt-5.6-terra-pro"),
+  ]).toEqual([
+    "openai/gpt-5.6-luna",
+    "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-terra",
+  ]);
   expect(model).toMatchObject({
     base_model: "openai/gpt-5.6-sol",
     name: "GPT-5.6 Sol Pro",

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -19,7 +19,12 @@ import {
   resolveDigitalOceanBaseModel,
   type DigitalOceanSourceModel,
 } from "../src/sync/providers/digitalocean.js";
-import { buildOpenRouterModel, openrouter, type OpenRouterModel } from "../src/sync/providers/openrouter.js";
+import {
+  buildOpenRouterModel,
+  openrouter,
+  resolveCanonicalBaseModel,
+  type OpenRouterModel,
+} from "../src/sync/providers/openrouter.js";
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
 import { openai, parseOpenAIModels } from "../src/sync/providers/openai.js";
 import { buildWandbModel, type WandbModel } from "../src/sync/providers/wandb.js";
@@ -729,6 +734,27 @@ test("syncs OpenRouter reasoning efforts from model metadata", () => {
       { type: "effort", values: ["max", "xhigh", "high", "medium", "low"] },
     ],
   });
+});
+
+test("factors OpenRouter Pro routes against canonical OpenAI metadata", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    id: "openai/gpt-5.6-sol-pro",
+    name: "OpenAI: GPT-5.6 Sol Pro",
+    knowledge_cutoff: "2026-02-16",
+    context_length: 1_050_000,
+    top_provider: {
+      context_length: 1_050_000,
+      max_completion_tokens: 128_000,
+    },
+  }), undefined);
+
+  expect(resolveCanonicalBaseModel("openai/gpt-5.6-sol-pro")).toBe("openai/gpt-5.6-sol");
+  expect(model).toMatchObject({
+    base_model: "openai/gpt-5.6-sol",
+    name: "GPT-5.6 Sol Pro",
+  });
+  expect("family" in model).toBe(false);
+  expect("release_date" in model).toBe(false);
 });
 
 test("preserves authored OpenRouter reasoning options over model metadata", () => {


### PR DESCRIPTION
## Summary

- explicitly map the three OpenRouter GPT-5.6 Pro route IDs to their canonical GPT-5.6 metadata
- preserve each Pro route display name while inheriting provider-agnostic fields through `base_model`
- add regression coverage for all three mappings and factored output

The allowlist contains only:

- `openai/gpt-5.6-sol-pro` -> `openai/gpt-5.6-sol`
- `openai/gpt-5.6-terra-pro` -> `openai/gpt-5.6-terra`
- `openai/gpt-5.6-luna-pro` -> `openai/gpt-5.6-luna`

There is no general `-pro` suffix inference. Existing and future Pro IDs remain distinct unless explicitly mapped.

## Validation

- `bun test packages/core/test/sync.test.ts` (36 pass)
- `bun validate`
- `bun models:sync openrouter --dry-run`
- `git diff --check`

After merge, re-run the OpenRouter sync to refresh #3152.
