### PR TITLE
feat(requesty): add latest models

### DIFF
--- a/providers/requesty/models/anthropic/claude-fable-5.toml
+++ b/providers/requesty/models/anthropic/claude-fable-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-fable-5"
+structured_output = true
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/requesty/models/anthropic/claude-opus-4-7.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-opus-4-7"
+structured_output = true
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/requesty/models/anthropic/claude-opus-4-8.toml
+++ b/providers/requesty/models/anthropic/claude-opus-4-8.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-opus-4-8"
+structured_output = true
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/requesty/models/anthropic/claude-sonnet-5.toml
+++ b/providers/requesty/models/anthropic/claude-sonnet-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-5"
+structured_output = true
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/requesty/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/requesty/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,15 @@
+base_model = "google/gemini-3.1-flash-image-preview"
+tool_call = true
+structured_output = false
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 0.5
+output = 2
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 131_072
+output = 32_768

--- a/providers/requesty/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/requesty/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+
+[limit]
+output = 65_535

--- a/providers/requesty/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/requesty/models/google/gemini-3.1-pro-preview.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 4.5
+
+[limit]
+output = 65_535

--- a/providers/requesty/models/openai/gpt-5.4-mini.toml
+++ b/providers/requesty/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.4-mini"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075

--- a/providers/requesty/models/openai/gpt-5.4-nano.toml
+++ b/providers/requesty/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.4-nano"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02

--- a/providers/requesty/models/openai/gpt-5.5.toml
+++ b/providers/requesty/models/openai/gpt-5.5.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.5"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5

--- a/providers/requesty/models/openai/gpt-5.6-luna.toml
+++ b/providers/requesty/models/openai/gpt-5.6-luna.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.6-luna"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 1
+output = 6
+cache_read = 0.1

--- a/providers/requesty/models/openai/gpt-5.6-sol.toml
+++ b/providers/requesty/models/openai/gpt-5.6-sol.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.6-sol"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5

--- a/providers/requesty/models/openai/gpt-5.6-terra.toml
+++ b/providers/requesty/models/openai/gpt-5.6-terra.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.6-terra"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }, { type = "budget_tokens" }]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25

--- a/providers/requesty/models/xai/grok-4.3.toml
+++ b/providers/requesty/models/xai/grok-4.3.toml
@@ -1,0 +1,8 @@
+base_model = "xai/grok-4.3"
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+cache_write = 1.25

--- a/providers/requesty/models/xai/grok-4.5.toml
+++ b/providers/requesty/models/xai/grok-4.5.toml
@@ -1,0 +1,8 @@
+base_model = "xai/grok-4.5"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+cache_write = 2


### PR DESCRIPTION
## Summary

- add current Anthropic, Google, OpenAI, and xAI models available through Requesty
- inherit provider-agnostic metadata with `base_model`
- include Requesty pricing and documented reasoning controls

## Sources

- [Requesty models API](https://router.requesty.ai/v1/models)
- [Requesty model listing documentation](https://docs.requesty.ai/api-reference/endpoint/models-list)
- [Requesty reasoning documentation](https://docs.requesty.ai/features/reasoning)

## Validation

- `bun validate`