### PR TITLE
feat: add provider request variants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,9 +105,23 @@ items are **hard blockers**; the last two are **strongly recommended** but not b
   - Plain objects from metadata and provider TOML (`[limit]`, `[modalities]`, …) are **deep-merged**
   - Arrays (e.g. `modalities.input`) and primitives are **replaced** wholesale by the child
   - Any provider field omitted is inherited verbatim from model metadata
-  - `cost`, `provider`, `experimental`, `reasoning_options`, `interleaved`, and `status` are provider-specific and must be declared in provider TOMLs when needed
+  - `cost`, `provider`, `experimental`, `reasoning_options`, `variants`, `interleaved`, and `status` are provider-specific and must be declared in provider TOMLs when needed
 - `base_model_omit` runs **after** the merge and deletes each dot-path from the result. Missing paths are ignored. Ancestor tables that become empty as a result are also pruned.
 - The base model metadata file must exist; `base_model` pointing at a missing `models/` entry is an error
+
+### Provider request variants
+
+- Provider model TOMLs may declare exact request bodies under `variants.<id>` when semantic `reasoning_options` are insufficient to describe the provider's wire format.
+- Variant values are copied unchanged into clients' ordinary model variants; do not use them for client-specific transformations.
+- Keep provider defaults separate under `provider.body`. Selecting no variant preserves that default.
+- Example:
+  ```toml
+  [variants.none.chat_template_kwargs]
+  thinking_mode = "disabled"
+
+  [variants.thinking.chat_template_kwargs]
+  thinking_mode = "enabled"
+  ```
 
 ### Bedrock Naming Patterns
 - Dated models: `-v1:0` suffix (`anthropic.claude-3-5-sonnet-20241022-v1:0.toml`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ items are **hard blockers**; the last two are **strongly recommended** but not b
 
 - Provider model TOMLs may declare exact request bodies under `variants.<id>` when semantic `reasoning_options` are insufficient to describe the provider's wire format.
 - Variant values are copied unchanged into clients' ordinary model variants; do not use them for client-specific transformations.
-- Keep provider defaults separate under `provider.body`. Selecting no variant preserves that default.
+- Select an ordinary default variant with `provider.variant`. Use `provider.body` only for defaults shared by every variant.
 - Example:
   ```toml
   [variants.none.chat_template_kwargs]

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -3,12 +3,7 @@ import { z } from "zod";
 import { ModelFamily } from "./family";
 
 type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: JsonValue }
-  | JsonValue[];
+  string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
 
 const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
   z.union([
@@ -25,7 +20,16 @@ const ReasoningEffortValue = z.preprocess(
   (value) => (value === "null" ? null : value),
   z.union([
     z.null(),
-    z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max", "default"]),
+    z.enum([
+      "none",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "default",
+    ]),
   ]),
 );
 
@@ -219,6 +223,7 @@ const ModelBase = z.object({
   attachment: z.boolean(),
   reasoning: z.boolean(),
   reasoning_options: z.array(ReasoningOption).optional(),
+  variants: z.record(z.record(JsonValue)).optional(),
   tool_call: z.boolean(),
   interleaved: z
     .union([
@@ -273,7 +278,8 @@ const ModelBase = z.object({
 });
 
 function refineModel<
-  Output extends z.infer<typeof ModelShape> | z.infer<typeof AuthoredModelShape>,
+  Output extends
+    z.infer<typeof ModelShape> | z.infer<typeof AuthoredModelShape>,
   Def extends z.ZodTypeDef,
   Input,
 >(schema: z.ZodType<Output, Def, Input>) {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -271,6 +271,7 @@ const ModelBase = z.object({
       npm: z.string().optional(),
       api: z.string().optional(),
       shape: z.enum(["responses", "completions"]).optional(),
+      variant: z.string().optional(),
       body: z.record(JsonValue).optional(),
       headers: z.record(z.string()).optional(),
     })
@@ -300,6 +301,18 @@ function refineModel<
       {
         message: "Cannot set reasoning_options when reasoning is false",
         path: ["reasoning_options"],
+      },
+    )
+    .refine(
+      (data) => {
+        return (
+          data.provider?.variant === undefined ||
+          data.variants?.[data.provider.variant] !== undefined
+        );
+      },
+      {
+        message: "Provider default variant must reference a declared variant",
+        path: ["provider", "variant"],
       },
     )
     .refine(

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -203,8 +203,9 @@ type = "disabled"
 [variants.thinking.thinking]
 type = "adaptive"
 
-[provider.body.thinking]
-type = "adaptive"
+[provider]
+variant = "thinking"
+body = { thinking = { type = "adaptive" } }
 
 [cost]
 input = 1.25
@@ -219,7 +220,10 @@ output = 2.50
           none: { thinking: { type: "disabled" } },
           thinking: { thinking: { type: "adaptive" } },
         },
-        provider: { body: { thinking: { type: "adaptive" } } },
+        provider: {
+          variant: "thinking",
+          body: { thinking: { type: "adaptive" } },
+        },
       });
     });
   });

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -37,8 +37,16 @@ function stable(value: unknown): string {
 describe("catalog generation", () => {
   test("base_model can factor metadata without changing provider JSON", async () => {
     await withFixture(async (root) => {
-      await write(root, "providers/direct/provider.toml", providerToml("Direct"));
-      await write(root, "providers/factored/provider.toml", providerToml("Factored"));
+      await write(
+        root,
+        "providers/direct/provider.toml",
+        providerToml("Direct"),
+      );
+      await write(
+        root,
+        "providers/factored/provider.toml",
+        providerToml("Factored"),
+      );
       await write(root, "models/lab/model.toml", modelMetadataToml());
       await write(
         root,
@@ -100,7 +108,11 @@ cache_read = 0.125
 
   test("base_model_omit removes inherited metadata fields", async () => {
     await withFixture(async (root) => {
-      await write(root, "providers/provider/provider.toml", providerToml("Provider"));
+      await write(
+        root,
+        "providers/provider/provider.toml",
+        providerToml("Provider"),
+      );
       await write(root, "models/lab/model.toml", modelMetadataToml());
       await write(
         root,
@@ -132,7 +144,11 @@ output = 32_000
 
   test("base_model can inherit sibling fields from partial object overrides", async () => {
     await withFixture(async (root) => {
-      await write(root, "providers/provider/provider.toml", providerToml("Provider"));
+      await write(
+        root,
+        "providers/provider/provider.toml",
+        providerToml("Provider"),
+      );
       await write(root, "models/lab/model.toml", modelMetadataToml());
       await write(
         root,
@@ -169,6 +185,45 @@ input = ["text"]
     });
   });
 
+  test("provider request defaults and variants are emitted unchanged", async () => {
+    await withFixture(async (root) => {
+      await write(
+        root,
+        "providers/provider/provider.toml",
+        providerToml("Provider"),
+      );
+      await write(
+        root,
+        "providers/provider/models/model.toml",
+        `${providerFieldsToml()}
+
+[variants.none.thinking]
+type = "disabled"
+
+[variants.thinking.thinking]
+type = "adaptive"
+
+[provider.body.thinking]
+type = "adaptive"
+
+[cost]
+input = 1.25
+output = 2.50
+`,
+      );
+
+      const providers = await generate(path.join(root, "providers"));
+
+      expect(providers.provider?.models.model).toMatchObject({
+        variants: {
+          none: { thinking: { type: "disabled" } },
+          thinking: { thinking: { type: "adaptive" } },
+        },
+        provider: { body: { thinking: { type: "adaptive" } } },
+      });
+    });
+  });
+
   test("repository provider TOMLs do not use legacy extends tables", async () => {
     const root = path.join(import.meta.dirname, "..", "..", "..");
     const matches: string[] = [];
@@ -191,7 +246,10 @@ input = ["text"]
     for (const [providerID, provider] of Object.entries(providers)) {
       for (const [modelID, model] of Object.entries(provider.models)) {
         const encoded = stable(model);
-        if (encoded.includes("base_model") || encoded.includes("base_model_omit")) {
+        if (
+          encoded.includes("base_model") ||
+          encoded.includes("base_model_omit")
+        ) {
           leaked.push(`${providerID}/${modelID}`);
         }
       }
@@ -228,7 +286,7 @@ input = ["text"]
       "zai",
     ];
     const namespaceDirs = providerNamespaces.filter((namespace) =>
-      existsSync(path.join(root, "models", namespace))
+      existsSync(path.join(root, "models", namespace)),
     );
     const baseModelRefs: string[] = [];
 

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -45,6 +45,17 @@ describe("model schema", () => {
       thinking: { chat_template_kwargs: { thinking_mode: "enabled" } },
     });
   });
+
+  test("rejects an undeclared provider default variant", () => {
+    const model = baseModel({
+      reasoning: true,
+      reasoning_options: [{ type: "toggle" }],
+      variants: { none: { thinking: { type: "disabled" } } },
+      provider: { variant: "thinking" },
+    });
+
+    expect(AuthoredModel.safeParse(model).success).toBe(false);
+  });
 });
 
 function baseModel(overrides: Partial<AuthoredModelData>) {

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -29,6 +29,22 @@ describe("model schema", () => {
 
     expect(AuthoredModel.safeParse(model).success).toBe(false);
   });
+
+  test("accepts provider request variants", () => {
+    const model = baseModel({
+      reasoning: true,
+      reasoning_options: [{ type: "toggle" }],
+      variants: {
+        none: { chat_template_kwargs: { thinking_mode: "disabled" } },
+        thinking: { chat_template_kwargs: { thinking_mode: "enabled" } },
+      },
+    });
+
+    expect(AuthoredModel.parse(model).variants).toEqual({
+      none: { chat_template_kwargs: { thinking_mode: "disabled" } },
+      thinking: { chat_template_kwargs: { thinking_mode: "enabled" } },
+    });
+  });
 });
 
 function baseModel(overrides: Partial<AuthoredModelData>) {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -192,6 +192,8 @@ export interface ModelProviderConfig {
   api?: string
   /** API shape when the npm package supports multiple. */
   shape?: "responses" | "completions"
+  /** Variant selected when a request does not choose one explicitly. */
+  variant?: string
   /** Extra request body fields required by this model. */
   body?: Record<string, JsonValue>
   /** Extra request headers required by this model. */
@@ -214,6 +216,8 @@ export interface Model {
   reasoning: boolean
   /** Present exactly when `reasoning` is true. */
   reasoning_options?: ReasoningOption[]
+  /** Provider-authored request body variants keyed by variant ID. */
+  variants?: Record<string, Record<string, JsonValue>>
   /** Supports tool/function calling. */
   tool_call: boolean
   /** Supports interleaved thinking between tool calls. */

--- a/providers/crossmodel/models/minimax/minimax-m3.toml
+++ b/providers/crossmodel/models/minimax/minimax-m3.toml
@@ -3,6 +3,12 @@ base_model = "minimax/MiniMax-M3"
 [[reasoning_options]]
 type = "toggle"
 
+[variants.none.thinking]
+type = "disabled"
+
+[variants.thinking.thinking]
+type = "adaptive"
+
 [cost]
 input = 0.33
 output = 1.32

--- a/providers/kilo/models/minimax/minimax-m3.toml
+++ b/providers/kilo/models/minimax/minimax-m3.toml
@@ -3,6 +3,12 @@ name = "MiniMax: MiniMax M3"
 last_updated = "2026-06-30"
 reasoning_options = [{ type = "toggle" }]
 
+[variants.none.reasoning]
+enabled = false
+
+[variants.thinking.reasoning]
+enabled = true
+
 [cost]
 input = 0.3
 output = 1.2

--- a/providers/lilac/models/minimaxai/minimax-m3.toml
+++ b/providers/lilac/models/minimaxai/minimax-m3.toml
@@ -7,6 +7,12 @@ family = "minimax-m3"
 reasoning_options = [{ type = "toggle" }]
 structured_output = true
 
+[variants.none.chat_template_kwargs]
+thinking_mode = "disabled"
+
+[variants.thinking.chat_template_kwargs]
+thinking_mode = "enabled"
+
 [cost]
 input = 0.28
 output = 1.1

--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -12,6 +12,12 @@ open_weights = true
 [[reasoning_options]]
 type = "toggle"
 
+[variants.none.thinking]
+type = "disabled"
+
+[variants.thinking.thinking]
+type = "adaptive"
+
 [cost]
 input = 0
 output = 0
@@ -25,3 +31,6 @@ output = 128_000
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[provider.body.thinking]
+type = "adaptive"

--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -32,5 +32,5 @@ output = 128_000
 input = ["text", "image", "video"]
 output = ["text"]
 
-[provider.body.thinking]
-type = "adaptive"
+[provider]
+variant = "thinking"

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -37,5 +37,5 @@ output = 128_000
 input = ["text", "image", "video"]
 output = ["text"]
 
-[provider.body.thinking]
-type = "adaptive"
+[provider]
+variant = "thinking"

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -12,6 +12,12 @@ open_weights = true
 [[reasoning_options]]
 type = "toggle"
 
+[variants.none.thinking]
+type = "disabled"
+
+[variants.thinking.thinking]
+type = "adaptive"
+
 [cost]
 input = 0.30
 output = 1.20
@@ -30,3 +36,6 @@ output = 128_000
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[provider.body.thinking]
+type = "adaptive"

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -12,6 +12,12 @@ open_weights = true
 [[reasoning_options]]
 type = "toggle"
 
+[variants.none.thinking]
+type = "disabled"
+
+[variants.thinking.thinking]
+type = "adaptive"
+
 [cost]
 input = 0
 output = 0
@@ -25,3 +31,6 @@ output = 128_000
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[provider.body.thinking]
+type = "adaptive"

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -32,5 +32,5 @@ output = 128_000
 input = ["text", "image", "video"]
 output = ["text"]
 
-[provider.body.thinking]
-type = "adaptive"
+[provider]
+variant = "thinking"

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -37,5 +37,5 @@ output = 128_000
 input = ["text", "image", "video"]
 output = ["text"]
 
-[provider.body.thinking]
-type = "adaptive"
+[provider]
+variant = "thinking"

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -12,6 +12,12 @@ open_weights = true
 [[reasoning_options]]
 type = "toggle"
 
+[variants.none.thinking]
+type = "disabled"
+
+[variants.thinking.thinking]
+type = "adaptive"
+
 [cost]
 input = 0.30
 output = 1.20
@@ -30,3 +36,6 @@ output = 128_000
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[provider.body.thinking]
+type = "adaptive"

--- a/providers/nvidia/models/minimaxai/minimax-m3.toml
+++ b/providers/nvidia/models/minimaxai/minimax-m3.toml
@@ -1,6 +1,12 @@
 base_model = "minimax/MiniMax-M3"
 reasoning_options = [{ type = "toggle" }]
 
+[variants.none.chat_template_kwargs]
+thinking_mode = "disabled"
+
+[variants.thinking.chat_template_kwargs]
+thinking_mode = "enabled"
+
 [cost]
 input = 0.0
 output = 0.0

--- a/providers/opencode-go/models/minimax-m3.toml
+++ b/providers/opencode-go/models/minimax-m3.toml
@@ -11,6 +11,12 @@ tool_call = true
 knowledge = "2025-01"
 open_weights = true
 
+[variants.none.thinking]
+type = "disabled"
+
+[variants.thinking.thinking]
+type = "adaptive"
+
 [cost]
 input = 0.3
 output = 1.2
@@ -32,3 +38,6 @@ output = ["text"]
 
 [provider]
 npm = "@ai-sdk/anthropic"
+
+[provider.body.thinking]
+type = "adaptive"

--- a/providers/opencode-go/models/minimax-m3.toml
+++ b/providers/opencode-go/models/minimax-m3.toml
@@ -38,6 +38,4 @@ output = ["text"]
 
 [provider]
 npm = "@ai-sdk/anthropic"
-
-[provider.body.thinking]
-type = "adaptive"
+variant = "thinking"

--- a/providers/opencode/models/minimax-m3-free.toml
+++ b/providers/opencode/models/minimax-m3-free.toml
@@ -12,6 +12,12 @@ knowledge = "2025-01"
 open_weights = true
 status = "deprecated"
 
+[variants.none.thinking]
+type = "disabled"
+
+[variants.thinking.thinking]
+type = "adaptive"
+
 [cost]
 input = 0
 output = 0
@@ -27,3 +33,6 @@ output = ["text"]
 
 [provider]
 npm = "@ai-sdk/anthropic"
+
+[provider.body.thinking]
+type = "adaptive"

--- a/providers/opencode/models/minimax-m3-free.toml
+++ b/providers/opencode/models/minimax-m3-free.toml
@@ -33,6 +33,4 @@ output = ["text"]
 
 [provider]
 npm = "@ai-sdk/anthropic"
-
-[provider.body.thinking]
-type = "adaptive"
+variant = "thinking"

--- a/providers/zenmux/models/minimax/minimax-m3.toml
+++ b/providers/zenmux/models/minimax/minimax-m3.toml
@@ -1,6 +1,12 @@
 base_model = "minimax/MiniMax-M3"
 reasoning_options = [{ type = "toggle" }]
 
+[variants.none.thinking]
+type = "disabled"
+
+[variants.thinking.thinking]
+type = "adaptive"
+
 [cost]
 input = 0.60
 output = 2.40
@@ -8,3 +14,6 @@ output = 2.40
 [provider]
 npm = "@ai-sdk/anthropic"
 api = "https://zenmux.ai/api/anthropic/v1"
+
+[provider.body.thinking]
+type = "adaptive"

--- a/providers/zenmux/models/minimax/minimax-m3.toml
+++ b/providers/zenmux/models/minimax/minimax-m3.toml
@@ -14,6 +14,4 @@ output = 2.40
 [provider]
 npm = "@ai-sdk/anthropic"
 api = "https://zenmux.ai/api/anthropic/v1"
-
-[provider.body.thinking]
-type = "adaptive"
+variant = "thinking"


### PR DESCRIPTION
## Summary

- add provider-model `variants` as ordinary request-body records
- add `provider.variant` for selecting an ordinary default variant
- declare MiniMax M3 toggle bodies for direct MiniMax, NVIDIA, Lilac, Kilo, CrossModel, OpenCode, and ZenMux routes
- select the existing `thinking` variant by default only on Anthropic-compatible MiniMax routes

This lets clients apply provider-authored variants directly instead of inferring wire formats from `reasoning_options` or model IDs.

## Sources

- MiniMax: https://platform.minimax.io/docs/api-reference/text-anthropic-api
- NVIDIA: https://docs.api.nvidia.com/nim/reference/minimaxai-minimax-m3-infer
- Lilac: https://docs.getlilac.com/inference/chat-completions#reasoning
- Kilo: https://kilo.ai/docs/gateway

## Testing

- `bun test packages/core/test/schema.test.ts`
- `bun test packages/core/test/generate.test.ts --test-name-pattern "provider request defaults"`
- `bun validate`
- `git diff --check`

The full `generate.test.ts` suite has an unrelated existing failure for open-weight model records missing weights links; the changed generation test passes.