### PR TITLE
feat(kimi-for-coding): add k3-256k model

### DIFF
--- a/providers/kimi-for-coding/models/k3-256k.toml
+++ b/providers/kimi-for-coding/models/k3-256k.toml
@@ -1,0 +1,25 @@
+# k3-256k is the 256K-context variant of Kimi K3 on the Kimi For Coding
+# endpoint. Unlike full K3 it accepts no video input (image only).
+# reasoning_options per the Kimi Code docs:
+#   reasoning_effort = "low" | "high" | "max" (default "high")
+# Cost is zeroed per this provider's subscription convention.
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3-256K"
+description = "256K-context version of Kimi K3, reducing token consumption for shorter coding sessions"
+attachment = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 262_144
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
## Summary

Adds `k3-256k`, the 256K-context variant of Kimi K3 served on the Kimi For Coding endpoint.

- Inherits from `base_model = "moonshotai/kimi-k3"`; overrides `limit.context` to 262144 and `modalities.input` to text+image (no video)
- `reasoning_options` declares effort only (`low`/`high`/`max`), no toggle — the endpoint enforces always-on thinking
- Cost zeroed per this provider's subscription convention

## Source

Verified against the live endpoint `GET https://api.kimi.com/coding/v1/models`:

```json
{
  "id": "k3-256k",
  "context_length": 262144,
  "supports_reasoning": true,
  "supports_image_in": true,
  "supports_video_in": false,
  "supports_thinking_type": "only",
  "think_efforts": { "support": true, "valid_efforts": ["low", "high", "max"], "default_effort": "high" }
}
```

Also smoke-tested `POST /coding/v1/messages` with `model: "k3-256k"` (200, text + image input both work).

`bun validate` passes.