### PR TITLE
fix: align *-latest alias reasoning_options with current model targets

### DIFF
--- a/models/google/gemini-flash-latest.toml
+++ b/models/google/gemini-flash-latest.toml
@@ -1,8 +1,9 @@
+# Tracks the current Gemini Flash release (gemini-3.5-flash).
 name = "Gemini Flash Latest"
 description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
 family = "gemini-flash"
-release_date = "2025-09-25"
-last_updated = "2025-09-25"
+release_date = "2026-05-19"
+last_updated = "2026-05-19"
 attachment = true
 reasoning = true
 temperature = true
@@ -16,5 +17,5 @@ context = 1_048_576
 output = 65_536
 
 [modalities]
-input = ["text", "image", "audio", "video", "pdf"]
+input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]

--- a/models/google/gemini-flash-lite-latest.toml
+++ b/models/google/gemini-flash-lite-latest.toml
@@ -1,8 +1,9 @@
+# Tracks the current Gemini Flash-Lite release (gemini-3.1-flash-lite).
 name = "Gemini Flash-Lite Latest"
 description = "Low-latency Gemini model for high-volume multimodal and agent workloads"
 family = "gemini-flash-lite"
-release_date = "2025-09-25"
-last_updated = "2025-09-25"
+release_date = "2026-05-07"
+last_updated = "2026-05-07"
 attachment = true
 reasoning = true
 temperature = true
@@ -16,5 +17,5 @@ context = 1_048_576
 output = 65_536
 
 [modalities]
-input = ["text", "image", "audio", "video", "pdf"]
+input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -175,9 +175,11 @@ export function buildOpenRouterModel(
   const prompt = price(model.pricing.prompt);
   const completion = price(model.pricing.completion);
   const reasoning = params.has("reasoning") || params.has("include_reasoning");
-  const reasoning_options = existing?.reasoning_options?.length
-    ? existing.reasoning_options
-    : openRouterReasoningOptions(model.reasoning) ?? existing?.reasoning_options;
+  // Prefer OpenRouter's live reasoning metadata over authored options so aliases
+  // and rotated models pick up new efforts/budget support. Fall back to authored
+  // only when the API omits a reasoning object.
+  const reasoning_options = openRouterReasoningOptions(model.reasoning)
+    ?? (reasoning ? existing?.reasoning_options : undefined);
   const context = model.context_length;
   const family = inferFamily(model, name);
   const releaseDate = dateFromTimestamp(model.created);

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -966,12 +966,38 @@ test("resolves Venice Pro routes to canonical OpenAI metadata", () => {
   ]);
 });
 
-test("preserves authored OpenRouter reasoning options over model metadata", () => {
+test("prefers OpenRouter API reasoning options over authored ones", () => {
   const model = buildOpenRouterModel(openRouterModel({
     reasoning: {
       mandatory: false,
       supported_efforts: ["max", "xhigh", "high", "medium", "low"],
     },
+  }), {
+    name: "Claude Sonnet 5",
+    description: "Balanced Claude model for coding and agentic workflows",
+    release_date: "2026-06-30",
+    last_updated: "2026-06-30",
+    attachment: true,
+    reasoning: true,
+    reasoning_options: [{ type: "toggle" }],
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 2, output: 10 },
+    limit: { context: 1_000_000, output: 128_000 },
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    reasoning_options: [
+      { type: "effort", values: ["max", "xhigh", "high", "medium", "low"] },
+    ],
+  });
+});
+
+test("keeps authored OpenRouter reasoning options when API omits reasoning metadata", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    supported_parameters: ["tools", "tool_choice", "reasoning", "temperature"],
+    reasoning: undefined,
   }), {
     name: "Claude Sonnet 5",
     description: "Balanced Claude model for coding and agentic workflows",

--- a/providers/google-vertex/models/gemini-flash-latest.toml
+++ b/providers/google-vertex/models/gemini-flash-latest.toml
@@ -1,26 +1,9 @@
-name = "Gemini Flash Latest"
-description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
-family = "gemini-flash"
-release_date = "2025-09-25"
-last_updated = "2025-09-25"
-attachment = true
-reasoning = true
+# Alias for the current Gemini Flash release (gemini-3.5-flash).
+base_model = "google/gemini-flash-latest"
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
-temperature = true
-knowledge = "2025-01"
-tool_call = true
-open_weights = false
 
 [cost]
-input = 0.30
-output = 2.50
-cache_read = 0.075
-cache_write = 0.383
-
-[limit]
-context = 1_048_576
-output = 65_536
-
-[modalities]
-input = ["text", "image", "audio", "video", "pdf"]
-output = ["text"]
+input = 1.5
+output = 9
+cache_read = 0.15
+input_audio = 1.5

--- a/providers/google-vertex/models/gemini-flash-lite-latest.toml
+++ b/providers/google-vertex/models/gemini-flash-lite-latest.toml
@@ -1,8 +1,10 @@
+# Alias for the current Gemini Flash-Lite release (gemini-3.1-flash-lite).
 base_model = "google/gemini-flash-lite-latest"
 base_model_omit = ["structured_output"]
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
-input = 0.1
-output = 0.4
+input = 0.25
+output = 1.5
 cache_read = 0.025
+input_audio = 0.5

--- a/providers/google/models/gemini-flash-latest.toml
+++ b/providers/google/models/gemini-flash-latest.toml
@@ -1,34 +1,32 @@
+# Alias for the current Gemini Flash release (gemini-3.5-flash).
+# Keep reasoning_options and cost in sync with gemini-3.5-flash.
 name = "Gemini Flash Latest"
 description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
 family = "gemini-flash"
-release_date = "2025-09-25"
-last_updated = "2025-09-25"
+release_date = "2026-05-19"
+last_updated = "2026-05-19"
 attachment = true
 reasoning = true
 temperature = true
-knowledge = "2025-01"
 tool_call = true
 structured_output = true
+knowledge = "2025-01"
 open_weights = false
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 0
-max = 24_576
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
 
 [cost]
-input = 0.30
-output = 2.50
-cache_read = 0.075
-input_audio = 1.00
+input = 1.50
+output = 9.00
+cache_read = 0.15
+input_audio = 1.50
 
 [limit]
 context = 1_048_576
 output = 65_536
 
 [modalities]
-input = ["text", "image", "audio", "video", "pdf"]
+input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]

--- a/providers/google/models/gemini-flash-lite-latest.toml
+++ b/providers/google/models/gemini-flash-lite-latest.toml
@@ -1,33 +1,32 @@
+# Alias for the current Gemini Flash-Lite release (gemini-3.1-flash-lite).
+# Keep reasoning_options and cost in sync with gemini-3.1-flash-lite.
 name = "Gemini Flash-Lite Latest"
 description = "Low-latency Gemini model for high-volume multimodal and agent workloads"
 family = "gemini-flash-lite"
-release_date = "2025-09-25"
-last_updated = "2025-09-25"
+release_date = "2026-05-07"
+last_updated = "2026-05-07"
 attachment = true
 reasoning = true
 temperature = true
-knowledge = "2025-01"
 tool_call = true
 structured_output = true
+knowledge = "2025-01"
 open_weights = false
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 512
-max = 24_576
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
 
 [cost]
-input = 0.10
-output = 0.40
+input = 0.25
+output = 1.50
 cache_read = 0.025
+input_audio = 0.50
 
 [limit]
 context = 1_048_576
 output = 65_536
 
 [modalities]
-input = ["text", "image", "audio", "video", "pdf"]
+input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]

--- a/providers/kilo/models/~anthropic/claude-haiku-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-haiku-latest.toml
@@ -1,9 +1,10 @@
+# Tracks the current Claude Haiku alias target on Kilo (Claude Haiku 4.5).
 name = "Anthropic: Claude Haiku Latest"
 description = "Fast Claude model for responsive assistance, classification, and lightweight agents"
-release_date = "2026-04-27"
+release_date = "2025-10-15"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 tool_call = true
 temperature = true

--- a/providers/kilo/models/~anthropic/claude-sonnet-latest.toml
+++ b/providers/kilo/models/~anthropic/claude-sonnet-latest.toml
@@ -1,12 +1,14 @@
+# Tracks the current Claude Sonnet alias target on Kilo (Claude Sonnet 4.6 by pricing).
 name = "Anthropic: Claude Sonnet Latest"
 description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
-release_date = "2026-04-27"
+release_date = "2026-02-17"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
 reasoning = true
 tool_call = true
 temperature = true
+knowledge = "2025-08-31"
 open_weights = false
 
 [cost]

--- a/providers/kilo/models/~google/gemini-flash-latest.toml
+++ b/providers/kilo/models/~google/gemini-flash-latest.toml
@@ -1,7 +1,8 @@
+# Tracks the current Gemini Flash alias target (Gemini 3.5 Flash).
 name = "Google: Gemini Flash Latest"
 description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
-release_date = "2026-04-27"
-last_updated = "2026-05-01"
+release_date = "2026-05-19"
+last_updated = "2026-05-19"
 attachment = true
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 reasoning = true
@@ -10,9 +11,9 @@ temperature = true
 open_weights = false
 
 [cost]
-input = 0.5
-output = 3.0
-cache_read = 0.05
+input = 1.5
+output = 9.0
+cache_read = 0.15
 cache_write = 0.08333333333333334
 
 [limit]

--- a/providers/kilo/models/~openai/gpt-latest.toml
+++ b/providers/kilo/models/~openai/gpt-latest.toml
@@ -1,9 +1,10 @@
+# Tracks the current GPT frontier alias target on Kilo (GPT-5.5).
 name = "OpenAI: GPT Latest"
 description = "GPT model for general reasoning, writing, coding, and tool-assisted tasks"
-release_date = "2026-04-27"
+release_date = "2026-04-24"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/kilo/models/~openai/gpt-mini-latest.toml
+++ b/providers/kilo/models/~openai/gpt-mini-latest.toml
@@ -1,9 +1,10 @@
+# Tracks the current GPT Mini alias target on Kilo (GPT-5.4 Mini).
 name = "OpenAI: GPT Mini Latest"
 description = "Compact GPT model for low-latency assistance and high-volume workloads"
-release_date = "2026-04-27"
+release_date = "2026-03-17"
 last_updated = "2026-05-01"
 attachment = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 reasoning = true
 tool_call = true
 temperature = false

--- a/providers/merge-gateway/models/google/gemini-flash-latest.toml
+++ b/providers/merge-gateway/models/google/gemini-flash-latest.toml
@@ -1,8 +1,9 @@
+# Alias for the current Gemini Flash release (gemini-3.5-flash).
 base_model = "google/gemini-flash-latest"
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
-input = 0.3
-output = 2.5
-cache_read = 0.075
-input_audio = 1
+input = 1.5
+output = 9
+cache_read = 0.15
+input_audio = 1.5

--- a/providers/merge-gateway/models/google/gemini-flash-lite-latest.toml
+++ b/providers/merge-gateway/models/google/gemini-flash-lite-latest.toml
@@ -1,7 +1,9 @@
+# Alias for the current Gemini Flash-Lite release (gemini-3.1-flash-lite).
 base_model = "google/gemini-flash-lite-latest"
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
-input = 0.1
-output = 0.4
+input = 0.25
+output = 1.5
 cache_read = 0.025
+input_audio = 0.5

--- a/providers/nano-gpt/models/google/gemini-flash-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-flash-latest.toml
@@ -1,13 +1,14 @@
 # Not included in subscription
+# Tracks Gemini 3.5 Flash (current flash-latest target).
 name = "Gemini Flash Latest"
 description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
-release_date = "2026-03-29"
-last_updated = "2026-03-29"
+release_date = "2026-05-19"
+last_updated = "2026-05-19"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
-tool_call = false
-structured_output = false
+tool_call = true
+structured_output = true
 open_weights = false
 
 [cost]
@@ -16,8 +17,8 @@ output = 9
 cache_read = 0.15
 
 [limit]
-context = 1048756
-input = 1048756
+context = 1048576
+input = 1048576
 output = 65536
 
 [modalities]

--- a/providers/nano-gpt/models/google/gemini-flash-lite-latest.toml
+++ b/providers/nano-gpt/models/google/gemini-flash-lite-latest.toml
@@ -1,8 +1,9 @@
 # Not included in subscription
+# Tracks Gemini 3.1 Flash Lite (current flash-lite-latest target).
 name = "Gemini Flash Lite Latest"
 description = "Low-latency Gemini model for high-volume multimodal and agent workloads"
-release_date = "2026-03-29"
-last_updated = "2026-03-29"
+release_date = "2026-05-07"
+last_updated = "2026-05-07"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]

--- a/providers/openrouter/models/~anthropic/claude-sonnet-latest.toml
+++ b/providers/openrouter/models/~anthropic/claude-sonnet-latest.toml
@@ -1,26 +1,21 @@
+# OpenRouter alias currently redirects to Claude Sonnet 5.
+# https://openrouter.ai/~anthropic/claude-sonnet-latest
 name = "Anthropic Claude Sonnet Latest"
 description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
 family = "claude-sonnet"
-release_date = "2026-04-27"
-last_updated = "2026-04-27"
+release_date = "2026-06-30"
+last_updated = "2026-06-30"
 attachment = true
 reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
+knowledge = "2026-01-31"
 open_weights = false
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "max"]
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
-max = 127_999
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 2

--- a/providers/openrouter/models/~google/gemini-flash-latest.toml
+++ b/providers/openrouter/models/~google/gemini-flash-latest.toml
@@ -1,15 +1,17 @@
+# OpenRouter alias currently redirects to Gemini 3.5 Flash.
+# https://openrouter.ai/~google/gemini-flash-latest
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 name = "Google Gemini Flash Latest"
 description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
 family = "gemini-flash"
-release_date = "2026-04-27"
-last_updated = "2026-04-27"
+release_date = "2026-05-19"
+last_updated = "2026-05-19"
 attachment = true
 reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-knowledge = "2025-01-01"
+knowledge = "2025-01"
 open_weights = false
 
 [cost]

--- a/providers/openrouter/models/~google/gemini-pro-latest.toml
+++ b/providers/openrouter/models/~google/gemini-pro-latest.toml
@@ -1,14 +1,17 @@
+# OpenRouter alias currently redirects to Gemini 3.1 Pro Preview.
+# https://openrouter.ai/~google/gemini-pro-latest
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 name = "Google Gemini Pro Latest"
 description = "Advanced Gemini model for complex reasoning, coding, and multimodal analysis"
 family = "gemini-pro"
-release_date = "2026-04-27"
-last_updated = "2026-04-27"
+release_date = "2026-02-19"
+last_updated = "2026-02-19"
 attachment = true
 reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
+knowledge = "2025-01"
 open_weights = false
 
 [cost]
@@ -18,10 +21,16 @@ reasoning = 12
 cache_read = 0.2
 cache_write = 0.375
 
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4
+
 [limit]
 context = 1_048_576
 output = 65_536
 
 [modalities]
-input = ["audio", "pdf", "image", "text", "video"]
+input = ["text", "image", "video", "audio", "pdf"]
 output = ["text"]

--- a/providers/openrouter/models/~openai/gpt-latest.toml
+++ b/providers/openrouter/models/~openai/gpt-latest.toml
@@ -1,8 +1,10 @@
+# OpenRouter alias currently redirects to GPT-5.6 Sol.
+# https://openrouter.ai/~openai/gpt-latest
 name = "OpenAI GPT Latest"
 description = "GPT model for general reasoning, writing, coding, and tool-assisted tasks"
 family = "gpt"
-release_date = "2026-04-27"
-last_updated = "2026-04-27"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
 attachment = true
 reasoning = true
 temperature = false
@@ -13,7 +15,7 @@ open_weights = false
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "xhigh"]
+values = ["none", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5
@@ -26,5 +28,5 @@ context = 1_050_000
 output = 128_000
 
 [modalities]
-input = ["pdf", "image", "text"]
+input = ["text", "image", "pdf"]
 output = ["text"]

--- a/providers/orcarouter/models/google/gemini-flash-latest.toml
+++ b/providers/orcarouter/models/google/gemini-flash-latest.toml
@@ -1,8 +1,9 @@
+# Alias for the current Gemini Flash release (gemini-3.5-flash).
 base_model = "google/gemini-flash-latest"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
-input = 0.5
-output = 3
-cache_read = 0.075
-input_audio = 1
+input = 1.5
+output = 9
+cache_read = 0.15
+input_audio = 1.5

--- a/providers/orcarouter/models/google/gemini-flash-lite-latest.toml
+++ b/providers/orcarouter/models/google/gemini-flash-lite-latest.toml
@@ -1,7 +1,9 @@
+# Alias for the current Gemini Flash-Lite release (gemini-3.1-flash-lite).
 base_model = "google/gemini-flash-lite-latest"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25
 output = 1.5
 cache_read = 0.025
+input_audio = 0.5


### PR DESCRIPTION
## Summary

`*-latest` aliases were out of date vs the models they currently resolve to. The headline case: `gemini-flash-latest` still advertised Gemini 2.5-style `toggle` + `budget_tokens` and 2.5 pricing while mapping to **Gemini 3.5 Flash** (`effort`: minimal/low/medium/high, $1.50/$9).

This PR audits alias→target pairs and corrects reasoning options plus related cost/metadata so latest tracks the live target.

## Mappings corrected

| Alias | Current target | What was wrong | Fix |
| --- | --- | --- | --- |
| `google/gemini-flash-latest` | `gemini-3.5-flash` | RO toggle+budget; 2.5 cost | effort + 3.5 cost/dates |
| `google/gemini-flash-lite-latest` | `gemini-3.1-flash-lite` | RO toggle+budget; 2.5-lite cost | effort + 3.1-lite cost/dates |
| `google-vertex` flash/flash-lite latest | same | stale cost (RO already effort) | cost/audio aligned |
| `merge-gateway` / `orcarouter` google latest | same | stale cost; orcarouter `RO=[]` | effort + current cost |
| `openrouter/~google/gemini-flash-latest` | [3.5 Flash](https://openrouter.ai/~google/gemini-flash-latest) | dates only (RO already OK) | dates/knowledge |
| `openrouter/~google/gemini-pro-latest` | [3.1 Pro Preview](https://openrouter.ai/~google/gemini-pro-latest) | missing context tiers | tiers + dates |
| `openrouter/~anthropic/claude-sonnet-latest` | [Sonnet 5](https://openrouter.ai/~anthropic/claude-sonnet-latest) | 4.6-style toggle+budget+effort | Sonnet 5 effort only |
| `openrouter/~openai/gpt-latest` | [GPT-5.6 Sol](https://openrouter.ai/~openai/gpt-latest) | missing `max` effort | match 5.6 Sol RO |
| `kilo` gpt/gpt-mini/haiku/sonnet/flash latest | provider versioned counterparts | mismatched RO vs priced target | align to kilo’s current targets |
| `nano-gpt` flash/flash-lite latest | 3.5 / 3.1-lite | tool_call/limit/dates drift | match versioned nano entries |
| `models/google/*-latest` metadata | same | stale release dates/modalities | track current targets |

## Evidence

- [OpenRouter gemini-flash-latest → Gemini 3.5 Flash](https://openrouter.ai/~google/gemini-flash-latest)
- [OpenRouter gemini-pro-latest → Gemini 3.1 Pro Preview](https://openrouter.ai/~google/gemini-pro-latest)
- [OpenRouter claude-sonnet-latest → Claude Sonnet 5](https://openrouter.ai/~anthropic/claude-sonnet-latest)
- [OpenRouter gpt-latest → GPT-5.6 Sol](https://openrouter.ai/~openai/gpt-latest)
- [Gemini 3.5 Flash pricing](https://ai.google.dev/gemini-api/docs/pricing) ($1.50 / $9.00)
- [Gemini 3.1 Flash-Lite pricing](https://ai.google.dev/gemini-api/docs/pricing) ($0.25 / $1.50)
- In-repo targets: `providers/google/models/gemini-3.5-flash.toml`, `gemini-3.1-flash-lite.toml`, OpenRouter/Kilo versioned counterparts

## Notes

- Provider-specific `reasoning_options` stay provider-scoped; aliases only inherit what that provider exposes for the resolved model.
- Kilo Sonnet Latest is aligned to **Sonnet 4.6** (Kilo still prices it at $3/$15; OpenRouter’s alias already points at Sonnet 5).
- When Google/OpenRouter rotate aliases again, update these files with the new target’s RO + cost together.

## Validation

- `bun validate` (pass)
- `git diff --check` (pass)