### PR TITLE
feat(moonshotai): add Kimi K3 low/high effort options

### DIFF
--- a/providers/kimi-for-coding/models/k3.toml
+++ b/providers/kimi-for-coding/models/k3.toml
@@ -1,6 +1,6 @@
 # reasoning_options mirror the Moonshot AI platform API surface:
 #   thinking.type = "enabled" | "disabled" | "adaptive"
-#   output_config.effort accepts only "max"
+#   output_config.effort = "low" | "high" | "max"
 # Cost is zeroed per this provider's subscription convention.
 base_model = "moonshotai/kimi-k3"
 attachment = false
@@ -10,7 +10,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["max"]
+values = ["low", "high", "max"]
 
 [cost]
 input = 0

--- a/providers/moonshotai/models/kimi-k3.toml
+++ b/providers/moonshotai/models/kimi-k3.toml
@@ -1,5 +1,5 @@
 # API: thinking.type = "enabled" | "disabled" | "adaptive"; in adaptive mode the
-# reasoning depth is set by output_config.effort, which only accepts "max".
+# reasoning depth is set by output_config.effort = "low" | "high" | "max".
 # Pricing: https://platform.kimi.ai/docs/pricing/chat-k3 (accessed 2026-07-17).
 base_model = "moonshotai/kimi-k3"
 
@@ -8,7 +8,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["max"]
+values = ["low", "high", "max"]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
K3 adaptive thinking now accepts output_config.effort = "low" | "high" | "max" (previously max-only) on both the Moonshot AI platform and Kimi For Coding, which mirrors the platform API surface.