### PR TITLE
feat: add gitlab duo-chat-opus-5 model

### DIFF
--- a/providers/gitlab/models/duo-chat-opus-5.toml
+++ b/providers/gitlab/models/duo-chat-opus-5.toml
@@ -1,0 +1,9 @@
+base_model = "anthropic/claude-opus-5"
+name = "Agentic Chat (Claude Opus 5)"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
## What

Adds `providers/gitlab/models/duo-chat-opus-5.toml` for the GitLab provider's new `duo-chat-opus-5` model id (Claude Opus 5) so it shows up in opencode's model picker.

## Details

Uses `base_model = "anthropic/claude-opus-5"` to inherit provider-agnostic metadata (context 1,000,000 / output 128,000 tokens, modalities `text, image, pdf` input / `text` output, `temperature = false`, reasoning options), matching the shape already used for `duo-chat-sonnet-5` and `duo-chat-fable-5`. Only overrides:

- `name` — GitLab's "Agentic Chat (...)" branding
- `reasoning_options` — trimmed to the `effort` variant (no `toggle`), matching Opus 5's base reasoning options
- `[cost]` — zeroed out (billed upstream via the GitLab AI Gateway proxy)

Source: `ai_gateway/model_selection/models.yml` in `gitlab-org/modelops/applied-ml/code-suggestions/ai-assist` — `claude_opus_5` entry (`proxy_provider: anthropic`, `params.model: claude-opus-5`).

Companion change: `vglafirov/gitlab-ai-provider!33` adds the `duo-chat-opus-5` / `duo-workflow-opus-5` mappings in the provider itself.

## Verification

`bun validate` passes and confirms `duo-chat-opus-5` is present in the generated model registry, correctly inheriting all fields from `anthropic/claude-opus-5`.