### PR TITLE
feat(alibaba-token-plan): add qwen3.8-max-preview

### DIFF
--- a/models/alibaba/qwen3.8-max-preview.toml
+++ b/models/alibaba/qwen3.8-max-preview.toml
@@ -1,6 +1,8 @@
 # Sources (accessed 2026-07-20):
 # https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
 # https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
+# https://docs.qwencloud.com/developer-guides/getting-started/text-generation-models
+# https://platform.qianwenai.com/docs/developer-guides/getting-started/text-generation-models
 # https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
 # https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
 # https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/kilo-cli
@@ -20,7 +22,7 @@ tool_call = true
 open_weights = false
 
 [limit]
-context = 983_616
+context = 1_000_000
 output = 131_072
 
 [modalities]

--- a/models/alibaba/qwen3.8-max-preview.toml
+++ b/models/alibaba/qwen3.8-max-preview.toml
@@ -1,0 +1,24 @@
+# Sources (accessed 2026-07-20):
+# https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
+# https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
+# https://github.com/QwenLM/qwen-code/issues/7198
+# https://github.com/QwenLM/qwen-code/pull/7199
+
+name = "Qwen3.8 Max Preview"
+description = "Preview Qwen flagship for million-token multimodal reasoning and long-horizon agentic workflows"
+family = "qwen"
+release_date = "2026-07-19"
+last_updated = "2026-07-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/models/alibaba/qwen3.8-max-preview.toml
+++ b/models/alibaba/qwen3.8-max-preview.toml
@@ -1,6 +1,8 @@
 # Sources (accessed 2026-07-20):
 # https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
 # https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/kilo-cli
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/kilo-cli
 # https://github.com/QwenLM/qwen-code/issues/7198
 # https://github.com/QwenLM/qwen-code/pull/7199
 
@@ -16,8 +18,8 @@ tool_call = true
 open_weights = false
 
 [limit]
-context = 1_000_000
-output = 65_536
+context = 983_616
+output = 131_072
 
 [modalities]
 input = ["text", "image", "video"]

--- a/models/alibaba/qwen3.8-max-preview.toml
+++ b/models/alibaba/qwen3.8-max-preview.toml
@@ -1,6 +1,8 @@
 # Sources (accessed 2026-07-20):
 # https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
 # https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
 # https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/kilo-cli
 # https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/kilo-cli
 # https://github.com/QwenLM/qwen-code/issues/7198

--- a/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
@@ -6,17 +6,18 @@
 # https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
 # https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
 # Thinking is always enabled. In thinking mode, temperature defaults to 0.6
-# and values below 0.6 are raised to 0.6. The OpenCode guide documents
-# low/high/xhigh (default xhigh) and configures a 262144-token thinking budget
-# for the China endpoint.
-# `thinking_budget` (0..262144) is an alternative and cannot be combined with
-# `reasoning_effort`. API: {"reasoning_effort":"high"} or
+# and values below 0.6 are raised to 0.6. This provider uses the OpenAI-compatible
+# Chat API, whose native qwen3.8 effort values are low/medium/xhigh (default
+# xhigh); the standard high value is accepted as an alias and maps to xhigh.
+# The OpenCode guide labels its tiers low/high/xhigh and configures a 262144-token
+# thinking budget for the China endpoint. `thinking_budget` (0..262144) cannot
+# be combined with `reasoning_effort`. API: {"reasoning_effort":"medium"} or
 # {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
 # must replay every historical `reasoning_content` value unchanged.
 
 base_model = "alibaba/qwen3.8-max-preview"
 reasoning_options = [
-  { type = "effort", values = ["low", "high", "xhigh"] },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
   { type = "budget_tokens", min = 0, max = 262_144 },
 ]
 status = "beta"

--- a/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
@@ -1,0 +1,14 @@
+# Sources (accessed 2026-07-20):
+# https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
+# https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-quickstart
+# No per-request reasoning control is documented for this preview model yet.
+
+base_model = "alibaba/qwen3.8-max-preview"
+reasoning_options = []
+status = "beta"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
@@ -1,13 +1,14 @@
 # Sources (accessed 2026-07-20):
 # https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
 # https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-quickstart
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
 # https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/kilo-cli
 # https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
 # https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
 # Thinking is always enabled. In thinking mode, temperature defaults to 0.6
-# and values below 0.6 are raised to 0.6. The Token Plan Kilo guide documents
-# low/high/xhigh, while the Chat API reference documents low/medium/xhigh; both
-# specify xhigh as the default, so both middle-tier spellings are exposed here.
+# and values below 0.6 are raised to 0.6. The OpenCode guide documents
+# low/high/xhigh (default xhigh) and configures a 262144-token thinking budget
+# for the China endpoint.
 # `thinking_budget` (0..262144) is an alternative and cannot be combined with
 # `reasoning_effort`. API: {"reasoning_effort":"high"} or
 # {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
@@ -15,7 +16,7 @@
 
 base_model = "alibaba/qwen3.8-max-preview"
 reasoning_options = [
-  { type = "effort", values = ["low", "medium", "high", "xhigh"] },
+  { type = "effort", values = ["low", "high", "xhigh"] },
   { type = "budget_tokens", min = 0, max = 262_144 },
 ]
 status = "beta"

--- a/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
@@ -1,11 +1,25 @@
 # Sources (accessed 2026-07-20):
 # https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
 # https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-quickstart
-# No per-request reasoning control is documented for this preview model yet.
+# https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
+# https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
+# Thinking is always enabled. In thinking mode, temperature defaults to 0.6
+# and values below 0.6 are raised to 0.6. Native `reasoning_effort` values are
+# low, medium, and xhigh (default xhigh); `high` is accepted as an xhigh alias.
+# `thinking_budget` (0..262144) is an alternative and cannot be combined with
+# `reasoning_effort`. API: {"reasoning_effort":"medium"} or
+# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
+# must replay every historical `reasoning_content` value unchanged.
 
 base_model = "alibaba/qwen3.8-max-preview"
-reasoning_options = []
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262_144 },
+]
 status = "beta"
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
@@ -1,19 +1,21 @@
 # Sources (accessed 2026-07-20):
 # https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
 # https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-quickstart
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/kilo-cli
 # https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
 # https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
 # Thinking is always enabled. In thinking mode, temperature defaults to 0.6
-# and values below 0.6 are raised to 0.6. Native `reasoning_effort` values are
-# low, medium, and xhigh (default xhigh); `high` is accepted as an xhigh alias.
+# and values below 0.6 are raised to 0.6. The Token Plan Kilo guide documents
+# low/high/xhigh, while the Chat API reference documents low/medium/xhigh; both
+# specify xhigh as the default, so both middle-tier spellings are exposed here.
 # `thinking_budget` (0..262144) is an alternative and cannot be combined with
-# `reasoning_effort`. API: {"reasoning_effort":"medium"} or
+# `reasoning_effort`. API: {"reasoning_effort":"high"} or
 # {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
 # must replay every historical `reasoning_content` value unchanged.
 
 base_model = "alibaba/qwen3.8-max-preview"
 reasoning_options = [
-  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "effort", values = ["low", "medium", "high", "xhigh"] },
   { type = "budget_tokens", min = 0, max = 262_144 },
 ]
 status = "beta"

--- a/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
@@ -11,9 +11,10 @@
 # xhigh); the standard high value is accepted as an alias and maps to xhigh.
 # The OpenCode guide labels its tiers low/high/xhigh and configures a 262144-token
 # thinking budget for the China endpoint. `thinking_budget` (0..262144) cannot
-# be combined with `reasoning_effort`. API: {"reasoning_effort":"medium"} or
-# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
-# must replay every historical `reasoning_content` value unchanged.
+# be combined with `reasoning_effort`. A zero budget maps to low effort; it does
+# not disable thinking. API: {"reasoning_effort":"medium"} or
+# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients must
+# replay every historical `reasoning_content` value unchanged.
 
 base_model = "alibaba/qwen3.8-max-preview"
 reasoning_options = [

--- a/providers/alibaba-token-plan-cn/provider.toml
+++ b/providers/alibaba-token-plan-cn/provider.toml
@@ -1,17 +1,24 @@
-name = "Alibaba Token Plan (China)"
-env = ["ALIBABA_TOKEN_PLAN_API_KEY"]
-npm = "@ai-sdk/openai-compatible"
-# Reasoning HTTP format (accessed 2026-06-25):
-# OpenAI plan base .../compatible-mode/v1 uses POST /chat/completions with
-# top-level `enable_thinking`: true or false and integer `thinking_budget`.
+# Reasoning HTTP format (accessed 2026-07-20):
+# The OpenAI plan base .../compatible-mode/v1 uses POST /chat/completions.
+# Hybrid-thinking models use top-level `enable_thinking` and `thinking_budget`.
+# qwen3.8-max-preview is always thinking and instead accepts either the canonical
+# `reasoning_effort` values low, medium, and xhigh or `thinking_budget` from 0 to
+# 262144. The two controls are mutually exclusive; zero maps to low effort and
+# does not disable thinking.
 # POST /responses uses `reasoning.effort`: none, minimal, low, medium, or high;
 # `thinking_budget` is not accepted there. Anthropic plan base .../apps/anthropic
 # uses POST /v1/messages with `thinking.type`: enabled or disabled, integer
 # `thinking.budget_tokens`, and DeepSeek V4-only `reasoning_effort`: high or max.
 # Sources:
+# https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
+# https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
 # https://help.aliyun.com/zh/model-studio/token-plan-quickstart
 # https://help.aliyun.com/zh/model-studio/deep-thinking
 # https://help.aliyun.com/zh/model-studio/compatibility-with-openai-responses-api
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
+
+name = "Alibaba Token Plan (China)"
+env = ["ALIBABA_TOKEN_PLAN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
 doc = "https://www.alibabacloud.com/help/zh/model-studio/token-plan-overview"
 api = "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"

--- a/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
@@ -1,13 +1,14 @@
 # Sources (accessed 2026-07-20):
 # https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
 # https://docs.qwencloud.com/token-plan/personal/token-plan-personal-quickstart
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
 # https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/kilo-cli
 # https://docs.qwencloud.com/developer-guides/text-generation/thinking
 # https://docs.qwencloud.com/api-reference/chat/openai-chat
 # Thinking is always enabled. In thinking mode, temperature defaults to 0.6
-# and values below 0.6 are raised to 0.6. The Token Plan Kilo guide documents
-# low/high/xhigh, while the Chat API reference documents low/medium/xhigh; both
-# specify xhigh as the default, so both middle-tier spellings are exposed here.
+# and values below 0.6 are raised to 0.6. The OpenCode guide documents
+# low/high/xhigh (default xhigh) and configures a 99072-token thinking budget
+# for the international endpoint. The API permits budgets up to 262144.
 # `thinking_budget` (0..262144) is an alternative and cannot be combined with
 # `reasoning_effort`. API: {"reasoning_effort":"high"} or
 # {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
@@ -15,7 +16,7 @@
 
 base_model = "alibaba/qwen3.8-max-preview"
 reasoning_options = [
-  { type = "effort", values = ["low", "medium", "high", "xhigh"] },
+  { type = "effort", values = ["low", "high", "xhigh"] },
   { type = "budget_tokens", min = 0, max = 262_144 },
 ]
 status = "beta"

--- a/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
@@ -1,0 +1,14 @@
+# Sources (accessed 2026-07-20):
+# https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
+# https://docs.qwencloud.com/token-plan/personal/token-plan-personal-quickstart
+# No per-request reasoning control is documented for this preview model yet.
+
+base_model = "alibaba/qwen3.8-max-preview"
+reasoning_options = []
+status = "beta"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
@@ -6,17 +6,18 @@
 # https://docs.qwencloud.com/developer-guides/text-generation/thinking
 # https://docs.qwencloud.com/api-reference/chat/openai-chat
 # Thinking is always enabled. In thinking mode, temperature defaults to 0.6
-# and values below 0.6 are raised to 0.6. The OpenCode guide documents
-# low/high/xhigh (default xhigh) and configures a 99072-token thinking budget
-# for the international endpoint. The API permits budgets up to 262144.
-# `thinking_budget` (0..262144) is an alternative and cannot be combined with
-# `reasoning_effort`. API: {"reasoning_effort":"high"} or
+# and values below 0.6 are raised to 0.6. This provider uses the OpenAI-compatible
+# Chat API, whose native qwen3.8 effort values are low/medium/xhigh (default
+# xhigh); the standard high value is accepted as an alias and maps to xhigh.
+# The OpenCode guide labels its tiers low/high/xhigh and configures a 99072-token
+# thinking budget for the international endpoint. `thinking_budget` (0..262144)
+# cannot be combined with `reasoning_effort`. API: {"reasoning_effort":"medium"} or
 # {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
 # must replay every historical `reasoning_content` value unchanged.
 
 base_model = "alibaba/qwen3.8-max-preview"
 reasoning_options = [
-  { type = "effort", values = ["low", "high", "xhigh"] },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
   { type = "budget_tokens", min = 0, max = 262_144 },
 ]
 status = "beta"

--- a/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
@@ -1,19 +1,21 @@
 # Sources (accessed 2026-07-20):
 # https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
 # https://docs.qwencloud.com/token-plan/personal/token-plan-personal-quickstart
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/kilo-cli
 # https://docs.qwencloud.com/developer-guides/text-generation/thinking
 # https://docs.qwencloud.com/api-reference/chat/openai-chat
 # Thinking is always enabled. In thinking mode, temperature defaults to 0.6
-# and values below 0.6 are raised to 0.6. Native `reasoning_effort` values are
-# low, medium, and xhigh (default xhigh); `high` is accepted as an xhigh alias.
+# and values below 0.6 are raised to 0.6. The Token Plan Kilo guide documents
+# low/high/xhigh, while the Chat API reference documents low/medium/xhigh; both
+# specify xhigh as the default, so both middle-tier spellings are exposed here.
 # `thinking_budget` (0..262144) is an alternative and cannot be combined with
-# `reasoning_effort`. API: {"reasoning_effort":"medium"} or
+# `reasoning_effort`. API: {"reasoning_effort":"high"} or
 # {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
 # must replay every historical `reasoning_content` value unchanged.
 
 base_model = "alibaba/qwen3.8-max-preview"
 reasoning_options = [
-  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "effort", values = ["low", "medium", "high", "xhigh"] },
   { type = "budget_tokens", min = 0, max = 262_144 },
 ]
 status = "beta"

--- a/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
@@ -1,11 +1,25 @@
 # Sources (accessed 2026-07-20):
 # https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
 # https://docs.qwencloud.com/token-plan/personal/token-plan-personal-quickstart
-# No per-request reasoning control is documented for this preview model yet.
+# https://docs.qwencloud.com/developer-guides/text-generation/thinking
+# https://docs.qwencloud.com/api-reference/chat/openai-chat
+# Thinking is always enabled. In thinking mode, temperature defaults to 0.6
+# and values below 0.6 are raised to 0.6. Native `reasoning_effort` values are
+# low, medium, and xhigh (default xhigh); `high` is accepted as an xhigh alias.
+# `thinking_budget` (0..262144) is an alternative and cannot be combined with
+# `reasoning_effort`. API: {"reasoning_effort":"medium"} or
+# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
+# must replay every historical `reasoning_content` value unchanged.
 
 base_model = "alibaba/qwen3.8-max-preview"
-reasoning_options = []
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262_144 },
+]
 status = "beta"
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
@@ -11,9 +11,10 @@
 # xhigh); the standard high value is accepted as an alias and maps to xhigh.
 # The OpenCode guide labels its tiers low/high/xhigh and configures a 99072-token
 # thinking budget for the international endpoint. `thinking_budget` (0..262144)
-# cannot be combined with `reasoning_effort`. API: {"reasoning_effort":"medium"} or
-# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients
-# must replay every historical `reasoning_content` value unchanged.
+# cannot be combined with `reasoning_effort`. A zero budget maps to low effort;
+# it does not disable thinking. API: {"reasoning_effort":"medium"} or
+# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients must
+# replay every historical `reasoning_content` value unchanged.
 
 base_model = "alibaba/qwen3.8-max-preview"
 reasoning_options = [

--- a/providers/alibaba-token-plan/provider.toml
+++ b/providers/alibaba-token-plan/provider.toml
@@ -1,17 +1,24 @@
-name = "Alibaba Token Plan"
-env = ["ALIBABA_TOKEN_PLAN_API_KEY"]
-npm = "@ai-sdk/openai-compatible"
-# Reasoning HTTP format (accessed 2026-06-25):
-# OpenAI plan base .../compatible-mode/v1 uses POST /chat/completions with
-# top-level `enable_thinking`: true or false and integer `thinking_budget`.
+# Reasoning HTTP format (accessed 2026-07-20):
+# The OpenAI plan base .../compatible-mode/v1 uses POST /chat/completions.
+# Hybrid-thinking models use top-level `enable_thinking` and `thinking_budget`.
+# qwen3.8-max-preview is always thinking and instead accepts either the canonical
+# `reasoning_effort` values low, medium, and xhigh or `thinking_budget` from 0 to
+# 262144. The two controls are mutually exclusive; zero maps to low effort and
+# does not disable thinking.
 # POST /responses uses `reasoning.effort`: none, minimal, low, medium, or high;
 # `thinking_budget` is not accepted there. Anthropic plan base .../apps/anthropic
 # uses POST /v1/messages with `thinking.type`: enabled or disabled, integer
 # `thinking.budget_tokens`, and DeepSeek V4-only `reasoning_effort`: high or max.
 # Sources:
+# https://docs.qwencloud.com/api-reference/chat/openai-chat
+# https://docs.qwencloud.com/developer-guides/text-generation/thinking
 # https://www.alibabacloud.com/help/en/model-studio/token-plan-quickstart
 # https://www.alibabacloud.com/help/en/model-studio/deep-thinking
 # https://www.alibabacloud.com/help/en/model-studio/compatibility-with-openai-responses-api
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
+
+name = "Alibaba Token Plan"
+env = ["ALIBABA_TOKEN_PLAN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
 doc = "https://www.alibabacloud.com/help/en/model-studio/token-plan-overview"
 api = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"


### PR DESCRIPTION
## Summary

- add provider-agnostic metadata for `qwen3.8-max-preview`
- expose the model through both Alibaba Token Plan Personal Edition endpoints:
  - international (`alibaba-token-plan`, Singapore)
  - China (`alibaba-token-plan-cn`, Beijing)
- record the native 1,000,000-token context window and 131,072-token maximum output
- mark the preview as `beta`
- declare the documented reasoning controls and `reasoning_content` interleaving

The OpenCode integration uses a 983,616-token client context setting, but the Qwen model catalog specifies a native 1M context window. This PR records the native model limit; it does not treat the client reservation as an API input limit.

## Reasoning behavior

- thinking is always enabled and cannot be toggled off
- the OpenAI-compatible Chat API accepts the native qwen3.8 `reasoning_effort` values `low`, `medium`, and `xhigh` (default `xhigh`)
- `thinking_budget` accepts 0 through 262,144 and is mutually exclusive with `reasoning_effort`; a zero budget maps to low effort and does not disable thinking
- the documented effort mappings are `low` → 4,096 tokens, `medium` → 16,384 tokens, and `xhigh` → 262,144 tokens
- the OpenCode integration guides label their tiers `low`, `high`, and `xhigh`; the Chat API reference clarifies that the standard `high` alias maps to native `xhigh`, so exposing both would duplicate the maximum tier and omit the native middle tier
- the international OpenCode example configures a 99,072-token thinking budget, while the China example configures 262,144
- thinking-mode temperature defaults to 0.6 and lower values are raised to 0.6
- `preserve_thinking` defaults to true, so historical `reasoning_content` must be replayed unchanged

The provider-level HTTP-format comments were updated for both regions so this qwen3.8-specific API surface is not confused with the toggle used by hybrid-thinking Qwen models.

## Sources

- [Qwen Cloud Token Plan Individual overview](https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview)
- [Qwen Cloud Token Plan Individual quick start](https://docs.qwencloud.com/token-plan/personal/token-plan-personal-quickstart)
- [Qwen Cloud text-generation model catalog](https://docs.qwencloud.com/developer-guides/getting-started/text-generation-models)
- [Qwen Cloud OpenCode integration](https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode)
- [Qwen Cloud Kilo CLI integration](https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/kilo-cli)
- [Qwen Cloud thinking-mode guide](https://docs.qwencloud.com/developer-guides/text-generation/thinking)
- [Qwen Cloud OpenAI Chat API reference](https://docs.qwencloud.com/api-reference/chat/openai-chat)
- [千问 AI 平台 Token Plan 个人版概述](https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview)
- [千问 AI 平台 Token Plan 个人版快速开始](https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-quickstart)
- [千问 AI 平台文本生成模型列表](https://platform.qianwenai.com/docs/developer-guides/getting-started/text-generation-models)
- [千问 AI 平台 OpenCode 配置](https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode)
- [千问 AI 平台 Kilo CLI 配置](https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/kilo-cli)
- [千问 AI 平台思考模式说明](https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking)
- [千问 AI 平台 OpenAI Chat API 参考](https://platform.qianwenai.com/docs/api-reference/chat/openai-chat)
- [Qwen Code model request and verified configuration](https://github.com/QwenLM/qwen-code/issues/7198)
- [Qwen Code merged Token Plan integration](https://github.com/QwenLM/qwen-code/pull/7199)

## Validation

- `bun validate`
- inspected generated entries for both `alibaba-token-plan` and `alibaba-token-plan-cn`
- `git diff --check`
