### PR TITLE
fix(anthropic): stop sync from nuking fast mode / duping base fields

### DIFF
--- a/packages/core/src/sync/providers/anthropic.ts
+++ b/packages/core/src/sync/providers/anthropic.ts
@@ -2,7 +2,8 @@ import path from "node:path";
 import { existsSync } from "node:fs";
 import { z } from "zod";
 
-import type { ExistingModel, SyncProvider, SyncedModel } from "../index.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://api.anthropic.com/v1/models";
 const PRICING_ENDPOINT = "https://platform.claude.com/docs/en/about-claude/pricing";
@@ -310,20 +311,42 @@ export function buildAnthropicModel(
   const output = model.max_tokens > 0 ? model.max_tokens : existing?.limit?.output;
   const cost = syncedCost(model, existing);
   const options = reasoningOptions(model, existing);
+  // Models API has no fast-mode surface; preserve authored experimental/provider config.
+  const experimental = existing?.experimental;
+  const provider = existing?.provider;
+  const status = model.pricing?.deprecated ? "deprecated" as const : existing?.status;
+  const structured_output = model.capabilities.structured_outputs?.supported
+    ?? existing?.structured_output;
+  const limit = context !== undefined || output !== undefined || existing?.limit !== undefined
+    ? {
+        context: context ?? existing?.limit?.context ?? 0,
+        input: existing?.limit?.input,
+        output: output ?? existing?.limit?.output ?? 0,
+      }
+    : undefined;
+  const modalities = { input, output: ["text" as const] };
 
   if (baseModel !== undefined) {
-    return {
-      base_model: baseModel,
+    const overrides: Partial<SyncedFullModel> = {
       name: model.canonical_id === undefined ? undefined : name,
       attachment: input.length > 1,
       reasoning,
       reasoning_options: options,
-      structured_output: model.capabilities.structured_outputs?.supported,
-      status: model.pricing?.deprecated ? "deprecated" : undefined,
+      structured_output,
+      status,
+      interleaved: existing?.interleaved,
+      experimental,
+      provider,
       cost,
-      limit: context !== undefined && output !== undefined ? { context, output } : undefined,
-      modalities: { input, output: ["text"] },
+      limit,
+      modalities,
     };
+    return factorBaseModel(
+      baseModel,
+      overrides,
+      limit ?? { context: 0, output: 0 },
+      existing?.base_model_omit,
+    );
   }
 
   if (
@@ -349,15 +372,15 @@ export function buildAnthropicModel(
     reasoning_options: options,
     temperature: existing.temperature,
     tool_call: existing.tool_call,
-    structured_output: model.capabilities.structured_outputs?.supported ?? existing.structured_output,
+    structured_output,
     knowledge: existing.knowledge,
     open_weights: existing.open_weights,
-    status: model.pricing?.deprecated ? "deprecated" : existing.status,
+    status,
     interleaved: existing.interleaved,
-    experimental: existing.experimental,
-    provider: existing.provider,
+    experimental,
+    provider,
     cost,
     limit: { context, input: existing.limit?.input, output },
-    modalities: { input, output: ["text"] },
+    modalities,
   };
 }

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -177,10 +177,82 @@ test("Anthropic sync preserves base model inheritance", () => {
 
   expect(translated?.model).toMatchObject({
     base_model: "anthropic/claude-opus-4-5",
-    name: "Claude Opus 4.5 (latest)",
   });
+  // Name matches models/anthropic/claude-opus-4-5.toml, so factoring omits it.
+  expect(translated?.model).not.toHaveProperty("name");
   expect(translated?.model).not.toHaveProperty("knowledge");
   expect(translated?.model).not.toHaveProperty("release_date");
+});
+
+test("Anthropic factored models omit inherited fields and keep authored fast mode", () => {
+  const model = buildAnthropicModel(
+    anthropicModel({
+      id: "claude-opus-5",
+      display_name: "Claude Opus 5",
+      created_at: "2026-07-24T00:00:00Z",
+      max_input_tokens: 1_000_000,
+      max_tokens: 128_000,
+      capabilities: {
+        effort: {
+          supported: true,
+          low: { supported: true },
+          medium: { supported: true },
+          high: { supported: true },
+          xhigh: { supported: true },
+          max: { supported: true },
+        },
+        image_input: { supported: true },
+        pdf_input: { supported: true },
+        structured_outputs: { supported: true },
+        thinking: { supported: true },
+      },
+    }),
+    {
+      base_model: "anthropic/claude-opus-5",
+      name: "Claude Opus 5",
+      description: "Strongest Claude Opus model for coding, agents, and professional work",
+      attachment: true,
+      reasoning: true,
+      reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+      structured_output: true,
+      tool_call: true,
+      open_weights: false,
+      cost: { input: 5, output: 25, cache_read: 0.5, cache_write: 6.25 },
+      limit: { context: 1_000_000, output: 128_000 },
+      modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+      experimental: {
+        modes: {
+          fast: {
+            cost: { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
+            provider: {
+              body: { speed: "fast" },
+              headers: { "anthropic-beta": "fast-mode-2026-02-01" },
+            },
+          },
+        },
+      },
+    },
+    "anthropic/claude-opus-5",
+  );
+
+  expect(model).toMatchObject({
+    base_model: "anthropic/claude-opus-5",
+    structured_output: true,
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+    cost: { input: 5, output: 25, cache_read: 0.5, cache_write: 6.25 },
+    experimental: {
+      modes: {
+        fast: {
+          cost: { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
+        },
+      },
+    },
+  });
+  expect(model).not.toHaveProperty("attachment");
+  expect(model).not.toHaveProperty("reasoning");
+  expect(model).not.toHaveProperty("limit");
+  expect(model).not.toHaveProperty("modalities");
+  expect(model).not.toHaveProperty("name");
 });
 
 test("filters customer-owned OpenAI models from availability tracking", () => {


### PR DESCRIPTION
## Summary
Fixes the Anthropic sync bug behind #3714.

- **Models API has no fast-mode fields** (fast mode is only on the pricing docs / request API). Sync must never drop authored `[experimental.modes.fast]`.
- **Factor `base_model` properly** via `factorBaseModel` so `attachment` / `reasoning` / `limit` / `modalities` are not duplicated when they match `models/` metadata.

## Test plan
- [x] `bun test packages/core/test/sync.test.ts`
- [x] `bun validate`

## Follow-up
Close #3714 without merging — its diff deletes fast mode and adds inherited noise.