### PR TITLE
fix(venice): factor Pro routes against base models

### DIFF
--- a/packages/core/src/sync/providers/venice.ts
+++ b/packages/core/src/sync/providers/venice.ts
@@ -78,6 +78,9 @@ const BASE_MODEL_ALIASES: Record<string, string> = {
   "claude-opus-4-6-fast": "anthropic/claude-opus-4-6",
   "claude-opus-4-7-fast": "anthropic/claude-opus-4-7",
   "claude-opus-4-8-fast": "anthropic/claude-opus-4-8",
+  "openai-gpt-56-luna-pro": "openai/gpt-5.6-luna",
+  "openai-gpt-56-sol-pro": "openai/gpt-5.6-sol",
+  "openai-gpt-56-terra-pro": "openai/gpt-5.6-terra",
 };
 
 export const venice = {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../src/sync/providers/openrouter.js";
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
 import { openai, parseOpenAIModels } from "../src/sync/providers/openai.js";
+import { resolveVeniceBaseModel } from "../src/sync/providers/venice.js";
 import { buildVercelModel, vercel } from "../src/sync/providers/vercel.js";
 import { buildWandbModel, type WandbModel } from "../src/sync/providers/wandb.js";
 import { buildXAIModel } from "../src/sync/providers/xai.js";
@@ -764,6 +765,18 @@ test("factors OpenRouter Pro routes against canonical OpenAI metadata", () => {
   });
   expect("family" in model).toBe(false);
   expect("release_date" in model).toBe(false);
+});
+
+test("resolves Venice Pro routes to canonical OpenAI metadata", () => {
+  expect([
+    resolveVeniceBaseModel("openai-gpt-56-luna-pro", "GPT-5.6 Luna Pro"),
+    resolveVeniceBaseModel("openai-gpt-56-sol-pro", "GPT-5.6 Sol Pro"),
+    resolveVeniceBaseModel("openai-gpt-56-terra-pro", "GPT-5.6 Terra Pro"),
+  ]).toEqual([
+    "openai/gpt-5.6-luna",
+    "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-terra",
+  ]);
 });
 
 test("preserves authored OpenRouter reasoning options over model metadata", () => {


### PR DESCRIPTION
## Summary
- map Venice GPT-5.6 Luna, Sol, and Terra Pro routes to their canonical OpenAI metadata
- ensure future Venice syncs emit `base_model` TOMLs instead of duplicated full definitions
- add regression coverage for all three Pro aliases

Fixes the incorrect generated output in #3158.

## Verification
- `bun test packages/core/test/sync.test.ts`
- `bun validate`
- `bun venice:sync` (confirmed all three Pro TOMLs use `base_model`)
