### PR TITLE
feat(aihubmix): add GPT 5.6 and priority LLM models

### DIFF
--- a/providers/aihubmix/models/claude-fable-5.toml
+++ b/providers/aihubmix/models/claude-fable-5.toml
@@ -1,0 +1,18 @@
+base_model = "anthropic/claude-fable-5"
+structured_output = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+interleaved = true
+
+[cost]
+input = 11
+output = 55
+cache_read = 1.1
+cache_write = 13.75
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/claude-sonnet-5.toml
+++ b/providers/aihubmix/models/claude-sonnet-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
+structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 interleaved = true
 temperature = false

--- a/providers/aihubmix/models/claude-sonnet-5.toml
+++ b/providers/aihubmix/models/claude-sonnet-5.toml
@@ -1,0 +1,18 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+interleaved = true
+temperature = false
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/gemini-3.5-flash.toml
+++ b/providers/aihubmix/models/gemini-3.5-flash.toml
@@ -1,0 +1,15 @@
+base_model = "google/gemini-3.5-flash"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 1.5
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/aihubmix/models/gpt-5.6-luna.toml
+++ b/providers/aihubmix/models/gpt-5.6-luna.toml
@@ -1,0 +1,17 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+temperature = false
+
+[cost]
+input = 1
+output = 6
+cache_read = 0.1
+cache_write = 1.25
+
+[limit]
+context = 1_050_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/gpt-5.6-sol.toml
+++ b/providers/aihubmix/models/gpt-5.6-sol.toml
@@ -1,0 +1,17 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+temperature = false
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 1_050_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/gpt-5.6-terra.toml
+++ b/providers/aihubmix/models/gpt-5.6-terra.toml
@@ -1,0 +1,17 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+temperature = false
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+cache_write = 3.125
+
+[limit]
+context = 1_050_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/grok-4.5.toml
+++ b/providers/aihubmix/models/grok-4.5.toml
@@ -1,0 +1,15 @@
+base_model = "xai/grok-4.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[limit]
+context = 1_000_000
+output = 1_000_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/grok-build-0.1.toml
+++ b/providers/aihubmix/models/grok-build-0.1.toml
@@ -1,5 +1,5 @@
 base_model = "xai/grok-build-0.1"
-reasoning_options = [{ type = "effort", values = ["none"] }]
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/aihubmix/models/grok-build-0.1.toml
+++ b/providers/aihubmix/models/grok-build-0.1.toml
@@ -1,0 +1,15 @@
+base_model = "xai/grok-build-0.1"
+reasoning_options = [{ type = "effort", values = ["none"] }]
+
+[cost]
+input = 1
+output = 2
+cache_read = 0.2
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/hy3-preview.toml
+++ b/providers/aihubmix/models/hy3-preview.toml
@@ -1,0 +1,17 @@
+base_model = "tencent/hy3-preview"
+name = "Hy3 Preview"
+structured_output = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "high"] }]
+
+[cost]
+input = 0.17
+output = 0.566661
+cache_read = 0.051
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aihubmix/models/kimi-k2.7-code-highspeed.toml
+++ b/providers/aihubmix/models/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,18 @@
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.9
+output = 7.999
+cache_read = 0.32167
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/aihubmix/models/kimi-k2.7-code.toml
+++ b/providers/aihubmix/models/kimi-k2.7-code.toml
@@ -1,0 +1,18 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 3.9995
+cache_read = 0.160835
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
﻿## Changes

- Added 11 AIHubMix model configs under `providers/aihubmix/models`:
  - `gpt-5.6-luna`
  - `gpt-5.6-sol`
  - `gpt-5.6-terra`
  - `grok-4.5`
  - `claude-sonnet-5`
  - `claude-fable-5`
  - `gemini-3.5-flash`
  - `grok-build-0.1`
  - `kimi-k2.7-code`
  - `kimi-k2.7-code-highspeed`
  - `hy3-preview`
- Reused the existing read-only `base_model` entries from OpenAI, xAI, Anthropic, Google, Moonshot AI, and Tencent.
- Added AIHubMix-specific pricing, context/output limits, cache pricing where available, and input modality overrides.
- Added verified reasoning options:
  - GPT 5.6 Luna/Sol/Terra: `effort` values `none`, `low`, `medium`, `high`, `xhigh`, `max`.
  - Grok 4.5: `effort` values `none`, `low`, `medium`, `high`.
  - Claude Sonnet 5 and Claude Fable 5: `toggle` plus `effort` values `low`, `medium`, `high`, `xhigh`, `max`, with interleaved reasoning enabled.
  - Gemini 3.5 Flash: `effort` values `minimal`, `low`, `medium`, `high`.
  - Grok Build 0.1: `effort` value `none` only; `low`, `medium`, and `high` were rejected by live smoke.
  - Kimi K2.7 Code and Kimi K2.7 Code Highspeed: `toggle` only, with `reasoning_content` interleaving.
  - Hy3 Preview: `effort` values `none`, `low`, `high`.

## Validation

- Confirmed AIHubMix model facts with the AIHubMix MCP / Models API for all 11 model IDs.
- Ran `validate_aihubmix_opencode_model.py --live` for the configured reasoning and structured-output smoke cases.
- Confirmed the newly added six models returned HTTP 200 for their configured live smoke cases:
  - Claude Fable 5: `low`, `medium`, `high`, `xhigh`, `max`, and `response_format=json_schema`.
  - Gemini 3.5 Flash: `minimal`, `low`, `medium`, `high`, and `response_format=json_schema`.
  - Grok Build 0.1: `none` and `response_format=json_schema`.
  - Kimi K2.7 Code and Kimi K2.7 Code Highspeed: `response_format=json_schema`.
  - Hy3 Preview: `none`, `low`, `high`, and `response_format=json_schema`.
- Ran `validate_aihubmix_opencode_model.py` for the six newly added models in this PR worktree.
- Ran `bun run validate` and `cd packages/web && bun run build`.
- Confirmed generated `packages/web/dist/_api.json` contains all 11 new AIHubMix models.
- Loaded the generated registry with `OPENCODE_MODELS_PATH=... opencode models aihubmix --refresh`; all 11 `aihubmix/<model>` entries appeared in the refreshed OpenCode model list.
