### PR TITLE
feat(aiand): add kimi-k3; remove glm-5.1 and kimi-k2.6 (not in live catalog)

### DIFF
--- a/providers/aiand/models/moonshotai/kimi-k3.toml
+++ b/providers/aiand/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,22 @@
+# Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
+# 2026-07-28). Pricing is aiand-specific: $3.00 input, $0.50 cache_read,
+# $12.50 output (differs from Moonshot official rates).
+# Modalities: text + image accepted; video rejected ("does not support video
+# input"); document capability from /v1/models — overridden from shared base
+# text+image+video. No [interleaved] block (matches other aiand entries).
+# reasoning_effort verified live: gateway schema accepts
+# none/minimal/low/medium/high/xhigh/max, but the K3 backend only accepts
+# none/low/high/max (minimal/medium/xhigh rejected). Invalid values rejected
+# with 400 (negative control).
+base_model = "moonshotai/kimi-k3"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+
+[cost]
+input = 3.00
+cache_read = 0.50
+output = 12.50
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/aiand/models/moonshotai/kimi-k3.toml
+++ b/providers/aiand/models/moonshotai/kimi-k3.toml
@@ -2,8 +2,8 @@
 # 2026-07-28). Pricing is aiand-specific: $3.00 input, $0.50 cache_read,
 # $12.50 output (differs from Moonshot official rates).
 # Modalities: text + image accepted; video rejected ("does not support video
-# input"); document capability from /v1/models — overridden from shared base
-# text+image+video. No [interleaved] block (matches other aiand entries).
+# input"); pdf removed — overridden from shared base text+image+video to
+# match other providers serving K3 (fireworks, ollama-cloud).
 # reasoning_effort verified live: gateway schema accepts
 # none/minimal/low/medium/high/xhigh/max, but the K3 backend only accepts
 # none/low/high/max (minimal/medium/xhigh rejected). Invalid values rejected
@@ -18,5 +18,5 @@ cache_read = 0.50
 output = 12.50
 
 [modalities]
-input = ["text", "image", "pdf"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/aiand/models/moonshotai/kimi-k3.toml
+++ b/providers/aiand/models/moonshotai/kimi-k3.toml
@@ -1,9 +1,11 @@
 # Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
 # 2026-07-28). Pricing is aiand-specific: $3.00 input, $0.50 cache_read,
 # $12.50 output (differs from Moonshot official rates).
-# Modalities: text + image accepted; video rejected ("does not support video
-# input"); pdf removed — overridden from shared base text+image+video to
-# match other providers serving K3 (fireworks, ollama-cloud).
+# Modalities: text + image + pdf accepted per GET /v1/models; video rejected
+# ("does not support video input") — overridden from shared base
+# text+image+video. PDF kept: sibling aiand Moonshot entries (kimi-k2.6,
+# kimi-k2.7-code) include pdf after catalog/probe evidence; aiand treats
+# PDF as a provider-level Files API modality.
 # reasoning_effort verified live: gateway schema accepts
 # none/minimal/low/medium/high/xhigh/max, but the K3 backend only accepts
 # none/low/high/max (minimal/medium/xhigh rejected). Invalid values rejected
@@ -18,5 +20,5 @@ cache_read = 0.50
 output = 12.50
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "pdf"]
 output = ["text"]


### PR DESCRIPTION
## Summary

Adds `moonshotai/kimi-k3` to the **ai&** (`aiand`) provider and removes two models that are no longer available in the live catalog.

---

## Added — `moonshotai/kimi-k3`

**Sources**
- Model catalog: https://docs.aiand.com/models/catalog/
- Live API: `GET https://api.aiand.com/v1/models` (accessed 2026-07-28)

**Pricing (USD per 1M tokens)**

| Model | Input | Cached Input | Output |
|-------|-------|-------------|--------|
| Kimi K3 | $3.00 | $0.50 | $12.50 |

Pricing is aiand-specific and differs from Moonshot official rates.

**Reasoning options (API-verified 2026-07-28)**

- `none`, `low`, `high`, `max` → accepted (200)
- `minimal`, `medium`, `xhigh` → rejected by the K3 backend (400)
- Gateway-wide schema accepts more values, but the K3 backend enforces the four above only

**Modalities**

Base model declares `["text", "image", "video"]`. Video is rejected by ai& (`"does not support video input"`). PDF accepted via the Files API (consistent with sibling aiand Moonshot entries `kimi-k2.7-code`, `kimi-k2.6`). Overridden to `["text", "image", "pdf"]`.

---

## Removed

| File | Reason |
|------|--------|
| `zai-org/glm-5.1.toml` | No longer in live catalog — superseded by `glm-5.2`. Not present in `GET /v1/models`. |
| `moonshotai/kimi-k2.6.toml` | Not available on ai& inference. Only `kimi-k2.7-code` and `kimi-k3` are present in `GET /v1/models`. |

---

## Validation

- `bun validate` passes
- Format follows existing aiand Moonshot entries (`kimi-k2.7-code.toml`)
