### PR TITLE
feat: add Cursor Bridge provider

### DIFF
--- a/providers/cursor-bridge/logo.svg
+++ b/providers/cursor-bridge/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor">
+  <path d="M12 10h40v12H24v20h28v12H12z"/>
+  <path d="M40 27h12v12H40z"/>
+</svg>

--- a/providers/cursor-bridge/models/claude-fable-5.toml
+++ b/providers/cursor-bridge/models/claude-fable-5.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-fable-5"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-fable-5.toml
+++ b/providers/cursor-bridge/models/claude-fable-5.toml
@@ -1,2 +1,2 @@
 base_model = "anthropic/claude-fable-5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/claude-fable-5.toml
+++ b/providers/cursor-bridge/models/claude-fable-5.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/claude-fable-5
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "anthropic/claude-fable-5"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/claude-haiku-4-5.toml
+++ b/providers/cursor-bridge/models/claude-haiku-4-5.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-opus-4-5.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-5.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-opus-4-5"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-opus-4-6.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-6.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/claude-opus-4-6
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "anthropic/claude-opus-4-6"
 reasoning_options = [{ type = "effort", values = ["high", "max"] }]

--- a/providers/cursor-bridge/models/claude-opus-4-6.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-6.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-opus-4-6"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-opus-4-6.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-6.toml
@@ -1,2 +1,2 @@
 base_model = "anthropic/claude-opus-4-6"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]

--- a/providers/cursor-bridge/models/claude-opus-4-7.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-7.toml
@@ -1,2 +1,2 @@
 base_model = "anthropic/claude-opus-4-7"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/claude-opus-4-7.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-7.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/claude-opus-4-7
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "anthropic/claude-opus-4-7"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/claude-opus-4-7.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-7.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-opus-4-7"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-opus-4-8.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-8.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/claude-opus-4-8
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "anthropic/claude-opus-4-8"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/claude-opus-4-8.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-8.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-opus-4-8.toml
+++ b/providers/cursor-bridge/models/claude-opus-4-8.toml
@@ -1,2 +1,2 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/claude-sonnet-4-5.toml
+++ b/providers/cursor-bridge/models/claude-sonnet-4-5.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-sonnet-4-5"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-sonnet-4-6.toml
+++ b/providers/cursor-bridge/models/claude-sonnet-4-6.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-sonnet-4.toml
+++ b/providers/cursor-bridge/models/claude-sonnet-4.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-sonnet-4-0"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-sonnet-5.toml
+++ b/providers/cursor-bridge/models/claude-sonnet-5.toml
@@ -1,2 +1,2 @@
 base_model = "anthropic/claude-sonnet-5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/claude-sonnet-5.toml
+++ b/providers/cursor-bridge/models/claude-sonnet-5.toml
@@ -1,0 +1,2 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = []

--- a/providers/cursor-bridge/models/claude-sonnet-5.toml
+++ b/providers/cursor-bridge/models/claude-sonnet-5.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/claude-sonnet-5
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "anthropic/claude-sonnet-5"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/composer-2.5.toml
+++ b/providers/cursor-bridge/models/composer-2.5.toml
@@ -1,0 +1,21 @@
+# Cursor's live model catalog identifies Composer 2.5 as a proprietary model.
+# Source (accessed 2026-07-16): https://cursorbridge.dev/v1/models
+name = "Cursor Composer 2.5"
+description = "Cursor's proprietary coding model for fast agentic software development workflows."
+release_date = "2026-07-09"
+last_updated = "2026-07-16"
+attachment = false
+reasoning = true
+reasoning_options = []
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 272_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cursor-bridge/models/composer-2.5.toml
+++ b/providers/cursor-bridge/models/composer-2.5.toml
@@ -1,5 +1,7 @@
-# Cursor's live model catalog identifies Composer 2.5 as a proprietary model.
-# Source (accessed 2026-07-16): https://cursorbridge.dev/v1/models
+# Sources (accessed 2026-07-16):
+# - https://cursorbridge.dev/docs#model-metadata defines the metadata fields.
+# - https://cursorbridge.dev/v1/models/composer-2.5 reports the 272k context,
+#   32,768 output limit, and 2026-07-09 first-observed release date.
 name = "Cursor Composer 2.5"
 description = "Cursor's proprietary coding model for fast agentic software development workflows."
 release_date = "2026-07-09"

--- a/providers/cursor-bridge/models/default.toml
+++ b/providers/cursor-bridge/models/default.toml
@@ -1,0 +1,24 @@
+# Cursor Bridge's default model delegates model selection to Cursor. Capabilities
+# and conservative limits reflect the bridge rather than any one upstream model;
+# availability and billing depend on the user's Cursor plan.
+# Source (accessed 2026-07-16): https://cursorbridge.dev/docs
+name = "Cursor Default"
+description = "Uses Cursor's automatic model selection based on the models available to the authenticated Cursor account."
+family = "auto"
+release_date = "2026-07-13"
+last_updated = "2026-07-16"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/cursor-bridge/models/default.toml
+++ b/providers/cursor-bridge/models/default.toml
@@ -1,7 +1,9 @@
-# Cursor Bridge's default model delegates model selection to Cursor. Capabilities
-# and conservative limits reflect the bridge rather than any one upstream model;
-# availability and billing depend on the user's Cursor plan.
-# Source (accessed 2026-07-16): https://cursorbridge.dev/docs
+# Cursor Bridge's default model delegates model selection to Cursor; availability
+# and billing depend on the user's Cursor plan.
+# Sources (accessed 2026-07-16):
+# - https://cursorbridge.dev/docs#model-metadata defines the metadata fields.
+# - https://cursorbridge.dev/v1/models/default reports the 200k context,
+#   64k output limit, and 2026-07-13 first-observed release date.
 name = "Cursor Default"
 description = "Uses Cursor's automatic model selection based on the models available to the authenticated Cursor account."
 family = "auto"

--- a/providers/cursor-bridge/models/gemini-2.5-flash.toml
+++ b/providers/cursor-bridge/models/gemini-2.5-flash.toml
@@ -1,0 +1,2 @@
+base_model = "google/gemini-2.5-flash"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gemini-3-flash.toml
+++ b/providers/cursor-bridge/models/gemini-3-flash.toml
@@ -1,0 +1,3 @@
+# Cursor serves Gemini 3 Flash under this stable model ID.
+base_model = "google/gemini-3-flash-preview"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gemini-3.1-pro.toml
+++ b/providers/cursor-bridge/models/gemini-3.1-pro.toml
@@ -1,0 +1,3 @@
+# Cursor serves Gemini 3.1 Pro under this stable model ID.
+base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gemini-3.5-flash.toml
+++ b/providers/cursor-bridge/models/gemini-3.5-flash.toml
@@ -1,0 +1,2 @@
+base_model = "google/gemini-3.5-flash"
+reasoning_options = []

--- a/providers/cursor-bridge/models/glm-5.2.toml
+++ b/providers/cursor-bridge/models/glm-5.2.toml
@@ -1,0 +1,2 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = []

--- a/providers/cursor-bridge/models/glm-5.2.toml
+++ b/providers/cursor-bridge/models/glm-5.2.toml
@@ -1,2 +1,2 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]

--- a/providers/cursor-bridge/models/glm-5.2.toml
+++ b/providers/cursor-bridge/models/glm-5.2.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/glm-5.2
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "zhipuai/glm-5.2"
 reasoning_options = [{ type = "effort", values = ["high", "max"] }]

--- a/providers/cursor-bridge/models/gpt-5-mini.toml
+++ b/providers/cursor-bridge/models/gpt-5-mini.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5-mini"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.1-codex-max.toml
+++ b/providers/cursor-bridge/models/gpt-5.1-codex-max.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.1-codex-max"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.1-codex-max.toml
+++ b/providers/cursor-bridge/models/gpt-5.1-codex-max.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.1-codex-max
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.1-codex-max"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.1-codex-max.toml
+++ b/providers/cursor-bridge/models/gpt-5.1-codex-max.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.1-codex-max"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.1-codex-mini.toml
+++ b/providers/cursor-bridge/models/gpt-5.1-codex-mini.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.1-codex-mini
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.1-codex-mini"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/cursor-bridge/models/gpt-5.1-codex-mini.toml
+++ b/providers/cursor-bridge/models/gpt-5.1-codex-mini.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.1-codex-mini"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/cursor-bridge/models/gpt-5.1-codex-mini.toml
+++ b/providers/cursor-bridge/models/gpt-5.1-codex-mini.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.1-codex-mini"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.1.toml
+++ b/providers/cursor-bridge/models/gpt-5.1.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.1"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/cursor-bridge/models/gpt-5.1.toml
+++ b/providers/cursor-bridge/models/gpt-5.1.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.1"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.1.toml
+++ b/providers/cursor-bridge/models/gpt-5.1.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.1
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.1"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/cursor-bridge/models/gpt-5.2-codex.toml
+++ b/providers/cursor-bridge/models/gpt-5.2-codex.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.2-codex"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.2-codex.toml
+++ b/providers/cursor-bridge/models/gpt-5.2-codex.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.2-codex
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.2-codex"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.2-codex.toml
+++ b/providers/cursor-bridge/models/gpt-5.2-codex.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.2-codex"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.2.toml
+++ b/providers/cursor-bridge/models/gpt-5.2.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.2.toml
+++ b/providers/cursor-bridge/models/gpt-5.2.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.2"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.2.toml
+++ b/providers/cursor-bridge/models/gpt-5.2.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.2
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.2"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.3-codex.toml
+++ b/providers/cursor-bridge/models/gpt-5.3-codex.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.3-codex"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.3-codex.toml
+++ b/providers/cursor-bridge/models/gpt-5.3-codex.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.3-codex"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.3-codex.toml
+++ b/providers/cursor-bridge/models/gpt-5.3-codex.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.3-codex
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.3-codex"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.4-mini.toml
+++ b/providers/cursor-bridge/models/gpt-5.4-mini.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.4-mini"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.4-mini.toml
+++ b/providers/cursor-bridge/models/gpt-5.4-mini.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.4-mini"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.4-mini.toml
+++ b/providers/cursor-bridge/models/gpt-5.4-mini.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.4-mini
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.4-mini"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.4-nano.toml
+++ b/providers/cursor-bridge/models/gpt-5.4-nano.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.4-nano"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.4-nano.toml
+++ b/providers/cursor-bridge/models/gpt-5.4-nano.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.4-nano
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.4-nano"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.4-nano.toml
+++ b/providers/cursor-bridge/models/gpt-5.4-nano.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.4-nano"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.4.toml
+++ b/providers/cursor-bridge/models/gpt-5.4.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.4"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.4.toml
+++ b/providers/cursor-bridge/models/gpt-5.4.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.4"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.4.toml
+++ b/providers/cursor-bridge/models/gpt-5.4.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.4
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.4"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.5.toml
+++ b/providers/cursor-bridge/models/gpt-5.5.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.5.toml
+++ b/providers/cursor-bridge/models/gpt-5.5.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.5
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.5"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]

--- a/providers/cursor-bridge/models/gpt-5.5.toml
+++ b/providers/cursor-bridge/models/gpt-5.5.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.5"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.6-luna.toml
+++ b/providers/cursor-bridge/models/gpt-5.6-luna.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.6-luna.toml
+++ b/providers/cursor-bridge/models/gpt-5.6-luna.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.6-luna"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/gpt-5.6-luna.toml
+++ b/providers/cursor-bridge/models/gpt-5.6-luna.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.6-luna
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.6-luna"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/gpt-5.6-sol.toml
+++ b/providers/cursor-bridge/models/gpt-5.6-sol.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.6-sol
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/gpt-5.6-sol.toml
+++ b/providers/cursor-bridge/models/gpt-5.6-sol.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.6-sol"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/gpt-5.6-sol.toml
+++ b/providers/cursor-bridge/models/gpt-5.6-sol.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = []

--- a/providers/cursor-bridge/models/gpt-5.6-terra.toml
+++ b/providers/cursor-bridge/models/gpt-5.6-terra.toml
@@ -1,2 +1,2 @@
 base_model = "openai/gpt-5.6-terra"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/gpt-5.6-terra.toml
+++ b/providers/cursor-bridge/models/gpt-5.6-terra.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/gpt-5.6-terra
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "openai/gpt-5.6-terra"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor-bridge/models/gpt-5.6-terra.toml
+++ b/providers/cursor-bridge/models/gpt-5.6-terra.toml
@@ -1,0 +1,2 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = []

--- a/providers/cursor-bridge/models/grok-4.3.toml
+++ b/providers/cursor-bridge/models/grok-4.3.toml
@@ -1,0 +1,2 @@
+base_model = "xai/grok-4.3"
+reasoning_options = []

--- a/providers/cursor-bridge/models/grok-4.5.toml
+++ b/providers/cursor-bridge/models/grok-4.5.toml
@@ -1,2 +1,4 @@
+# Source: https://cursorbridge.dev/v1/models/grok-4.5
+# The authenticated response reports these accepted reasoning effort values.
 base_model = "xai/grok-4.5"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/cursor-bridge/models/grok-4.5.toml
+++ b/providers/cursor-bridge/models/grok-4.5.toml
@@ -1,2 +1,2 @@
 base_model = "xai/grok-4.5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/cursor-bridge/models/grok-4.5.toml
+++ b/providers/cursor-bridge/models/grok-4.5.toml
@@ -1,0 +1,2 @@
+base_model = "xai/grok-4.5"
+reasoning_options = []

--- a/providers/cursor-bridge/models/grok-build-0.1.toml
+++ b/providers/cursor-bridge/models/grok-build-0.1.toml
@@ -1,0 +1,2 @@
+base_model = "xai/grok-build-0.1"
+reasoning_options = []

--- a/providers/cursor-bridge/models/kimi-k2.7-code.toml
+++ b/providers/cursor-bridge/models/kimi-k2.7-code.toml
@@ -1,0 +1,2 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []

--- a/providers/cursor-bridge/provider.toml
+++ b/providers/cursor-bridge/provider.toml
@@ -1,0 +1,5 @@
+name = "Cursor Bridge"
+env = ["CURSOR_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://cursorbridge.dev/v1"
+doc = "https://cursorbridge.dev/docs"


### PR DESCRIPTION
## Summary

- add Cursor Bridge as an OpenAI-compatible provider
- register all 35 model IDs currently exposed by the live Cursor catalog, including Claude Fable 5, Claude Opus/Sonnet, GPT/Codex, Gemini, Grok, Kimi, GLM, Composer 2.5, and Cursor Default
- include model-specific reasoning effort controls backed by Cursor variants
- include a monochrome provider logo compatible with light and dark themes

## Why

Cursor Bridge lets users access models available to their Cursor account through an OpenAI-compatible API. Adding it to models.dev makes the provider and its model catalog selectable in OpenCode without requiring a custom provider definition.

Cursor Bridge is unofficial community software and is not affiliated with or endorsed by Cursor.

## Provider details

- API: https://cursorbridge.dev/v1
- Authentication: `CURSOR_API_KEY`
- Documentation: https://cursorbridge.dev/docs#model-metadata
- SDK: `@ai-sdk/openai-compatible`

## Model metadata

- 33 upstream models use canonical `base_model` metadata
- `default` and Cursor-proprietary `composer-2.5` are defined directly
- 20 models declare verified `low`, `medium`, `high`, `xhigh`, and/or `max` effort variants
- models with fixed reasoning behavior use an empty reasoning-options list
- fixed token costs are intentionally omitted because availability and billing depend on the authenticated Cursor account and plan

## Provider evidence

Authenticated `GET /v1/models/{model}` responses expose the exact `context_window`, `max_output_tokens`, `reasoning`, `reasoning_options`, and applicable `release_date` values represented in this PR:

```sh
curl -H "Authorization: Bearer $CURSOR_API_KEY" https://cursorbridge.dev/v1/models/claude-fable-5
```

Each TOML with configurable reasoning links directly to its corresponding endpoint. The public documentation defines the response fields and explains that effort values come from Cursor usable-model variants. Unsupported effort values are rejected rather than silently substituted.

For Cursor-owned virtual models, `release_date` is documented as the first date that ID was observed in the live Cursor Bridge catalog.

## Validation

- verified the authored catalog exactly matches the 35 model IDs observed across live Cursor account catalogs
- programmatically compared all 20 TOML effort arrays with their live authenticated endpoint responses
- verified inline limits and dates against the live `default` and `composer-2.5` endpoint responses
- validated all TOML files parse and every `base_model` target exists
- validated required resolved model fields and reasoning declarations
- validated SVG structure and `currentColor` requirements
- `git diff --check` passes

Full repository validation runs in GitHub Actions because Bun is not installed in the local environment.
