### PR TITLE
feat(aiand): add Kimi K3

### DIFF
--- a/providers/aiand/models/moonshotai/kimi-k3.toml
+++ b/providers/aiand/models/moonshotai/kimi-k3.toml
@@ -1,9 +1,8 @@
 # Source: https://docs.aiand.com/models/catalog/ (USD list prices; accessed
-# 2026-07-28). The catalog lists moonshotai/kimi-k3 with the same
-# reasoning support as the base model. Not runtime-verified: model access
-# is org-scoped. Pricing follows official Moonshot AI rates ($3/$15/$0.30)
-# consistent with other providers. reasoning_options follows the
-# verified effort set from the base model (low/high/max).
+# 2026-07-28). Pricing is aiand-specific: $3.00 input, $0.50 cache_read,
+# $12.50 output (differs from Moonshot official rates).
+# reasoning_options verified: supported values are low, high, max only.
+# 'medium' is NOT supported on this provider/endpoint.
 base_model = "moonshotai/kimi-k3"
 
 reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
@@ -13,5 +12,5 @@ field = "reasoning_content"
 
 [cost]
 input = 3.00
-cache_read = 0.30
-output = 15.00
+cache_read = 0.50
+output = 12.50

--- a/providers/aiand/models/moonshotai/kimi-k3.toml
+++ b/providers/aiand/models/moonshotai/kimi-k3.toml
@@ -9,8 +9,12 @@
 # "Unsupported thinking_effort=...; supported values are ['high', 'low', 'max']".
 # none/low/high/max accepted; none emits no reasoning tokens.
 # Interleaved field is "reasoning" (not reasoning_content) on this gateway.
-# Capabilities from /v1/models: reasoning, tool_calling, vision, document
-# (no video) — modalities overridden from shared base text+image+video.
+# Modalities verified live 2026-07-28 (max_tokens=8, reasoning_effort=none):
+# text accepted; image_url (1x1 PNG data URL) accepted; video_url rejected
+# with "does not support video input". /v1/models lists vision+document (no
+# video); Files API uploads were blocked for this key so PDF not runtime-
+# exercised — document capability maps to pdf like kimi-k2.7-code.
+# Modalities overridden from shared base text+image+video.
 base_model = "moonshotai/kimi-k3"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]

--- a/providers/aiand/models/moonshotai/kimi-k3.toml
+++ b/providers/aiand/models/moonshotai/kimi-k3.toml
@@ -1,16 +1,28 @@
-# Source: https://docs.aiand.com/models/catalog/ (USD list prices; accessed
-# 2026-07-28). Pricing is aiand-specific: $3.00 input, $0.50 cache_read,
-# $12.50 output (differs from Moonshot official rates).
-# reasoning_options verified: supported values are low, high, max only.
-# 'medium' is NOT supported on this provider/endpoint.
+# Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
+# 2026-07-28). Pricing is aiand-specific: input=$3.00, cache_read=$0.50,
+# output=$12.50 per 1M (differs from Moonshot official $3/$0.30/$15).
+# Docs catalog does not yet list this org-scoped model; API is the source of
+# truth per https://docs.aiand.com/models/catalog/.
+# reasoning_effort verified live against api.aiand.com on 2026-07-28:
+# gateway schema accepts none/minimal/low/medium/high/xhigh/max (400 on other
+# input), but the model backend rejects minimal/medium/xhigh with 500:
+# "Unsupported thinking_effort=...; supported values are ['high', 'low', 'max']".
+# none/low/high/max accepted; none emits no reasoning tokens.
+# Interleaved field is "reasoning" (not reasoning_content) on this gateway.
+# Capabilities from /v1/models: reasoning, tool_calling, vision, document
+# (no video) — modalities overridden from shared base text+image+video.
 base_model = "moonshotai/kimi-k3"
 
-reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
 
 [interleaved]
-field = "reasoning_content"
+field = "reasoning"
 
 [cost]
 input = 3.00
 cache_read = 0.50
 output = 12.50
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/aiand/models/moonshotai/kimi-k3.toml
+++ b/providers/aiand/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,17 @@
+# Source: https://docs.aiand.com/models/catalog/ (USD list prices; accessed
+# 2026-07-28). The catalog lists moonshotai/kimi-k3 with the same
+# reasoning support as the base model. Not runtime-verified: model access
+# is org-scoped. Pricing follows official Moonshot AI rates ($3/$15/$0.30)
+# consistent with other providers. reasoning_options follows the
+# verified effort set from the base model (low/high/max).
+base_model = "moonshotai/kimi-k3"
+
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.00
+cache_read = 0.30
+output = 15.00


### PR DESCRIPTION
## Summary

Adds `moonshotai/kimi-k3` to the **ai&** (`aiand`) provider.

- Inherits shared metadata via `base_model = "moonshotai/kimi-k3"`
- `reasoning_options` curated from **live probe** of `api.aiand.com`: `none`, `low`, `high`, `max`
- Interleaved field is `reasoning` (ai& gateway shape; not Moonshot's `reasoning_content`)
- Modalities overridden to `text`/`image`/`pdf` (API capabilities: vision + document; no video)
- Pricing from **ai&** `GET /v1/models`: $3.00 input / $0.50 cache_read / $12.50 output per 1M tokens

## Sources

- Model ID / pricing / capabilities: live `GET https://api.aiand.com/v1/models` (accessed 2026-07-28) — returns `input_per_1m=3.000000`, `cached_input_per_1m=0.500000`, `output_per_1m=12.500000`, `context_window=1048576`, capabilities `[reasoning, tool_calling, vision, document]`
- Catalog docs note API is source of truth for org-scoped models: https://docs.aiand.com/models/catalog/
- (For comparison only) Moonshot official rates are $3 / $0.30 / $15 — **not** used here

## Validation (live probe, 2026-07-28)

| `reasoning_effort` | Result |
| --- | --- |
| `none` | accepted — no reasoning tokens |
| `low` | accepted — emits `reasoning` |
| `high` | accepted — emits `reasoning` |
| `max` | accepted — emits `reasoning` |
| `minimal` | rejected 500 — supported values are `['high', 'low', 'max']` |
| `medium` | rejected 500 — same |
| `xhigh` | rejected 500 — same |
| `invalid_bogus_value` | rejected 400 — gateway schema negative control |

Note: gateway schema lists `none/minimal/low/medium/high/xhigh/max`, but the K3 backend only honors `none` plus `low/high/max` (same pattern as aiand `gpt-oss-120b` narrowing and Nebius #3792).

Pattern mirrors merged K3 PRs [#3783](https://github.com/anomalyco/models.dev/pull/3783) (togetherai), [#3777](https://github.com/anomalyco/models.dev/pull/3777) (fireworks-ai), [#3795](https://github.com/anomalyco/models.dev/pull/3795) (crof — also `none/low/high/max`), with aiand-specific probe results like `kimi-k2.7-code.toml` / `gpt-oss-120b.toml`.
