### PR TITLE
chore(cerebras): update prices 20260713

### DIFF
--- a/providers/cerebras/models/zai-glm-4.7.toml
+++ b/providers/cerebras/models/zai-glm-4.7.toml
@@ -21,7 +21,7 @@ status = "beta"
 [cost]
 input = 2.25
 output = 2.75
-cache_read = 0
+cache_read = 2.25
 cache_write = 0
 
 [limit]


### PR DESCRIPTION
- cerebras charges for the cache of GLM
- confirmed with docs: https://inference-docs.cerebras.ai/capabilities/prompt-caching#how-are-cached-tokens-priced
- confirmed with Cerebras support: https://discord.com/channels/1085960591052644463/1526158313576726538