### PR TITLE
feat(amazon-bedrock): add GPT-5.6 models

### DIFF
--- a/providers/amazon-bedrock/models/openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-luna.toml
@@ -1,0 +1,19 @@
+# Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
+# In-region pricing basis: https://aws.amazon.com/bedrock/pricing/
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
+
+[cost]
+input = 1.10
+output = 6.60
+cache_read = 0.11
+
+[limit]
+context = 272_000
+output = 128_000
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-luna.toml
@@ -1,13 +1,14 @@
 # Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
-# In-region pricing basis: https://aws.amazon.com/bedrock/pricing/
+# In-region pricing: https://aws.amazon.com/bedrock/pricing/
 base_model = "openai/gpt-5.6-luna"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
 
 [cost]
-input = 1.10
-output = 6.60
-cache_read = 0.11
+input = 1.00
+output = 6.00
+cache_read = 0.10
+cache_write = 1.25
 
 [limit]
 context = 272_000

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
@@ -1,13 +1,14 @@
 # Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
-# In-region pricing basis: https://aws.amazon.com/bedrock/pricing/
+# In-region pricing: https://aws.amazon.com/bedrock/pricing/
 base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
 
 [cost]
-input = 5.50
-output = 33.00
-cache_read = 0.55
+input = 5.00
+output = 30.00
+cache_read = 0.50
+cache_write = 6.25
 
 [limit]
 context = 272_000

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
@@ -1,0 +1,19 @@
+# Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
+# In-region pricing basis: https://aws.amazon.com/bedrock/pricing/
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
+
+[cost]
+input = 5.50
+output = 33.00
+cache_read = 0.55
+
+[limit]
+context = 272_000
+output = 128_000
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-terra.toml
@@ -1,0 +1,19 @@
+# Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
+# In-region pricing basis: https://aws.amazon.com/bedrock/pricing/
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
+
+[cost]
+input = 2.75
+output = 16.50
+cache_read = 0.275
+
+[limit]
+context = 272_000
+output = 128_000
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-terra.toml
@@ -1,13 +1,14 @@
 # Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
-# In-region pricing basis: https://aws.amazon.com/bedrock/pricing/
+# In-region pricing: https://aws.amazon.com/bedrock/pricing/
 base_model = "openai/gpt-5.6-terra"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
 
 [cost]
-input = 2.75
-output = 16.50
-cache_read = 0.275
+input = 2.50
+output = 15.00
+cache_read = 0.25
+cache_write = 3.125
 
 [limit]
 context = 272_000


### PR DESCRIPTION
## Summary

- add Amazon Bedrock entries for GPT-5.6 Sol, Terra, and Luna
- inherit provider-agnostic model metadata through `base_model`
- configure the Bedrock Mantle Responses endpoint, 272K context limits, and reasoning effort through `max`
- add source comments for the Bedrock model IDs and GA in-region pricing

## Why

OpenAI's Codex Bedrock catalog now includes the three GPT-5.6 Mantle model IDs, while the models.dev Bedrock catalog only included GPT-5.4 and GPT-5.5.

## Impact

Consumers of the Amazon Bedrock provider catalog can discover and configure `openai.gpt-5.6-sol`, `openai.gpt-5.6-terra`, and `openai.gpt-5.6-luna` with the correct Bedrock endpoint shape, context limits, and supported reasoning values.

The entries include AWS's published GA input, 30-minute cache-write, cache-read, and output prices for each GPT-5.6 variant.

## Validation

- `bun validate`
- `git diff --check`

## Sources

- https://github.com/openai/codex/pull/30285
- https://aws.amazon.com/bedrock/pricing/
