### PR TITLE
fix(fireworks-ai): mark MiniMax-M3 as multimodal (text, image, video)

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m3.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/minimax-m3.toml
@@ -25,7 +25,7 @@ context = 512_000
 output = 512_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image", "video"]
 output = ["text"]
 
 [interleaved]


### PR DESCRIPTION
## What

Add `image` and `video` to `modalities.input` for `fireworks-ai` → `accounts/fireworks/models/minimax-m3`. It is currently `["text"]` only.

## Why

MiniMax-M3 is a **natively multimodal** model, and Fireworks serves it as such:

- Fireworks launch post: ["MiniMax M3 is live: long context + **native multimodality**"](https://fireworks.ai/blog/minimax-m3-launch)
- MiniMax: ["M3 … Native Multimodality"](https://www.minimax.io/blog/minimax-m3)

Every other provider entry for this model in models.dev already lists image (and usually video) input — `openrouter`, `abacus`, `nvidia`, `huggingface`, `nano-gpt`, etc. Only the `fireworks-ai` entry is `input = ["text"]`, which appears to be an omission from the model's original addition in #2271.

## Impact

Downstream clients trust `modalities.input`. With `["text"]`, opencode (and other models.dev consumers) refuse image input for this model client-side — `ai-sdk` runtime error: **"Image read not supported by this model"** — before any request reaches Fireworks.

Verified locally: forcing `modalities.input = ["text", "image"]` in opencode config makes opencode attach the image, and the Fireworks API accepts it and returns a correct image-derived answer. So the capability is real; only the metadata was wrong.