### PR TITLE
refactor(cohere): centralize model metadata

### DIFF
--- a/models/cohere/c4ai-aya-expanse-32b.toml
+++ b/models/cohere/c4ai-aya-expanse-32b.toml
@@ -1,0 +1,23 @@
+# https://huggingface.co/CohereLabs/aya-expanse-32b
+name = "Aya Expanse 32B"
+description = "Open multilingual model optimized for generation across 23 languages"
+release_date = "2024-10-24"
+last_updated = "2024-10-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+license = "CC-BY-NC-4.0"
+
+[limit]
+context = 128_000
+output = 4_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/aya-expanse-32b"

--- a/models/cohere/c4ai-aya-expanse-8b.toml
+++ b/models/cohere/c4ai-aya-expanse-8b.toml
@@ -1,0 +1,23 @@
+# https://huggingface.co/CohereLabs/aya-expanse-8b
+name = "Aya Expanse 8B"
+description = "Compact open multilingual model optimized for generation across 23 languages"
+release_date = "2024-10-24"
+last_updated = "2024-10-24"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+license = "CC-BY-NC-4.0"
+
+[limit]
+context = 8_000
+output = 4_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/aya-expanse-8b"

--- a/models/cohere/c4ai-aya-vision-32b.toml
+++ b/models/cohere/c4ai-aya-vision-32b.toml
@@ -1,0 +1,23 @@
+# https://huggingface.co/CohereLabs/aya-vision-32b
+name = "Aya Vision 32B"
+description = "Open multilingual vision model for OCR, visual reasoning, and image question answering"
+release_date = "2025-03-04"
+last_updated = "2025-05-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+license = "CC-BY-NC-4.0"
+
+[limit]
+context = 16_000
+output = 4_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/aya-vision-32b"

--- a/models/cohere/c4ai-aya-vision-8b.toml
+++ b/models/cohere/c4ai-aya-vision-8b.toml
@@ -1,0 +1,23 @@
+# https://huggingface.co/CohereLabs/aya-vision-8b
+name = "Aya Vision 8B"
+description = "Compact open multilingual vision model for OCR and visual question answering"
+release_date = "2025-03-04"
+last_updated = "2025-05-14"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+license = "CC-BY-NC-4.0"
+
+[limit]
+context = 16_000
+output = 4_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/aya-vision-8b"

--- a/models/cohere/command-a-reasoning-08-2025.toml
+++ b/models/cohere/command-a-reasoning-08-2025.toml
@@ -1,0 +1,25 @@
+# https://docs.cohere.com/docs/command-a-reasoning
+# https://huggingface.co/CohereLabs/c4ai-command-a-reasoning-08-2025
+name = "Command A Reasoning"
+description = "Cohere reasoning model for multilingual enterprise agents, tools, and complex workflows"
+family = "command-a"
+release_date = "2025-08-21"
+last_updated = "2025-08-21"
+attachment = false
+reasoning = true
+temperature = true
+knowledge = "2024-06-01"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/c4ai-command-a-reasoning-08-2025"

--- a/models/cohere/command-a-translate-08-2025.toml
+++ b/models/cohere/command-a-translate-08-2025.toml
@@ -1,0 +1,25 @@
+# https://docs.cohere.com/docs/models
+# https://huggingface.co/CohereLabs/c4ai-command-a-translate-08-2025
+name = "Command A Translate"
+description = "Translation model for multilingual conversion, localization, and cross-language workflows"
+family = "command-a"
+release_date = "2025-08-28"
+last_updated = "2025-08-28"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-06-01"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 8_000
+output = 8_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/c4ai-command-a-translate-08-2025"

--- a/models/cohere/command-a-vision-07-2025.toml
+++ b/models/cohere/command-a-vision-07-2025.toml
@@ -1,0 +1,25 @@
+# https://docs.cohere.com/docs/command-a-vision
+# https://huggingface.co/CohereLabs/c4ai-command-a-vision-07-2025
+name = "Command A Vision"
+description = "Cohere vision model for multilingual document analysis, OCR, and image understanding"
+family = "command-a"
+release_date = "2025-07-31"
+last_updated = "2025-07-31"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-06-01"
+tool_call = false
+open_weights = true
+
+[limit]
+context = 128_000
+output = 8_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/c4ai-command-a-vision-07-2025"

--- a/models/cohere/command-r7b-arabic-02-2025.toml
+++ b/models/cohere/command-r7b-arabic-02-2025.toml
@@ -1,0 +1,25 @@
+# https://huggingface.co/CohereLabs/c4ai-command-r7b-arabic-02-2025
+# https://docs.cohere.com/changelog/command-r7b-arabic
+name = "Command R7B Arabic"
+description = "Open Command R model optimized for Arabic enterprise chat, RAG, and cultural knowledge"
+family = "command-r"
+release_date = "2025-02-27"
+last_updated = "2025-02-27"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-06-01"
+tool_call = true
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/c4ai-command-r7b-arabic-02-2025"

--- a/providers/cohere/models/c4ai-aya-expanse-32b.toml
+++ b/providers/cohere/models/c4ai-aya-expanse-32b.toml
@@ -1,17 +1,1 @@
-name = "Aya Expanse 32B"
-description = "Cohere command model for multilingual enterprise agents, tools, and chat"
-release_date = "2024-10-24"
-last_updated = "2024-10-24"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = false
-open_weights = true
-
-[limit]
-context = 128_000
-output = 4_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "cohere/c4ai-aya-expanse-32b"

--- a/providers/cohere/models/c4ai-aya-expanse-8b.toml
+++ b/providers/cohere/models/c4ai-aya-expanse-8b.toml
@@ -1,17 +1,1 @@
-name = "Aya Expanse 8B"
-description = "Cohere command model for multilingual enterprise agents, tools, and chat"
-release_date = "2024-10-24"
-last_updated = "2024-10-24"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = false
-open_weights = true
-
-[limit]
-context = 8_000
-output = 4_000
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "cohere/c4ai-aya-expanse-8b"

--- a/providers/cohere/models/c4ai-aya-vision-32b.toml
+++ b/providers/cohere/models/c4ai-aya-vision-32b.toml
@@ -1,17 +1,1 @@
-name = "Aya Vision 32B"
-description = "Cohere command model for multilingual enterprise agents, tools, and chat"
-release_date = "2025-03-04"
-last_updated = "2025-05-14"
-attachment = true
-reasoning = false
-temperature = true
-tool_call = false
-open_weights = true
-
-[limit]
-context = 16_000
-output = 4_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "cohere/c4ai-aya-vision-32b"

--- a/providers/cohere/models/c4ai-aya-vision-8b.toml
+++ b/providers/cohere/models/c4ai-aya-vision-8b.toml
@@ -1,17 +1,1 @@
-name = "Aya Vision 8B"
-description = "Cohere command model for multilingual enterprise agents, tools, and chat"
-release_date = "2025-03-04"
-last_updated = "2025-05-14"
-attachment = true
-reasoning = false
-temperature = true
-tool_call = false
-open_weights = true
-
-[limit]
-context = 16_000
-output = 4_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "cohere/c4ai-aya-vision-8b"

--- a/providers/cohere/models/command-a-03-2025.toml
+++ b/providers/cohere/models/command-a-03-2025.toml
@@ -1,23 +1,5 @@
-name = "Command A"
-description = "Cohere command model for multilingual enterprise agents, tools, and chat"
-family = "command-a"
-release_date = "2025-03-13"
-last_updated = "2025-03-13"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-06-01"
-tool_call = true
-open_weights = true
+base_model = "cohere/command-a-03-2025"
 
 [cost]
 input = 2.50
 output = 10.00
-
-[limit]
-context = 256_000
-output = 8_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/cohere/models/command-a-reasoning-08-2025.toml
+++ b/providers/cohere/models/command-a-reasoning-08-2025.toml
@@ -1,5 +1,3 @@
-name = "Command A Reasoning"
-description = "Cohere command model for multilingual enterprise agents, tools, and chat"
 # Model-specific reasoning HTTP restrictions (accessed 2026-06-25):
 # Native thinking.token_budget must be positive; leave at least 1K output tokens.
 # OpenAI compatibility instead accepts reasoning_effort = "none"|"high" and
@@ -8,15 +6,7 @@ description = "Cohere command model for multilingual enterprise agents, tools, a
 # https://docs.cohere.com/docs/command-a-reasoning
 # https://docs.cohere.com/docs/reasoning
 # https://docs.cohere.com/docs/compatibility-api
-family = "command-a"
-release_date = "2025-08-21"
-last_updated = "2025-08-21"
-attachment = false
-reasoning = true
-temperature = true
-knowledge = "2024-06-01"
-tool_call = true
-open_weights = true
+base_model = "cohere/command-a-reasoning-08-2025"
 
 [[reasoning_options]]
 type = "toggle"
@@ -28,11 +18,3 @@ min = 1
 [cost]
 input = 2.50
 output = 10.00
-
-[limit]
-context = 256_000
-output = 32_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/cohere/models/command-a-translate-08-2025.toml
+++ b/providers/cohere/models/command-a-translate-08-2025.toml
@@ -1,23 +1,5 @@
-name = "Command A Translate"
-description = "Translation model for multilingual conversion, localization, and cross-language workflows"
-family = "command-a"
-release_date = "2025-08-28"
-last_updated = "2025-08-28"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-06-01"
-tool_call = true
-open_weights = true
+base_model = "cohere/command-a-translate-08-2025"
 
 [cost]
 input = 2.50
 output = 10.00
-
-[limit]
-context = 8_000
-output = 8_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/cohere/models/command-a-vision-07-2025.toml
+++ b/providers/cohere/models/command-a-vision-07-2025.toml
@@ -1,23 +1,5 @@
-name = "Command A Vision"
-description = "Cohere command model for multilingual enterprise agents, tools, and chat"
-family = "command-a"
-release_date = "2025-07-31"
-last_updated = "2025-07-31"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-06-01"
-tool_call = false
-open_weights = true
+base_model = "cohere/command-a-vision-07-2025"
 
 [cost]
 input = 2.50
 output = 10.00
-
-[limit]
-context = 128_000
-output = 8_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/cohere/models/command-r-08-2024.toml
+++ b/providers/cohere/models/command-r-08-2024.toml
@@ -1,23 +1,5 @@
-name = "Command R"
-description = "Cohere retrieval model for long-context chat and enterprise RAG workflows"
-family = "command-r"
-release_date = "2024-08-30"
-last_updated = "2024-08-30"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-06-01"
-tool_call = true
-open_weights = true
+base_model = "cohere/command-r-08-2024"
 
 [cost]
 input = 0.15
 output = 0.60
-
-[limit]
-context = 128_000
-output = 4_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/cohere/models/command-r-plus-08-2024.toml
+++ b/providers/cohere/models/command-r-plus-08-2024.toml
@@ -1,23 +1,5 @@
-name = "Command R+"
-description = "Cohere's RAG workhorse for long-context enterprise search and tool use"
-family = "command-r"
-release_date = "2024-08-30"
-last_updated = "2024-08-30"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-06-01"
-tool_call = true
-open_weights = true
+base_model = "cohere/command-r-plus-08-2024"
 
 [cost]
 input = 2.50
 output = 10.00
-
-[limit]
-context = 128_000
-output = 4_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/cohere/models/command-r7b-12-2024.toml
+++ b/providers/cohere/models/command-r7b-12-2024.toml
@@ -1,23 +1,5 @@
-name = "Command R7B"
-description = "Cohere retrieval model for long-context chat and enterprise RAG workflows"
-family = "command-r"
-release_date = "2024-12-02"
-last_updated = "2024-12-02"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-06-01"
-tool_call = true
-open_weights = true
+base_model = "cohere/command-r7b-12-2024"
 
 [cost]
 input = 0.0375
 output = 0.15
-
-[limit]
-context = 128_000
-output = 4_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/cohere/models/command-r7b-arabic-02-2025.toml
+++ b/providers/cohere/models/command-r7b-arabic-02-2025.toml
@@ -1,23 +1,5 @@
-name = "Command R7B Arabic"
-description = "Cohere retrieval model for long-context chat and enterprise RAG workflows"
-family = "command-r"
-release_date = "2025-02-27"
-last_updated = "2025-02-27"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-06-01"
-tool_call = true
-open_weights = true
+base_model = "cohere/command-r7b-arabic-02-2025"
 
 [cost]
 input = 0.0375
 output = 0.15
-
-[limit]
-context = 128_000
-output = 4_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/sap-ai-core/models/cohere--command-a-reasoning.toml
+++ b/providers/sap-ai-core/models/cohere--command-a-reasoning.toml
@@ -1,18 +1,9 @@
-# Cannot use base_model: models/cohere/command-a-reasoning-08-2025.toml does not exist in the top-level models/ directory.
 # Deployed as version "2508" on SAP AI Core; older versions share the same model name and can be selected at deployment time.
 # Not all models support the full range of configuration options. Where possible, orchestration maps unsupported values to the closest equivalent.
 # model_params.thinking = {"type": "enabled", "token_budget": N} or {"type": "disabled"}; token_budget >= 1. https://docs.cohere.com/docs/reasoning (accessed 2026-07-14)
 # Reasoning support: https://help.sap.com/docs/sap-ai-core/generative-ai/reasoning?locale=en-US (accessed 2026-07-14)
+base_model = "cohere/command-a-reasoning-08-2025"
 name = "cohere--command-a-reasoning"
-description = "Cohere command model for multilingual enterprise agents, tools, and chat"
-family = "command-a"
-release_date = "2025-08-21"
-last_updated = "2025-08-21"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-open_weights = true
 
 [[reasoning_options]]
 type = "toggle"
@@ -28,11 +19,3 @@ min = 1
 [cost]
 input = 0.63
 output = 5.05
-
-[limit]
-context = 256_000
-output = 32_000
-
-[modalities]
-input = ["text"]
-output = ["text"]


### PR DESCRIPTION
## Summary

- add canonical metadata for the eight Cohere models that were still defined only inside provider files
- convert all 14 Cohere provider model files to `base_model`
- update SAP AI Core Command A Reasoning to inherit `cohere/command-a-reasoning-08-2025`
- correct Command A Vision attachment support and improve generic model descriptions
- add official Hugging Face weight links for the newly centralized open-weight models

## Sources

- https://docs.cohere.com/docs/models
- https://docs.cohere.com/docs/command-a-reasoning
- https://docs.cohere.com/docs/command-a-vision
- https://docs.cohere.com/changelog/command-r7b-arabic
- https://huggingface.co/CohereLabs/aya-expanse-32b
- https://huggingface.co/CohereLabs/aya-expanse-8b
- https://huggingface.co/CohereLabs/aya-vision-32b
- https://huggingface.co/CohereLabs/aya-vision-8b

## Validation

- `bun validate`
- `git diff --check`
- verified all 14 `providers/cohere/models/*.toml` files use `base_model`