### PR TITLE
fix(sync): disable Google missing-model tracking

### DIFF
--- a/packages/core/src/sync/providers/google.ts
+++ b/packages/core/src/sync/providers/google.ts
@@ -48,6 +48,9 @@ export const google = {
   name: "Google",
   modelsDir: "providers/google/models",
   skipCreates: true,
+  // /v1beta/models has no lifecycle fields and can retain shut-down,
+  // superseded, moving-alias, and EAP model IDs.
+  trackMissingModels: false,
   sourceID(model) {
     const id = model.name.replace(/^models\//, "");
     return shouldTrackGoogleModel(id) ? id : undefined;

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -34,7 +34,7 @@ import {
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
 import { openai, parseOpenAIModels } from "../src/sync/providers/openai.js";
 import { pioneer } from "../src/sync/providers/pioneer.js";
-import { shouldTrackGoogleModel } from "../src/sync/providers/google.js";
+import { google, shouldTrackGoogleModel } from "../src/sync/providers/google.js";
 import { resolveVeniceBaseModel } from "../src/sync/providers/venice.js";
 import { buildVercelModel, vercel } from "../src/sync/providers/vercel.js";
 import { buildWandbModel, type WandbModel } from "../src/sync/providers/wandb.js";
@@ -251,6 +251,8 @@ test("OpenAI availability sync retains models absent from a scoped response", as
 });
 
 test("does not track unreliable remote-only models", () => {
+  expect(google.skipCreates).toBe(true);
+  expect(google.trackMissingModels).toBe(false);
   expect(openai.skipCreates).toBe(true);
   expect(openai.trackMissingModels).toBe(false);
   expect(pioneer.skipCreates).toBe(true);

--- a/sync.md
+++ b/sync.md
@@ -62,6 +62,8 @@ Pioneer sets `trackMissingModels: false`: its API currently assigns the placehol
 
 OpenAI also sets `trackMissingModels: false`: `/v1/models` is scoped to the automation account and mixes public models with legacy, internal experiment, dated snapshot, and non-catalog IDs without lifecycle metadata. Existing OpenAI TOMLs are still preserved by the availability sync.
 
+Google sets `trackMissingModels: false`: `/v1beta/models` does not expose lifecycle metadata and can retain shut-down models, superseded snapshots, moving aliases, and EAP IDs. Existing Google TOMLs are still updated from API-authoritative fields.
+
 ## Provider Modules
 
 Provider modules live in `packages/core/src/sync/providers/`. A provider exports an object satisfying `SyncProvider<SourceModel>`:
@@ -180,7 +182,7 @@ Google is implemented in `packages/core/src/sync/providers/google.ts`.
 - Model IDs are derived from the `models/{model}` resource names.
 - The API is authoritative for display names, token limits, temperature metadata, and the `thinking` flag when present.
 - Local Google models missing from the API response are removed.
-- New Google API models are not created automatically (`skipCreates`); each missing ID opens a deduped GitHub issue for the issue fixer / maintainers.
+- New Google API models are not created automatically (`skipCreates`) and do not open missing-model issues because the endpoint is not lifecycle-authoritative.
 - Missing-model tracking is limited to recognizable public model families; opaque API codenames such as `ajax`, `perseus`, and `thorin` are ignored.
 
 ## xAI Notes


### PR DESCRIPTION
## Summary

- stop opening and dispatching missing-model issues from Google's raw `/v1beta/models` response
- retain updates to already-authored Google models
- document that the endpoint lacks lifecycle metadata and returns shut-down, superseded, moving-alias, and EAP IDs

## Verification

- `bun test packages/core/test/sync.test.ts` (48 passed)
- `bun validate`
- `git diff --check`