### PR TITLE
feat(fireworks-ai): add Kimi K3 and Kimi K3 Fast

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k3.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/kimi-k3.toml
@@ -1,0 +1,25 @@
+base_model = "moonshotai/kimi-k3"
+release_date = "2026-07-27"
+last_updated = "2026-07-27"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+
+[modalities]
+input = ["text", "image"]

--- a/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k3-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k3-fast.toml
@@ -1,0 +1,26 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 Fast"
+release_date = "2026-07-27"
+last_updated = "2026-07-27"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 4.5
+output = 22.5
+cache_read = 0.45
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
## Summary

Adds Kimi K3 and Kimi K3 Fast to the Fireworks AI provider. Both inherit
from the existing `moonshotai/kimi-k3` base model metadata.

## Sources

- Model page: https://app.fireworks.ai/models/fireworks/kimi-k3
- Pricing: https://docs.fireworks.ai/serverless/pricing
- Blog: https://fireworks.ai/blog/kimik3-on-fireworks
- API reference: https://docs.fireworks.ai/api-reference/post-chatcompletions

## Pricing (USD per 1M tokens)

| Model         | Input | Cached Input | Output |
|---------------|-------|-------------|--------|
| Kimi K3       | $3.00 | $0.30       | $15.00 |
| Kimi K3 Fast  | $4.50 | $0.45       | $22.50 |

## Reasoning options (API-verified 2026-07-27)

All reasoning controls were verified against the live Fireworks API
(`accounts/fireworks/models/kimi-k3`):

- **toggle**: `reasoning_effort: "none"` disables reasoning (200, no
  `reasoning_content`). `thinking: {type: "disabled"}` also disables.
  `reasoning_effort: false` (boolean) is rejected with a 400 type error.
- **effort**: `low`, `medium`, `high`, `max` all return 200 with
  `reasoning_content`. `xhigh` is accepted but treated as an alias for
  `max` (per DeepSeek V4 precedent in the schema docs). `adaptive` is
  rejected: "only supported by MiniMax M3."
- **budget_tokens**: `thinking: {type: "enabled", budget_tokens: N}`
  accepted with N >= 1024. N=512 returns 400 ("must be >= 1024"). No
  upper bound documented.

## Modalities

The base model declares `["text", "image", "video"]` but video input
returns 400 on Fireworks ("missing video_placeholder configuration").
The blog confirms "Text and Vision" only. Overridden to
`["text", "image"]` in both provider TOMLs.

## Validation

`bun validate` passes.