### PR TITLE
fix(muse-spark): omit none from reasoning effort options

### DIFF
--- a/providers/llmgateway/models/muse-spark-1.1.toml
+++ b/providers/llmgateway/models/muse-spark-1.1.toml
@@ -1,5 +1,5 @@
 base_model = "meta/muse-spark-1.1"
-reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.25

--- a/providers/meta/models/muse-spark-1.1.toml
+++ b/providers/meta/models/muse-spark-1.1.toml
@@ -4,7 +4,7 @@
 
 base_model = "meta/muse-spark-1.1"
 
-reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1.25

--- a/providers/vercel/models/meta/muse-spark-1.1.toml
+++ b/providers/vercel/models/meta/muse-spark-1.1.toml
@@ -5,7 +5,7 @@ attachment = false
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "minimal", "low", "medium", "high", "xhigh"]
+values = ["minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
 input = 1.25


### PR DESCRIPTION
## Summary
- Remove `none` from Muse Spark 1.1 `reasoning_options` effort values on providers that still listed it (meta, vercel, llmgateway)
- Align with openrouter and empiriolabs, which already omit `none`

## Providers
| Provider | Change |
| --- | --- |
| meta | `none` removed |
| vercel | `none` removed |
| llmgateway | `none` removed |
| openrouter | already correct |
| empiriolabs | already correct |
| abacus | empty `reasoning_options` (no effort list) |

Final effort values: `minimal`, `low`, `medium`, `high`, `xhigh`

## Test plan
- [x] `bun validate`
- [ ] Confirm no remaining muse-spark provider lists `none` in effort values