### PR TITLE
fix(sync): stop unreliable missing-model issue spam

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -67,6 +67,8 @@ export interface SyncProvider<SourceModel> {
    * deduped GitHub issue per missing model ID.
    */
   skipCreates?: boolean;
+  /** Report remote-only models skipped by skipCreates as GitHub issues. */
+  trackMissingModels?: boolean;
   deleteMissing?: boolean;
   preserveSymlinks?: boolean;
   preserveBaseModels?: boolean;
@@ -375,6 +377,7 @@ export async function syncProvider<SourceModel>(
 
   if (
     provider.skipCreates === true
+    && provider.trackMissingModels !== false
     && skippedRemote.length > 0
     && options.openIssues === true
   ) {

--- a/packages/core/src/sync/providers/openai.ts
+++ b/packages/core/src/sync/providers/openai.ts
@@ -56,6 +56,9 @@ export const openai = {
   name: "OpenAI",
   modelsDir: "providers/openai/models",
   skipCreates: true,
+  // /v1/models is account-scoped and includes legacy, internal, and
+  // non-catalog surfaces without authoritative lifecycle metadata.
+  trackMissingModels: false,
   deleteMissing: false,
   sourceID(model) {
     return model.id;

--- a/packages/core/src/sync/providers/pioneer.ts
+++ b/packages/core/src/sync/providers/pioneer.ts
@@ -92,6 +92,9 @@ export const pioneer = {
   name: "Pioneer",
   modelsDir: "providers/pioneer/models",
   skipCreates: true,
+  // Pioneer reports 2024-01-01 for every model, so its creation dates cannot
+  // support a meaningful age cutoff for remote-only model notifications.
+  trackMissingModels: false,
   deleteMissing: false,
   async fetchModels() {
     const response = await fetch(API_ENDPOINT);

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -33,6 +33,7 @@ import {
 } from "../src/sync/providers/openrouter.js";
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
 import { openai, parseOpenAIModels } from "../src/sync/providers/openai.js";
+import { pioneer } from "../src/sync/providers/pioneer.js";
 import { resolveVeniceBaseModel } from "../src/sync/providers/venice.js";
 import { buildVercelModel, vercel } from "../src/sync/providers/vercel.js";
 import { buildWandbModel, type WandbModel } from "../src/sync/providers/wandb.js";
@@ -246,6 +247,13 @@ test("OpenAI availability sync retains models absent from a scoped response", as
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test("does not track unreliable remote-only models", () => {
+  expect(openai.skipCreates).toBe(true);
+  expect(openai.trackMissingModels).toBe(false);
+  expect(pioneer.skipCreates).toBe(true);
+  expect(pioneer.trackMissingModels).toBe(false);
 });
 
 function digitalOceanModel(overrides: Partial<DigitalOceanSourceModel> = {}): DigitalOceanSourceModel {

--- a/sync.md
+++ b/sync.md
@@ -46,7 +46,7 @@ Because the runner removes files missing from the desired set, a provider module
 
 ## Missing-model GitHub issues
 
-Providers that cannot safely auto-create TOMLs set `skipCreates: true`. In GitHub Actions (or with `--open-issues`), each skipped remote ID may open a GitHub issue:
+Providers that cannot safely auto-create TOMLs set `skipCreates: true`. In GitHub Actions (or with `--open-issues`), each skipped remote ID may open a GitHub issue unless the provider sets `trackMissingModels: false`:
 
 1. Title: `[missing-model] <provider>: <model-id>` (stable for dedupe)
 2. Labels: `automation`, `model-sync`, `missing-model`, `provider:<id>`
@@ -56,6 +56,10 @@ Providers that cannot safely auto-create TOMLs set `skipCreates: true`. In GitHu
 Requires `GH_TOKEN` on the sync workflow step. Local runs are notice-only unless `--open-issues`. Use `--no-issues` / `--dry-run` to skip creates. Issue-fixer ignores these titles (`[missing-model]…`) — they need hand-authored metadata.
 
 The first Actions run may open a batch of issues per provider, including remote IDs the catalog intentionally omits (e.g. OpenAI whisper/tts/moderation surfaces, dated snapshots). This one-time volume is accepted by design: close unwanted issues once and the closed-title dedupe suppresses them permanently. If the dedupe list window (1000 labeled issues per provider) ever fills, the sync fails closed and creates nothing rather than risk duplicates.
+
+Pioneer sets `trackMissingModels: false`: its API currently assigns the placeholder creation date `2024-01-01` to every model, so neither its timestamps nor an age cutoff can identify meaningful new additions. Existing Pioneer TOMLs are still updated by the sync.
+
+OpenAI also sets `trackMissingModels: false`: `/v1/models` is scoped to the automation account and mixes public models with legacy, internal experiment, dated snapshot, and non-catalog IDs without lifecycle metadata. Existing OpenAI TOMLs are still preserved by the availability sync.
 
 ## Provider Modules
 
@@ -193,7 +197,7 @@ xAI is implemented in `packages/core/src/sync/providers/xai.ts`.
 - Source endpoint: `https://api.openai.com/v1/models`.
 - Required auth: `OPENAI_API_KEY` from an automation account with access to the full first-party catalog.
 - The endpoint is used only to monitor catalog availability. Existing TOMLs are preserved byte-for-byte, including models absent from the response, because model access can be scoped to the API project.
-- Fine-tuned and customer-owned models are excluded. Unknown first-party models open deduped GitHub issues (`skipCreates`) without changing the catalog.
+- Fine-tuned and customer-owned models are excluded. Unknown first-party models are ignored because the endpoint does not provide enough lifecycle or visibility metadata to distinguish public catalog additions.
 
 ## OVHcloud Notes
 


### PR DESCRIPTION
## Summary

- add a provider-level switch for missing-model issue tracking
- disable remote-only issue creation for OpenAI because its account-scoped catalog mixes public, legacy, internal, and non-catalog IDs without lifecycle metadata
- disable remote-only issue creation for Pioneer because every model has the same placeholder creation date
- continue syncing already-authored OpenAI and Pioneer models

## Verification

- `bun test packages/core/test/sync.test.ts`
- `bun validate`
- `git diff --check`

This stops the hourly issue growth once merged.