### PR TITLE
fix(openai): distinguish GPT-5.6 alias name

### DIFF
--- a/providers/openai/models/gpt-5.6.toml
+++ b/providers/openai/models/gpt-5.6.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]


### PR DESCRIPTION
## Summary

- label the `gpt-5.6` alias as `GPT-5.6`
- keep the concrete `gpt-5.6-sol` entry labeled `GPT-5.6 Sol`

## Why

OpenAI documents that `gpt-5.6` routes to `gpt-5.6-sol`, but they remain distinct selectable API IDs: https://developers.openai.com/api/docs/guides/latest-model

Both provider entries currently inherit the same `GPT-5.6 Sol` display name. Consumers such as OpenCode also project each entry's `fast` and `pro` modes into selectable models, producing indistinguishable Sol, Sol Fast, and Sol Pro rows under the same provider.

This provider-level name override distinguishes the alias without changing model IDs, pricing, capabilities, reasoning options, or request configuration.

## Validation

- `bun validate`
- `cd packages/sdk && bun run test` (23 passed)
- generated OpenAI catalog inspection confirms `gpt-5.6` is named `GPT-5.6` while `gpt-5.6-sol` remains `GPT-5.6 Sol`
