### PR TITLE
Add Kimi K2.7-Code and MiniMax-M3 to Nebius Token Factory

### DIFF
--- a/providers/nebius/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/nebius/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,0 +1,15 @@
+base_model = "minimax/MiniMax-M3"
+attachment = false
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 1_048_576
+output = 1_048_576
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/nebius/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,0 +1,18 @@
+base_model = "moonshotai/kimi-k2.7-code"
+attachment = false
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4
+
+[limit]
+context = 262_144
+output = 8_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds two newly available models on [Nebius Token Factory](https://tokenfactory.nebius.com/endpoints) to the Nebius provider:

| Model ID | Cost (in / out per 1M) | Context | Output |
|---|---|---|---|
| `moonshotai/Kimi-K2.7-Code` | $0.95 / $4.00 | 256K | 8K |
| `MiniMaxAI/MiniMax-M3` | $0.30 / $1.20 | 1M | 1M |

Both inherit shared metadata via `base_model` and override Nebius-specific pricing, limits, and text-only modalities (Nebius serves both as text-to-text endpoints).

### Details

- **Kimi-K2.7-Code**: coding-focused reasoning model; `reasoning_options = []` (no verified control surface); interleaved `reasoning_content`; attachment disabled on this provider.
- **MiniMax-M3**: 428B MoE reasoning model with 1M context; `reasoning_options = []`; attachment disabled; text-only modalities on Nebius.

### Sources

- [Nebius Token Factory endpoints](https://tokenfactory.nebius.com/endpoints)
- Nebius `models_info` API (`/proxy/inference/private/v1/models_info`) — pricing, context windows, and max lengths

## Test plan

- [x] `bun validate` passes with only these two model files added
- [ ] Confirm model IDs match Nebius API usage: `moonshotai/Kimi-K2.7-Code`, `MiniMaxAI/MiniMax-M3`
- [ ] Spot-check pricing on the endpoints page remains $0.95/$4 and $0.30/$1.20