### PR TITLE
fix(nebius): add Kimi K3 model availability

### DIFF
--- a/providers/nebius/models/moonshotai/Kimi-K3.toml
+++ b/providers/nebius/models/moonshotai/Kimi-K3.toml
@@ -1,0 +1,12 @@
+# Source: https://tokenfactory.nebius.com/?modals=endpoint-details&model-id=moonshotai/Kimi-K3
+# $3.00/1M in, $15.00/1M out; 1,024K context; text-to-text; tool calling and reasoning available.
+base_model = "moonshotai/kimi-k3"
+reasoning_options = []
+
+[cost]
+input = 3
+output = 15
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nebius/models/moonshotai/Kimi-K3.toml
+++ b/providers/nebius/models/moonshotai/Kimi-K3.toml
@@ -1,7 +1,13 @@
 # Source: https://tokenfactory.nebius.com/?modals=endpoint-details&model-id=moonshotai/Kimi-K3
 # $3.00/1M in, $15.00/1M out; 1,024K context; text-to-text; tool calling and reasoning available.
+# reasoning_effort verified live against api.tokenfactory.nebius.com/v1/chat/completions:
+# invalid values 422 with the exact accepted literal list below; valid values visibly change
+# reasoning_content length (low=20 chars, high=199 chars, max=2470 chars on the same prompt).
 base_model = "moonshotai/kimi-k3"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort" # API: {"reasoning_effort": "low" | "medium" | ...}
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 3

--- a/providers/nebius/models/moonshotai/Kimi-K3.toml
+++ b/providers/nebius/models/moonshotai/Kimi-K3.toml
@@ -4,10 +4,14 @@
 # invalid values 422 with the exact accepted literal list below; valid values visibly change
 # reasoning_content length (low=20 chars, high=199 chars, max=2470 chars on the same prompt).
 base_model = "moonshotai/kimi-k3"
+attachment = false
 
 [[reasoning_options]]
 type = "effort" # API: {"reasoning_effort": "low" | "medium" | ...}
 values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 3


### PR DESCRIPTION
## Summary
- Adds `moonshotai/Kimi-K3` to Nebius Token Factory (`providers/nebius/models/moonshotai/Kimi-K3.toml`)
- $3.00 / 1M input, $15.00 / 1M output tokens; text-only modality on this endpoint (no image/video passthrough)
- Inherits the rest (context, reasoning, tool_call, temperature, etc.) from the existing `moonshotai/kimi-k3` base model metadata

Source: [Nebius Token Factory endpoint details](https://tokenfactory.nebius.com/?modals=endpoint-details&model-id=moonshotai/Kimi-K3)

## Test plan
- [x] `bun validate` passes
- [x] Confirmed the resolved model JSON correctly inherits `temperature: false` and `output: 131072` from the base metadata while applying Nebius-specific cost/modalities