### PR TITLE
fix(crossmodel): map x-ai vendor to xai author prefix

### DIFF
--- a/packages/core/src/sync/providers/crossmodel.ts
+++ b/packages/core/src/sync/providers/crossmodel.ts
@@ -81,6 +81,7 @@ const AUTHOR_BY_VENDOR: Record<string, string> = {
   xiaomi: "xiaomi",
   minimax: "minimax",
   "z-ai": "zhipuai",
+  "x-ai": "xai",
   tencent: "tencent",
 };
 


### PR DESCRIPTION
## Problem

CrossModel serves xAI Grok models with `vendor_code = "x-ai"` (public ids like `x-ai/grok-4.5`, `x-ai/grok-4.3`, `x-ai/grok-build-0.1`). The sync's `AUTHOR_BY_VENDOR` map in `packages/core/src/sync/providers/crossmodel.ts` had **no `x-ai` entry**, so `deriveBaseModel` returned `undefined` and `buildCrossModel` skipped every Grok model — no TOML was ever created under `providers/crossmodel/models/xai/`.

By contrast, OpenAI GPT models (`vendor_code = "openai"`) are mapped, which is why GPT-5.6 synced fine while Grok silently disappeared.

## Fix

Add `"x-ai": "xai"` to `AUTHOR_BY_VENDOR`. The corresponding base-model TOMLs already exist in the repo (`models/xai/grok-4.5.toml`, `grok-4.3.toml`, `grok-build-0.1.toml`), so the sync can now factor them.

## Verification

`bun ./packages/core/script/sync-models.ts crossmodel --dry-run` after the change:

```
Would create x-ai/grok-4.5.toml
Would create x-ai/grok-4.3.toml
Would create x-ai/grok-build-0.1.toml
Dry run: 3 created, 1 updated, 0 removed, 39 unchanged
```

The generated TOMLs are intentionally left out of this PR; the hourly sync automation will create them once this mapping lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
