### PR TITLE
umans-ai + coding-plan: add Kimi K3 and DeepSeek V4 Flash

### DIFF
--- a/providers/umans-ai-coding-plan/models/umans-deepseek-v4-flash-0731.toml
+++ b/providers/umans-ai-coding-plan/models/umans-deepseek-v4-flash-0731.toml
@@ -1,16 +1,14 @@
 # Toggle: thinking.type = enabled|disabled
 # Effort: reasoning_effort = low|high|max
-base_model = "deepseek/deepseek-v4-flash-0731"
-name = "DeepSeek V4 Flash"
 # Live metadata: levels none/low/high/max, default low, and `can_disable=true`
 # (accessed 2026-08-03): https://api.code.umans.ai/v1/models/info
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"
 
-# Cost is zeroed per this provider's subscription (flat-fee coding plan)
-# convention.
 [cost]
 input = 0
 output = 0

--- a/providers/umans-ai-coding-plan/models/umans-deepseek-v4-flash-0731.toml
+++ b/providers/umans-ai-coding-plan/models/umans-deepseek-v4-flash-0731.toml
@@ -1,3 +1,5 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
 base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash"
 # Live metadata: levels none/low/high/max, default low, and `can_disable=true`

--- a/providers/umans-ai-coding-plan/models/umans-deepseek-v4-flash-0731.toml
+++ b/providers/umans-ai-coding-plan/models/umans-deepseek-v4-flash-0731.toml
@@ -2,6 +2,9 @@
 # Effort: reasoning_effort = low|high|max
 # Live metadata: levels none/low/high/max, default low, and `can_disable=true`
 # (accessed 2026-08-03): https://api.code.umans.ai/v1/models/info
+# limit.output is cap-1 on purpose: the gateway 400s max_tokens >=
+# max_completion_tokens (393216), so 393215 is the largest value that serves
+# (its advertised `recommended_max_tokens`).
 base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]

--- a/providers/umans-ai-coding-plan/models/umans-deepseek-v4-flash-0731.toml
+++ b/providers/umans-ai-coding-plan/models/umans-deepseek-v4-flash-0731.toml
@@ -1,0 +1,20 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash"
+# Live metadata: levels none/low/high/max, default low, and `can_disable=true`
+# (accessed 2026-08-03): https://api.code.umans.ai/v1/models/info
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+# Cost is zeroed per this provider's subscription (flat-fee coding plan)
+# convention.
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_048_576
+output = 393_215

--- a/providers/umans-ai-coding-plan/models/umans-kimi-k3.toml
+++ b/providers/umans-ai-coding-plan/models/umans-kimi-k3.toml
@@ -1,7 +1,5 @@
 base_model = "moonshotai/kimi-k3"
 name = "Kimi K3"
-# Prerelease: seat-gated through Umans Labs.
-status = "beta"
 # Live metadata: levels none/low/high/max, default max, and `can_disable=true`
 # (accessed 2026-07-28): https://api.code.umans.ai/v1/models/info
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]

--- a/providers/umans-ai-coding-plan/models/umans-kimi-k3.toml
+++ b/providers/umans-ai-coding-plan/models/umans-kimi-k3.toml
@@ -1,16 +1,13 @@
 # Toggle: thinking.type = enabled|disabled
 # Effort: reasoning_effort = low|high|max
-base_model = "moonshotai/kimi-k3"
-name = "Kimi K3"
 # Live metadata: levels none/low/high/max, default max, and `can_disable=true`
 # (accessed 2026-07-28): https://api.code.umans.ai/v1/models/info
+base_model = "moonshotai/kimi-k3"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"
 
-# Cost is zeroed per this provider's subscription (flat-fee coding plan)
-# convention.
 [cost]
 input = 0
 output = 0

--- a/providers/umans-ai-coding-plan/models/umans-kimi-k3.toml
+++ b/providers/umans-ai-coding-plan/models/umans-kimi-k3.toml
@@ -1,3 +1,5 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
 base_model = "moonshotai/kimi-k3"
 name = "Kimi K3"
 # Live metadata: levels none/low/high/max, default max, and `can_disable=true`

--- a/providers/umans-ai-coding-plan/models/umans-kimi-k3.toml
+++ b/providers/umans-ai-coding-plan/models/umans-kimi-k3.toml
@@ -1,0 +1,21 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3"
+# Prerelease: seat-gated through Umans Labs.
+status = "beta"
+# Live metadata: levels none/low/high/max, default max, and `can_disable=true`
+# (accessed 2026-07-28): https://api.code.umans.ai/v1/models/info
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+# Cost is zeroed per this provider's subscription (flat-fee coding plan)
+# convention.
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[modalities]
+input = ["text", "image"]

--- a/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
+++ b/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
@@ -1,11 +1,11 @@
 # Toggle: thinking.type = enabled|disabled
 # Effort: reasoning_effort = low|high|max
-base_model = "deepseek/deepseek-v4-flash-0731"
-name = "DeepSeek V4 Flash"
 # Pay-per-token (llm-gateway 00315): Umans AI's public rate, which is what
 # GET /v1/models renders. Live metadata: levels none/low/high/max, default
 # low, and `can_disable=true` (accessed 2026-08-03):
 # https://api.code.umans.ai/v1/models/info
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]

--- a/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
+++ b/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
@@ -2,9 +2,9 @@
 # Effort: reasoning_effort = low|high|max
 base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash"
-# Pay-per-token at DeepSeek first-party list pricing (llm-gateway 00315).
-# Live metadata: levels none/low/high/max, default low,
-# and `can_disable=true` (accessed 2026-08-03):
+# Pay-per-token (llm-gateway 00315): Umans AI's public rate, which is what
+# GET /v1/models renders. Live metadata: levels none/low/high/max, default
+# low, and `can_disable=true` (accessed 2026-08-03):
 # https://api.code.umans.ai/v1/models/info
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
@@ -14,7 +14,7 @@ field = "reasoning_content"
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.0028
+cache_read = 0.028
 
 [limit]
 context = 1_048_576

--- a/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
+++ b/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
@@ -1,3 +1,5 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
 base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash"
 # Pay-per-token at DeepSeek first-party list pricing (llm-gateway 00315).

--- a/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
+++ b/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
@@ -1,0 +1,19 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash"
+# Pay-per-token at DeepSeek first-party list pricing (llm-gateway 00315).
+# Live metadata: levels none/low/high/max, default low,
+# and `can_disable=true` (accessed 2026-08-03):
+# https://api.code.umans.ai/v1/models/info
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028
+
+[limit]
+context = 1_048_576
+output = 393_215

--- a/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
+++ b/providers/umans-ai/models/umans-deepseek-v4-flash-0731.toml
@@ -4,6 +4,9 @@
 # GET /v1/models renders. Live metadata: levels none/low/high/max, default
 # low, and `can_disable=true` (accessed 2026-08-03):
 # https://api.code.umans.ai/v1/models/info
+# limit.output is cap-1 on purpose: the gateway 400s max_tokens >=
+# max_completion_tokens (393216), so 393215 is the largest value that serves
+# (its advertised `recommended_max_tokens`).
 base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]

--- a/providers/umans-ai/models/umans-kimi-k3.toml
+++ b/providers/umans-ai/models/umans-kimi-k3.toml
@@ -1,8 +1,5 @@
 base_model = "moonshotai/kimi-k3"
 name = "Kimi K3"
-# Prerelease: seat-gated through Umans Labs (free during the experiment
-# window); the cost below is the GA pricing (Moonshot-list-anchored).
-status = "beta"
 # Live metadata: levels none/low/high/max, default max, and `can_disable=true`
 # (accessed 2026-07-28): https://api.code.umans.ai/v1/models/info
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]

--- a/providers/umans-ai/models/umans-kimi-k3.toml
+++ b/providers/umans-ai/models/umans-kimi-k3.toml
@@ -1,9 +1,8 @@
 # Toggle: thinking.type = enabled|disabled
 # Effort: reasoning_effort = low|high|max
-base_model = "moonshotai/kimi-k3"
-name = "Kimi K3"
 # Live metadata: levels none/low/high/max, default max, and `can_disable=true`
 # (accessed 2026-07-28): https://api.code.umans.ai/v1/models/info
+base_model = "moonshotai/kimi-k3"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]

--- a/providers/umans-ai/models/umans-kimi-k3.toml
+++ b/providers/umans-ai/models/umans-kimi-k3.toml
@@ -1,0 +1,19 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3"
+# Prerelease: seat-gated through Umans Labs (free during the experiment
+# window); the cost below is the GA pricing (Moonshot-list-anchored).
+status = "beta"
+# Live metadata: levels none/low/high/max, default max, and `can_disable=true`
+# (accessed 2026-07-28): https://api.code.umans.ai/v1/models/info
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+
+[modalities]
+input = ["text", "image"]

--- a/providers/umans-ai/models/umans-kimi-k3.toml
+++ b/providers/umans-ai/models/umans-kimi-k3.toml
@@ -1,3 +1,5 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
 base_model = "moonshotai/kimi-k3"
 name = "Kimi K3"
 # Live metadata: levels none/low/high/max, default max, and `can_disable=true`


### PR DESCRIPTION
Adds `umans-kimi-k3` to both Umans AI providers (`umans-ai` and `umans-ai-coding-plan`).

Kimi K3 is Moonshot's largest open-weight release (2.8T MoE, 1M context, native vision) — **released on the Umans gateway 2026-07-31** (pay-per-token + coding plan). The `moonshotai/kimi-k3` base model already exists (added via #3787); this PR only registers the provider entries.

Facts verified against the live catalog (`https://api.code.umans.ai/v1/models/info`, accessed 2026-07-28; re-confirmed at release):

- No `status` field — released, stable; matches the sibling Umans models (was `beta` while K3 was in its prerelease window).
- `[cost]` differs per provider convention:
  - **`umans-ai`** (pay-per-token): $3.00/M input, $15.00/M output, $0.30/M cache read — Moonshot list rates, effective 2026-07-31.
  - **`umans-ai-coding-plan`** (flat-fee subscription): zeroed, per this provider's subscription convention (same as every other model on the plan, and e.g. `kimi-for-coding` / `alibaba-coding-plan`).
- `reasoning_options`: toggle + effort `low/high/max` — live reasoning metadata reports levels `none/low/high/max`, default `max`, `can_disable=true`
- `[modalities] input = ["text", "image"]` — the gateway accepts text + image only (no video blocks), narrowing the base model's `text/image/video`
- Context 1,048,576 / output 131,072 inherited from the base model and matching the live limits
- `interleaved.field = "reasoning_content"` per the OpenAI-compatible route contract

`bun validate` passes locally.


---

Also adds `umans-deepseek-v4-flash-0731` to both Umans AI providers, based on the canonical `deepseek/deepseek-v4-flash-0731` lab entry (the 2026-07-31 release identity — inherited description, benchmarks, and weights).

Facts verified against the live catalog (`https://api.code.umans.ai/v1/models/info`, accessed 2026-08-03) and DeepSeek's first-party pricing page (`https://api-docs.deepseek.com/quick_start/pricing/`):

- `base_model = "deepseek/deepseek-v4-flash-0731"` — Umans serves the official 0731 checkpoint (`https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731`), the same identity every other 0731 host maps.
- `[cost]`:
  - **`umans-ai`** (pay-per-token): $0.14/M input, $0.28/M output, $0.028/M cache read — Umans AI's public per-token rate, which is what `GET /v1/models` renders. (Umans AI also runs a cheaper founding-user cache rate on its own platform until 2026-08-10; the public rate is the catalog one.)
  - **`umans-ai-coding-plan`** (flat-fee subscription): zeroed, per this provider's convention.
- `reasoning_options`: toggle + effort `low/high/max` — live reasoning metadata reports levels `none/low/high/max`, default `low`, `can_disable=true` (the 0731 encoding spec has a real think-low tier, unlike the first-party API's `high|max` surface).
- `[limit] context = 1_048_576`, `output = 393_215` — the gateway's served limits (`context_window` 1048576; `max_completion_tokens` 393216, advertised recommended 393215 = cap-1 since the gateway rejects `max_tokens` at the cap). Overrides the lab entry's `1_000_000` / `384_000`.
- No `[modalities]` override — text-only, identical to the lab entry.

`bun validate` passes locally.

