### PR TITLE
Add databricks-kimi-k2-7-code and databricks-glm-5-2 models

### DIFF
--- a/providers/databricks/models/databricks-glm-5-2.toml
+++ b/providers/databricks/models/databricks-glm-5-2.toml
@@ -1,0 +1,9 @@
+base_model = "zhipuai/glm-5.2"
+# Chat `reasoning_effort = low|medium|high`; `medium` is the default.
+# https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models (accessed 2026-07-11)
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26

--- a/providers/databricks/models/databricks-kimi-k2-7-code.toml
+++ b/providers/databricks/models/databricks-kimi-k2-7-code.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k2.7-code"
+# Chat `reasoning_effort = low|medium|high`; `medium` is the default.
+# https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models (accessed 2026-07-11)
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.95
+output = 4.0
+cache_read = 0.19


### PR DESCRIPTION
Adds two Databricks Foundation Model API pay-per-token endpoints, following the same `base_model`-extension pattern established in #1706:

- **`databricks-kimi-k2-7-code`** — extends `moonshotai/kimi-k2.7-code`
- **`databricks-glm-5-2`** — extends `zhipuai/glm-5.2`

Each file inherits the canonical model metadata (name, family, limits, modalities, benchmarks) and overrides only the Databricks-specific pricing and reasoning shape. Both endpoints are `ai_gateway_v2_supported`, served over `mlflow/v1/chat/completions`, and expose OpenAI-style `reasoning_effort` (low/medium/high, default medium).

### Pricing
| Model | Input ($/M) | Output ($/M) | Cache-read ($/M) |
|-------|-------------|--------------|------------------|
| Kimi K2.7 Code | 0.95 | 4.00 | 0.19 |
| GLM 5.2 | 1.40 | 4.40 | 0.26 |

Validated with `bun run validate` — both models resolve with correct metadata, pricing, and reasoning options.