### PR TITLE
BlueClaw: add image generation, speech, and transcription models

### DIFF
--- a/providers/blueclaw/models/black-forest-labs/FLUX.1-dev.toml
+++ b/providers/blueclaw/models/black-forest-labs/FLUX.1-dev.toml
@@ -1,0 +1,24 @@
+# Served via POST /v1/images/generations on https://openai.blueclaw.network/v1
+# No models/black-forest-labs/ metadata entry exists, so this is a full inline definition.
+# Sources: https://bfl.ai/announcing-black-forest-labs/ (FLUX.1 suite launched 2024-08-01)
+#   https://huggingface.co/black-forest-labs/FLUX.1-dev (open weights, FLUX.1 [dev]
+#   Non-Commercial License; model card usage example sets max_sequence_length=512)
+name = "FLUX.1 [dev]"
+description = "Image model for prompt-driven generation, editing, and visual design workflows"
+family = "flux"
+release_date = "2024-08-01"
+last_updated = "2024-08-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+status = "beta"
+
+[limit]
+context = 512
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/blueclaw/models/kokoro.toml
+++ b/providers/blueclaw/models/kokoro.toml
@@ -1,0 +1,22 @@
+# Served via POST /v1/audio/speech on https://openai.blueclaw.network/v1
+# No models/ metadata entry exists for Kokoro, so this is a full inline definition.
+# Source: https://huggingface.co/hexgrad/Kokoro-82M
+#   v0.19 released 2024-12-25, v1.0 released 2025-01-27, Apache 2.0, open weights.
+name = "Kokoro"
+description = "Speech generation model for controllable voice, narration, and audio delivery"
+release_date = "2024-12-25"
+last_updated = "2025-01-27"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+status = "beta"
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/blueclaw/models/whisper-large-v3.toml
+++ b/providers/blueclaw/models/whisper-large-v3.toml
@@ -1,0 +1,3 @@
+# Served via POST /v1/audio/transcriptions (multipart/form-data) on https://openai.blueclaw.network/v1
+base_model = "openai/whisper-large-v3"
+status = "beta"


### PR DESCRIPTION
Adds three models served by BlueClaw's OpenAI-compatible endpoint (`https://openai.blueclaw.network/v1`), covering the image, speech, and transcription routes.

  | Model ID | Endpoint | Modalities |
  |---|---|---|
  | `black-forest-labs/FLUX.1-dev` | `POST /v1/images/generations` | `text` → `image` |
  | `kokoro` | `POST /v1/audio/speech` | `text` → `audio` |
  | `whisper-large-v3` | `POST /v1/audio/transcriptions` | `audio` → `text` |

  Model IDs match the `"model"` value each endpoint accepts, verified against live request payloads.

  ### `base_model` usage

  `whisper-large-v3` inherits from the existing `models/openai/whisper-large-v3.toml` metadata entry via `base_model`, per the contribution checklist. No `models/` entry exists for
  FLUX.1-dev (there is no `models/black-forest-labs/` directory) or for Kokoro, so those are full inline definitions.

  ### Sources

  - **FLUX.1-dev** — `release_date = 2024-08-01`: Black Forest Labs launched the company and the FLUX.1 suite (`[pro]`, `[dev]`, `[schnell]`) on that date.
  https://bfl.ai/announcing-black-forest-labs/
  - **FLUX.1-dev** — open weights and `limit.context = 512`: the model card's usage example sets `max_sequence_length=512`. https://huggingface.co/black-forest-labs/FLUX.1-dev
  - **Kokoro** — `release_date = 2024-12-25` (v0.19), `last_updated = 2025-01-27` (v1.0), Apache 2.0, open weights. https://huggingface.co/hexgrad/Kokoro-82M

  Citations are also duplicated as top-of-file comment blocks so they survive the daily sync rewrite.

  ### Notes

  - **No `[cost]` blocks**, consistent with the existing BlueClaw models. These endpoints aren't billed per token upstream (image generation is per-image, speech per-character,
  transcription per audio duration), so a per-million-token figure would be misleading. Existing repo entries for these model types are likewise mostly `0.0` or absent.
  - `limit` values of `0` on Kokoro and on FLUX.1-dev's `output` follow the convention used by comparable entries (`providers/digitalocean/models/fal-ai/flux/schnell.toml`,
  `providers/groq/models/whisper-large-v3.toml`), where token limits don't apply.
  - All three are marked `status = "beta"`, matching the other BlueClaw models.
  - FLUX.1 [dev] ships under the FLUX.1 [dev] Non-Commercial License. The provider model schema has no `license` field (it exists only on `models/` metadata entries), so it isn't
  recorded in the TOML.

  ### Validation

  `bun validate` passes (exit 0). Confirmed all three resolve in the generated catalog with the correct IDs, modalities, and limits, and that `base_model` is stripped from the resolved
  output.