### PR TITLE
zai, zhipuai: add missing limit.input for GLM models

### DIFF
--- a/providers/zai/models/glm-4.5-air.toml
+++ b/providers/zai/models/glm-4.5-air.toml
@@ -22,6 +22,7 @@ cache_write = 0
 [limit]
 context = 131_072
 output = 98_304
+input = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/zai/models/glm-4.5-flash.toml
+++ b/providers/zai/models/glm-4.5-flash.toml
@@ -22,6 +22,7 @@ cache_write = 0
 [limit]
 context = 131_072
 output = 98_304
+input = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/zai/models/glm-4.5.toml
+++ b/providers/zai/models/glm-4.5.toml
@@ -22,6 +22,7 @@ cache_write = 0
 [limit]
 context = 131_072
 output = 98_304
+input = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/zai/models/glm-4.5v.toml
+++ b/providers/zai/models/glm-4.5v.toml
@@ -20,6 +20,7 @@ output = 1.8
 [limit]
 context = 64_000
 output = 16_384
+input = 47_616
 
 
 [modalities]

--- a/providers/zai/models/glm-4.6.toml
+++ b/providers/zai/models/glm-4.6.toml
@@ -22,6 +22,7 @@ cache_write = 0
 [limit]
 context = 204800
 output = 131072
+input = 73728
 
 [modalities]
 input = ["text"]

--- a/providers/zai/models/glm-4.6v.toml
+++ b/providers/zai/models/glm-4.6v.toml
@@ -20,6 +20,7 @@ output = 0.9
 [limit]
 context = 128000
 output = 32768
+input = 95232
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/zai/models/glm-4.7-flash.toml
+++ b/providers/zai/models/glm-4.7-flash.toml
@@ -22,6 +22,7 @@ cache_write = 0
 [limit]
 context = 200_000
 output = 131_072
+input = 68_928
 
 [modalities]
 input = ["text"]

--- a/providers/zai/models/glm-4.7-flashx.toml
+++ b/providers/zai/models/glm-4.7-flashx.toml
@@ -22,6 +22,7 @@ cache_write = 0
 [limit]
 context = 200_000
 output = 131_072
+input = 68_928
 
 [modalities]
 input = ["text"]

--- a/providers/zai/models/glm-4.7.toml
+++ b/providers/zai/models/glm-4.7.toml
@@ -25,6 +25,7 @@ cache_write = 0
 [limit]
 context = 204800
 output = 131072
+input = 73728
 
 [modalities]
 input = ["text"]

--- a/providers/zai/models/glm-5-turbo.toml
+++ b/providers/zai/models/glm-5-turbo.toml
@@ -25,6 +25,7 @@ cache_write = 0
 [limit]
 context = 200000
 output = 131072
+input = 68928
 
 [modalities]
 input = ["text"]

--- a/providers/zai/models/glm-5v-turbo.toml
+++ b/providers/zai/models/glm-5v-turbo.toml
@@ -24,6 +24,7 @@ cache_write = 0
 [limit]
 context = 200000
 output = 131072
+input = 68928
 
 [modalities]
 input = ["text", "image", "video", "pdf"]

--- a/providers/zhipuai/models/glm-5.1.toml
+++ b/providers/zhipuai/models/glm-5.1.toml
@@ -25,6 +25,7 @@ cache_write = 0
 [limit]
 context = 200000
 output = 131072
+input = 68928
 
 [modalities]
 input = ["text"]

--- a/providers/zhipuai/models/glm-5.2.toml
+++ b/providers/zhipuai/models/glm-5.2.toml
@@ -29,6 +29,7 @@ cache_write = 0
 [limit]
 context = 1000000
 output = 131072
+input = 868928
 
 [modalities]
 input = ["text"]

--- a/providers/zhipuai/models/glm-5.toml
+++ b/providers/zhipuai/models/glm-5.toml
@@ -24,6 +24,7 @@ cache_write = 0
 [limit]
 context = 204800
 output = 131072
+input = 73728
 
 [modalities]
 input = ["text"]

--- a/providers/zhipuai/models/glm-5v-turbo.toml
+++ b/providers/zhipuai/models/glm-5v-turbo.toml
@@ -24,6 +24,7 @@ cache_write = 0
 [limit]
 context = 200000
 output = 131072
+input = 68928
 
 [modalities]
 input = ["text", "image", "video", "pdf"]


### PR DESCRIPTION
## What

Add the missing `limit.input` field for GLM models in the `zhipuai` and `zai` providers. These models currently declare only `limit.context` and `limit.output`, omitting `limit.input`.

## Why

Downstream consumers that rely on `limit.input` silently misbehave for these models. Concrete example: **opencode**'s `compaction.reserved` threshold is computed as `limit.input - reserved` when `limit.input` is present, but falls back to `context - maxOutputTokens` (ignoring `reserved` entirely) when it is absent. Users who set `compaction.reserved` get no error and no effect — the setting is silently dropped for every GLM model. (Tracked in anomalyco/opencode#38835.)

Per the registry's own convention, models that do declare `input` satisfy `input + output == context` (e.g. openai gpt-5: 272000 + 128000 = 400000). This PR follows the same convention: `input = context - output`.

## Data source

`output` values were verified against Zhipu's official `max_tokens` table (all 13 match exactly):
https://docs.z.ai/guides/overview/concept-param

`context` values are taken as-is from the existing entries (see radix note below). Zhipu's docs only express context as `1M` / `200K` / `128K` without precise integers, except glm-5.2's `1M` which is decimal 1,000,000.

## Coverage

The `zhipuai` and `zai` providers share model data in two directions, so canonical sources are edited:

- **4.5 / 4.6 / 4.7 series**: `zhipuai` symlinks these to `zai`, so `zai` files are the canonical source (11 files edited).
- **glm-5.x series**: `zai` declares `base_model = "zhipuai/glm-5.x"` and inherits `[limit]`, so `zhipuai` files are canonical (4 files edited: glm-5, glm-5.1, glm-5.2, glm-5v-turbo). `zai/glm-5`, `zai/glm-5.1`, `zai/glm-5.2` inherit the new `input` via `base_model`.
- `zai/glm-5-turbo` and `zai/glm-5v-turbo` have their own `[limit]` and are edited directly.

## Not in scope

- **`limit.context` radix inconsistency**: the existing entries store `200K` as both `200000` (decimal) and `204800` (binary), and `128K` as both `131072` and `128000`. This PR does **not** modify `context` and derives `input` from the existing `context` value, so `input` inherits the same radix ambiguity. Filed separately as #3738 for maintainers to resolve against Zhipu's official spec.
- **`zhipuai/glm-4.6v-flash.toml`**: a pre-existing broken symlink (target `zai/glm-4.6v-flash.toml` does not exist). Not touched here; flagged in the radix issue.

## Verification

- `output` matches the official `max_tokens` table for all models.
- `input = context - output` computed per file from the actual `[limit]` values present.
- Underscore formatting matches each file's existing style (`131_072` style preserved where used, plain elsewhere).
