### PR TITLE
fix: add Muse Spark cache pricing

### DIFF
--- a/providers/meta/models/muse-spark-1.1.toml
+++ b/providers/meta/models/muse-spark-1.1.toml
@@ -1,4 +1,5 @@
 # Sources:
+# https://ai.developer.meta.com/docs/getting-started/pricing-rate-limits/
 # https://developer.meta.com/ai/resources/blog/build-with-muse-spark/
 
 base_model = "meta/muse-spark-1.1"
@@ -8,3 +9,4 @@ reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "med
 [cost]
 input = 1.25
 output = 4.25
+cache_read = 0.15


### PR DESCRIPTION
## Summary

- add Muse Spark 1.1 cached-input pricing at $0.15 per million tokens
- cite Meta's dedicated pricing and rate-limit documentation
- follow up on #3149

## Source

- https://ai.developer.meta.com/docs/getting-started/pricing-rate-limits/

## Validation

- `bun validate`