### PR TITLE
Add Baseten GLM 5.2 Fast (zai-org/GLM-5.2-Fast)

### DIFF
--- a/providers/baseten/models/zai-org/GLM-5.2-Fast.toml
+++ b/providers/baseten/models/zai-org/GLM-5.2-Fast.toml
@@ -1,0 +1,22 @@
+# Fast tier of GLM 5.2: same weights/API as zai-org/GLM-5.2, dedicated
+# higher-throughput capacity. Opt in with chat_template_args.enable_thinking=true.
+# Baseten documents no explicit false behavior, effort values, or reasoning-token budget.
+# https://docs.baseten.co/inference/model-apis/overview
+# https://docs.baseten.co/inference/model-apis/reasoning
+base_model = "zhipuai/glm-5.2"
+name = "GLM 5.2 Fast"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 2.1
+output = 6.6
+cache_read = 0.21
+
+[limit]
+context = 524_288
+output = 262_144


### PR DESCRIPTION
## Summary

Adds `providers/baseten/models/zai-org/GLM-5.2-Fast.toml` for Baseten model id **`zai-org/GLM-5.2-Fast`**.

GLM 5.2 Fast is the premium Fast tier: same weights and API surface as `zai-org/GLM-5.2`, with dedicated higher-throughput capacity.

## Pricing

Per [Baseten pricing](https://www.baseten.co/pricing/) (per 1M tokens):

| | Input | Cache read | Output |
|---|------:|-----------:|-------:|
| GLM 5.2 | $1.40 | $0.30 | $4.40 |
| **GLM 5.2 Fast** | **$2.10** | **$0.21** | **$6.60** |

Fast tier input/output are 1.5× the base GLM 5.2 rates.

## Limits & docs

From [Model APIs overview](https://docs.baseten.co/inference/model-apis/overview):

- Context: 524,288 tokens
- Max output: 262,144 tokens

Reasoning behavior: [Model APIs — reasoning](https://docs.baseten.co/inference/model-apis/reasoning)