### PR TITLE
feat(openai): add GPT-Realtime-2.1

### DIFF
--- a/models/openai/gpt-realtime-2.1.toml
+++ b/models/openai/gpt-realtime-2.1.toml
@@ -1,0 +1,21 @@
+name = "GPT-Realtime-2.1"
+description = "Realtime speech-to-speech model with configurable reasoning, tool use, and robust voice-agent behavior"
+family = "gpt"
+release_date = "2026-07-06"
+last_updated = "2026-07-06"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = false
+knowledge = "2024-09-30"
+open_weights = false
+
+[limit]
+context = 128_000
+input = 96_000
+output = 32_000
+
+[modalities]
+input = ["text", "audio", "image"]
+output = ["text", "audio"]

--- a/providers/openai/models/gpt-realtime-2.1.toml
+++ b/providers/openai/models/gpt-realtime-2.1.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-realtime-2.1"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 4.00
+output = 24.00
+cache_read = 0.40
+input_audio = 32.00
+output_audio = 64.00


### PR DESCRIPTION
## Summary

- add canonical metadata for GPT-Realtime-2.1
- add the model to the OpenAI provider with text/audio pricing and verified reasoning effort controls
- allow synced catalogs to resolve `openai/gpt-realtime-2.1` automatically as a `base_model`, including #3191

## Evidence

- [OpenAI model page](https://developers.openai.com/api/docs/models/gpt-realtime-2.1) documents the 128K context window, 32K output limit, September 30, 2024 knowledge cutoff, modalities, function calling, and lack of structured outputs.
- [OpenAI changelog](https://developers.openai.com/api/docs/changelog) dates the release to July 6, 2026.
- [OpenAI pricing](https://developers.openai.com/api/docs/pricing#realtime-and-audio-generation-models) documents text pricing of $4/$0.40/$24 and audio pricing of $32/$0.40/$64 per million tokens.
- [OpenAI realtime guide](https://developers.openai.com/api/docs/guides/realtime-models-prompting#set-reasoning-effort) documents `reasoning.effort` values `minimal`, `low`, `medium`, `high`, and `xhigh`.

## Validation

- `bun validate`
- `git diff --check`
- verified `resolveCanonicalBaseModel("openai/gpt-realtime-2.1")` and the Vercel model builder both return `openai/gpt-realtime-2.1`
- `bun test packages/core/test/generate.test.ts`: 9 passed; the existing open-weight links audit still fails for unrelated catalog entries