### PR TITLE
feat(github-copilot): add GPT-5.6 models and long-context pricing

### DIFF
--- a/providers/github-copilot/models/gemini-2.5-pro.toml
+++ b/providers/github-copilot/models/gemini-2.5-pro.toml
@@ -6,12 +6,6 @@ input = 1.25
 output = 10
 cache_read = 0.125
 
-[[cost.tiers]]
-tier = { type = "context", size = 200_000 }
-input = 2.5
-output = 15
-cache_read = 0.25
-
 [limit]
 context = 128_000
 input = 128_000

--- a/providers/github-copilot/models/gemini-3.1-pro-preview.toml
+++ b/providers/github-copilot/models/gemini-3.1-pro-preview.toml
@@ -13,6 +13,6 @@ output = 18
 cache_read = 0.4
 
 [limit]
-context = 200_000
-input = 136_000
+context = 1_000_000
+input = 936_000
 output = 64_000

--- a/providers/github-copilot/models/gpt-5.4.toml
+++ b/providers/github-copilot/models/gpt-5.4.toml
@@ -13,5 +13,5 @@ output = 22.5
 cache_read = 0.5
 
 [limit]
-context = 400_000
-input = 272_000
+context = 1_050_000
+input = 922_000

--- a/providers/github-copilot/models/gpt-5.5.toml
+++ b/providers/github-copilot/models/gpt-5.5.toml
@@ -13,5 +13,5 @@ output = 45
 cache_read = 1
 
 [limit]
-context = 400_000
-input = 272_000
+context = 1_050_000
+input = 922_000

--- a/providers/github-copilot/models/gpt-5.6-luna.toml
+++ b/providers/github-copilot/models/gpt-5.6-luna.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 1
+output = 6
+cache_read = 0.1

--- a/providers/github-copilot/models/gpt-5.6-luna.toml
+++ b/providers/github-copilot/models/gpt-5.6-luna.toml
@@ -5,3 +5,9 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 input = 1
 output = 6
 cache_read = 0.1
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2
+output = 9
+cache_read = 0.2

--- a/providers/github-copilot/models/gpt-5.6-sol.toml
+++ b/providers/github-copilot/models/gpt-5.6-sol.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5

--- a/providers/github-copilot/models/gpt-5.6-sol.toml
+++ b/providers/github-copilot/models/gpt-5.6-sol.toml
@@ -5,3 +5,9 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 input = 5
 output = 30
 cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1

--- a/providers/github-copilot/models/gpt-5.6-terra.toml
+++ b/providers/github-copilot/models/gpt-5.6-terra.toml
@@ -5,3 +5,9 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 input = 2.5
 output = 15
 cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5

--- a/providers/github-copilot/models/gpt-5.6-terra.toml
+++ b/providers/github-copilot/models/gpt-5.6-terra.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25


### PR DESCRIPTION
## Summary

- add GPT-5.6 Luna, Sol, and Terra to the GitHub Copilot provider
- expose all six supported reasoning efforts and inherited 1.05M-token limits
- add documented long-context pricing above 200K for Luna and above 272K for Sol and Terra
- update GPT-5.4, GPT-5.5, and Gemini 3.1 Pro limits so their documented long-context tiers are reachable
- remove Gemini 2.5 Pro's obsolete long-context tier, which GitHub now marks as not applicable

## Evidence

- [Supported AI models in GitHub Copilot](https://docs.github.com/en/copilot/reference/ai-models/supported-models#models-with-extended-capabilities) lists all three GPT-5.6 models as GA with 1M-token context and configurable reasoning.
- [Models and pricing for GitHub Copilot](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing) documents the standard and long-context prices and thresholds used here. It also documents Gemini 2.5 Pro as default-only pricing and Gemini 3.1 Pro as having a long-context tier.
- Authenticated `GET https://api.githubcopilot.com/models` on 2026-07-10 returned 1,050,000 context / 922,000 prompt / 128,000 output limits for GPT-5.4, GPT-5.5, and all three GPT-5.6 models; Gemini 3.1 Pro returned 1,000,000 / 936,000 / 64,000.
- The authenticated catalog returned all six GPT-5.6 reasoning efforts: `none`, `low`, `medium`, `high`, `xhigh`, and `max`.

## Validation

- `bun validate`
- generated-record assertions for standard and long-context costs, thresholds, inherited limits, reasoning options, and `base_model` removal
- reachability assertions ensuring each context-tier threshold is below the model's maximum input
- assertion that Gemini 2.5 Pro has no generated long-context tier
- `git diff --cached --check`
