### PR TITLE
fix(thinkingmachines): document Inkling reasoning_effort options

### DIFF
--- a/providers/baseten/models/thinkingmachines/inkling.toml
+++ b/providers/baseten/models/thinkingmachines/inkling.toml
@@ -1,7 +1,16 @@
+# Baseten documents top-level reasoning_effort for Inkling with values
+# none | minimal | low | medium | high | xhigh. Reasoning is enabled by
+# default; reasoning_effort: "none" disables it (chat_template_args
+# enable_thinking does not). No budget_tokens control.
+# https://docs.baseten.co/inference/model-apis/reasoning (accessed 2026-07-16)
+# API: {"reasoning_effort": "none"|"minimal"|"low"|"medium"|"high"|"xhigh"}
 base_model = "thinkingmachines/inkling"
 description = "Multimodal reasoning model for visual analysis, planning, and tool use"
 structured_output = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 1

--- a/providers/vercel/models/thinkingmachines/inkling.toml
+++ b/providers/vercel/models/thinkingmachines/inkling.toml
@@ -1,7 +1,10 @@
 # Sources (accessed 2026-07-16):
-# - https://ai-gateway.vercel.sh/v1/models (thinkingmachines/inkling)
+# - https://ai-gateway.vercel.sh/v1/models (thinkingmachines/inkling) — provider: baseten
+# - https://vercel.com/ai-gateway/models/inkling — routes to baseten
+# - https://docs.baseten.co/inference/model-apis/reasoning — Inkling reasoning_effort
+# API: {"reasoning_effort": "none"|"minimal"|"low"|"medium"|"high"|"xhigh"}
 base_model = "thinkingmachines/inkling"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1


### PR DESCRIPTION
## Summary
- Corrects `reasoning_options = []` for Inkling on **Baseten** and **Vercel**
- Documents verified `reasoning_effort` values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
- Adds Baseten `interleaved.field = "reasoning_content"` (matches provider response shape)
- Leaves `thinkingmachines` provider unchanged (already correct)

## Evidence
- [Baseten reasoning docs](https://docs.baseten.co/inference/model-apis/reasoning) — Inkling supports top-level `reasoning_effort` with `none | minimal | low | medium | high | xhigh`; `none` disables reasoning; `chat_template_args.enable_thinking` does **not** control Inkling
- [Tinker OpenAI-compatible API](https://tinker-docs.thinkingmachines.ai/tinker/compatible-apis/openai/) — same named presets (and optional float effort)
- [Vercel Inkling model page](https://vercel.com/ai-gateway/models/inkling) — routes to Baseten; pricing matches Baseten Model APIs

## Notes
- No `budget_tokens` for Inkling (Anthropic `thinking.budget_tokens` is accepted for wire compat on Tinker but ignored)
- No separate `toggle` option on OpenAI-compatible surfaces; disable is via `reasoning_effort: "none"`

## Test plan
- [x] `bun validate`
- [ ] Confirm generated JSON shows effort options for `baseten` / `vercel` `thinkingmachines/inkling`