### PR TITLE
feat: add ClinePass as a built-in provider

### DIFF
--- a/providers/clinepass/models/cline-pass/deepseek-v4-flash.toml
+++ b/providers/clinepass/models/cline-pass/deepseek-v4-flash.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/cline-pass/deepseek-v4-pro.toml
+++ b/providers/clinepass/models/cline-pass/deepseek-v4-pro.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/cline-pass/glm-5.2.toml
+++ b/providers/clinepass/models/cline-pass/glm-5.2.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/cline-pass/kimi-k2.6.toml
+++ b/providers/clinepass/models/cline-pass/kimi-k2.6.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/cline-pass/kimi-k2.7-code.toml
+++ b/providers/clinepass/models/cline-pass/kimi-k2.7-code.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/cline-pass/mimo-v2.5-pro.toml
+++ b/providers/clinepass/models/cline-pass/mimo-v2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/cline-pass/mimo-v2.5.toml
+++ b/providers/clinepass/models/cline-pass/mimo-v2.5.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/cline-pass/minimax-m3.toml
+++ b/providers/clinepass/models/cline-pass/minimax-m3.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M3"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/cline-pass/qwen3.7-max.toml
+++ b/providers/clinepass/models/cline-pass/qwen3.7-max.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-max"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/cline-pass/qwen3.7-plus.toml
+++ b/providers/clinepass/models/cline-pass/qwen3.7-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-plus"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/clinepass/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
+name = "DeepSeek V4 Flash (Free)"
+description = "Free tier DeepSeek V4 Flash through Cline API"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/poolside/laguna-m.1:free.toml
+++ b/providers/clinepass/models/poolside/laguna-m.1:free.toml
@@ -1,0 +1,8 @@
+base_model = "poolside/laguna-m.1"
+reasoning_options = []
+name = "Poolside Laguna M.1 (Free)"
+description = "Poolside Laguna M.1 available for free through Cline API"
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/stepfun/step-3.7-flash.toml
+++ b/providers/clinepass/models/stepfun/step-3.7-flash.toml
@@ -1,0 +1,6 @@
+base_model = "stepfun/step-3.7-flash"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/models/tencent/hy3:free.toml
+++ b/providers/clinepass/models/tencent/hy3:free.toml
@@ -1,0 +1,21 @@
+name = "Hy3 (Free)"
+description = "Tencent Hy3 reasoning model available for free through Cline API"
+family = "Hy"
+release_date = "2026-04-20"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 256_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/clinepass/provider.toml
+++ b/providers/clinepass/provider.toml
@@ -1,0 +1,5 @@
+name = "ClinePass"
+env = ["CLINE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://docs.cline.bot/api/models"
+api = "https://api.cline.bot/api/v1"


### PR DESCRIPTION
## feat: add ClinePass as a built-in provider

Adds [Cline/ClinePass](https://docs.cline.bot/api/overview) as a native provider in the \/connect\ list.

ClinePass is a subscription service that provides access to models from Anthropic, OpenAI, Google, DeepSeek, Moonshot AI, Z.AI, Xiaomi, MiniMax, Alibaba, StepFun, Tencent, Poolside, and more through a single OpenAI-compatible endpoint.

### Provider

- **ID**: \clinepass\
- **Name**: ClinePass
- **API**: \https://api.cline.bot/api/v1\
- **SDK**: \@ai-sdk/openai-compatible\
- **Auth**: \CLINE_API_KEY\ env var or \/connect\ credential
- **Docs**: https://docs.cline.bot/api/models

### Models (14 total)

**ClinePass subscription models** (cost: 0 — flat monthly subscription, not per-token):

| Model ID | Base model |
|---|---|
| \cline-pass/glm-5.2\ | \zhipuai/glm-5.2\ |
| \cline-pass/deepseek-v4-pro\ | \deepseek/deepseek-v4-pro\ |
| \cline-pass/deepseek-v4-flash\ | \deepseek/deepseek-v4-flash\ |
| \cline-pass/kimi-k2.7-code\ | \moonshotai/kimi-k2.7-code\ |
| \cline-pass/kimi-k2.6\ | \moonshotai/kimi-k2.6\ |
| \cline-pass/mimo-v2.5-pro\ | \xiaomi/mimo-v2.5-pro\ |
| \cline-pass/mimo-v2.5\ | \xiaomi/mimo-v2.5\ |
| \cline-pass/minimax-m3\ | \minimax/MiniMax-M3\ |
| \cline-pass/qwen3.7-max\ | \libaba/qwen3.7-max\ |
| \cline-pass/qwen3.7-plus\ | \libaba/qwen3.7-plus\ |

**Free tier models** (cost: 0):

| Model ID | Base model |
|---|---|
| \deepseek/deepseek-v4-flash\ | \deepseek/deepseek-v4-flash\ |
| \stepfun/step-3.7-flash\ | \stepfun/step-3.7-flash\ |
| \	encent/hy3:free\ | (inline) |
| \poolside/laguna-m.1:free\ | \poolside/laguna-m.1\ |

### Verification

Model metadata verified against the live Cline API (\GET /api/v1/ai/cline/recommended-models\). All 14 model IDs match the API response exactly.