### PR TITLE
feat(crof): add Kimi K3

### DIFF
--- a/providers/crof/models/kimi-k3.toml
+++ b/providers/crof/models/kimi-k3.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k3"
-reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/kimi-k3.toml
+++ b/providers/crof/models/kimi-k3.toml
@@ -1,0 +1,17 @@
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2
+output = 8
+cache_read = 0.25
+
+[limit]
+context = 1_000_000
+output = 262_144
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/kimi-k3.toml
+++ b/providers/crof/models/kimi-k3.toml
@@ -1,5 +1,5 @@
 base_model = "moonshotai/kimi-k3"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
- Source: https://crof.ai/pricing & https://crof.ai/v1/models
- Reasoning ~~follows other models based on current testing in CrofAI playground page (None, Low, Medium, High)~~ changed to None/Low/High/Max
- Format following Kimi K2.7 Code submission from #2655 
- Only differs from Moonshot metadata in pricing ($2 in/$8 out/$0.25 cache) and output token (1M context, 262k output)