### PR TITLE
fix(github-copilot): correct long-context metadata

### DIFF
--- a/providers/github-copilot/models/gemini-2.5-pro.toml
+++ b/providers/github-copilot/models/gemini-2.5-pro.toml
@@ -6,12 +6,6 @@ input = 1.25
 output = 10
 cache_read = 0.125
 
-[[cost.tiers]]
-tier = { type = "context", size = 200_000 }
-input = 2.5
-output = 15
-cache_read = 0.25
-
 [limit]
 context = 128_000
 input = 128_000

--- a/providers/github-copilot/models/gemini-3.1-pro-preview.toml
+++ b/providers/github-copilot/models/gemini-3.1-pro-preview.toml
@@ -13,6 +13,6 @@ output = 18
 cache_read = 0.4
 
 [limit]
-context = 200_000
-input = 136_000
+context = 1_000_000
+input = 936_000
 output = 64_000

--- a/providers/github-copilot/models/gpt-5.4.toml
+++ b/providers/github-copilot/models/gpt-5.4.toml
@@ -13,5 +13,5 @@ output = 22.5
 cache_read = 0.5
 
 [limit]
-context = 400_000
-input = 272_000
+context = 1_050_000
+input = 922_000

--- a/providers/github-copilot/models/gpt-5.5.toml
+++ b/providers/github-copilot/models/gpt-5.5.toml
@@ -13,5 +13,5 @@ output = 45
 cache_read = 1
 
 [limit]
-context = 400_000
-input = 272_000
+context = 1_050_000
+input = 922_000


### PR DESCRIPTION
## Summary

- update GPT-5.4 and GPT-5.5 to their current 1.05M context and 922K input limits
- update Gemini 3.1 Pro to its current 1M context and 936K input limits
- remove Gemini 2.5 Pro's obsolete long-context pricing tier
- ensure every remaining long-context pricing tier is reachable within the model's input limit

## Evidence

- [Models and pricing for GitHub Copilot](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing) documents long-context tiers for GPT-5.4, GPT-5.5, and Gemini 3.1 Pro, while Gemini 2.5 Pro is listed as default-only with no threshold.
- [Models with extended capabilities](https://docs.github.com/en/copilot/reference/ai-models/supported-models#models-with-extended-capabilities) documents the selectable 1M-token context capability for GPT-5.4 and GPT-5.5.
- Authenticated `GET https://api.githubcopilot.com/models` on 2026-07-10 returned 1,050,000 context / 922,000 prompt / 128,000 output limits for GPT-5.4 and GPT-5.5; 1,000,000 context / 936,000 prompt / 64,000 output limits for Gemini 3.1 Pro; and 128,000 context / 128,000 prompt / 64,000 output limits for Gemini 2.5 Pro.
- The replaced limits originated from a verified 2026-06-02 CAPI snapshot and no longer match the current authenticated catalog.

## Validation

- `bun validate`
- generated-record assertions that all documented context tiers are reachable
- generated-record assertion that Gemini 2.5 Pro has no context tier or legacy `context_over_200k` cost
- `git diff --cached --check`