### PR TITLE
feat(cloudflare-ai-gateway): add GLM 5.2

### DIFF
--- a/providers/cloudflare-ai-gateway/models/workers-ai/@cf/zai-org/glm-5.2.toml
+++ b/providers/cloudflare-ai-gateway/models/workers-ai/@cf/zai-org/glm-5.2.toml
@@ -1,0 +1,15 @@
+# Raw Workers AI input uses `reasoning_effort = low|medium|high` and
+# `chat_template_kwargs.enable_thinking = true|false`.
+# https://developers.cloudflare.com/workers-ai/models/glm-5.2/sync-input.json (accessed 2026-07-13)
+base_model = "zhipuai/glm-5.2"
+name = "Glm 5.2"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 262_144
+output = 262_144


### PR DESCRIPTION
## Summary

- add `workers-ai/@cf/zai-org/glm-5.2` to the Cloudflare AI Gateway catalog
- reuse the canonical `zhipuai/glm-5.2` metadata
- preserve the Workers AI pricing, limits, and documented reasoning controls

## Why

Cloudflare Workers AI supports GLM 5.2, and models.dev already lists it under `cloudflare-workers-ai`. The corresponding `cloudflare-ai-gateway` entry is missing, so consumers such as OpenCode reject `cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-5.2` as an unknown model before sending a request to AI Gateway.

This follows the existing dual-catalog pattern used for other Workers AI models. The automated sync in #2620 added GLM 5.2 only to the direct Workers AI catalog.

## Sources

- https://developers.cloudflare.com/workers-ai/models/glm-5.2/
- https://developers.cloudflare.com/workers-ai/models/glm-5.2/sync-input.json

## Validation

- `bun validate`
- `git diff --check`
- verified the generated model ID is `workers-ai/@cf/zai-org/glm-5.2`
