### PR TITLE
feat(ollama-cloud): add kimi k3 model

### DIFF
--- a/providers/ollama-cloud/models/kimi-k3.toml
+++ b/providers/ollama-cloud/models/kimi-k3.toml
@@ -13,7 +13,7 @@ name = "kimi-k3"
 last_updated = "2026-07-27"
 temperature = true
 
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
 [modalities]
 input = ["text", "image"]

--- a/providers/ollama-cloud/models/kimi-k3.toml
+++ b/providers/ollama-cloud/models/kimi-k3.toml
@@ -1,0 +1,19 @@
+# Ollama Cloud direct API model id verified from https://ollama.com/api/tags.
+# Library page documents Kimi K3 as a cloud thinking model with 1M context,
+# text/image input in the model table, and extra-high usage.
+# Sources accessed 2026-07-27:
+# https://ollama.com/library/kimi-k3
+# https://ollama.com/library/kimi-k3:cloud
+# https://docs.ollama.com/cloud
+# https://docs.ollama.com/capabilities/thinking
+# https://docs.ollama.com/openai
+
+base_model = "moonshotai/kimi-k3"
+name = "kimi-k3"
+last_updated = "2026-07-27"
+temperature = true
+
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "max"] }]
+
+[modalities]
+input = ["text", "image"]

--- a/providers/ollama-cloud/models/kimi-k3.toml
+++ b/providers/ollama-cloud/models/kimi-k3.toml
@@ -1,17 +1,13 @@
-# Ollama Cloud direct API model id verified from https://ollama.com/api/tags.
-# Library page documents Kimi K3 as a cloud thinking model with 1M context,
-# text/image input in the model table, and extra-high usage.
+# Ollama Cloud direct API model ID verified from https://docs.ollama.com/api/tags.
+# Library page documents Kimi K3 as a cloud thinking model with 1M context
+# and text/image input.
 # Sources accessed 2026-07-27:
-# https://ollama.com/library/kimi-k3
+# https://docs.ollama.com/api/tags
 # https://ollama.com/library/kimi-k3:cloud
-# https://docs.ollama.com/cloud
-# https://docs.ollama.com/capabilities/thinking
-# https://docs.ollama.com/openai
 
 base_model = "moonshotai/kimi-k3"
 name = "kimi-k3"
 last_updated = "2026-07-27"
-temperature = true
 
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 


### PR DESCRIPTION
## Description

Add support for **Moonshot Kimi K3** to the Ollama Cloud provider.

This PR adds the `moonshotai/kimi-k3` model to the Ollama Cloud catalog with the provider's published metadata, including thinking mode, configurable reasoning effort, image input support, and temperature support.

**References:**
- https://ollama.com/library/kimi-k3
- https://ollama.com/library/kimi-k3:cloud
- https://docs.ollama.com/cloud
- https://docs.ollama.com/capabilities/thinking

### Model Metadata

| Field | Value |
|-------|-------|
| Model | Kimi K3 |
| ID | `moonshotai/kimi-k3` |
| Reasoning | Toggle |
| Reasoning Effort | `low`, `high`, `max` |
| Input Modalities | Text, Image |
| Output Modalities | Text |

This update enables users to discover and select **Kimi K3** from the Ollama Cloud model picker with the correct provider metadata.