### PR TITLE
Add app.nz provider

### DIFF
--- a/providers/app-nz/logo.svg
+++ b/providers/app-nz/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path fill-rule="evenodd" d="M12 23 1 3.95h22L12 23ZM6.1 7l5.9 10.22L17.9 7H6.1Z" clip-rule="evenodd"/>
+</svg>

--- a/providers/app-nz/models/app/auto-cheap.toml
+++ b/providers/app-nz/models/app/auto-cheap.toml
@@ -1,0 +1,22 @@
+name = "Auto Cheap"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream low-cost models; pricing is variable. Values below
+# are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 0.20
+output = 0.60
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto-cheap.toml
+++ b/providers/app-nz/models/app/auto-cheap.toml
@@ -1,6 +1,7 @@
 name = "Auto Cheap"
+description = "app.nz route biased toward the lowest-cost capable model"
 release_date = "2026-06-28"
-last_updated = "2026-06-28"
+last_updated = "2026-07-24"
 attachment = false
 reasoning = false
 tool_call = true

--- a/providers/app-nz/models/app/auto-code.toml
+++ b/providers/app-nz/models/app/auto-code.toml
@@ -1,0 +1,22 @@
+name = "Auto Code"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream coding models; pricing is variable. Values below
+# are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 1.50
+output = 6.00
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto-code.toml
+++ b/providers/app-nz/models/app/auto-code.toml
@@ -1,6 +1,7 @@
 name = "Auto Code"
+description = "app.nz route biased toward models suited to coding and agent workflows"
 release_date = "2026-06-28"
-last_updated = "2026-06-28"
+last_updated = "2026-07-24"
 attachment = false
 reasoning = false
 tool_call = true

--- a/providers/app-nz/models/app/auto-fast.toml
+++ b/providers/app-nz/models/app/auto-fast.toml
@@ -1,0 +1,22 @@
+name = "Auto Fast"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream low-latency models; pricing is variable. Values
+# below are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 0.50
+output = 1.50
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto-fast.toml
+++ b/providers/app-nz/models/app/auto-fast.toml
@@ -1,6 +1,7 @@
 name = "Auto Fast"
+description = "app.nz route biased toward low-latency interactive models"
 release_date = "2026-06-28"
-last_updated = "2026-06-28"
+last_updated = "2026-07-24"
 attachment = false
 reasoning = false
 tool_call = true

--- a/providers/app-nz/models/app/auto-reasoning.toml
+++ b/providers/app-nz/models/app/auto-reasoning.toml
@@ -1,0 +1,23 @@
+name = "Auto Reasoning"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream reasoning models; pricing is variable. Values below
+# are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 2.00
+output = 8.00
+
+[limit]
+context = 200_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto-reasoning.toml
+++ b/providers/app-nz/models/app/auto-reasoning.toml
@@ -1,6 +1,7 @@
 name = "Auto Reasoning"
+description = "app.nz route that selects a reasoning model and supports effort control"
 release_date = "2026-06-28"
-last_updated = "2026-06-28"
+last_updated = "2026-07-24"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/app-nz/models/app/auto-vision.toml
+++ b/providers/app-nz/models/app/auto-vision.toml
@@ -1,0 +1,22 @@
+name = "Auto Vision"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# Routed to mixed upstream vision models; pricing is variable. Values below
+# are modest representative numbers, not a fixed per-token rate.
+[cost]
+input = 1.50
+output = 5.00
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto-vision.toml
+++ b/providers/app-nz/models/app/auto-vision.toml
@@ -1,6 +1,7 @@
 name = "Auto Vision"
+description = "app.nz route biased toward models that accept image input"
 release_date = "2026-06-28"
-last_updated = "2026-06-28"
+last_updated = "2026-07-24"
 attachment = true
 reasoning = false
 tool_call = true

--- a/providers/app-nz/models/app/auto.toml
+++ b/providers/app-nz/models/app/auto.toml
@@ -1,0 +1,23 @@
+name = "Auto"
+release_date = "2026-06-28"
+last_updated = "2026-06-28"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+# app.nz is an aggregating gateway; requests are routed to mixed upstream
+# models, so pricing is variable. Values below are modest representative
+# numbers, not a fixed per-token rate.
+[cost]
+input = 1.00
+output = 3.00
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/app-nz/models/app/auto.toml
+++ b/providers/app-nz/models/app/auto.toml
@@ -1,6 +1,7 @@
 name = "Auto"
+description = "General-purpose app.nz route that selects an upstream model for each request"
 release_date = "2026-06-28"
-last_updated = "2026-06-28"
+last_updated = "2026-07-24"
 attachment = false
 reasoning = false
 tool_call = true

--- a/providers/app-nz/provider.toml
+++ b/providers/app-nz/provider.toml
@@ -1,0 +1,5 @@
+name = "app.nz"
+env = ["APP_NZ_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://app.nz/v1"
+doc = "https://app.nz/docs"

--- a/providers/app-nz/provider.toml
+++ b/providers/app-nz/provider.toml
@@ -1,5 +1,5 @@
 name = "app.nz"
-env = ["APP_NZ_API_KEY"]
+env = ["APP_API_KEY", "APP_NZ_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
 api = "https://app.nz/v1"
-doc = "https://app.nz/docs"
+doc = "https://app.nz/gateway"


### PR DESCRIPTION
## Summary

Adds app.nz as an OpenAI-compatible model gateway provider:

- canonical `https://app.nz/v1` base URL;
- `APP_API_KEY` authentication, with the older `APP_NZ_API_KEY` alias;
- six workload-aware auto routes for general, coding, reasoning, latency, cost, and vision use cases;
- a monochrome `currentColor` SVG logo.

This resumes #2890 and directly addresses the missing-logo review feedback. It is rebased on the current `dev` branch and includes the now-required model descriptions.

## Sources

- Gateway documentation: https://app.nz/gateway
- Live model catalogue: https://app.nz/v1/models
- Public model metadata and pricing: https://app.nz/api/models

app.nz is an aggregator, so an auto route's chosen upstream and actual metered price can vary. The route records keep the representative pricing notes from the original submission.

## Validation

- `bun install --frozen-lockfile`
- `bun validate`
