### PR TITLE
feat(moonshotai): add Kimi K3

### DIFF
--- a/models/moonshotai/kimi-k3.toml
+++ b/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,19 @@
+name = "Kimi K3"
+description = "Multimodal Kimi model with 1M context and toggleable max-effort thinking for long-horizon agent work"
+family = "kimi-k3"
+release_date = "2026-07-16"
+last_updated = "2026-07-16"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -76,6 +76,7 @@ export const ModelFamilyValues = [
   // Moonshot Kimi
   "kimi",
   "kimi-k2",
+  "kimi-k3",
   "kimi-free",
   "kimi-thinking",
 
@@ -445,5 +446,6 @@ export function inferKimiFamily(...values: string[]): ModelFamily | undefined {
   const target = values.join(" ").toLowerCase();
   if (/kimi[^a-z0-9]*k2(?:[^a-z0-9]*\d+)?[^a-z0-9]*thinking/.test(target)) return "kimi-thinking";
   if (/kimi[\s_-]*k2/.test(target)) return "kimi-k2";
+  if (/kimi[\s_-]*k3/.test(target)) return "kimi-k3";
   return undefined;
 }

--- a/packages/core/test/family.test.ts
+++ b/packages/core/test/family.test.ts
@@ -13,3 +13,8 @@ test("Kimi family inference preserves thinking variants", () => {
   expect(inferKimiFamily("Kimi K2.5 Thinking")).toBe("kimi-thinking");
   expect(inferKimiFamily("moonshotai/kimi-k2.6:thinking")).toBe("kimi-thinking");
 });
+
+test("Kimi family inference maps K3 to its own family", () => {
+  expect(inferKimiFamily("moonshotai/kimi-k3")).toBe("kimi-k3");
+  expect(inferKimiFamily("Kimi K3")).toBe("kimi-k3");
+});

--- a/providers/kimi-for-coding/models/k3.toml
+++ b/providers/kimi-for-coding/models/k3.toml
@@ -1,0 +1,19 @@
+# reasoning_options mirror the Moonshot AI platform API surface:
+#   thinking.type = "enabled" | "disabled" | "adaptive"
+#   output_config.effort accepts only "max"
+# Cost is zeroed per this provider's subscription convention.
+base_model = "moonshotai/kimi-k3"
+attachment = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["max"]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/kimi-for-coding/provider.toml
+++ b/providers/kimi-for-coding/provider.toml
@@ -1,3 +1,8 @@
+# NOTE: api.kimi.com/coding serves BOTH Anthropic (/v1/messages) and
+# OpenAI-compatible (/v1/chat/completions) protocols (verified 2026-07).
+# Registered as @ai-sdk/anthropic: the Messages surface is the officially
+# documented one (see doc) and round-trips reasoning natively via
+# thinking blocks.
 name = "Kimi For Coding"
 env = ["KIMI_API_KEY"]
 npm = "@ai-sdk/anthropic"

--- a/providers/moonshotai-cn/models/kimi-k3.toml
+++ b/providers/moonshotai-cn/models/kimi-k3.toml
@@ -1,0 +1,1 @@
+../../moonshotai/models/kimi-k3.toml

--- a/providers/moonshotai/models/kimi-k3.toml
+++ b/providers/moonshotai/models/kimi-k3.toml
@@ -1,0 +1,14 @@
+# API: thinking.type = "enabled" | "disabled" | "adaptive"; in adaptive mode the
+# reasoning depth is set by output_config.effort, which only accepts "max".
+# Pricing not yet published — cost intentionally omitted.
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["max"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
## Summary

- `models/moonshotai/kimi-k3.toml` — base metadata: 1M context, 128K output, text/image/video input, open weights, reasoning.
- `providers/moonshotai/models/kimi-k3.toml` + `moonshotai-cn` symlink — inherits via `base_model`; `reasoning_options` (toggle + effort `max`), `interleaved.field = "reasoning_content"`, cost omitted.
- `providers/kimi-for-coding/models/k3.toml` — subscription-plan entry (cost zeroed), short-alias naming per provider convention (k2p5/k2p6/k2p7).
- New `kimi-k3` model family: enum value, inference rule, tests. `bun validate` and family tests pass.

Docs: https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html · https://platform.moonshot.ai/docs/api/chat
