### PR TITLE
Add Volcengine (Doubao) provider with 42 models across 3 billing plans

### DIFF
--- a/models/volcengine/deepseek-v3.2.toml
+++ b/models/volcengine/deepseek-v3.2.toml
@@ -1,4 +1,5 @@
 name = "DeepSeek-V3.2"
+description = "DeepSeek-V3.2 via Volcengine Ark platform"
 family = "deepseek"
 reasoning = true
 tool_call = true

--- a/models/volcengine/deepseek-v3.2.toml
+++ b/models/volcengine/deepseek-v3.2.toml
@@ -1,0 +1,12 @@
+name = "DeepSeek-V3.2"
+family = "deepseek"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/deepseek-v4-flash.toml
+++ b/models/volcengine/deepseek-v4-flash.toml
@@ -1,5 +1,6 @@
 name = "DeepSeek-V4-Flash"
-family = "deepseek"
+description = "DeepSeek-V4-Flash via Volcengine Ark platform"
+family = "deepseek-flash"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/deepseek-v4-flash.toml
+++ b/models/volcengine/deepseek-v4-flash.toml
@@ -1,0 +1,12 @@
+name = "DeepSeek-V4-Flash"
+family = "deepseek"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/deepseek-v4-pro.toml
+++ b/models/volcengine/deepseek-v4-pro.toml
@@ -1,4 +1,5 @@
 name = "DeepSeek-V4-Pro"
+description = "DeepSeek-V4-Pro via Volcengine Ark platform"
 family = "deepseek"
 reasoning = true
 tool_call = true

--- a/models/volcengine/deepseek-v4-pro.toml
+++ b/models/volcengine/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+name = "DeepSeek-V4-Pro"
+family = "deepseek"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-1-5-thinking-pro-250415.toml
+++ b/models/volcengine/doubao-1-5-thinking-pro-250415.toml
@@ -1,5 +1,6 @@
 name = "Doubao 1.5 Thinking Pro"
-family = "doubao-1.5"
+description = "Doubao 1.5 thinking pro"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-1-5-thinking-pro-250415.toml
+++ b/models/volcengine/doubao-1-5-thinking-pro-250415.toml
@@ -1,0 +1,12 @@
+name = "Doubao 1.5 Thinking Pro"
+family = "doubao-1.5"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-1-5-thinking-pro-vision-250415.toml
+++ b/models/volcengine/doubao-1-5-thinking-pro-vision-250415.toml
@@ -1,0 +1,12 @@
+name = "Doubao 1.5 Thinking Pro Vision"
+family = "doubao-1.5"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-1-5-thinking-pro-vision-250415.toml
+++ b/models/volcengine/doubao-1-5-thinking-pro-vision-250415.toml
@@ -1,5 +1,6 @@
 name = "Doubao 1.5 Thinking Pro Vision"
-family = "doubao-1.5"
+description = "Doubao 1.5 thinking pro with vision"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-1-5-thinking-vision-pro-250428.toml
+++ b/models/volcengine/doubao-1-5-thinking-vision-pro-250428.toml
@@ -1,5 +1,6 @@
 name = "Doubao 1.5 Thinking Vision Pro"
-family = "doubao-1.5"
+description = "Doubao 1.5 thinking vision pro"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-1-5-thinking-vision-pro-250428.toml
+++ b/models/volcengine/doubao-1-5-thinking-vision-pro-250428.toml
@@ -1,0 +1,12 @@
+name = "Doubao 1.5 Thinking Vision Pro"
+family = "doubao-1.5"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 128_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-1.5-pro-256k.toml
+++ b/models/volcengine/doubao-1.5-pro-256k.toml
@@ -1,0 +1,12 @@
+name = "Doubao 1.5 Pro 256k"
+family = "doubao-1.5"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 256_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-1.5-pro-256k.toml
+++ b/models/volcengine/doubao-1.5-pro-256k.toml
@@ -1,5 +1,6 @@
 name = "Doubao 1.5 Pro 256k"
-family = "doubao-1.5"
+description = "Doubao 1.5 pro 256k context"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-1.5-pro-32k.toml
+++ b/models/volcengine/doubao-1.5-pro-32k.toml
@@ -1,5 +1,6 @@
 name = "Doubao 1.5 Pro 32k"
-family = "doubao-1.5"
+description = "Doubao 1.5 pro 32k context"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-1.5-pro-32k.toml
+++ b/models/volcengine/doubao-1.5-pro-32k.toml
@@ -1,0 +1,12 @@
+name = "Doubao 1.5 Pro 32k"
+family = "doubao-1.5"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 32_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-1.5-thinking-pro.toml
+++ b/models/volcengine/doubao-1.5-thinking-pro.toml
@@ -1,5 +1,6 @@
 name = "Doubao 1.5 Thinking Pro"
-family = "doubao-1.5"
+description = "Doubao 1.5 thinking pro"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-1.5-thinking-pro.toml
+++ b/models/volcengine/doubao-1.5-thinking-pro.toml
@@ -1,0 +1,12 @@
+name = "Doubao 1.5 Thinking Pro"
+family = "doubao-1.5"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 128_000
+output = 16_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-1.5-vision-pro-32k.toml
+++ b/models/volcengine/doubao-1.5-vision-pro-32k.toml
@@ -1,0 +1,12 @@
+name = "Doubao 1.5 Vision Pro 32k"
+family = "doubao-1.5"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 32_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-1.5-vision-pro-32k.toml
+++ b/models/volcengine/doubao-1.5-vision-pro-32k.toml
@@ -1,5 +1,6 @@
 name = "Doubao 1.5 Vision Pro 32k"
-family = "doubao-1.5"
+description = "Doubao 1.5 vision pro 32k"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-1.5-vision-pro.toml
+++ b/models/volcengine/doubao-1.5-vision-pro.toml
@@ -1,0 +1,12 @@
+name = "Doubao 1.5 Vision Pro"
+family = "doubao-1.5"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 128_000
+output = 16_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-1.5-vision-pro.toml
+++ b/models/volcengine/doubao-1.5-vision-pro.toml
@@ -1,5 +1,6 @@
 name = "Doubao 1.5 Vision Pro"
-family = "doubao-1.5"
+description = "Doubao 1.5 vision pro"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-seed-1-6-250615.toml
+++ b/models/volcengine/doubao-seed-1-6-250615.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 1.6"
-family = "doubao-seed-1.6"
+description = "Doubao Seed 1.6 base model"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-seed-1-6-250615.toml
+++ b/models/volcengine/doubao-seed-1-6-250615.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 1.6"
+family = "doubao-seed-1.6"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 256_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-1-6-flash-250615.toml
+++ b/models/volcengine/doubao-seed-1-6-flash-250615.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 1.6 Flash"
+family = "doubao-seed-1.6"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 256_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-1-6-flash-250615.toml
+++ b/models/volcengine/doubao-seed-1-6-flash-250615.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 1.6 Flash"
-family = "doubao-seed-1.6"
+description = "Doubao Seed 1.6 flash model"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-seed-1-6-thinking-250615.toml
+++ b/models/volcengine/doubao-seed-1-6-thinking-250615.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 1.6 Thinking"
+family = "doubao-seed-1.6"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 256_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-1-6-thinking-250615.toml
+++ b/models/volcengine/doubao-seed-1-6-thinking-250615.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 1.6 Thinking"
-family = "doubao-seed-1.6"
+description = "Doubao Seed 1.6 deep reasoning model"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-seed-1-6-thinking-250715.toml
+++ b/models/volcengine/doubao-seed-1-6-thinking-250715.toml
@@ -1,0 +1,12 @@
+name = "doubao-seed-1-6-thinking-250715"
+family = "doubao-seed-1.6"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 16_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-1-6-thinking-250715.toml
+++ b/models/volcengine/doubao-seed-1-6-thinking-250715.toml
@@ -1,5 +1,6 @@
 name = "doubao-seed-1-6-thinking-250715"
-family = "doubao-seed-1.6"
+description = "Doubao Seed 1.6 deep reasoning model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-1-6-vision-250815.toml
+++ b/models/volcengine/doubao-seed-1-6-vision-250815.toml
@@ -1,5 +1,6 @@
 name = "doubao-seed-1-6-vision-250815"
-family = "doubao-seed-1.6"
+description = "Doubao Seed 1.6 vision model"
+family = "seed"
 reasoning = false
 tool_call = true
 

--- a/models/volcengine/doubao-seed-1-6-vision-250815.toml
+++ b/models/volcengine/doubao-seed-1-6-vision-250815.toml
@@ -1,0 +1,12 @@
+name = "doubao-seed-1-6-vision-250815"
+family = "doubao-seed-1.6"
+reasoning = false
+tool_call = true
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-1-8-251215.toml
+++ b/models/volcengine/doubao-seed-1-8-251215.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 1.8"
-family = "doubao-seed-1.8"
+description = "Doubao Seed 1.8 model"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-seed-1-8-251215.toml
+++ b/models/volcengine/doubao-seed-1-8-251215.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 1.8"
+family = "doubao-seed-1.8"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-1.6-flash.toml
+++ b/models/volcengine/doubao-seed-1.6-flash.toml
@@ -1,5 +1,6 @@
 name = "Doubao-Seed 1.6 Flash"
-family = "doubao-seed-1.6"
+description = "Doubao Seed 1.6 flash model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-1.6-flash.toml
+++ b/models/volcengine/doubao-seed-1.6-flash.toml
@@ -1,0 +1,12 @@
+name = "Doubao-Seed 1.6 Flash"
+family = "doubao-seed-1.6"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-1.6-thinking.toml
+++ b/models/volcengine/doubao-seed-1.6-thinking.toml
@@ -1,5 +1,6 @@
 name = "Doubao-Seed 1.6 Thinking"
-family = "doubao-seed-1.6"
+description = "Doubao Seed 1.6 thinking model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-1.6-thinking.toml
+++ b/models/volcengine/doubao-seed-1.6-thinking.toml
@@ -1,0 +1,12 @@
+name = "Doubao-Seed 1.6 Thinking"
+family = "doubao-seed-1.6"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-1.6.toml
+++ b/models/volcengine/doubao-seed-1.6.toml
@@ -1,5 +1,6 @@
 name = "Doubao-Seed 1.6"
-family = "doubao-seed-1.6"
+description = "Doubao Seed 1.6 base model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-1.6.toml
+++ b/models/volcengine/doubao-seed-1.6.toml
@@ -1,0 +1,12 @@
+name = "Doubao-Seed 1.6"
+family = "doubao-seed-1.6"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-1.8.toml
+++ b/models/volcengine/doubao-seed-1.8.toml
@@ -1,5 +1,6 @@
 name = "Doubao-Seed-1.8"
-family = "doubao-seed-1.8"
+description = "Doubao Seed 1.8 model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-1.8.toml
+++ b/models/volcengine/doubao-seed-1.8.toml
@@ -1,0 +1,12 @@
+name = "Doubao-Seed-1.8"
+family = "doubao-seed-1.8"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2-0-code-preview-260215.toml
+++ b/models/volcengine/doubao-seed-2-0-code-preview-260215.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Code Preview"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 coding model"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-seed-2-0-code-preview-260215.toml
+++ b/models/volcengine/doubao-seed-2-0-code-preview-260215.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Code Preview"
+family = "doubao-seed-2"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2-0-code-preview.toml
+++ b/models/volcengine/doubao-seed-2-0-code-preview.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Code Preview"
+family = "doubao-seed-2"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2-0-code-preview.toml
+++ b/models/volcengine/doubao-seed-2-0-code-preview.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Code Preview"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 coding model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-2-0-lite-260215.toml
+++ b/models/volcengine/doubao-seed-2-0-lite-260215.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Lite"
+family = "doubao-seed-2"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2-0-lite-260215.toml
+++ b/models/volcengine/doubao-seed-2-0-lite-260215.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Lite"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 ultra-fast model"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-seed-2-0-lite-260428.toml
+++ b/models/volcengine/doubao-seed-2-0-lite-260428.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Lite 260428"
+family = "doubao-seed-2"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2-0-lite-260428.toml
+++ b/models/volcengine/doubao-seed-2-0-lite-260428.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Lite 260428"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 ultra-fast model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-2-0-mini-260215.toml
+++ b/models/volcengine/doubao-seed-2-0-mini-260215.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Mini"
+family = "doubao-seed-2"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2-0-mini-260215.toml
+++ b/models/volcengine/doubao-seed-2-0-mini-260215.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Mini"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 lightweight model"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-seed-2-0-mini-260428.toml
+++ b/models/volcengine/doubao-seed-2-0-mini-260428.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Mini 260428"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 lightweight model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-2-0-mini-260428.toml
+++ b/models/volcengine/doubao-seed-2-0-mini-260428.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Mini 260428"
+family = "doubao-seed-2"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2-0-pro-260215.toml
+++ b/models/volcengine/doubao-seed-2-0-pro-260215.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Pro"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 flagship model"
+family = "seed"
 reasoning = false
 tool_call = false
 

--- a/models/volcengine/doubao-seed-2-0-pro-260215.toml
+++ b/models/volcengine/doubao-seed-2-0-pro-260215.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Pro"
+family = "doubao-seed-2"
+reasoning = false
+tool_call = false
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2-0-pro.toml
+++ b/models/volcengine/doubao-seed-2-0-pro.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Pro"
+family = "doubao-seed-2"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2-0-pro.toml
+++ b/models/volcengine/doubao-seed-2-0-pro.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Pro"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 flagship model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-2.0-code.toml
+++ b/models/volcengine/doubao-seed-2.0-code.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Code"
+family = "doubao-seed-2"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2.0-code.toml
+++ b/models/volcengine/doubao-seed-2.0-code.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Code"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 coding model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-2.0-lite.toml
+++ b/models/volcengine/doubao-seed-2.0-lite.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Lite"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 ultra-fast model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-2.0-lite.toml
+++ b/models/volcengine/doubao-seed-2.0-lite.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Lite"
+family = "doubao-seed-2"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2.0-mini.toml
+++ b/models/volcengine/doubao-seed-2.0-mini.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Mini"
+family = "doubao-seed-2"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2.0-mini.toml
+++ b/models/volcengine/doubao-seed-2.0-mini.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Mini"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 lightweight model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-2.0-pro.toml
+++ b/models/volcengine/doubao-seed-2.0-pro.toml
@@ -1,0 +1,12 @@
+name = "Doubao Seed 2.0 Pro"
+family = "doubao-seed-2"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-2.0-pro.toml
+++ b/models/volcengine/doubao-seed-2.0-pro.toml
@@ -1,5 +1,6 @@
 name = "Doubao Seed 2.0 Pro"
-family = "doubao-seed-2"
+description = "Doubao Seed 2.0 flagship model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-code-preview-251028.toml
+++ b/models/volcengine/doubao-seed-code-preview-251028.toml
@@ -1,5 +1,6 @@
 name = "doubao-seed-code-preview-251028"
-family = "doubao-seed-code"
+description = "Doubao Seed code preview model"
+family = "seed"
 reasoning = false
 tool_call = true
 

--- a/models/volcengine/doubao-seed-code-preview-251028.toml
+++ b/models/volcengine/doubao-seed-code-preview-251028.toml
@@ -1,0 +1,12 @@
+name = "doubao-seed-code-preview-251028"
+family = "doubao-seed-code"
+reasoning = false
+tool_call = true
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/doubao-seed-code.toml
+++ b/models/volcengine/doubao-seed-code.toml
@@ -1,5 +1,6 @@
 name = "Doubao-Seed-Code"
-family = "doubao-seed-code"
+description = "Doubao Seed coding model"
+family = "seed"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/doubao-seed-code.toml
+++ b/models/volcengine/doubao-seed-code.toml
@@ -1,0 +1,12 @@
+name = "Doubao-Seed-Code"
+family = "doubao-seed-code"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 256_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/glm-5.1.toml
+++ b/models/volcengine/glm-5.1.toml
@@ -1,0 +1,12 @@
+name = "GLM-5.1"
+family = "glm"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/glm-5.1.toml
+++ b/models/volcengine/glm-5.1.toml
@@ -1,4 +1,5 @@
 name = "GLM-5.1"
+description = "GLM-5.1 via Volcengine Ark platform"
 family = "glm"
 reasoning = true
 tool_call = true

--- a/models/volcengine/glm-5.2.toml
+++ b/models/volcengine/glm-5.2.toml
@@ -1,4 +1,5 @@
 name = "GLM-5.2"
+description = "GLM-5.2 via Volcengine Ark platform"
 family = "glm"
 reasoning = true
 tool_call = true

--- a/models/volcengine/glm-5.2.toml
+++ b/models/volcengine/glm-5.2.toml
@@ -1,0 +1,12 @@
+name = "GLM-5.2"
+family = "glm"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/kimi-k2.6.toml
+++ b/models/volcengine/kimi-k2.6.toml
@@ -1,5 +1,6 @@
 name = "Kimi-K2.6"
-family = "kimi"
+description = "Kimi-K2.6 via Volcengine Ark platform"
+family = "kimi-k2"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/kimi-k2.6.toml
+++ b/models/volcengine/kimi-k2.6.toml
@@ -1,0 +1,12 @@
+name = "Kimi-K2.6"
+family = "kimi"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/kimi-k2.7-code.toml
+++ b/models/volcengine/kimi-k2.7-code.toml
@@ -1,0 +1,12 @@
+name = "Kimi-K2.7-Code"
+family = "kimi"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/kimi-k2.7-code.toml
+++ b/models/volcengine/kimi-k2.7-code.toml
@@ -1,5 +1,6 @@
 name = "Kimi-K2.7-Code"
-family = "kimi"
+description = "Kimi-K2.7-Code via Volcengine Ark platform"
+family = "kimi-k2"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/kimi-k3.toml
+++ b/models/volcengine/kimi-k3.toml
@@ -1,5 +1,6 @@
 name = "Kimi-K3"
-family = "kimi"
+description = "Kimi-K3 via Volcengine Ark platform"
+family = "kimi-k3"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/kimi-k3.toml
+++ b/models/volcengine/kimi-k3.toml
@@ -1,0 +1,12 @@
+name = "Kimi-K3"
+family = "kimi"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/volcengine/minimax-m2.7.toml
+++ b/models/volcengine/minimax-m2.7.toml
@@ -1,5 +1,6 @@
 name = "MiniMax-M2.7"
-family = "minimax"
+description = "MiniMax-M2.7 via Volcengine Ark platform"
+family = "minimax-m2.7"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/minimax-m2.7.toml
+++ b/models/volcengine/minimax-m2.7.toml
@@ -1,0 +1,12 @@
+name = "MiniMax-M2.7"
+family = "minimax"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/volcengine/minimax-m3.toml
+++ b/models/volcengine/minimax-m3.toml
@@ -1,5 +1,6 @@
 name = "MiniMax-M3"
-family = "minimax"
+description = "MiniMax-M3 via Volcengine Ark platform"
+family = "minimax-m3"
 reasoning = true
 tool_call = true
 

--- a/models/volcengine/minimax-m3.toml
+++ b/models/volcengine/minimax-m3.toml
@@ -1,0 +1,12 @@
+name = "MiniMax-M3"
+family = "minimax"
+reasoning = true
+tool_call = true
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/volcengine-coding-plan/models/deepseek-v3.2.toml
+++ b/providers/volcengine-coding-plan/models/deepseek-v3.2.toml
@@ -1,0 +1,5 @@
+name = "DeepSeek-V3.2"
+
+[limit]
+context = 1_000_000
+output = 384_000

--- a/providers/volcengine-coding-plan/models/deepseek-v4-flash.toml
+++ b/providers/volcengine-coding-plan/models/deepseek-v4-flash.toml
@@ -1,0 +1,5 @@
+name = "DeepSeek-V4-Flash"
+
+[limit]
+context = 1_000_000
+output = 384_000

--- a/providers/volcengine-coding-plan/models/deepseek-v4-pro.toml
+++ b/providers/volcengine-coding-plan/models/deepseek-v4-pro.toml
@@ -1,0 +1,5 @@
+name = "DeepSeek-V4-Pro"
+
+[limit]
+context = 1_000_000
+output = 384_000

--- a/providers/volcengine-coding-plan/models/doubao-1-5-thinking-pro-250415.toml
+++ b/providers/volcengine-coding-plan/models/doubao-1-5-thinking-pro-250415.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Thinking Pro"
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/volcengine-coding-plan/models/doubao-1-5-thinking-pro-vision-250415.toml
+++ b/providers/volcengine-coding-plan/models/doubao-1-5-thinking-pro-vision-250415.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Thinking Pro Vision"
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/volcengine-coding-plan/models/doubao-1-5-thinking-vision-pro-250428.toml
+++ b/providers/volcengine-coding-plan/models/doubao-1-5-thinking-vision-pro-250428.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Thinking Vision Pro"
+
+[cost]
+input = 0.55
+output = 1.43
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/volcengine-coding-plan/models/doubao-1.5-pro-256k.toml
+++ b/providers/volcengine-coding-plan/models/doubao-1.5-pro-256k.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Pro 256k"
+
+[cost]
+input = 0.799
+output = 1.445
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine-coding-plan/models/doubao-1.5-pro-32k.toml
+++ b/providers/volcengine-coding-plan/models/doubao-1.5-pro-32k.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Pro 32k"
+
+[cost]
+input = 0.1343
+output = 0.3349
+
+[limit]
+context = 32_000
+output = 8_192

--- a/providers/volcengine-coding-plan/models/doubao-1.5-thinking-pro.toml
+++ b/providers/volcengine-coding-plan/models/doubao-1.5-thinking-pro.toml
@@ -1,0 +1,5 @@
+name = "Doubao 1.5 Thinking Pro"
+
+[limit]
+context = 128_000
+output = 16_000

--- a/providers/volcengine-coding-plan/models/doubao-1.5-vision-pro-32k.toml
+++ b/providers/volcengine-coding-plan/models/doubao-1.5-vision-pro-32k.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Vision Pro 32k"
+
+[cost]
+input = 0.459
+output = 1.377
+
+[limit]
+context = 32_000
+output = 8_192

--- a/providers/volcengine-coding-plan/models/doubao-1.5-vision-pro.toml
+++ b/providers/volcengine-coding-plan/models/doubao-1.5-vision-pro.toml
@@ -1,0 +1,5 @@
+name = "Doubao 1.5 Vision Pro"
+
+[limit]
+context = 128_000
+output = 16_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-1-6-250615.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1-6-250615.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.6"
+
+[cost]
+input = 0.204
+output = 0.51
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine-coding-plan/models/doubao-seed-1-6-flash-250615.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1-6-flash-250615.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.6 Flash"
+
+[cost]
+input = 0.0374
+output = 0.374
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine-coding-plan/models/doubao-seed-1-6-thinking-250615.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1-6-thinking-250615.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.6 Thinking"
+
+[cost]
+input = 0.204
+output = 2.04
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine-coding-plan/models/doubao-seed-1-6-thinking-250715.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1-6-thinking-250715.toml
@@ -1,0 +1,9 @@
+name = "doubao-seed-1-6-thinking-250715"
+
+[cost]
+input = 0.121
+output = 1.21
+
+[limit]
+context = 256_000
+output = 16_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-1-6-vision-250815.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1-6-vision-250815.toml
@@ -1,0 +1,9 @@
+name = "doubao-seed-1-6-vision-250815"
+
+[cost]
+input = 0.114
+output = 1.143
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-1-8-251215.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1-8-251215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.8"
+
+[cost]
+input = 0.612
+output = 6.12
+
+[limit]
+context = 128_000
+output = 8_192

--- a/providers/volcengine-coding-plan/models/doubao-seed-1.6-flash.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1.6-flash.toml
@@ -1,0 +1,5 @@
+name = "Doubao-Seed 1.6 Flash"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-1.6-thinking.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1.6-thinking.toml
@@ -1,0 +1,5 @@
+name = "Doubao-Seed 1.6 Thinking"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-1.6.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1.6.toml
@@ -1,0 +1,5 @@
+name = "Doubao-Seed 1.6"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-1.8.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-1.8.toml
@@ -1,0 +1,10 @@
+name = "Doubao-Seed-1.8"
+
+[cost]
+input = 0.11
+output = 0.28
+cache_read = 0.02
+
+[limit]
+context = 256_000
+output = 64_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2-0-code-preview-260215.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2-0-code-preview-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Code Preview"
+
+[cost]
+input = 0.782
+output = 3.893
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2-0-code-preview.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2-0-code-preview.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Code Preview"
+
+[cost]
+input = 0.48
+output = 2.41
+cache_read = 0.09644
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2-0-lite-260215.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2-0-lite-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Lite"
+
+[cost]
+input = 0.1462
+output = 0.8738
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2-0-lite-260428.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Lite 260428"
+
+[cost]
+input = 0.08
+output = 0.51
+cache_read = 0.01692
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2-0-mini-260215.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2-0-mini-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Mini"
+
+[cost]
+input = 0.0493
+output = 0.4845
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2-0-mini-260428.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Mini 260428"
+
+[cost]
+input = 0.03
+output = 0.28
+cache_read = 0.00564
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2-0-pro-260215.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2-0-pro-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Pro"
+
+[cost]
+input = 0.782
+output = 3.876
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2-0-pro.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2-0-pro.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Pro"
+
+[cost]
+input = 0.48
+output = 2.41
+cache_read = 0.09644
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2.0-code.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2.0-code.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Code"
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2.0-lite.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2.0-lite.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Lite"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2.0-mini.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2.0-mini.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Mini"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-2.0-pro.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-2.0-pro.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Pro"
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-code-preview-251028.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-code-preview-251028.toml
@@ -1,0 +1,9 @@
+name = "doubao-seed-code-preview-251028"
+
+[cost]
+input = 0.17
+output = 1.14
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/doubao-seed-code.toml
+++ b/providers/volcengine-coding-plan/models/doubao-seed-code.toml
@@ -1,0 +1,10 @@
+name = "Doubao-Seed-Code"
+
+[cost]
+input = 0.17
+output = 1.12
+cache_read = 0.03
+
+[limit]
+context = 256_000
+output = 64_000

--- a/providers/volcengine-coding-plan/models/glm-5.1.toml
+++ b/providers/volcengine-coding-plan/models/glm-5.1.toml
@@ -1,0 +1,5 @@
+name = "GLM-5.1"
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/volcengine-coding-plan/models/glm-5.2.toml
+++ b/providers/volcengine-coding-plan/models/glm-5.2.toml
@@ -1,0 +1,5 @@
+name = "GLM-5.2"
+
+[limit]
+context = 1_000_000
+output = 131_072

--- a/providers/volcengine-coding-plan/models/kimi-k2.6.toml
+++ b/providers/volcengine-coding-plan/models/kimi-k2.6.toml
@@ -1,0 +1,5 @@
+name = "Kimi-K2.6"
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/volcengine-coding-plan/models/kimi-k2.7-code.toml
+++ b/providers/volcengine-coding-plan/models/kimi-k2.7-code.toml
@@ -1,0 +1,5 @@
+name = "Kimi-K2.7-Code"
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/volcengine-coding-plan/models/minimax-m2.7.toml
+++ b/providers/volcengine-coding-plan/models/minimax-m2.7.toml
@@ -1,0 +1,5 @@
+name = "MiniMax-M2.7"
+
+[limit]
+context = 204_800
+output = 131_072

--- a/providers/volcengine-coding-plan/models/minimax-m3.toml
+++ b/providers/volcengine-coding-plan/models/minimax-m3.toml
@@ -1,0 +1,5 @@
+name = "MiniMax-M3"
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/volcengine-coding-plan/provider.toml
+++ b/providers/volcengine-coding-plan/provider.toml
@@ -1,0 +1,5 @@
+name = "Volcengine Coding Plan"
+env = ["VOLCENGINE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://www.volcengine.com/docs/82379/1399008"
+api = "https://ark.cn-beijing.volces.com/api/coding/v3"

--- a/providers/volcengine-token-plan/models/deepseek-v3.2.toml
+++ b/providers/volcengine-token-plan/models/deepseek-v3.2.toml
@@ -1,0 +1,5 @@
+name = "DeepSeek-V3.2"
+
+[limit]
+context = 1_000_000
+output = 384_000

--- a/providers/volcengine-token-plan/models/deepseek-v4-flash.toml
+++ b/providers/volcengine-token-plan/models/deepseek-v4-flash.toml
@@ -1,0 +1,5 @@
+name = "DeepSeek-V4-Flash"
+
+[limit]
+context = 1_000_000
+output = 384_000

--- a/providers/volcengine-token-plan/models/deepseek-v4-pro.toml
+++ b/providers/volcengine-token-plan/models/deepseek-v4-pro.toml
@@ -1,0 +1,5 @@
+name = "DeepSeek-V4-Pro"
+
+[limit]
+context = 1_000_000
+output = 384_000

--- a/providers/volcengine-token-plan/models/doubao-1-5-thinking-pro-250415.toml
+++ b/providers/volcengine-token-plan/models/doubao-1-5-thinking-pro-250415.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Thinking Pro"
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/volcengine-token-plan/models/doubao-1-5-thinking-pro-vision-250415.toml
+++ b/providers/volcengine-token-plan/models/doubao-1-5-thinking-pro-vision-250415.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Thinking Pro Vision"
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/volcengine-token-plan/models/doubao-1-5-thinking-vision-pro-250428.toml
+++ b/providers/volcengine-token-plan/models/doubao-1-5-thinking-vision-pro-250428.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Thinking Vision Pro"
+
+[cost]
+input = 0.55
+output = 1.43
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/volcengine-token-plan/models/doubao-1.5-pro-256k.toml
+++ b/providers/volcengine-token-plan/models/doubao-1.5-pro-256k.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Pro 256k"
+
+[cost]
+input = 0.799
+output = 1.445
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine-token-plan/models/doubao-1.5-pro-32k.toml
+++ b/providers/volcengine-token-plan/models/doubao-1.5-pro-32k.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Pro 32k"
+
+[cost]
+input = 0.1343
+output = 0.3349
+
+[limit]
+context = 32_000
+output = 8_192

--- a/providers/volcengine-token-plan/models/doubao-1.5-thinking-pro.toml
+++ b/providers/volcengine-token-plan/models/doubao-1.5-thinking-pro.toml
@@ -1,0 +1,5 @@
+name = "Doubao 1.5 Thinking Pro"
+
+[limit]
+context = 128_000
+output = 16_000

--- a/providers/volcengine-token-plan/models/doubao-1.5-vision-pro-32k.toml
+++ b/providers/volcengine-token-plan/models/doubao-1.5-vision-pro-32k.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Vision Pro 32k"
+
+[cost]
+input = 0.459
+output = 1.377
+
+[limit]
+context = 32_000
+output = 8_192

--- a/providers/volcengine-token-plan/models/doubao-1.5-vision-pro.toml
+++ b/providers/volcengine-token-plan/models/doubao-1.5-vision-pro.toml
@@ -1,0 +1,5 @@
+name = "Doubao 1.5 Vision Pro"
+
+[limit]
+context = 128_000
+output = 16_000

--- a/providers/volcengine-token-plan/models/doubao-seed-1-6-250615.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1-6-250615.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.6"
+
+[cost]
+input = 0.204
+output = 0.51
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine-token-plan/models/doubao-seed-1-6-flash-250615.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1-6-flash-250615.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.6 Flash"
+
+[cost]
+input = 0.0374
+output = 0.374
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine-token-plan/models/doubao-seed-1-6-thinking-250615.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1-6-thinking-250615.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.6 Thinking"
+
+[cost]
+input = 0.204
+output = 2.04
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine-token-plan/models/doubao-seed-1-6-thinking-250715.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1-6-thinking-250715.toml
@@ -1,0 +1,9 @@
+name = "doubao-seed-1-6-thinking-250715"
+
+[cost]
+input = 0.121
+output = 1.21
+
+[limit]
+context = 256_000
+output = 16_000

--- a/providers/volcengine-token-plan/models/doubao-seed-1-6-vision-250815.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1-6-vision-250815.toml
@@ -1,0 +1,9 @@
+name = "doubao-seed-1-6-vision-250815"
+
+[cost]
+input = 0.114
+output = 1.143
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/doubao-seed-1-8-251215.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1-8-251215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.8"
+
+[cost]
+input = 0.612
+output = 6.12
+
+[limit]
+context = 128_000
+output = 8_192

--- a/providers/volcengine-token-plan/models/doubao-seed-1.6-flash.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1.6-flash.toml
@@ -1,0 +1,5 @@
+name = "Doubao-Seed 1.6 Flash"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/doubao-seed-1.6-thinking.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1.6-thinking.toml
@@ -1,0 +1,5 @@
+name = "Doubao-Seed 1.6 Thinking"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/doubao-seed-1.6.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1.6.toml
@@ -1,0 +1,5 @@
+name = "Doubao-Seed 1.6"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/doubao-seed-1.8.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-1.8.toml
@@ -1,0 +1,10 @@
+name = "Doubao-Seed-1.8"
+
+[cost]
+input = 0.11
+output = 0.28
+cache_read = 0.02
+
+[limit]
+context = 256_000
+output = 64_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2-0-code-preview-260215.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2-0-code-preview-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Code Preview"
+
+[cost]
+input = 0.782
+output = 3.893
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2-0-code-preview.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2-0-code-preview.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Code Preview"
+
+[cost]
+input = 0.48
+output = 2.41
+cache_read = 0.09644
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2-0-lite-260215.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2-0-lite-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Lite"
+
+[cost]
+input = 0.1462
+output = 0.8738
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2-0-lite-260428.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Lite 260428"
+
+[cost]
+input = 0.08
+output = 0.51
+cache_read = 0.01692
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2-0-mini-260215.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2-0-mini-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Mini"
+
+[cost]
+input = 0.0493
+output = 0.4845
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2-0-mini-260428.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Mini 260428"
+
+[cost]
+input = 0.03
+output = 0.28
+cache_read = 0.00564
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2-0-pro-260215.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2-0-pro-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Pro"
+
+[cost]
+input = 0.782
+output = 3.876
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2-0-pro.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2-0-pro.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Pro"
+
+[cost]
+input = 0.48
+output = 2.41
+cache_read = 0.09644
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2.0-code.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2.0-code.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Code"
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2.0-lite.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2.0-lite.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Lite"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2.0-mini.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2.0-mini.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Mini"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/doubao-seed-2.0-pro.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-2.0-pro.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Pro"
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine-token-plan/models/doubao-seed-code-preview-251028.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-code-preview-251028.toml
@@ -1,0 +1,9 @@
+name = "doubao-seed-code-preview-251028"
+
+[cost]
+input = 0.17
+output = 1.14
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/doubao-seed-code.toml
+++ b/providers/volcengine-token-plan/models/doubao-seed-code.toml
@@ -1,0 +1,10 @@
+name = "Doubao-Seed-Code"
+
+[cost]
+input = 0.17
+output = 1.12
+cache_read = 0.03
+
+[limit]
+context = 256_000
+output = 64_000

--- a/providers/volcengine-token-plan/models/glm-5.1.toml
+++ b/providers/volcengine-token-plan/models/glm-5.1.toml
@@ -1,0 +1,5 @@
+name = "GLM-5.1"
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/volcengine-token-plan/models/glm-5.2.toml
+++ b/providers/volcengine-token-plan/models/glm-5.2.toml
@@ -1,0 +1,5 @@
+name = "GLM-5.2"
+
+[limit]
+context = 1_000_000
+output = 131_072

--- a/providers/volcengine-token-plan/models/kimi-k2.6.toml
+++ b/providers/volcengine-token-plan/models/kimi-k2.6.toml
@@ -1,0 +1,5 @@
+name = "Kimi-K2.6"
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/volcengine-token-plan/models/kimi-k2.7-code.toml
+++ b/providers/volcengine-token-plan/models/kimi-k2.7-code.toml
@@ -1,0 +1,5 @@
+name = "Kimi-K2.7-Code"
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/volcengine-token-plan/models/kimi-k3.toml
+++ b/providers/volcengine-token-plan/models/kimi-k3.toml
@@ -1,0 +1,5 @@
+name = "Kimi-K3"
+
+[limit]
+context = 1_048_576
+output = 131_072

--- a/providers/volcengine-token-plan/models/minimax-m2.7.toml
+++ b/providers/volcengine-token-plan/models/minimax-m2.7.toml
@@ -1,0 +1,5 @@
+name = "MiniMax-M2.7"
+
+[limit]
+context = 204_800
+output = 131_072

--- a/providers/volcengine-token-plan/models/minimax-m3.toml
+++ b/providers/volcengine-token-plan/models/minimax-m3.toml
@@ -1,0 +1,5 @@
+name = "MiniMax-M3"
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/volcengine-token-plan/provider.toml
+++ b/providers/volcengine-token-plan/provider.toml
@@ -1,0 +1,5 @@
+name = "Volcengine Token Plan"
+env = ["VOLCENGINE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://www.volcengine.com/docs/82379/1399008"
+api = "https://ark.cn-beijing.volces.com/api/v3"

--- a/providers/volcengine/models/doubao-1-5-thinking-pro-250415.toml
+++ b/providers/volcengine/models/doubao-1-5-thinking-pro-250415.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Thinking Pro"
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/volcengine/models/doubao-1-5-thinking-pro-vision-250415.toml
+++ b/providers/volcengine/models/doubao-1-5-thinking-pro-vision-250415.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Thinking Pro Vision"
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/volcengine/models/doubao-1-5-thinking-vision-pro-250428.toml
+++ b/providers/volcengine/models/doubao-1-5-thinking-vision-pro-250428.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Thinking Vision Pro"
+
+[cost]
+input = 0.55
+output = 1.43
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/volcengine/models/doubao-1.5-pro-256k.toml
+++ b/providers/volcengine/models/doubao-1.5-pro-256k.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Pro 256k"
+
+[cost]
+input = 0.799
+output = 1.445
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine/models/doubao-1.5-pro-32k.toml
+++ b/providers/volcengine/models/doubao-1.5-pro-32k.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Pro 32k"
+
+[cost]
+input = 0.1343
+output = 0.3349
+
+[limit]
+context = 32_000
+output = 8_192

--- a/providers/volcengine/models/doubao-1.5-thinking-pro.toml
+++ b/providers/volcengine/models/doubao-1.5-thinking-pro.toml
@@ -1,0 +1,5 @@
+name = "Doubao 1.5 Thinking Pro"
+
+[limit]
+context = 128_000
+output = 16_000

--- a/providers/volcengine/models/doubao-1.5-vision-pro-32k.toml
+++ b/providers/volcengine/models/doubao-1.5-vision-pro-32k.toml
@@ -1,0 +1,9 @@
+name = "Doubao 1.5 Vision Pro 32k"
+
+[cost]
+input = 0.459
+output = 1.377
+
+[limit]
+context = 32_000
+output = 8_192

--- a/providers/volcengine/models/doubao-1.5-vision-pro.toml
+++ b/providers/volcengine/models/doubao-1.5-vision-pro.toml
@@ -1,0 +1,5 @@
+name = "Doubao 1.5 Vision Pro"
+
+[limit]
+context = 128_000
+output = 16_000

--- a/providers/volcengine/models/doubao-seed-1-6-250615.toml
+++ b/providers/volcengine/models/doubao-seed-1-6-250615.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.6"
+
+[cost]
+input = 0.204
+output = 0.51
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine/models/doubao-seed-1-6-flash-250615.toml
+++ b/providers/volcengine/models/doubao-seed-1-6-flash-250615.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.6 Flash"
+
+[cost]
+input = 0.0374
+output = 0.374
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine/models/doubao-seed-1-6-thinking-250615.toml
+++ b/providers/volcengine/models/doubao-seed-1-6-thinking-250615.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.6 Thinking"
+
+[cost]
+input = 0.204
+output = 2.04
+
+[limit]
+context = 256_000
+output = 16_384

--- a/providers/volcengine/models/doubao-seed-1-6-thinking-250715.toml
+++ b/providers/volcengine/models/doubao-seed-1-6-thinking-250715.toml
@@ -1,0 +1,9 @@
+name = "doubao-seed-1-6-thinking-250715"
+
+[cost]
+input = 0.121
+output = 1.21
+
+[limit]
+context = 256_000
+output = 16_000

--- a/providers/volcengine/models/doubao-seed-1-6-vision-250815.toml
+++ b/providers/volcengine/models/doubao-seed-1-6-vision-250815.toml
@@ -1,0 +1,9 @@
+name = "doubao-seed-1-6-vision-250815"
+
+[cost]
+input = 0.114
+output = 1.143
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine/models/doubao-seed-1-8-251215.toml
+++ b/providers/volcengine/models/doubao-seed-1-8-251215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 1.8"
+
+[cost]
+input = 0.612
+output = 6.12
+
+[limit]
+context = 128_000
+output = 8_192

--- a/providers/volcengine/models/doubao-seed-1.6-flash.toml
+++ b/providers/volcengine/models/doubao-seed-1.6-flash.toml
@@ -1,0 +1,5 @@
+name = "Doubao-Seed 1.6 Flash"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine/models/doubao-seed-1.6-thinking.toml
+++ b/providers/volcengine/models/doubao-seed-1.6-thinking.toml
@@ -1,0 +1,5 @@
+name = "Doubao-Seed 1.6 Thinking"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine/models/doubao-seed-1.6.toml
+++ b/providers/volcengine/models/doubao-seed-1.6.toml
@@ -1,0 +1,5 @@
+name = "Doubao-Seed 1.6"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine/models/doubao-seed-1.8.toml
+++ b/providers/volcengine/models/doubao-seed-1.8.toml
@@ -1,0 +1,10 @@
+name = "Doubao-Seed-1.8"
+
+[cost]
+input = 0.11
+output = 0.28
+cache_read = 0.02
+
+[limit]
+context = 256_000
+output = 64_000

--- a/providers/volcengine/models/doubao-seed-2-0-code-preview-260215.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-code-preview-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Code Preview"
+
+[cost]
+input = 0.782
+output = 3.893
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine/models/doubao-seed-2-0-code-preview.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-code-preview.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Code Preview"
+
+[cost]
+input = 0.48
+output = 2.41
+cache_read = 0.09644
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine/models/doubao-seed-2-0-lite-260215.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-lite-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Lite"
+
+[cost]
+input = 0.1462
+output = 0.8738
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-lite-260428.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Lite 260428"
+
+[cost]
+input = 0.08
+output = 0.51
+cache_read = 0.01692
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine/models/doubao-seed-2-0-mini-260215.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-mini-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Mini"
+
+[cost]
+input = 0.0493
+output = 0.4845
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-mini-260428.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Mini 260428"
+
+[cost]
+input = 0.03
+output = 0.28
+cache_read = 0.00564
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine/models/doubao-seed-2-0-pro-260215.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-pro-260215.toml
@@ -1,0 +1,9 @@
+name = "Doubao Seed 2.0 Pro"
+
+[cost]
+input = 0.782
+output = 3.876
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine/models/doubao-seed-2-0-pro.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-pro.toml
@@ -1,0 +1,10 @@
+name = "Doubao Seed 2.0 Pro"
+
+[cost]
+input = 0.48
+output = 2.41
+cache_read = 0.09644
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine/models/doubao-seed-2.0-code.toml
+++ b/providers/volcengine/models/doubao-seed-2.0-code.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Code"
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine/models/doubao-seed-2.0-lite.toml
+++ b/providers/volcengine/models/doubao-seed-2.0-lite.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Lite"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine/models/doubao-seed-2.0-mini.toml
+++ b/providers/volcengine/models/doubao-seed-2.0-mini.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Mini"
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine/models/doubao-seed-2.0-pro.toml
+++ b/providers/volcengine/models/doubao-seed-2.0-pro.toml
@@ -1,0 +1,5 @@
+name = "Doubao Seed 2.0 Pro"
+
+[limit]
+context = 256_000
+output = 128_000

--- a/providers/volcengine/models/doubao-seed-code-preview-251028.toml
+++ b/providers/volcengine/models/doubao-seed-code-preview-251028.toml
@@ -1,0 +1,9 @@
+name = "doubao-seed-code-preview-251028"
+
+[cost]
+input = 0.17
+output = 1.14
+
+[limit]
+context = 256_000
+output = 32_000

--- a/providers/volcengine/models/doubao-seed-code.toml
+++ b/providers/volcengine/models/doubao-seed-code.toml
@@ -1,0 +1,10 @@
+name = "Doubao-Seed-Code"
+
+[cost]
+input = 0.17
+output = 1.12
+cache_read = 0.03
+
+[limit]
+context = 256_000
+output = 64_000

--- a/providers/volcengine/provider.toml
+++ b/providers/volcengine/provider.toml
@@ -1,0 +1,5 @@
+name = "Volcengine"
+env = ["VOLCENGINE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://www.volcengine.com/docs/82379/1399008"
+api = "https://ark.cn-beijing.volces.com/api/v3"


### PR DESCRIPTION
## Summary

Add **Volcengine (火山引擎/方舟)** as a new provider with comprehensive model coverage across 3 billing plan types.

### Providers (3)

| Provider Key | Plan Type | API Endpoint |
|---|---|---|
| `volcengine` | PayGo (pay-per-token) | `https://ark.cn-beijing.volces.com/api/v3` |
| `volcengine-coding-plan` | Coding Plan (subscription) | `https://ark.cn-beijing.volces.com/api/coding/v3` |
| `volcengine-token-plan` | Token Plan / Agent Plan (subscription) | `https://ark.cn-beijing.volces.com/api/v3` |

### Models (42 total)

**32 Doubao (first-party) models:**
- **Seed 2.0 series**: Pro, Mini, Lite, Code (including dated variants like `-260215`, `-260428`)
- **Seed 1.8**: Base model
- **Seed 1.6 series**: Base, Flash, Thinking (including dated variants)
- **1.5 series**: Pro (32k/256k), Vision Pro, Thinking Pro
- **Seed Code**: Base and preview variants

**10 third-party models via Ark platform:**
- GLM-5.1, GLM-5.2 (Zhipu AI)
- MiniMax-M2.7, MiniMax-M3 (MiniMax)
- Kimi-K2.6, Kimi-K2.7-Code, Kimi-K3 (Moonshot AI, K3 is Token Plan only)
- DeepSeek-V3.2, DeepSeek-V4-Flash, DeepSeek-V4-Pro (DeepSeek)

### Files (160 TOML)

- `models/volcengine/` — 42 universal model definitions
- `providers/volcengine/` — PayGo provider + 32 model pricing files
- `providers/volcengine-coding-plan/` — Coding Plan provider + 41 model pricing files
- `providers/volcengine-token-plan/` — Token Plan provider + 42 model pricing files

### Pricing Note

Pricing data sourced from multiple reseller APIs (nano-gpt, aihubmix, qiniu-ai, 302ai, zenmux). **Official Volcengine pricing may differ** — please verify against [volcengine.com docs](https://www.volcengine.com/docs/82379/1399008). Coding Plan and Token Plan use bundled subscription pricing (not per-token), so cost fields reflect the effective per-token rate where available.