### PR TITLE
fix: Azure Foundry context limits (Claude + non-Claude)

### DIFF
--- a/providers/azure-cognitive-services/models/claude-opus-4-6.toml
+++ b/providers/azure-cognitive-services/models/claude-opus-4-6.toml
@@ -1,8 +1,10 @@
+# Context window: Azure Foundry serves 1M (legacy 200K cap removed).
+# https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/claude-models?tabs=pay-go#available-claude-models
 name = "Claude Opus 4.6"
 description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
 family = "claude-opus"
 release_date = "2026-02-05"
-last_updated = "2026-02-05"
+last_updated = "2026-07-17"
 attachment = true
 reasoning = true
 # POST /anthropic/v1/messages supports adaptive thinking with output_config.effort
@@ -28,7 +30,7 @@ cache_read = 1.00
 cache_write = 12.50
 
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/claude-opus-4-6.toml
+++ b/providers/azure/models/claude-opus-4-6.toml
@@ -1,8 +1,10 @@
+# Context window: Azure Foundry serves 1M (legacy 200K cap removed).
+# https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/claude-models?tabs=pay-go#available-claude-models
 name = "Claude Opus 4.6"
 description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
 family = "claude-opus"
 release_date = "2026-02-05"
-last_updated = "2026-02-05"
+last_updated = "2026-07-17"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
@@ -25,7 +27,7 @@ cache_read = 1.00
 cache_write = 12.50
 
 [limit]
-context = 200_000
+context = 1_000_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/cohere-command-a.toml
+++ b/providers/azure/models/cohere-command-a.toml
@@ -16,8 +16,8 @@ input = 2.50
 output = 10.00
 
 [limit]
-context = 256_000
-output = 8_000
+context = 131_072
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/azure/models/cohere-embed-v-4-0.toml
+++ b/providers/azure/models/cohere-embed-v-4-0.toml
@@ -14,7 +14,7 @@ input = 0.12
 output = 0.00
 
 [limit]
-context = 512
+context = 128_000
 output = 1_536
 
 [modalities]

--- a/providers/azure/models/cohere-embed-v-4-0.toml
+++ b/providers/azure/models/cohere-embed-v-4-0.toml
@@ -14,7 +14,7 @@ input = 0.12
 output = 0.00
 
 [limit]
-context = 128_000
+context = 512
 output = 1_536
 
 [modalities]

--- a/providers/azure/models/gpt-5-codex.toml
+++ b/providers/azure/models/gpt-5-codex.toml
@@ -18,6 +18,7 @@ cache_read = 0.13
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/gpt-5-mini.toml
+++ b/providers/azure/models/gpt-5-mini.toml
@@ -17,7 +17,8 @@ output = 2.00
 cache_read = 0.03
 
 [limit]
-context = 272_000
+context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/gpt-5-nano.toml
+++ b/providers/azure/models/gpt-5-nano.toml
@@ -17,7 +17,8 @@ output = 0.40
 cache_read = 0.01
 
 [limit]
-context = 272_000
+context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/gpt-5.1-codex-mini.toml
+++ b/providers/azure/models/gpt-5.1-codex-mini.toml
@@ -19,6 +19,7 @@ cache_read = 0.025
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/gpt-5.1-codex.toml
+++ b/providers/azure/models/gpt-5.1-codex.toml
@@ -19,6 +19,7 @@ cache_read = 0.125
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/gpt-5.1.toml
+++ b/providers/azure/models/gpt-5.1.toml
@@ -18,7 +18,8 @@ output = 10.00
 cache_read = 0.125
 
 [limit]
-context = 272_000
+context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/gpt-5.2-codex.toml
+++ b/providers/azure/models/gpt-5.2-codex.toml
@@ -19,6 +19,7 @@ cache_read = 0.175
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/gpt-5.2.toml
+++ b/providers/azure/models/gpt-5.2.toml
@@ -19,6 +19,7 @@ cache_read = 0.125
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/gpt-5.3-codex.toml
+++ b/providers/azure/models/gpt-5.3-codex.toml
@@ -19,6 +19,7 @@ cache_read = 0.175
 
 [limit]
 context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/gpt-5.toml
+++ b/providers/azure/models/gpt-5.toml
@@ -17,7 +17,8 @@ output = 10.00
 cache_read = 0.13
 
 [limit]
-context = 272_000
+context = 400_000
+input = 272_000
 output = 128_000
 
 [modalities]

--- a/providers/azure/models/llama-4-maverick-17b-128e-instruct-fp8.toml
+++ b/providers/azure/models/llama-4-maverick-17b-128e-instruct-fp8.toml
@@ -15,8 +15,8 @@ input = 0.25
 output = 1.00
 
 [limit]
-context = 128_000
-output = 8_192
+context = 1_000_000
+output = 16_384
 
 [modalities]
 input = ["text", "image"]

--- a/providers/azure/models/model-router.toml
+++ b/providers/azure/models/model-router.toml
@@ -13,7 +13,7 @@ input = 0.14
 output = 0.00
 
 [limit]
-context = 128_000
+context = 200_000
 output = 16_384
 
 [modalities]


### PR DESCRIPTION
## Summary
Follow-up to #3309 / Azure Foundry context accuracy for **azure** and **azure-cognitive-services**.

### Claude (prior commit)
- `claude-opus-4-6`: `200_000` → `1_000_000` on azure + ACS
- Other Claude models already matched Foundry docs (1M via `base_model`, or correctly 200K)

### Non-Claude (this commit)
Per [Foundry Models sold by Azure](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure):

| Model | Before | After | Source |
| --- | --- | --- | --- |
| gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.1 | context 272K | context 400K + input 272K | GPT-5 / GPT-5.1 series |
| gpt-5-codex, gpt-5.1-codex(-mini), gpt-5.2, gpt-5.2-codex, gpt-5.3-codex | 400K (no input) | 400K + input 272K | same |
| Llama-4-Maverick-17B-128E-Instruct-FP8 | 128K / 8K | 1M / 16K | Meta sold-by-Azure + catalog |
| model-router | 128K | 200K | Microsoft models table |
| Cohere-command-a | 256K / 8K | 131,072 / 8,192 | Cohere sold-by-Azure |
| embed-v-4-0 | 128K | 512 | Cohere sold-by-Azure (text) |

Note: most ACS model files symlink into `providers/azure/models/`, so one edit covers both providers.

### Checked OK (no change)
- DeepSeek-V3.2: 128K matches Azure Direct (Fireworks partner catalog 163.8k is a different SKU)
- DeepSeek-R1: 163.84K matches catalog
- Grok-4-fast-reasoning: 2M retained (xAI/Foundry long-context)
- Kimi K2.5/2.6: 262,144 matches Moonshot sold-by-Azure
- gpt-5.4/5.5/5.6 series: inherit correct limits via `base_model`

## Sources
- https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure
- https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/claude-models?tabs=pay-go#available-claude-models
- https://ai.azure.com/catalog/models/Llama-4-Maverick-17B-128E-Instruct-FP8

## Test plan
- [x] `bun validate`
- [ ] Spot-check generated JSON for azure `gpt-5` / `llama-4-maverick` limits