### PR TITLE
feat(google): add Gemini 3.6 Flash and 3.5 Flash Lite

### DIFF
--- a/providers/google/models/gemini-3.5-flash-lite.toml
+++ b/providers/google/models/gemini-3.5-flash-lite.toml
@@ -1,0 +1,13 @@
+# Sources:
+# - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/
+# - https://ai.google.dev/gemini-api/docs/pricing
+base_model = "google/gemini-3.5-flash-lite"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.30
+output = 2.50
+cache_read = 0.03

--- a/providers/google/models/gemini-3.6-flash.toml
+++ b/providers/google/models/gemini-3.6-flash.toml
@@ -1,0 +1,14 @@
+# Sources:
+# - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/
+# - https://ai.google.dev/gemini-api/docs/pricing
+base_model = "google/gemini-3.6-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.50
+output = 7.50
+cache_read = 0.15
+input_audio = 1.50


### PR DESCRIPTION
## Summary
- Add `providers/google/models/gemini-3.6-flash.toml` and `gemini-3.5-flash-lite.toml`
- Inherit provider-agnostic metadata via `base_model` from Frank's earlier `models/google` commit
- Pricing from https://ai.google.dev/gemini-api/docs/pricing
  - 3.6 Flash: $1.50 / $7.50 / $0.15 cache_read (+ $1.50 input_audio)
  - 3.5 Flash Lite: $0.30 / $2.50 / $0.03 cache_read
- `reasoning_options` effort levels match sibling Gemini Flash models

## Sources
- https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/
- https://ai.google.dev/gemini-api/docs/pricing

## Validation
- `bun validate`
- `bun models:sync google` → 0 created, 0 updated, 0 deleted (both IDs now present)

Note: Google sync uses `skipCreates: true` because the Models API lacks authoritative cost/modalities/release metadata, so new models still need hand-authored provider TOMLs.