### PR TITLE
feat: add gitlab duo-chat-gpt-5.6 models (sol, terra, luna)

### DIFF
--- a/providers/gitlab/models/duo-chat-gpt-5-6-luna.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-6-luna.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-5.6-luna"
+name = "Agentic Chat (GPT-5.6 Luna)"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/gitlab/models/duo-chat-gpt-5-6-luna.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-6-luna.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.6-luna"
 name = "Agentic Chat (GPT-5.6 Luna)"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 
 [cost]
 input = 0

--- a/providers/gitlab/models/duo-chat-gpt-5-6-sol.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-6-sol.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.6-sol"
 name = "Agentic Chat (GPT-5.6 Sol)"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 
 [cost]
 input = 0

--- a/providers/gitlab/models/duo-chat-gpt-5-6-sol.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-6-sol.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-5.6-sol"
+name = "Agentic Chat (GPT-5.6 Sol)"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/gitlab/models/duo-chat-gpt-5-6-terra.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-6-terra.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.6-terra"
 name = "Agentic Chat (GPT-5.6 Terra)"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 
 [cost]
 input = 0

--- a/providers/gitlab/models/duo-chat-gpt-5-6-terra.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-6-terra.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-5.6-terra"
+name = "Agentic Chat (GPT-5.6 Terra)"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
Adds GitLab Duo Agentic Chat entries for the three GPT-5.6 variants: Sol (flagship), Terra (balanced), and Luna (fast/cost-efficient).

Each file uses `base_model` to inherit metadata (description, family, limits, modalities, knowledge cutoff) from the canonical `openai/gpt-5.6-sol` / `openai/gpt-5.6-terra` / `openai/gpt-5.6-luna` entries, following the same pattern as the existing `duo-chat-fable-5.toml` and `duo-chat-sonnet-5.toml` GitLab entries. Overrides are limited to:

- `name` — GitLab-specific display name ("Agentic Chat (GPT-5.6 <Variant>)")
- `reasoning_options` — required since `reasoning = true` is inherited
- `cost` — zeroed out (0 input/output/cache_read/cache_write), since GitLab Duo requests are proxy-billed rather than billed per-token to the end user

`bun validate` passes and all three models resolve with the expected inherited fields (context 1,050,000 / output 128,000 / modalities text+image+pdf) and cost = 0.

Related: gitlab-ai-provider added the corresponding `duo-chat-gpt-5-6-sol`, `duo-chat-gpt-5-6-terra`, and `duo-chat-gpt-5-6-luna` model mappings in v6.11.0 (published to npm).