### PR TITLE
feat(providers): add GPT-5.6 hosted models

### DIFF
--- a/providers/azure-cognitive-services/models/gpt-5.6-luna.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.6-luna.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.6-luna"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 1
+output = 6
+cache_read = 0.1
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 2
+output = 9
+cache_read = 0.2

--- a/providers/azure-cognitive-services/models/gpt-5.6-sol.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.6-sol.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.6-sol"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1

--- a/providers/azure-cognitive-services/models/gpt-5.6-terra.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.6-terra.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.6-terra"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5

--- a/providers/azure-cognitive-services/models/gpt-chat-latest.toml
+++ b/providers/azure-cognitive-services/models/gpt-chat-latest.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-5.5-instant"
+name = "GPT Chat Latest"
+status = "beta"
+temperature = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[limit]
+context = 128_000
+input = 111_616
+output = 16_384

--- a/providers/azure/models/gpt-5.6-luna.toml
+++ b/providers/azure/models/gpt-5.6-luna.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.6-luna"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 1
+output = 6
+cache_read = 0.1
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 2
+output = 9
+cache_read = 0.2

--- a/providers/azure/models/gpt-5.6-sol.toml
+++ b/providers/azure/models/gpt-5.6-sol.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.6-sol"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1

--- a/providers/azure/models/gpt-5.6-terra.toml
+++ b/providers/azure/models/gpt-5.6-terra.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.6-terra"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5

--- a/providers/azure/models/gpt-chat-latest.toml
+++ b/providers/azure/models/gpt-chat-latest.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-5.5-instant"
+name = "GPT Chat Latest"
+status = "beta"
+temperature = false
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[limit]
+context = 128_000
+input = 111_616
+output = 16_384

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-luna.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-luna.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 1
+output = 6
+cache_read = 0.1
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 2
+output = 9
+cache_read = 0.2

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-sol.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-sol.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-terra.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-terra.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5

--- a/providers/databricks/models/databricks-gpt-5-6-luna.toml
+++ b/providers/databricks/models/databricks-gpt-5-6-luna.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 1
+output = 6
+cache_read = 0.1
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 2
+output = 9
+cache_read = 0.2
+
+[limit]
+context = 400_000
+input = 272_000
+output = 128_000

--- a/providers/databricks/models/databricks-gpt-5-6-sol.toml
+++ b/providers/databricks/models/databricks-gpt-5-6-sol.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1

--- a/providers/databricks/models/databricks-gpt-5-6-terra.toml
+++ b/providers/databricks/models/databricks-gpt-5-6-terra.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5

--- a/providers/snowflake-cortex/models/openai-gpt-5.6-luna.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5.6-luna.toml
@@ -1,0 +1,3 @@
+base_model = "openai/gpt-5.6-luna"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]

--- a/providers/snowflake-cortex/models/openai-gpt-5.6-sol.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5.6-sol.toml
@@ -1,0 +1,3 @@
+base_model = "openai/gpt-5.6-sol"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]

--- a/providers/snowflake-cortex/models/openai-gpt-5.6-terra.toml
+++ b/providers/snowflake-cortex/models/openai-gpt-5.6-terra.toml
@@ -1,0 +1,3 @@
+base_model = "openai/gpt-5.6-terra"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol, Terra, and Luna to Azure and Azure Cognitive Services
- add Azure's `gpt-chat-latest` alias for GPT-5.5 Instant
- add the GPT-5.6 family to Databricks, Snowflake Cortex, and Cloudflare AI Gateway
- preserve provider-specific reasoning controls, preview status, pricing tiers, and Databricks Luna's 400K context limit

This addresses the missing Azure models reported in anomalyco/opencode#36211 and audits the same OpenAI family across mainstream hosted providers.

Amazon Bedrock is intentionally unchanged. AWS currently documents GPT-5.4 and GPT-5.5 as its proprietary OpenAI models, and both are already present.

## Evidence

- [Azure model catalog](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure#gpt-56) lists `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` as preview models, and identifies `gpt-chat-latest` as GPT-5.5 Instant.
- [Azure reasoning documentation](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/reasoning) documents availability and reasoning-effort support for the GPT-5.6 family.
- [Databricks supported models](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models) lists all three endpoint IDs and documents Luna's 400K context window.
- [Databricks reasoning documentation](https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models) lists all three GPT-5.6 endpoints and their `reasoning_effort` control.
- [Snowflake announcement](https://www.snowflake.com/en/blog/openai-gpt-5-6-snowflake-cortex-ai/) announces all three models in private preview and demonstrates the `openai-gpt-5-6-*` IDs through Cortex APIs.
- [Cloudflare Sol](https://developers.cloudflare.com/ai/models/openai/gpt-5.6-sol/), [Terra](https://developers.cloudflare.com/ai/models/openai/gpt-5.6-terra/), and [Luna](https://developers.cloudflare.com/ai/models/openai/gpt-5.6-luna/) document the model IDs and Responses API reasoning surface.
- [AWS OpenAI model catalog](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-openai.html) currently lists only GPT-5.4 and GPT-5.5 among proprietary OpenAI models.

## Validation

- `bun validate`
- `git diff --check`
