### PR TITLE
fix(ofox): align reasoning_options with verified API behavior

### DIFF
--- a/providers/ofox/models/anthropic/claude-fable-5.toml
+++ b/providers/ofox/models/anthropic/claude-fable-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-fable-5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
 [cost]
 input = 10

--- a/providers/ofox/models/anthropic/claude-opus-4.8.toml
+++ b/providers/ofox/models/anthropic/claude-opus-4.8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
 [cost]
 input = 5

--- a/providers/ofox/models/anthropic/claude-sonnet-5.toml
+++ b/providers/ofox/models/anthropic/claude-sonnet-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
 [cost]
 input = 2

--- a/providers/ofox/models/bailian/qwen3.7-max.toml
+++ b/providers/ofox/models/bailian/qwen3.7-max.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]
 input = 2.5

--- a/providers/ofox/models/bailian/qwen3.7-max.toml
+++ b/providers/ofox/models/bailian/qwen3.7-max.toml
@@ -1,5 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
+reasoning_options = []
 
 [cost]
 input = 2.5

--- a/providers/ofox/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/ofox/models/deepseek/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
 
 [cost]
 input = 0.45

--- a/providers/ofox/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/ofox/models/deepseek/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+reasoning_options = []
 
 [cost]
 input = 0.45

--- a/providers/ofox/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/ofox/models/google/gemini-3.1-pro-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens" }]
 
 [cost]
 input = 2

--- a/providers/ofox/models/moonshotai/kimi-k2.6.toml
+++ b/providers/ofox/models/moonshotai/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.95

--- a/providers/ofox/models/moonshotai/kimi-k2.6.toml
+++ b/providers/ofox/models/moonshotai/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 0.95

--- a/providers/ofox/models/openai/gpt-5.6-luna.toml
+++ b/providers/ofox/models/openai/gpt-5.6-luna.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.6-luna"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 1

--- a/providers/ofox/models/openai/gpt-5.6-sol.toml
+++ b/providers/ofox/models/openai/gpt-5.6-sol.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.6-sol"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 5

--- a/providers/ofox/models/openai/gpt-5.6-terra.toml
+++ b/providers/ofox/models/openai/gpt-5.6-terra.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.6-terra"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2.5


### PR DESCRIPTION
Follow-up to #3254, addressing the review bot's point that reasoning_options must reflect controls **verified on this provider**. I tested every declared option against Ofox's live API — including streaming, which turned out to matter (see below). Changes:

| Model | Was | Now | Evidence |
|---|---|---|---|
| gpt-5.6-luna/sol/terra | effort incl. `max` | effort `none..xhigh` | `max` rejected: *"Unsupported value... Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'"* |
| claude-opus-4.8 / sonnet-5 / fable-5 | effort levels | toggle + budget_tokens | `thinking: {type:"enabled", budget_tokens}` → `thinking` content blocks; omitting `thinking` → text only. `effort` inside `thinking` is unverifiable (unknown keys are silently accepted), so removed |
| gemini-3.1-pro-preview | effort | effort + budget_tokens | `thinkingLevel` low/medium/high → thoughtsTokenCount 58/82/97 (monotonic); `thinkingBudget` honored |
| deepseek-v4-pro | toggle + effort [high, max] | effort [none, low, medium, high, max] | via streaming: `reasoning_effort: none` → 0 reasoning deltas; low/medium/high/max → 58–66 non-empty `delta.reasoning` chunks |
| qwen3.7-max | toggle + budget_tokens | effort [none, low, medium, high] | `none` → reasoning off (0 deltas / no reasoning_tokens); low/medium/high map to upstream thinking budgets (low surfaced `thinking_budget [8192]` in a validation error, confirming the mapping); each produced 60+ reasoning deltas |
| kimi-k2.6 | toggle | toggle (unchanged, now verified) | default → 60 reasoning deltas; `reasoning_effort: none` → 0 |

Unchanged (verified): gpt-5.5 effort none..xhigh, grok-4.3 effort none..high, glm-5.2 effort high/max.

**Methodology note:** deepseek/qwen/kimi expose reasoning via streaming `delta.reasoning` / `delta.reasoning_details` (not in non-streaming usage), and Ofox normalizes control to OpenAI-style `reasoning_effort` across vendors — an earlier non-streaming pass missed this, hence the revision.

`bun run validate` passes. 10 files, one line each.