### PR TITLE
feat(sync): add safe NanoGPT model catalog sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "huggingface:sync": "bun ./packages/core/script/sync-models.ts huggingface",
     "kilo:sync": "bun ./packages/core/script/sync-models.ts kilo",
     "llmgateway:sync": "bun ./packages/core/script/sync-models.ts llmgateway",
+    "nano-gpt:sync": "bun ./packages/core/script/sync-models.ts nano-gpt",
     "venice:sync": "bun ./packages/core/script/sync-models.ts venice",
     "vercel:generate": "bun ./packages/core/script/sync-models.ts vercel",
     "wandb:generate": "bun ./packages/core/script/sync-models.ts wandb",

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -73,6 +73,7 @@ export interface SyncProvider<SourceModel> {
   deleteMissing?: boolean;
   preserveSymlinks?: boolean;
   preserveBaseModels?: boolean;
+  preserveDescriptions?: boolean;
   sameModel?(current: ExistingModel, desired: SyncedModel): boolean;
   missingNotice?(paths: string[]): string[];
   /**
@@ -242,16 +243,17 @@ export async function syncProvider<SourceModel>(
     } else {
       resolvedReasoning = existing.get(relativePath)?.toml.reasoning;
     }
+    const withReasoningOptions = preserveReasoningOptions(
+      translatedModel,
+      existing.get(relativePath)?.authored,
+      resolvedReasoning,
+    );
+    const withDescription = provider.preserveDescriptions === false
+      ? withReasoningOptions
+      : preserveDescription(withReasoningOptions, existing.get(relativePath)?.authored);
     const parsed = SyncedAuthoredModel.safeParse(stripUndefined({
       id: translated.id,
-      ...preserveDescription(
-        preserveReasoningOptions(
-          translatedModel,
-          existing.get(relativePath)?.authored,
-          resolvedReasoning,
-        ),
-        existing.get(relativePath)?.authored,
-      ),
+      ...withDescription,
     }));
     if (!parsed.success) {
       parsed.error.cause = { provider: provider.id, path: relativePath };

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -18,6 +18,7 @@ import { google } from "./providers/google.js";
 import { huggingface } from "./providers/huggingface.js";
 import { kilo } from "./providers/kilo.js";
 import { llmgateway } from "./providers/llmgateway.js";
+import { nanoGpt } from "./providers/nano-gpt.js";
 import { openai } from "./providers/openai.js";
 import { openrouter } from "./providers/openrouter.js";
 import { ovhcloud } from "./providers/ovhcloud.js";
@@ -117,6 +118,7 @@ export const providers: {
   kilo: SyncProvider<any>;
   huggingface: SyncProvider<any>;
   llmgateway: SyncProvider<any>;
+  "nano-gpt": SyncProvider<any>;
   openai: SyncProvider<any>;
   openrouter: SyncProvider<any>;
   ovhcloud: SyncProvider<any>;
@@ -139,6 +141,7 @@ export const providers: {
   kilo,
   huggingface,
   llmgateway,
+  "nano-gpt": nanoGpt,
   openai,
   openrouter,
   ovhcloud,
@@ -150,7 +153,7 @@ export const providers: {
 };
 
 export const groups = {
-  aggregators: ["crossmodel", "empiriolabs", "huggingface", "kilo", "llmgateway", "openrouter", "vercel"],
+  aggregators: ["crossmodel", "empiriolabs", "huggingface", "kilo", "llmgateway", "nano-gpt", "openrouter", "vercel"],
   cloudflare: ["cloudflare-workers-ai"],
   direct: ["ambient", "anthropic", "baseten", "chutes", "deepinfra", "digitalocean", "google", "openai", "ovhcloud", "pioneer", "venice", "wandb", "xai"],
 } as const;

--- a/packages/core/src/sync/providers/nano-gpt.ts
+++ b/packages/core/src/sync/providers/nano-gpt.ts
@@ -62,6 +62,7 @@ export const nanoGpt = {
   id: "nano-gpt",
   name: "NanoGPT",
   modelsDir: "providers/nano-gpt/models",
+  preserveDescriptions: false,
   async fetchModels() {
     const response = await fetch(process.env.NANO_GPT_MODELS_URL ?? API_ENDPOINT);
     if (!response.ok) {
@@ -142,15 +143,15 @@ export function buildNanoGptModel(
   const reasoning = inferredSourceReasoning ?? existing?.reasoning ?? false;
   const cost = buildCost(model.pricing, existing);
   if (baseModel !== undefined) {
-    const preserveExistingOverrides = existing?.base_model === baseModel;
+    const existingAlreadyFactored = existing?.base_model === baseModel;
     const factoredModalities = {
-      input: hasInputMetadata || preserveExistingOverrides ? input : undefined,
-      output: hasOutputMetadata || preserveExistingOverrides ? output : undefined,
+      input: hasInputMetadata || existing !== undefined ? input : undefined,
+      output: hasOutputMetadata || existing !== undefined ? output : undefined,
     };
     const factoredLimit = {
-      context: sourceContext ?? (preserveExistingOverrides ? existing?.limit?.context : undefined),
-      input: sourceContext ?? (preserveExistingOverrides ? existing?.limit?.input : undefined),
-      output: sourceOutputLimit ?? (preserveExistingOverrides ? existing?.limit?.output : undefined),
+      context: sourceContext ?? existing?.limit?.context,
+      input: sourceContext ?? existing?.limit?.input,
+      output: sourceOutputLimit ?? existing?.limit?.output,
     };
     const sourceReasoning = inferredSourceReasoning;
     const sourceReasoningOptions = reasoningOptions(model, sourceReasoning, existing?.reasoning_options);
@@ -159,21 +160,19 @@ export function buildNanoGptModel(
       baseModel,
       {
         name: existing?.name ?? model.name ?? undefined,
-        description: preserveExistingOverrides ? existing?.description : undefined,
-        family: preserveExistingOverrides ? existing?.family : undefined,
-        release_date: preserveExistingOverrides ? existing?.release_date : undefined,
-        last_updated: preserveExistingOverrides ? existing?.last_updated : undefined,
+        description: existingAlreadyFactored ? existing?.description : undefined,
+        family: existingAlreadyFactored ? existing?.family : undefined,
+        release_date: existingAlreadyFactored ? existing?.release_date : undefined,
+        last_updated: existingAlreadyFactored ? existing?.last_updated : undefined,
         attachment: hasInputMetadata
           ? input.some((value) => value !== "text")
-          : preserveExistingOverrides ? existing?.attachment : undefined,
-        reasoning: sourceReasoning ?? (preserveExistingOverrides ? existing?.reasoning : undefined),
+          : existing?.attachment,
+        reasoning: sourceReasoning ?? existing?.reasoning,
         reasoning_options: sourceReasoningOptions,
-        temperature: preserveExistingOverrides ? existing?.temperature : undefined,
-        tool_call: capabilities.tool_calling
-          ?? (preserveExistingOverrides ? existing?.tool_call : undefined),
-        structured_output: capabilities.structured_output
-          ?? (preserveExistingOverrides ? existing?.structured_output : undefined),
-        knowledge: preserveExistingOverrides ? existing?.knowledge : undefined,
+        temperature: existing?.temperature,
+        tool_call: capabilities.tool_calling ?? existing?.tool_call,
+        structured_output: capabilities.structured_output ?? existing?.structured_output,
+        knowledge: existing?.knowledge,
         status: existing?.status,
         interleaved: existing?.interleaved,
         provider: existing?.provider,
@@ -183,7 +182,7 @@ export function buildNanoGptModel(
         modalities: factoredModalities,
       },
       factoredLimit,
-      preserveExistingOverrides ? existing?.base_model_omit : undefined,
+      existingAlreadyFactored ? existing?.base_model_omit : undefined,
     );
   }
 

--- a/packages/core/src/sync/providers/nano-gpt.ts
+++ b/packages/core/src/sync/providers/nano-gpt.ts
@@ -2,14 +2,13 @@ import { z } from "zod";
 
 import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
-import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
+import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://nano-gpt.com/api/v1/models?detailed=true";
 
-const ReasoningEffort = z.union([
-  z.null(),
-  z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max", "default"]),
-]);
+// NanoGPT accepts these exact request values, including `max`:
+// https://github.com/Nano-GPT-com/nanogpt/blob/073b25b07e9af619333c679e694de664bf1ceb30/lib/utils/reasoningInput.ts#L12-L28
+const ReasoningEffort = z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
 
 const Pricing = z.object({
   prompt: z.number().nullish(),
@@ -75,9 +74,13 @@ export const nanoGpt = {
   },
   translateModel(model, context) {
     const id = normalizeModelID(model.id);
+    const existing = context.existing(id);
+    const baseModel = existing?.base_model ?? resolveNanoGptBaseModel(model.id);
+    const translated = buildNanoGptModel(model, existing, baseModel);
+    if (translated === undefined) return undefined;
     return {
       id,
-      model: buildNanoGptModel(model, context.existing(id)),
+      model: translated,
     };
   },
 } satisfies SyncProvider<NanoGptModel>;
@@ -92,34 +95,11 @@ const BASE_MODEL_ALIASES: Record<string, string | undefined> = {
   "claude-opus-4": "anthropic/claude-opus-4-0",
   "claude-sonnet-4": "anthropic/claude-sonnet-4-0",
   "cohere/north-mini-code": "cohere/north-mini-code-1-0",
-  "sakana/fugu-ultra": "sakana/fugu-ultra",
 };
 
-const NANO_GPT_VARIANT_SUFFIX = /(?::(?:thinking|none|minimal|low|medium|high|xhigh|max|default|\d+)|-thinking)$/i;
-
-const UNPREFIXED_CANONICAL_PREFIXES = [
-  "alibaba",
-  "anthropic",
-  "cohere",
-  "deepseek",
-  "google",
-  "meta",
-  "minimax",
-  "mistralai",
-  "moonshotai",
-  "nvidia",
-  "openai",
-  "qwen",
-  "stepfun",
-  "tencent",
-  "thinkingmachines",
-  "xai",
-  "xiaomi",
-  "z-ai",
-] as const;
+const NANO_GPT_VARIANT_SUFFIX = /(?::(?:thinking|none|minimal|low|medium|high|xhigh|max|\d+)|-thinking)$/i;
 
 const KNOWN_OPEN_WEIGHT_IDS = new Set([
-  "cohere/north-mini-code",
   "nex-agi/nex-n2-pro",
 ]);
 
@@ -127,58 +107,111 @@ export function buildNanoGptModel(
   model: NanoGptModel,
   existing: ExistingModel | undefined,
   baseModel = existing?.base_model ?? resolveNanoGptBaseModel(model.id),
-  today = new Date().toISOString().slice(0, 10),
-): SyncedModel {
+): SyncedModel | undefined {
   const capabilities = model.capabilities ?? {};
-  const input = normalizeModalities([
-    ...model.architecture?.input_modalities ?? ["text"],
+  const explicitInputModalities = model.architecture?.input_modalities;
+  const hasInputCapabilityMetadata = capabilities.vision !== undefined
+    || capabilities.audio_input !== undefined
+    || capabilities.video_input !== undefined
+    || capabilities.pdf_upload !== undefined;
+  const addedInputModalities = [
     ...(capabilities.vision ? ["image"] : []),
     ...(capabilities.audio_input ? ["audio"] : []),
     ...(capabilities.video_input ? ["video"] : []),
     ...(capabilities.pdf_upload ? ["pdf"] : []),
+  ];
+  const hasInputMetadata = explicitInputModalities !== undefined || hasInputCapabilityMetadata;
+  const hasOutputMetadata = model.architecture?.output_modalities !== undefined;
+  const input = normalizeModalities([
+    ...explicitInputModalities
+      ?? (hasInputCapabilityMetadata ? ["text"] : existing?.modalities?.input)
+      ?? ["text"],
+    ...addedInputModalities,
   ]);
-  const output = normalizeModalities(model.architecture?.output_modalities ?? ["text"]);
-  const context = positive(model.context_length) ?? existing?.limit?.context ?? 0;
-  const outputLimit = positive(model.max_output_tokens) ?? existing?.limit?.output ?? 0;
-  const releaseDate = dateFromTimestamp(model.created) ?? existing?.release_date ?? today;
-  const reasoning = capabilities.reasoning ?? existing?.reasoning ?? false;
+  const output = normalizeModalities(
+    model.architecture?.output_modalities ?? existing?.modalities?.output ?? ["text"],
+  );
+  const sourceContext = positive(model.context_length);
+  const sourceOutputLimit = positive(model.max_output_tokens);
+  const context = sourceContext ?? existing?.limit?.context;
+  const inputLimit = sourceContext ?? existing?.limit?.input;
+  const outputLimit = sourceOutputLimit ?? existing?.limit?.output;
+  const releaseDate = dateFromTimestamp(model.created) ?? existing?.release_date;
+  const inferredSourceReasoning = capabilities.reasoning
+    ?? (model.reasoning_efforts != null ? true : undefined);
+  const reasoning = inferredSourceReasoning ?? existing?.reasoning ?? false;
   const cost = buildCost(model.pricing, existing);
-  const limit = {
-    context,
-    input: context,
-    output: outputLimit,
-  };
+  if (baseModel !== undefined) {
+    const preserveExistingOverrides = existing?.base_model === baseModel;
+    const factoredModalities = {
+      input: hasInputMetadata || preserveExistingOverrides ? input : undefined,
+      output: hasOutputMetadata || preserveExistingOverrides ? output : undefined,
+    };
+    const factoredLimit = {
+      context: sourceContext ?? (preserveExistingOverrides ? existing?.limit?.context : undefined),
+      input: sourceContext ?? (preserveExistingOverrides ? existing?.limit?.input : undefined),
+      output: sourceOutputLimit ?? (preserveExistingOverrides ? existing?.limit?.output : undefined),
+    };
+    const sourceReasoning = inferredSourceReasoning;
+    const sourceReasoningOptions = reasoningOptions(model, sourceReasoning, existing?.reasoning_options);
+
+    return factorBaseModel(
+      baseModel,
+      {
+        name: existing?.name ?? model.name ?? undefined,
+        description: preserveExistingOverrides ? existing?.description : undefined,
+        family: preserveExistingOverrides ? existing?.family : undefined,
+        release_date: preserveExistingOverrides ? existing?.release_date : undefined,
+        last_updated: preserveExistingOverrides ? existing?.last_updated : undefined,
+        attachment: hasInputMetadata
+          ? input.some((value) => value !== "text")
+          : preserveExistingOverrides ? existing?.attachment : undefined,
+        reasoning: sourceReasoning ?? (preserveExistingOverrides ? existing?.reasoning : undefined),
+        reasoning_options: sourceReasoningOptions,
+        temperature: preserveExistingOverrides ? existing?.temperature : undefined,
+        tool_call: capabilities.tool_calling
+          ?? (preserveExistingOverrides ? existing?.tool_call : undefined),
+        structured_output: capabilities.structured_output
+          ?? (preserveExistingOverrides ? existing?.structured_output : undefined),
+        knowledge: preserveExistingOverrides ? existing?.knowledge : undefined,
+        status: existing?.status,
+        interleaved: existing?.interleaved,
+        provider: existing?.provider,
+        experimental: existing?.experimental,
+        cost,
+        limit: factoredLimit,
+        modalities: factoredModalities,
+      },
+      factoredLimit,
+      preserveExistingOverrides ? existing?.base_model_omit : undefined,
+    );
+  }
+
+  if (context === undefined || outputLimit === undefined || releaseDate === undefined) {
+    return undefined;
+  }
+
   const values = {
     name: existing?.name ?? model.name ?? humanizeModelName(model.id),
     description: existing?.description ?? model.description ?? `${model.name ?? humanizeModelName(model.id)} on NanoGPT.`,
     family: existing?.family ?? inferFamily(model.id, model.name ?? ""),
-    release_date: existing?.release_date ?? releaseDate,
+    release_date: releaseDate,
     last_updated: existing?.last_updated ?? releaseDate,
     attachment: input.some((value) => value !== "text"),
     reasoning,
-    reasoning_options: reasoningOptions(model, reasoning),
+    reasoning_options: reasoningOptions(model, reasoning, existing?.reasoning_options),
     temperature: existing?.temperature,
     tool_call: capabilities.tool_calling ?? existing?.tool_call ?? false,
     structured_output: capabilities.structured_output ?? existing?.structured_output,
     knowledge: existing?.knowledge,
     status: existing?.status,
     interleaved: existing?.interleaved,
+    provider: existing?.provider,
+    experimental: existing?.experimental,
     cost,
-    limit,
+    limit: { context, input: inputLimit ?? context, output: outputLimit },
     modalities: { input, output },
   };
-
-  if (baseModel !== undefined) {
-    return factorBaseModel(
-      baseModel,
-      {
-        ...values,
-        open_weights: model.open_weights ?? undefined,
-      },
-      limit,
-      existing?.base_model === baseModel ? existing.base_model_omit : undefined,
-    );
-  }
 
   return {
     ...values,
@@ -193,20 +226,20 @@ function buildCost(
   existing: ExistingModel | undefined,
 ): SyncedFullModel["cost"] {
   if (pricing === undefined) return existing?.cost;
-  if (pricing.note === "varies_by_modality") return undefined;
+  if (pricing.note === "varies_by_modality") return existing?.cost;
 
   const input = pricing.input ?? pricing.prompt;
   const output = pricing.output ?? pricing.completion;
-  if (input == null || output == null) return existing?.cost;
+  if (!validPrice(input) || !validPrice(output)) return existing?.cost;
 
   return {
     input: price(input),
     output: price(output),
     reasoning: existing?.cost?.reasoning,
-    cache_read: pricing.cacheReadInputPer1kTokens == null
+    cache_read: !validPrice(pricing.cacheReadInputPer1kTokens)
       ? existing?.cost?.cache_read
       : price(pricing.cacheReadInputPer1kTokens * 1_000),
-    cache_write: pricing.cacheWriteInputPer1kTokens == null
+    cache_write: !validPrice(pricing.cacheWriteInputPer1kTokens)
       ? existing?.cost?.cache_write
       : price(pricing.cacheWriteInputPer1kTokens * 1_000),
     input_audio: existing?.cost?.input_audio,
@@ -217,34 +250,31 @@ function buildCost(
 
 function reasoningOptions(
   model: NanoGptModel,
-  reasoning: boolean,
+  reasoning: boolean | undefined,
+  existing: SyncedFullModel["reasoning_options"],
 ): SyncedFullModel["reasoning_options"] {
-  if (!reasoning) return undefined;
-  if (model.reasoning_efforts == null || model.reasoning_efforts.length === 0) return [];
+  if (reasoning === false) return undefined;
+  if (reasoning === undefined) return existing;
+  if (model.reasoning_efforts == null) return existing ?? [];
+  if (model.reasoning_efforts.length === 0) return [];
   return [{ type: "effort", values: [...model.reasoning_efforts] }];
 }
 
 export function resolveNanoGptBaseModel(modelID: string) {
-  let normalized = stripNanoGptVariantSuffixes(normalizeModelID(modelID));
+  let normalized = normalizeModelID(modelID);
   if (normalized.toLowerCase().startsWith("tee/")) {
     normalized = normalizeModelID(normalized.slice("TEE/".length));
   }
 
-  const alias = BASE_MODEL_ALIASES[normalized.toLowerCase()];
-  if (alias !== undefined) return alias;
+  const exact = resolveNanoGptCanonicalCandidate(normalized);
+  if (exact !== undefined) return exact;
 
-  if (normalized.toLowerCase().startsWith("zai-org/")) {
-    return resolveCanonicalBaseModel(`z-ai/${normalized.slice("zai-org/".length)}`);
-  }
+  const stripped = stripNanoGptVariantSuffixes(normalized);
+  return stripped === normalized ? undefined : resolveNanoGptCanonicalCandidate(stripped);
+}
 
-  const direct = resolveCanonicalBaseModel(normalized);
-  if (direct !== undefined || normalized.includes("/")) return direct;
-
-  const matches = UNPREFIXED_CANONICAL_PREFIXES
-    .map((prefix) => resolveCanonicalBaseModel(`${prefix}/${normalized}`))
-    .filter((candidate): candidate is string => candidate !== undefined);
-  const unique = [...new Set(matches)];
-  return unique.length === 1 ? unique[0] : undefined;
+function resolveNanoGptCanonicalCandidate(modelID: string) {
+  return BASE_MODEL_ALIASES[modelID.toLowerCase()] ?? resolveModelMetadataBaseModel(modelID);
 }
 
 function stripNanoGptVariantSuffixes(modelID: string) {
@@ -289,7 +319,7 @@ function inferFamily(id: string, name: string) {
     .sort((a, b) => b.length - a.length)
     .find((family) => {
       const value = family.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      if (family === "o") return new RegExp(`(^|[^a-z0-9])${value}(?=\\d|$|[^a-z0-9])`).test(target);
+      if (family === "o") return new RegExp(`(^|[^a-z0-9])${value}(?=\\d)`).test(target);
       return new RegExp(`(^|[^a-z0-9])${value}(?=$|[^a-z0-9])`).test(target);
     });
 }
@@ -312,4 +342,8 @@ function positive(value: number | null | undefined) {
 
 function price(value: number) {
   return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function validPrice(value: number | null | undefined): value is number {
+  return value !== null && value !== undefined && value >= 0;
 }

--- a/packages/core/src/sync/providers/nano-gpt.ts
+++ b/packages/core/src/sync/providers/nano-gpt.ts
@@ -1,0 +1,279 @@
+import { z } from "zod";
+
+import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://nano-gpt.com/api/v1/models?detailed=true";
+
+const ReasoningEffort = z.union([
+  z.null(),
+  z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max", "default"]),
+]);
+
+const Pricing = z.object({
+  prompt: z.number().nullish(),
+  completion: z.number().nullish(),
+  input: z.number().nullish(),
+  output: z.number().nullish(),
+  cacheReadInputPer1kTokens: z.number().nullish(),
+  cacheWriteInputPer1kTokens: z.number().nullish(),
+  note: z.string().optional(),
+}).passthrough();
+
+const Architecture = z.object({
+  input_modalities: z.array(z.string()).optional(),
+  output_modalities: z.array(z.string()).optional(),
+}).passthrough();
+
+const Capabilities = z.object({
+  vision: z.boolean().optional(),
+  video_input: z.boolean().optional(),
+  audio_input: z.boolean().optional(),
+  reasoning: z.boolean().optional(),
+  tool_calling: z.boolean().optional(),
+  structured_output: z.boolean().optional(),
+  pdf_upload: z.boolean().optional(),
+}).passthrough();
+
+export const NanoGptModel = z.object({
+  id: z.string().min(1),
+  name: z.string().nullish(),
+  description: z.string().nullish(),
+  created: z.number().nullish(),
+  owned_by: z.string().nullish(),
+  context_length: z.number().int().nonnegative().nullish(),
+  max_output_tokens: z.number().int().nonnegative().nullish(),
+  architecture: Architecture.optional(),
+  capabilities: Capabilities.optional(),
+  reasoning_efforts: z.array(ReasoningEffort).nullish(),
+  open_weights: z.boolean().nullish(),
+  pricing: Pricing.optional(),
+}).passthrough();
+
+export const NanoGptResponse = z.object({
+  data: z.array(NanoGptModel),
+}).passthrough();
+
+export type NanoGptModel = z.infer<typeof NanoGptModel>;
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+export const nanoGpt = {
+  id: "nano-gpt",
+  name: "NanoGPT",
+  modelsDir: "providers/nano-gpt/models",
+  async fetchModels() {
+    const response = await fetch(process.env.NANO_GPT_MODELS_URL ?? API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`NanoGPT models request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return NanoGptResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    const id = normalizeModelID(model.id);
+    return {
+      id,
+      model: buildNanoGptModel(model, context.existing(id)),
+    };
+  },
+} satisfies SyncProvider<NanoGptModel>;
+
+const ORG_ID_NORMALIZATION: Record<string, string | undefined> = {
+  nousresearch: "NousResearch",
+  qwen: "qwen",
+  thedrummer: "TheDrummer",
+};
+
+const BASE_MODEL_ALIASES: Record<string, string | undefined> = {
+  "cohere/north-mini-code": "cohere/north-mini-code-1-0",
+  "sakana/fugu-ultra": "sakana/fugu-ultra",
+  "xiaomi/mimo-v2.5-pro-ultraspeed": "xiaomi/mimo-v2.5-pro",
+};
+
+const KNOWN_OPEN_WEIGHT_IDS = new Set([
+  "cohere/north-mini-code",
+  "nex-agi/nex-n2-pro",
+]);
+
+export function buildNanoGptModel(
+  model: NanoGptModel,
+  existing: ExistingModel | undefined,
+  baseModel = existing?.base_model ?? resolveNanoGptBaseModel(model.id),
+  today = new Date().toISOString().slice(0, 10),
+): SyncedModel {
+  const capabilities = model.capabilities ?? {};
+  const input = normalizeModalities([
+    ...model.architecture?.input_modalities ?? ["text"],
+    ...(capabilities.vision ? ["image"] : []),
+    ...(capabilities.audio_input ? ["audio"] : []),
+    ...(capabilities.video_input ? ["video"] : []),
+    ...(capabilities.pdf_upload ? ["pdf"] : []),
+  ]);
+  const output = normalizeModalities(model.architecture?.output_modalities ?? ["text"]);
+  const context = positive(model.context_length) ?? existing?.limit?.context ?? 0;
+  const outputLimit = positive(model.max_output_tokens) ?? existing?.limit?.output ?? 0;
+  const releaseDate = dateFromTimestamp(model.created) ?? existing?.release_date ?? today;
+  const reasoning = capabilities.reasoning ?? existing?.reasoning ?? false;
+  const cost = buildCost(model.pricing, existing);
+  const limit = {
+    context,
+    input: context,
+    output: outputLimit,
+  };
+  const values = {
+    name: existing?.name ?? model.name ?? humanizeModelName(model.id),
+    description: existing?.description ?? model.description ?? `${model.name ?? humanizeModelName(model.id)} on NanoGPT.`,
+    family: existing?.family ?? inferFamily(model.id, model.name ?? ""),
+    release_date: existing?.release_date ?? releaseDate,
+    last_updated: existing?.last_updated ?? releaseDate,
+    attachment: input.some((value) => value !== "text"),
+    reasoning,
+    reasoning_options: reasoningOptions(model, reasoning),
+    temperature: existing?.temperature,
+    tool_call: capabilities.tool_calling ?? existing?.tool_call ?? false,
+    structured_output: capabilities.structured_output ?? existing?.structured_output,
+    knowledge: existing?.knowledge,
+    status: existing?.status,
+    interleaved: existing?.interleaved,
+    cost,
+    limit,
+    modalities: { input, output },
+  };
+
+  if (baseModel !== undefined) {
+    return factorBaseModel(
+      baseModel,
+      {
+        ...values,
+        open_weights: model.open_weights ?? undefined,
+      },
+      limit,
+      existing?.base_model === baseModel ? existing.base_model_omit : undefined,
+    );
+  }
+
+  return {
+    ...values,
+    open_weights: model.open_weights
+      ?? (KNOWN_OPEN_WEIGHT_IDS.has(model.id.toLowerCase()) ? true : existing?.open_weights)
+      ?? false,
+  } satisfies SyncedFullModel;
+}
+
+function buildCost(
+  pricing: NanoGptModel["pricing"],
+  existing: ExistingModel | undefined,
+): SyncedFullModel["cost"] {
+  if (pricing === undefined) return existing?.cost;
+  if (pricing.note === "varies_by_modality") return undefined;
+
+  const input = pricing.input ?? pricing.prompt;
+  const output = pricing.output ?? pricing.completion;
+  if (input == null || output == null) return existing?.cost;
+
+  return {
+    input: price(input),
+    output: price(output),
+    reasoning: existing?.cost?.reasoning,
+    cache_read: pricing.cacheReadInputPer1kTokens == null
+      ? existing?.cost?.cache_read
+      : price(pricing.cacheReadInputPer1kTokens * 1_000),
+    cache_write: pricing.cacheWriteInputPer1kTokens == null
+      ? existing?.cost?.cache_write
+      : price(pricing.cacheWriteInputPer1kTokens * 1_000),
+    input_audio: existing?.cost?.input_audio,
+    output_audio: existing?.cost?.output_audio,
+    tiers: existing?.cost?.tiers,
+  };
+}
+
+function reasoningOptions(
+  model: NanoGptModel,
+  reasoning: boolean,
+): SyncedFullModel["reasoning_options"] {
+  if (!reasoning) return undefined;
+  if (model.reasoning_efforts == null || model.reasoning_efforts.length === 0) return [];
+  return [{ type: "effort", values: [...model.reasoning_efforts] }];
+}
+
+export function resolveNanoGptBaseModel(modelID: string) {
+  const normalized = normalizeModelID(modelID).replace(/:thinking$/, "");
+  const alias = BASE_MODEL_ALIASES[normalized.toLowerCase()];
+  if (alias !== undefined) return alias;
+
+  if (normalized.toLowerCase().startsWith("zai-org/")) {
+    return resolveCanonicalBaseModel(`z-ai/${normalized.slice("zai-org/".length)}`);
+  }
+
+  if (normalized.startsWith("TEE/")) {
+    const model = normalized.slice("TEE/".length);
+    const lower = model.toLowerCase();
+    if (lower.startsWith("deepseek")) return resolveCanonicalBaseModel(`deepseek/${model}`);
+    if (lower.startsWith("qwen")) return resolveCanonicalBaseModel(`qwen/${model}`);
+    if (lower.startsWith("glm")) return resolveCanonicalBaseModel(`z-ai/${model}`);
+  }
+
+  return resolveCanonicalBaseModel(normalized);
+}
+
+function normalizeModalities(values: string[]): Modality[] {
+  const allowed = new Set<Modality>(["text", "audio", "image", "video", "pdf"]);
+  const result = values
+    .map((value) => normalizeModality(value))
+    .filter((value): value is Modality => allowed.has(value as Modality));
+  return [...new Set(result.length > 0 ? result : ["text"] as Modality[])];
+}
+
+function normalizeModality(value: string) {
+  const lower = value.toLowerCase();
+  if (lower === "images") return "image";
+  if (lower === "videos") return "video";
+  if (lower === "audios") return "audio";
+  if (lower === "documents") return "pdf";
+  return lower;
+}
+
+function normalizeModelID(modelId: string) {
+  const [org, ...parts] = modelId.split("/");
+  if (org === undefined || parts.length === 0) return modelId;
+  const normalizedOrg = ORG_ID_NORMALIZATION[org.toLowerCase()];
+  return normalizedOrg === undefined ? modelId : `${normalizedOrg}/${parts.join("/")}`;
+}
+
+function inferFamily(id: string, name: string) {
+  const kimiFamily = inferKimiFamily(id, name);
+  if (kimiFamily !== undefined) return kimiFamily;
+
+  const target = `${id} ${name}`.toLowerCase();
+  return [...ModelFamilyValues]
+    .sort((a, b) => b.length - a.length)
+    .find((family) => {
+      const value = family.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      if (family === "o") return new RegExp(`(^|[^a-z0-9])${value}(?=\\d|$|[^a-z0-9])`).test(target);
+      return new RegExp(`(^|[^a-z0-9])${value}(?=$|[^a-z0-9])`).test(target);
+    });
+}
+
+function humanizeModelName(modelId: string) {
+  const modelPart = modelId.split("/").at(-1) ?? modelId;
+  return modelPart
+    .replace(/[:/_-]+/g, " ")
+    .replace(/\b\w/g, (value) => value.toUpperCase());
+}
+
+function dateFromTimestamp(timestamp: number | null | undefined) {
+  if (timestamp == null || timestamp <= 0) return undefined;
+  return new Date(timestamp * 1_000).toISOString().slice(0, 10);
+}
+
+function positive(value: number | null | undefined) {
+  return value == null || value <= 0 ? undefined : value;
+}
+
+function price(value: number) {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}

--- a/packages/core/src/sync/providers/nano-gpt.ts
+++ b/packages/core/src/sync/providers/nano-gpt.ts
@@ -93,8 +93,9 @@ const BASE_MODEL_ALIASES: Record<string, string | undefined> = {
   "claude-sonnet-4": "anthropic/claude-sonnet-4-0",
   "cohere/north-mini-code": "cohere/north-mini-code-1-0",
   "sakana/fugu-ultra": "sakana/fugu-ultra",
-  "xiaomi/mimo-v2.5-pro-ultraspeed": "xiaomi/mimo-v2.5-pro",
 };
+
+const NANO_GPT_VARIANT_SUFFIX = /(?::(?:thinking|none|minimal|low|medium|high|xhigh|max|default|\d+)|-thinking)$/i;
 
 const UNPREFIXED_CANONICAL_PREFIXES = [
   "alibaba",
@@ -224,22 +225,16 @@ function reasoningOptions(
 }
 
 export function resolveNanoGptBaseModel(modelID: string) {
-  const normalized = normalizeModelID(modelID)
-    .replace(/:\d+$/, "")
-    .replace(/(?::thinking|-thinking)$/, "");
+  let normalized = stripNanoGptVariantSuffixes(normalizeModelID(modelID));
+  if (normalized.toLowerCase().startsWith("tee/")) {
+    normalized = normalizeModelID(normalized.slice("TEE/".length));
+  }
+
   const alias = BASE_MODEL_ALIASES[normalized.toLowerCase()];
   if (alias !== undefined) return alias;
 
   if (normalized.toLowerCase().startsWith("zai-org/")) {
     return resolveCanonicalBaseModel(`z-ai/${normalized.slice("zai-org/".length)}`);
-  }
-
-  if (normalized.startsWith("TEE/")) {
-    const model = normalized.slice("TEE/".length);
-    const lower = model.toLowerCase();
-    if (lower.startsWith("deepseek")) return resolveCanonicalBaseModel(`deepseek/${model}`);
-    if (lower.startsWith("qwen")) return resolveCanonicalBaseModel(`qwen/${model}`);
-    if (lower.startsWith("glm")) return resolveCanonicalBaseModel(`z-ai/${model}`);
   }
 
   const direct = resolveCanonicalBaseModel(normalized);
@@ -250,6 +245,15 @@ export function resolveNanoGptBaseModel(modelID: string) {
     .filter((candidate): candidate is string => candidate !== undefined);
   const unique = [...new Set(matches)];
   return unique.length === 1 ? unique[0] : undefined;
+}
+
+function stripNanoGptVariantSuffixes(modelID: string) {
+  let normalized = modelID;
+  while (true) {
+    const stripped = normalized.replace(NANO_GPT_VARIANT_SUFFIX, "");
+    if (stripped === normalized) return normalized;
+    normalized = stripped;
+  }
 }
 
 function normalizeModalities(values: string[]): Modality[] {

--- a/packages/core/src/sync/providers/nano-gpt.ts
+++ b/packages/core/src/sync/providers/nano-gpt.ts
@@ -89,10 +89,33 @@ const ORG_ID_NORMALIZATION: Record<string, string | undefined> = {
 };
 
 const BASE_MODEL_ALIASES: Record<string, string | undefined> = {
+  "claude-opus-4": "anthropic/claude-opus-4-0",
+  "claude-sonnet-4": "anthropic/claude-sonnet-4-0",
   "cohere/north-mini-code": "cohere/north-mini-code-1-0",
   "sakana/fugu-ultra": "sakana/fugu-ultra",
   "xiaomi/mimo-v2.5-pro-ultraspeed": "xiaomi/mimo-v2.5-pro",
 };
+
+const UNPREFIXED_CANONICAL_PREFIXES = [
+  "alibaba",
+  "anthropic",
+  "cohere",
+  "deepseek",
+  "google",
+  "meta",
+  "minimax",
+  "mistralai",
+  "moonshotai",
+  "nvidia",
+  "openai",
+  "qwen",
+  "stepfun",
+  "tencent",
+  "thinkingmachines",
+  "xai",
+  "xiaomi",
+  "z-ai",
+] as const;
 
 const KNOWN_OPEN_WEIGHT_IDS = new Set([
   "cohere/north-mini-code",
@@ -201,7 +224,9 @@ function reasoningOptions(
 }
 
 export function resolveNanoGptBaseModel(modelID: string) {
-  const normalized = normalizeModelID(modelID).replace(/:thinking$/, "");
+  const normalized = normalizeModelID(modelID)
+    .replace(/:\d+$/, "")
+    .replace(/(?::thinking|-thinking)$/, "");
   const alias = BASE_MODEL_ALIASES[normalized.toLowerCase()];
   if (alias !== undefined) return alias;
 
@@ -217,7 +242,14 @@ export function resolveNanoGptBaseModel(modelID: string) {
     if (lower.startsWith("glm")) return resolveCanonicalBaseModel(`z-ai/${model}`);
   }
 
-  return resolveCanonicalBaseModel(normalized);
+  const direct = resolveCanonicalBaseModel(normalized);
+  if (direct !== undefined || normalized.includes("/")) return direct;
+
+  const matches = UNPREFIXED_CANONICAL_PREFIXES
+    .map((prefix) => resolveCanonicalBaseModel(`${prefix}/${normalized}`))
+    .filter((candidate): candidate is string => candidate !== undefined);
+  const unique = [...new Set(matches)];
+  return unique.length === 1 ? unique[0] : undefined;
 }
 
 function normalizeModalities(values: string[]): Modality[] {

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -10,6 +10,7 @@ const API_ENDPOINT = "https://openrouter.ai/api/v1/models";
 const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
 const modelMetadataByID = new Map<string, Record<string, unknown>>();
 const modelMetadataFilesByProvider = new Map<string, Set<string>>();
+let allModelMetadataIDs: string[] | undefined;
 
 const CANONICAL_BASE_MODEL_OVERRIDES = {
   "openai/gpt-5.6-luna-pro": "openai/gpt-5.6-luna",
@@ -34,6 +35,7 @@ const CANONICAL_PROVIDER_PREFIXES = {
   nvidia: { provider: "nvidia", metadata: "nvidia" },
   qwen: { provider: "alibaba", metadata: "alibaba" },
   stepfun: { provider: "stepfun", metadata: "stepfun" },
+  "stepfun-ai": { provider: "stepfun", metadata: "stepfun" },
   tencent: { provider: "tencent", metadata: "tencent" },
   thinkingmachines: { provider: "thinkingmachines", metadata: "thinkingmachines" },
   "x-ai": { provider: "xai", metadata: "xai" },
@@ -41,6 +43,7 @@ const CANONICAL_PROVIDER_PREFIXES = {
   xiaomi: { provider: "xiaomi", metadata: "xiaomi" },
   zai: { provider: "zai", metadata: "zhipuai" },
   "z-ai": { provider: "zai", metadata: "zhipuai" },
+  "zai-org": { provider: "zai", metadata: "zhipuai" },
 } as const;
 
 export const OpenRouterModel = z.object({
@@ -309,19 +312,39 @@ export function resolveCanonicalBaseModel(openrouterID: string) {
   if (prefix === undefined || modelParts.length === 0) return undefined;
   if (openrouterID.startsWith("~/") || prefix.startsWith("~")) return undefined;
 
-  const canonical = CANONICAL_PROVIDER_PREFIXES[prefix as keyof typeof CANONICAL_PROVIDER_PREFIXES];
+  const canonical = CANONICAL_PROVIDER_PREFIXES[
+    prefix.toLowerCase() as keyof typeof CANONICAL_PROVIDER_PREFIXES
+  ];
   if (canonical === undefined) return undefined;
 
   const modelID = modelParts.join("/").replace(/:free$/, "");
   const candidates = canonicalCandidates(canonical.provider, modelID);
-  const match = candidates.find((candidate) => {
-    return modelMetadataExists(canonical.metadata, candidate);
-  });
+  const match = matchingModelMetadataFile(canonical.metadata, candidates);
 
   return match === undefined ? undefined : `${canonical.metadata}/${match}`;
 }
 
-function modelMetadataExists(provider: string, modelID: string) {
+/**
+ * Resolve provider IDs that are not OpenRouter-shaped against the same canonical
+ * metadata tree. Exact paths win; bare IDs only resolve when their filename is
+ * unique across every metadata provider.
+ */
+export function resolveModelMetadataBaseModel(modelID: string) {
+  const routed = resolveCanonicalBaseModel(modelID);
+  if (routed !== undefined) return routed;
+
+  const normalized = modelID.replace(/:free$/, "");
+  const ids = modelMetadataIDs();
+  const exact = ids.find((candidate) => candidate.toLowerCase() === normalized.toLowerCase());
+  if (exact !== undefined) return exact;
+  if (normalized.includes("/")) return undefined;
+
+  const lower = normalized.toLowerCase();
+  const matches = ids.filter((candidate) => candidate.split("/").at(-1)?.toLowerCase() === lower);
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function matchingModelMetadataFile(provider: string, candidates: string[]) {
   let files = modelMetadataFilesByProvider.get(provider);
   if (files === undefined) {
     try {
@@ -331,7 +354,30 @@ function modelMetadataExists(provider: string, modelID: string) {
     }
     modelMetadataFilesByProvider.set(provider, files);
   }
-  return files.has(`${modelID}.toml`);
+
+  for (const candidate of candidates) {
+    const expected = `${candidate}.toml`.toLowerCase();
+    const match = [...files].find((file) => file.toLowerCase() === expected);
+    if (match !== undefined) return match.slice(0, -".toml".length);
+  }
+  return undefined;
+}
+
+function modelMetadataIDs() {
+  if (allModelMetadataIDs !== undefined) return allModelMetadataIDs;
+
+  try {
+    allModelMetadataIDs = readdirSync(MODELS_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .flatMap((entry) => {
+        return readdirSync(path.join(MODELS_DIR, entry.name))
+          .filter((file) => file.endsWith(".toml"))
+          .map((file) => `${entry.name}/${file.slice(0, -".toml".length)}`);
+      });
+  } catch {
+    allModelMetadataIDs = [];
+  }
+  return allModelMetadataIDs;
 }
 
 function canonicalBaseModelOverride(openrouterID: string) {
@@ -358,10 +404,18 @@ function normalizeModelSlug(value: string) {
   return value.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
 }
 
+type BaseModelOverrides = Omit<Partial<SyncedFullModel>, "limit" | "modalities"> & {
+  limit?: Partial<SyncedFullModel["limit"]>;
+  modalities?: {
+    input?: SyncedFullModel["modalities"]["input"];
+    output?: SyncedFullModel["modalities"]["output"];
+  };
+};
+
 export function factorBaseModel(
   modelID: string,
-  values: Partial<SyncedFullModel>,
-  limit: SyncedFullModel["limit"],
+  values: BaseModelOverrides,
+  limit?: Partial<SyncedFullModel["limit"]>,
   existingOmit?: string[],
 ): SyncedModel {
   return {
@@ -373,14 +427,16 @@ export function factorBaseModel(
 
 function baseModelOmit(
   modelID: string,
-  limit: SyncedFullModel["limit"],
+  limit: Partial<SyncedFullModel["limit"]> | undefined,
 ) {
+  if (limit === undefined) return undefined;
   const metadata = modelMetadata(modelID);
   const omit: string[] = [];
   const baseLimit = metadata.limit;
   if (
     isPlainObject(baseLimit) &&
     baseLimit.input !== undefined &&
+    limit.context !== undefined &&
     limit.input === undefined &&
     baseLimit.context !== limit.context
   ) {
@@ -392,7 +448,7 @@ function baseModelOmit(
 
 function baseModelOverrides(
   modelID: string,
-  values: Partial<SyncedFullModel>,
+  values: BaseModelOverrides,
 ) {
   const metadata = modelMetadata(modelID);
   const result: Record<string, unknown> = {};

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -150,11 +150,20 @@ test("factors NanoGPT variants against canonical models without retaining wrong 
   expect(resolveNanoGptBaseModel("zai-org/glm-5.2:thinking")).toBe("zhipuai/glm-5.2");
   expect(resolveNanoGptBaseModel("TEE/qwen3.6-35b-a3b")).toBe("alibaba/qwen3.6-35b-a3b");
   expect(resolveNanoGptBaseModel("TEE/deepseek-v4-flash")).toBe("deepseek/deepseek-v4-flash");
+  expect(resolveNanoGptBaseModel("TEE/kimi-k2.5")).toBe("moonshotai/kimi-k2.5");
+  expect(resolveNanoGptBaseModel("TEE/gpt-oss-120b")).toBe("openai/gpt-oss-120b");
+  expect(resolveNanoGptBaseModel("TEE/gemma-4-31b-it")).toBe("google/gemma-4-31b-it");
   expect(resolveNanoGptBaseModel("cohere/north-mini-code")).toBe("cohere/north-mini-code-1-0");
+  expect(resolveNanoGptBaseModel("xiaomi/mimo-v2.5-pro-ultraspeed"))
+    .toBe("xiaomi/mimo-v2.5-pro-ultraspeed");
   expect(resolveNanoGptBaseModel("claude-haiku-4-5-20251001-thinking"))
     .toBe("anthropic/claude-haiku-4-5-20251001");
   expect(resolveNanoGptBaseModel("claude-sonnet-4-thinking:8192"))
     .toBe("anthropic/claude-sonnet-4-0");
+  expect(resolveNanoGptBaseModel("anthropic/claude-opus-4.6:thinking:low"))
+    .toBe("anthropic/claude-opus-4-6");
+  expect(resolveNanoGptBaseModel("anthropic/claude-opus-4.6:thinking:thinking:max"))
+    .toBe("anthropic/claude-opus-4-6");
   expect(resolveNanoGptBaseModel("gemini-2.5-pro")).toBe("google/gemini-2.5-pro");
   expect(resolveNanoGptBaseModel("qwen3.5-27b")).toBe("alibaba/qwen3.5-27b");
 

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -35,6 +35,7 @@ import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/provider
 import {
   buildNanoGptModel,
   nanoGpt,
+  NanoGptResponse,
   resolveNanoGptBaseModel,
   type NanoGptModel,
 } from "../src/sync/providers/nano-gpt.js";
@@ -124,7 +125,7 @@ test("syncs NanoGPT's verified reasoning, pricing, limits, and open-weight metad
   });
 });
 
-test("does not invent NanoGPT reasoning controls or zero prices", () => {
+test("does not invent NanoGPT reasoning controls or absent prices", () => {
   const fixedReasoning = buildNanoGptModel(nanoGptModel({
     id: "example/fixed-reasoner",
     reasoning_efforts: null,
@@ -140,10 +141,32 @@ test("does not invent NanoGPT reasoning controls or zero prices", () => {
     id: "example/omni-model",
     pricing: { note: "varies_by_modality" },
   }), undefined);
+  const free = buildNanoGptModel(nanoGptModel({
+    id: "example/free-model",
+    pricing: { prompt: 0, completion: 0 },
+  }), undefined);
+  const invalid = buildNanoGptModel(nanoGptModel({
+    id: "example/invalid-pricing",
+    pricing: { prompt: -1, completion: 1, cacheReadInputPer1kTokens: -1 },
+  }), { cost: { input: 0.9, output: 2.7, cache_read: 0.2 } });
 
   expect(fixedReasoning).toMatchObject({ reasoning: true, reasoning_options: [] });
-  expect(fixedReasoning.cost).toBeUndefined();
-  expect(variablePricing.cost).toBeUndefined();
+  expect(fixedReasoning?.cost).toBeUndefined();
+  expect(variablePricing?.cost).toBeUndefined();
+  expect(free?.cost).toEqual({ input: 0, output: 0 });
+  expect(invalid?.cost).toEqual({ input: 0.9, output: 2.7, cache_read: 0.2 });
+});
+
+test("accepts only NanoGPT's supported reasoning effort values", () => {
+  expect(NanoGptResponse.safeParse({
+    data: [nanoGptModel({ reasoning_efforts: ["none", "max"] })],
+  }).success).toBe(true);
+  expect(NanoGptResponse.safeParse({
+    data: [{ ...nanoGptModel(), reasoning_efforts: ["low", null] }],
+  }).success).toBe(false);
+  expect(NanoGptResponse.safeParse({
+    data: [{ ...nanoGptModel(), reasoning_efforts: ["default"] }],
+  }).success).toBe(false);
 });
 
 test("factors NanoGPT variants against canonical models without retaining wrong intrinsic metadata", () => {
@@ -166,6 +189,35 @@ test("factors NanoGPT variants against canonical models without retaining wrong 
     .toBe("anthropic/claude-opus-4-6");
   expect(resolveNanoGptBaseModel("gemini-2.5-pro")).toBe("google/gemini-2.5-pro");
   expect(resolveNanoGptBaseModel("qwen3.5-27b")).toBe("alibaba/qwen3.5-27b");
+  expect(resolveNanoGptBaseModel("moonshotai/kimi-k2-thinking"))
+    .toBe("moonshotai/kimi-k2-thinking");
+  expect(resolveNanoGptBaseModel("qwen/qwen3-next-80b-a3b-thinking"))
+    .toBe("alibaba/qwen3-next-80b-a3b-thinking");
+
+  const additionalCanonicalIDs = new Map([
+    ["poolside/laguna-s-2.1", "poolside/laguna-s-2.1"],
+    ["poolside/laguna-s-2.1:thinking", "poolside/laguna-s-2.1"],
+    ["longcat-2.0", "meituan/longcat-2.0"],
+    ["longcat-2.0:thinking", "meituan/longcat-2.0"],
+    ["stepfun-ai/step-3.5-flash-2603", "stepfun/step-3.5-flash-2603"],
+    ["stepfun-ai/step-3.5-flash", "stepfun/step-3.5-flash"],
+    ["Qwen/Qwen3-Next-80B-A3B-Instruct", "alibaba/qwen3-next-80b-a3b-instruct"],
+    ["Qwen/Qwen3.6-35B-A3B", "alibaba/qwen3.6-35b-a3b"],
+    ["Qwen/Qwen3.6-35B-A3B:thinking", "alibaba/qwen3.6-35b-a3b"],
+    ["sonar-pro", "perplexity/sonar-pro"],
+    ["sonar-reasoning-pro", "perplexity/sonar-reasoning-pro"],
+    ["sonar", "perplexity/sonar"],
+    ["zai-org/GLM-4.5:thinking", "zhipuai/glm-4.5"],
+    ["zai-org/GLM-4.5-Air", "zhipuai/glm-4.5-air"],
+    ["zai-org/GLM-4.5-Air:thinking", "zhipuai/glm-4.5-air"],
+    ["poolside/laguna-m.1", "poolside/laguna-m.1"],
+    ["nvidia/Llama-3.3-Nemotron-Super-49B-v1", "nvidia/llama-3.3-nemotron-super-49b-v1"],
+    ["sarvam-30b", "sarvam/sarvam-30b"],
+    ["sarvam-105b", "sarvam/sarvam-105b"],
+  ]);
+  for (const [id, canonical] of additionalCanonicalIDs) {
+    expect(resolveNanoGptBaseModel(id)).toBe(canonical);
+  }
 
   const north = buildNanoGptModel(nanoGptModel({
     id: "cohere/north-mini-code",
@@ -180,11 +232,144 @@ test("factors NanoGPT variants against canonical models without retaining wrong 
   expect(north).not.toHaveProperty("open_weights");
 });
 
+test("factored NanoGPT models inherit missing intrinsic metadata without zero overrides", () => {
+  const sparse = buildNanoGptModel(nanoGptModel({
+    id: "google/gemini-2.5-pro",
+    name: null,
+    description: null,
+    created: null,
+    context_length: null,
+    max_output_tokens: null,
+    architecture: undefined,
+    capabilities: undefined,
+    reasoning_efforts: null,
+    open_weights: false,
+    pricing: undefined,
+  }), undefined);
+
+  expect(sparse).toMatchObject({ base_model: "google/gemini-2.5-pro" });
+  expect(sparse).not.toHaveProperty("name");
+  expect(sparse).not.toHaveProperty("family");
+  expect(sparse).not.toHaveProperty("release_date");
+  expect(sparse).not.toHaveProperty("attachment");
+  expect(sparse).not.toHaveProperty("reasoning");
+  expect(sparse).not.toHaveProperty("tool_call");
+  expect(sparse).not.toHaveProperty("open_weights");
+  expect(sparse).not.toHaveProperty("limit");
+  expect(sparse).not.toHaveProperty("modalities");
+});
+
+test("preserves route-specific NanoGPT names when first factoring existing models", () => {
+  const thinking = buildNanoGptModel(nanoGptModel({
+    id: "claude-opus-4-thinking:8192",
+    name: "Claude 4 Opus Thinking (8K)",
+  }), {
+    name: "Claude 4 Opus Thinking (8K)",
+    limit: { context: 200_000, input: 200_000, output: 32_000 },
+  });
+  const tee = buildNanoGptModel(nanoGptModel({
+    id: "TEE/glm-5",
+    name: "GLM 5 TEE",
+  }), undefined);
+
+  expect(thinking).toMatchObject({
+    base_model: "anthropic/claude-opus-4-0",
+    name: "Claude 4 Opus Thinking (8K)",
+  });
+  expect(tee).toMatchObject({
+    base_model: "zhipuai/glm-5",
+    name: "GLM 5 TEE",
+  });
+});
+
+test("preserves explicit NanoGPT route overrides while inheriting absent base fields", () => {
+  const model = buildNanoGptModel(nanoGptModel({
+    id: "google/gemini-2.5-pro",
+    context_length: 500_000,
+    max_output_tokens: null,
+    architecture: { input_modalities: ["text", "image"] },
+    capabilities: { tool_calling: false },
+    open_weights: false,
+  }), {
+    provider: { body: { route: "secure" } },
+    experimental: {
+      modes: { fast: { provider: { body: { speed: "fast" } } } },
+    },
+  });
+
+  expect(model).toMatchObject({
+    base_model: "google/gemini-2.5-pro",
+    tool_call: false,
+    provider: { body: { route: "secure" } },
+    experimental: {
+      modes: { fast: { provider: { body: { speed: "fast" } } } },
+    },
+    limit: { context: 500_000, input: 500_000 },
+    modalities: { input: ["text", "image"] },
+  });
+  expect(model).not.toHaveProperty("limit.output");
+  expect(model).not.toHaveProperty("modalities.output");
+  expect(model).not.toHaveProperty("open_weights");
+
+  const textOnly = buildNanoGptModel(nanoGptModel({
+    id: "google/gemini-2.5-pro",
+    architecture: undefined,
+    capabilities: { vision: false },
+  }), undefined);
+  expect(textOnly).toMatchObject({
+    base_model: "google/gemini-2.5-pro",
+    attachment: false,
+    modalities: { input: ["text"] },
+  });
+});
+
+test("preserves standalone modalities and skips incomplete new standalone models", () => {
+  const existing = buildNanoGptModel(nanoGptModel({
+    id: "example/sparse-existing",
+    created: null,
+    context_length: null,
+    max_output_tokens: null,
+    architecture: undefined,
+    capabilities: undefined,
+    pricing: undefined,
+  }), {
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: true,
+    provider: { body: { route: "secure" } },
+    experimental: {
+      modes: { fast: { provider: { body: { speed: "fast" } } } },
+    },
+    limit: { context: 100_000, input: 90_000, output: 10_000 },
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+  const missing = buildNanoGptModel(nanoGptModel({
+    id: "example/sparse-new",
+    created: null,
+    context_length: null,
+    max_output_tokens: null,
+    architecture: undefined,
+    capabilities: undefined,
+    pricing: undefined,
+  }), undefined);
+
+  expect(existing).toMatchObject({
+    attachment: true,
+    provider: { body: { route: "secure" } },
+    experimental: {
+      modes: { fast: { provider: { body: { speed: "fast" } } } },
+    },
+    limit: { context: 100_000, input: 90_000, output: 10_000 },
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+  expect(missing).toBeUndefined();
+});
+
 test("NanoGPT sync deletes missing downstream entries and never emits internal providers", () => {
   const source = nanoGptModel({ providers: ["private-upstream"] });
   const model = buildNanoGptModel(source, undefined);
 
-  expect(nanoGpt.deleteMissing).toBeUndefined();
+  expect((nanoGpt as SyncProvider<NanoGptModel>).deleteMissing).toBeUndefined();
   expect(model).not.toHaveProperty("providers");
 });
 

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -151,6 +151,12 @@ test("factors NanoGPT variants against canonical models without retaining wrong 
   expect(resolveNanoGptBaseModel("TEE/qwen3.6-35b-a3b")).toBe("alibaba/qwen3.6-35b-a3b");
   expect(resolveNanoGptBaseModel("TEE/deepseek-v4-flash")).toBe("deepseek/deepseek-v4-flash");
   expect(resolveNanoGptBaseModel("cohere/north-mini-code")).toBe("cohere/north-mini-code-1-0");
+  expect(resolveNanoGptBaseModel("claude-haiku-4-5-20251001-thinking"))
+    .toBe("anthropic/claude-haiku-4-5-20251001");
+  expect(resolveNanoGptBaseModel("claude-sonnet-4-thinking:8192"))
+    .toBe("anthropic/claude-sonnet-4-0");
+  expect(resolveNanoGptBaseModel("gemini-2.5-pro")).toBe("google/gemini-2.5-pro");
+  expect(resolveNanoGptBaseModel("qwen3.5-27b")).toBe("alibaba/qwen3.5-27b");
 
   const north = buildNanoGptModel(nanoGptModel({
     id: "cohere/north-mini-code",

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -32,6 +32,12 @@ import {
   type OpenRouterModel,
 } from "../src/sync/providers/openrouter.js";
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
+import {
+  buildNanoGptModel,
+  nanoGpt,
+  resolveNanoGptBaseModel,
+  type NanoGptModel,
+} from "../src/sync/providers/nano-gpt.js";
 import { openai, parseOpenAIModels } from "../src/sync/providers/openai.js";
 import { pioneer } from "../src/sync/providers/pioneer.js";
 import { google, shouldTrackGoogleModel } from "../src/sync/providers/google.js";
@@ -67,6 +73,105 @@ function anthropicModel(overrides: Partial<AnthropicModel> = {}): AnthropicModel
     ...overrides,
   };
 }
+
+function nanoGptModel(overrides: Partial<NanoGptModel> = {}): NanoGptModel {
+  return {
+    id: "example/reasoning-model",
+    name: "Example Reasoning Model",
+    description: "Example model used to test NanoGPT catalog translation",
+    created: Date.parse("2026-06-01T00:00:00Z") / 1_000,
+    owned_by: "example",
+    context_length: 500_000,
+    max_output_tokens: 64_000,
+    architecture: {
+      input_modalities: ["text"],
+      output_modalities: ["text"],
+    },
+    capabilities: {
+      reasoning: true,
+      tool_calling: true,
+      structured_output: true,
+    },
+    reasoning_efforts: ["low", "high"],
+    open_weights: true,
+    pricing: {
+      prompt: 0.42,
+      completion: 1.32,
+      cacheReadInputPer1kTokens: 0.000078,
+    },
+    ...overrides,
+  };
+}
+
+test("syncs NanoGPT's verified reasoning, pricing, limits, and open-weight metadata", () => {
+  const model = buildNanoGptModel(nanoGptModel({
+    pricing: {
+      prompt: 0.42,
+      completion: 1.32,
+      cacheReadInputPer1kTokens: null,
+    },
+  }), {
+    cost: { input: 0.9, output: 2.7, cache_read: 0.2 },
+    limit: { context: 1_000_000, input: 1_000_000, output: 128_000 },
+  });
+
+  expect(model).toMatchObject({
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+    open_weights: true,
+    cost: { input: 0.42, output: 1.32, cache_read: 0.2 },
+    limit: { context: 500_000, input: 500_000, output: 64_000 },
+  });
+});
+
+test("does not invent NanoGPT reasoning controls or zero prices", () => {
+  const fixedReasoning = buildNanoGptModel(nanoGptModel({
+    id: "example/fixed-reasoner",
+    reasoning_efforts: null,
+    open_weights: null,
+    pricing: {
+      prompt: null,
+      completion: null,
+      cacheReadInputPer1kTokens: null,
+      cacheWriteInputPer1kTokens: null,
+    },
+  }), undefined);
+  const variablePricing = buildNanoGptModel(nanoGptModel({
+    id: "example/omni-model",
+    pricing: { note: "varies_by_modality" },
+  }), undefined);
+
+  expect(fixedReasoning).toMatchObject({ reasoning: true, reasoning_options: [] });
+  expect(fixedReasoning.cost).toBeUndefined();
+  expect(variablePricing.cost).toBeUndefined();
+});
+
+test("factors NanoGPT variants against canonical models without retaining wrong intrinsic metadata", () => {
+  expect(resolveNanoGptBaseModel("zai-org/glm-5.2:thinking")).toBe("zhipuai/glm-5.2");
+  expect(resolveNanoGptBaseModel("TEE/qwen3.6-35b-a3b")).toBe("alibaba/qwen3.6-35b-a3b");
+  expect(resolveNanoGptBaseModel("TEE/deepseek-v4-flash")).toBe("deepseek/deepseek-v4-flash");
+  expect(resolveNanoGptBaseModel("cohere/north-mini-code")).toBe("cohere/north-mini-code-1-0");
+
+  const north = buildNanoGptModel(nanoGptModel({
+    id: "cohere/north-mini-code",
+    name: "North Mini Code",
+    open_weights: null,
+  }), {
+    open_weights: false,
+    limit: { context: 256_000, input: 256_000, output: 64_000 },
+  });
+
+  expect(north).toMatchObject({ base_model: "cohere/north-mini-code-1-0" });
+  expect(north).not.toHaveProperty("open_weights");
+});
+
+test("NanoGPT sync deletes missing downstream entries and never emits internal providers", () => {
+  const source = nanoGptModel({ providers: ["private-upstream"] });
+  const model = buildNanoGptModel(source, undefined);
+
+  expect(nanoGpt.deleteMissing).toBeUndefined();
+  expect(model).not.toHaveProperty("providers");
+});
 
 const anthropicPricingMarkdown = `
 ## Model pricing

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -282,6 +282,29 @@ test("preserves route-specific NanoGPT names when first factoring existing model
   });
 });
 
+test("preserves API-silent NanoGPT overrides when first factoring existing models", () => {
+  const model = buildNanoGptModel(nanoGptModel({
+    id: "anthropic/claude-sonnet-4.6",
+    context_length: 1_000_000,
+    max_output_tokens: null,
+    architecture: undefined,
+    capabilities: undefined,
+    reasoning_efforts: null,
+  }), {
+    reasoning: false,
+    structured_output: true,
+    limit: { context: 1_000_000, input: 1_000_000, output: 128_000 },
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    base_model: "anthropic/claude-sonnet-4-6",
+    reasoning: false,
+    structured_output: true,
+    limit: { output: 128_000 },
+  });
+});
+
 test("preserves explicit NanoGPT route overrides while inheriting absent base fields", () => {
   const model = buildNanoGptModel(nanoGptModel({
     id: "google/gemini-2.5-pro",
@@ -371,6 +394,62 @@ test("NanoGPT sync deletes missing downstream entries and never emits internal p
 
   expect((nanoGpt as SyncProvider<NanoGptModel>).deleteMissing).toBeUndefined();
   expect(model).not.toHaveProperty("providers");
+});
+
+test("NanoGPT sync drops stale descriptions while first factoring existing models", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "sync-nano-gpt-"));
+  const modelsDir = path.join(dir, "providers", "nano-gpt", "models");
+  const modelPath = path.join(modelsDir, "anthropic", "claude-sonnet-4.6.toml");
+  const metadataPath = path.join(dir, "models", "anthropic", "claude-sonnet-4-6.toml");
+  await mkdir(path.dirname(modelPath), { recursive: true });
+  await mkdir(path.dirname(metadataPath), { recursive: true });
+  await Bun.write(modelPath, [
+    'description = "Stale provider description"',
+    "reasoning = false",
+    "structured_output = true",
+    "",
+    "[limit]",
+    "context = 1_000_000",
+    "input = 1_000_000",
+    "output = 128_000",
+    "",
+  ].join("\n"));
+  await Bun.write(metadataPath, [
+    'description = "Canonical description"',
+    "reasoning = true",
+    "",
+    "[limit]",
+    "context = 1_000_000",
+    "output = 64_000",
+    "",
+  ].join("\n"));
+
+  try {
+    await syncProvider({
+      ...nanoGpt,
+      modelsDir,
+      async fetchModels() {
+        return {
+          data: [nanoGptModel({
+            id: "anthropic/claude-sonnet-4.6",
+            description: null,
+            max_output_tokens: null,
+            capabilities: undefined,
+            reasoning_efforts: null,
+          })],
+        };
+      },
+    });
+
+    const content = await readFile(modelPath, "utf8");
+    expect(content).toContain('base_model = "anthropic/claude-sonnet-4-6"');
+    expect(content).not.toContain("Stale provider description");
+    expect(content).toContain("reasoning = false");
+    expect(content).toContain("structured_output = true");
+    expect(content).toContain("output = 128_000");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 const anthropicPricingMarkdown = `


### PR DESCRIPTION
## Summary

This supersedes #2891 with the sync implementation separated from generated catalog data, addressing the automated review feedback.

- add NanoGPT as an automated aggregator sync source
- consume verified `reasoning_efforts` rather than inferring controls from IDs
- preserve existing prices when source pricing is null and omit modality-dependent token prices
- refresh `limit.input` from the source context length
- factor known variants through canonical `base_model` metadata
- use the normal stale-entry deletion behavior
- never propagate NanoGPT's internal `providers` field
- leave generated model files to the existing hourly automation

## Safety and compatibility

- NanoGPT's source change is additive and limited to the detailed catalog response
- no provider identifiers are written to models.dev output
- missing pricing is never converted to zero
- fixed-reasoning models do not receive invented toggles
- open-weight metadata is sourced explicitly or inherited from canonical metadata

## Evidence

- [Models endpoint](https://docs.nano-gpt.com/api-reference/endpoint/models) documents the public `/api/v1/models?detailed=true` catalog and its detailed pricing, limits, and capability fields.
- [Live detailed catalog](https://nano-gpt.com/api/v1/models?detailed=true) is the authoritative per-model source for the optional `reasoning_efforts` arrays consumed by this sync.
- [Chat Completions reasoning effort](https://docs.nano-gpt.com/api-reference/endpoint/chat-completion#parameter-reasoning-effort) documents the request values represented by those arrays: `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
- [Model suffixes](https://docs.nano-gpt.com/api-reference/miscellaneous/model-suffixes) documents thinking and budget aliases normalized before canonical `base_model` lookup.

## Verification

- `bun test packages/core/test/sync.test.ts` — 50 passing
- `bun validate`
- live dry run on 2026-07-20 — 57 created, 544 updated, 59 stale removed, 14 unchanged
- generated-output audit — no provider fields, no invalid input limits, and no inferred toggle controls
