### PR TITLE
fix(deepseek): deprecate legacy model aliases

### DIFF
--- a/providers/deepseek/models/deepseek-chat.toml
+++ b/providers/deepseek/models/deepseek-chat.toml
@@ -1,14 +1,18 @@
+# DeepSeek will retire this legacy alias after 2026-07-24 15:59 UTC.
+# It currently routes to deepseek-v4-flash in non-thinking mode.
+# https://api-docs.deepseek.com/updates (accessed 2026-07-22)
 name = "DeepSeek Chat"
 description = "DeepSeek chat model for instruction following, coding, and analysis"
 family = "deepseek"
 release_date = "2025-12-01"
-last_updated = "2026-02-28"
+last_updated = "2026-04-24"
 attachment = true
 reasoning = false
 temperature = true
 knowledge = "2025-09"
 tool_call = true
 open_weights = true
+status = "deprecated"
 
 [cost]
 input = 0.14

--- a/providers/deepseek/models/deepseek-reasoner.toml
+++ b/providers/deepseek/models/deepseek-reasoner.toml
@@ -1,17 +1,21 @@
+# DeepSeek will retire this legacy alias after 2026-07-24 15:59 UTC.
+# It currently routes to deepseek-v4-flash in thinking mode.
+# https://api-docs.deepseek.com/updates (accessed 2026-07-22)
+# The legacy request schema exposes no toggle, effort, or token budget;
+# reasoning is returned as `reasoning_content`.
+# https://api-docs.deepseek.com/guides/reasoning_model (accessed 2026-06-25)
 name = "DeepSeek Reasoner"
 description = "DeepSeek reasoning model for multi-step analysis, math, coding, and tools"
-# Legacy reasoning-only request schema documents no toggle, effort, or token
-# budget; reasoning is returned as `reasoning_content`.
-# https://api-docs.deepseek.com/guides/reasoning_model (accessed 2026-06-25)
 family = "deepseek-thinking"
 release_date = "2025-12-01"
-last_updated = "2026-02-28"
+last_updated = "2026-04-24"
 attachment = true
 reasoning = true
 temperature = true
 knowledge = "2025-09"
 tool_call = true
 open_weights = true
+status = "deprecated"
 
 reasoning_options = []
 


### PR DESCRIPTION
## Summary

- mark `deepseek-chat` and `deepseek-reasoner` as deprecated so clients stop offering the legacy aliases
- keep `deepseek-v4-flash` and `deepseek-v4-pro` active
- document the aliases' current routing modes and retirement deadline

## Evidence

[DeepSeek's official updates page](https://api-docs.deepseek.com/updates/) documents that `deepseek-chat` and `deepseek-reasoner` route to the non-thinking and thinking modes of `deepseek-v4-flash`, respectively, and will be retired after 2026-07-24 15:59 UTC.

## Validation

- `bun validate`
- verified generated statuses: legacy aliases are `deprecated`; V4 Flash and V4 Pro remain `active`