### PR TITLE
feat(novita): Add Kimi K2.7 code and Kimi K3

### DIFF
--- a/providers/novita-ai/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,16 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.95
+output = 4.00
+cache_read = 0.19
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video"]

--- a/providers/novita-ai/models/moonshotai/kimi-k3.toml
+++ b/providers/novita-ai/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,20 @@
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.3
+
+[limit]
+context = 1_048_576
+output = 1_048_576
+
+[modalities]
+input = ["text", "image", "video"]


### PR DESCRIPTION
Adding these two models for Novita.AI provider...

`bun run validate` passed

<img width="1578" height="637" alt="image" src="https://github.com/user-attachments/assets/146e20a9-cfbd-48a9-b0f9-7a2168cf9af8" />

<img width="1549" height="615" alt="image" src="https://github.com/user-attachments/assets/d3fa9f1d-6bd0-4b2d-aa7b-65a608fb5459" />
