### PR TITLE
Add Kimi K3 to Nebius Token Factory

### DIFF
--- a/providers/nebius/models/moonshotai/Kimi-K3.toml
+++ b/providers/nebius/models/moonshotai/Kimi-K3.toml
@@ -1,0 +1,23 @@
+# Sources:
+# - https://tokenfactory.nebius.com/ (model catalog)
+# - https://tokenfactory.nebius.com/api/public/models_info (pricing, context, max length)
+# - https://tokenfactory.nebius.com/model-catalog.md
+# Accessed 2026-07-27.
+base_model = "moonshotai/kimi-k3"
+attachment = false
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3
+output = 15
+
+[limit]
+context = 1_048_576
+output = 8_000
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds the newly available **Kimi K3** model on [Nebius Token Factory](https://tokenfactory.nebius.com/) to the Nebius provider:

| Model ID | Cost (in / out per 1M) | Context | Output |
|---|---|---|---|
| `moonshotai/Kimi-K3` | $3.00 / $15.00 | 1M | 8K |

Inherits shared metadata via `base_model = "moonshotai/kimi-k3"` and overrides Nebius-specific pricing, limits, and text-only modalities (Nebius serves this endpoint as text-to-text).

### Details

- **Kimi-K3**: frontier open-weights MoE (≈2.8T) with 1M context, reasoning, and agentic tool use
- `reasoning_options = []` (no verified control surface on Nebius; same pattern as other recent Nebius Kimi models)
- Interleaved `reasoning_content`
- Attachment disabled; modalities restricted to text (catalog type: `text2text`)

### Sources

- [Nebius Token Factory](https://tokenfactory.nebius.com/)
- [Public models_info API](https://tokenfactory.nebius.com/api/public/models_info) — pricing, context window, max length
- [Model catalog (Markdown)](https://tokenfactory.nebius.com/model-catalog.md)

## Test plan

- [x] `bun validate` passes with only this model file added
- [ ] Confirm model ID matches Nebius API usage: `moonshotai/Kimi-K3`
- [ ] Spot-check pricing on Token Factory remains $3 / $15