### PR TITLE
add kimi-k3 model for together-ai

### DIFF
--- a/providers/togetherai/models/moonshotai/Kimi-K3.toml
+++ b/providers/togetherai/models/moonshotai/Kimi-K3.toml
@@ -1,0 +1,26 @@
+base_model = "moonshotai/Kimi-K3"
+release_date = "2026-07-27"
+last_updated = "2026-07-27"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1024
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Description

Add support for **Moonshot Kimi K3** to the Together AI provider.

Kimi K3 is Moonshot AI's latest flagship Mixture-of-Experts (MoE) model and is available on Together AI under the model ID:

- `moonshotai/Kimi-K3`

This PR adds the model to the Together AI catalog with the provider's published metadata, including its **1M context window**, multimodal support, reasoning capabilities, and pricing.

**Reference:** https://www.together.ai/models/moonshotai/Kimi-K3

### Model Metadata

| Field | Value |
|-------|-------|
| Model | Kimi K3 |
| ID | `moonshotai/Kimi-K3` |
| Context Window | 1,000,000 tokens |
| Input Cost | $3.00 / 1M tokens |
| Cached Input Cost | $0.30 / 1M tokens |
| Output Cost | $15.00 / 1M tokens |
| Tool Calling | Yes |
| Attachments | Yes |
| Input Modalities | Text, Image |
| Output Modalities | Text |

This update enables users to discover and select **Kimi K3** from the Together AI model picker with the correct metadata and pricing.