### PR TITLE
fix(sync): auto-factor -fast variants onto base_model

### DIFF
--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -216,7 +216,7 @@ export function buildOpenRouterModel(
     return factorBaseModel(
       canonical,
       {
-        name: baseModel !== undefined || model.id.endsWith(":free") || canonicalOverride === canonical
+        name: shouldPreserveFactoredName(model.id, canonical, baseModel, canonicalOverride)
           ? name
           : undefined,
         description: existing?.description ?? describeModel({
@@ -338,6 +338,24 @@ function canonicalBaseModelOverride(openrouterID: string) {
   return CANONICAL_BASE_MODEL_OVERRIDES[
     openrouterID as keyof typeof CANONICAL_BASE_MODEL_OVERRIDES
   ];
+}
+
+function shouldPreserveFactoredName(
+  modelID: string,
+  canonical: string,
+  baseModel: string | undefined,
+  canonicalOverride: string | undefined,
+) {
+  if (baseModel !== undefined) return true;
+  if (modelID.endsWith(":free")) return true;
+  if (canonicalOverride === canonical) return true;
+  const modelSlug = modelID.split("/").slice(1).join("/").replace(/:free$/, "");
+  const canonicalSlug = canonical.split("/").slice(1).join("/");
+  return normalizeModelSlug(modelSlug) !== normalizeModelSlug(canonicalSlug);
+}
+
+function normalizeModelSlug(value: string) {
+  return value.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
 }
 
 export function factorBaseModel(

--- a/packages/core/src/sync/providers/venice.ts
+++ b/packages/core/src/sync/providers/venice.ts
@@ -206,14 +206,26 @@ export function resolveVeniceBaseModel(id: string, name: string) {
   const alias = BASE_MODEL_ALIASES[id];
   if (alias !== undefined) return alias;
   const entries = getMetadataEntries();
-  const normalizedID = normalize(id);
-  const normalizedName = normalize(name);
-  const ranked = [
-    entries.filter((entry) => entry.normalizedFull === normalizedID),
-    entries.filter((entry) => entry.normalizedFilename === normalizedID),
-    entries.filter((entry) => entry.normalizedFilename === normalizedName),
-  ];
-  return ranked.find((matches) => matches.length === 1)?.[0]?.id;
+  for (const candidate of veniceBaseModelCandidates(id, name)) {
+    const normalized = normalize(candidate);
+    const ranked = [
+      entries.filter((entry) => entry.normalizedFull === normalized),
+      entries.filter((entry) => entry.normalizedFilename === normalized),
+    ];
+    const match = ranked.find((matches) => matches.length === 1)?.[0]?.id;
+    if (match !== undefined) return match;
+  }
+  return undefined;
+}
+
+function veniceBaseModelCandidates(id: string, name: string) {
+  const candidates = [id, name];
+  for (const value of [id, name]) {
+    if (value.toLowerCase().endsWith("-fast")) candidates.push(value.slice(0, -"-fast".length));
+    const withoutFastLabel = value.replace(/\s*\(?\s*fast\s*\)?\s*$/i, "").trim();
+    if (withoutFastLabel !== "" && withoutFastLabel !== value) candidates.push(withoutFastLabel);
+  }
+  return [...new Set(candidates)];
 }
 
 function getMetadataEntries() {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -983,10 +983,14 @@ test("resolves Venice Pro routes to canonical OpenAI metadata", () => {
     resolveVeniceBaseModel("openai-gpt-56-luna-pro", "GPT-5.6 Luna Pro"),
     resolveVeniceBaseModel("openai-gpt-56-sol-pro", "GPT-5.6 Sol Pro"),
     resolveVeniceBaseModel("openai-gpt-56-terra-pro", "GPT-5.6 Terra Pro"),
+    resolveVeniceBaseModel("claude-opus-5-fast", "Claude Opus 5 Fast"),
+    resolveVeniceBaseModel("claude-opus-4-8-fast", "Claude Opus 4.8 Fast"),
   ]).toEqual([
     "openai/gpt-5.6-luna",
     "openai/gpt-5.6-sol",
     "openai/gpt-5.6-terra",
+    "anthropic/claude-opus-5",
+    "anthropic/claude-opus-4-8",
   ]);
 });
 
@@ -1192,6 +1196,34 @@ test("Vercel Claude Opus fast variants factor onto base opus metadata", () => {
   });
 
   expect(buildVercelModel(model!, undefined)).toMatchObject({
+    base_model: "anthropic/claude-opus-5",
+    name: "Claude Opus 5 (Fast)",
+    cost: { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
+  });
+});
+
+test("OpenRouter Claude Opus fast variants factor onto base opus metadata", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    id: "anthropic/claude-opus-5-fast",
+    name: "Anthropic: Claude Opus 5 (Fast)",
+    context_length: 1_000_000,
+    top_provider: {
+      context_length: 1_000_000,
+      max_completion_tokens: 128_000,
+    },
+    pricing: {
+      prompt: "0.00001",
+      completion: "0.00005",
+      input_cache_read: "0.000001",
+      input_cache_write: "0.0000125",
+    },
+    reasoning: {
+      mandatory: false,
+      supported_efforts: ["low", "medium", "high", "xhigh", "max"],
+    },
+  }), undefined);
+
+  expect(model).toMatchObject({
     base_model: "anthropic/claude-opus-5",
     name: "Claude Opus 5 (Fast)",
     cost: { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },

--- a/providers/openrouter/models/anthropic/claude-opus-5-fast.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-5-fast.toml
@@ -1,14 +1,7 @@
+base_model = "anthropic/claude-opus-5"
 name = "Claude Opus 5 (Fast)"
 description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
-family = "claude-opus"
-release_date = "2026-07-24"
-last_updated = "2026-07-24"
-attachment = true
-reasoning = true
-temperature = false
-tool_call = true
 structured_output = true
-open_weights = false
 
 [[reasoning_options]]
 type = "effort"
@@ -19,11 +12,3 @@ input = 10
 output = 50
 cache_read = 1
 cache_write = 12.5
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]


### PR DESCRIPTION
## Summary
- OpenRouter: preserve variant names when resolving `-fast` routes to canonical `base_model`
- Venice: strip `-fast` / `(Fast)` when resolving base model metadata
- Fix merged openrouter `claude-opus-5-fast` to use `base_model = anthropic/claude-opus-5`

## Test plan
- [x] `bun test packages/core/test/sync.test.ts`
- [x] `bun validate`