### PR TITLE
ci: auto-merge whitelisted model syncs

### DIFF
--- a/.github/actions/setup-git-committer/action.yml
+++ b/.github/actions/setup-git-committer/action.yml
@@ -24,6 +24,7 @@ runs:
         app-id: ${{ inputs.opencode-app-id }}
         private-key: ${{ inputs.opencode-app-secret }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
 
     - name: Configure git user
       shell: bash

--- a/.github/actions/setup-git-committer/action.yml
+++ b/.github/actions/setup-git-committer/action.yml
@@ -1,0 +1,41 @@
+name: "Setup Git Committer"
+description: "Create an OpenCode GitHub App token and configure git"
+inputs:
+  opencode-app-id:
+    description: "OpenCode GitHub App ID"
+    required: true
+  opencode-app-secret:
+    description: "OpenCode GitHub App private key"
+    required: true
+outputs:
+  token:
+    description: "GitHub App token"
+    value: ${{ steps.app-token.outputs.token }}
+  app-slug:
+    description: "GitHub App slug"
+    value: ${{ steps.app-token.outputs.app-slug }}
+runs:
+  using: "composite"
+  steps:
+    - name: Create app token
+      id: app-token
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+      with:
+        app-id: ${{ inputs.opencode-app-id }}
+        private-key: ${{ inputs.opencode-app-secret }}
+        owner: ${{ github.repository_owner }}
+
+    - name: Configure git user
+      shell: bash
+      run: |
+        slug="${{ steps.app-token.outputs.app-slug }}"
+        git config --global user.name "${slug}[bot]"
+        git config --global user.email "${slug}[bot]@users.noreply.github.com"
+
+    - name: Clear checkout authentication
+      shell: bash
+      run: git config --local --unset-all http.https://github.com/.extraheader || true
+
+    - name: Configure git remote
+      shell: bash
+      run: git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}"

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -14,6 +14,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   AUTO_MERGE_PROVIDERS: '["openrouter","venice"]'
+  MAX_AUTO_MERGE_DELETIONS: "0"
 
 jobs:
   providers:
@@ -106,6 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "deleted_count=0" >> "$GITHUB_OUTPUT"
           tee -a "$GITHUB_STEP_SUMMARY" < .sync/model-sync-report.md >/dev/null
 
           label_args=()
@@ -120,6 +122,7 @@ jobs:
             exit 0
           fi
 
+          deleted_count="$(git diff --name-only --diff-filter=D -- models providers | awk 'END { print NR }')"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --no-tags --depth=1 origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || true
@@ -140,10 +143,26 @@ jobs:
           fi
 
           echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "deleted_count=$deleted_count" >> "$GITHUB_OUTPUT"
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for CI and merge
+      - name: Check auto-merge safety
         if: steps.report.outputs.changed == 'true' && contains(fromJSON(env.AUTO_MERGE_PROVIDERS), matrix.provider)
+        id: safety
+        env:
+          DELETED_COUNT: ${{ steps.report.outputs.deleted_count }}
+        run: |
+          set -euo pipefail
+
+          if [ "$DELETED_COUNT" -gt "$MAX_AUTO_MERGE_DELETIONS" ]; then
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+            echo "Leaving PR #${{ steps.report.outputs.pr_number }} open because the sync deletes $DELETED_COUNT files." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "allowed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for CI and merge
+        if: steps.safety.outputs.allowed == 'true'
         env:
           GH_TOKEN: ${{ steps.committer.outputs.token }}
           PR_NUMBER: ${{ steps.report.outputs.pr_number }}
@@ -151,13 +170,15 @@ jobs:
           set -euo pipefail
 
           for _ in $(seq 1 120); do
-            if check_count="$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null)" && [ "$check_count" -gt 0 ]; then
+            check_count="$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || true)"
+            if [ "${check_count:-0}" -gt 0 ]; then
               break
             fi
             sleep 5
           done
 
-          if ! check_count="$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null)" || [ "$check_count" -eq 0 ]; then
+          check_count="$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || true)"
+          if [ "${check_count:-0}" -eq 0 ]; then
             echo "No CI checks appeared for PR #$PR_NUMBER within 10 minutes." >&2
             exit 1
           fi

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -12,6 +12,9 @@ permissions:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  AUTO_MERGE_PROVIDERS: '["openrouter","venice"]'
+
 jobs:
   providers:
     if: github.repository == 'anomalyco/models.dev'
@@ -85,13 +88,24 @@ jobs:
       - name: Validate models
         run: bun validate
 
+      - name: Setup git committer for auto-merge
+        if: contains(fromJSON(env.AUTO_MERGE_PROVIDERS), matrix.provider)
+        id: committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+
       - name: Report changes
+        id: report
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ contains(fromJSON(env.AUTO_MERGE_PROVIDERS), matrix.provider) && steps.committer.outputs.token || github.token }}
           BRANCH: automation/sync-models-${{ matrix.provider }}
           LABELS: automation,model-sync,provider:${{ matrix.provider }}
           TITLE: "chore(sync): update ${{ matrix.name }} model catalog"
         run: |
+          set -euo pipefail
+          echo "changed=false" >> "$GITHUB_OUTPUT"
           tee -a "$GITHUB_STEP_SUMMARY" < .sync/model-sync-report.md >/dev/null
 
           label_args=()
@@ -122,4 +136,31 @@ jobs:
             done
           else
             gh pr create --base dev --head "$BRANCH" --title "$TITLE" --body-file .sync/model-sync-report.md "${label_args[@]}"
+            pr_number="$(gh pr list --head "$BRANCH" --base dev --json number --jq '.[0].number')"
           fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for CI and merge
+        if: steps.report.outputs.changed == 'true' && contains(fromJSON(env.AUTO_MERGE_PROVIDERS), matrix.provider)
+        env:
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
+          PR_NUMBER: ${{ steps.report.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          for _ in $(seq 1 120); do
+            if check_count="$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null)" && [ "$check_count" -gt 0 ]; then
+              break
+            fi
+            sleep 5
+          done
+
+          if ! check_count="$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null)" || [ "$check_count" -eq 0 ]; then
+            echo "No CI checks appeared for PR #$PR_NUMBER within 10 minutes." >&2
+            exit 1
+          fi
+
+          gh pr checks "$PR_NUMBER" --watch --fail-fast --interval 10
+          gh pr merge "$PR_NUMBER" --squash --delete-branch


### PR DESCRIPTION
## Summary

- authenticate whitelisted model syncs with the OpenCode GitHub App so PR CI runs
- auto-merge OpenRouter and Venice sync PRs after all checks pass
- preserve the existing PR-only behavior for every other provider

## Validation

- `bun validate`
- `git diff --check`
- parsed both changed workflow files as YAML