### PR TITLE
Add MuiRouter provider

### DIFF
--- a/providers/muirouter/logo.svg
+++ b/providers/muirouter/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <ellipse cx="5.5" cy="9" rx="1.9" ry="2.5" fill="currentColor"/>
+  <ellipse cx="10" cy="5.5" rx="1.9" ry="2.5" fill="currentColor"/>
+  <ellipse cx="14" cy="5.5" rx="1.9" ry="2.5" fill="currentColor"/>
+  <ellipse cx="18.5" cy="9" rx="1.9" ry="2.5" fill="currentColor"/>
+  <path
+    d="M12 10.5c-3.3 0-5.5 2.6-5.5 5.3 0 1.9 1.6 3.4 3.5 3.4.9 0 1.3-.4 2-.4s1.1.4 2 .4c1.9 0 3.5-1.5 3.5-3.4 0-2.7-2.2-5.3-5.5-5.3z"
+    fill="currentColor"
+  />
+</svg>

--- a/providers/muirouter/models/claude-fable-5.toml
+++ b/providers/muirouter/models/claude-fable-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-fable-5"
+name = "Claude Fable 5"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/muirouter/models/claude-fable-5.toml
+++ b/providers/muirouter/models/claude-fable-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-fable-5"
+
+[cost]
+input = 11
+output = 55
+cache_read = 1.1
+cache_write = 13.75

--- a/providers/muirouter/models/claude-fable-5.toml
+++ b/providers/muirouter/models/claude-fable-5.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-fable-5"
 
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 11
 output = 55

--- a/providers/muirouter/models/claude-haiku-4-5.toml
+++ b/providers/muirouter/models/claude-haiku-4-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 1.05
+output = 5.25
+cache_read = 0.105
+cache_write = 1.3125

--- a/providers/muirouter/models/claude-haiku-4-5.toml
+++ b/providers/muirouter/models/claude-haiku-4-5.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-haiku-4-5"
 
+reasoning_options = [{ type = "budget_tokens", min = 1024 }]
+
 [cost]
 input = 1.05
 output = 5.25

--- a/providers/muirouter/models/claude-haiku-4-5.toml
+++ b/providers/muirouter/models/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+name = "Claude Haiku 4.5 (latest)"
 
 reasoning_options = [{ type = "budget_tokens", min = 1024 }]
 

--- a/providers/muirouter/models/claude-opus-4-6.toml
+++ b/providers/muirouter/models/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+name = "Claude Opus 4.6"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1024 }]
 

--- a/providers/muirouter/models/claude-opus-4-6.toml
+++ b/providers/muirouter/models/claude-opus-4-6.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-6"
+
+[cost]
+input = 5.25
+output = 26.25
+cache_read = 0.525
+cache_write = 6.5625

--- a/providers/muirouter/models/claude-opus-4-6.toml
+++ b/providers/muirouter/models/claude-opus-4-6.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-opus-4-6"
 
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1024 }]
+
 [cost]
 input = 5.25
 output = 26.25

--- a/providers/muirouter/models/claude-opus-4-7.toml
+++ b/providers/muirouter/models/claude-opus-4-7.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[cost]
+input = 5.25
+output = 26.25
+cache_read = 0.525
+cache_write = 6.5625

--- a/providers/muirouter/models/claude-opus-4-7.toml
+++ b/providers/muirouter/models/claude-opus-4-7.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-opus-4-7"
 
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 5.25
 output = 26.25

--- a/providers/muirouter/models/claude-opus-4-7.toml
+++ b/providers/muirouter/models/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+name = "Claude Opus 4.7"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/muirouter/models/claude-opus-4-8.toml
+++ b/providers/muirouter/models/claude-opus-4-8.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[cost]
+input = 5.25
+output = 26.25
+cache_read = 0.525
+cache_write = 6.5625

--- a/providers/muirouter/models/claude-opus-4-8.toml
+++ b/providers/muirouter/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/muirouter/models/claude-opus-4-8.toml
+++ b/providers/muirouter/models/claude-opus-4-8.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-opus-4-8"
 
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 5.25
 output = 26.25

--- a/providers/muirouter/models/claude-opus-5.toml
+++ b/providers/muirouter/models/claude-opus-5.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-opus-5"
 
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 5.25
 output = 26.25

--- a/providers/muirouter/models/claude-opus-5.toml
+++ b/providers/muirouter/models/claude-opus-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-5"
+
+[cost]
+input = 5.25
+output = 26.25
+cache_read = 0.525
+cache_write = 6.5625

--- a/providers/muirouter/models/claude-opus-5.toml
+++ b/providers/muirouter/models/claude-opus-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/muirouter/models/claude-sonnet-4-6.toml
+++ b/providers/muirouter/models/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1024 }]
 

--- a/providers/muirouter/models/claude-sonnet-4-6.toml
+++ b/providers/muirouter/models/claude-sonnet-4-6.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-sonnet-4-6"
 
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1024 }]
+
 [cost]
 input = 3.15
 output = 15.75

--- a/providers/muirouter/models/claude-sonnet-4-6.toml
+++ b/providers/muirouter/models/claude-sonnet-4-6.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[cost]
+input = 3.15
+output = 15.75
+cache_read = 0.315
+cache_write = 3.9375

--- a/providers/muirouter/models/claude-sonnet-5.toml
+++ b/providers/muirouter/models/claude-sonnet-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-sonnet-5"
+
+[cost]
+input = 2.1
+output = 10.5
+cache_read = 0.21
+cache_write = 2.625

--- a/providers/muirouter/models/claude-sonnet-5.toml
+++ b/providers/muirouter/models/claude-sonnet-5.toml
@@ -1,5 +1,7 @@
 base_model = "anthropic/claude-sonnet-5"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 2.1
 output = 10.5

--- a/providers/muirouter/models/claude-sonnet-5.toml
+++ b/providers/muirouter/models/claude-sonnet-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5"
 
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/muirouter/models/gemini-2.5-flash-lite.toml
+++ b/providers/muirouter/models/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+name = "Gemini 2.5 Flash-Lite"
 
 reasoning_options = []
 

--- a/providers/muirouter/models/gemini-2.5-flash-lite.toml
+++ b/providers/muirouter/models/gemini-2.5-flash-lite.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash-lite"
+
+[cost]
+input = 0.12
+output = 0.48
+cache_read = 0.03

--- a/providers/muirouter/models/gemini-2.5-flash-lite.toml
+++ b/providers/muirouter/models/gemini-2.5-flash-lite.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-2.5-flash-lite"
 
+reasoning_options = []
+
 [cost]
 input = 0.12
 output = 0.48

--- a/providers/muirouter/models/gemini-2.5-flash.toml
+++ b/providers/muirouter/models/gemini-2.5-flash.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-2.5-flash"
 
+reasoning_options = []
+
 [cost]
 input = 0.36
 output = 3

--- a/providers/muirouter/models/gemini-2.5-flash.toml
+++ b/providers/muirouter/models/gemini-2.5-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash"
+
+[cost]
+input = 0.36
+output = 3
+cache_read = 0.09

--- a/providers/muirouter/models/gemini-2.5-flash.toml
+++ b/providers/muirouter/models/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+name = "Gemini 2.5 Flash"
 
 reasoning_options = []
 

--- a/providers/muirouter/models/gemini-2.5-pro.toml
+++ b/providers/muirouter/models/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+name = "Gemini 2.5 Pro"
 
 reasoning_options = []
 

--- a/providers/muirouter/models/gemini-2.5-pro.toml
+++ b/providers/muirouter/models/gemini-2.5-pro.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-2.5-pro"
 
+reasoning_options = []
+
 [cost]
 input = 1.5
 output = 12

--- a/providers/muirouter/models/gemini-2.5-pro.toml
+++ b/providers/muirouter/models/gemini-2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-pro"
+
+[cost]
+input = 1.5
+output = 12
+cache_read = 0.375

--- a/providers/muirouter/models/gemini-3-flash-preview.toml
+++ b/providers/muirouter/models/gemini-3-flash-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3-flash-preview"
+
+[cost]
+input = 2
+output = 12

--- a/providers/muirouter/models/gemini-3-flash-preview.toml
+++ b/providers/muirouter/models/gemini-3-flash-preview.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-3-flash-preview"
 
+reasoning_options = []
+
 [cost]
 input = 2
 output = 12

--- a/providers/muirouter/models/gemini-3-flash-preview.toml
+++ b/providers/muirouter/models/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+name = "Gemini 3 Flash Preview"
 
 reasoning_options = []
 

--- a/providers/muirouter/models/gemini-3-flash-preview.toml
+++ b/providers/muirouter/models/gemini-3-flash-preview.toml
@@ -1,8 +1,0 @@
-base_model = "google/gemini-3-flash-preview"
-name = "Gemini 3 Flash Preview"
-
-reasoning_options = []
-
-[cost]
-input = 2
-output = 12

--- a/providers/muirouter/models/gemini-3-flash.toml
+++ b/providers/muirouter/models/gemini-3-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3-flash-preview"
+
+[cost]
+input = 0.6
+output = 3.6
+cache_read = 0.15

--- a/providers/muirouter/models/gemini-3-flash.toml
+++ b/providers/muirouter/models/gemini-3-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+name = "Gemini 3 Flash Preview"
 
 reasoning_options = []
 

--- a/providers/muirouter/models/gemini-3-flash.toml
+++ b/providers/muirouter/models/gemini-3-flash.toml
@@ -4,6 +4,6 @@ name = "Gemini 3 Flash Preview"
 reasoning_options = []
 
 [cost]
-input = 0.6
-output = 3.6
-cache_read = 0.15
+input = 0.5
+output = 3
+cache_read = 0.05

--- a/providers/muirouter/models/gemini-3-flash.toml
+++ b/providers/muirouter/models/gemini-3-flash.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-3-flash-preview"
 
+reasoning_options = []
+
 [cost]
 input = 0.6
 output = 3.6

--- a/providers/muirouter/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/muirouter/models/gemini-3.1-flash-lite-preview.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
 
+reasoning_options = []
+
 [cost]
 input = 0.25
 output = 1.5

--- a/providers/muirouter/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/muirouter/models/gemini-3.1-flash-lite-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-preview"
+name = "Gemini 3.1 Flash Lite Preview"
 
 reasoning_options = []
 

--- a/providers/muirouter/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/muirouter/models/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+
+[cost]
+input = 0.25
+output = 1.5

--- a/providers/muirouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/muirouter/models/gemini-3.1-pro-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[cost]
+input = 2
+output = 12

--- a/providers/muirouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/muirouter/models/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+name = "Gemini 3.1 Pro Preview"
 
 reasoning_options = []
 

--- a/providers/muirouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/muirouter/models/gemini-3.1-pro-preview.toml
@@ -1,5 +1,7 @@
 base_model = "google/gemini-3.1-pro-preview"
 
+reasoning_options = []
+
 [cost]
 input = 2
 output = 12

--- a/providers/muirouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/muirouter/models/gemini-3.1-pro-preview.toml
@@ -6,3 +6,4 @@ reasoning_options = []
 [cost]
 input = 2
 output = 12
+cache_read = 0.2

--- a/providers/muirouter/models/gemini-3.5-flash-lite.toml
+++ b/providers/muirouter/models/gemini-3.5-flash-lite.toml
@@ -1,0 +1,9 @@
+base_model = "google/gemini-3.5-flash-lite"
+name = "Gemini 3.5 Flash Lite"
+
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/muirouter/models/gemini-3.5-flash.toml
+++ b/providers/muirouter/models/gemini-3.5-flash.toml
@@ -1,0 +1,9 @@
+base_model = "google/gemini-3.5-flash"
+name = "Gemini 3.5 Flash"
+
+reasoning_options = []
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15

--- a/providers/muirouter/models/gemini-3.6-flash.toml
+++ b/providers/muirouter/models/gemini-3.6-flash.toml
@@ -1,0 +1,9 @@
+base_model = "google/gemini-3.6-flash"
+name = "Gemini 3.6 Flash"
+
+reasoning_options = []
+
+[cost]
+input = 1.5
+output = 7.5
+cache_read = 0.15

--- a/providers/muirouter/models/glm-4.7-flash.toml
+++ b/providers/muirouter/models/glm-4.7-flash.toml
@@ -1,5 +1,7 @@
 base_model = "zhipuai/glm-4.7-flash"
 
+reasoning_options = [{ type = "toggle" }]
+
 [cost]
 input = 0.072
 output = 0.48

--- a/providers/muirouter/models/glm-4.7-flash.toml
+++ b/providers/muirouter/models/glm-4.7-flash.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-4.7-flash"
+
+[cost]
+input = 0.072
+output = 0.48

--- a/providers/muirouter/models/glm-4.7-flash.toml
+++ b/providers/muirouter/models/glm-4.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
+name = "GLM-4.7-Flash"
 
 reasoning_options = [{ type = "toggle" }]
 

--- a/providers/muirouter/models/gpt-4.1.toml
+++ b/providers/muirouter/models/gpt-4.1.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-4.1"
+
+[cost]
+input = 2.4
+output = 9.6
+cache_read = 0.24

--- a/providers/muirouter/models/gpt-4.1.toml
+++ b/providers/muirouter/models/gpt-4.1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-4.1"
+name = "GPT-4.1"
 
 [cost]
 input = 2.4

--- a/providers/muirouter/models/gpt-4o-mini.toml
+++ b/providers/muirouter/models/gpt-4o-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-4o-mini"
+name = "GPT-4o mini"
 
 [cost]
 input = 0.18

--- a/providers/muirouter/models/gpt-4o-mini.toml
+++ b/providers/muirouter/models/gpt-4o-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-4o-mini"
+
+[cost]
+input = 0.18
+output = 0.72
+cache_read = 0.018

--- a/providers/muirouter/models/gpt-4o.toml
+++ b/providers/muirouter/models/gpt-4o.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-4o"
+
+[cost]
+input = 3
+output = 12
+cache_read = 0.3

--- a/providers/muirouter/models/gpt-4o.toml
+++ b/providers/muirouter/models/gpt-4o.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-4o"
+name = "GPT-4o"
 
 [cost]
 input = 3

--- a/providers/muirouter/models/gpt-5-mini.toml
+++ b/providers/muirouter/models/gpt-5-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5-mini"
+
+[cost]
+input = 0.3
+output = 2.4
+cache_read = 0.03

--- a/providers/muirouter/models/gpt-5-mini.toml
+++ b/providers/muirouter/models/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+name = "GPT-5 Mini"
 
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 

--- a/providers/muirouter/models/gpt-5-mini.toml
+++ b/providers/muirouter/models/gpt-5-mini.toml
@@ -1,5 +1,7 @@
 base_model = "openai/gpt-5-mini"
 
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
 [cost]
 input = 0.3
 output = 2.4

--- a/providers/muirouter/models/gpt-5-nano.toml
+++ b/providers/muirouter/models/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+name = "GPT-5 Nano"
 
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 

--- a/providers/muirouter/models/gpt-5-nano.toml
+++ b/providers/muirouter/models/gpt-5-nano.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5-nano"
+
+[cost]
+input = 0.06
+output = 0.48
+cache_read = 0.006

--- a/providers/muirouter/models/gpt-5-nano.toml
+++ b/providers/muirouter/models/gpt-5-nano.toml
@@ -1,5 +1,7 @@
 base_model = "openai/gpt-5-nano"
 
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
 [cost]
 input = 0.06
 output = 0.48

--- a/providers/muirouter/models/gpt-5.4.toml
+++ b/providers/muirouter/models/gpt-5.4.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4"
+
+[cost]
+input = 2.625
+output = 15.75

--- a/providers/muirouter/models/gpt-5.4.toml
+++ b/providers/muirouter/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+name = "GPT-5.4"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 

--- a/providers/muirouter/models/gpt-5.4.toml
+++ b/providers/muirouter/models/gpt-5.4.toml
@@ -6,3 +6,4 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 [cost]
 input = 2.625
 output = 15.75
+cache_read = 0.2625

--- a/providers/muirouter/models/gpt-5.4.toml
+++ b/providers/muirouter/models/gpt-5.4.toml
@@ -1,5 +1,7 @@
 base_model = "openai/gpt-5.4"
 
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
 [cost]
 input = 2.625
 output = 15.75

--- a/providers/muirouter/models/gpt-5.5.toml
+++ b/providers/muirouter/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+name = "GPT-5.5"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 

--- a/providers/muirouter/models/gpt-5.5.toml
+++ b/providers/muirouter/models/gpt-5.5.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.5"
+
+[cost]
+input = 5.25
+output = 31.5
+cache_read = 0.525

--- a/providers/muirouter/models/gpt-5.5.toml
+++ b/providers/muirouter/models/gpt-5.5.toml
@@ -1,5 +1,7 @@
 base_model = "openai/gpt-5.5"
 
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
 [cost]
 input = 5.25
 output = 31.5

--- a/providers/muirouter/models/gpt-5.6-luna.toml
+++ b/providers/muirouter/models/gpt-5.6-luna.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.6-luna"
+
+[cost]
+input = 1.05
+output = 6.3
+cache_read = 0.105
+cache_write = 1.3125

--- a/providers/muirouter/models/gpt-5.6-luna.toml
+++ b/providers/muirouter/models/gpt-5.6-luna.toml
@@ -1,5 +1,7 @@
 base_model = "openai/gpt-5.6-luna"
 
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 1.05
 output = 6.3

--- a/providers/muirouter/models/gpt-5.6-luna.toml
+++ b/providers/muirouter/models/gpt-5.6-luna.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.6-luna"
+name = "GPT-5.6 Luna"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/muirouter/models/gpt-5.6-sol.toml
+++ b/providers/muirouter/models/gpt-5.6-sol.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6 Sol"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/muirouter/models/gpt-5.6-sol.toml
+++ b/providers/muirouter/models/gpt-5.6-sol.toml
@@ -1,5 +1,7 @@
 base_model = "openai/gpt-5.6-sol"
 
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 5.25
 output = 31.5

--- a/providers/muirouter/models/gpt-5.6-sol.toml
+++ b/providers/muirouter/models/gpt-5.6-sol.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.6-sol"
+
+[cost]
+input = 5.25
+output = 31.5
+cache_read = 0.525
+cache_write = 6.5625

--- a/providers/muirouter/models/gpt-5.6-terra.toml
+++ b/providers/muirouter/models/gpt-5.6-terra.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.6-terra"
+name = "GPT-5.6 Terra"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/muirouter/models/gpt-5.6-terra.toml
+++ b/providers/muirouter/models/gpt-5.6-terra.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.6-terra"
+
+[cost]
+input = 2.625
+output = 15.75
+cache_read = 0.2625
+cache_write = 3.28125

--- a/providers/muirouter/models/gpt-5.6-terra.toml
+++ b/providers/muirouter/models/gpt-5.6-terra.toml
@@ -1,5 +1,7 @@
 base_model = "openai/gpt-5.6-terra"
 
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
 [cost]
 input = 2.625
 output = 15.75

--- a/providers/muirouter/models/gpt-5.6.toml
+++ b/providers/muirouter/models/gpt-5.6.toml
@@ -3,6 +3,7 @@ description = "Frontier GPT-5.6 model for complex professional work, coding, and
 family = "gpt-sol"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 tool_call = true
 temperature = false
 structured_output = true

--- a/providers/muirouter/models/gpt-5.6.toml
+++ b/providers/muirouter/models/gpt-5.6.toml
@@ -1,27 +1,10 @@
+base_model = "openai/gpt-5.6-sol"
 name = "GPT-5.6"
-description = "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows"
-family = "gpt-sol"
-attachment = true
-reasoning = true
+
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
-tool_call = true
-temperature = false
-structured_output = true
-open_weights = false
-knowledge = "2026-02-16"
-release_date = "2026-07-09"
-last_updated = "2026-07-09"
 
 [cost]
 input = 5.25
 output = 31.5
 cache_read = 0.525
 cache_write = 6.5625
-
-[limit]
-context = 1050000
-output = 128000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/muirouter/models/gpt-5.6.toml
+++ b/providers/muirouter/models/gpt-5.6.toml
@@ -1,0 +1,26 @@
+name = "GPT-5.6"
+description = "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows"
+family = "gpt-sol"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = false
+structured_output = true
+open_weights = false
+knowledge = "2026-02-16"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+
+[cost]
+input = 5.25
+output = 31.5
+cache_read = 0.525
+cache_write = 6.5625
+
+[limit]
+context = 1050000
+output = 128000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/muirouter/models/gpt-5.toml
+++ b/providers/muirouter/models/gpt-5.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5"
+
+[cost]
+input = 1.5
+output = 12
+cache_read = 0.15

--- a/providers/muirouter/models/gpt-5.toml
+++ b/providers/muirouter/models/gpt-5.toml
@@ -1,5 +1,7 @@
 base_model = "openai/gpt-5"
 
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
 [cost]
 input = 1.5
 output = 12

--- a/providers/muirouter/models/gpt-5.toml
+++ b/providers/muirouter/models/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+name = "GPT-5"
 
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 

--- a/providers/muirouter/models/grok-4.3.toml
+++ b/providers/muirouter/models/grok-4.3.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.3"
+name = "Grok 4.3"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 

--- a/providers/muirouter/models/grok-4.3.toml
+++ b/providers/muirouter/models/grok-4.3.toml
@@ -1,5 +1,7 @@
 base_model = "xai/grok-4.3"
 
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
 [cost]
 input = 1.3125
 output = 2.625

--- a/providers/muirouter/models/grok-4.3.toml
+++ b/providers/muirouter/models/grok-4.3.toml
@@ -1,0 +1,6 @@
+base_model = "xai/grok-4.3"
+
+[cost]
+input = 1.3125
+output = 2.625
+cache_read = 0.21

--- a/providers/muirouter/models/grok-4.5.toml
+++ b/providers/muirouter/models/grok-4.5.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.5"
+name = "Grok 4.5"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 

--- a/providers/muirouter/models/grok-4.5.toml
+++ b/providers/muirouter/models/grok-4.5.toml
@@ -1,5 +1,7 @@
 base_model = "xai/grok-4.5"
 
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
 [cost]
 input = 2.1
 output = 6.3

--- a/providers/muirouter/models/grok-4.5.toml
+++ b/providers/muirouter/models/grok-4.5.toml
@@ -1,0 +1,6 @@
+base_model = "xai/grok-4.5"
+
+[cost]
+input = 2.1
+output = 6.3
+cache_read = 0.525

--- a/providers/muirouter/models/grok-build-0.1.toml
+++ b/providers/muirouter/models/grok-build-0.1.toml
@@ -1,5 +1,7 @@
 base_model = "xai/grok-build-0.1"
 
+reasoning_options = []
+
 [cost]
 input = 1.05
 output = 2.1

--- a/providers/muirouter/models/grok-build-0.1.toml
+++ b/providers/muirouter/models/grok-build-0.1.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-build-0.1"
+name = "Grok Build 0.1"
 
 reasoning_options = []
 

--- a/providers/muirouter/models/grok-build-0.1.toml
+++ b/providers/muirouter/models/grok-build-0.1.toml
@@ -1,0 +1,6 @@
+base_model = "xai/grok-build-0.1"
+
+[cost]
+input = 1.05
+output = 2.1
+cache_read = 0.21

--- a/providers/muirouter/models/kimi-k2.6.toml
+++ b/providers/muirouter/models/kimi-k2.6.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6"
 
 reasoning_options = [{ type = "toggle" }]
 

--- a/providers/muirouter/models/kimi-k2.6.toml
+++ b/providers/muirouter/models/kimi-k2.6.toml
@@ -1,5 +1,7 @@
 base_model = "moonshotai/kimi-k2.6"
 
+reasoning_options = [{ type = "toggle" }]
+
 [cost]
 input = 1.14
 output = 4.8

--- a/providers/muirouter/models/kimi-k2.6.toml
+++ b/providers/muirouter/models/kimi-k2.6.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 1.14
+output = 4.8

--- a/providers/muirouter/models/kimi-k3.toml
+++ b/providers/muirouter/models/kimi-k3.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k3"
+name = "Kimi K3"
 
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 

--- a/providers/muirouter/models/kimi-k3.toml
+++ b/providers/muirouter/models/kimi-k3.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k3"
+
+[cost]
+input = 3.6
+output = 18
+cache_read = 0.36

--- a/providers/muirouter/models/kimi-k3.toml
+++ b/providers/muirouter/models/kimi-k3.toml
@@ -1,5 +1,7 @@
 base_model = "moonshotai/kimi-k3"
 
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
+
 [cost]
 input = 3.6
 output = 18

--- a/providers/muirouter/models/mimo-v2-omni.toml
+++ b/providers/muirouter/models/mimo-v2-omni.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2-omni"
+
+[cost]
+input = 0.48
+output = 2.4
+cache_read = 0.048

--- a/providers/muirouter/models/mimo-v2-omni.toml
+++ b/providers/muirouter/models/mimo-v2-omni.toml
@@ -1,5 +1,7 @@
 base_model = "xiaomi/mimo-v2-omni"
 
+reasoning_options = [{ type = "toggle" }]
+
 [cost]
 input = 0.48
 output = 2.4

--- a/providers/muirouter/models/mimo-v2-omni.toml
+++ b/providers/muirouter/models/mimo-v2-omni.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-omni"
+name = "MiMo-V2-Omni"
 
 reasoning_options = [{ type = "toggle" }]
 

--- a/providers/muirouter/models/mimo-v2-pro.toml
+++ b/providers/muirouter/models/mimo-v2-pro.toml
@@ -1,5 +1,7 @@
 base_model = "xiaomi/mimo-v2-pro"
 
+reasoning_options = [{ type = "toggle" }]
+
 [cost]
 input = 1.2
 output = 3.6

--- a/providers/muirouter/models/mimo-v2-pro.toml
+++ b/providers/muirouter/models/mimo-v2-pro.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2-pro"
+
+[cost]
+input = 1.2
+output = 3.6
+cache_read = 0.12

--- a/providers/muirouter/models/mimo-v2-pro.toml
+++ b/providers/muirouter/models/mimo-v2-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2-pro"
+name = "MiMo-V2-Pro"
 
 reasoning_options = [{ type = "toggle" }]
 

--- a/providers/muirouter/models/mimo-v2.5-pro.toml
+++ b/providers/muirouter/models/mimo-v2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+
+[cost]
+input = 1.2
+output = 3.6
+cache_read = 0.12

--- a/providers/muirouter/models/mimo-v2.5-pro.toml
+++ b/providers/muirouter/models/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+name = "MiMo-V2.5-Pro"
 
 reasoning_options = [{ type = "toggle" }]
 

--- a/providers/muirouter/models/mimo-v2.5-pro.toml
+++ b/providers/muirouter/models/mimo-v2.5-pro.toml
@@ -1,5 +1,7 @@
 base_model = "xiaomi/mimo-v2.5-pro"
 
+reasoning_options = [{ type = "toggle" }]
+
 [cost]
 input = 1.2
 output = 3.6

--- a/providers/muirouter/models/mimo-v2.5.toml
+++ b/providers/muirouter/models/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+name = "MiMo-V2.5"
 
 reasoning_options = [{ type = "toggle" }]
 

--- a/providers/muirouter/models/mimo-v2.5.toml
+++ b/providers/muirouter/models/mimo-v2.5.toml
@@ -1,5 +1,7 @@
 base_model = "xiaomi/mimo-v2.5"
 
+reasoning_options = [{ type = "toggle" }]
+
 [cost]
 input = 0.48
 output = 2.4

--- a/providers/muirouter/models/mimo-v2.5.toml
+++ b/providers/muirouter/models/mimo-v2.5.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5"
+
+[cost]
+input = 0.48
+output = 2.4
+cache_read = 0.048

--- a/providers/muirouter/models/qwen3-30b.toml
+++ b/providers/muirouter/models/qwen3-30b.toml
@@ -1,0 +1,23 @@
+name = "Qwen3 30B A3b fp8"
+description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
+family = "qwen"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+structured_output = false
+open_weights = true
+release_date = "2025-04-30"
+last_updated = "2025-04-30"
+
+[cost]
+input = 0.0612
+output = 0.402
+
+[limit]
+context = 32768
+output = 32768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/muirouter/models/qwen3-30b.toml
+++ b/providers/muirouter/models/qwen3-30b.toml
@@ -3,6 +3,7 @@ description = "Qwen instruction model for multilingual chat, reasoning, and tool
 family = "qwen"
 attachment = false
 reasoning = true
+reasoning_options = []
 tool_call = true
 temperature = true
 structured_output = false

--- a/providers/muirouter/provider.toml
+++ b/providers/muirouter/provider.toml
@@ -1,0 +1,5 @@
+name = "MuiRouter"
+env = ["MUIROUTER_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.muirouter.com/v1"
+doc = "https://muirouter.com/pricing"


### PR DESCRIPTION
MuiRouter is an OpenAI-compatible LLM gateway that routes to Anthropic, OpenAI, Google, xAI, Moonshot and Xiaomi behind a single API key, billed per token with no subscription.

- **38 chat models.** 36 use `base_model` to inherit metadata from `models/`, overriding only provider-specific pricing. `gpt-5.6` and `qwen3-30b` are written out in full because they have no entry under the top-level `models/` directory yet — happy to switch them over if those get extracted.
- **Costs are what users actually pay** (upstream list price times our markup), matching what the API bills.
- Image, TTS and video models are intentionally left out for now.
- No `logo.svg` in this PR; can add one in a follow-up.

Endpoint: `https://api.muirouter.com/v1` · Docs: https://muirouter.com/pricing

I could not run `bun run validate` locally (no bun on this machine), so I simulated `generateModels` + `mergeBaseModel` against the schema instead: every `base_model` reference resolves, all merged models satisfy the required `AuthoredModel` fields, and no `[cost]` keys leak in from base models.