### PR TITLE
Add Echols AI provider (Jah 2.0)

### DIFF
--- a/models/rmdwllc/jah-2.0.toml
+++ b/models/rmdwllc/jah-2.0.toml
@@ -1,0 +1,20 @@
+name = "Jah 2.0"
+description = "Echols AI's private model. Chat, agentic coding, and tool use over the OpenAI and Anthropic API formats, served on hardware Echols owns."
+attachment = false
+reasoning = false
+tool_call = true
+structured_output = true
+temperature = true
+open_weights = true
+license = "MIT"
+release_date = "2026-07"
+last_updated = "2026-07"
+knowledge = "2025-04"
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[limit]
+context = 65_536
+output = 16_384

--- a/providers/echols/logo.svg
+++ b/providers/echols/logo.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 6h22v5.4H14.6v6.1H27.6v5.4H14.6v6.3H30.4V34.6H8V6Z" fill="#B11E2F"/>
+<path d="M31.2 6.2 36 13.1l-4.8 6.9-4.8-6.9 4.8-6.9Z" fill="#E23A50"/>
+</svg>

--- a/providers/echols/models/jah-2.0.toml
+++ b/providers/echols/models/jah-2.0.toml
@@ -1,0 +1,6 @@
+base_model = "rmdwllc/jah-2.0"
+name = "Jah 2.0"
+
+[limit]
+context = 65_536
+output = 16_384

--- a/providers/echols/provider.toml
+++ b/providers/echols/provider.toml
@@ -1,0 +1,5 @@
+name = "Echols AI"
+env = ["ECHOLS_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://echols.ai/v1"
+doc = "https://echols.ai/developers"


### PR DESCRIPTION
## Summary

Adds **Echols AI** as a provider, serving **Jah 2.0** — a private model on dedicated, owned hardware behind an OpenAI-compatible endpoint. It also speaks the Anthropic Messages and OpenAI Responses formats, so it works across Claude Code, Codex CLI, and opencode.

## What's included
- `providers/echols/provider.toml` — `@ai-sdk/openai-compatible`, api `https://echols.ai/v1`, env `ECHOLS_API_KEY`
- `providers/echols/models/jah-2.0.toml` — serving details (65,536 context / 16,384 output)
- `models/rmdwllc/jah-2.0.toml` — open-weights model card (weights: [RMDWLLC/Jah-2.0](https://huggingface.co/RMDWLLC/Jah-2.0))
- `providers/echols/logo.svg`

## Verification
- `bun run validate` passes.
- Tool calling verified end-to-end in **opencode**, **Claude Code**, and **Codex CLI** (each completed a real agentic file-write against the live endpoint).

## Access
Included with an Echols membership; keys and one-line setup at [echols.ai/developers](https://echols.ai/developers).