### PR TITLE
feat(kimi-for-coding): add HighSpeed model

### DIFF
--- a/providers/kimi-for-coding/models/kimi-for-coding-highspeed.toml
+++ b/providers/kimi-for-coding/models/kimi-for-coding-highspeed.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
+name = "Kimi For Coding HighSpeed"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+output = 32_768


### PR DESCRIPTION

## Summary

- add the official `kimi-for-coding-highspeed` model ID to the Kimi For Coding provider
- inherit Kimi K2.7 Code HighSpeed capabilities from the canonical model metadata
- preserve the Kimi Code subscription pricing metadata and documented 32,768-token output limit

## Validation

- verified the model ID with an OpenCode custom model configuration
- parsed and validated the TOML structure with Python `tomllib`
- ran `git diff --check`
- passed the repository's GitHub Actions `validate` and automated `review` checks

## References

- [Kimi Code: Using in Third-Party Coding Agents](https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html)
- Related to #1441
