### PR TITLE
fix(thinkingmachines): name 256K variant "Inkling (256K)"

### DIFF
--- a/providers/thinkingmachines/models/thinkingmachines/Inkling:peft:262144.toml
+++ b/providers/thinkingmachines/models/thinkingmachines/Inkling:peft:262144.toml
@@ -4,6 +4,7 @@
 # API: {"output_config":{"effort":"low"|"medium"|"high"|"xhigh"|"max"}}
 # Disable reasoning with {"thinking":{"type":"disabled"}}.
 base_model = "thinkingmachines/inkling"
+name = "Inkling (256K)"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]


### PR DESCRIPTION
## Problem

The Thinking Machines provider lists two models that both render with the display name **"Inkling"**:

- `thinkingmachines/Inkling` — 64K context, $1.87/$4.68 per M tokens
- `thinkingmachines/Inkling:peft:262144` — 256K context, $3.74/$9.36 per M tokens

OpenCode's model picker shows two indistinguishable "Inkling" entries:

![opencode model picker showing two identical "Inkling — Thinking Machines" entries](https://raw.githubusercontent.com/jcfrancisco/models.dev/pr-assets/thinky.png)

## Change

Set `name = "Inkling (256K)"` on the `:peft:262144` variant, overriding the `name` inherited via `base_model`. This matches:

- Tinker's own Models & Pricing page, which labels this tier **"Inkling (256K)"**: https://tinker-docs.thinkingmachines.ai/tinker/models/
- Existing models.dev precedent for context-tier variants, e.g. nano-gpt's `Claude 4 Sonnet Thinking (64K)` / stepfun's `Step 1 (32K)`

The 64K variant keeps the plain "Inkling" name, matching Tinker's labeling. Inkling entries from other providers (baseten, openrouter, vercel) are unaffected.

## Validation

- `bun validate` passes
- Generated output now emits `"name": "Inkling (256K)"` for `thinkingmachines/Inkling:peft:262144`; all other Inkling entries unchanged


## Scope: other providers' Inkling entries (intentionally unchanged)

An audit turned up five other Inkling listings; this PR leaves them alone on purpose:

| Provider | Served context | Why no rename |
|---|---|---|
| vercel | 256K | Single Inkling entry in Vercel's catalog — nothing to disambiguate |
| togetherai | 512K | Same: single entry |
| venice | 1M | Single entry; sync-managed (see below) |
| openrouter | 1M (inherited) | Single entry; sync-managed |
| baseten | 1M (inherited) | Single entry; sync-managed |

Two reasons:

1. **The duplicate-name problem only exists within a provider that lists multiple tiers of the same model.** Existing context-suffixed names in the repo (nano-gpt's `(64K)` variants, stepfun's `(32K)`) all arise in exactly that situation — which only the Thinking Machines provider has, since it alone lists two Inkling tiers.
2. **The openrouter, baseten, and venice TOMLs are regenerated by the daily catalog sync**, which rewrites file contents from the provider's API and drops hand edits. A naming change there wouldn't survive the next sync run; it would have to happen in the sync pipeline itself.
