### PR TITLE
routing.run: add gpt-5.6 sol/terra/luna

### DIFF
--- a/providers/routing-run/models/gpt-5.6-luna.toml
+++ b/providers/routing-run/models/gpt-5.6-luna.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = []
+
+[cost]
+input = 0.70
+output = 4.20
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/routing-run/models/gpt-5.6-sol.toml
+++ b/providers/routing-run/models/gpt-5.6-sol.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = []
+
+[cost]
+input = 2.50
+output = 15.00
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/routing-run/models/gpt-5.6-terra.toml
+++ b/providers/routing-run/models/gpt-5.6-terra.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = []
+
+[cost]
+input = 1.50
+output = 9.00
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
## What

Adds the three **GPT-5.6** tiers to the `routing.run` provider — `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` — now served on routing.run's OpenAI-compatible endpoint. Follow-up to #3143.

Each `base_model`s the corresponding `openai/gpt-5.6-<tier>` metadata (reasoning, `tool_call`, vision, structured output all inherited) and overrides only:
- **`cost`** — routing.run's list pricing from `GET https://api.routing.run/v1/models`: sol $2.50/$15, terra $1.50/$9, luna $0.70/$4.20 (per 1M in/out).
- **`limit`** — 1M context / 128K output.
- **`reasoning_options = []`** + `interleaved reasoning_content`, matching the rest of the provider (no request-side reasoning toggle on the OpenAI-compatible surface).

## Verification
- `bun validate` passes; all three resolve under `routing-run` (15 models total).
- Live `200` on bare ids via `api.routing.run/v1/chat/completions` (e.g. `gpt-5.6-terra`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
