### PR TITLE
chore(ci): switch automation models to opencode/grok-4.5

### DIFF
--- a/.github/workflows/ci-fixer.yml
+++ b/.github/workflows/ci-fixer.yml
@@ -140,7 +140,7 @@ jobs:
           Failed log excerpt:
           EOF
             cat "$LOG_FILE"
-          } | opencode run --agent ci-fixer -m opencode/glm-5.2 | tee "$RESPONSE_FILE"
+          } | opencode run --agent ci-fixer -m opencode/grok-4.5 | tee "$RESPONSE_FILE"
 
       - name: Check changed paths
         if: steps.budget.outputs.run == 'true' && steps.budget-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/issue-fixer.yml
+++ b/.github/workflows/issue-fixer.yml
@@ -40,7 +40,7 @@ jobs:
           RESPONSE_FILE="$RUNNER_TEMP/issue-fixer-response.md"
           echo "RESPONSE_FILE=$RESPONSE_FILE" >> "$GITHUB_ENV"
 
-          opencode run --agent issue-fixer -m opencode/glm-5.2 --format json <<EOF | tee "$EVENTS_FILE"
+          opencode run --agent issue-fixer -m opencode/grok-4.5 --format json <<EOF | tee "$EVENTS_FILE"
           A new GitHub issue was opened in anomalyco/models.dev.
 
           Issue #$ISSUE_NUMBER: $ISSUE_TITLE

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -27,4 +27,4 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode/gpt-5.5
+          model: opencode/grok-4.5

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -60,7 +60,7 @@ jobs:
           RESPONSE_FILE="$RUNNER_TEMP/pr-reviewer-response.md"
           echo "RESPONSE_FILE=$RESPONSE_FILE" >> "$GITHUB_ENV"
 
-          opencode run --agent pr-reviewer -m opencode/glm-5.2 --format json <<'EOF' | tee "$EVENTS_FILE"
+          opencode run --agent pr-reviewer -m opencode/grok-4.5 --format json <<'EOF' | tee "$EVENTS_FILE"
           Review this pull request using the trusted reviewer instructions. Start with `.pr-review/pull-request.json`, `.pr-review/diff.patch`, `AGENTS.md`, and the contributing guidance in `README.md`. Read `sync.md`, the reasoning-options audit guide, schema code, and nearby base-revision files when relevant to the changed files. Use only the read, glob, and grep tools. Return only the final review comment in the agent's required output format. Never include progress narration or passed-check summaries.
           EOF
 


### PR DESCRIPTION
## Summary
- Point all OpenCode CI automations at `opencode/grok-4.5`
- Covers opencode comment bot, CI fixer, issue fixer, and PR reviewer

## Test plan
- [ ] Confirm workflow YAML diffs only change the model id
- [ ] Spot-check one automation run after merge (e.g. PR reviewer or `/oc` comment)