### PR TITLE
Map mistral-small-4 and mistral-medium-3 to canonical base models

### DIFF
--- a/packages/core/src/sync/providers/empiriolabs.ts
+++ b/packages/core/src/sync/providers/empiriolabs.ts
@@ -11,6 +11,8 @@ const CANONICAL_BASE_MODELS: Record<string, string> = {
   "fugu-ultra": "sakana/fugu-ultra",
   "gemma-4-26b-a4b": "google/gemma-4-26b-a4b-it",
   "gemma-4-e4b": "google/gemma-4-E4B-it",
+  "mistral-medium-3": "mistral/mistral-medium-2505",
+  "mistral-small-4": "mistral/mistral-small-2603",
   "muse-spark-1-1": "meta/muse-spark-1.1",
   "qwen3-5-9b": "alibaba/qwen3.5-9b",
   "qwen3-7-max": "alibaba/qwen3.7-max",


### PR DESCRIPTION
Adds two exact canonical mappings so the EmpirioLabs sync can pick up these models on its next run:

- `mistral-small-4` -> `mistral/mistral-small-2603` (the dated snapshot EmpirioLabs serves)
- `mistral-medium-3` -> `mistral/mistral-medium-2505`

Only models with an exact canonical entry are mapped, per the sync-safety rule. The remaining skipped EmpirioLabs IDs stay skipped because no canonical lab metadata exists for them yet (Amazon Nova and ByteDance Seed labs, Gemma 3, Qwen3.5 Flash and the omni models, dated Magistral/Mistral 3.1 snapshots).