### PR TITLE
feat(github-copilot): add GPT-5.6 models

### DIFF
--- a/providers/github-copilot/models/gpt-5.6-luna.toml
+++ b/providers/github-copilot/models/gpt-5.6-luna.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 1
+output = 6
+cache_read = 0.1
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2
+output = 9
+cache_read = 0.2

--- a/providers/github-copilot/models/gpt-5.6-sol.toml
+++ b/providers/github-copilot/models/gpt-5.6-sol.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1

--- a/providers/github-copilot/models/gpt-5.6-terra.toml
+++ b/providers/github-copilot/models/gpt-5.6-terra.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5


### PR DESCRIPTION
## Summary

- add GPT-5.6 Luna, Sol, and Terra to the GitHub Copilot provider
- expose the six reasoning-effort values supported by Copilot
- add standard and long-context pricing using GitHub's provider-specific rates
- inherit the documented 1.05M context, 922K input, and 128K output limits

Fixes #3177

## Evidence

- [Supported AI models in GitHub Copilot](https://docs.github.com/en/copilot/reference/ai-models/supported-models#models-with-extended-capabilities) lists all three models as GA with 1M-token context and configurable reasoning.
- [Models and pricing for GitHub Copilot](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing) documents each model's standard and long-context rates. Luna switches above 200K input tokens; Sol and Terra switch above 272K.
- Authenticated `GET https://api.githubcopilot.com/models` on 2026-07-10 returned all three IDs with 1,050,000 context, 922,000 prompt, and 128,000 output tokens, plus `none`, `low`, `medium`, `high`, `xhigh`, and `max` reasoning efforts.

## Validation

- `bun validate`
- generated-record assertions for standard and long-context pricing, thresholds, limits, reasoning options, and resolved `base_model` inheritance
- `git diff --cached --check`