### PR TITLE
feat(dinference): add GLM-5.2 model

### DIFF
--- a/providers/dinference/models/glm-5.2.toml
+++ b/providers/dinference/models/glm-5.2.toml
@@ -1,0 +1,12 @@
+reasoning_options = []
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.25
+output = 3.89
+
+[limit]
+output = 128_000


### PR DESCRIPTION
## Summary
- Add GLM-5.2 model configuration (1M context, reasoning, tool calling)

## Model Details

| Model  | Context | Output | Input Price | Output Price |
|--------|---------|--------|-------------|--------------|
| GLM-5.2 | 1M      | 128K   | $1.25/M     | $3.89/M      |

## Notes
- Wraps the canonical `zhipuai/glm-5.2` definition (Z.ai flagship, MIT,
  1M context, released 2026-06-13) via `base_model`.
- DInference pricing and output cap: first-party from the operator. The model
  is not yet on https://dinference.com/pricing but the rate (input $1.25/M,
  output $3.89/M, output cap 128K) matches DInference's GLM-5.1 rate and is
  authoritative from the operator.
- `cache_read` / `cache_write` fields omitted — DInference does not bill cache.
- `reasoning_options = []` because DInference's API does not expose the
  effort control surfaced by Z.ai (`high` / `max`).