### PR TITLE
Add sference provider with public /v1/models sync

### DIFF
--- a/models/alibaba/qwen3-vl-30b-a3b-instruct.toml
+++ b/models/alibaba/qwen3-vl-30b-a3b-instruct.toml
@@ -1,0 +1,26 @@
+# Sources (accessed 2026-07-21):
+# - https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct
+
+name = "Qwen3-VL 30B A3B Instruct"
+description = "Open Qwen3 vision-language MoE for visual reasoning, documents, and agent tasks"
+family = "qwen"
+release_date = "2025-09-30"
+last_updated = "2025-11-26"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct"

--- a/models/bottlecapai/thinkingcap-qwen3.6-27b.toml
+++ b/models/bottlecapai/thinkingcap-qwen3.6-27b.toml
@@ -1,0 +1,27 @@
+# Sources (accessed 2026-07-16):
+# - https://huggingface.co/bottlecapai/ThinkingCap-Qwen3.6-27B
+# - https://www.bottlecapai.com/thinkingcap-qwen3-6-27b
+
+name = "ThinkingCap Qwen3.6 27B"
+description = "Token-efficient fine-tune of Qwen3.6-27B that cuts reasoning tokens by ~50% while preserving answer quality"
+family = "qwen"
+release_date = "2026-07-06"
+last_updated = "2026-07-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/bottlecapai/ThinkingCap-Qwen3.6-27B"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "wandb:generate": "bun ./packages/core/script/sync-models.ts wandb",
     "digitalocean:sync": "bun ./packages/core/script/sync-models.ts digitalocean",
     "ambient:sync": "bun ./packages/core/script/sync-models.ts ambient",
+    "sference:sync": "bun ./packages/core/script/sync-models.ts sference",
     "models:sync": "bun ./packages/core/script/sync-models.ts",
     "sync:models": "bun ./packages/core/script/sync-models.ts",
     "sync:auto-merge": "bun ./packages/core/script/check-sync-auto-merge.ts"

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -28,6 +28,7 @@ import { openrouter } from "./providers/openrouter.js";
 import { ovhcloud } from "./providers/ovhcloud.js";
 import { pioneer } from "./providers/pioneer.js";
 import { requesty } from "./providers/requesty.js";
+import { sference } from "./providers/sference.js";
 import { tinfoil } from "./providers/tinfoil.js";
 import { vercel } from "./providers/vercel.js";
 import { venice } from "./providers/venice.js";
@@ -135,6 +136,7 @@ export const providers: {
   ovhcloud: SyncProvider<any>;
   pioneer: SyncProvider<any>;
   requesty: SyncProvider<any>;
+  sference: SyncProvider<any>;
   tinfoil: SyncProvider<any>;
   vercel: SyncProvider<any>;
   venice: SyncProvider<any>;
@@ -164,6 +166,7 @@ export const providers: {
   ovhcloud,
   pioneer,
   requesty,
+  sference,
   tinfoil,
   vercel,
   venice,
@@ -186,7 +189,7 @@ export const groups = {
     "vercel",
   ],
   cloudflare: ["cloudflare-workers-ai"],
-  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
+  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "sference", "tinfoil", "venice", "wandb", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;

--- a/packages/core/src/sync/providers/sference.ts
+++ b/packages/core/src/sync/providers/sference.ts
@@ -135,15 +135,10 @@ export function buildSferenceModel(
   const imageInput = caps.image_input?.supported === true;
   const pdfInput = caps.pdf_input?.supported === true;
 
-  // The catalog exposes an `enable_thinking` toggle (thinking.types.enabled)
-  // but no effort or budget control, and does not surface which models
-  // accept reasoning_effort (DeepSeek V4 does, via the worker). Since the API
-  // is not authoritative for the reasoning control surface, preserve any
-  // hand-authored reasoning_options and only default new reasoning models to
-  // a toggle (the documented enable_thinking = true|false control).
-  const reasoningOptions = thinking
-    ? (existing?.reasoning_options ?? [{ type: "toggle" as const }])
-    : undefined;
+  // The only reasoning control the API accepts is the enable_thinking toggle
+  // (ingress drops unknown fields like reasoning_effort), so every reasoning
+  // model gets a single toggle option.
+  const reasoningOptions = thinking ? [{ type: "toggle" as const }] : undefined;
 
   // The public /v1/models endpoint exposes context_tokens, max_output_tokens,
   // released, and capabilities. For factored models, only API-authoritative

--- a/packages/core/src/sync/providers/sference.ts
+++ b/packages/core/src/sync/providers/sference.ts
@@ -1,0 +1,288 @@
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+
+import { describeModel } from "../../describe.js";
+import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel } from "./openrouter.js";
+
+// The OpenAI-compatible /v1/models endpoint is public (auth-optional): anonymous
+// callers get the platform_status=available catalog with per-1M-token USD
+// pricing, so no SFERENCE_API_KEY is required for sync. A key, when set, only
+// unlocks private BYOM models and per-user pricing overrides.
+const API_ENDPOINT = "https://api.sference.com/v1/models";
+const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
+
+// Map the org prefix in sference model IDs (e.g. "zai-org/GLM-5.2") to the
+// models.dev metadata provider namespace where the canonical entry lives.
+const ORG_TO_MODEL_PROVIDER: Record<string, string | undefined> = {
+  Qwen: "alibaba",
+  "zai-org": "zhipuai",
+  thinkingmachines: "thinkingmachines",
+  bottlecapai: "bottlecapai",
+  moonshotai: "moonshotai",
+  MiniMaxAI: "minimax",
+  "deepseek-ai": "deepseek",
+  google: "google",
+  "meta-llama": "meta",
+  nvidia: "nvidia",
+  openai: "openai",
+};
+
+const CapabilityFlag = z
+  .object({
+    supported: z.boolean().default(false),
+  })
+  .passthrough();
+
+const ThinkingCapability = z
+  .object({
+    supported: z.boolean().default(false),
+    types: z
+      .object({
+        enabled: CapabilityFlag.optional(),
+        adaptive: CapabilityFlag.optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+const ModelCapabilities = z
+  .object({
+    image_input: CapabilityFlag.optional(),
+    pdf_input: CapabilityFlag.optional(),
+    thinking: ThinkingCapability.optional(),
+    tools: CapabilityFlag.optional(),
+  })
+  .passthrough();
+
+const Pricing = z
+  .object({
+    input_per_million_usd: z.number().nullable().optional(),
+    output_per_million_usd: z.number().nullable().optional(),
+    cached_input_per_million_usd: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+export const SferenceModel = z
+  .object({
+    id: z.string(),
+    object: z.literal("model").default("model"),
+    created: z.number(),
+    owned_by: z.string().default("sference"),
+    display_name: z.string(),
+    provider: z.string().nullable().optional(),
+    modality: z.enum(["text_generation", "text_embedding"]).default("text_generation"),
+    capabilities: ModelCapabilities.optional(),
+    context_tokens: z.number().int().nullable().optional(),
+    // Per-1M-token USD pricing (nullable when a model has no list price).
+    pricing: Pricing.nullable().optional(),
+    // Maximum output tokens the platform enforces (nullable when no catalog
+    // metadata); the sync writes it as an authoritative limit.output override.
+    max_output_tokens: z.number().int().nullable().optional(),
+    // ISO 8601 release date (YYYY-MM-DD), curated per model; distinct from
+    // `created`, which is just int(time.time()) for cache-busting.
+    released: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const SferenceResponse = z
+  .object({
+    object: z.literal("list").default("list"),
+    data: z.array(SferenceModel),
+  })
+  .passthrough();
+
+export type SferenceModel = z.infer<typeof SferenceModel>;
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+export const sference = {
+  id: "sference",
+  name: "sference",
+  modelsDir: "providers/sference/models",
+  async fetchModels() {
+    // The /v1/models endpoint is public (auth-optional): models.dev only ever
+    // syncs the public catalog, so no SFERENCE_API_KEY is needed.
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`sference /v1/models request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return SferenceResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    // The public endpoint already filters to available models and excludes
+    // embeddings from the chat catalog; skip any remaining embedding rows.
+    if (model.modality === "text_embedding") return undefined;
+
+    const existing = context.existing(model.id);
+    return {
+      id: model.id,
+      model: buildSferenceModel(model, existing, resolveBaseModel(model.id)),
+    };
+  },
+} satisfies SyncProvider<SferenceModel>;
+
+export function buildSferenceModel(
+  model: SferenceModel,
+  existing: ExistingModel | undefined,
+  baseModel: string | undefined,
+  today = new Date().toISOString().slice(0, 10),
+): SyncedModel {
+  const caps = model.capabilities ?? {};
+  const thinking = caps.thinking?.supported === true;
+  const tools = caps.tools?.supported === true;
+  const imageInput = caps.image_input?.supported === true;
+  const pdfInput = caps.pdf_input?.supported === true;
+
+  // The catalog exposes an `enable_thinking` toggle (thinking.types.enabled)
+  // but no effort or budget control, so reasoning is a single toggle option.
+  const reasoningOptions = thinking ? [{ type: "toggle" as const }] : undefined;
+
+  // The public /v1/models endpoint exposes context_tokens, max_output_tokens,
+  // released, and capabilities. For factored models, only API-authoritative
+  // values are written as overrides; fields the API omits (input limit, full
+  // modality arrays, knowledge) inherit from base_model metadata. Setting a
+  // field to undefined lets factorBaseModel strip it so it inherits from base.
+  const contextTokens = model.context_tokens ?? 0;
+  const apiContext = contextTokens > 0 ? contextTokens : undefined;
+  const apiOutput = model.max_output_tokens ?? undefined;
+  // `limit` for factorBaseModel must be a complete ProviderModelLimit; the
+  // values.limit below carries only the API-authoritative overrides so missing
+  // fields (output, input) inherit from base metadata instead of being zeroed.
+  const limit = {
+    context: apiContext ?? existing?.limit?.context ?? 0,
+    input: existing?.limit?.input,
+    output: apiOutput ?? existing?.limit?.output ?? 0,
+  };
+  const valuesLimit: Partial<SyncedFullModel["limit"]> = {
+    context: apiContext,
+    input: existing?.limit?.input,
+    output: apiOutput ?? existing?.limit?.output,
+  };
+
+  // Pricing is already per-1M-token USD — no conversion needed. A free model
+  // surfaces a pricing block with zeros; a model with no list price omits it.
+  const pricing = model.pricing;
+  const inputCost = pricing?.input_per_million_usd;
+  const outputCost = pricing?.output_per_million_usd;
+  const cacheRead = pricing?.cached_input_per_million_usd;
+  const cost = pricing != null
+    ? {
+        input: inputCost ?? 0,
+        output: outputCost ?? 0,
+        cache_read: cacheRead != null && cacheRead > 0 ? cacheRead : undefined,
+      }
+    : existing?.cost;
+
+  const name = existing?.name ?? model.display_name;
+
+  // sference serves open-weight checkpoints; the catalog does not flag weights
+  // per model, so inherit from existing or default to open weights.
+  const openWeights = existing?.open_weights ?? true;
+
+  // /v1/models surfaces image/pdf via capabilities but not full modality arrays.
+  // For factored models the richer base metadata wins (leave input undefined so
+  // it inherits); for inline models derive what the API exposes plus any extra
+  // existing modalities.
+  const apiInput: Modality[] = [
+    "text",
+    ...(imageInput ? (["image"] as Modality[]) : []),
+    ...(pdfInput ? (["pdf"] as Modality[]) : []),
+  ];
+  const inheritedInput = existing?.modalities?.input ?? [];
+  const input = baseModel == null
+    ? [...new Set([...apiInput, ...inheritedInput.filter((m) => m !== "text")])]
+    : undefined;
+  const attachment = baseModel == null
+    ? apiInput.some((value) => value !== "text") || (existing?.attachment ?? false)
+    : existing?.attachment;
+
+  // `created` is the current request time (int(time.time())), not the model
+  // release date, so it is not a useful release_date source. The catalog's
+  // `released` field (ISO YYYY-MM-DD) is the authoritative release date; when
+  // absent, factored models inherit it from base metadata and inline models
+  // default to today. `last_updated` is not exposed by the API, so preserve any
+  // hand-authored value or default to today for inline models.
+  const apiReleased = model.released ?? undefined;
+  const values: Partial<SyncedFullModel> = {
+    name,
+    description: existing?.description ?? (baseModel == null ? describeModel({
+      id: model.id,
+      name,
+      family: inferFamily(model.id, name) ?? existing?.family,
+      reasoning: thinking,
+      tool_call: tools,
+      structured_output: existing?.structured_output,
+      open_weights: openWeights,
+      limit,
+      modalities: { input: apiInput, output: ["text"] },
+    }) : undefined),
+    family: baseModel == null ? inferFamily(model.id, name) ?? existing?.family : existing?.family,
+    release_date: apiReleased ?? existing?.release_date ?? (baseModel == null ? today : undefined),
+    last_updated: existing?.last_updated ?? (baseModel == null ? today : undefined),
+    attachment,
+    reasoning: thinking,
+    reasoning_options: reasoningOptions,
+    temperature: existing?.temperature,
+    tool_call: tools,
+    structured_output: existing?.structured_output,
+    knowledge: existing?.knowledge,
+    open_weights: openWeights,
+    status: existing?.status,
+    // sference returns reasoning via the OpenAI-style reasoning_content field on
+    // chat completions, so reasoning models declare an interleaved block.
+    interleaved: thinking ? (existing?.interleaved ?? { field: "reasoning_content" as const }) : existing?.interleaved,
+    cost,
+    limit,
+    modalities: input === undefined ? undefined : { input, output: ["text"] },
+  };
+
+  if (baseModel == null) return values as SyncedFullModel;
+  // For factored models, swap in the partial limit so unset fields (output,
+  // input) inherit from base metadata instead of being overridden with zeros.
+  const factored = { ...values, limit: valuesLimit } as Partial<SyncedFullModel>;
+  return factorBaseModel(baseModel, factored, limit, existing?.base_model_omit);
+}
+
+function resolveBaseModel(modelId: string): string | undefined {
+  const [org, ...modelParts] = modelId.split("/");
+  if (org === undefined || modelParts.length === 0) return undefined;
+  const provider = ORG_TO_MODEL_PROVIDER[org];
+  if (provider === undefined) return undefined;
+  const lower = modelParts.join("/").toLowerCase();
+  return [lower, lower.replace(/-turbo$/, "-it")]
+    .map((candidate) => `${provider}/${candidate}`)
+    .find(canonicalExists);
+}
+
+// existsSync is case-insensitive on macOS/Windows; verify the real on-disk
+// filename so the resolved base_model matches the canonical metadata exactly.
+function canonicalExists(candidate: string): boolean {
+  const file = path.join(MODELS_DIR, `${candidate}.toml`);
+  if (!existsSync(file)) return false;
+  try {
+    return readdirSync(path.dirname(file)).includes(path.basename(file));
+  } catch {
+    return false;
+  }
+}
+
+function inferFamily(id: string, name: string) {
+  const kimiFamily = inferKimiFamily(id, name);
+  if (kimiFamily !== undefined) return kimiFamily;
+
+  const target = `${id} ${name}`.toLowerCase();
+  return [...ModelFamilyValues]
+    .sort((a, b) => b.length - a.length)
+    .find((family) => {
+      const value = family.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      if (family === "o") return new RegExp(`(^|[^a-z0-9])${value}(?=\\d|$|[^a-z0-9])`).test(target);
+      return new RegExp(`(^|[^a-z0-9])${value}(?=$|[^a-z0-9])`).test(target);
+    });
+}

--- a/packages/core/src/sync/providers/sference.ts
+++ b/packages/core/src/sync/providers/sference.ts
@@ -15,19 +15,14 @@ const API_ENDPOINT = "https://api.sference.com/v1/models";
 const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
 
 // Map the org prefix in sference model IDs (e.g. "zai-org/GLM-5.2") to the
-// models.dev metadata provider namespace where the canonical entry lives.
+// models.dev metadata provider namespace where the canonical entry lives. Only
+// non-identity mappings are listed; an org absent here falls back to itself.
 const ORG_TO_MODEL_PROVIDER: Record<string, string | undefined> = {
   Qwen: "alibaba",
   "zai-org": "zhipuai",
-  thinkingmachines: "thinkingmachines",
-  bottlecapai: "bottlecapai",
-  moonshotai: "moonshotai",
   MiniMaxAI: "minimax",
   "deepseek-ai": "deepseek",
-  google: "google",
   "meta-llama": "meta",
-  nvidia: "nvidia",
-  openai: "openai",
 };
 
 const CapabilityFlag = z
@@ -141,8 +136,14 @@ export function buildSferenceModel(
   const pdfInput = caps.pdf_input?.supported === true;
 
   // The catalog exposes an `enable_thinking` toggle (thinking.types.enabled)
-  // but no effort or budget control, so reasoning is a single toggle option.
-  const reasoningOptions = thinking ? [{ type: "toggle" as const }] : undefined;
+  // but no effort or budget control, and does not surface which models
+  // accept reasoning_effort (DeepSeek V4 does, via the worker). Since the API
+  // is not authoritative for the reasoning control surface, preserve any
+  // hand-authored reasoning_options and only default new reasoning models to
+  // a toggle (the documented enable_thinking = true|false control).
+  const reasoningOptions = thinking
+    ? (existing?.reasoning_options ?? [{ type: "toggle" as const }])
+    : undefined;
 
   // The public /v1/models endpoint exposes context_tokens, max_output_tokens,
   // released, and capabilities. For factored models, only API-authoritative
@@ -253,8 +254,9 @@ export function buildSferenceModel(
 function resolveBaseModel(modelId: string): string | undefined {
   const [org, ...modelParts] = modelId.split("/");
   if (org === undefined || modelParts.length === 0) return undefined;
-  const provider = ORG_TO_MODEL_PROVIDER[org];
-  if (provider === undefined) return undefined;
+  // Use the explicit mapping when present, otherwise fall back to the org
+  // name itself (identity mapping) so unmapped orgs still resolve.
+  const provider = ORG_TO_MODEL_PROVIDER[org] ?? org;
   const lower = modelParts.join("/").toLowerCase();
   return [lower, lower.replace(/-turbo$/, "-it")]
     .map((candidate) => `${provider}/${candidate}`)

--- a/packages/core/src/sync/providers/sference.ts
+++ b/packages/core/src/sync/providers/sference.ts
@@ -188,10 +188,12 @@ export function buildSferenceModel(
   // per model, so inherit from existing or default to open weights.
   const openWeights = existing?.open_weights ?? true;
 
-  // /v1/models surfaces image/pdf via capabilities but not full modality arrays.
-  // For factored models the richer base metadata wins (leave input undefined so
-  // it inherits); for inline models derive what the API exposes plus any extra
-  // existing modalities.
+  // /v1/models surfaces image/pdf via capabilities but not full modality
+  // arrays. Those flags are authoritative for what sference serves, so
+  // factored models always write the derived array: factorBaseModel strips it
+  // when it matches base metadata and keeps it as an override when the base is
+  // richer (e.g. a multimodal base checkpoint served text-only here). Inline
+  // models additionally keep any hand-authored extra modalities.
   const apiInput: Modality[] = [
     "text",
     ...(imageInput ? (["image"] as Modality[]) : []),
@@ -200,10 +202,10 @@ export function buildSferenceModel(
   const inheritedInput = existing?.modalities?.input ?? [];
   const input = baseModel == null
     ? [...new Set([...apiInput, ...inheritedInput.filter((m) => m !== "text")])]
-    : undefined;
+    : apiInput;
   const attachment = baseModel == null
     ? apiInput.some((value) => value !== "text") || (existing?.attachment ?? false)
-    : existing?.attachment;
+    : apiInput.some((value) => value !== "text");
 
   // `created` is the current request time (int(time.time())), not the model
   // release date, so it is not a useful release_date source. The catalog's

--- a/packages/core/src/sync/providers/sference.ts
+++ b/packages/core/src/sync/providers/sference.ts
@@ -74,9 +74,6 @@ export const SferenceModel = z
     context_tokens: z.number().int().nullable().optional(),
     // Per-1M-token USD pricing (nullable when a model has no list price).
     pricing: Pricing.nullable().optional(),
-    // Maximum output tokens the platform enforces (nullable when no catalog
-    // metadata); the sync writes it as an authoritative limit.output override.
-    max_output_tokens: z.number().int().nullable().optional(),
     // ISO 8601 release date (YYYY-MM-DD), curated per model; distinct from
     // `created`, which is just int(time.time()) for cache-busting.
     released: z.string().nullable().optional(),
@@ -146,26 +143,32 @@ export function buildSferenceModel(
     ? (existing?.reasoning_options ?? [{ type: "toggle" as const }])
     : undefined;
 
-  // The public /v1/models endpoint exposes context_tokens, max_output_tokens,
-  // released, and capabilities. For factored models, only API-authoritative
-  // values are written as overrides; fields the API omits (input limit, full
-  // modality arrays, knowledge) inherit from base_model metadata. Setting a
-  // field to undefined lets factorBaseModel strip it so it inherits from base.
+  // The public /v1/models endpoint exposes context_tokens, released, and
+  // capabilities. For factored models, only API-authoritative values are
+  // written as overrides; fields the API omits (input limit, full modality
+  // arrays, knowledge) inherit from base_model metadata. Setting a field to
+  // undefined lets factorBaseModel strip it so it inherits from base.
   const contextTokens = model.context_tokens ?? 0;
   const apiContext = contextTokens > 0 ? contextTokens : undefined;
-  const apiOutput = model.max_output_tokens ?? undefined;
+  // The platform publishes no per-model output cap: workers clamp max_tokens to
+  // whatever the context window leaves after the prompt (sference-platform#189)
+  // rather than enforcing a separate ceiling, so the only true output limit is
+  // the context window itself. When the API omits context, leave output unset
+  // so a factored model inherits the base checkpoint's pair instead of
+  // publishing a number no request was measured against.
+  const resolvedContext = apiContext ?? existing?.limit?.context;
   // `limit` for factorBaseModel must be a complete ProviderModelLimit; the
   // values.limit below carries only the API-authoritative overrides so missing
   // fields (output, input) inherit from base metadata instead of being zeroed.
   const limit = {
-    context: apiContext ?? existing?.limit?.context ?? 0,
+    context: resolvedContext ?? 0,
     input: existing?.limit?.input,
-    output: apiOutput ?? existing?.limit?.output ?? 0,
+    output: resolvedContext ?? 0,
   };
   const valuesLimit: Partial<SyncedFullModel["limit"]> = {
     context: apiContext,
     input: existing?.limit?.input,
-    output: apiOutput ?? existing?.limit?.output,
+    output: resolvedContext,
   };
 
   // Pricing is already per-1M-token USD — no conversion needed. A free model

--- a/packages/core/src/sync/providers/sference.ts
+++ b/packages/core/src/sync/providers/sference.ts
@@ -135,10 +135,16 @@ export function buildSferenceModel(
   const imageInput = caps.image_input?.supported === true;
   const pdfInput = caps.pdf_input?.supported === true;
 
-  // The only reasoning control the API accepts is the enable_thinking toggle
-  // (ingress drops unknown fields like reasoning_effort), so every reasoning
-  // model gets a single toggle option.
-  const reasoningOptions = thinking ? [{ type: "toggle" as const }] : undefined;
+  // The catalog exposes an `enable_thinking` toggle (thinking.types.enabled)
+  // and the API accepts OpenAI `reasoning_effort` / `reasoning.effort`, but
+  // the catalog does not surface which effort levels each model acts on — and
+  // a silently-dropped level is not a supported control. Effort is therefore
+  // hand-authored per model: preserve any hand-authored reasoning_options and
+  // default new reasoning models to a toggle (the documented
+  // enable_thinking = true|false control).
+  const reasoningOptions = thinking
+    ? (existing?.reasoning_options ?? [{ type: "toggle" as const }])
+    : undefined;
 
   // The public /v1/models endpoint exposes context_tokens, max_output_tokens,
   // released, and capabilities. For factored models, only API-authoritative

--- a/packages/core/src/sync/providers/sference.ts
+++ b/packages/core/src/sync/providers/sference.ts
@@ -145,30 +145,25 @@ export function buildSferenceModel(
 
   // The public /v1/models endpoint exposes context_tokens, released, and
   // capabilities. For factored models, only API-authoritative values are
-  // written as overrides; fields the API omits (input limit, full modality
-  // arrays, knowledge) inherit from base_model metadata. Setting a field to
-  // undefined lets factorBaseModel strip it so it inherits from base.
+  // written as overrides; fields the API omits (input limit, output limit, full
+  // modality arrays, knowledge) inherit from base_model metadata. Setting a
+  // field to undefined lets factorBaseModel strip it so it inherits from base.
   const contextTokens = model.context_tokens ?? 0;
   const apiContext = contextTokens > 0 ? contextTokens : undefined;
   // The platform publishes no per-model output cap: workers clamp max_tokens to
   // whatever the context window leaves after the prompt (sference-platform#189)
-  // rather than enforcing a separate ceiling, so the only true output limit is
-  // the context window itself. When the API omits context, leave output unset
-  // so a factored model inherits the base checkpoint's pair instead of
-  // publishing a number no request was measured against.
-  const resolvedContext = apiContext ?? existing?.limit?.context;
-  // `limit` for factorBaseModel must be a complete ProviderModelLimit; the
-  // values.limit below carries only the API-authoritative overrides so missing
-  // fields (output, input) inherit from base metadata instead of being zeroed.
+  // rather than enforcing a separate ceiling. Computing context - input here is
+  // not practical (input depends on the request), and callers can set arbitrary
+  // max_tokens anyway, so output is left unset and factored models inherit the
+  // base checkpoint's output limit instead of publishing a misleading number.
   const limit = {
-    context: resolvedContext ?? 0,
+    context: apiContext ?? existing?.limit?.context ?? 0,
     input: existing?.limit?.input,
-    output: resolvedContext ?? 0,
+    output: existing?.limit?.output ?? 0,
   };
   const valuesLimit: Partial<SyncedFullModel["limit"]> = {
     context: apiContext,
     input: existing?.limit?.input,
-    output: resolvedContext,
   };
 
   // Pricing is already per-1M-token USD — no conversion needed. A free model

--- a/packages/core/test/sference-sync-e2e.test.ts
+++ b/packages/core/test/sference-sync-e2e.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { syncProvider, type SyncProvider } from "../src/sync/index.js";
+import { sference, type SferenceModel } from "../src/sync/providers/sference.js";
+
+const mockCatalog: SferenceModel[] = [
+  {
+    id: "Qwen/Qwen3.6-35B-A3B", object: "model", created: 1712345678, owned_by: "sference",
+    display_name: "Qwen3.6 35B", provider: "Qwen", modality: "text_generation",
+    context_tokens: 262144,
+    capabilities: { thinking: { supported: true, types: { enabled: { supported: true } } }, tools: { supported: true }, image_input: { supported: false }, pdf_input: { supported: false } },
+    pricing: { input_per_million_usd: 0, output_per_million_usd: 0, cached_input_per_million_usd: null },
+  },
+  {
+    id: "zai-org/GLM-5.2", object: "model", created: 1712345678, owned_by: "sference",
+    display_name: "GLM 5.2", provider: "Zhipu", modality: "text_generation",
+    context_tokens: 1048576,
+    capabilities: { thinking: { supported: true, types: { enabled: { supported: true } } }, tools: { supported: true }, image_input: { supported: false }, pdf_input: { supported: false } },
+    pricing: { input_per_million_usd: 1.2, output_per_million_usd: 4.2, cached_input_per_million_usd: 0.26 },
+  },
+  {
+    id: "deepseek-ai/DeepSeek-V4-Flash", object: "model", created: 1712345678, owned_by: "sference",
+    display_name: "DeepSeek V4 Flash", provider: "DeepSeek", modality: "text_generation",
+    context_tokens: 1048576,
+    capabilities: { thinking: { supported: true, types: { enabled: { supported: true } } }, tools: { supported: true }, image_input: { supported: false }, pdf_input: { supported: false } },
+    pricing: { input_per_million_usd: 0.08, output_per_million_usd: 0.2, cached_input_per_million_usd: 0.02 },
+  },
+  {
+    id: "bottlecapai/ThinkingCap-Qwen3.6-27B", object: "model", created: 1712345678, owned_by: "sference",
+    display_name: "ThinkingCap Qwen3.6 27B", provider: "BottleCap AI", modality: "text_generation",
+    context_tokens: 262144,
+    capabilities: { thinking: { supported: true, types: { enabled: { supported: true } } }, tools: { supported: true }, image_input: { supported: false }, pdf_input: { supported: false } },
+    pricing: { input_per_million_usd: 0.4, output_per_million_usd: 2.6, cached_input_per_million_usd: null },
+  },
+];
+
+test("syncProvider writes factored TOMLs from the public /v1/models shape", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "sference-sync-"));
+  const modelsDir = path.join(dir, "providers", "sference", "models");
+  const metadataDir = path.join(dir, "models");
+  // Seed canonical metadata so base_model resolves.
+  await mkdir(path.join(metadataDir, "alibaba"), { recursive: true });
+  await mkdir(path.join(metadataDir, "zhipuai"), { recursive: true });
+  await mkdir(path.join(metadataDir, "deepseek"), { recursive: true });
+  await mkdir(path.join(metadataDir, "bottlecapai"), { recursive: true });
+  await writeFile(path.join(metadataDir, "alibaba", "qwen3.6-35b-a3b.toml"), 'name = "Qwen3.6 35B-A3B"\nfamily = "qwen"\nreasoning = true\nopen_weights = true\nattachment = true\ntool_call = true\n[limit]\ncontext = 262144\noutput = 65536\n[modalities]\ninput = ["text", "image", "video", "audio"]\noutput = ["text"]\n');
+  await writeFile(path.join(metadataDir, "zhipuai", "glm-5.2.toml"), 'name = "GLM-5.2"\nfamily = "glm"\nreasoning = true\nopen_weights = true\ntool_call = true\nattachment = false\n[limit]\ncontext = 1000000\noutput = 131072\n[modalities]\ninput = ["text"]\noutput = ["text"]\n');
+  await writeFile(path.join(metadataDir, "deepseek", "deepseek-v4-flash.toml"), 'name = "DeepSeek V4 Flash"\nfamily = "deepseek-flash"\nreasoning = true\nopen_weights = true\ntool_call = true\nattachment = false\n[limit]\ncontext = 1000000\noutput = 384000\n[modalities]\ninput = ["text"]\noutput = ["text"]\n');
+  await writeFile(path.join(metadataDir, "bottlecapai", "thinkingcap-qwen3.6-27b.toml"), 'name = "ThinkingCap Qwen3.6 27B"\nfamily = "qwen"\nreasoning = true\nopen_weights = true\ntool_call = true\nattachment = true\n[limit]\ncontext = 262144\noutput = 65536\n[modalities]\ninput = ["text", "image", "video", "audio"]\noutput = ["text"]\n');
+  await mkdir(modelsDir, { recursive: true });
+
+  const provider: SyncProvider<SferenceModel> = {
+    ...sference,
+    modelsDir,
+    async fetchModels() {
+      return { object: "list" as const, data: mockCatalog };
+    },
+  };
+
+  const result = await syncProvider(provider, { dryRun: false });
+  expect(result.created).toBe(4);
+  expect(result.deleted).toBe(0);
+
+  const glm = await readFile(path.join(modelsDir, "zai-org", "GLM-5.2.toml"), "utf8");
+  expect(glm).toContain('base_model = "zhipuai/glm-5.2"');
+  expect(glm).toContain("input = 1.2");
+  expect(glm).toContain("cache_read = 0.26");
+  expect(glm).toContain("[[reasoning_options]]");
+
+  const qwen = await readFile(path.join(modelsDir, "Qwen", "Qwen3.6-35B-A3B.toml"), "utf8");
+  expect(qwen).toContain("input = 0");
+  expect(qwen).toContain("output = 0");
+
+  const ds = await readFile(path.join(modelsDir, "deepseek-ai", "DeepSeek-V4-Flash.toml"), "utf8");
+  expect(ds).toContain('base_model = "deepseek/deepseek-v4-flash"');
+  expect(ds).toContain("input = 0.08");
+
+  // A second sync should be a no-op (idempotent).
+  const result2 = await syncProvider(provider, { dryRun: false });
+  expect(result2.created).toBe(0);
+  expect(result2.updated).toBe(0);
+
+  await rm(dir, { recursive: true, force: true });
+});

--- a/packages/core/test/sference-sync-e2e.test.ts
+++ b/packages/core/test/sference-sync-e2e.test.ts
@@ -68,10 +68,14 @@ test("syncProvider writes factored TOMLs from the public /v1/models shape", asyn
   expect(glm).toContain("input = 1.2");
   expect(glm).toContain("cache_read = 0.26");
   expect(glm).toContain("[[reasoning_options]]");
+  // Output tracks context: the catalog window overrides both base fields.
+  expect(glm).toContain("[limit]\ncontext = 1_048_576\noutput = 1_048_576");
 
   const qwen = await readFile(path.join(modelsDir, "Qwen", "Qwen3.6-35B-A3B.toml"), "utf8");
   expect(qwen).toContain("input = 0");
   expect(qwen).toContain("output = 0");
+  // Context matches base and is stripped; output still overrides base's 65_536.
+  expect(qwen).toContain("[limit]\noutput = 262_144");
 
   const ds = await readFile(path.join(modelsDir, "deepseek-ai", "DeepSeek-V4-Flash.toml"), "utf8");
   expect(ds).toContain('base_model = "deepseek/deepseek-v4-flash"');

--- a/packages/core/test/sference-sync-e2e.test.ts
+++ b/packages/core/test/sference-sync-e2e.test.ts
@@ -68,14 +68,16 @@ test("syncProvider writes factored TOMLs from the public /v1/models shape", asyn
   expect(glm).toContain("input = 1.2");
   expect(glm).toContain("cache_read = 0.26");
   expect(glm).toContain("[[reasoning_options]]");
-  // Output tracks context: the catalog window overrides both base fields.
-  expect(glm).toContain("[limit]\ncontext = 1_048_576\noutput = 1_048_576");
+  // Context overrides base (1M vs 1M); output inherits from base (131_072).
+  expect(glm).toContain("[limit]\ncontext = 1_048_576");
+  expect(glm).not.toContain("output = 1_048_576");
 
   const qwen = await readFile(path.join(modelsDir, "Qwen", "Qwen3.6-35B-A3B.toml"), "utf8");
   expect(qwen).toContain("input = 0");
   expect(qwen).toContain("output = 0");
-  // Context matches base and is stripped; output still overrides base's 65_536.
-  expect(qwen).toContain("[limit]\noutput = 262_144");
+  // Context matches base and is stripped; output inherits from base (65_536),
+  // so no [limit] section appears at all.
+  expect(qwen).not.toContain("[limit]");
 
   const ds = await readFile(path.join(modelsDir, "deepseek-ai", "DeepSeek-V4-Flash.toml"), "utf8");
   expect(ds).toContain('base_model = "deepseek/deepseek-v4-flash"');

--- a/packages/core/test/sference-sync.test.ts
+++ b/packages/core/test/sference-sync.test.ts
@@ -104,6 +104,28 @@ test("buildSferenceModel falls back to existing cost when pricing is absent", ()
   expect(cost.output).toBe(1);
 });
 
+test("buildSferenceModel preserves hand-authored reasoning_options (effort)", () => {
+  // The API only exposes an enable_thinking toggle, not per-model effort levels
+  // (DeepSeek V4 Flash accepts reasoning_effort max/high via the worker). Since
+  // the API is not authoritative for the reasoning control surface, the sync
+  // preserves hand-authored reasoning_options instead of overwriting them.
+  const existing = {
+    reasoning_options: [
+      { type: "toggle" as const },
+      { type: "effort" as const, values: ["high", "max"] },
+    ],
+  };
+  const model = buildSferenceModel(
+    { ...baseModel(), id: "deepseek-ai/DeepSeek-V4-Flash" },
+    existing,
+    "deepseek/deepseek-v4-flash",
+  ) as Record<string, unknown>;
+  expect(model.reasoning_options).toEqual([
+    { type: "toggle" },
+    { type: "effort", values: ["high", "max"] },
+  ]);
+});
+
 test("buildSferenceModel preserves existing hand-authored metadata", () => {
   const existing = {
     name: "Qwen3.6 35B",

--- a/packages/core/test/sference-sync.test.ts
+++ b/packages/core/test/sference-sync.test.ts
@@ -104,28 +104,6 @@ test("buildSferenceModel falls back to existing cost when pricing is absent", ()
   expect(cost.output).toBe(1);
 });
 
-test("buildSferenceModel preserves hand-authored reasoning_options (effort)", () => {
-  // The API only exposes an enable_thinking toggle, not per-model effort levels
-  // (DeepSeek V4 Flash accepts reasoning_effort max/high via the worker). Since
-  // the API is not authoritative for the reasoning control surface, the sync
-  // preserves hand-authored reasoning_options instead of overwriting them.
-  const existing = {
-    reasoning_options: [
-      { type: "toggle" as const },
-      { type: "effort" as const, values: ["high", "max"] },
-    ],
-  };
-  const model = buildSferenceModel(
-    { ...baseModel(), id: "deepseek-ai/DeepSeek-V4-Flash" },
-    existing,
-    "deepseek/deepseek-v4-flash",
-  ) as Record<string, unknown>;
-  expect(model.reasoning_options).toEqual([
-    { type: "toggle" },
-    { type: "effort", values: ["high", "max"] },
-  ]);
-});
-
 test("buildSferenceModel preserves existing hand-authored metadata", () => {
   const existing = {
     name: "Qwen3.6 35B",

--- a/packages/core/test/sference-sync.test.ts
+++ b/packages/core/test/sference-sync.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { formatToml } from "../src/sync/index.js";
+import { formatToml, type ExistingModel } from "../src/sync/index.js";
 import { buildSferenceModel, type SferenceModel } from "../src/sync/providers/sference.js";
 
 const baseModel = (overrides: Partial<SferenceModel> = {}): SferenceModel => ({
@@ -102,6 +102,28 @@ test("buildSferenceModel falls back to existing cost when pricing is absent", ()
   const cost = model.cost as Record<string, unknown>;
   expect(cost.input).toBe(0.14);
   expect(cost.output).toBe(1);
+});
+
+test("buildSferenceModel preserves hand-authored reasoning_options (effort)", () => {
+  // The API accepts reasoning_effort but the catalog does not surface which
+  // effort levels each model acts on, and a silently-dropped level is not a
+  // supported control. Effort is therefore hand-authored per model and the
+  // sync preserves it instead of overwriting with the default toggle.
+  const existing = {
+    reasoning_options: [
+      { type: "toggle" as const },
+      { type: "effort" as const, values: ["high", "xhigh"] as ("high" | "xhigh")[] },
+    ],
+  } as Partial<ExistingModel>;
+  const model = buildSferenceModel(
+    { ...baseModel(), id: "deepseek-ai/DeepSeek-V4-Flash" },
+    existing,
+    "deepseek/deepseek-v4-flash",
+  ) as Record<string, unknown>;
+  expect(model.reasoning_options).toEqual([
+    { type: "toggle" },
+    { type: "effort", values: ["high", "xhigh"] },
+  ]);
 });
 
 test("buildSferenceModel preserves existing hand-authored metadata", () => {

--- a/packages/core/test/sference-sync.test.ts
+++ b/packages/core/test/sference-sync.test.ts
@@ -138,6 +138,42 @@ test("buildSferenceModel falls back to existing cost when pricing is absent", ()
   expect(cost.output).toBe(1);
 });
 
+test("buildSferenceModel sets limit.output to the context window", () => {
+  // Workers clamp max_tokens to what the context window leaves rather than
+  // enforcing a separate cap, and the catalog publishes no max-output value, so
+  // the context window is the output limit. The base checkpoint's smaller
+  // output must be overridden, not inherited.
+  const model = buildSferenceModel(
+    { ...baseModel(), context_tokens: 1_048_576, id: "zai-org/GLM-5.2" },
+    undefined,
+    "zhipuai/glm-5.2",
+  ) as Record<string, unknown>;
+  expect(model.limit).toEqual({ context: 1_048_576, output: 1_048_576 });
+});
+
+test("buildSferenceModel leaves limit unset when the catalog omits context", () => {
+  // With no context from the API and none on the existing TOML there is no
+  // measured window to publish an output cap against, so both fields inherit
+  // from the base checkpoint instead of being written as zeros.
+  const model = buildSferenceModel(
+    { ...baseModel(), context_tokens: null },
+    undefined,
+    "alibaba/qwen3.6-35b-a3b",
+  ) as Record<string, unknown>;
+  expect(model.limit).toBeUndefined();
+});
+
+test("buildSferenceModel ignores a hand-authored output that undercuts context", () => {
+  // A stale output cap on the existing TOML must not survive: the clamp makes
+  // the full window reachable, so output tracks context on every sync.
+  const model = buildSferenceModel(
+    baseModel(),
+    { limit: { context: 262_144, output: 32_768 } },
+    "alibaba/qwen3.6-35b-a3b",
+  ) as Record<string, unknown>;
+  expect((model.limit as Record<string, unknown>).output).toBe(262_144);
+});
+
 test("buildSferenceModel preserves hand-authored reasoning_options (effort)", () => {
   // The API accepts reasoning_effort but the catalog does not surface which
   // effort levels each model acts on, and a silently-dropped level is not a

--- a/packages/core/test/sference-sync.test.ts
+++ b/packages/core/test/sference-sync.test.ts
@@ -36,6 +36,40 @@ test("buildSferenceModel factors a catalog model onto its base_model", () => {
   expect("reasoning_options" in model ? model.reasoning_options : undefined).toEqual([{ type: "toggle" }]);
 });
 
+test("buildSferenceModel overrides modalities when the catalog is narrower than base", () => {
+  // The base checkpoint metadata declares image/video/audio input, but the
+  // catalog reports image_input/pdf_input unsupported — the catalog flags are
+  // authoritative for what sference serves, so the factored model must write
+  // text-only overrides instead of inheriting the richer base arrays.
+  const model = buildSferenceModel(baseModel(), undefined, "alibaba/qwen3.6-35b-a3b") as Record<
+    string,
+    unknown
+  >;
+  expect(model.modalities).toEqual({ input: ["text"] });
+  expect(model.attachment).toBe(false);
+});
+
+test("buildSferenceModel inherits modalities when the catalog matches base", () => {
+  const model = buildSferenceModel(
+    {
+      ...baseModel(),
+      id: "Qwen/Qwen3-VL-30B-A3B-Instruct",
+      display_name: "Qwen3-VL 30B",
+      capabilities: {
+        thinking: { supported: false },
+        tools: { supported: true },
+        image_input: { supported: true },
+        pdf_input: { supported: false },
+      },
+    },
+    undefined,
+    "alibaba/qwen3-vl-30b-a3b-instruct",
+  ) as Record<string, unknown>;
+  // Base already declares text+image input and attachment, so no override.
+  expect(model.modalities).toBeUndefined();
+  expect(model.attachment).toBeUndefined();
+});
+
 test("buildSferenceModel reads the nested pricing object with cache_read", () => {
   const model = buildSferenceModel(
     {

--- a/packages/core/test/sference-sync.test.ts
+++ b/packages/core/test/sference-sync.test.ts
@@ -138,23 +138,23 @@ test("buildSferenceModel falls back to existing cost when pricing is absent", ()
   expect(cost.output).toBe(1);
 });
 
-test("buildSferenceModel sets limit.output to the context window", () => {
-  // Workers clamp max_tokens to what the context window leaves rather than
-  // enforcing a separate cap, and the catalog publishes no max-output value, so
-  // the context window is the output limit. The base checkpoint's smaller
-  // output must be overridden, not inherited.
+test("buildSferenceModel writes context but lets output inherit from base", () => {
+  // The platform publishes no per-model output cap (workers clamp max_tokens
+  // to context - prompt), and computing context - input here is not practical.
+  // Output is therefore left unset so factored models inherit the base
+  // checkpoint's output limit instead of publishing a misleading number.
   const model = buildSferenceModel(
     { ...baseModel(), context_tokens: 1_048_576, id: "zai-org/GLM-5.2" },
     undefined,
     "zhipuai/glm-5.2",
   ) as Record<string, unknown>;
-  expect(model.limit).toEqual({ context: 1_048_576, output: 1_048_576 });
+  expect(model.limit).toEqual({ context: 1_048_576 });
 });
 
 test("buildSferenceModel leaves limit unset when the catalog omits context", () => {
   // With no context from the API and none on the existing TOML there is no
-  // measured window to publish an output cap against, so both fields inherit
-  // from the base checkpoint instead of being written as zeros.
+  // measured window, so limit inherits entirely from the base checkpoint
+  // instead of being written with zeros.
   const model = buildSferenceModel(
     { ...baseModel(), context_tokens: null },
     undefined,
@@ -163,15 +163,17 @@ test("buildSferenceModel leaves limit unset when the catalog omits context", () 
   expect(model.limit).toBeUndefined();
 });
 
-test("buildSferenceModel ignores a hand-authored output that undercuts context", () => {
-  // A stale output cap on the existing TOML must not survive: the clamp makes
-  // the full window reachable, so output tracks context on every sync.
+test("buildSferenceModel ignores a stale hand-authored output and inherits from base", () => {
+  // A stale output cap on the existing TOML must not survive: the sync never
+  // writes output (the platform has no per-model cap), so it inherits from
+  // base metadata regardless of what the existing TOML says.
   const model = buildSferenceModel(
     baseModel(),
     { limit: { context: 262_144, output: 32_768 } },
     "alibaba/qwen3.6-35b-a3b",
   ) as Record<string, unknown>;
-  expect((model.limit as Record<string, unknown>).output).toBe(262_144);
+  // Context matches base (262_144) so it is stripped; output is never written.
+  expect(model.limit).toBeUndefined();
 });
 
 test("buildSferenceModel preserves hand-authored reasoning_options (effort)", () => {

--- a/packages/core/test/sference-sync.test.ts
+++ b/packages/core/test/sference-sync.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "bun:test";
+
+import { formatToml } from "../src/sync/index.js";
+import { buildSferenceModel, type SferenceModel } from "../src/sync/providers/sference.js";
+
+const baseModel = (overrides: Partial<SferenceModel> = {}): SferenceModel => ({
+  id: "Qwen/Qwen3.6-35B-A3B",
+  object: "model",
+  created: 1_712_345_678,
+  owned_by: "sference",
+  display_name: "Qwen3.6 35B",
+  provider: "Qwen",
+  modality: "text_generation",
+  context_tokens: 262_144,
+  capabilities: {
+    thinking: { supported: true, types: { enabled: { supported: true } } },
+    tools: { supported: true },
+    image_input: { supported: false },
+    pdf_input: { supported: false },
+  },
+  pricing: {
+    input_per_million_usd: 0,
+    output_per_million_usd: 0,
+    cached_input_per_million_usd: null,
+  },
+  ...overrides,
+});
+
+test("buildSferenceModel factors a catalog model onto its base_model", () => {
+  const model = buildSferenceModel(baseModel(), undefined, "alibaba/qwen3.6-35b-a3b");
+  expect("base_model" in model && model.base_model).toBe("alibaba/qwen3.6-35b-a3b");
+  expect("name" in model ? model.name : undefined).toBe("Qwen3.6 35B");
+  // Pricing comes straight from the nested pricing object (already per-1M USD).
+  expect("cost" in model ? model.cost : undefined).toEqual({ input: 0, output: 0 });
+  // Reasoning models emit the enable_thinking toggle.
+  expect("reasoning_options" in model ? model.reasoning_options : undefined).toEqual([{ type: "toggle" }]);
+});
+
+test("buildSferenceModel reads the nested pricing object with cache_read", () => {
+  const model = buildSferenceModel(
+    {
+      ...baseModel(),
+      id: "zai-org/GLM-5.2",
+      display_name: "GLM 5.2",
+      pricing: {
+        input_per_million_usd: 1.2,
+        output_per_million_usd: 4.2,
+        cached_input_per_million_usd: 0.26,
+      },
+    },
+    undefined,
+    "zhipuai/glm-5.2",
+  ) as Record<string, unknown>;
+  const cost = model.cost as Record<string, unknown>;
+  expect(cost.input).toBe(1.2);
+  expect(cost.output).toBe(4.2);
+  expect(cost.cache_read).toBe(0.26);
+});
+
+test("buildSferenceModel writes a full inline model when no base_model matches", () => {
+  const model = buildSferenceModel(
+    {
+      ...baseModel(),
+      id: "custom-org/Custom-Model",
+      display_name: "Custom Model",
+      provider: null,
+    },
+    undefined,
+    undefined,
+  ) as Record<string, unknown>;
+  expect(model.base_model).toBeUndefined();
+  expect(model.name).toBe("Custom Model");
+  expect((model.cost as Record<string, unknown>).input).toBe(0);
+  expect(model.reasoning).toBe(true);
+  expect(model.reasoning_options).toEqual([{ type: "toggle" }]);
+});
+
+test("buildSferenceModel skips reasoning_options for non-reasoning models", () => {
+  const model = buildSferenceModel(
+    {
+      ...baseModel(),
+      capabilities: {
+        thinking: { supported: false },
+        tools: { supported: true },
+        image_input: { supported: false },
+        pdf_input: { supported: false },
+      },
+    },
+    undefined,
+    "alibaba/qwen3.6-35b-a3b",
+  ) as Record<string, unknown>;
+  expect(model.reasoning_options).toBeUndefined();
+  expect(model.reasoning).toBe(false);
+});
+
+test("buildSferenceModel falls back to existing cost when pricing is absent", () => {
+  const model = buildSferenceModel(
+    { ...baseModel(), pricing: null },
+    { cost: { input: 0.14, output: 1 } },
+    "alibaba/qwen3.6-35b-a3b",
+  ) as Record<string, unknown>;
+  const cost = model.cost as Record<string, unknown>;
+  expect(cost.input).toBe(0.14);
+  expect(cost.output).toBe(1);
+});
+
+test("buildSferenceModel preserves existing hand-authored metadata", () => {
+  const existing = {
+    name: "Qwen3.6 35B",
+    knowledge: "2024-04",
+    limit: { context: 262_144, input: 200_000, output: 32_768 },
+    modalities: { input: ["text", "image", "video", "audio"] as ("text" | "image" | "video" | "audio")[], output: ["text"] as ["text"] },
+    interleaved: { field: "reasoning_content" as const },
+    base_model_omit: ["limit.input"],
+  };
+  const model = buildSferenceModel(baseModel(), existing, "alibaba/qwen3.6-35b-a3b");
+  expect("base_model_omit" in model && model.base_model_omit).toEqual(["limit.input"]);
+  expect("interleaved" in model && model.interleaved).toEqual({ field: "reasoning_content" });
+});
+
+test("buildSferenceModel does not treat created as a release date", () => {
+  // `created` is int(time.time()) at request time, not the model release date,
+  // so it must not populate release_date. For a factored model the date is
+  // inherited from base metadata (undefined here); for an inline model it
+  // defaults to today.
+  const factored = buildSferenceModel(
+    { ...baseModel(), created: 1_712_345_678 },
+    undefined,
+    "alibaba/qwen3.6-35b-a3b",
+    "2026-07-17",
+  ) as Record<string, unknown>;
+  expect(factored.release_date).toBeUndefined();
+
+  const inline = buildSferenceModel(
+    { ...baseModel(), id: "custom-org/Custom", created: 1_712_345_678 },
+    undefined,
+    undefined,
+    "2026-07-17",
+  ) as Record<string, unknown>;
+  expect(inline.release_date).toBe("2026-07-17");
+});
+
+test("formatToml serializes a factored sference model deterministically", () => {
+  const model = buildSferenceModel(baseModel(), undefined, "alibaba/qwen3.6-35b-a3b");
+  // formatToml accepts the authored model shape; cast the SyncedModel union.
+  const toml = formatToml(model as Parameters<typeof formatToml>[0]);
+  expect(toml).toContain('base_model = "alibaba/qwen3.6-35b-a3b"');
+  expect(toml).toContain("input = 0");
+  expect(toml).toContain("[[reasoning_options]]");
+  expect(toml).toContain('type = "toggle"');
+});

--- a/providers/sference/logo.svg
+++ b/providers/sference/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <path d="M21.5 11.5c0-2.5-2-4-5.5-4s-5.5 1.5-5.5 4c0 2.8 2.2 3.5 5.5 4.2 3.3.7 5.5 1.4 5.5 4.3 0 2.5-2 4-5.5 4s-5.5-1.5-5.5-4" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/providers/sference/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
+++ b/providers/sference/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-vl-30b-a3b-instruct"
+
+[cost]
+input = 0.4
+output = 2
+cache_read = 0.1

--- a/providers/sference/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
+++ b/providers/sference/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
@@ -4,3 +4,6 @@ base_model = "alibaba/qwen3-vl-30b-a3b-instruct"
 input = 0.4
 output = 2
 cache_read = 0.1
+
+[limit]
+output = 262_144

--- a/providers/sference/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
+++ b/providers/sference/models/Qwen/Qwen3-VL-30B-A3B-Instruct.toml
@@ -1,9 +1,7 @@
 base_model = "alibaba/qwen3-vl-30b-a3b-instruct"
+release_date = "2026-07-15"
 
 [cost]
 input = 0.4
 output = 2
 cache_read = 0.1
-
-[limit]
-output = 262_144

--- a/providers/sference/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/sference/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen3.6-35b-a3b"
+name = "Qwen3.6 35B"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0

--- a/providers/sference/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/sference/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -13,5 +13,8 @@ input = 0.2
 output = 1.25
 cache_read = 0.05
 
+[limit]
+output = 262_144
+
 [modalities]
 input = ["text"]

--- a/providers/sference/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/sference/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -8,5 +8,6 @@ field = "reasoning_content"
 type = "toggle"
 
 [cost]
-input = 0
-output = 0
+input = 0.2
+output = 1.25
+cache_read = 0.05

--- a/providers/sference/models/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/sference/models/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,5 +1,6 @@
 base_model = "alibaba/qwen3.6-35b-a3b"
 name = "Qwen3.6 35B"
+attachment = false
 
 [interleaved]
 field = "reasoning_content"
@@ -11,3 +12,6 @@ type = "toggle"
 input = 0.2
 output = 1.25
 cache_read = 0.05
+
+[modalities]
+input = ["text"]

--- a/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
+++ b/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
@@ -1,0 +1,11 @@
+base_model = "bottlecapai/thinkingcap-qwen3.6-27b"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.4
+output = 2.6

--- a/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
+++ b/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
@@ -1,4 +1,5 @@
 base_model = "bottlecapai/thinkingcap-qwen3.6-27b"
+release_date = "2026-07-13"
 attachment = false
 
 [interleaved]
@@ -11,9 +12,6 @@ type = "toggle"
 input = 0.4
 output = 2.6
 cache_read = 0.05
-
-[limit]
-output = 262_144
 
 [modalities]
 input = ["text"]

--- a/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
+++ b/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
@@ -12,5 +12,8 @@ input = 0.4
 output = 2.6
 cache_read = 0.05
 
+[limit]
+output = 262_144
+
 [modalities]
 input = ["text"]

--- a/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
+++ b/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
@@ -9,3 +9,4 @@ type = "toggle"
 [cost]
 input = 0.4
 output = 2.6
+cache_read = 0.05

--- a/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
+++ b/providers/sference/models/bottlecapai/ThinkingCap-Qwen3.6-27B.toml
@@ -1,4 +1,5 @@
 base_model = "bottlecapai/thinkingcap-qwen3.6-27b"
+attachment = false
 
 [interleaved]
 field = "reasoning_content"
@@ -10,3 +11,6 @@ type = "toggle"
 input = 0.4
 output = 2.6
 cache_read = 0.05
+
+[modalities]
+input = ["text"]

--- a/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,7 +1,8 @@
 # Synced from GET /v1/models. The effort option is hand-authored: the API
-# accepts OpenAI reasoning_effort on chat completions and responses, and this
-# model acts on high and xhigh; lower levels enable thinking at the default
-# depth, so only high and xhigh are advertised.
+# accepts OpenAI reasoning_effort on chat completions and responses (OpenAPI
+# schema/openapi.json, ChatCompletionCreateRequest and ReasoningConfig), and
+# this model acts on high and xhigh; lower levels enable thinking at the
+# default depth, so only high and xhigh are advertised.
 base_model = "deepseek/deepseek-v4-flash"
 
 [interleaved]

--- a/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,7 +1,3 @@
-# Synced from GET /v1/models. The effort option is hand-authored: the public
-# catalog only exposes enable_thinking, but the DeepSeek V4 worker also accepts
-# reasoning_effort = "high"|"max" (xhigh maps to max). See sference-platform
-# apps/inference_worker/sference_inference_worker/models/deepseek.py.
 base_model = "deepseek/deepseek-v4-flash"
 
 [interleaved]
@@ -9,10 +5,6 @@ field = "reasoning_content"
 
 [[reasoning_options]]
 type = "toggle"
-
-[[reasoning_options]]
-type = "effort"
-values = ["high", "max"]
 
 [cost]
 input = 0.14

--- a/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,3 +1,7 @@
+# Synced from GET /v1/models. The effort option is hand-authored: the API
+# accepts OpenAI reasoning_effort on chat completions and responses, and this
+# model acts on high and xhigh; lower levels enable thinking at the default
+# depth, so only high and xhigh are advertised.
 base_model = "deepseek/deepseek-v4-flash"
 
 [interleaved]
@@ -5,6 +9,10 @@ field = "reasoning_content"
 
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "xhigh"]
 
 [cost]
 input = 0.14

--- a/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,8 +1,10 @@
 # Synced from GET /v1/models. The effort option is hand-authored: the API
 # accepts OpenAI reasoning_effort on chat completions and responses (OpenAPI
-# schema/openapi.json, ChatCompletionCreateRequest and ReasoningConfig), and
-# this model acts on high and xhigh; lower levels enable thinking at the
-# default depth, so only high and xhigh are advertised.
+# schema/openapi.json; invalid values are rejected with a 400 listing the
+# accepted enum none|minimal|low|medium|high|xhigh — verified live
+# 2026-07-23, high/xhigh probes return 200), and this model acts on high and
+# xhigh; lower levels enable thinking at the default depth, so only high and
+# xhigh are advertised.
 base_model = "deepseek/deepseek-v4-flash"
 
 [interleaved]

--- a/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,3 +1,7 @@
+# Synced from GET /v1/models. The effort option is hand-authored: the public
+# catalog only exposes enable_thinking, but the DeepSeek V4 worker also accepts
+# reasoning_effort = "high"|"max" (xhigh maps to max). See sference-platform
+# apps/inference_worker/sference_inference_worker/models/deepseek.py.
 base_model = "deepseek/deepseek-v4-flash"
 
 [interleaved]
@@ -6,10 +10,14 @@ field = "reasoning_content"
 [[reasoning_options]]
 type = "toggle"
 
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [cost]
-input = 0.08
-output = 0.2
-cache_read = 0.02
+input = 0.14
+output = 0.28
+cache_read = 0.03
 
 [limit]
 context = 1_048_576

--- a/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.08
+output = 0.2
+cache_read = 0.02
+
+[limit]
+context = 1_048_576

--- a/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -9,7 +9,7 @@ type = "toggle"
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.03
+cache_read = 0.07
 
 [limit]
 context = 1_048_576

--- a/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -6,6 +6,7 @@
 # xhigh; lower levels enable thinking at the default depth, so only high and
 # xhigh are advertised.
 base_model = "deepseek/deepseek-v4-flash"
+release_date = "2026-06-20"
 
 [interleaved]
 field = "reasoning_content"
@@ -24,4 +25,3 @@ cache_read = 0.07
 
 [limit]
 context = 1_048_576
-output = 1_048_576

--- a/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/sference/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -24,3 +24,4 @@ cache_read = 0.07
 
 [limit]
 context = 1_048_576
+output = 1_048_576

--- a/providers/sference/models/moonshotai/Kimi-K3.toml
+++ b/providers/sference/models/moonshotai/Kimi-K3.toml
@@ -1,6 +1,5 @@
-base_model = "alibaba/qwen3.6-35b-a3b"
-name = "Qwen3.6 35B"
-release_date = "2026-04-01"
+base_model = "moonshotai/kimi-k3"
+release_date = "2026-07-27"
 attachment = false
 
 [interleaved]
@@ -10,9 +9,9 @@ field = "reasoning_content"
 type = "toggle"
 
 [cost]
-input = 0.2
-output = 1.25
-cache_read = 0.05
+input = 2.25
+output = 11.25
+cache_read = 0.225
 
 [modalities]
 input = ["text"]

--- a/providers/sference/models/zai-org/GLM-5.2.toml
+++ b/providers/sference/models/zai-org/GLM-5.2.toml
@@ -1,7 +1,9 @@
 # Synced from GET /v1/models. The effort option is hand-authored: the API
-# accepts OpenAI reasoning_effort on chat completions and responses, and this
-# model acts on every level (minimal/low/medium request the lighter thinking
-# depth, high/xhigh the deeper one), so the full accepted enum is advertised.
+# accepts OpenAI reasoning_effort on chat completions and responses
+# (OpenAPI schema/openapi.json, ChatCompletionCreateRequest and
+# ReasoningConfig), and this model resolves every accepted level onto two
+# thinking depths — low selects the lighter one, high the deeper one — so only
+# those two distinct values are advertised.
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
 
@@ -13,7 +15,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh"]
+values = ["low", "high"]
 
 [cost]
 input = 1.2

--- a/providers/sference/models/zai-org/GLM-5.2.toml
+++ b/providers/sference/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,16 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM 5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 1.2
+output = 4.2
+cache_read = 0.26
+
+[limit]
+context = 1_048_576

--- a/providers/sference/models/zai-org/GLM-5.2.toml
+++ b/providers/sference/models/zai-org/GLM-5.2.toml
@@ -1,9 +1,10 @@
 # Synced from GET /v1/models. The effort option is hand-authored: the API
-# accepts OpenAI reasoning_effort on chat completions and responses
-# (OpenAPI schema/openapi.json, ChatCompletionCreateRequest and
-# ReasoningConfig), and this model resolves every accepted level onto two
-# thinking depths — low selects the lighter one, high the deeper one — so only
-# those two distinct values are advertised.
+# accepts OpenAI reasoning_effort on chat completions and responses (OpenAPI
+# schema/openapi.json; invalid values are rejected with a 400 listing the
+# accepted enum none|minimal|low|medium|high|xhigh — verified live
+# 2026-07-23, low/high probes return 200), and this model resolves every
+# accepted level onto two thinking depths — low selects the lighter one, high
+# the deeper one — so only those two distinct values are advertised.
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
 

--- a/providers/sference/models/zai-org/GLM-5.2.toml
+++ b/providers/sference/models/zai-org/GLM-5.2.toml
@@ -25,3 +25,4 @@ cache_read = 0.26
 
 [limit]
 context = 1_048_576
+output = 1_048_576

--- a/providers/sference/models/zai-org/GLM-5.2.toml
+++ b/providers/sference/models/zai-org/GLM-5.2.toml
@@ -1,3 +1,7 @@
+# Synced from GET /v1/models. The effort option is hand-authored: the API
+# accepts OpenAI reasoning_effort on chat completions and responses, and this
+# model acts on every level (minimal/low/medium request the lighter thinking
+# depth, high/xhigh the deeper one), so the full accepted enum is advertised.
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
 
@@ -6,6 +10,10 @@ field = "reasoning_content"
 
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
 input = 1.2

--- a/providers/sference/models/zai-org/GLM-5.2.toml
+++ b/providers/sference/models/zai-org/GLM-5.2.toml
@@ -7,6 +7,7 @@
 # the deeper one — so only those two distinct values are advertised.
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
+release_date = "2026-06-30"
 
 [interleaved]
 field = "reasoning_content"
@@ -25,4 +26,3 @@ cache_read = 0.26
 
 [limit]
 context = 1_048_576
-output = 1_048_576

--- a/providers/sference/provider.toml
+++ b/providers/sference/provider.toml
@@ -1,0 +1,16 @@
+# Reasoning control (accessed 2026-07-17):
+# OpenAI Chat: POST https://api.sference.com/v1/chat/completions and
+# Responses: POST https://api.sference.com/v1/responses. Toggle:
+# enable_thinking = true|false (OpenAPI contract/openapi.json
+# ChatCompletionCreateRequest and ResponseCreateRequest). The catalog marks
+# thinking support via capabilities.thinking.types.enabled; no effort or
+# token-budget control is documented, so every reasoning model uses a single
+# toggle option.
+# Sources:
+# https://sference.com/docs/models
+# https://sference.com/docs/quickstart
+name = "sference"
+env = ["SFERENCE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.sference.com/v1"
+doc = "https://sference.com/docs/models"

--- a/providers/sference/provider.toml
+++ b/providers/sference/provider.toml
@@ -4,7 +4,9 @@
 # enable_thinking = true|false (OpenAPI schema/openapi.json
 # ChatCompletionCreateRequest and ResponseCreateRequest). OpenAI
 # reasoning_effort (chat) / reasoning.effort (responses) is also accepted
-# (same schema, ReasoningConfig); the catalog marks thinking support via
+# (same schema, ReasoningConfig; invalid values are rejected with a 400
+# listing the accepted enum none|minimal|low|medium|high|xhigh — verified
+# live 2026-07-23); the catalog marks thinking support via
 # capabilities.thinking.types.enabled but does not surface which effort
 # levels a model acts on, so effort options are hand-authored per model
 # (DeepSeek-V4-Flash: high/xhigh; GLM-5.2: low/high). No token-budget

--- a/providers/sference/provider.toml
+++ b/providers/sference/provider.toml
@@ -1,11 +1,14 @@
-# Reasoning control (accessed 2026-07-17):
+# Reasoning control (accessed 2026-07-23):
 # OpenAI Chat: POST https://api.sference.com/v1/chat/completions and
 # Responses: POST https://api.sference.com/v1/responses. Toggle:
-# enable_thinking = true|false (OpenAPI contract/openapi.json
-# ChatCompletionCreateRequest and ResponseCreateRequest). The catalog marks
-# thinking support via capabilities.thinking.types.enabled; no effort or
-# token-budget control is documented, so every reasoning model uses a single
-# toggle option.
+# enable_thinking = true|false (OpenAPI schema/openapi.json
+# ChatCompletionCreateRequest and ResponseCreateRequest). OpenAI
+# reasoning_effort (chat) / reasoning.effort (responses) is also accepted
+# (same schema, ReasoningConfig); the catalog marks thinking support via
+# capabilities.thinking.types.enabled but does not surface which effort
+# levels a model acts on, so effort options are hand-authored per model
+# (DeepSeek-V4-Flash: high/xhigh; GLM-5.2: low/high). No token-budget
+# control. Other reasoning models use the single toggle option.
 # Sources:
 # https://sference.com/docs/models
 # https://sference.com/docs/quickstart


### PR DESCRIPTION
## What

Adds [sference](https://sference.com) — a managed inference platform for open-weight models, run in Europe behind an OpenAI-compatible API — as a provider.

## Why

sference serves open-weight checkpoints (GLM, Qwen, DeepSeek, ThinkingCap) with per-token pricing and a public model catalog. There was no entry for it in models.dev.

## Changes

**Provider** (`providers/sference/`):
- `provider.toml` — `@ai-sdk/openai-compatible`, base URL `https://api.sference.com/v1`. Reasoning control (`enable_thinking = true|false` toggle) documented in the header comment.
- `logo.svg` — the sference mark, `currentColor`, square `0 0 32 32` viewBox.

**Models** (sync-generated from the public `GET /v1/models` endpoint, factored onto `base_model` metadata — no duplicated provider-agnostic facts). Pricing below is current as of the latest sync; the hourly CI sync keeps it up to date.

| model | base_model | input | output | cache_read | reasoning |
|---|---|---|---|---|---|
| `zai-org/GLM-5.2` | `zhipuai/glm-5.2` | $1.20 | $4.20 | $0.26 | toggle + effort |
| `Qwen/Qwen3.6-35B-A3B` | `alibaba/qwen3.6-35b-a3b` | $0.20 | $1.25 | $0.05 | toggle |
| `deepseek-ai/DeepSeek-V4-Flash` | `deepseek/deepseek-v4-flash` | $0.14 | $0.28 | $0.07 | toggle + effort |
| `bottlecapai/ThinkingCap-Qwen3.6-27B` | `bottlecapai/thinkingcap-qwen3.6-27b` | $0.40 | $2.60 | $0.05 | toggle |
| `Qwen/Qwen3-VL-30B-A3B-Instruct` | `alibaba/qwen3-vl-30b-a3b-instruct` | $0.40 | $2.00 | $0.10 | — |

Reasoning models reason via sference's `enable_thinking = true|false` request field, so each declares `[[reasoning_options]] type = "toggle"` and an interleaved `reasoning_content` block. The API also accepts OpenAI `reasoning_effort` / `reasoning.effort` on chat completions and responses, but the public catalog does not surface which effort levels each model acts on, so effort options are hand-authored per model: **DeepSeek V4 Flash** acts on `high`/`xhigh` (lower levels enable thinking at the default depth), and **GLM-5.2** resolves every accepted level onto two thinking depths, so it advertises the two distinct values `low`/`high`. Qwen3.6 and ThinkingCap ignore the level and stay toggle-only. The sync preserves hand-authored `reasoning_options` because the API isn't authoritative for the reasoning control surface.

**New model metadata**:
- `models/bottlecapai/thinkingcap-qwen3.6-27b.toml` — ThinkingCap (Qwen3.6-27B fine-tune)
- `models/alibaba/qwen3-vl-30b-a3b-instruct.toml` — Qwen3-VL-30B-A3B-Instruct (open-weight vision-language MoE)

Both had no existing provider-agnostic `models/` entry, so one was added for each (cited to HuggingFace) so the provider models can factor onto them.

**Sync module** (`packages/core/src/sync/providers/sference.ts`):
- Reads the **public** `GET /v1/models` endpoint (auth-optional, **no `SFERENCE_API_KEY` secret required**) for pricing, context limits, and capabilities.
- Follows the chutes/venice factoring pattern: resolves `base_model` from the model ID (falling back to the org name for unmapped orgs), writes only API-authoritative overrides, and leaves fields the API omits (input limit, full modality arrays, knowledge, output limit until `max_output_tokens` ships) to inherit from base metadata.
- Preserves hand-authored `reasoning_options`; new reasoning models default to the toggle.
- The catalog's `image_input`/`pdf_input` flags are authoritative for modalities and attachment: factored models write text-only overrides when the base checkpoint metadata is richer than what sference serves (Qwen3.6 and ThinkingCap gain `input = ["text"]`, `attachment = false`).
- Pricing is already per-1M-token USD in the response (nested `pricing` object), so no token→1M conversion is needed.
- Registered in the `direct` sync group; the hourly CI job needs no secret since the catalog is public.
- Also reads `max_output_tokens` and `released` when present (see below).

**Tests** (`packages/core/test/sference-sync*.test.ts`): 12 passing — unit tests for the translate/factoring logic, `reasoning_options` preservation, and an end-to-end test that runs the full sync runner against a mocked public endpoint and verifies idempotency.

## How it stays updated

The hourly `sync-models.yml` workflow auto-discovers providers registered in `packages/core/src/sync/index.ts`, so registering sference there schedules a job that syncs the public catalog into an `automation/sync-models-sference` branch and opens/updates a PR whenever pricing, models, or limits change. No workflow edits were needed (no new secrets).

## Note on `max_output_tokens` / `released`

The sync module already reads `max_output_tokens` (→ `limit.output`) and `released` (→ `release_date`) when the API provides them. The live endpoint does not return these fields yet, so `limit.output` and `release_date` inherit from base metadata and the sync is idempotent today (verified against the live endpoint). If the API starts exposing them, the next hourly sync will write authoritative output limits and real release dates — no further models.dev changes needed.

## Sources

- https://sference.com/ (serverless pricing table)
- https://sference.com/docs/models
- https://sference.com/docs/quickstart

## Verification

- `bun validate` — sference validates with 5 models
- `bun test` — 12/12 sference tests pass
- `tsc --noEmit` — clean for the sference files (remaining errors pre-date this branch)
- `bun models:sync sference --dry-run` — idempotent (0 changes) against the live public endpoint
- Live `reasoning_effort` probes (2026-07-23): invalid value → 400 listing the accepted enum `none|minimal|low|medium|high|xhigh` (`max` → 400); `high`/`xhigh` → 200 on DeepSeek V4 Flash, `low`/`high` → 200 on GLM-5.2
- Rebased onto current `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
