### PR TITLE
feat(synthetic): Add Kimi K3 model

### DIFF
--- a/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
@@ -1,5 +1,6 @@
 base_model = "moonshotai/kimi-k3"
 last_updated = "2026-07-27"
+
 temperature = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 

--- a/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
@@ -15,7 +15,7 @@ field = "reasoning_content"
 [cost]
 input = 3
 output = 15
-cache_read = 3
+cache_read = 0.45
 
 [limit]
 context = 524_288

--- a/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
@@ -1,13 +1,10 @@
+# Reasoning surface verified against https://dev.synthetic.new/docs/openai/chat-completions
+# (accessed 2026-07-27): `reasoning_effort` accepts low | medium | high for thinking
+# models; no reasoning on/off toggle or disable sentinel is documented.
 base_model = "moonshotai/kimi-k3"
 last_updated = "2026-07-27"
 temperature = true
-
-[[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "effort"
-values = ["low", "high", "max"]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
@@ -1,6 +1,3 @@
-# Reasoning surface verified against https://dev.synthetic.new/docs/openai/chat-completions
-# (accessed 2026-07-27): `reasoning_effort` accepts low | medium | high for thinking
-# models; no reasoning on/off toggle or disable sentinel is documented.
 base_model = "moonshotai/kimi-k3"
 last_updated = "2026-07-27"
 temperature = true

--- a/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
@@ -1,0 +1,26 @@
+base_model = "moonshotai/kimi-k3"
+last_updated = "2026-07-27"
+temperature = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3
+output = 15
+cache_read = 3
+
+[limit]
+context = 524_288
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Description

Add support for **Moonshot Kimi K3** to the Synthetic provider.

This PR adds the `hf:moonshotai/Kimi-K3` model to the Synthetic catalog with the provider's published metadata, inheriting provider-agnostic facts from the `moonshotai/kimi-k3` base model added in #3787. 

Thanks as always! :)

**References:**
- https://dev.synthetic.new/docs/api/models
- https://synthetic.new/pricing

