### PR TITLE
feat(github-copilot): add Claude Opus 5

### DIFF
--- a/providers/github-copilot/models/claude-opus-5.toml
+++ b/providers/github-copilot/models/claude-opus-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-5"
+structured_output = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+input = 936_000
+output = 64_000


### PR DESCRIPTION
## Summary

- Add Claude Opus 5 to the GitHub Copilot provider.
- Inherit the canonical Anthropic model metadata.
- Add Copilot-specific pricing, capabilities, reasoning options, and limits.

## Evidence

- [GitHub's release announcement](https://github.blog/changelog/2026-07-24-claude-opus-5-is-now-available-in-github-copilot/) confirms Copilot availability.
- [Supported models](https://docs.github.com/en/copilot/reference/ai-models/supported-models#models-with-extended-capabilities) lists Claude Opus 5 as GA with 1M-token context and configurable reasoning.
- [Models and pricing](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing#anthropic) documents the input, cached input, cache write, and output rates.
- Authenticated `GET /models` on 2026-07-25 returned `claude-opus-5` with structured outputs; `low`, `medium`, `high`, `xhigh`, and `max` reasoning efforts; and 1,000,000 context, 936,000 prompt, and 64,000 output tokens.
- A real Copilot Enterprise `anthropic-messages` request using `claude-opus-5` completed successfully.