### PR TITLE
fix(inferx): update api endpoint to endpoints/v1

### DIFF
--- a/providers/inferx/provider.toml
+++ b/providers/inferx/provider.toml
@@ -1,5 +1,5 @@
 name = "InferX"
 env = ["INFERX_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-api = "https://model.inferx.net/v1"
+api = "https://model.inferx.net/endpoints/v1"
 doc = "https://model.inferx.net/endpoints"


### PR DESCRIPTION
This PR updates the base API URL to point directly to our endpoint routing at https://model.inferx.net/endpoints/v1. This change aligns the registry calls with our actual backend endpoint structure. 

You can verify the valid endpoint configuration base under our official developer documentation here: https://model.inferx.net/endpoints
