### PR TITLE
feat(ollama-cloud) add kimi k3

### DIFF
--- a/providers/ollama-cloud/models/kimi-k3.toml
+++ b/providers/ollama-cloud/models/kimi-k3.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k3"
+name = "kimi-k3"
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/ollama-cloud/models/kimi-k3.toml
+++ b/providers/ollama-cloud/models/kimi-k3.toml
@@ -1,6 +1,14 @@
 base_model = "moonshotai/kimi-k3"
 name = "kimi-k3"
 
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
 [modalities]
 input = ["text", "image"]
 output = ["text"]


### PR DESCRIPTION
Added kimi k3 model on ollama cloud. According to the ollama cloud website, it does not support video input, so I have overwritten the modalities section from the base model: https://ollama.com/library/kimi-k3