### PR TITLE
feat(ofox): fill the gaps automation left — 4 models, native gemini protocol, verified reasoning fixes

### DIFF
--- a/providers/ofox/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/ofox/models/google/gemini-3.1-pro-preview.toml
@@ -9,3 +9,7 @@ input = 2
 output = 12
 cache_read = 0.2
 cache_write = 4.5
+
+[provider]
+npm = "@ai-sdk/google"
+api = "https://api.ofox.ai/gemini/v1beta"

--- a/providers/ofox/models/google/gemini-3.5-flash-lite.toml
+++ b/providers/ofox/models/google/gemini-3.5-flash-lite.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.5-flash-lite"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03
+
+[provider]
+npm = "@ai-sdk/google"
+api = "https://api.ofox.ai/gemini/v1beta"

--- a/providers/ofox/models/google/gemini-3.5-flash.toml
+++ b/providers/ofox/models/google/gemini-3.5-flash.toml
@@ -15,3 +15,7 @@ output = 9
 cache_read = 0.15
 cache_write = 0.83
 input_audio = 3
+
+[provider]
+npm = "@ai-sdk/google"
+api = "https://api.ofox.ai/gemini/v1beta"

--- a/providers/ofox/models/google/gemini-3.6-flash.toml
+++ b/providers/ofox/models/google/gemini-3.6-flash.toml
@@ -12,4 +12,9 @@ values = ["minimal", "low", "medium", "high"]
 input = 1.5
 output = 7.5
 cache_read = 0.15
+input_audio = 1.5
 cache_write = 0.083
+
+[provider]
+npm = "@ai-sdk/google"
+api = "https://api.ofox.ai/gemini/v1beta"

--- a/providers/ofox/models/minimax/minimax-m2.7.toml
+++ b/providers/ofox/models/minimax/minimax-m2.7.toml
@@ -1,0 +1,8 @@
+base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+cache_write = 0.375

--- a/providers/ofox/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/ofox/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19

--- a/providers/ofox/models/moonshotai/kimi-k3.toml
+++ b/providers/ofox/models/moonshotai/kimi-k3.toml
@@ -1,10 +1,13 @@
+# OpenAI-compatible: `thinking.type = enabled|disabled` (verified: reasoning_tokens
+# 118 vs none on toggle, 2026-08-04). Graded effort is not available on this host:
+# `thinking.type = adaptive` is rejected outright ("invalid value for thinking type"),
+# and `output_config.effort` / `reasoning_effort` probed low-vs-max on hard prompts show
+# no graded reasoning_tokens effect, so only the toggle is declared.
 # Sources:
 # https://ofox.ai/models/moonshotai/kimi-k3 (pricing; accessed 2026-08-06)
 # https://platform.kimi.ai/docs/pricing/chat-k3 (official $3/$15/$0.30)
-# https://platform.kimi.ai/docs/guide/use-reasoning-effort (reasoning_effort = low|high|max; always on)
-# Effort: reasoning_effort = low|high|max
 base_model = "moonshotai/kimi-k3"
-reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 3

--- a/providers/ofox/models/openai/gpt-5.4-pro.toml
+++ b/providers/ofox/models/openai/gpt-5.4-pro.toml
@@ -1,0 +1,12 @@
+# Ofox bills a flat 30/180 across the full advertised context window; the Ofox
+# catalog publishes no >=272k context tier, so no [[cost.tiers]] applies here.
+base_model = "openai/gpt-5.4-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
+
+[cost]
+input = 30
+output = 180
+
+[provider]
+npm = "@ai-sdk/openai"
+api = "https://api.ofox.ai/v1"


### PR DESCRIPTION
## Summary

Rebuilt on top of the issue-fixer's full Ofox listing (72 models — thanks for enabling `trackMissingModels`!). This PR now covers only what automation could not author:

- **4 models the pipeline missed**: `gemini-3.5-flash-lite`, `minimax/minimax-m2.7`, `moonshotai/kimi-k2.7-code`, `openai/gpt-5.4-pro` (with a leading flat-rate comment — Ofox bills 30/180 across the full window, no 272k tier)
- **Native gemini protocol** for the four Gemini models: `[provider]` with `@ai-sdk/google` + `https://api.ofox.ai/gemini/v1beta` — verified end-to-end against the live surface (model listing, generateContent, SSE streaming, `x-goog-api-key` auth; model IDs map 1:1 to `models/google/<slug>`)
- **kimi-k3 reasoning correction**: the current entry declares graded `reasoning_effort` as always-on, but behavioral probes show the opposite — the toggle works (`thinking.type`, reasoning_tokens 118 vs none), `adaptive` is rejected outright, and neither effort path shows a graded effect. Replaced with the verified toggle-only declaration (wire-path comment in the leading block)
- **gemini-3.6-flash**: add `input_audio = 1.5`, matching both our live catalog and the first-party entry

All costs cross-checked against our live catalog and first-party entries. `bun validate` passes; `bun models:sync ofox --dry-run` is clean apart from the known cache-write field the sync will backfill from our catalog either way.