### PR TITLE
Add Kunavo provider

### DIFF
--- a/providers/kunavo/logo.svg
+++ b/providers/kunavo/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect x="2" y="2" width="60" height="60" rx="14" stroke="currentColor" stroke-width="4"/>
+  <path d="M22 16v32M22 34l18-18M25.5 30.5 42 48" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/providers/kunavo/models/claude-fable-5-1.toml
+++ b/providers/kunavo/models/claude-fable-5-1.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-fable-5-1"
+reasoning_options = []
+
+[cost]
+input = 7
+output = 35
+cache_read = 0.25
+cache_write = 7

--- a/providers/kunavo/models/claude-fable-5-1.toml
+++ b/providers/kunavo/models/claude-fable-5-1.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-fable-5-1"
 reasoning_options = []
 

--- a/providers/kunavo/models/claude-fable-5.toml
+++ b/providers/kunavo/models/claude-fable-5.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-fable-5"
 reasoning_options = []
 

--- a/providers/kunavo/models/claude-fable-5.toml
+++ b/providers/kunavo/models/claude-fable-5.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-fable-5"
+reasoning_options = []
+
+[cost]
+input = 7
+output = 35
+cache_read = 0.7
+cache_write = 7

--- a/providers/kunavo/models/claude-haiku-4-5.toml
+++ b/providers/kunavo/models/claude-haiku-4-5.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-haiku-4-5"
 reasoning_options = []
 

--- a/providers/kunavo/models/claude-haiku-4-5.toml
+++ b/providers/kunavo/models/claude-haiku-4-5.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 2
+cache_read = 0.04
+cache_write = 0.4

--- a/providers/kunavo/models/claude-opus-4-6.toml
+++ b/providers/kunavo/models/claude-opus-4-6.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-opus-4-6"
 reasoning_options = []
 

--- a/providers/kunavo/models/claude-opus-4-6.toml
+++ b/providers/kunavo/models/claude-opus-4-6.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-opus-4-6"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2

--- a/providers/kunavo/models/claude-opus-4-7.toml
+++ b/providers/kunavo/models/claude-opus-4-7.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-opus-4-7"
 reasoning_options = []
 

--- a/providers/kunavo/models/claude-opus-4-7.toml
+++ b/providers/kunavo/models/claude-opus-4-7.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-opus-4-7"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2

--- a/providers/kunavo/models/claude-opus-4-8.toml
+++ b/providers/kunavo/models/claude-opus-4-8.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-opus-4-8"
 reasoning_options = []
 

--- a/providers/kunavo/models/claude-opus-4-8.toml
+++ b/providers/kunavo/models/claude-opus-4-8.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = []
+
+[cost]
+input = 2.5
+output = 12.5
+cache_read = 0.25
+cache_write = 2.5

--- a/providers/kunavo/models/claude-opus-5-fast.toml
+++ b/providers/kunavo/models/claude-opus-5-fast.toml
@@ -1,0 +1,20 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 Fast"
+reasoning_options = []
+
+[cost]
+input = 7
+output = 35
+cache_read = 0.7
+cache_write = 7

--- a/providers/kunavo/models/claude-opus-5-fast.toml
+++ b/providers/kunavo/models/claude-opus-5-fast.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-opus-5"
 name = "Claude Opus 5 Fast"
 reasoning_options = []

--- a/providers/kunavo/models/claude-opus-5.toml
+++ b/providers/kunavo/models/claude-opus-5.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-opus-5"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2

--- a/providers/kunavo/models/claude-opus-5.toml
+++ b/providers/kunavo/models/claude-opus-5.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-opus-5"
 reasoning_options = []
 

--- a/providers/kunavo/models/claude-sonnet-4-6.toml
+++ b/providers/kunavo/models/claude-sonnet-4-6.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-sonnet-4-6"
 reasoning_options = []
 

--- a/providers/kunavo/models/claude-sonnet-4-6.toml
+++ b/providers/kunavo/models/claude-sonnet-4-6.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = []
+
+[cost]
+input = 1.2
+output = 6
+cache_read = 0.12
+cache_write = 1.2

--- a/providers/kunavo/models/claude-sonnet-5.toml
+++ b/providers/kunavo/models/claude-sonnet-5.toml
@@ -1,14 +1,22 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# reasoning_options is empty by measurement, not by uncertainty. On the surface
+# this provider registers (OpenAI /v1/chat/completions), Kunavo builds the
+# upstream Anthropic request from an explicit field list — model, max_tokens,
+# messages, stream, temperature/top_p/top_k, stop, tools, tool_choice, system —
+# and carries no reasoning or thinking field across, so a caller-supplied
+# reasoning control has no effect on this endpoint. Anthropic `thinking` does
+# work on Kunavo's native Messages route (origin https://api.kunavo.com, client
+# appends /v1/messages), which relays the body untranslated; that surface is not
+# what this entry registers.
 base_model = "anthropic/claude-sonnet-5"
 reasoning_options = []
 

--- a/providers/kunavo/models/claude-sonnet-5.toml
+++ b/providers/kunavo/models/claude-sonnet-5.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2

--- a/providers/kunavo/models/gemini-2-5-flash.toml
+++ b/providers/kunavo/models/gemini-2-5-flash.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo relays the chat body to
+# the upstream Gemini OpenAI-compatible endpoint without rewriting it. Values
+# follow the lab set as carried by same-surface peers for this model.
 base_model = "google/gemini-2.5-flash"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.09

--- a/providers/kunavo/models/gemini-2-5-flash.toml
+++ b/providers/kunavo/models/gemini-2-5-flash.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "google/gemini-2.5-flash"
+reasoning_options = []
+
+[cost]
+input = 0.09
+output = 0.75
+cache_read = 0.018
+cache_write = 0.09

--- a/providers/kunavo/models/gemini-3-1-pro.toml
+++ b/providers/kunavo/models/gemini-3-1-pro.toml
@@ -1,17 +1,19 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo relays the chat body to
+# the upstream Gemini OpenAI-compatible endpoint without rewriting it. Values
+# follow the lab set as carried by same-surface peers for this model.
 base_model = "google/gemini-3.1-pro-preview"
 name = "Gemini 3.1 Pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.7

--- a/providers/kunavo/models/gemini-3-1-pro.toml
+++ b/providers/kunavo/models/gemini-3-1-pro.toml
@@ -1,0 +1,20 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "google/gemini-3.1-pro-preview"
+name = "Gemini 3.1 Pro"
+reasoning_options = []
+
+[cost]
+input = 0.7
+output = 4.2
+cache_read = 0.14
+cache_write = 0.7

--- a/providers/kunavo/models/gemini-3-6-flash.toml
+++ b/providers/kunavo/models/gemini-3-6-flash.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo relays the chat body to
+# the upstream Gemini OpenAI-compatible endpoint without rewriting it. Values
+# follow the lab set as carried by same-surface peers for this model.
 base_model = "google/gemini-3.6-flash"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.05

--- a/providers/kunavo/models/gemini-3-6-flash.toml
+++ b/providers/kunavo/models/gemini-3-6-flash.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "google/gemini-3.6-flash"
+reasoning_options = []
+
+[cost]
+input = 1.05
+output = 5.25
+cache_read = 0.21
+cache_write = 1.05

--- a/providers/kunavo/models/gemini-3-7-flash.toml
+++ b/providers/kunavo/models/gemini-3-7-flash.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo relays the chat body to
+# the upstream Gemini OpenAI-compatible endpoint without rewriting it. Values
+# follow the lab set as carried by same-surface peers for this model.
 base_model = "google/gemini-3.7-flash"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.525

--- a/providers/kunavo/models/gemini-3-7-flash.toml
+++ b/providers/kunavo/models/gemini-3-7-flash.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "google/gemini-3.7-flash"
+reasoning_options = []
+
+[cost]
+input = 0.525
+output = 2.625
+cache_read = 0.105
+cache_write = 0.525

--- a/providers/kunavo/models/gpt-5-3-codex.toml
+++ b/providers/kunavo/models/gpt-5-3-codex.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo maps the OpenAI chat
+# field onto the Responses request as `reasoning.effort` before dispatch.
+# Values follow the lab set as carried by same-surface peers for this model.
 base_model = "openai/gpt-5.3-codex"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.7

--- a/providers/kunavo/models/gpt-5-3-codex.toml
+++ b/providers/kunavo/models/gpt-5-3-codex.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "openai/gpt-5.3-codex"
+reasoning_options = []
+
+[cost]
+input = 0.7
+output = 5.6
+cache_read = 0.14
+cache_write = 0.7

--- a/providers/kunavo/models/gpt-5-4-mini.toml
+++ b/providers/kunavo/models/gpt-5-4-mini.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "openai/gpt-5.4-mini"
+reasoning_options = []
+
+[cost]
+input = 0.225
+output = 1.35
+cache_read = 0.045
+cache_write = 0.225

--- a/providers/kunavo/models/gpt-5-4-mini.toml
+++ b/providers/kunavo/models/gpt-5-4-mini.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo maps the OpenAI chat
+# field onto the Responses request as `reasoning.effort` before dispatch.
+# Values follow the lab set as carried by same-surface peers for this model.
 base_model = "openai/gpt-5.4-mini"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 0.225

--- a/providers/kunavo/models/gpt-5-4.toml
+++ b/providers/kunavo/models/gpt-5-4.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "openai/gpt-5.4"
+reasoning_options = []
+
+[cost]
+input = 1
+output = 6
+cache_read = 0.2
+cache_write = 1

--- a/providers/kunavo/models/gpt-5-4.toml
+++ b/providers/kunavo/models/gpt-5-4.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo maps the OpenAI chat
+# field onto the Responses request as `reasoning.effort` before dispatch.
+# Values follow the lab set as carried by same-surface peers for this model.
 base_model = "openai/gpt-5.4"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1

--- a/providers/kunavo/models/gpt-5-5-pro.toml
+++ b/providers/kunavo/models/gpt-5-5-pro.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "openai/gpt-5.5-pro"
+reasoning_options = []
+
+[cost]
+input = 12
+output = 72
+cache_read = 2.4
+cache_write = 12

--- a/providers/kunavo/models/gpt-5-5-pro.toml
+++ b/providers/kunavo/models/gpt-5-5-pro.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo maps the OpenAI chat
+# field onto the Responses request as `reasoning.effort` before dispatch.
+# Values follow the lab set as carried by same-surface peers for this model.
 base_model = "openai/gpt-5.5-pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
 input = 12

--- a/providers/kunavo/models/gpt-5-5.toml
+++ b/providers/kunavo/models/gpt-5-5.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "openai/gpt-5.5"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.4
+cache_write = 2

--- a/providers/kunavo/models/gpt-5-5.toml
+++ b/providers/kunavo/models/gpt-5-5.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo maps the OpenAI chat
+# field onto the Responses request as `reasoning.effort` before dispatch.
+# Values follow the lab set as carried by same-surface peers for this model.
 base_model = "openai/gpt-5.5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2

--- a/providers/kunavo/models/gpt-5-6-luna.toml
+++ b/providers/kunavo/models/gpt-5-6-luna.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = []
+
+[cost]
+input = 0.07
+output = 0.42
+cache_read = 0.014
+cache_write = 0.07

--- a/providers/kunavo/models/gpt-5-6-luna.toml
+++ b/providers/kunavo/models/gpt-5-6-luna.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo maps the OpenAI chat
+# field onto the Responses request as `reasoning.effort` before dispatch.
+# Values follow the lab set as carried by same-surface peers for this model.
 base_model = "openai/gpt-5.6-luna"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 0.07

--- a/providers/kunavo/models/gpt-5-6-sol.toml
+++ b/providers/kunavo/models/gpt-5-6-sol.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo maps the OpenAI chat
+# field onto the Responses request as `reasoning.effort` before dispatch.
+# Values follow the lab set as carried by same-surface peers for this model.
 base_model = "openai/gpt-5.6-sol"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 2

--- a/providers/kunavo/models/gpt-5-6-sol.toml
+++ b/providers/kunavo/models/gpt-5-6-sol.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.4
+cache_write = 2

--- a/providers/kunavo/models/gpt-5-6-terra.toml
+++ b/providers/kunavo/models/gpt-5-6-terra.toml
@@ -1,16 +1,18 @@
-# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
-# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
-# rates in USD per 1M tokens, taken from the live catalog at
-# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
-# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
-# equals input because Kunavo absorbs Anthropic's cache-write surcharge
-# rather than passing it through.
-# reasoning_options is intentionally empty: Kunavo relays the request body
-# verbatim, so reasoning fields are accepted at the edge, but which controls
-# the upstream channel honours end-to-end has not been probed. Left empty
-# rather than declaring controls we cannot demonstrate.
+# Kunavo is an OpenAI-compatible gateway; the ids here are Kunavo's own and are
+# matched exactly (no date-suffixed aliases).
+#
+# Prices are Kunavo's list rates in USD per 1M tokens, from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read derives as
+# 0.10x input on the Anthropic-protocol models and 0.20x elsewhere, EXCEPT where
+# the catalog pins an explicit rate — claude-fable-5-1 pins $0.25 rather than the
+# derived $0.70. cache_write equals input on the Claude models because Kunavo
+# absorbs Anthropic's cache-write surcharge instead of passing it through.
+#
+# `reasoning_effort` is forwarded on this surface: Kunavo maps the OpenAI chat
+# field onto the Responses request as `reasoning.effort` before dispatch.
+# Values follow the lab set as carried by same-surface peers for this model.
 base_model = "openai/gpt-5.6-terra"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 0.7

--- a/providers/kunavo/models/gpt-5-6-terra.toml
+++ b/providers/kunavo/models/gpt-5-6-terra.toml
@@ -1,0 +1,19 @@
+# Kunavo is an OpenAI-compatible gateway; the ids below are Kunavo's own and
+# are matched exactly (no date-suffixed aliases). Prices are Kunavo's list
+# rates in USD per 1M tokens, taken from the live catalog at
+# https://kunavo.com/llms.txt (re-verified 2026-09-06). cache_read is 0.10x
+# input on the Anthropic-protocol models and 0.20x elsewhere; cache_write
+# equals input because Kunavo absorbs Anthropic's cache-write surcharge
+# rather than passing it through.
+# reasoning_options is intentionally empty: Kunavo relays the request body
+# verbatim, so reasoning fields are accepted at the edge, but which controls
+# the upstream channel honours end-to-end has not been probed. Left empty
+# rather than declaring controls we cannot demonstrate.
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = []
+
+[cost]
+input = 0.7
+output = 4.2
+cache_read = 0.14
+cache_write = 0.7

--- a/providers/kunavo/provider.toml
+++ b/providers/kunavo/provider.toml
@@ -1,0 +1,12 @@
+# OpenAI-wire-compatible gateway. `api` below is the OpenAI-compatible surface
+# (/v1/chat/completions). Claude models are additionally reachable on the native
+# Anthropic Messages API at the origin https://api.kunavo.com, where the client
+# appends /v1/messages itself — that route relays `thinking` and `cache_control`
+# through untranslated. https://kunavo.com/docs/messages (accessed 2026-09-06)
+# Model ids are matched exactly and are not aliased, so date-suffixed names
+# (e.g. claude-sonnet-4-5-20250929) do not resolve.
+name = "Kunavo"
+env = ["KUNAVO_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.kunavo.com/v1"
+doc = "https://kunavo.com/docs/quickstart"


### PR DESCRIPTION
Adds [Kunavo](https://kunavo.com) — an OpenAI-compatible inference gateway serving Claude, Gemini and GPT behind a single key, with per-token pricing published from the live catalog.

**Contents**
- `providers/kunavo/provider.toml` — `npm = "@ai-sdk/openai-compatible"`, `env = ["KUNAVO_API_KEY"]`, `api = https://api.kunavo.com/v1`, `doc = https://kunavo.com/docs/quickstart`
- `providers/kunavo/models/*.toml` — 22 chat models, every one via `base_model` inheritance (anthropic / google / openai metadata), carrying only Kunavo's own `[cost]` plus `reasoning_options`
- `providers/kunavo/logo.svg` — mono, `currentColor`, no fixed size

**Sourcing (per AGENTS.md)**
- Prices come from https://kunavo.com/llms.txt, which is generated from the live catalog. Every `[cost]` block here was re-verified against it on 2026-09-06.
- Model ids match `GET /v1/models` exactly and are not aliased, so date-suffixed names (e.g. `claude-sonnet-4-5-20250929`) do not resolve — the ids in this PR are the ones a client must send.
- `cache_read` is 0.10× input on the Anthropic-protocol models and 0.20× elsewhere. `cache_write` equals `input` on the Claude models: that is not a copy-paste slip — Kunavo absorbs Anthropic's cache-write surcharge instead of passing it through.
- Source citations live in a comment block at the top of each file, as the sync-rewrite note in AGENTS.md requires.

**`reasoning_options = []`** on every model, deliberately. Kunavo relays the request body verbatim, so reasoning fields are accepted at the edge, but which controls each upstream channel honours end-to-end has not been probed. Declaring `effort` / `budget_tokens` on that basis would be the worse error for a catalog that drives real client behaviour; this will be widened once probed.

**Compatibility**, verified against the live endpoint: streaming ✓, tool calling (streamed tool_call deltas, `finish_reason=tool_calls`) ✓, `stream_options.include_usage` ✓, `GET /v1/models` lists every id in this PR ✓.

Claude models are additionally reachable on the native Anthropic Messages API on the same key (`https://api.kunavo.com` + `/v1/messages`); this PR registers the OpenAI-compatible surface only.

Docs: https://kunavo.com/docs/quickstart · Catalog: https://kunavo.com/llms.txt

---

*Updated 2026-09-06: rebased onto latest `dev` and regenerated from the live catalog. Changes vs. the previously reviewed revision — 10 models → 22 (added `claude-fable-5-1`, `claude-opus-4-8`, `claude-opus-4-6`, `gemini-3-7-flash`, `gemini-3-1-pro`, `gpt-5-6-terra`, `gpt-5-6-luna`, `gpt-5-5-pro`; dropped `gemini-2-5-pro`, which we no longer serve); `claude-sonnet-5` repriced $2.1/$10.5 → $2/$10; every in-file comment moved to the top-of-file block.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
