### PR TITLE
[evroc] add GLM 5.2

### DIFF
--- a/providers/evroc/models/zai-org/GLM-5.2.toml
+++ b/providers/evroc/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "toggle" # API: {"chat_template_kwargs": {"enable_thinking": false}}
+
+[[reasoning_options]]
+type = "effort" # API: {"reasoning_effort": "none"|"high"|"max"}; "none" disables thinking
+values = ["none", "high", "max"]
+
+[cost]
+input = 1.4375
+output = 5.75
+
+[limit]
+context = 1_048_576


### PR DESCRIPTION
evroc now serves GLM 5.2 as a shared model, so this adds it to the provider list.

Follows up on #2765.

## Sources

**Pricing** — evroc billing API (public): https://api.billing.evroc.com/api/v1/pricing
- `shared_models.input_tokens.zai-org/glm-5.2` = EUR 1.25/1M
- `shared_models.output_tokens.zai-org/glm-5.2` = EUR 5.00/1M
- Converted at the same 1.15 EUR→USD rate as the existing evroc entries → $1.4375/$5.75.

**Reasoning controls** — verified against the live endpoint (`models.think.evroc.com/v1`, `system_fingerprint: vllm-0.24.0-tp8`):
- Default request → `reasoning` populated (thinking on by default).
- `{"reasoning_effort": "none"}` → accepted, `reasoning: null`, ~2 completion tokens (thinking off).
- Unknown value (negative control) → 400 with vLLM enum `none|minimal|low|medium|high|xhigh|max`, so acceptance of `none` is meaningful validation, not passthrough.
- GLM-5.2's chat template only trains two effort levels: `{%- set effective_reasoning_effort = 'high' if reasoning_effort == 'high' else 'max' -%}` — everything except `high`/`none` collapses to `max`, hence `values = ["none", "high", "max"]`. Empirically: `max` → ~16-18k reasoning chars, `high` → ~3-7k, `none` → 0.
- `{"chat_template_kwargs": {"enable_thinking": false}}` → toggle off, verified same way.

**Context** — 1,048,576 confirmed via oversized `max_tokens` error revealing `max_model_len`; matches the stock vLLM recipe evroc runs (recipes.vllm.ai/zai-org/GLM-5.2).