### PR TITLE
fix(llmgateway): Gemini 3.6/3.5 Flash Lite reasoning_options

### DIFF
--- a/providers/llmgateway/models/gemini-3.5-flash-lite.toml
+++ b/providers/llmgateway/models/gemini-3.5-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.5-flash-lite"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.3

--- a/providers/llmgateway/models/gemini-3.5-flash-lite.toml
+++ b/providers/llmgateway/models/gemini-3.5-flash-lite.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.5-flash-lite"
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03
+cache_write = 0.08333

--- a/providers/llmgateway/models/gemini-3.6-flash.toml
+++ b/providers/llmgateway/models/gemini-3.6-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.6-flash"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.5

--- a/providers/llmgateway/models/gemini-3.6-flash.toml
+++ b/providers/llmgateway/models/gemini-3.6-flash.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.6-flash"
+reasoning_options = []
+
+[cost]
+input = 1.5
+output = 7.5
+cache_read = 0.15
+cache_write = 0.08333


### PR DESCRIPTION
## Summary
Follow-up to automation sync [#3357](https://github.com/anomalyco/models.dev/pull/3357).

LLM Gateway auto-create factors new models against `models/google/*` but only writes cost/limit. `preserveReasoningOptions` then fills `reasoning_options = []` for new reasoning models.

This sets the same effort surface as sibling LLM Gateway Gemini Flash entries:
- `gemini-3.6-flash`: `minimal | low | medium | high`
- `gemini-3.5-flash-lite`: `minimal | low | medium | high`

Matches existing `providers/llmgateway/models/gemini-3.5-flash.toml` and `gemini-3.1-flash-lite.toml`.

## Note
Prefer landing this on top of #3357, or fold into that PR before merge. Closing #3357 in favor of this branch is also fine (this branch is based on the sync branch).