### PR TITLE
fix(nano-gpt): correct reasoning options

### DIFF
--- a/providers/nano-gpt/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-flash.toml
@@ -5,7 +5,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro-cheaper.toml
@@ -5,7 +5,7 @@ release_date = "2026-04-25"
 last_updated = "2026-04-25"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/nano-gpt/models/deepseek/deepseek-v4-pro.toml
@@ -5,7 +5,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "high", "xhigh"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-06-17.toml
@@ -4,7 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite-preview-09-2025.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-lite.toml
@@ -4,7 +4,7 @@ release_date = "2025-06-17"
 last_updated = "2025-06-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-04-17.toml
@@ -4,7 +4,7 @@ release_date = "2025-04-17"
 last_updated = "2025-04-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash-preview-09-2025.toml
@@ -4,7 +4,7 @@ release_date = "2025-09-25"
 last_updated = "2025-09-25"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/nano-gpt/models/gemini-2.5-flash.toml
+++ b/providers/nano-gpt/models/gemini-2.5-flash.toml
@@ -4,7 +4,7 @@ release_date = "2025-06-05"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 tool_call = false
 structured_output = false
 open_weights = false


### PR DESCRIPTION
## Summary
- remove unsupported toggle reasoning controls from the audited NanoGPT DeepSeek and Gemini entries
- add `none` as the first DeepSeek reasoning effort while preserving the existing Gemini effort values

## Source
- NanoGPT documents `reasoning_effort: "none"` as the explicit way to disable reasoning: https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking

## Validation
- `bun validate`
- `git diff --check`
- `bun test` (81 passed, 1 unrelated existing repository-data failure: `repository open-weight model metadata includes weights links`)
