### PR TITLE
Add automatic April Series model sync

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -64,6 +64,7 @@ jobs:
         run: bun models:sync ${{ matrix.provider }}
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          APRIL_API_KEY: ${{ secrets.APRIL_API_KEY }}
           BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
           DEEPINFRA_API_KEY: ${{ secrets.DEEPINFRA_API_KEY }}
           DIGITALOCEAN_API_TOKEN: ${{ secrets.DIGITALOCEAN_API_TOKEN }}

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { AuthoredModel, AuthoredModelShape, ModelMetadata } from "../schema.js";
 import { ambient } from "./providers/ambient.js";
+import { aprilseries } from "./providers/aprilseries.js";
 import { anthropic } from "./providers/anthropic.js";
 import { baseten } from "./providers/baseten.js";
 import { chutes } from "./providers/chutes.js";
@@ -94,6 +95,7 @@ export interface SyncResult {
 
 export const providers: {
   ambient: SyncProvider<any>;
+  aprilseries: SyncProvider<any>;
   anthropic: SyncProvider<any>;
   baseten: SyncProvider<any>;
   chutes: SyncProvider<any>;
@@ -116,6 +118,7 @@ export const providers: {
   xai: SyncProvider<any>;
 } = {
   ambient,
+  aprilseries,
   anthropic,
   baseten,
   chutes,
@@ -141,7 +144,7 @@ export const providers: {
 export const groups = {
   aggregators: ["crossmodel", "empiriolabs", "huggingface", "kilo", "llmgateway", "openrouter", "vercel"],
   cloudflare: ["cloudflare-workers-ai"],
-  direct: ["ambient", "anthropic", "baseten", "chutes", "deepinfra", "digitalocean", "google", "openai", "ovhcloud", "pioneer", "venice", "wandb", "xai"],
+  direct: ["ambient", "anthropic", "aprilseries", "baseten", "chutes", "deepinfra", "digitalocean", "google", "openai", "ovhcloud", "pioneer", "venice", "wandb", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;

--- a/packages/core/src/sync/providers/aprilseries.ts
+++ b/packages/core/src/sync/providers/aprilseries.ts
@@ -1,0 +1,79 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+
+import type { ExistingModel, SyncProvider, SyncedModel } from "../index.js";
+import { factorBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://aprilseries.lat/v1/models";
+const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
+const AprilModel = z.object({
+  id: z.string().min(1),
+  display_name: z.string().optional(),
+  created: z.number().int().nonnegative(),
+  context: z.union([z.string(), z.number()]).optional(),
+  context_window: z.number().int().nonnegative().optional(),
+  max_output_tokens: z.number().int().nonnegative().optional(),
+  price_per_1m: z.number().nonnegative().optional(),
+  price_out_per_1m: z.number().nonnegative().optional(),
+  capabilities: z.object({ vision: z.boolean().optional(), tool_calling: z.boolean().optional(), structured_outputs: z.boolean().optional() }).passthrough().optional(),
+  reasoning: z.object({ effort_levels: z.array(z.object({ value: z.string() }).passthrough()).optional(), budget_tokens: z.object({ min: z.number().optional(), max: z.number().optional() }).optional() }).nullable().optional(),
+}).passthrough();
+const AprilResponse = z.object({ data: z.array(AprilModel) }).passthrough();
+export type AprilModel = z.infer<typeof AprilModel>;
+
+export const aprilseries = {
+  id: "aprilseries",
+  name: "April Series",
+  modelsDir: "providers/aprilseries/models",
+  async fetchModels() {
+    const key = process.env.APRIL_API_KEY;
+    if (!key) throw new Error("April Series sync requires APRIL_API_KEY");
+    const response = await fetch(API_ENDPOINT, { headers: { Authorization: `Bearer ${key}` } });
+    if (!response.ok) throw new Error(`April Series models request failed: ${response.status} ${response.statusText}`);
+    return response.json();
+  },
+  parseModels(raw) { return AprilResponse.parse(raw).data; },
+  translateModel(model, context) {
+    const existing = context.existing(model.id);
+    const baseModel = existing?.base_model ?? resolveBaseModel(model.id);
+    if (baseModel === undefined || !baseModelExists(baseModel)) return undefined;
+    return { id: model.id, model: buildAprilModel(model, existing, baseModel) };
+  },
+} satisfies SyncProvider<AprilModel>;
+
+function buildAprilModel(model: AprilModel, existing: ExistingModel | undefined, baseModel: string): SyncedModel {
+  const context = number(model.context_window) ?? parseContext(model.context) ?? existing?.limit?.context;
+  if (context === undefined) return { base_model: baseModel };
+  const input = model.capabilities?.vision === true ? ["text" as const, "image" as const] : existing?.modalities?.input ?? ["text" as const];
+  const remote = model.reasoning;
+  const reasoningOptions = reasoningOptionsFor(remote, existing?.reasoning_options);
+  const reasoning = remote === null ? false : existing?.reasoning;
+  const output = model.max_output_tokens ?? existing?.limit?.output;
+  const cost = model.price_per_1m !== undefined && model.price_out_per_1m !== undefined
+    ? { input: model.price_per_1m, output: model.price_out_per_1m, reasoning: existing?.cost?.reasoning, cache_read: existing?.cost?.cache_read, cache_write: existing?.cost?.cache_write, tiers: existing?.cost?.tiers }
+    : existing?.cost;
+  return factorBaseModel(baseModel, { name: model.display_name ?? existing?.name, attachment: input.length > 1, reasoning, reasoning_options: reasoningOptions, tool_call: model.capabilities?.tool_calling ?? existing?.tool_call, structured_output: model.capabilities?.structured_outputs ?? existing?.structured_output, temperature: existing?.temperature, cost, limit: { context, input: existing?.limit?.input, output }, modalities: { input, output: ["text"] }, status: existing?.status, interleaved: existing?.interleaved, provider: existing?.provider, experimental: existing?.experimental }, { context, input: existing?.limit?.input, output }, existing?.base_model_omit);
+}
+
+function reasoningOptionsFor(remote: AprilModel["reasoning"], existing: ExistingModel["reasoning_options"]) {
+  if (remote === undefined) return existing;
+  const options = (existing ?? []).filter((option) => option.type !== "effort" && option.type !== "budget_tokens");
+  const efforts = remote?.effort_levels?.map((level) => level.value).filter(isReasoningEffort);
+  if (efforts !== undefined && efforts.length > 0) options.push({ type: "effort", values: efforts });
+  if (remote?.budget_tokens !== undefined) options.push({ type: "budget_tokens", ...remote.budget_tokens });
+  return options;
+}
+
+function parseContext(value: string | number | undefined) {
+  if (typeof value === "number") return value;
+  if (value === undefined) return undefined;
+  const match = value.trim().toUpperCase().match(/^(\d+(?:\.\d+)?)\s*([KM])?$/);
+  if (match === null) return undefined;
+  return Math.round(Number(match[1]) * (match[2] === "M" ? 1_000_000 : match[2] === "K" ? 1_000 : 1));
+}
+function number(value: number | undefined) { return value !== undefined && Number.isFinite(value) && value >= 0 ? value : undefined; }
+const BASE_MODEL_ALIASES: Record<string, string> = { "gpt-5.5-fast": "openai/gpt-5.5" };
+function resolveBaseModel(id: string) { const alias = BASE_MODEL_ALIASES[id]; if (alias !== undefined) return alias; const provider = id.startsWith("claude-") ? "anthropic" : id.startsWith("gpt-") ? "openai" : undefined; return provider === undefined ? undefined : `${provider}/${id}`; }
+function baseModelExists(modelID: string) { return existsSync(path.join(MODELS_DIR, `${modelID}.toml`)); }
+function isReasoningEffort(value: string): value is "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "default" { return ["none", "minimal", "low", "medium", "high", "xhigh", "max", "default"].includes(value); }

--- a/providers/aprilseries/logo.svg
+++ b/providers/aprilseries/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M4 20 12 4l8 16M7 14h10"/>
+</svg>

--- a/providers/aprilseries/models/claude-opus-4-8.toml
+++ b/providers/aprilseries/models/claude-opus-4-8.toml
@@ -1,0 +1,11 @@
+# Source: https://aprilseries.lat/models (accessed 2026-07-23)
+# API: /v1/messages {"thinking":{"type":"enabled","budget_tokens":<n>}}
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+
+[limit]
+context = 262_000
+
+[cost]
+input = 0.45
+output = 2.25

--- a/providers/aprilseries/models/gpt-5.5-fast.toml
+++ b/providers/aprilseries/models/gpt-5.5-fast.toml
@@ -1,0 +1,11 @@
+# Source: https://aprilseries.lat/models (accessed 2026-07-23)
+# API: /v1/chat/completions {"reasoning_effort":"none|low|medium|high"}
+base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[limit]
+context = 1_000_000
+
+[cost]
+input = 0.99
+output = 0.99

--- a/providers/aprilseries/models/gpt-5.5.toml
+++ b/providers/aprilseries/models/gpt-5.5.toml
@@ -1,0 +1,11 @@
+# Source: https://aprilseries.lat/models (accessed 2026-07-23)
+# API: /v1/chat/completions {"reasoning_effort":"none|low|medium|high"}
+base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[limit]
+context = 1_000_000
+
+[cost]
+input = 0.15
+output = 0.16

--- a/providers/aprilseries/models/gpt-5.6-luna.toml
+++ b/providers/aprilseries/models/gpt-5.6-luna.toml
@@ -1,0 +1,11 @@
+# Source: https://aprilseries.lat/models (accessed 2026-07-23)
+# API: /v1/chat/completions {"reasoning_effort":"none|low|medium|high"}
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[limit]
+context = 1_000_000
+
+[cost]
+input = 0.03
+output = 0.18

--- a/providers/aprilseries/models/gpt-5.6-sol.toml
+++ b/providers/aprilseries/models/gpt-5.6-sol.toml
@@ -1,0 +1,11 @@
+# Source: https://aprilseries.lat/models (accessed 2026-07-23)
+# API: /v1/chat/completions {"reasoning_effort":"none|low|medium|high"}
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[limit]
+context = 1_000_000
+
+[cost]
+input = 0.15
+output = 0.90

--- a/providers/aprilseries/models/gpt-5.6-terra.toml
+++ b/providers/aprilseries/models/gpt-5.6-terra.toml
@@ -1,0 +1,11 @@
+# Source: https://aprilseries.lat/models (accessed 2026-07-23)
+# API: /v1/chat/completions {"reasoning_effort":"none|low|medium|high"}
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[limit]
+context = 1_000_000
+
+[cost]
+input = 0.08
+output = 0.45

--- a/providers/aprilseries/provider.toml
+++ b/providers/aprilseries/provider.toml
@@ -1,0 +1,7 @@
+# Sources: https://aprilseries.lat/ and https://aprilseries.lat/models
+# (accessed 2026-07-23)
+name = "April API"
+env = ["APRIL_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://aprilseries.lat/v1"
+doc = "https://aprilseries.lat/dashboard/docs"


### PR DESCRIPTION
## Summary
- add a registered April Series sync adapter
- sync current catalog IDs, context, and pricing
- preserve custom reasoning metadata until April publishes capabilities, then prefer machine-readable remote fields
- preserve canonical base-model metadata and skip unknown models safely

## Verification
- `bun models:sync aprilseries --dry-run` reports 6 unchanged
- `bun validate`
- `git diff --check`