### PR TITLE
feat(sync): auto-merge trusted full-catalog sync PRs

### DIFF
--- a/.github/actions/setup-git-committer/action.yml
+++ b/.github/actions/setup-git-committer/action.yml
@@ -1,0 +1,43 @@
+name: "Setup Git Committer"
+description: "Create GitHub App token and configure git user for automation pushes"
+inputs:
+  app-id:
+    description: "GitHub App ID"
+    required: true
+  app-secret:
+    description: "GitHub App private key"
+    required: true
+outputs:
+  token:
+    description: "GitHub App token"
+    value: ${{ steps.apptoken.outputs.token }}
+  app-slug:
+    description: "GitHub App slug"
+    value: ${{ steps.apptoken.outputs.app-slug }}
+runs:
+  using: "composite"
+  steps:
+    - name: Create app token
+      id: apptoken
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.app-secret }}
+        owner: ${{ github.repository_owner }}
+
+    - name: Configure git user
+      run: |
+        slug="${{ steps.apptoken.outputs.app-slug }}"
+        git config --global user.name "${slug}[bot]"
+        git config --global user.email "${slug}[bot]@users.noreply.github.com"
+      shell: bash
+
+    - name: Clear checkout auth
+      run: |
+        git config --local --unset-all http.https://github.com/.extraheader || true
+      shell: bash
+
+    - name: Configure git remote
+      run: |
+        git remote set-url origin "https://x-access-token:${{ steps.apptoken.outputs.token }}@github.com/${{ github.repository }}"
+      shell: bash

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -97,7 +97,7 @@ jobs:
           BRANCH: automation/sync-models-${{ matrix.provider }}
           PROVIDER: ${{ matrix.provider }}
           # Full-catalog syncs that are safe to merge after CI without human review.
-          AUTOMERGE_PROVIDERS: openrouter kilo venice chutes ovhcloud wandb
+          AUTOMERGE_PROVIDERS: openrouter venice wandb
           TITLE: "chore(sync): update ${{ matrix.name }} model catalog"
         run: |
           tee -a "$GITHUB_STEP_SUMMARY" < .sync/model-sync-report.md >/dev/null

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -84,19 +84,46 @@ jobs:
       - name: Validate models
         run: bun validate
 
+      - name: Setup git committer
+        id: committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          app-id: ${{ vars.OPENCODE_APP_ID }}
+          app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+
       - name: Report changes
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
           BRANCH: automation/sync-models-${{ matrix.provider }}
-          LABELS: automation,model-sync,provider:${{ matrix.provider }}
+          PROVIDER: ${{ matrix.provider }}
+          # Full-catalog syncs that are safe to merge after CI without human review.
+          AUTOMERGE_PROVIDERS: openrouter kilo venice chutes ovhcloud wandb
           TITLE: "chore(sync): update ${{ matrix.name }} model catalog"
         run: |
           tee -a "$GITHUB_STEP_SUMMARY" < .sync/model-sync-report.md >/dev/null
 
+          automerge=false
+          for candidate in $AUTOMERGE_PROVIDERS; do
+            if [ "$candidate" = "$PROVIDER" ]; then
+              automerge=true
+              break
+            fi
+          done
+
+          labels=(automation model-sync "provider:${PROVIDER}")
+          if [ "$automerge" = true ]; then
+            labels+=(sync-automerge)
+          fi
+
           label_args=()
-          IFS=',' read -ra labels <<< "$LABELS"
           for label in "${labels[@]}"; do
-            gh label create "$label" --color "0E8A16" --description "Automated model catalog sync" >/dev/null 2>&1 || true
+            description="Automated model catalog sync"
+            color="0E8A16"
+            if [ "$label" = "sync-automerge" ]; then
+              description="Trusted full-catalog sync; auto-merge after required checks"
+              color="5319E7"
+            fi
+            gh label create "$label" --color "$color" --description "$description" >/dev/null 2>&1 || true
             label_args+=(--label "$label")
           done
 
@@ -105,15 +132,13 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --no-tags --depth=1 origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || true
           git checkout -B "$BRANCH"
           git add models providers
           git commit -m "$TITLE"
           git push --force-with-lease origin "$BRANCH"
 
-          pr_number="$(gh pr list --head "$BRANCH" --base dev --json number --jq '.[0].number')"
+          pr_number="$(gh pr list --head "$BRANCH" --base dev --json number --jq '.[0].number // empty')"
           if [ -n "$pr_number" ]; then
             gh pr edit "$pr_number" --title "$TITLE" --body-file .sync/model-sync-report.md
             for label in "${labels[@]}"; do
@@ -121,4 +146,10 @@ jobs:
             done
           else
             gh pr create --base dev --head "$BRANCH" --title "$TITLE" --body-file .sync/model-sync-report.md "${label_args[@]}"
+            pr_number="$(gh pr list --head "$BRANCH" --base dev --json number --jq '.[0].number // empty')"
+          fi
+
+          if [ "$automerge" = true ] && [ -n "$pr_number" ]; then
+            echo "Enabling auto-merge for trusted provider sync #$pr_number"
+            gh pr merge "$pr_number" --auto --squash
           fi

--- a/sync.md
+++ b/sync.md
@@ -105,12 +105,31 @@ The workflow:
 - Discovers sync providers with `bun models:sync --list-providers`.
 - Runs one provider per matrix job with `bun models:sync ${{ matrix.provider }}`.
 - Runs `bun validate`.
+- Mints a short-lived GitHub App token (`vars.OPENCODE_APP_ID` + `secrets.OPENCODE_APP_SECRET`) so pushes and PRs are authored by the App bot and PR CI can run.
 - Creates or updates a provider-specific sync PR only when `providers` changed.
 - Uses `.sync/model-sync-report.md` as the PR body.
+- Labels every sync PR with `automation`, `model-sync`, and `provider:<id>`.
+- Trusted full-catalog providers also get `sync-automerge` and `gh pr merge --auto --squash` so they merge once required checks pass.
+
+Trusted auto-merge providers (edit `AUTOMERGE_PROVIDERS` in the workflow to change):
+
+- `openrouter`
+- `kilo`
+- `venice`
+- `chutes`
+- `ovhcloud`
+- `wandb`
+
+Repo setup required for auto-merge:
+
+- Install the OpenCode GitHub App on `anomalyco/models.dev` (Contents + Pull requests).
+- Set Actions variable `OPENCODE_APP_ID` and secret `OPENCODE_APP_SECRET` (same values as the opencode repo, or a models.dev-only App).
+- Enable auto-merge on the repository.
+- Ensure branch protection on `dev` allows the App bot path (required checks only, or review bypass for the App).
 
 Each provider job checks out `dev` and writes to a fixed provider branch like `automation/sync-models-openrouter`. If that provider's sync PR is already open, later scheduled runs force-update the same branch and edit the existing PR instead of creating another one. Provider jobs do not share unmerged changes with each other; OpenRouter only uses `base_model` for model metadata entries already present on `dev`.
 
-CI automatically picks up providers registered in `providers` in `packages/core/src/sync/index.ts`. Adding a new sync provider there is enough to get an hourly provider-specific sync job, branch, labels, title, and PR naming convention. The workflow only needs manual updates when a new provider requires new secrets or other environment variables.
+CI automatically picks up providers registered in `providers` in `packages/core/src/sync/index.ts`. Adding a new sync provider there is enough to get an hourly provider-specific sync job, branch, labels, title, and PR naming convention. The workflow only needs manual updates when a new provider requires new secrets or other environment variables, or when adding a provider to the auto-merge allowlist.
 
 Actions are pinned by commit SHA. Keep new workflow actions pinned the same way.
 

--- a/sync.md
+++ b/sync.md
@@ -111,13 +111,10 @@ The workflow:
 - Labels every sync PR with `automation`, `model-sync`, and `provider:<id>`.
 - Trusted full-catalog providers also get `sync-automerge` and `gh pr merge --auto --squash` so they merge once required checks pass.
 
-Trusted auto-merge providers (edit `AUTOMERGE_PROVIDERS` in the workflow to change):
+Trusted auto-merge providers (edit `AUTOMERGE_PROVIDERS` in the workflow to change). Only providers whose catalog API exposes real reasoning controls (not just a boolean), plus full create/update/delete:
 
 - `openrouter`
-- `kilo`
 - `venice`
-- `chutes`
-- `ovhcloud`
 - `wandb`
 
 Repo setup required for auto-merge:


### PR DESCRIPTION
## Summary
- Mint a GitHub App token (`OPENCODE_APP_ID` / `OPENCODE_APP_SECRET`) for sync pushes/PRs so `pull_request` CI actually runs (unlike `GITHUB_TOKEN` bot pushes).
- Label every sync PR with `automation`, `model-sync`, `provider:<id>`.
- Trusted full-catalog providers also get `sync-automerge` and `gh pr merge --auto --squash`.

**Auto-merge allowlist:** `openrouter`, `kilo`, `venice`, `chutes`, `ovhcloud`, `wandb`

## Repo setup (required before this works)
1. Install the OpenCode GitHub App on `anomalyco/models.dev` (Contents + Pull requests).
2. Add Actions variable `OPENCODE_APP_ID` = `1549082` (plaintext) and secret `OPENCODE_APP_SECRET` (App private key from opencode).
3. Enable **Allow auto-merge** on the repo.
4. Branch protection on `dev`: required checks only, or App review bypass if reviews are mandatory.

## Test plan
- [ ] Confirm App install + secrets on models.dev
- [ ] Manually run **Sync Model Catalogs** for `openrouter` (or wait for schedule)
- [ ] PR opens as App bot, has `sync-automerge`, auto-merge queued
- [ ] After validate CI green, PR squash-merges to `dev`
- [ ] Non-allowlisted provider PR still opens without auto-merge