### PR TITLE
feat(poolside): add laguna-s-2.1, remove laguna-xs.2

### DIFF
--- a/providers/poolside/models/poolside/laguna-m.1.toml
+++ b/providers/poolside/models/poolside/laguna-m.1.toml
@@ -1,5 +1,7 @@
 base_model = "poolside/laguna-m.1"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle" # API: {"chat_template_kwargs": {"enable_thinking": false}}
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/poolside/models/poolside/laguna-s-2.1.toml
+++ b/providers/poolside/models/poolside/laguna-s-2.1.toml
@@ -1,4 +1,4 @@
-base_model = "poolside/laguna-xs.2"
+base_model = "poolside/laguna-s-2.1"
 reasoning_options = []
 
 [interleaved]

--- a/providers/poolside/models/poolside/laguna-s-2.1.toml
+++ b/providers/poolside/models/poolside/laguna-s-2.1.toml
@@ -1,5 +1,7 @@
 base_model = "poolside/laguna-s-2.1"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle" # API: {"chat_template_kwargs": {"enable_thinking": false}}
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/poolside/models/poolside/laguna-xs-2.1.toml
+++ b/providers/poolside/models/poolside/laguna-xs-2.1.toml
@@ -1,5 +1,7 @@
 base_model = "poolside/laguna-xs-2.1"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle" # API: {"chat_template_kwargs": {"enable_thinking": false}}
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Laguna S 2.1 is available through the Poolside Platform, so I added it to the `poolside` provider, and also removed the no longer available XS.2 model, which errors out with `Not Found: please check the model you provided`.

Also adds reasoning toggle to all `poolside` provider models, as documented in the Poolside Platform API examples:
<img width="1580" height="900" alt="image" src="https://github.com/user-attachments/assets/2b9be5de-2c2c-4e53-9695-325abb831e15" />

Sources:
- https://docs.poolside.ai/get-started/supported-models#supported-models
- https://platform.poolside.ai/ (requires login)