### PR TITLE
Add Sakana Fugu Cyber Model

### DIFF
--- a/models/sakana/fugu-cyber.toml
+++ b/models/sakana/fugu-cyber.toml
@@ -1,0 +1,23 @@
+name = "Fugu Cyber"
+description = "The same frontier capabilities as Fugu Ultra, but with specific adaptation for cybersecurity tasks."
+family = "fugu"
+release_date = "2026-07-24"
+last_updated = "2026-07-24"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[links]]
+label = "Official model catalog"
+url = "https://raw.githubusercontent.com/SakanaAI/fugu/refs/heads/main/configs/files/fugu.json"
+type = "docs"

--- a/providers/sakana/models/fugu-cyber.toml
+++ b/providers/sakana/models/fugu-cyber.toml
@@ -1,0 +1,19 @@
+base_model = "sakana/fugu-cyber"
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
+
+[limit]
+output = 1_000_000
+
+[cost]
+input = 6
+output = 36
+cache_read = 0.6
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 12
+output = 54
+cache_read = 1.2
+
+[provider]
+shape = "responses"


### PR DESCRIPTION
## Summary
Adds to the Sakana AI available models *fugu-cyber* (https://sakana.ai/fugu-cyber-release/) which reachable via the same OpenAI compatible endpoints as the existing Sakana AI models, fugu and fugu-ultra.

## Changes

- `models/sakana/fugu-cyber.toml` - provider-agnostic model metadata
  (1M context window, text + image input, reasoning, tool calling,
  structured output).
- `providers/sakana/models/fugu-cyber.toml` - Sakana serving details via
  `base_model = "sakana/fugu-cyber"`: reasoning effort options
  (`high`, `xhigh`), 1M output limit, and pricing ($6/M input, $36/M output,
  $0.6/M cache read; tiered to $12/$54/$1.2 above 272K context). Pricing information can be found [here](https://sakana.ai/fugu/#pricing) and supported fields (including reasoning effort) [here](https://console.sakana.ai/models#supported-request-fields-2).

No new provider or model family is introduced. Sakana AI and the `fugu`
family already exist, so `provider.toml` and `family.ts` are unchanged.

## Validation

- TOML files parse cleanly and conform to the schema in
  `packages/core/src/schema.ts` (mirrors the existing `fugu-ultra` pair).
- `reasoning = true` is paired with `reasoning_options` as required.
- Merged provider model includes required `limit.context` and `limit.output`.
- `bun validate` passes
- `packages/web` `bun run build` passes
