### PR TITLE
chore(bedrock): mark Claude Opus 4.1 as deprecated

### DIFF
--- a/providers/amazon-bedrock/models/anthropic.claude-opus-4-1-20250805-v1:0.toml
+++ b/providers/amazon-bedrock/models/anthropic.claude-opus-4-1-20250805-v1:0.toml
@@ -1,5 +1,6 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
 reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+status = "deprecated"
 
 [cost]
 input = 15

--- a/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-1-20250805-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.anthropic.claude-opus-4-1-20250805-v1:0.toml
@@ -1,5 +1,6 @@
 base_model = "anthropic/claude-opus-4-1-20250805"
 reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+status = "deprecated"
 name = "Claude Opus 4.1 (US)"
 
 [cost]


### PR DESCRIPTION
## Summary
- Mark Bedrock **Claude Opus 4.1** as `status = "deprecated"` (base + US cross-region IDs)
- Model is **Legacy** (still serves) until EOL **2027-01-08** — not deleted

| Model ID | Legacy | EOL |
| --- | --- | --- |
| `anthropic.claude-opus-4-1-20250805-v1:0` | 2026-07-08 | 2027-01-08 |
| `us.anthropic.claude-opus-4-1-20250805-v1:0` | 2026-07-08 | 2027-01-08 |

No other catalog models match the current Bedrock Legacy/EOL table (Claude 3.x, Sonnet 4, Command R, Jamba, Nova Canvas/Reel/etc. are not listed).

## Source
https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html

## Test plan
- [x] `bun validate` passes
- [ ] Catalog shows Opus 4.1 as deprecated for amazon-bedrock