### PR TITLE
Fix Kimi K3 temperature support for OpenCode Go

### DIFF
--- a/providers/opencode-go/models/kimi-k3.toml
+++ b/providers/opencode-go/models/kimi-k3.toml
@@ -1,5 +1,6 @@
 base_model = "moonshotai/kimi-k3"
 name = "Kimi K3 (2x usage)"
+temperature = false
 
 [[reasoning_options]]
 type = "effort"


### PR DESCRIPTION
## Summary

Mark OpenCode Go's Kimi K3 as `temperature = false`. The base model currently advertises temperature support, so clients send the field and OpenCode Go rejects the request upstream.

This does not change reasoning support; the resolved model still exposes the `max` effort variant.

## Evidence

- Reproduced against OpenCode Go with identical Kimi K3 max requests: `temperature: 0.2` returned HTTP 400, while omitting `temperature` completed successfully.
- Related report: https://github.com/anomalyco/opencode/issues/37552
- The same base model's OpenRouter entry also disables temperature: https://github.com/anomalyco/models.dev/blob/dev/providers/openrouter/models/moonshotai/kimi-k3.toml

## Validation

- `bun validate`
- Resolved catalog: `temperature: false`, reasoning effort values: `["max"]`