### PR TITLE
feat: add qwen3.7-flash model for alibaba and alibaba-cn providers

### DIFF
--- a/models/alibaba/qwen3.7-flash.toml
+++ b/models/alibaba/qwen3.7-flash.toml
@@ -1,0 +1,20 @@
+name = "Qwen3.7 Flash"
+description = "Lightweight multimodal Qwen model for high-throughput text, image, and video tasks"
+family = "qwen"
+release_date = "2026-07-15"
+last_updated = "2026-07-15"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+input = 991_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/alibaba-cn/models/qwen3.7-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.7-flash.toml
@@ -1,0 +1,30 @@
+# CNY→USD rate: 6.4, 2026-07-27, source: https://help.aliyun.com/zh/model-studio/model-pricing
+# Beijing region pricing (CNY): 0.2/0.8 (≤32K), 0.6/2.4 (≤256K), 1.2/4.8 (≤1M)
+base_model = "alibaba/qwen3.7-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
+[cost]
+input = 0.03125
+output = 0.125
+cache_read = 0.003125
+cache_write = 0.0390625
+
+[[cost.tiers]]
+tier = { type = "context", size = 32_000 }
+input = 0.09375
+output = 0.375
+cache_read = 0.009375
+cache_write = 0.1171875
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 0.1875
+output = 0.75
+cache_read = 0.01875
+cache_write = 0.234375

--- a/providers/alibaba/models/qwen3.7-flash.toml
+++ b/providers/alibaba/models/qwen3.7-flash.toml
@@ -1,0 +1,30 @@
+# CNY→USD rate: 6.4, 2026-07-27, source: https://help.aliyun.com/zh/model-studio/model-pricing
+# International deployment pricing (CNY): 0.225/0.974 (≤32K), 0.749/2.998 (≤256K), 1.499/5.995 (≤1M)
+base_model = "alibaba/qwen3.7-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
+[cost]
+input = 0.035
+output = 0.152
+cache_read = 0.0035
+cache_write = 0.04375
+
+[[cost.tiers]]
+tier = { type = "context", size = 32_000 }
+input = 0.117
+output = 0.468
+cache_read = 0.0117
+cache_write = 0.14625
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 0.234
+output = 0.937
+cache_read = 0.0234
+cache_write = 0.2925


### PR DESCRIPTION
Add qwen3.7-flash model definition for both Alibaba (international) and Alibaba (China) providers.

## Model specs (from Alibaba Cloud Bailian)

- Context: 1M tokens
- Max input: 991K (983K in thinking mode)
- Max output: 64K
- Max thinking chain: 256K
- Input modalities: text, image, video
- Output: text
- Supports: thinking mode, function calling, built-in tools, structured output

## Pricing (Beijing region, per million tokens)

| Token range | Input | Output |
|---|---|---|
| 0–32K | ¥0.2 | ¥0.8 |
| 32K–256K | ¥0.6 | ¥2.4 |
| 256K–1M | ¥1.2 | ¥4.8 |

## Files added

- `models/alibaba/qwen3.7-flash.toml` — shared model metadata
- `providers/alibaba-cn/models/qwen3.7-flash.toml` — China provider (base_model reference)
- `providers/alibaba/models/qwen3.7-flash.toml` — International provider (self-contained)

Sources:
- https://help.aliyun.com/zh/model-studio/text-generation-model/
- https://help.aliyun.com/zh/model-studio/vision-model/
- https://help.aliyun.com/zh/model-studio/model-pricing