### PR TITLE
baseten: record GLM-5.2 enforced input limit (202,720)

### DIFF
--- a/providers/baseten/models/zai-org/GLM-5.2.toml
+++ b/providers/baseten/models/zai-org/GLM-5.2.toml
@@ -1,6 +1,11 @@
 # Opt in with chat_template_args.enable_thinking=true. Baseten documents no
 # explicit false behavior, effort values, or reasoning-token budget.
 # https://docs.baseten.co/inference/model-apis/reasoning
+#
+# limit.input: Baseten serves this model with a prompt ceiling below the
+# advertised context window. Requests above it are rejected before inference:
+#   HTTP 400 "Input length 202935 exceeds the maximum allowed input length of
+#   202720 tokens." (observed 2026-07-22, inference.baseten.co/v1/chat/completions)
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
 
@@ -17,4 +22,5 @@ cache_read = 0.3
 
 [limit]
 context = 256_000
+input = 202_720
 output = 256_000


### PR DESCRIPTION
## Problem

Baseten enforces a prompt ceiling on `zai-org/GLM-5.2` that is well below the
context window it reports. Requests are rejected before inference with an HTTP 400:

```
{"message":"Input length 202935 exceeds the maximum allowed input length of 202720 tokens.","type":"Bad Request","code":400}
```

Observed 2026-07-22 against `https://inference.baseten.co/v1/chat/completions`.

Because only `limit.context = 256_000` is recorded today, consumers that size a
context budget from it overshoot the real ceiling and fail mid-session. In
opencode, for instance, the auto-compaction trigger is
`limit.context - min(limit.output, 32000)` when `limit.input` is absent, which
lands at 224,000 — about 21k tokens past what Baseten will accept.

## Change

Adds `limit.input = 202_720` to `providers/baseten/models/zai-org/GLM-5.2.toml`.

`limit.context` and `limit.output` are deliberately left alone — those come from
Baseten's API on every sync, and this PR does not dispute them. The input ceiling
is a separate, independently enforced value.

This is sync-stable: `packages/core/src/sync/providers/baseten.ts` already
preserves `limit.input` from the existing entry while refreshing context/output
from the API, so the value survives the daily run.

```ts
const limit = {
  context: model.context_length,
  input: existing?.limit?.input,   // preserved
  output: model.max_completion_tokens,
}
```

The citation comment is placed in the file's leading header block, per the
`AGENTS.md` note that mid-file comments are discarded on re-serialization.

## Prior art

`providers/alibaba-token-plan/models/MiniMax-M2.5.toml` records the same shape —
a 196,608 context alongside an enforced `input = 196_601`.

## Sources

- https://docs.baseten.co/inference/model-apis/overview — Baseten's published limits,
  noting that "context and output limits reflect Baseten's live serving configuration"
  and may differ from the original model specs
- The 400 response quoted above, reproduced across 5 separate requests, each
  reporting the identical 202,720 ceiling

## Scope

I checked every other Baseten model in the registry against Baseten's published
limits — the remaining entries are consistent with the docs, and their derived
budgets already fall below the documented ceilings. GLM-5.2 is the only one that
needed a change, so this PR touches one file.

Note: I could not run `bun validate` locally (no bun on this machine). The edit
conforms to `ProviderModelLimit` in `packages/core/src/schema.ts` — strict keys
`context`/`input`/`output`, all non-negative, with `input <= context`.
