### PR TITLE
feat(perplexity-agent): add gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna

### DIFF
--- a/providers/perplexity-agent/models/openai/gpt-5.6-luna.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.6-luna.toml
@@ -6,7 +6,7 @@ base_model = "openai/gpt-5.6-luna"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 1.00

--- a/providers/perplexity-agent/models/openai/gpt-5.6-luna.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.6-luna.toml
@@ -1,0 +1,20 @@
+# Perplexity Agent API pricing for openai/gpt-5.6-luna.
+# Source: https://docs.perplexity.ai/docs/agent-api/models#openai
+# Cache read is published as 90% off the active input rate
+# (luna/terra/sol all use the same discount); tier switch is at 272k input tokens.
+base_model = "openai/gpt-5.6-luna"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 1.00
+output = 6.00
+cache_read = 0.10
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 2.00
+output = 9.00
+cache_read = 0.20

--- a/providers/perplexity-agent/models/openai/gpt-5.6-sol.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.6-sol.toml
@@ -6,7 +6,7 @@ base_model = "openai/gpt-5.6-sol"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5.00

--- a/providers/perplexity-agent/models/openai/gpt-5.6-sol.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.6-sol.toml
@@ -1,0 +1,20 @@
+# Perplexity Agent API pricing for openai/gpt-5.6-sol.
+# Source: https://docs.perplexity.ai/docs/agent-api/models#openai
+# Cache read is published as 90% off the active input rate
+# (luna/terra/sol all use the same discount); tier switch is at 272k input tokens.
+base_model = "openai/gpt-5.6-sol"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10.00
+output = 45.00
+cache_read = 1.00

--- a/providers/perplexity-agent/models/openai/gpt-5.6-terra.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.6-terra.toml
@@ -1,0 +1,20 @@
+# Perplexity Agent API pricing for openai/gpt-5.6-terra.
+# Source: https://docs.perplexity.ai/docs/agent-api/models#openai
+# Cache read is published as 90% off the active input rate
+# (luna/terra/sol all use the same discount); tier switch is at 272k input tokens.
+base_model = "openai/gpt-5.6-terra"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5.00
+output = 22.50
+cache_read = 0.50

--- a/providers/perplexity-agent/models/openai/gpt-5.6-terra.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.6-terra.toml
@@ -6,7 +6,7 @@ base_model = "openai/gpt-5.6-terra"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 2.50


### PR DESCRIPTION

## Description

Adds gpt-5.6 family `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to the Perplexity Agent provider. Each model uses `base_model` to inherit shared metadata and only overrides provider-specific configuration.

## Cache & Pricing

Source: Perplexity Agent API (`PRICING.agent.models[]`, `_meta.cacheEncoding`).

| Model | Input (≤272k / >272k) | Output (≤272k / >272k) | Cache Read (≤272k / >272k) |
| ------ | --------------------: | ---------------------: | -------------------------: |
| `gpt-5.6-sol` | $5 / $10 | $30 / $45 | $0.50 / $1.00 |
| `gpt-5.6-terra` | $2.50 / $5 | $15 / $22.50 | $0.25 / $0.50 |
| `gpt-5.6-luna` | $1 / $2 | $6 / $9 | $0.10 / $0.20 |

- Pricing is in **USD per 1M tokens**.
- The first value applies to requests with **≤272k** input (context) tokens; the second applies to requests with **>272k** input tokens.
- `tierThreshold = 272,000` input tokens for all three models.

## Reasoning

- Adds `reasoning_options` with:
  - `low`
  - `medium`
  - `high`
  - `xhigh`
  - `max`
- Matches the existing reasoning effort values used by the Perplexity Agent provider.

## References

- Perplexity Agent API Models: <https://docs.perplexity.ai/docs/agent-api/models#openai>
- OpenAI GPT-5.6 Guide: <https://platform.openai.com/docs/guides/latest-model>
- Introducing GPT-5.6: <https://openai.com/index/gpt-5-6/>

