### PR TITLE
fix: use Anthropic for Alibaba plans

### DIFF
--- a/providers/alibaba-coding-plan-cn/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-coding-plan-cn/models/MiniMax-M2.5.toml
@@ -1,11 +1,11 @@
 name = "MiniMax-M2.5"
 description = "MiniMax model for chat, coding, office work, and agentic tasks"
-# Reasoning HTTP format (accessed 2026-06-25):
+# Reasoning HTTP format (accessed 2026-07-23):
 # Coding Plan exact-string allowlist model; Alibaba-deployed MiniMax-M2.5 is
-# thinking-only. No toggle, effort, or numeric budget request field is documented.
+# thinking-only and does not require a thinking budget.
 # Sources:
 # https://help.aliyun.com/zh/model-studio/coding-plan
-# https://help.aliyun.com/zh/model-studio/deep-thinking
+# https://help.aliyun.com/zh/model-studio/coding-plan-faq
 family = "minimax"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
@@ -15,9 +15,6 @@ reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-coding-plan-cn/models/glm-4.7.toml
+++ b/providers/alibaba-coding-plan-cn/models/glm-4.7.toml
@@ -5,14 +5,11 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 32_768 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"
 open_weights = true
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-coding-plan-cn/models/glm-5.toml
+++ b/providers/alibaba-coding-plan-cn/models/glm-5.toml
@@ -1,23 +1,20 @@
 name = "GLM-5"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-# Reasoning HTTP format (accessed 2026-06-25):
-# Coding Plan exact-string allowlist model. Hybrid thinking is on by default and
-# top-level `enable_thinking`: true|false toggles it. No effort/budget documented.
+# Reasoning HTTP format (accessed 2026-07-23):
+# Coding Plan exact-string allowlist model. The Anthropic endpoint controls
+# hybrid thinking with `thinking.type` and optional `thinking.budget_tokens`.
 # Sources:
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
 # https://help.aliyun.com/zh/model-studio/coding-plan
-# https://help.aliyun.com/zh/model-studio/deep-thinking
 family = "glm"
 release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 32_768 }]
 temperature = true
 tool_call = true
 open_weights = false
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-coding-plan-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-coding-plan-cn/models/kimi-k2.5.toml
@@ -1,25 +1,21 @@
 name = "Kimi K2.5"
 description = "Kimi multimodal agent model for visual understanding, coding, and planning"
-# Reasoning HTTP format (accessed 2026-06-25):
-# Coding Plan exact-string allowlist model. Hybrid thinking uses top-level
-# `enable_thinking`: true enables; false (default) disables. No effort or numeric
-# budget bound is documented specifically for the plan endpoint.
+# Reasoning HTTP format (accessed 2026-07-23):
+# Coding Plan exact-string allowlist model. The Anthropic endpoint controls
+# hybrid thinking with `thinking.type` and optional `thinking.budget_tokens`.
 # Sources:
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
 # https://help.aliyun.com/zh/model-studio/coding-plan
-# https://www.alibabacloud.com/help/en/model-studio/kimi-api
 family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-01"
 open_weights = true
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-coding-plan-cn/models/qwen3-max-2026-01-23.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3-max-2026-01-23.toml
@@ -4,7 +4,8 @@ family = "qwen"
 release_date = "2026-01-23"
 last_updated = "2026-01-23"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true
@@ -18,7 +19,7 @@ cache_write = 0
 
 [limit]
 context = 262_144
-output = 32_768
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/alibaba-coding-plan-cn/models/qwen3.5-plus.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3.5-plus.toml
@@ -5,7 +5,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true

--- a/providers/alibaba-coding-plan-cn/models/qwen3.6-flash.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3.6-flash.toml
@@ -1,7 +1,0 @@
-base_model = "alibaba/qwen3.6-flash"
-reasoning_options = [{ type = "toggle" }]
-
-[cost]
-input = 0.1875
-output = 1.125
-cache_write = 0.234375

--- a/providers/alibaba-coding-plan-cn/models/qwen3.6-plus.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3.6-plus.toml
@@ -22,5 +22,5 @@ context = 1_000_000
 output = 65_536
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video"]
 output = ["text"]

--- a/providers/alibaba-coding-plan-cn/models/qwen3.6-plus.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3.6-plus.toml
@@ -5,7 +5,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true
@@ -22,5 +22,5 @@ context = 1_000_000
 output = 65_536
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/alibaba-coding-plan-cn/models/qwen3.7-max.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3.7-max.toml
@@ -1,8 +1,0 @@
-base_model = "alibaba/qwen3.7-max"
-reasoning_options = [{ type = "toggle" }]
-
-[cost]
-input = 2.5
-output = 7.5
-cache_read = 0.5
-cache_write = 3.125

--- a/providers/alibaba-coding-plan-cn/models/qwen3.7-plus.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3.7-plus.toml
@@ -1,12 +1,15 @@
 base_model = "alibaba/qwen3.7-plus"
-# Reasoning HTTP format (accessed 2026-06-25):
-# Coding Plan exact-string allowlist model. Hybrid thinking is on by default;
-# top-level `enable_thinking`: true|false toggles it. The plan docs do not state
-# a numeric budget bound or a plan-specific effort control.
+# Reasoning HTTP format (accessed 2026-07-23):
+# Coding Plan exact-string allowlist model. The Anthropic endpoint controls
+# hybrid thinking with `thinking.type` and optional `thinking.budget_tokens`.
 # Sources:
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
 # https://help.aliyun.com/zh/model-studio/coding-plan
-# https://help.aliyun.com/zh/model-studio/deep-thinking
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
 
 [cost]
 input = 0

--- a/providers/alibaba-coding-plan-cn/models/qwen3.7-plus.toml
+++ b/providers/alibaba-coding-plan-cn/models/qwen3.7-plus.toml
@@ -7,10 +7,6 @@ base_model = "alibaba/qwen3.7-plus"
 # https://help.aliyun.com/zh/model-studio/coding-plan
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
 
-[modalities]
-input = ["text", "image"]
-output = ["text"]
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-coding-plan-cn/provider.toml
+++ b/providers/alibaba-coding-plan-cn/provider.toml
@@ -1,15 +1,13 @@
 name = "Alibaba Coding Plan (China)"
 env = ["ALIBABA_CODING_PLAN_API_KEY"]
-npm = "@ai-sdk/openai-compatible"
-# Reasoning HTTP format (accessed 2026-06-25):
-# OpenAI plan base https://coding.dashscope.aliyuncs.com/v1 uses POST
-# /chat/completions with top-level `enable_thinking`: true or false.
-# Anthropic plan base https://coding.dashscope.aliyuncs.com/apps/anthropic uses
-# POST /v1/messages with `thinking.type`: enabled or disabled and optional
-# integer `thinking.budget_tokens`. No plan-specific effort field is documented.
+npm = "@ai-sdk/anthropic"
+# Anthropic Messages format (accessed 2026-07-23):
+# The official OpenCode guide uses @ai-sdk/anthropic with the Coding Plan
+# .../apps/anthropic/v1 base URL. Extended thinking uses `thinking.type` and
+# `thinking.budget_tokens`; responses return Anthropic `thinking` content blocks.
 # Sources:
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
 # https://help.aliyun.com/zh/model-studio/coding-plan
-# https://help.aliyun.com/zh/model-studio/deep-thinking
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
 doc = "https://help.aliyun.com/zh/model-studio/coding-plan"
-api = "https://coding.dashscope.aliyuncs.com/v1"
+api = "https://coding.dashscope.aliyuncs.com/apps/anthropic/v1"

--- a/providers/alibaba-coding-plan/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-coding-plan/models/MiniMax-M2.5.toml
@@ -1,11 +1,11 @@
 name = "MiniMax-M2.5"
 description = "MiniMax model for chat, coding, office work, and agentic tasks"
-# Reasoning HTTP format (accessed 2026-06-25):
+# Reasoning HTTP format (accessed 2026-07-23):
 # Coding Plan exact-string allowlist model; Alibaba-deployed MiniMax-M2.5 is
-# thinking-only. No toggle, effort, or numeric budget request field is documented.
+# thinking-only and does not require a thinking budget.
 # Sources:
 # https://www.alibabacloud.com/help/en/model-studio/coding-plan
-# https://www.alibabacloud.com/help/en/model-studio/deep-thinking
+# https://www.alibabacloud.com/help/en/model-studio/coding-plan-faq
 family = "minimax"
 release_date = "2026-02-12"
 last_updated = "2026-02-12"
@@ -15,9 +15,6 @@ reasoning_options = []
 temperature = true
 tool_call = true
 open_weights = true
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-coding-plan/models/glm-4.7.toml
+++ b/providers/alibaba-coding-plan/models/glm-4.7.toml
@@ -5,14 +5,11 @@ release_date = "2025-12-22"
 last_updated = "2025-12-22"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 32_768 }]
 temperature = true
 tool_call = true
 knowledge = "2025-04"
 open_weights = true
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-coding-plan/models/glm-5.toml
+++ b/providers/alibaba-coding-plan/models/glm-5.toml
@@ -1,23 +1,20 @@
 name = "GLM-5"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-# Reasoning HTTP format (accessed 2026-06-25):
-# Coding Plan exact-string allowlist model. Hybrid thinking is on by default and
-# top-level `enable_thinking`: true|false toggles it. No effort/budget documented.
+# Reasoning HTTP format (accessed 2026-07-23):
+# Coding Plan exact-string allowlist model. The Anthropic endpoint controls
+# hybrid thinking with `thinking.type` and optional `thinking.budget_tokens`.
 # Sources:
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
 # https://www.alibabacloud.com/help/en/model-studio/coding-plan
-# https://www.alibabacloud.com/help/en/model-studio/deep-thinking
 family = "glm"
 release_date = "2026-02-11"
 last_updated = "2026-02-11"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 32_768 }]
 temperature = true
 tool_call = true
 open_weights = false
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-coding-plan/models/kimi-k2.5.toml
+++ b/providers/alibaba-coding-plan/models/kimi-k2.5.toml
@@ -1,25 +1,21 @@
 name = "Kimi K2.5"
 description = "Kimi multimodal agent model for visual understanding, coding, and planning"
-# Reasoning HTTP format (accessed 2026-06-25):
-# Coding Plan exact-string allowlist model. Hybrid thinking uses top-level
-# `enable_thinking`: true enables; false (default) disables. No effort or numeric
-# budget bound is documented specifically for the plan endpoint.
+# Reasoning HTTP format (accessed 2026-07-23):
+# Coding Plan exact-string allowlist model. The Anthropic endpoint controls
+# hybrid thinking with `thinking.type` and optional `thinking.budget_tokens`.
 # Sources:
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
 # https://www.alibabacloud.com/help/en/model-studio/coding-plan
-# https://www.alibabacloud.com/help/en/model-studio/kimi-api
 family = "kimi-k2"
 release_date = "2026-01-27"
 last_updated = "2026-01-27"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 tool_call = true
 knowledge = "2025-01"
 open_weights = true
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0
@@ -32,5 +28,5 @@ context = 262_144
 output = 32_768
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/alibaba-coding-plan/models/kimi-k2.5.toml
+++ b/providers/alibaba-coding-plan/models/kimi-k2.5.toml
@@ -28,5 +28,5 @@ context = 262_144
 output = 32_768
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video"]
 output = ["text"]

--- a/providers/alibaba-coding-plan/models/qwen3-max-2026-01-23.toml
+++ b/providers/alibaba-coding-plan/models/qwen3-max-2026-01-23.toml
@@ -4,7 +4,8 @@ family = "qwen"
 release_date = "2026-01-23"
 last_updated = "2026-01-23"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true
@@ -18,7 +19,7 @@ cache_write = 0
 
 [limit]
 context = 262_144
-output = 32_768
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/alibaba-coding-plan/models/qwen3.5-plus.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.5-plus.toml
@@ -22,5 +22,5 @@ context = 1_000_000
 output = 65_536
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video"]
 output = ["text"]

--- a/providers/alibaba-coding-plan/models/qwen3.5-plus.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.5-plus.toml
@@ -5,7 +5,7 @@ release_date = "2026-02-16"
 last_updated = "2026-02-16"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true
@@ -22,5 +22,5 @@ context = 1_000_000
 output = 65_536
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/alibaba-coding-plan/models/qwen3.6-flash.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.6-flash.toml
@@ -1,7 +1,0 @@
-base_model = "alibaba/qwen3.6-flash"
-reasoning_options = [{ type = "toggle" }]
-
-[cost]
-input = 0.1875
-output = 1.125
-cache_write = 0.234375

--- a/providers/alibaba-coding-plan/models/qwen3.6-plus.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.6-plus.toml
@@ -22,5 +22,5 @@ context = 1_000_000
 output = 65_536
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video"]
 output = ["text"]

--- a/providers/alibaba-coding-plan/models/qwen3.6-plus.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.6-plus.toml
@@ -5,7 +5,7 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 81_920 }]
 temperature = true
 knowledge = "2025-04"
 tool_call = true
@@ -22,5 +22,5 @@ context = 1_000_000
 output = 65_536
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/alibaba-coding-plan/models/qwen3.7-max.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.7-max.toml
@@ -1,8 +1,0 @@
-base_model = "alibaba/qwen3.7-max"
-reasoning_options = [{ type = "toggle" }]
-
-[cost]
-input = 2.5
-output = 7.5
-cache_read = 0.5
-cache_write = 3.125

--- a/providers/alibaba-coding-plan/models/qwen3.7-plus.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.7-plus.toml
@@ -7,10 +7,6 @@ base_model = "alibaba/qwen3.7-plus"
 # https://www.alibabacloud.com/help/en/model-studio/coding-plan
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
 
-[modalities]
-input = ["text", "image"]
-output = ["text"]
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-coding-plan/models/qwen3.7-plus.toml
+++ b/providers/alibaba-coding-plan/models/qwen3.7-plus.toml
@@ -1,12 +1,15 @@
 base_model = "alibaba/qwen3.7-plus"
-# Reasoning HTTP format (accessed 2026-06-25):
-# Coding Plan exact-string allowlist model. Hybrid thinking is on by default;
-# top-level `enable_thinking`: true|false toggles it. The plan docs do not state
-# a numeric budget bound or a plan-specific effort control.
+# Reasoning HTTP format (accessed 2026-07-23):
+# Coding Plan exact-string allowlist model. The Anthropic endpoint controls
+# hybrid thinking with `thinking.type` and optional `thinking.budget_tokens`.
 # Sources:
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
 # https://www.alibabacloud.com/help/en/model-studio/coding-plan
-# https://www.alibabacloud.com/help/en/model-studio/deep-thinking
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
 
 [cost]
 input = 0

--- a/providers/alibaba-coding-plan/provider.toml
+++ b/providers/alibaba-coding-plan/provider.toml
@@ -1,15 +1,13 @@
 name = "Alibaba Coding Plan"
 env = ["ALIBABA_CODING_PLAN_API_KEY"]
-npm = "@ai-sdk/openai-compatible"
-# Reasoning HTTP format (accessed 2026-06-25):
-# OpenAI plan base https://coding-intl.dashscope.aliyuncs.com/v1 uses POST
-# /chat/completions with top-level `enable_thinking`: true or false.
-# Anthropic plan base https://coding-intl.dashscope.aliyuncs.com/apps/anthropic
-# uses POST /v1/messages with `thinking.type`: enabled or disabled and optional
-# integer `thinking.budget_tokens`. No plan-specific effort field is documented.
+npm = "@ai-sdk/anthropic"
+# Anthropic Messages format (accessed 2026-07-23):
+# The official OpenCode guide uses @ai-sdk/anthropic with the Coding Plan
+# .../apps/anthropic/v1 base URL. Extended thinking uses `thinking.type` and
+# `thinking.budget_tokens`; responses return Anthropic `thinking` content blocks.
 # Sources:
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
 # https://www.alibabacloud.com/help/en/model-studio/coding-plan
-# https://www.alibabacloud.com/help/en/model-studio/deep-thinking
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
 doc = "https://www.alibabacloud.com/help/en/model-studio/coding-plan"
-api = "https://coding-intl.dashscope.aliyuncs.com/v1"
+api = "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1"

--- a/providers/alibaba-token-plan-cn/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-token-plan-cn/models/MiniMax-M2.5.toml
@@ -6,9 +6,6 @@ base_model = "minimax/MiniMax-M2.5"
 # https://help.aliyun.com/zh/model-studio/deep-thinking
 reasoning_options = []
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-flash.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-flash.toml
@@ -10,9 +10,6 @@ base_model = "deepseek/deepseek-v4-flash"
 [[reasoning_options]]
 type = "toggle"
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-pro.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-pro.toml
@@ -10,9 +10,6 @@ base_model = "deepseek/deepseek-v4-pro"
 [[reasoning_options]]
 type = "toggle"
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/glm-5.1.toml
+++ b/providers/alibaba-token-plan-cn/models/glm-5.1.toml
@@ -3,9 +3,6 @@ base_model = "zhipuai/glm-5.1"
 [[reasoning_options]]
 type = "toggle"
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/glm-5.2.toml
+++ b/providers/alibaba-token-plan-cn/models/glm-5.2.toml
@@ -4,9 +4,6 @@ base_model = "zhipuai/glm-5.2"
 type = "effort"
 values = ["high", "max"]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/glm-5.toml
+++ b/providers/alibaba-token-plan-cn/models/glm-5.toml
@@ -4,9 +4,6 @@ open_weights = false
 [[reasoning_options]]
 type = "toggle"
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/kimi-k2.5.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.5.toml
@@ -13,9 +13,6 @@ temperature = true
 [[reasoning_options]]
 type = "toggle"
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/kimi-k2.6.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.6.toml
@@ -11,9 +11,6 @@ family = "kimi-k2"
 [[reasoning_options]]
 type = "toggle"
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/kimi-k2.7-code.toml
+++ b/providers/alibaba-token-plan-cn/models/kimi-k2.7-code.toml
@@ -9,9 +9,6 @@ base_model_omit = ["structured_output"]
 family = "kimi-k2"
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.8-max-preview.toml
@@ -4,27 +4,15 @@
 # https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
 # https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/kilo-cli
 # https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
-# https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
+# https://platform.qianwenai.com/docs/api-reference/chat/anthropic
 # Thinking is always enabled. In thinking mode, temperature defaults to 0.6
-# and values below 0.6 are raised to 0.6. This provider uses the OpenAI-compatible
-# Chat API, whose native qwen3.8 effort values are low/medium/xhigh (default
-# xhigh); the standard high value is accepted as an alias and maps to xhigh.
-# The OpenCode guide labels its tiers low/high/xhigh and configures a 262144-token
-# thinking budget for the China endpoint. `thinking_budget` (0..262144) cannot
-# be combined with `reasoning_effort`. A zero budget maps to low effort; it does
-# not disable thinking. API: {"reasoning_effort":"medium"} or
-# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients must
-# replay every historical `reasoning_content` value unchanged.
+# and values below 0.6 are raised to 0.6. This provider uses the Anthropic
+# Messages API. The OpenCode guide configures `thinking.type = enabled` with a
+# 99072-token budget. Clients must replay every historical thinking content block.
 
 base_model = "alibaba/qwen3.8-max-preview"
-reasoning_options = [
-  { type = "effort", values = ["low", "medium", "xhigh"] },
-  { type = "budget_tokens", min = 0, max = 262_144 },
-]
+reasoning_options = [{ type = "budget_tokens" }]
 status = "beta"
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-token-plan-cn/provider.toml
+++ b/providers/alibaba-token-plan-cn/provider.toml
@@ -1,24 +1,15 @@
-# Reasoning HTTP format (accessed 2026-07-20):
-# The OpenAI plan base .../compatible-mode/v1 uses POST /chat/completions.
-# Hybrid-thinking models use top-level `enable_thinking` and `thinking_budget`.
-# qwen3.8-max-preview is always thinking and instead accepts either the canonical
-# `reasoning_effort` values low, medium, and xhigh or `thinking_budget` from 0 to
-# 262144. The two controls are mutually exclusive; zero maps to low effort and
-# does not disable thinking.
-# POST /responses uses `reasoning.effort`: none, minimal, low, medium, or high;
-# `thinking_budget` is not accepted there. Anthropic plan base .../apps/anthropic
-# uses POST /v1/messages with `thinking.type`: enabled or disabled, integer
-# `thinking.budget_tokens`, and DeepSeek V4-only `reasoning_effort`: high or max.
+# Anthropic Messages format (accessed 2026-07-23):
+# The official OpenCode guide uses @ai-sdk/anthropic with the Token Plan
+# .../apps/anthropic/v1 base URL. Extended thinking uses `thinking.type` and
+# `thinking.budget_tokens`; responses return Anthropic `thinking` content blocks.
 # Sources:
-# https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
-# https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
+# https://platform.qianwenai.com/docs/api-reference/chat/anthropic
 # https://help.aliyun.com/zh/model-studio/token-plan-quickstart
-# https://help.aliyun.com/zh/model-studio/deep-thinking
-# https://help.aliyun.com/zh/model-studio/compatibility-with-openai-responses-api
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
 
 name = "Alibaba Token Plan (China)"
 env = ["ALIBABA_TOKEN_PLAN_API_KEY"]
-npm = "@ai-sdk/openai-compatible"
+npm = "@ai-sdk/anthropic"
 doc = "https://www.alibabacloud.com/help/zh/model-studio/token-plan-overview"
-api = "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+api = "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic/v1"

--- a/providers/alibaba-token-plan/models/MiniMax-M2.5.toml
+++ b/providers/alibaba-token-plan/models/MiniMax-M2.5.toml
@@ -7,9 +7,6 @@ base_model = "minimax/MiniMax-M2.5"
 
 reasoning_options = []
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/deepseek-v4-flash.toml
+++ b/providers/alibaba-token-plan/models/deepseek-v4-flash.toml
@@ -9,9 +9,6 @@ base_model = "deepseek/deepseek-v4-flash"
 
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/deepseek-v4-pro.toml
+++ b/providers/alibaba-token-plan/models/deepseek-v4-pro.toml
@@ -9,9 +9,6 @@ base_model = "deepseek/deepseek-v4-pro"
 
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/glm-5.1.toml
+++ b/providers/alibaba-token-plan/models/glm-5.1.toml
@@ -2,9 +2,6 @@ base_model = "zhipuai/glm-5.1"
 
 reasoning_options = [{ type = "toggle" }]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/glm-5.2.toml
+++ b/providers/alibaba-token-plan/models/glm-5.2.toml
@@ -4,9 +4,6 @@ base_model = "zhipuai/glm-5.2"
 type = "effort"
 values = ["high", "max"]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/glm-5.toml
+++ b/providers/alibaba-token-plan/models/glm-5.toml
@@ -2,9 +2,6 @@ base_model = "zhipuai/glm-5"
 open_weights = false
 reasoning_options = [{ type = "toggle" }]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/kimi-k2.5.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.5.toml
@@ -11,9 +11,6 @@ attachment = true
 temperature = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/kimi-k2.6.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.6.toml
@@ -9,9 +9,6 @@ base_model_omit = ["structured_output"]
 family = "kimi-k2"
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/kimi-k2.7-code.toml
+++ b/providers/alibaba-token-plan/models/kimi-k2.7-code.toml
@@ -9,9 +9,6 @@ base_model_omit = ["structured_output"]
 family = "kimi-k2"
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens" }]
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 0
 output = 0

--- a/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
+++ b/providers/alibaba-token-plan/models/qwen3.8-max-preview.toml
@@ -4,27 +4,15 @@
 # https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
 # https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/kilo-cli
 # https://docs.qwencloud.com/developer-guides/text-generation/thinking
-# https://docs.qwencloud.com/api-reference/chat/openai-chat
+# https://docs.qwencloud.com/api-reference/chat/anthropic
 # Thinking is always enabled. In thinking mode, temperature defaults to 0.6
-# and values below 0.6 are raised to 0.6. This provider uses the OpenAI-compatible
-# Chat API, whose native qwen3.8 effort values are low/medium/xhigh (default
-# xhigh); the standard high value is accepted as an alias and maps to xhigh.
-# The OpenCode guide labels its tiers low/high/xhigh and configures a 99072-token
-# thinking budget for the international endpoint. `thinking_budget` (0..262144)
-# cannot be combined with `reasoning_effort`. A zero budget maps to low effort;
-# it does not disable thinking. API: {"reasoning_effort":"medium"} or
-# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients must
-# replay every historical `reasoning_content` value unchanged.
+# and values below 0.6 are raised to 0.6. This provider uses the Anthropic
+# Messages API. The OpenCode guide configures `thinking.type = enabled` with a
+# 99072-token budget. Clients must replay every historical thinking content block.
 
 base_model = "alibaba/qwen3.8-max-preview"
-reasoning_options = [
-  { type = "effort", values = ["low", "medium", "xhigh"] },
-  { type = "budget_tokens", min = 0, max = 262_144 },
-]
+reasoning_options = [{ type = "budget_tokens" }]
 status = "beta"
-
-[interleaved]
-field = "reasoning_content"
 
 [cost]
 input = 0

--- a/providers/alibaba-token-plan/provider.toml
+++ b/providers/alibaba-token-plan/provider.toml
@@ -1,24 +1,15 @@
-# Reasoning HTTP format (accessed 2026-07-20):
-# The OpenAI plan base .../compatible-mode/v1 uses POST /chat/completions.
-# Hybrid-thinking models use top-level `enable_thinking` and `thinking_budget`.
-# qwen3.8-max-preview is always thinking and instead accepts either the canonical
-# `reasoning_effort` values low, medium, and xhigh or `thinking_budget` from 0 to
-# 262144. The two controls are mutually exclusive; zero maps to low effort and
-# does not disable thinking.
-# POST /responses uses `reasoning.effort`: none, minimal, low, medium, or high;
-# `thinking_budget` is not accepted there. Anthropic plan base .../apps/anthropic
-# uses POST /v1/messages with `thinking.type`: enabled or disabled, integer
-# `thinking.budget_tokens`, and DeepSeek V4-only `reasoning_effort`: high or max.
+# Anthropic Messages format (accessed 2026-07-23):
+# The official OpenCode guide uses @ai-sdk/anthropic with the Token Plan
+# .../apps/anthropic/v1 base URL. Extended thinking uses `thinking.type` and
+# `thinking.budget_tokens`; responses return Anthropic `thinking` content blocks.
 # Sources:
-# https://docs.qwencloud.com/api-reference/chat/openai-chat
-# https://docs.qwencloud.com/developer-guides/text-generation/thinking
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
+# https://docs.qwencloud.com/api-reference/chat/anthropic
 # https://www.alibabacloud.com/help/en/model-studio/token-plan-quickstart
-# https://www.alibabacloud.com/help/en/model-studio/deep-thinking
-# https://www.alibabacloud.com/help/en/model-studio/compatibility-with-openai-responses-api
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
 
 name = "Alibaba Token Plan"
 env = ["ALIBABA_TOKEN_PLAN_API_KEY"]
-npm = "@ai-sdk/openai-compatible"
+npm = "@ai-sdk/anthropic"
 doc = "https://www.alibabacloud.com/help/en/model-studio/token-plan-overview"
-api = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+api = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic/v1"


### PR DESCRIPTION
## Summary

- switch international and China Alibaba Token Plan and Coding Plan providers to `@ai-sdk/anthropic`
- use the documented `/apps/anthropic/v1` base URLs
- align reasoning metadata with Anthropic thinking budgets and content blocks
- remove OpenAI-specific `reasoning_content` replay metadata so Anthropic thinking blocks reach the SDK intact
- align Coding Plan with Alibaba's exact supported-model allowlist and documented reasoning limits

## Sources

- https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
- https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
- https://docs.qwencloud.com/api-reference/chat/anthropic
- https://www.alibabacloud.com/help/en/model-studio/token-plan-quickstart
- https://www.alibabacloud.com/help/en/model-studio/coding-plan
- https://www.alibabacloud.com/help/en/model-studio/coding-plan-faq

## Validation

- `bun validate`
- `git diff --check`
- independent subagent audits of provider URL handling, authentication, model allowlists, reasoning controls, and history replay