### PR TITLE
fix(vercel): fill non-language model costs from gateway pricing

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -77,7 +77,13 @@ export interface SyncProvider<SourceModel> {
       existing(id: string): ExistingModel | undefined;
       authored(id: string): ExistingModel | undefined;
     },
-  ): { id: string; model: SyncedModel; metadata?: { id: string; model: SyncedMetadata } } | undefined;
+  ): {
+    id: string;
+    model: SyncedModel;
+    /** Seeded only when the existing file has no leading header; existing headers always win. */
+    header?: string;
+    metadata?: { id: string; model: SyncedMetadata };
+  } | undefined;
 }
 
 export interface SyncResult {
@@ -242,9 +248,11 @@ export async function syncProvider<SourceModel>(
       throw parsed.error;
     }
 
+    const existingHeader = existing.get(relativePath)?.header ?? "";
+    const header = existingHeader || (translated.header ?? "");
     desired.set(relativePath, {
       model: parsed.data,
-      content: (existing.get(relativePath)?.header ?? "") + formatToml(parsed.data),
+      content: header + formatToml(parsed.data),
     });
   }
 

--- a/packages/core/src/sync/providers/vercel.ts
+++ b/packages/core/src/sync/providers/vercel.ts
@@ -53,6 +53,10 @@ const VercelResponse = z.object({
 
 export type VercelModel = z.infer<typeof VercelModel>;
 
+/** Leading header for models whose Vercel pricing cannot map to token cost.input/output. */
+export const ZEROED_COST_HEADER =
+  "# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).\n# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.\n";
+
 export const vercel = {
   id: "vercel",
   name: "Vercel AI Gateway",
@@ -69,9 +73,13 @@ export const vercel = {
     return VercelResponse.parse(raw).data;
   },
   translateModel(model, context) {
+    const existing = context.existing(model.id);
+    const built = buildVercelModel(model, existing);
     return {
       id: model.id,
-      model: buildVercelModel(model, context.existing(model.id)),
+      model: built.model,
+      // Only seed the header when first materializing a zeroed placeholder; existing headers persist on refresh.
+      header: built.costPlaceholder ? ZEROED_COST_HEADER : undefined,
     };
   },
   sameModel(current, desired) {
@@ -79,7 +87,16 @@ export const vercel = {
   },
 } satisfies SyncProvider<VercelModel>;
 
-export function buildVercelModel(model: VercelModel, existing: ExistingModel | undefined): SyncedModel {
+export type BuiltVercelModel = {
+  model: SyncedModel;
+  /** True when cost was zeroed because API pricing could not map to token in/out. */
+  costPlaceholder: boolean;
+};
+
+export function buildVercelModel(
+  model: VercelModel,
+  existing: ExistingModel | undefined,
+): BuiltVercelModel {
   const tags = new Set(model.tags);
   const releaseDate = model.released
     ? dateFromTimestamp(model.released)
@@ -93,7 +110,7 @@ export function buildVercelModel(model: VercelModel, existing: ExistingModel | u
   const input = model.id.startsWith("openai/") && context > output
     ? context - output
     : undefined;
-  const cost = buildCost(model.pricing, existing?.cost);
+  const { cost, placeholder: costPlaceholder } = buildCost(model.pricing, existing?.cost);
 
   const synced: SyncedFullModel = {
     name: existing?.name ?? model.name,
@@ -169,10 +186,15 @@ export function buildVercelModel(model: VercelModel, existing: ExistingModel | u
   };
 
   const baseModel = existing?.base_model ?? resolveCanonicalBaseModel(model.id);
-  if (baseModel === undefined) return synced;
+  if (baseModel === undefined) {
+    return { model: synced, costPlaceholder };
+  }
 
   const { last_updated: _lastUpdated, ...overrides } = synced;
-  return factorBaseModel(baseModel, overrides, synced.limit, existing?.base_model_omit);
+  return {
+    model: factorBaseModel(baseModel, overrides, synced.limit, existing?.base_model_omit),
+    costPlaceholder,
+  };
 }
 
 function dateFromTimestamp(timestamp: number) {
@@ -187,17 +209,43 @@ function price(value: string | undefined) {
     : undefined;
 }
 
-function buildCost(pricing: VercelModel["pricing"], existing?: ExistingModel["cost"]) {
+type BuiltCost = NonNullable<ExistingModel["cost"]>;
+
+/**
+ * Map Vercel pricing into token cost fields when possible.
+ * - input/output (+ cache) token prices → cost.input / cost.output
+ * - input-only (embeddings, speech, some rerank) → cost.input, cost.output = 0
+ * - non-token shapes (image, video duration, etc.) or missing → explicit zeros
+ */
+export function buildCost(
+  pricing: VercelModel["pricing"],
+  existing?: ExistingModel["cost"],
+): { cost: BuiltCost; placeholder: boolean } {
   const input = price(pricing?.input_tiers?.[0]?.cost ?? pricing?.input);
   const output = price(pricing?.output_tiers?.[0]?.cost ?? pricing?.output);
-  if (input === undefined || output === undefined) return undefined;
+  const cache_read = price(pricing?.input_cache_read_tiers?.[0]?.cost ?? pricing?.input_cache_read);
+  const cache_write = price(pricing?.input_cache_write_tiers?.[0]?.cost ?? pricing?.input_cache_write);
+
+  if (input !== undefined || output !== undefined) {
+    return {
+      cost: {
+        input: input ?? 0,
+        output: output ?? 0,
+        reasoning: existing?.reasoning,
+        cache_read,
+        cache_write,
+        tiers: existing?.tiers,
+      },
+      placeholder: false,
+    };
+  }
+
   return {
-    input,
-    output,
-    reasoning: existing?.reasoning,
-    cache_read: price(pricing?.input_cache_read_tiers?.[0]?.cost ?? pricing?.input_cache_read),
-    cache_write: price(pricing?.input_cache_write_tiers?.[0]?.cost ?? pricing?.input_cache_write),
-    tiers: existing?.tiers,
+    cost: {
+      input: 0,
+      output: 0,
+    },
+    placeholder: true,
   };
 }
 
@@ -245,15 +293,13 @@ function sameVercelModel(current: ExistingModel, desired: SyncedModel) {
   ];
 
   return fields.every(([currentValue, desiredValue, cost]) => {
-    if (cost && currentValue === 0 && desiredValue === undefined) return true;
-    if (cost && typeof currentValue === "number" && typeof desiredValue === "number") {
-      return Math.abs(currentValue - desiredValue) <= 0.001;
-    }
-    if (
-      (currentValue === 0 || desiredValue === 0)
-      && (typeof currentValue === "number" || typeof desiredValue === "number")
-    ) {
-      return true;
+    if (cost) {
+      // Missing authored cost vs explicit zero/value must rewrite so cost is never absent.
+      if (currentValue === undefined && desiredValue !== undefined) return false;
+      if (typeof currentValue === "number" && typeof desiredValue === "number") {
+        return Math.abs(currentValue - desiredValue) <= 0.001;
+      }
+      return currentValue === desiredValue;
     }
     return JSON.stringify(currentValue) === JSON.stringify(desiredValue);
   });

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1111,8 +1111,50 @@ test("parses Vercel pricing tiers with an implicit zero minimum", () => {
 
   expect(model).toBeDefined();
   expect(buildVercelModel(model!, undefined)).toMatchObject({
-    cost: { input: 1, output: 6, cache_read: 0.1 },
+    model: { cost: { input: 1, output: 6, cache_read: 0.1 } },
+    costPlaceholder: false,
   });
+});
+
+test("parses Vercel embedding input-only pricing", () => {
+  const [model] = vercel.parseModels({
+    data: [{
+      id: "alibaba/qwen3-embedding-0.6b",
+      name: "Qwen3 Embedding 0.6B",
+      created: 1_780_963_200,
+      type: "embedding",
+      pricing: { input: "0.00000001" },
+    }],
+  });
+
+  expect(buildVercelModel(model!, undefined)).toMatchObject({
+    model: { cost: { input: 0.01, output: 0 } },
+    costPlaceholder: false,
+  });
+});
+
+test("zeros Vercel non-token pricing and seeds a placeholder header", () => {
+  const [model] = vercel.parseModels({
+    data: [{
+      id: "bfl/flux-kontext-pro",
+      name: "FLUX.1 Kontext [pro]",
+      created: 1_780_963_200,
+      type: "image",
+      pricing: { image: "0.04" },
+    }],
+  });
+
+  const built = buildVercelModel(model!, undefined);
+  expect(built).toMatchObject({
+    model: { cost: { input: 0, output: 0 } },
+    costPlaceholder: true,
+  });
+
+  const translated = vercel.translateModel(model!, {
+    existing: () => undefined,
+    authored: () => undefined,
+  });
+  expect(translated?.header).toContain("Cost currently zeroed");
 });
 
 test("skips LLM Gateway base_model factoring when no metadata entry exists", () => {

--- a/providers/vercel/models/alibaba/qwen3-embedding-0.6b.toml
+++ b/providers/vercel/models/alibaba/qwen3-embedding-0.6b.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.01
+output = 0
+
 [limit]
 context = 32_768
 output = 32_768

--- a/providers/vercel/models/alibaba/qwen3-embedding-4b.toml
+++ b/providers/vercel/models/alibaba/qwen3-embedding-4b.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.02
+output = 0
+
 [limit]
 context = 32_768
 output = 32_768

--- a/providers/vercel/models/alibaba/qwen3-embedding-8b.toml
+++ b/providers/vercel/models/alibaba/qwen3-embedding-8b.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.05
+output = 0
+
 [limit]
 context = 32_768
 output = 32_768

--- a/providers/vercel/models/alibaba/wan-v2.5-t2v-preview.toml
+++ b/providers/vercel/models/alibaba/wan-v2.5-t2v-preview.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Wan v2.5 Text-to-Video Preview"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/alibaba/wan-v2.6-i2v-flash.toml
+++ b/providers/vercel/models/alibaba/wan-v2.6-i2v-flash.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Wan v2.6 Image-to-Video Flash"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/alibaba/wan-v2.6-i2v.toml
+++ b/providers/vercel/models/alibaba/wan-v2.6-i2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Wan v2.6 Image-to-Video"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/alibaba/wan-v2.6-r2v-flash.toml
+++ b/providers/vercel/models/alibaba/wan-v2.6-r2v-flash.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Wan v2.6 Reference-to-Video Flash"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/alibaba/wan-v2.6-r2v.toml
+++ b/providers/vercel/models/alibaba/wan-v2.6-r2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Wan v2.6 Reference-to-Video"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/alibaba/wan-v2.6-t2v.toml
+++ b/providers/vercel/models/alibaba/wan-v2.6-t2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Wan v2.6 Text-to-Video"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/alibaba/wan-v2.7-r2v.toml
+++ b/providers/vercel/models/alibaba/wan-v2.7-r2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Wan v2.7 Reference-to-Video"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/alibaba/wan-v2.7-t2v.toml
+++ b/providers/vercel/models/alibaba/wan-v2.7-t2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Wan v2.7 Text-to-Video"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/amazon/titan-embed-text-v2.toml
+++ b/providers/vercel/models/amazon/titan-embed-text-v2.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.02
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/bfl/flux-2-flex.toml
+++ b/providers/vercel/models/bfl/flux-2-flex.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX.2 [flex]"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bfl/flux-2-klein-4b.toml
+++ b/providers/vercel/models/bfl/flux-2-klein-4b.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX.2 [klein] 4B"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bfl/flux-2-klein-9b.toml
+++ b/providers/vercel/models/bfl/flux-2-klein-9b.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX.2 [klein] 9B"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bfl/flux-2-max.toml
+++ b/providers/vercel/models/bfl/flux-2-max.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX.2 [max]"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 67_300

--- a/providers/vercel/models/bfl/flux-2-pro.toml
+++ b/providers/vercel/models/bfl/flux-2-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX.2 [pro]"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 67_300

--- a/providers/vercel/models/bfl/flux-kontext-max.toml
+++ b/providers/vercel/models/bfl/flux-kontext-max.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX.1 Kontext Max"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 512

--- a/providers/vercel/models/bfl/flux-kontext-pro.toml
+++ b/providers/vercel/models/bfl/flux-kontext-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX.1 Kontext Pro"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 512

--- a/providers/vercel/models/bfl/flux-pro-1.0-fill.toml
+++ b/providers/vercel/models/bfl/flux-pro-1.0-fill.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX.1 Fill [pro]"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 512

--- a/providers/vercel/models/bfl/flux-pro-1.1-ultra.toml
+++ b/providers/vercel/models/bfl/flux-pro-1.1-ultra.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX1.1 [pro] Ultra"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 512

--- a/providers/vercel/models/bfl/flux-pro-1.1.toml
+++ b/providers/vercel/models/bfl/flux-pro-1.1.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "FLUX1.1 [pro]"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 512

--- a/providers/vercel/models/bytedance/seedance-2.0-fast.toml
+++ b/providers/vercel/models/bytedance/seedance-2.0-fast.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Seedance 2.0 Fast"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "seed"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bytedance/seedance-2.0.toml
+++ b/providers/vercel/models/bytedance/seedance-2.0.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Seedance 2.0"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "seed"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bytedance/seedance-v1.0-pro-fast.toml
+++ b/providers/vercel/models/bytedance/seedance-v1.0-pro-fast.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Seedance v1.0 Pro Fast"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "seed"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bytedance/seedance-v1.0-pro.toml
+++ b/providers/vercel/models/bytedance/seedance-v1.0-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Seedance v1.0 Pro"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "seed"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bytedance/seedance-v1.5-pro.toml
+++ b/providers/vercel/models/bytedance/seedance-v1.5-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Seedance v1.5 Pro"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "seed"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bytedance/seedream-4.0.toml
+++ b/providers/vercel/models/bytedance/seedream-4.0.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Seedream 4.0"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "seed"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bytedance/seedream-4.5.toml
+++ b/providers/vercel/models/bytedance/seedream-4.5.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Seedream 4.5"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "seed"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bytedance/seedream-5.0-lite.toml
+++ b/providers/vercel/models/bytedance/seedream-5.0-lite.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Seedream 5.0 Lite"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "seed"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/bytedance/seedream-5.0-pro.toml
+++ b/providers/vercel/models/bytedance/seedream-5.0-pro.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.003
+output = 0
+
 [limit]
 context = 0
 output = 0

--- a/providers/vercel/models/cohere/embed-v4.0.toml
+++ b/providers/vercel/models/cohere/embed-v4.0.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.12
+output = 0
+
 [limit]
 context = 128_000
 output = 1_536

--- a/providers/vercel/models/cohere/rerank-v3.5.toml
+++ b/providers/vercel/models/cohere/rerank-v3.5.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Cohere Rerank 3.5"
 description = "Reranking model for improving retrieval quality in search and recommendation systems"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 4_096

--- a/providers/vercel/models/cohere/rerank-v4-fast.toml
+++ b/providers/vercel/models/cohere/rerank-v4-fast.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Cohere Rerank 4 Fast"
 description = "Reranking model for improving retrieval quality in search and recommendation systems"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 32_000

--- a/providers/vercel/models/cohere/rerank-v4-pro.toml
+++ b/providers/vercel/models/cohere/rerank-v4-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Cohere Rerank 4 Pro"
 description = "Reranking model for improving retrieval quality in search and recommendation systems"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 32_000

--- a/providers/vercel/models/google/gemini-embedding-001.toml
+++ b/providers/vercel/models/google/gemini-embedding-001.toml
@@ -2,6 +2,10 @@ base_model = "google/gemini-embedding-001"
 family = "gemini-embedding"
 temperature = true
 
+[cost]
+input = 0.15
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/google/gemini-embedding-2.toml
+++ b/providers/vercel/models/google/gemini-embedding-2.toml
@@ -1,13 +1,17 @@
 name = "Gemini Embedding 2"
 description = "Embedding model for semantic search, retrieval, clustering, and ranking pipelines"
 family = "gemini-embedding"
-attachment = false
-reasoning = false
-tool_call = false
-temperature = true
 release_date = "2026-03-10"
 last_updated = "2026-03-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
 open_weights = false
+
+[cost]
+input = 0.2
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/google/imagen-4.0-fast-generate-001.toml
+++ b/providers/vercel/models/google/imagen-4.0-fast-generate-001.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Imagen 4 Fast"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "imagen"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 480

--- a/providers/vercel/models/google/imagen-4.0-generate-001.toml
+++ b/providers/vercel/models/google/imagen-4.0-generate-001.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Imagen 4"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "imagen"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 480

--- a/providers/vercel/models/google/imagen-4.0-ultra-generate-001.toml
+++ b/providers/vercel/models/google/imagen-4.0-ultra-generate-001.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Imagen 4 Ultra"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "imagen"
@@ -5,9 +7,13 @@ release_date = "2025-05-24"
 last_updated = "2025-05-24"
 attachment = false
 reasoning = false
-temperature = false
+temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 480

--- a/providers/vercel/models/google/text-embedding-005.toml
+++ b/providers/vercel/models/google/text-embedding-005.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.025
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/google/text-multilingual-embedding-002.toml
+++ b/providers/vercel/models/google/text-multilingual-embedding-002.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.025
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/google/veo-3.0-fast-generate-001.toml
+++ b/providers/vercel/models/google/veo-3.0-fast-generate-001.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Veo 3.0 Fast Generate"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "veo"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/google/veo-3.0-generate-001.toml
+++ b/providers/vercel/models/google/veo-3.0-generate-001.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Veo 3.0"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "veo"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/google/veo-3.1-fast-generate-001.toml
+++ b/providers/vercel/models/google/veo-3.1-fast-generate-001.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Veo 3.1 Fast Generate"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "veo"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/google/veo-3.1-generate-001.toml
+++ b/providers/vercel/models/google/veo-3.1-generate-001.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Veo 3.1"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "veo"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/klingai/kling-v2.5-turbo-i2v.toml
+++ b/providers/vercel/models/klingai/kling-v2.5-turbo-i2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Kling v2.5 Turbo Image-to-Video"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "ling"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/klingai/kling-v2.5-turbo-t2v.toml
+++ b/providers/vercel/models/klingai/kling-v2.5-turbo-t2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Kling v2.5 Turbo Text-to-Video"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "ling"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/klingai/kling-v2.6-i2v.toml
+++ b/providers/vercel/models/klingai/kling-v2.6-i2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Kling v2.6 Image-to-Video"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "ling"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/klingai/kling-v2.6-motion-control.toml
+++ b/providers/vercel/models/klingai/kling-v2.6-motion-control.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Kling v2.6 Motion Control"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "ling"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/klingai/kling-v2.6-t2v.toml
+++ b/providers/vercel/models/klingai/kling-v2.6-t2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Kling v2.6 Text-to-Video"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "ling"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/klingai/kling-v3.0-i2v.toml
+++ b/providers/vercel/models/klingai/kling-v3.0-i2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Kling v3.0 Image-to-Video"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "ling"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/klingai/kling-v3.0-motion-control.toml
+++ b/providers/vercel/models/klingai/kling-v3.0-motion-control.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Kling v3.0 Motion Control"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "ling"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/klingai/kling-v3.0-t2v.toml
+++ b/providers/vercel/models/klingai/kling-v3.0-t2v.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Kling v3.0 Text-to-Video"
 description = "Video model for prompt-guided generation, editing, and motion workflows"
 family = "ling"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/mistral/codestral-embed.toml
+++ b/providers/vercel/models/mistral/codestral-embed.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.15
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/mistral/mistral-embed.toml
+++ b/providers/vercel/models/mistral/mistral-embed.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.1
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/openai/gpt-realtime-whisper.toml
+++ b/providers/vercel/models/openai/gpt-realtime-whisper.toml
@@ -1,2 +1,6 @@
 base_model = "openai/gpt-realtime-whisper"
 name = "gpt-realtime-whisper"
+
+[cost]
+input = 0.0002
+output = 0

--- a/providers/vercel/models/openai/text-embedding-3-large.toml
+++ b/providers/vercel/models/openai/text-embedding-3-large.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.13
+output = 0
+
 [limit]
 context = 8_192
 input = 6_656

--- a/providers/vercel/models/openai/text-embedding-3-small.toml
+++ b/providers/vercel/models/openai/text-embedding-3-small.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.02
+output = 0
+
 [limit]
 context = 8_192
 input = 6_656

--- a/providers/vercel/models/openai/text-embedding-ada-002.toml
+++ b/providers/vercel/models/openai/text-embedding-ada-002.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.1
+output = 0
+
 [limit]
 context = 8_192
 input = 6_656

--- a/providers/vercel/models/openai/tts-1-hd.toml
+++ b/providers/vercel/models/openai/tts-1-hd.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 30
+output = 0
+
 [limit]
 context = 0
 output = 0

--- a/providers/vercel/models/openai/tts-1.toml
+++ b/providers/vercel/models/openai/tts-1.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 15
+output = 0
+
 [limit]
 context = 0
 output = 0

--- a/providers/vercel/models/openai/whisper-1.toml
+++ b/providers/vercel/models/openai/whisper-1.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.0001
+output = 0
+
 [limit]
 context = 0
 output = 0

--- a/providers/vercel/models/perplexity/sonar-pro.toml
+++ b/providers/vercel/models/perplexity/sonar-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Sonar Pro"
 description = "Advanced Sonar search model for deeper research and cited synthesis"
 family = "sonar-pro"
@@ -9,6 +11,10 @@ temperature = true
 tool_call = true
 knowledge = "2025-09"
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 200_000

--- a/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/vercel/models/perplexity/sonar-reasoning-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Sonar Reasoning Pro"
 description = "Web-grounded reasoning model for multi-step research and cited answers"
 family = "sonar-reasoning"
@@ -5,11 +7,18 @@ release_date = "2025-02-19"
 last_updated = "2025-02-19"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = false
 knowledge = "2025-09"
 open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 127_000

--- a/providers/vercel/models/perplexity/sonar.toml
+++ b/providers/vercel/models/perplexity/sonar.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Sonar"
 description = "Sonar search model for current answers, retrieval, and citation-backed chat"
 family = "sonar"
@@ -9,6 +11,10 @@ temperature = true
 tool_call = true
 knowledge = "2025-02"
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 127_000

--- a/providers/vercel/models/prodia/flux-fast-schnell.toml
+++ b/providers/vercel/models/prodia/flux-fast-schnell.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Flux Schnell"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "flux"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 512

--- a/providers/vercel/models/quiverai/arrow-1.1.toml
+++ b/providers/vercel/models/quiverai/arrow-1.1.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Arrow 1.1"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "o"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 131_072

--- a/providers/vercel/models/recraft/recraft-v2.toml
+++ b/providers/vercel/models/recraft/recraft-v2.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Recraft V2"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "recraft"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 512

--- a/providers/vercel/models/recraft/recraft-v3.toml
+++ b/providers/vercel/models/recraft/recraft-v3.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Recraft V3"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "recraft"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 512

--- a/providers/vercel/models/recraft/recraft-v4-pro.toml
+++ b/providers/vercel/models/recraft/recraft-v4-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Recraft V4 Pro"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "recraft"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/recraft/recraft-v4.1-pro.toml
+++ b/providers/vercel/models/recraft/recraft-v4.1-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Recraft V4.1 Pro"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "recraft"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/recraft/recraft-v4.1-utility-pro.toml
+++ b/providers/vercel/models/recraft/recraft-v4.1-utility-pro.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Recraft V4.1 Utility Pro"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "recraft"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/recraft/recraft-v4.1-utility.toml
+++ b/providers/vercel/models/recraft/recraft-v4.1-utility.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Recraft V4.1 Utility"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "recraft"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/recraft/recraft-v4.1.toml
+++ b/providers/vercel/models/recraft/recraft-v4.1.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Recraft V4.1"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "recraft"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/recraft/recraft-v4.toml
+++ b/providers/vercel/models/recraft/recraft-v4.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Recraft V4"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "recraft"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/voyage/rerank-2.5-lite.toml
+++ b/providers/vercel/models/voyage/rerank-2.5-lite.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.02
+output = 0
+
 [limit]
 context = 32_000
 output = 32_000

--- a/providers/vercel/models/voyage/rerank-2.5.toml
+++ b/providers/vercel/models/voyage/rerank-2.5.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.05
+output = 0
+
 [limit]
 context = 32_000
 output = 32_000

--- a/providers/vercel/models/voyage/voyage-3-large.toml
+++ b/providers/vercel/models/voyage/voyage-3-large.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.18
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/voyage/voyage-3.5-lite.toml
+++ b/providers/vercel/models/voyage/voyage-3.5-lite.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.02
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/voyage/voyage-3.5.toml
+++ b/providers/vercel/models/voyage/voyage-3.5.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.06
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/voyage/voyage-4-large.toml
+++ b/providers/vercel/models/voyage/voyage-4-large.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.12
+output = 0
+
 [limit]
 context = 32_000
 output = 0

--- a/providers/vercel/models/voyage/voyage-4-lite.toml
+++ b/providers/vercel/models/voyage/voyage-4-lite.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.02
+output = 0
+
 [limit]
 context = 32_000
 output = 0

--- a/providers/vercel/models/voyage/voyage-4.toml
+++ b/providers/vercel/models/voyage/voyage-4.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.06
+output = 0
+
 [limit]
 context = 32_000
 output = 0

--- a/providers/vercel/models/voyage/voyage-code-2.toml
+++ b/providers/vercel/models/voyage/voyage-code-2.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.12
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/voyage/voyage-code-3.toml
+++ b/providers/vercel/models/voyage/voyage-code-3.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.18
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/voyage/voyage-finance-2.toml
+++ b/providers/vercel/models/voyage/voyage-finance-2.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.12
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/voyage/voyage-law-2.toml
+++ b/providers/vercel/models/voyage/voyage-law-2.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0.12
+output = 0
+
 [limit]
 context = 8_192
 output = 1_536

--- a/providers/vercel/models/xai/grok-imagine-image.toml
+++ b/providers/vercel/models/xai/grok-imagine-image.toml
@@ -1,13 +1,19 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Grok Imagine Image"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "grok"
-attachment = false
-reasoning = false
-tool_call = false
-temperature = true
 release_date = "2026-01-28"
 last_updated = "2026-02-19"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0
@@ -15,4 +21,4 @@ output = 0
 
 [modalities]
 input = ["text"]
-output = ["text", "image"]
+output = ["image"]

--- a/providers/vercel/models/xai/grok-imagine-video-1.5-preview.toml
+++ b/providers/vercel/models/xai/grok-imagine-video-1.5-preview.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Grok Imagine Video 1.5 Preview"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "grok"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/xai/grok-imagine-video-1.5.toml
+++ b/providers/vercel/models/xai/grok-imagine-video-1.5.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Grok Imagine Video 1.5"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "grok"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/xai/grok-imagine-video.toml
+++ b/providers/vercel/models/xai/grok-imagine-video.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Grok Imagine"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "grok"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/xai/grok-stt.toml
+++ b/providers/vercel/models/xai/grok-stt.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 0
+output = 0
+
 [limit]
 context = 0
 output = 0

--- a/providers/vercel/models/xai/grok-tts.toml
+++ b/providers/vercel/models/xai/grok-tts.toml
@@ -9,6 +9,10 @@ temperature = true
 tool_call = false
 open_weights = false
 
+[cost]
+input = 15
+output = 0
+
 [limit]
 context = 0
 output = 0

--- a/providers/vercel/models/xai/grok-voice-think-fast-1.0.toml
+++ b/providers/vercel/models/xai/grok-voice-think-fast-1.0.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "Grok Voice Think Fast 1.0"
 description = "Speech generation model for controllable voice, narration, and audio delivery"
 family = "grok"
@@ -8,6 +10,10 @@ reasoning = false
 temperature = true
 tool_call = false
 open_weights = false
+
+[cost]
+input = 0
+output = 0
 
 [limit]
 context = 0

--- a/providers/vercel/models/zai/glm-4.6v-flash.toml
+++ b/providers/vercel/models/zai/glm-4.6v-flash.toml
@@ -1,3 +1,5 @@
+# Cost currently zeroed: Vercel pricing for this model is not token-based (e.g. per-image, per-second video).
+# Better non-token cost tracking is planned; until then keep an explicit zero cost so pricing is never absent.
 name = "GLM-4.6V-Flash"
 description = "GLM vision model for visual reasoning, documents, and multimodal agents"
 family = "glm"
@@ -5,15 +7,21 @@ release_date = "2025-09-30"
 last_updated = "2025-09-30"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
-open_weights = false
 knowledge = "2024-10"
+open_weights = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
 
 [limit]
-context = 128000
-output = 24000
+context = 128_000
+output = 24_000
 
 [modalities]
 input = ["text", "image", "pdf"]


### PR DESCRIPTION
## Summary
- Vercel sync previously only mapped chat-style `input`+`output` token pricing, so embed/image/video/audio models often had no `[cost]` at all.
- Parse token-like pricing when available (including input-only for embeddings/speech/rerank, with `output = 0`).
- For non-token shapes (per-image, per-second video) or missing pricing, write explicit zero costs and seed a leading header comment that survives sync refreshes until better non-token cost tracking exists.
- Resynced 96 Vercel models so every gateway entry now has a cost block.

## Test plan
- [x] `bun test packages/core/test/sync.test.ts` (including new embed/zeroed pricing cases)
- [x] `bun run vercel:generate` updates 96 models, then re-run is fully unchanged
- [x] `bun validate` succeeds
- [ ] Confirm a sample embed model has parsed input cost and a sample image/video model has zeros + header