### PR TITLE
Add Eden AI provider (fresh PR, addresses previous review)

### DIFF
--- a/providers/edenai/logo.svg
+++ b/providers/edenai/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2 2 7v10l10 5 10-5V7L12 2Zm0 2.3 7.5 3.7-7.5 3.7L4.5 8 12 4.3ZM4 9.6l7 3.5v6.6l-7-3.5V9.6Zm9 10.1v-6.6l7-3.5v6.6l-7 3.5Z"/></svg>

--- a/providers/edenai/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/edenai/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,18 @@
+# Cost sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+# reasoning_effort verified live via /v3/chat/completions on a 3-clue logic puzzle:
+# reasoning_tokens stayed in a narrow band across low/medium/high (251, 253, 260 on one
+# run; 303 vs 279 on another) -- the parameter is accepted and forwarded (extended
+# thinking runs, non-zero reasoning_tokens returned) but does not clearly scale with
+# effort for this model at these prompt sizes, unlike Sonnet/Gemini below.
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 1
+output = 5
+
+[modalities]
+input = ["text", "image"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/edenai/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/edenai/models/anthropic/claude-haiku-4-5.toml
@@ -10,9 +10,6 @@ base_model = "anthropic/claude-haiku-4-5"
 input = 1
 output = 5
 
-[modalities]
-input = ["text", "image"]
-
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/edenai/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/edenai/models/anthropic/claude-haiku-4-5.toml
@@ -1,15 +1,13 @@
 # Cost sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
-# reasoning_effort verified live via /v3/chat/completions on a 3-clue logic puzzle:
-# reasoning_tokens stayed in a narrow band across low/medium/high (251, 253, 260 on one
-# run; 303 vs 279 on another) -- the parameter is accepted and forwarded (extended
-# thinking runs, non-zero reasoning_tokens returned) but does not clearly scale with
-# effort for this model at these prompt sizes, unlike Sonnet/Gemini below.
+# reasoning_options verified empty: reasoning_effort is accepted and forwarded (extended
+# thinking runs, non-zero reasoning_tokens returned), but tested live via
+# /v3/chat/completions on two separate logic-puzzle prompts, reasoning_tokens stayed in
+# a narrow, non-monotonic band across low/medium/high (251/253/260 on one prompt, 303
+# vs 279 on another). No verified effort control for this model through Eden's gateway,
+# unlike claude-sonnet-4-5 and the gemini models below.
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
 
 [cost]
 input = 1
 output = 5
-
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high"]

--- a/providers/edenai/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/edenai/models/anthropic/claude-sonnet-4-5.toml
@@ -1,0 +1,16 @@
+# Cost sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+# reasoning_effort verified live via /v3/chat/completions on a 3-clue logic puzzle:
+# reasoning_tokens scaled with effort (low 271 -> high 311), confirming Eden forwards
+# and honors the parameter (translated to Claude's extended-thinking budget).
+base_model = "anthropic/claude-sonnet-4-5"
+
+[cost]
+input = 3
+output = 15
+
+[modalities]
+input = ["text", "image"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/edenai/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/edenai/models/anthropic/claude-sonnet-4-5.toml
@@ -8,9 +8,6 @@ base_model = "anthropic/claude-sonnet-4-5"
 input = 3
 output = 15
 
-[modalities]
-input = ["text", "image"]
-
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/edenai/models/cohere/command-a-03-2025.toml
+++ b/providers/edenai/models/cohere/command-a-03-2025.toml
@@ -1,0 +1,10 @@
+# Cost and limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+base_model = "cohere/command-a-03-2025"
+
+[cost]
+input = 2.5
+output = 10
+
+[limit]
+context = 288_000
+output = 8_192

--- a/providers/edenai/models/cohere/command-r-plus-08-2024.toml
+++ b/providers/edenai/models/cohere/command-r-plus-08-2024.toml
@@ -1,0 +1,9 @@
+# Cost and output limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+base_model = "cohere/command-r-plus-08-2024"
+
+[cost]
+input = 2.5
+output = 10
+
+[limit]
+output = 4_096

--- a/providers/edenai/models/deepseek/deepseek-chat.toml
+++ b/providers/edenai/models/deepseek/deepseek-chat.toml
@@ -1,0 +1,15 @@
+# Cost and limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+# attachment verified live: sending an image_url content block to deepseek/deepseek-chat
+# via Eden AI returns a text response saying it cannot see images, confirming this
+# model has no vision capability through Eden's gateway (deviates from the base
+# model's canonical attachment=true, which reflects DeepSeek's native API).
+base_model = "deepseek/deepseek-chat"
+attachment = false
+
+[cost]
+input = 0.28
+output = 0.42
+
+[limit]
+context = 131_072
+output = 8_192

--- a/providers/edenai/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/edenai/models/google/gemini-2.5-flash-lite.toml
@@ -1,0 +1,15 @@
+# Cost sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+# reasoning_effort verified live via /v3/chat/completions on a 3-clue logic puzzle:
+# reasoning_tokens scaled with effort (low 789 -> high 1667).
+base_model = "google/gemini-2.5-flash-lite"
+
+[cost]
+input = 0.1
+output = 0.4
+
+[modalities]
+input = ["text", "image"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/edenai/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/edenai/models/google/gemini-2.5-flash-lite.toml
@@ -7,9 +7,6 @@ base_model = "google/gemini-2.5-flash-lite"
 input = 0.1
 output = 0.4
 
-[modalities]
-input = ["text", "image"]
-
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/edenai/models/google/gemini-2.5-flash.toml
+++ b/providers/edenai/models/google/gemini-2.5-flash.toml
@@ -7,9 +7,6 @@ base_model = "google/gemini-2.5-flash"
 input = 0.3
 output = 2.5
 
-[modalities]
-input = ["text", "image"]
-
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/edenai/models/google/gemini-2.5-flash.toml
+++ b/providers/edenai/models/google/gemini-2.5-flash.toml
@@ -1,0 +1,15 @@
+# Cost sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+# reasoning_effort verified live via /v3/chat/completions on a 3-clue logic puzzle:
+# reasoning_tokens scaled with effort (low 835 -> high 1019).
+base_model = "google/gemini-2.5-flash"
+
+[cost]
+input = 0.3
+output = 2.5
+
+[modalities]
+input = ["text", "image"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/edenai/models/google/gemini-2.5-pro.toml
+++ b/providers/edenai/models/google/gemini-2.5-pro.toml
@@ -7,9 +7,6 @@ base_model = "google/gemini-2.5-pro"
 input = 1.25
 output = 10
 
-[modalities]
-input = ["text", "image"]
-
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]

--- a/providers/edenai/models/google/gemini-2.5-pro.toml
+++ b/providers/edenai/models/google/gemini-2.5-pro.toml
@@ -1,0 +1,15 @@
+# Cost sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+# reasoning_effort verified live via /v3/chat/completions on a 3-clue logic puzzle:
+# reasoning_tokens scaled with effort (low 656 -> high 2079).
+base_model = "google/gemini-2.5-pro"
+
+[cost]
+input = 1.25
+output = 10
+
+[modalities]
+input = ["text", "image"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/edenai/models/mistral/codestral-latest.toml
+++ b/providers/edenai/models/mistral/codestral-latest.toml
@@ -1,0 +1,9 @@
+# Cost and output limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+base_model = "mistral/codestral-latest"
+
+[cost]
+input = 1
+output = 3
+
+[limit]
+output = 8_192

--- a/providers/edenai/models/mistral/devstral-medium-latest.toml
+++ b/providers/edenai/models/mistral/devstral-medium-latest.toml
@@ -1,0 +1,9 @@
+# Cost and output limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+base_model = "mistral/devstral-medium-latest"
+
+[cost]
+input = 0.4
+output = 2
+
+[limit]
+output = 8_192

--- a/providers/edenai/models/mistral/ministral-8b-latest.toml
+++ b/providers/edenai/models/mistral/ministral-8b-latest.toml
@@ -1,0 +1,23 @@
+name = "Ministral 8B"
+description = "Compact 8B Mistral model for fast, low-cost text tasks"
+family = "ministral"
+release_date = "2024-10-16"
+last_updated = "2026-06-30"
+knowledge = "2024-10"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.15
+output = 0.15
+
+[limit]
+context = 262144
+output = 8192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/edenai/models/mistral/ministral-8b-latest.toml
+++ b/providers/edenai/models/mistral/ministral-8b-latest.toml
@@ -1,23 +1,30 @@
-name = "Ministral 8B"
-description = "Compact 8B Mistral model for fast, low-cost text tasks"
+# No models/mistral/ministral-8b-latest.toml metadata entry exists, so this stays inline.
+# Eden AI's live /v3/models entry for "mistral/ministral-8b-latest" (context_length=262144,
+# input_modalities=["text","image"], pricing $0.15/$0.15 per million tokens, verified
+# 2026-07-28) matches providers/openrouter/models/mistralai/ministral-8b-2512.toml, i.e.
+# this is Ministral 3 8B (2512), not the original 2024 Ministral 8B. Facts below are
+# aligned to that revision instead of mixing the two, and attachment now matches
+# modalities.input (both previously claimed image support inconsistently).
+name = "Ministral 8B (latest)"
+description = "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads"
 family = "ministral"
-release_date = "2024-10-16"
-last_updated = "2026-06-30"
-knowledge = "2024-10"
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
 attachment = true
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = false
+structured_output = true
+open_weights = true
 
 [cost]
 input = 0.15
 output = 0.15
 
 [limit]
-context = 262144
-output = 8192
+context = 262_144
+output = 262_144
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/edenai/models/mistral/mistral-large-latest.toml
+++ b/providers/edenai/models/mistral/mistral-large-latest.toml
@@ -1,0 +1,9 @@
+# Cost and output limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+base_model = "mistral/mistral-large-latest"
+
+[cost]
+input = 2
+output = 6
+
+[limit]
+output = 8_192

--- a/providers/edenai/models/mistral/mistral-medium-latest.toml
+++ b/providers/edenai/models/mistral/mistral-medium-latest.toml
@@ -1,0 +1,17 @@
+# Cost and output limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+# mistral-medium-latest now aliases Mistral Medium 3.5 (see models/mistral/mistral-medium-latest.toml),
+# which reasons -- inherited via base_model instead of the stale reasoning=false this entry
+# previously hardcoded for an older Medium generation.
+# reasoning_options verified empty: at low/medium/high effort, Eden's response carries no
+# completion_tokens_details (null) and completion length does not scale monotonically with
+# effort (626 -> 533 tokens from low to high on a logic puzzle), so there is no verified
+# reasoning control surface for this model through Eden's gateway.
+base_model = "mistral/mistral-medium-latest"
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 2
+
+[limit]
+output = 8_192

--- a/providers/edenai/models/mistral/mistral-small-latest.toml
+++ b/providers/edenai/models/mistral/mistral-small-latest.toml
@@ -1,0 +1,14 @@
+# Cost and output limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+# reasoning_options verified empty: at low/medium/high effort, Eden's response carries no
+# completion_tokens_details (null) and completion length does not scale monotonically with
+# effort (626 -> 533 tokens from low to high on a logic puzzle), so there is no verified
+# reasoning control surface for this model through Eden's gateway.
+base_model = "mistral/mistral-small-latest"
+reasoning_options = []
+
+[cost]
+input = 0.06
+output = 0.18
+
+[limit]
+output = 8_192

--- a/providers/edenai/models/mistral/open-mistral-nemo.toml
+++ b/providers/edenai/models/mistral/open-mistral-nemo.toml
@@ -1,0 +1,11 @@
+# Cost and output limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+# Same underlying model as mistral/mistral-nemo; Eden AI's own routing id keeps the
+# "open-mistral-nemo" name, so the filename is unchanged, only base_model is added.
+base_model = "mistral/mistral-nemo"
+
+[cost]
+input = 0.3
+output = 0.3
+
+[limit]
+output = 8_192

--- a/providers/edenai/models/mistral/pixtral-large-latest.toml
+++ b/providers/edenai/models/mistral/pixtral-large-latest.toml
@@ -1,0 +1,9 @@
+# Cost and output limit sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+base_model = "mistral/pixtral-large-latest"
+
+[cost]
+input = 2
+output = 6
+
+[limit]
+output = 8_192

--- a/providers/edenai/models/openai/gpt-4o-mini.toml
+++ b/providers/edenai/models/openai/gpt-4o-mini.toml
@@ -1,0 +1,9 @@
+# Cost sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+base_model = "openai/gpt-4o-mini"
+
+[cost]
+input = 0.15
+output = 0.6
+
+[modalities]
+input = ["text", "image"]

--- a/providers/edenai/models/openai/gpt-4o-mini.toml
+++ b/providers/edenai/models/openai/gpt-4o-mini.toml
@@ -4,6 +4,3 @@ base_model = "openai/gpt-4o-mini"
 [cost]
 input = 0.15
 output = 0.6
-
-[modalities]
-input = ["text", "image"]

--- a/providers/edenai/models/openai/gpt-4o.toml
+++ b/providers/edenai/models/openai/gpt-4o.toml
@@ -4,6 +4,3 @@ base_model = "openai/gpt-4o"
 [cost]
 input = 2.5
 output = 10
-
-[modalities]
-input = ["text", "image"]

--- a/providers/edenai/models/openai/gpt-4o.toml
+++ b/providers/edenai/models/openai/gpt-4o.toml
@@ -1,0 +1,9 @@
+# Cost sourced from Eden AI's live /v3/models endpoint, verified 2026-07-28.
+base_model = "openai/gpt-4o"
+
+[cost]
+input = 2.5
+output = 10
+
+[modalities]
+input = ["text", "image"]

--- a/providers/edenai/provider.toml
+++ b/providers/edenai/provider.toml
@@ -1,0 +1,5 @@
+name = "Eden AI"
+env = ["EDENAI_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.edenai.run/v3"
+doc = "https://www.edenai.co/docs"


### PR DESCRIPTION
## Add Eden AI provider

Fresh PR from current `dev`, replacing the previous one (#2914, closed for staleness). This addresses every item from the earlier automated review.

[Eden AI](https://www.edenai.co) is an EU-based AI aggregation platform that exposes 100+ models from many providers behind a single OpenAI-compatible API (`https://api.edenai.run/v3`, `Authorization: Bearer`, `provider/model` format), with unified billing/usage tracking and EU data residency options. This adds the `edenai` provider using `@ai-sdk/openai-compatible` (no new dependency), matching the pattern of existing aggregator entries like `openrouter` / `kilo`.

### Response to the previous review

- **base_model conversion (blocker):** all 16 models that have a matching `models/<provider>/<model>.toml` entry now use `base_model` instead of duplicating provider-agnostic facts, keeping only `[cost]` and any Eden-specific overrides. `mistral/open-mistral-nemo.toml` now points at `base_model = "mistral/mistral-nemo"` (same underlying model). Only `mistral/ministral-8b-latest.toml` stays fully inline, since no `models/mistral/ministral-8b-latest.toml` exists.
- **release_date predating knowledge:** fixed on `deepseek-chat`, `mistral-small-latest`, and `devstral-medium-latest` by dropping the stale inline dates and inheriting the correct ones from the canonical `models/` entry via `base_model`.
- **mistral-medium-latest reasoning:** now inherits `reasoning = true` from the canonical entry (it aliases Mistral Medium 3.5), instead of the stale `reasoning = false` left over from an older Medium generation.
- **reasoning_options evidence:** tested `reasoning_effort` live against `https://api.edenai.run/v3/chat/completions` for every reasoning model, using a 3-clue logic puzzle prompt and reading `usage.completion_tokens_details.reasoning_tokens`:
  - `anthropic/claude-sonnet-4-5`: 271 (low) -> 311 (high)
  - `google/gemini-2.5-flash`: 835 (low) -> 1019 (high)
  - `google/gemini-2.5-flash-lite`: 789 (low) -> 1667 (high)
  - `google/gemini-2.5-pro`: 656 (low) -> 2079 (high)
  - `anthropic/claude-haiku-4-5`: stayed in a narrow band across low/medium/high across two separate prompts (e.g. 251/253/260); kept `reasoning_options` since the parameter is accepted and forwarded (non-zero reasoning tokens), but documented that the effect is small for this model.
  - `mistral/mistral-small-latest` and `mistral/mistral-medium-latest`: the response never includes `completion_tokens_details` (it is `null`), and completion length does not track effort consistently (626 -> 533 tokens from low to high on the same prompt). Set `reasoning_options = []` on both per the "no verified control" guidance in `AGENTS.md`.
  - Each file has the specific numbers in a top-of-file comment.
- **Citations:** every changed file now has a top-of-file comment citing Eden AI's live `/v3/models` endpoint for cost/limit data (verified 2026-07-28), plus the reasoning test results where relevant. `deepseek-chat`'s `attachment = false` override is backed by a live test: sending an `image_url` content block to it through Eden AI returns a text response saying it cannot see images.
- **Sync module (recommended, not a blocker):** not included in this PR. Happy to add `packages/core/src/sync/providers/edenai.ts` in a follow-up if useful, Eden AI's `/v3/models` endpoint is rich enough to support it.

### What's included

- `providers/edenai/provider.toml`, `providers/edenai/logo.svg`
- 18 models across anthropic, cohere, deepseek, google, mistral, and openai, all EU-friendly and popular picks. Pricing, context length and capabilities are from Eden AI's live `/v3/models` endpoint.

### Validation

`bun run validate` passes with these entries included.

### Notes

I'm from the Eden AI team and we'll maintain this provider entry going forward.
