### PR TITLE
fix(sync): dispatch missing models to issue fixer

### DIFF
--- a/.github/workflows/issue-fixer.yml
+++ b/.github/workflows/issue-fixer.yml
@@ -3,32 +3,41 @@ name: Issue Fixer
 on:
   issues:
     types: [opened]
+  repository_dispatch:
+    types: [missing-model]
 
 permissions:
   contents: write
   issues: write
   pull-requests: write
 
-concurrency: issue-fixer-${{ github.event.issue.number }}
+concurrency: issue-fixer-${{ github.event.issue.number || github.event.client_payload.issue_number }}
 
 jobs:
   fix:
-    # Skip catalog-sync missing-model issues; those need hand-authored metadata.
     if: >-
       github.repository == 'anomalyco/models.dev'
-      && !startsWith(github.event.issue.title, '[missing-model]')
+      && !contains(github.event.issue.labels.*.name, 'provider:openai')
+      && !contains(github.event.issue.labels.*.name, 'provider:pioneer')
+      && github.event.client_payload.provider != 'openai'
+      && github.event.client_payload.provider != 'pioneer'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
-      ISSUE_NUMBER: ${{ github.event.issue.number }}
-      ISSUE_TITLE: ${{ github.event.issue.title }}
-      ISSUE_BODY: ${{ github.event.issue.body }}
+      ISSUE_NUMBER: ${{ github.event.issue.number || github.event.client_payload.issue_number }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: dev
+
+      - name: Load issue
+        run: |
+          set -euo pipefail
+          ISSUE_FILE="$RUNNER_TEMP/issue.json"
+          gh issue view "$ISSUE_NUMBER" --json number,title,body,labels > "$ISSUE_FILE"
+          echo "ISSUE_FILE=$ISSUE_FILE" >> "$GITHUB_ENV"
 
       - name: Install opencode
         run: curl -fsSL https://opencode.ai/install | bash
@@ -41,22 +50,19 @@ jobs:
           set -euo pipefail
           EVENTS_FILE="$RUNNER_TEMP/issue-fixer-events.jsonl"
           RESPONSE_FILE="$RUNNER_TEMP/issue-fixer-response.md"
+          PROMPT_FILE="$RUNNER_TEMP/issue-fixer-prompt.md"
           echo "RESPONSE_FILE=$RESPONSE_FILE" >> "$GITHUB_ENV"
 
-          opencode run --agent issue-fixer -m opencode/grok-4.5 --format json <<EOF | tee "$EVENTS_FILE"
-          A new GitHub issue was opened in anomalyco/models.dev.
+          jq -r '
+            "A new GitHub issue was opened in anomalyco/models.dev.\n\n"
+            + "Issue #\(.number): \(.title)\n\n"
+            + "Body:\n" + (.body // "") + "\n\n"
+            + "Decide whether this is an actionable model catalog data fix.\n\n"
+            + "If it asks for a model to be added or for factual model/provider metadata to be corrected, make the minimal TOML changes in the repository. Do not use Bash. Do not create branches, commits, comments, or pull requests yourself.\n\n"
+            + "If it is a feature request, a request to track a new kind of information, a question, or any miscellaneous non-catalog-data request, do not edit files. Respond briefly that it needs maintainer review and no automated fix was opened."
+          ' "$ISSUE_FILE" > "$PROMPT_FILE"
 
-          Issue #$ISSUE_NUMBER: $ISSUE_TITLE
-
-          Body:
-          $ISSUE_BODY
-
-          Decide whether this is an actionable model catalog data fix.
-
-          If it asks for a model to be added or for factual model/provider metadata to be corrected, make the minimal TOML changes in the repository. Do not use Bash. Do not create branches, commits, comments, or pull requests yourself.
-
-          If it is a feature request, a request to track a new kind of information, a question, or any miscellaneous non-catalog-data request, do not edit files. Respond briefly that it needs maintainer review and no automated fix was opened.
-          EOF
+          opencode run --agent issue-fixer -m opencode/grok-4.5 --format json < "$PROMPT_FILE" | tee "$EVENTS_FILE"
 
           if ! jq -ers 'map(select(.type == "text") | .part.text) | last | select(length > 0)' "$EVENTS_FILE" > "$RESPONSE_FILE"; then
             echo "Issue fixer did not produce a final response." >&2
@@ -77,9 +83,10 @@ jobs:
       - name: Create pull request
         if: success()
         env:
-          BRANCH: issue-${{ github.event.issue.number }}
+          BRANCH: issue-${{ github.event.issue.number || github.event.client_payload.issue_number }}
         run: |
           set -euo pipefail
+          ISSUE_TITLE="$(jq -r .title "$ISSUE_FILE")"
 
           if [ -z "$(git status --porcelain)" ]; then
             if [ -s "$RESPONSE_FILE" ]; then

--- a/packages/core/src/sync/missing-issues.ts
+++ b/packages/core/src/sync/missing-issues.ts
@@ -82,7 +82,8 @@ export async function openMissingModelIssues(
     try {
       const number = await createIssue(title, issueBody(provider, modelId), labels);
       existingByTitle.set(title, number);
-      const notice = `Opened GitHub issue #${number} for missing model \`${modelId}\``;
+      await dispatchIssueFixer(provider.id, number);
+      const notice = `Opened GitHub issue #${number} and dispatched the issue fixer for missing model \`${modelId}\``;
       notices.push(notice);
       console.log(notice);
     } catch (error) {
@@ -143,6 +144,29 @@ async function createIssue(title: string, body: string, labels: string[]) {
     throw new Error(`gh issue create returned no issue number: ${url}`);
   }
   return Number(number);
+}
+
+async function dispatchIssueFixer(providerId: string, issueNumber: number) {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (repository === undefined) {
+    throw new Error("GITHUB_REPOSITORY is required to dispatch the issue fixer");
+  }
+
+  const result = await runGh([
+    "api",
+    `repos/${repository}/dispatches`,
+    "--method",
+    "POST",
+    "--field",
+    "event_type=missing-model",
+    "--field",
+    `client_payload[provider]=${providerId}`,
+    "--field",
+    `client_payload[issue_number]=${issueNumber}`,
+  ]);
+  if (result.code !== 0) {
+    throw new Error(`issue fixer dispatch failed: ${result.stderr || result.stdout || `exit ${result.code}`}`);
+  }
 }
 
 async function runGh(args: string[]) {

--- a/packages/core/src/sync/providers/google.ts
+++ b/packages/core/src/sync/providers/google.ts
@@ -29,13 +29,28 @@ const GoogleResponse = z.object({
 
 type GoogleModel = z.infer<typeof GoogleModel>;
 
+const TrackedModelPrefixes = [
+  "deep-research-",
+  "gemini-",
+  "gemma-",
+  "imagen-",
+  "lyria-",
+  "nano-banana-",
+  "veo-",
+];
+
+export function shouldTrackGoogleModel(id: string) {
+  return TrackedModelPrefixes.some((prefix) => id.startsWith(prefix));
+}
+
 export const google = {
   id: "google",
   name: "Google",
   modelsDir: "providers/google/models",
   skipCreates: true,
   sourceID(model) {
-    return model.name.replace(/^models\//, "");
+    const id = model.name.replace(/^models\//, "");
+    return shouldTrackGoogleModel(id) ? id : undefined;
   },
   skippedNotice(ids) {
     if (ids.length === 0) return [];

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -34,6 +34,7 @@ import {
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
 import { openai, parseOpenAIModels } from "../src/sync/providers/openai.js";
 import { pioneer } from "../src/sync/providers/pioneer.js";
+import { shouldTrackGoogleModel } from "../src/sync/providers/google.js";
 import { resolveVeniceBaseModel } from "../src/sync/providers/venice.js";
 import { buildVercelModel, vercel } from "../src/sync/providers/vercel.js";
 import { buildWandbModel, type WandbModel } from "../src/sync/providers/wandb.js";
@@ -254,6 +255,15 @@ test("does not track unreliable remote-only models", () => {
   expect(openai.trackMissingModels).toBe(false);
   expect(pioneer.skipCreates).toBe(true);
   expect(pioneer.trackMissingModels).toBe(false);
+});
+
+test("tracks public Google model families but not opaque internal IDs", () => {
+  expect(shouldTrackGoogleModel("gemini-3.1-flash-live-preview")).toBe(true);
+  expect(shouldTrackGoogleModel("imagen-4.0-generate-001")).toBe(true);
+  expect(shouldTrackGoogleModel("veo-3.1-generate-preview")).toBe(true);
+  expect(shouldTrackGoogleModel("ajax")).toBe(false);
+  expect(shouldTrackGoogleModel("perseus-2")).toBe(false);
+  expect(shouldTrackGoogleModel("thorin")).toBe(false);
 });
 
 function digitalOceanModel(overrides: Partial<DigitalOceanSourceModel> = {}): DigitalOceanSourceModel {

--- a/sync.md
+++ b/sync.md
@@ -51,7 +51,8 @@ Providers that cannot safely auto-create TOMLs set `skipCreates: true`. In GitHu
 1. Title: `[missing-model] <provider>: <model-id>` (stable for dedupe)
 2. Labels: `automation`, `model-sync`, `missing-model`, `provider:<id>`
 3. Lists existing issues (open **and** closed) with those labels; skips create when the title already exists
-4. If listing fails, creates nothing (fail closed)
+4. Dispatches the Issue Fixer explicitly so issues created with `GITHUB_TOKEN` can still produce PRs
+5. If listing fails, creates nothing (fail closed)
 
 Requires `GH_TOKEN` on the sync workflow step. Local runs are notice-only unless `--open-issues`. Use `--no-issues` / `--dry-run` to skip creates. Issue-fixer ignores these titles (`[missing-model]…`) — they need hand-authored metadata.
 
@@ -180,6 +181,7 @@ Google is implemented in `packages/core/src/sync/providers/google.ts`.
 - The API is authoritative for display names, token limits, temperature metadata, and the `thinking` flag when present.
 - Local Google models missing from the API response are removed.
 - New Google API models are not created automatically (`skipCreates`); each missing ID opens a deduped GitHub issue for the issue fixer / maintainers.
+- Missing-model tracking is limited to recognizable public model families; opaque API codenames such as `ajax`, `perseus`, and `thorin` are ignored.
 
 ## xAI Notes
 


### PR DESCRIPTION
## Summary

- explicitly dispatch newly created missing-model issues to the Issue Fixer, bypassing GitHub's GITHUB_TOKEN event suppression
- allow missing-model issues through the fixer while continuing to exclude OpenAI and Pioneer
- load issue content safely at runtime for both issue and repository-dispatch events
- filter opaque Google API codenames while retaining recognizable public model families
- preserve the existing no-auto-create behavior so the fixer researches and authors valid TOML

## Verification

- `bun test packages/core/test/sync.test.ts` (48 passed)
- `bun validate`
- `git diff --check`
- exercised the jq prompt rendering with a null issue body

After merge, the existing eligible Google/xAI backlog will be dispatched manually.