### PR TITLE
feat(aihubmix): add Kimi K3 model configuration with pricing and modalities

### DIFF
--- a/providers/aihubmix/models/kimi-k3.toml
+++ b/providers/aihubmix/models/kimi-k3.toml
@@ -1,0 +1,26 @@
+# AIHubMix model page documents Kimi K3 pricing, supported input modalities
+# (text, vision, video), and a 1M-token context window.
+# Source accessed 2026-07-27:
+# https://aihubmix.com/model/kimi-k3
+
+base_model = "moonshotai/kimi-k3"
+last_updated = "2026-07-27"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Add metadata for AIHubMix's Kimi K3 model.

The metadata is based on the AIHubMix Kimi K3 model page and Unified Inference API documentation.

### Changes

- Add AIHubMix metadata for Kimi K3
- Configure reasoning support (`toggle` and provider-supported `reasoning_effort` values)
- Add `interleaved.reasoning_content`
- Add pricing metadata ($3.00 input, $15.00 output, $0.30 cache read)
- Add supported input modalities (text, image, video)

### References

- https://aihubmix.com/model/kimi-k3
- https://docs.aihubmix.com/cn/api/unified-inference