### PR TITLE
fix(github-copilot): add cache_write cost for GPT-5.6 models

### DIFF
--- a/providers/github-copilot/models/gpt-5.6-luna.toml
+++ b/providers/github-copilot/models/gpt-5.6-luna.toml
@@ -5,9 +5,11 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 input = 1
 output = 6
 cache_read = 0.1
+cache_write = 1.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 200_000 }
 input = 2
 output = 9
 cache_read = 0.2
+cache_write = 2.5

--- a/providers/github-copilot/models/gpt-5.6-sol.toml
+++ b/providers/github-copilot/models/gpt-5.6-sol.toml
@@ -5,9 +5,11 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 input = 5
 output = 30
 cache_read = 0.5
+cache_write = 6.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
 input = 10
 output = 45
 cache_read = 1
+cache_write = 12.5

--- a/providers/github-copilot/models/gpt-5.6-terra.toml
+++ b/providers/github-copilot/models/gpt-5.6-terra.toml
@@ -5,9 +5,11 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 input = 2.5
 output = 15
 cache_read = 0.25
+cache_write = 3.125
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
 input = 5
 output = 22.5
 cache_read = 0.5
+cache_write = 6.25


### PR DESCRIPTION
## Summary
- Add `cache_write` pricing to GitHub Copilot GPT-5.6 Sol, Terra, and Luna at **1.25×** the uncached input rate (including long-context tiers)
- Aligns Copilot entries with OpenAI GPT-5.6 pricing, where cache writes are billed starting with the GPT-5.6 family

## Rates (per 1M tokens)

| Model | Default cache_write | Long-context cache_write |
| --- | ---: | ---: |
| `gpt-5.6-sol` | 6.25 | 12.5 |
| `gpt-5.6-terra` | 3.125 | 6.25 |
| `gpt-5.6-luna` | 1.25 | 2.5 |

## Sources
- OpenAI prompt caching: https://developers.openai.com/api/docs/guides/prompt-caching — *"For GPT-5.6 models and later model families, cache writes cost 1.25× the uncached input token rate."*
- OpenAI pricing: https://developers.openai.com/api/docs/pricing
- Issue report that Copilot bills `cache_write` for these models even though GitHub docs omit the column: #3282 ([comment](https://github.com/anomalyco/models.dev/issues/3282#issuecomment-5009683793))

## Note
GitHub’s Copilot pricing page still only lists Input / Cached input / Output for OpenAI models (cache write is only documented under Anthropic). This change follows OpenAI’s published rates and the reporter’s observation that Copilot charges for cache writes on GPT-5.6; GitHub docs may lag.

Closes #3282

## Test plan
- [x] `bun validate`
- [ ] Confirm rates match OpenAI 1.25× input on default and long-context tiers