### PR TITLE
orcarouter: add tencent/hy3

### DIFF
--- a/providers/orcarouter/models/tencent/hy3.toml
+++ b/providers/orcarouter/models/tencent/hy3.toml
@@ -1,0 +1,26 @@
+name = "Hy3"
+description = "Tencent Hy reasoning model for coding, instruction following, and agent tasks"
+family = "hy3"
+release_date = "2026-07-06"
+last_updated = "2026-07-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.18
+output = 0.59
+
+[limit]
+context = 262_144
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Add support for Tencent Hy3 (295B-total/21B-active MoE, 256K context, configurable reasoning effort, tool use) to the OrcaRouter provider catalog.

Model is live on OrcaRouter's /v1/models endpoint with:
- Context: 262,144 tokens
- Pricing: $0.18/$0.59 per million tokens (input/output)
- Modalities: text in, text out
- Reasoning, tool call, temperature, open weights enabled

Configuration mirrors the existing openrouter tencent/hy3 entry with OrcaRouter-specific pricing and reasoning effort values.