### PR TITLE
Add Lynkr (self-hosted complexity-routing gateway)

### DIFF
--- a/providers/lynkr/logo.svg
+++ b/providers/lynkr/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#1a1d27"/><path d="M20 14v30h24v-6H27V14h-7z" fill="#7c8cff"/><circle cx="44" cy="20" r="5" fill="#7c8cff"/></svg>

--- a/providers/lynkr/logo.svg
+++ b/providers/lynkr/logo.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#1a1d27"/><path d="M20 14v30h24v-6H27V14h-7z" fill="#7c8cff"/><circle cx="44" cy="20" r="5" fill="#7c8cff"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><path d="M16 8v48h32v-8H25V8h-9z" fill="currentColor"/><circle cx="46" cy="14" r="6" fill="currentColor"/></svg>

--- a/providers/lynkr/models/lynkr-auto.toml
+++ b/providers/lynkr/models/lynkr-auto.toml
@@ -1,0 +1,24 @@
+name = "Lynkr Auto (complexity routing)"
+description = "Virtual model: Lynkr scores each request on complexity and routes it to the tier model the user configured (local Ollama/llama.cpp for simple requests, configured cloud providers for complex ones)."
+family = "lynkr"
+release_date = "2025-12-03"
+last_updated = "2026-07-11"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+# Cost and limits depend entirely on the backend model Lynkr routes to;
+# zeros/conservative defaults are placeholders for this self-hosted gateway.
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/lynkr/models/lynkr-auto.toml
+++ b/providers/lynkr/models/lynkr-auto.toml
@@ -1,6 +1,18 @@
+# Lynkr's lynkr-auto is a virtual router model: the gateway scores each request
+# on complexity and routes it to the user-configured tier model (local
+# Ollama/llama.cpp for simple requests, configured cloud providers for complex).
+# Sources (accessed 2026-07-11):
+# - release_date: first public release of the Lynkr repo/npm package,
+#   https://github.com/Fast-Editor/Lynkr (repo created 2025-12-03) and
+#   https://www.npmjs.com/package/lynkr
+# - tool_call: OpenAI- and Anthropic-compatible endpoints forward tool
+#   definitions and tool_use blocks, https://github.com/Fast-Editor/Lynkr/blob/main/documentation/api.md
+# - cost/limits: depend entirely on the backend model Lynkr routes to;
+#   zeros and conservative context/output values are placeholders, matching
+#   the convention for self-hosted gateway entries.
 name = "Lynkr Auto (complexity routing)"
 description = "Virtual model: Lynkr scores each request on complexity and routes it to the tier model the user configured (local Ollama/llama.cpp for simple requests, configured cloud providers for complex ones)."
-family = "lynkr"
+family = "auto"
 release_date = "2025-12-03"
 last_updated = "2026-07-11"
 attachment = false
@@ -9,8 +21,6 @@ temperature = true
 tool_call = true
 open_weights = false
 
-# Cost and limits depend entirely on the backend model Lynkr routes to;
-# zeros/conservative defaults are placeholders for this self-hosted gateway.
 [cost]
 input = 0
 output = 0

--- a/providers/lynkr/provider.toml
+++ b/providers/lynkr/provider.toml
@@ -1,0 +1,7 @@
+name = "Lynkr"
+# Lynkr is a self-hosted gateway: any non-empty API key is accepted locally;
+# provider credentials live in Lynkr's own configuration.
+env = ["LYNKR_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "http://127.0.0.1:8081/v1"
+doc = "https://github.com/Fast-Editor/Lynkr"


### PR DESCRIPTION
Adds Lynkr, an Apache-2.0 self-hosted LLM gateway with an OpenAI-compatible endpoint at localhost:8081. It routes each request by complexity to user-configured tiers: local models (Ollama, llama.cpp, LM Studio) for simple requests, configured cloud providers for complex ones — plus tool-schema stripping and JSON tool-result compression.

Follows the pattern of the existing atomic-chat local-server provider: local API base, @ai-sdk/openai-compatible, single model entry. The lynkr-auto model is virtual (the gateway picks the real backend per request), so cost fields are zeros and limits are conservative placeholders, noted in comments — happy to adjust to whatever convention you prefer for self-hosted gateways.

Repo: https://github.com/Fast-Editor/Lynkr