### PR TITLE
Add abliterated-model-large

### DIFF
--- a/providers/abliteration-ai/models/abliterated-model-large.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large.toml
@@ -1,4 +1,6 @@
 name = "Abliterated Model Large"
+# https://docs.abliteration.ai/models
+# https://docs.abliteration.ai/api-reference/chat-completions/create-a-chat-completion
 description = "GLM-5.2 model abliterated and finetuned for cyber, ML red teaming, and agent testing"
 release_date = "2026-07-25"
 last_updated = "2026-07-25"
@@ -9,15 +11,16 @@ structured_output = true
 temperature = true
 open_weights = false
 
-reasoning_options = [{ type = "reasoning_effort", values = ["none", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
 
+# https://abliteration.ai/pricing#api-pricing
 [cost]
 input = 5.00
 output = 5.00
 
 [limit]
-context = 250_000
-input = 250_000
+context = 1_000_000
+input = 1_000_000
 output = 32_768
 
 [modalities]

--- a/providers/abliteration-ai/models/abliterated-model-large.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large.toml
@@ -1,0 +1,29 @@
+name = "Abliterated Model Large"
+description = "GLM-5.2 model abliterated and finetuned for cyber, ML red teaming, and agent testing"
+# Reasoning HTTP format (accessed 2026-07-25):
+# This model thinks by default. On POST /v1/chat/completions or /v1/messages,
+# top-level `thinking: false` skips thinking; omission keeps it enabled.
+# Sources:
+# https://docs.abliteration.ai/models
+# https://docs.abliteration.ai/capabilities/thinking
+release_date = "2026-07-25"
+last_updated = "2026-07-25"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+open_weights = false
+
+[cost]
+input = 5.00
+output = 5.00
+
+[limit]
+context = 250_000
+input = 250_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/abliteration-ai/models/abliterated-model-large.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large.toml
@@ -15,6 +15,11 @@ structured_output = true
 temperature = true
 open_weights = false
 
+reasoning_options = [{ type = "reasoning_effort", values = ["none", "high", "max"] }]
+
+[interleaved]
+field = "reasoning"
+
 [cost]
 input = 5.00
 output = 5.00

--- a/providers/abliteration-ai/models/abliterated-model-large.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large.toml
@@ -1,9 +1,17 @@
+# Sources (accessed 2026-07-28):
+# - Model card, limits (1M context, 999,990 max output), capabilities, GLM-5.2 base:
+#   https://docs.abliteration.ai/models
+# - Reasoning effort ladder and per-endpoint request fields:
+#   https://docs.abliteration.ai/capabilities/thinking
+# - Pricing ($5 per 1M tokens, flat input + output):
+#   https://docs.abliteration.ai/pricing
+#   https://abliteration.ai/pricing#api-pricing
+# - Launch announcement (base model, fine-tuning, benchmarks):
+#   https://abliteration.ai/blog/introducing-abliterated-model-large
 name = "Abliterated Model Large"
-# https://docs.abliteration.ai/models
-# https://docs.abliteration.ai/api-reference/chat-completions/create-a-chat-completion
 description = "GLM-5.2 model abliterated and finetuned for cyber, ML red teaming, and agent testing"
 release_date = "2026-07-25"
-last_updated = "2026-07-25"
+last_updated = "2026-07-28"
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,9 +19,14 @@ structured_output = true
 temperature = true
 open_weights = false
 
-reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
+# Accepts the full ladder but maps it to two modes: minimal-high -> high, xhigh-max -> max.
+[[reasoning_options]]
+type = "effort" # API: {"reasoning_effort": "<value>"} on /v1/chat/completions
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
-# https://abliteration.ai/pricing#api-pricing
+[[reasoning_options]]
+type = "toggle" # API: {"thinking": false} on /v1/messages (legacy alias on /v1/chat/completions)
+
 [cost]
 input = 5.00
 output = 5.00
@@ -21,7 +34,7 @@ output = 5.00
 [limit]
 context = 1_000_000
 input = 1_000_000
-output = 32_768
+output = 999_990
 
 [modalities]
 input = ["text"]

--- a/providers/abliteration-ai/models/abliterated-model-large.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large.toml
@@ -1,11 +1,5 @@
 name = "Abliterated Model Large"
 description = "GLM-5.2 model abliterated and finetuned for cyber, ML red teaming, and agent testing"
-# Reasoning HTTP format (accessed 2026-07-25):
-# This model thinks by default. On POST /v1/chat/completions or /v1/messages,
-# top-level `thinking: false` skips thinking; omission keeps it enabled.
-# Sources:
-# https://docs.abliteration.ai/models
-# https://docs.abliteration.ai/capabilities/thinking
 release_date = "2026-07-25"
 last_updated = "2026-07-25"
 attachment = false

--- a/providers/abliteration-ai/models/abliterated-model-large.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large.toml
@@ -19,10 +19,11 @@ structured_output = true
 temperature = true
 open_weights = false
 
-# Accepts the full ladder but maps it to two modes: minimal-high -> high, xhigh-max -> max.
+# Two distinct reasoning depths: high and max. The API also accepts the other
+# ladder values as aliases, mapping minimal-high -> high and xhigh-max -> max.
 [[reasoning_options]]
 type = "effort" # API: {"reasoning_effort": "<value>"} on /v1/chat/completions
-values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+values = ["none", "high", "max"]
 
 [[reasoning_options]]
 type = "toggle" # API: {"thinking": false} on /v1/messages (legacy alias on /v1/chat/completions)

--- a/providers/abliteration-ai/models/abliterated-model-large.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large.toml
@@ -11,9 +11,6 @@ open_weights = false
 
 reasoning_options = [{ type = "reasoning_effort", values = ["none", "high", "max"] }]
 
-[interleaved]
-field = "reasoning"
-
 [cost]
 input = 5.00
 output = 5.00

--- a/providers/abliteration-ai/models/abliterated-model.toml
+++ b/providers/abliteration-ai/models/abliterated-model.toml
@@ -1,19 +1,26 @@
+# Sources (accessed 2026-07-28):
+# - Model card and capabilities: https://docs.abliteration.ai/models
+# - Reasoning effort ladder and per-endpoint request fields (reasoning on by
+#   default; "none" disables; top-level thinking:false disables on
+#   /v1/messages and as a legacy alias on /v1/chat/completions):
+#   https://docs.abliteration.ai/capabilities/thinking
 name = "Abliterated Model"
 description = "Multimodal model for analyzing text, images, documents, and rich media"
-# Reasoning HTTP format (accessed 2026-06-25):
-# This model thinks by default. On POST /v1/chat/completions or /v1/messages,
-# top-level `thinking: false` skips thinking; omission keeps it enabled.
-# Sources:
-# https://docs.abliteration.ai/models
-# https://docs.abliteration.ai/capabilities/thinking
 release_date = "2026-01-06"
-last_updated = "2026-01-06"
+last_updated = "2026-07-28"
 attachment = true
-reasoning = false
+reasoning = true
 tool_call = true
 structured_output = false
 temperature = true
 open_weights = true
+
+[[reasoning_options]]
+type = "effort" # API: {"reasoning_effort": "<value>"} on /v1/chat/completions
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[[reasoning_options]]
+type = "toggle" # API: {"thinking": false} on /v1/messages (legacy alias on /v1/chat/completions)
 
 [cost]
 input = 3.00

--- a/providers/abliteration-ai/provider.toml
+++ b/providers/abliteration-ai/provider.toml
@@ -1,3 +1,14 @@
+# Reasoning controls for the whole API surface (verified 2026-07-28):
+# https://docs.abliteration.ai/capabilities/thinking
+# Both models reason by default. Effort ladder, least to most:
+# none (disables reasoning), minimal, low, medium, high, xhigh, max.
+# Request field per endpoint:
+# - POST /v1/chat/completions: top-level "reasoning_effort": "<level>"
+#   (legacy top-level "thinking": false also disables reasoning)
+# - POST /v1/responses: "reasoning": { "effort": "<level>" }
+# - POST /v1/messages: "output_config": { "effort": "<level>" } or
+#   "thinking": { "type": "enabled", "budget_tokens": <n> };
+#   "thinking": false disables reasoning
 name = "abliteration.ai"
 env = ["ABLIT_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/abliteration-ai/provider.toml
+++ b/providers/abliteration-ai/provider.toml
@@ -1,12 +1,5 @@
 name = "abliteration.ai"
 env = ["ABLIT_KEY"]
 npm = "@ai-sdk/openai-compatible"
-# Reasoning HTTP format (accessed 2026-06-25):
-# POST /v1/chat/completions and POST /v1/messages: top-level `thinking` is true
-# by default; false skips thinking. POST /v1/responses has no thinking toggle.
-# No effort or numeric reasoning-budget request field is documented.
-# Sources:
-# https://docs.abliteration.ai/capabilities/thinking
-# https://docs.abliteration.ai/compatibility-matrix
 api = "https://api.abliteration.ai/v1"
 doc = "https://docs.abliteration.ai/models"


### PR DESCRIPTION
Adds `abliterated-model-large` and fixes the reasoning metadata for `abliterated-model` so OpenCode integration works for both models.

## Sources and what each one supports

- **Models page** — https://docs.abliteration.ai/models
  - Both models reason by default; `abliterated-model-large` is text-only with a 1M context window and 999,990 max output
  - Structured outputs supported on `abliterated-model-large`
- **Thinking & reasoning effort** — https://docs.abliteration.ai/capabilities/thinking
  - Effort ladder `none | minimal | low | medium | high | xhigh | max` (`none` disables reasoning), set via top-level `reasoning_effort` on `/v1/chat/completions` — backs `reasoning_options` on both model entries
  - `abliterated-model-large` accepts the full ladder and maps it to two modes: minimal–high → high, xhigh–max → max
  - Toggle: `thinking: false` on `/v1/messages` (legacy alias on `/v1/chat/completions`)
- **Pricing** — https://docs.abliteration.ai/pricing and https://abliteration.ai/pricing#api-pricing
  - `$5 / 1M tokens` flat (input + output) for `abliterated-model-large`; base model stays `$3`
- **Launch blog** — https://abliteration.ai/blog/introducing-abliterated-model-large
  - GLM-5.2 base, abliterated and fine-tuned for adversarial workloads; 2026-07-25 release
- **API reference** — https://docs.abliteration.ai/api-reference/chat-completions/create-a-chat-completion
  - OpenAI-compatible `/v1/chat/completions` request surface
