### PR TITLE
feat(aihubmix): add Gemini 3.6 Flash, Qwen 3.8 Max Preview, and Doubao Seed 2.1

### DIFF
--- a/providers/aihubmix/models/doubao-seed-2-1-pro.toml
+++ b/providers/aihubmix/models/doubao-seed-2-1-pro.toml
@@ -1,0 +1,30 @@
+# Source (accessed 2026-07-23):
+# https://aihubmix.com/api/v1/models?model=doubao-seed-2-1-pro
+name = "Doubao Seed 2.1 Pro"
+description = "Production-grade multimodal model for coding, agents, planning, and long-horizon enterprise tasks"
+family = "seed"
+release_date = "2026-06-30"
+last_updated = "2026-06-30"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.9295
+output = 4.6475
+cache_read = 0.1859
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/aihubmix/models/doubao-seed-2-1-turbo.toml
+++ b/providers/aihubmix/models/doubao-seed-2-1-turbo.toml
@@ -1,0 +1,30 @@
+# Source (accessed 2026-07-23):
+# https://aihubmix.com/api/v1/models?model=doubao-seed-2-1-turbo
+name = "Doubao Seed 2.1 Turbo"
+description = "Cost-efficient multimodal model for coding, agents, planning, and long-horizon enterprise tasks"
+family = "seed"
+release_date = "2026-06-30"
+last_updated = "2026-06-30"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.46475
+output = 2.32375
+cache_read = 0.09295
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/aihubmix/models/gemini-3.6-flash.toml
+++ b/providers/aihubmix/models/gemini-3.6-flash.toml
@@ -1,0 +1,15 @@
+base_model = "google/gemini-3.6-flash"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.5
+output = 7.5
+cache_read = 0.15
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/aihubmix/models/qwen3.8-max-preview.toml
+++ b/providers/aihubmix/models/qwen3.8-max-preview.toml
@@ -1,0 +1,24 @@
+base_model = "alibaba/qwen3.8-max-preview"
+structured_output = true
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262_144 },
+]
+status = "beta"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.169
+output = 0.507
+cache_read = 0.0169
+cache_write = 0.21125
+
+[limit]
+context = 983_616
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Why

AIHubMix exposes Gemini 3.6 Flash, Qwen 3.8 Max Preview, and the Doubao Seed 2.1 Pro/Turbo models, but its models.dev provider catalog does not yet include them.

## What Changed

- Added `gemini-3.6-flash` using the existing `google/gemini-3.6-flash` base model.
- Added `qwen3.8-max-preview` using the existing `alibaba/qwen3.8-max-preview` base model.
- Added provider-owned entries for `doubao-seed-2-1-pro` and `doubao-seed-2-1-turbo`.
- Added AIHubMix pricing, context/output limits, input modalities, structured output, tool calling, and interleaved reasoning metadata.
- Added verified reasoning options:
  - Gemini 3.6 Flash: effort values `minimal`, `low`, `medium`, and `high`.
  - Qwen 3.8 Max Preview: effort values `low`, `medium`, and `xhigh`, plus a `0..262144` token budget.
  - Doubao Seed 2.1 Pro/Turbo: toggle plus effort values `minimal`, `low`, `medium`, and `high`.

## Validation

- Confirmed live AIHubMix catalog facts for all four model IDs.
- Ran the AIHubMix OpenCode validator with `--live` for all four entries; every configured effort value and the minimal `json_schema` smoke returned HTTP 200.
- Verified Gemini 3.6 Flash through both the OpenAI-compatible and Gemini-native APIs, including all four reasoning levels, structured output, and forced tool calling.
- Ran additional minimal live checks for baseline generation, temperature, reasoning toggle/budget boundaries, structured output, automatic tool calling, and streaming.
- Ran `bun install`, `bun run validate`, and the `packages/web` build.
- Confirmed the generated `_api.json` contains all four AIHubMix entries with the expected merged metadata.
- Loaded the generated registry with `opencode models aihubmix --refresh`; all four model IDs appeared.
