### PR TITLE
feat(cloudflare-ai-gateway): add Claude Opus 5

### DIFF
--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-5.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-5.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-opus-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25


### PR DESCRIPTION
## Summary

Adds `anthropic/claude-opus-5` to the Cloudflare AI Gateway provider. Follow-up to #3706, which added Opus 5 to first-party and cloud providers and explicitly deferred the gateways:

> OpenRouter, Vercel AI Gateway, Cloudflare AI Gateway, and other resellers typically lag launch day or auto-sync. Follow-ups when those catalogs list Opus 5.

Cloudflare's catalog already lists it, so the follow-up is due. OpenRouter and Vercel have since landed Opus 5; Cloudflare was the remaining gap.

## Upstream availability

Cloudflare's model catalog lists **Claude Opus 5** as `anthropic/claude-opus-5`, tagged `Third-party` — the AI Gateway path, alongside the existing `claude-fable-5`, `claude-sonnet-5`, and `claude-opus-4.5`–`4.8` entries.

- https://developers.cloudflare.com/ai/models/?authors=anthropic

Note: `providers/cloudflare-ai-gateway/data/api_response.json` is stale (its newest Anthropic entry is `claude-opus-4.5`), so it does not reflect current availability. Refreshing that snapshot is out of scope here.

## Approach

Mirrors the existing pattern for this provider — `base_model` pointing at the shared model metadata, with only provider-specific fields restated:

```toml
base_model = "anthropic/claude-opus-5"
reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

[cost]
input = 5
output = 25
cache_read = 0.5
cache_write = 6.25
```

- Follows `providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-5.toml` (a45e491) and `claude-opus-4-8.toml`.
- Pricing is pass-through, matching Anthropic direct ($5 / $25 per MTok), consistent with every other Anthropic entry on this provider.
- Effort values `low`/`medium`/`high`/`xhigh`/`max` match the base model and #3706.
- No `base_model_omit` needed: `models/anthropic/claude-opus-5.toml` carries no `[experimental.modes.fast]` block (fast mode is declared in `providers/anthropic/`), so nothing provider-inappropriate is inherited.
- No `data/model_names.json` entry: that file is sync-script input, and hand-added models since `claude-opus-4-6` (including `claude-opus-4-7`, `claude-opus-4-8`, `claude-sonnet-5`) resolve their display names through `base_model` without it.

## Test plan

- [x] `bun validate` passes (exit 0)
- [x] Generated entry spot-checked: name, description, family, 1M context / 128k output, `text`/`image`/`pdf` modalities inherited from the shared base; cost and effort values applied from the provider override