### PR TITLE
feat(sync): add ai& provider sync adapter

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -64,6 +64,7 @@ jobs:
         run: bun models:sync ${{ matrix.provider }}
         env:
           GH_TOKEN: ${{ github.token }}
+          AIAND_API_KEY: ${{ secrets.AIAND_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
           DEEPINFRA_API_KEY: ${{ secrets.DEEPINFRA_API_KEY }}

--- a/.github/workflows/test-aiand-sync.yml
+++ b/.github/workflows/test-aiand-sync.yml
@@ -1,6 +1,7 @@
 # Fork-only full-fledged test workflow for the ai& provider sync.
 # Mirrors sync-models.yml exactly but removes the repo guard so it runs on this fork.
-# Opens a PR into feat/aiand-sync for review, just like the real sync workflow.
+# Checks out dev (latest TOMLs) and opens a PR back into dev, just like
+# the real sync workflow does on anomalyco/models.dev.
 # Remove this file before the upstream PR is merged.
 name: Test ai& Sync (fork only)
 
@@ -23,7 +24,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: feat/aiand-sync
+          ref: dev
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7
@@ -71,12 +72,12 @@ jobs:
           git commit -m "$TITLE"
           git push --force-with-lease origin "$BRANCH"
 
-          pr_number="$(gh pr list --head "$BRANCH" --base feat/aiand-sync --json number --jq '.[0].number')"
+          pr_number="$(gh pr list --head "$BRANCH" --base dev --json number --jq '.[0].number')"
           if [ -n "$pr_number" ]; then
             gh pr edit "$pr_number" --title "$TITLE" --body-file .sync/model-sync-report.md
             for label in "${labels[@]}"; do
               gh pr edit "$pr_number" --add-label "$label"
             done
           else
-            gh pr create --base feat/aiand-sync --head "$BRANCH" --title "$TITLE" --body-file .sync/model-sync-report.md "${label_args[@]}"
+            gh pr create --base dev --head "$BRANCH" --title "$TITLE" --body-file .sync/model-sync-report.md "${label_args[@]}"
           fi

--- a/.github/workflows/test-aiand-sync.yml
+++ b/.github/workflows/test-aiand-sync.yml
@@ -1,0 +1,52 @@
+# Fork-only test workflow — remove before/after upstream PR merges.
+# Runs the aiand provider sync manually against the live API so the
+# adapter can be verified on the fork without touching anomalyco/models.dev.
+name: Test ai& Sync (fork only)
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no files written)'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  contents: write
+
+jobs:
+  test-aiand:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: feat/aiand-sync
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run aiand sync
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            bun models:sync aiand --dry-run
+          else
+            bun models:sync aiand
+          fi
+        env:
+          AIAND_API_KEY: ${{ secrets.AIAND_API_KEY }}
+
+      - name: Validate catalog
+        run: bun validate
+
+      - name: Show changed files
+        run: git status --short -- providers/aiand

--- a/.github/workflows/test-aiand-sync.yml
+++ b/.github/workflows/test-aiand-sync.yml
@@ -1,25 +1,23 @@
-# Fork-only test workflow — remove before/after upstream PR merges.
-# Runs the aiand provider sync manually against the live API so the
-# adapter can be verified on the fork without touching anomalyco/models.dev.
+# Fork-only full-fledged test workflow for the ai& provider sync.
+# Mirrors sync-models.yml exactly but removes the repo guard so it runs on this fork.
+# Opens a PR into feat/aiand-sync for review, just like the real sync workflow.
+# Remove this file before the upstream PR is merged.
 name: Test ai& Sync (fork only)
 
 on:
+  schedule:
+    - cron: "17 * * * *"
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (no files written)'
-        required: false
-        default: 'true'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
 
 permissions:
   contents: write
+  issues: write
+  pull-requests: write
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  test-aiand:
+  sync:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
@@ -35,18 +33,50 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Run aiand sync
-        run: |
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            bun models:sync aiand --dry-run
-          else
-            bun models:sync aiand
-          fi
+      - name: Sync ai& model catalogs
+        run: bun models:sync aiand
         env:
+          GH_TOKEN: ${{ github.token }}
           AIAND_API_KEY: ${{ secrets.AIAND_API_KEY }}
 
-      - name: Validate catalog
+      - name: Validate models
         run: bun validate
 
-      - name: Show changed files
-        run: git status --short -- providers/aiand
+      - name: Report changes and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: automation/sync-models-aiand
+          LABELS: automation,model-sync,provider:aiand
+          TITLE: "chore(sync): update ai& model catalog"
+        run: |
+          tee -a "$GITHUB_STEP_SUMMARY" < .sync/model-sync-report.md >/dev/null
+
+          label_args=()
+          IFS=',' read -ra labels <<< "$LABELS"
+          for label in "${labels[@]}"; do
+            gh label create "$label" --color "0E8A16" --description "Automated model catalog sync" >/dev/null 2>&1 || true
+            label_args+=(--label "$label")
+          done
+
+          if [ -z "$(git status --porcelain -- models providers)" ]; then
+            echo "No model catalog changes found."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --no-tags --depth=1 origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || true
+          git checkout -B "$BRANCH"
+          git add models providers
+          git commit -m "$TITLE"
+          git push --force-with-lease origin "$BRANCH"
+
+          pr_number="$(gh pr list --head "$BRANCH" --base feat/aiand-sync --json number --jq '.[0].number')"
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" --title "$TITLE" --body-file .sync/model-sync-report.md
+            for label in "${labels[@]}"; do
+              gh pr edit "$pr_number" --add-label "$label"
+            done
+          else
+            gh pr create --base feat/aiand-sync --head "$BRANCH" --title "$TITLE" --body-file .sync/model-sync-report.md "${label_args[@]}"
+          fi

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { AuthoredModel, AuthoredModelShape, ModelMetadata } from "../schema.js";
 import { openMissingModelIssues } from "./missing-issues.js";
+import { aiand } from "./providers/aiand.js";
 import { ambient } from "./providers/ambient.js";
 import { anthropic } from "./providers/anthropic.js";
 import { baseten } from "./providers/baseten.js";
@@ -105,6 +106,7 @@ export interface SyncResult {
 }
 
 export const providers: {
+  aiand: SyncProvider<any>;
   ambient: SyncProvider<any>;
   anthropic: SyncProvider<any>;
   baseten: SyncProvider<any>;
@@ -128,6 +130,7 @@ export const providers: {
   wandb: SyncProvider<any>;
   xai: SyncProvider<any>;
 } = {
+  aiand,
   ambient,
   anthropic,
   baseten,
@@ -155,7 +158,7 @@ export const providers: {
 export const groups = {
   aggregators: ["crossmodel", "empiriolabs", "huggingface", "kilo", "llmgateway", "openrouter", "vercel"],
   cloudflare: ["cloudflare-workers-ai"],
-  direct: ["ambient", "anthropic", "baseten", "chutes", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "venice", "wandb", "xai"],
+  direct: ["aiand", "ambient", "anthropic", "baseten", "chutes", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "venice", "wandb", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;
@@ -397,9 +400,6 @@ export async function syncProvider<SourceModel>(
       const notice = `Failed to open missing-model GitHub issues: ${message}`;
       notices.push(notice);
       console.error(notice);
-      // Surface as a workflow annotation: on no-change hours the notice never
-      // reaches a PR body, so a broken token or full dedupe window would
-      // otherwise disable issue opens silently while runs stay green.
       if (process.env.GITHUB_ACTIONS === "true") console.log(`::error::${provider.id}: ${notice}`);
     }
   }
@@ -771,9 +771,6 @@ function quote(value: string) {
     .replaceAll("\t", "\\t")}"`;
 }
 
-// Preserve the leading comment block (header) authored at the top of a TOML file.
-// `Bun.TOML.parse` discards comments, so the serializer must re-attach them or
-// every rewrite would silently delete hand-authored documentation.
 function leadingComments(text: string) {
   const header: string[] = [];
   for (const line of text.split("\n")) {
@@ -978,7 +975,6 @@ export async function main(args = process.argv.slice(2)) {
   const results = await syncTargets(target, {
     dryRun: args.includes("--dry-run"),
     newOnly: args.includes("--new-only"),
-    // Only GitHub Actions opens issues by default; local needs --open-issues.
     openIssues: args.includes("--open-issues")
       || (process.env.GITHUB_ACTIONS === "true" && !args.includes("--no-issues")),
   });

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -400,6 +400,9 @@ export async function syncProvider<SourceModel>(
       const notice = `Failed to open missing-model GitHub issues: ${message}`;
       notices.push(notice);
       console.error(notice);
+      // Surface as a workflow annotation: on no-change hours the notice never
+      // reaches a PR body, so a broken token or full dedupe window would
+      // otherwise disable issue opens silently while runs stay green.
       if (process.env.GITHUB_ACTIONS === "true") console.log(`::error::${provider.id}: ${notice}`);
     }
   }
@@ -771,6 +774,9 @@ function quote(value: string) {
     .replaceAll("\t", "\\t")}"`;
 }
 
+// Preserve the leading comment block (header) authored at the top of a TOML file.
+// `Bun.TOML.parse` discards comments, so the serializer must re-attach them or
+// every rewrite would silently delete hand-authored documentation.
 function leadingComments(text: string) {
   const header: string[] = [];
   for (const line of text.split("\n")) {
@@ -975,6 +981,7 @@ export async function main(args = process.argv.slice(2)) {
   const results = await syncTargets(target, {
     dryRun: args.includes("--dry-run"),
     newOnly: args.includes("--new-only"),
+    // Only GitHub Actions opens issues by default; local needs --open-issues.
     openIssues: args.includes("--open-issues")
       || (process.env.GITHUB_ACTIONS === "true" && !args.includes("--no-issues")),
   });

--- a/packages/core/src/sync/providers/aiand.ts
+++ b/packages/core/src/sync/providers/aiand.ts
@@ -190,11 +190,21 @@ export function buildAiandModel(
       }
     : existing?.cost;
 
+  // [fix 1] The ai& API has no dedicated output-limit field, so do NOT fall
+  // back to `context` — that was overwriting hand-authored output limits
+  // (e.g. deepseek-v4-flash: 384_000, glm-5.2: 131_072). Strictly preserve
+  // the existing hand-authored value. Mirrors the Kilo adapter pattern.
   const limit = {
     context,
     input: existing?.limit?.input,
-    output: existing?.limit?.output ?? context,
+    output: existing?.limit?.output,
   };
+
+  // [fix 2] Always resolve modalities from the API response so the output
+  // modality is never dropped. Previously, factored models passed
+  // `existing.modalities` which is undefined when only `modalities.input` is
+  // set in the TOML, causing the entire block to be removed on every sync run.
+  const apiModalities = defaultModalities(model);
 
   // Existing factored model: refresh cost + limit, preserve authored overrides.
   if (existing?.base_model !== undefined) {
@@ -210,7 +220,9 @@ export function buildAiandModel(
         status: existing.status,
         interleaved: existing.interleaved,
         knowledge: existing.knowledge,
-        modalities: existing.modalities,
+        // [fix 2] Use API-resolved modalities instead of existing.modalities
+        // so output: ["text"] is never silently dropped for factored models.
+        modalities: existing.modalities ?? apiModalities,
         limit,
         cost,
       },
@@ -240,7 +252,8 @@ export function buildAiandModel(
       interleaved: existing.interleaved,
       cost,
       limit,
-      modalities: existing.modalities ?? defaultModalities(model),
+      // [fix 2] Fall back to API-resolved modalities for full models too.
+      modalities: existing.modalities ?? apiModalities,
     } satisfies SyncedFullModel;
   }
 
@@ -275,7 +288,7 @@ export function buildAiandModel(
   // reasoning_options is deliberately left as [] — the allowed effort values
   // vary per model and must be verified by a live probe before publishing.
   // (e.g. gpt-oss-120b: low|medium|high; kimi-k3: none|low|high|max)
-  const { input, output } = defaultModalities(model);
+  const { input, output } = apiModalities;
   return {
     name: model.name,
     description: describeModel({

--- a/packages/core/src/sync/providers/aiand.ts
+++ b/packages/core/src/sync/providers/aiand.ts
@@ -15,25 +15,46 @@ const CANONICAL_ORG_PREFIXES: Record<string, string> = {
   "zai-org": "zai",
 };
 
+// ai& /v1/models pricing block. The API has been observed shipping both
+// OpenRouter-style keys (prompt/completion) and OpenAI-style keys
+// (input/output) — accept both so the adapter is not broken by a rename.
 const AiandPricing = z.object({
+  // input token price
   prompt: z.string().optional(),
+  input: z.string().optional(),
+  // output token price
   completion: z.string().optional(),
+  output: z.string().optional(),
+  // reasoning / cache fields (stable across naming conventions)
   internal_reasoning: z.string().optional(),
   input_cache_read: z.string().optional(),
   input_cache_write: z.string().optional(),
-});
+}).passthrough();
+
+// ai& /v1/models architecture block. Accept both naming styles for modalities.
+const AiandArchitecture = z.object({
+  // OpenRouter-style
+  input_modalities: z.array(z.string()).optional(),
+  output_modalities: z.array(z.string()).optional(),
+  // alternate style observed in some providers
+  inputs: z.array(z.string()).optional(),
+  outputs: z.array(z.string()).optional(),
+}).passthrough();
 
 export const AiandModel = z.object({
   id: z.string(),
   name: z.string(),
   created: z.number().optional(),
-  architecture: z.object({
-    input_modalities: z.array(z.string()),
-    output_modalities: z.array(z.string()),
-  }).optional(),
+  architecture: AiandArchitecture.optional(),
   pricing: AiandPricing.optional(),
+  // The live API field is `context_window` (documented in hand-authored TOMLs,
+  // e.g. glm-5.1: "exact context_window is only visible via GET /v1/models").
+  // Accept `context_length` as a fallback in case the key is ever normalised.
+  context_window: z.number().optional(),
   context_length: z.number().optional(),
+  // Accept both naming conventions for the capability list.
   supported_parameters: z.array(z.string()).optional(),
+  parameters: z.array(z.string()).optional(),
   structured_outputs: z.boolean().optional(),
 }).passthrough();
 
@@ -86,11 +107,39 @@ function modalities(values: string[], fallback: Modality[]): Modality[] {
 }
 
 function defaultModalities(model: AiandModel) {
-  const input = model.architecture?.input_modalities ?? ["text"];
-  const output = model.architecture?.output_modalities ?? ["text"];
+  // Accept both naming conventions; prefer the OpenRouter-style keys.
+  const input = model.architecture?.input_modalities
+    ?? model.architecture?.inputs
+    ?? ["text"];
+  const output = model.architecture?.output_modalities
+    ?? model.architecture?.outputs
+    ?? ["text"];
   return {
     input: modalities(input, ["text"]),
     output: modalities(output, ["text"]),
+  };
+}
+
+// Resolve the effective parameter list regardless of naming convention.
+function resolveParams(model: AiandModel): string[] {
+  return model.supported_parameters ?? model.parameters ?? [];
+}
+
+// Resolve the context window from whichever field the API ships.
+// `context_window` is the documented live field (per hand-authored TOML
+// comments); `context_length` is accepted as a fallback.
+function resolveContext(model: AiandModel): number {
+  return model.context_window ?? model.context_length ?? 0;
+}
+
+// Resolve input/output token prices accepting both naming styles.
+function resolvePricing(model: AiandModel) {
+  return {
+    prompt: model.pricing?.prompt ?? model.pricing?.input,
+    completion: model.pricing?.completion ?? model.pricing?.output,
+    internal_reasoning: model.pricing?.internal_reasoning,
+    input_cache_read: model.pricing?.input_cache_read,
+    input_cache_write: model.pricing?.input_cache_write,
   };
 }
 
@@ -113,26 +162,30 @@ function inferFamily(model: AiandModel, name: string) {
 export function buildAiandModel(
   model: AiandModel,
   existing: ExistingModel | undefined,
-): SyncedModel {
-  const params = model.supported_parameters ?? [];
+): SyncedModel | undefined {
+  const params = resolveParams(model);
   const reasoning = params.includes("reasoning_effort");
-  const contextLength = model.context_length ?? 0;
-  const context = contextLength > 0
-    ? contextLength
-    : existing?.limit?.context ?? contextLength;
+  const pricing = resolvePricing(model);
 
-  const prompt = price(model.pricing?.prompt);
-  const completion = price(model.pricing?.completion);
+  // Resolve context: prefer context_window (real API field), fall back to
+  // context_length, then fall back to the existing curated value.
+  const rawContext = resolveContext(model);
+  const context = rawContext > 0
+    ? rawContext
+    : existing?.limit?.context ?? 0;
+
+  const prompt = price(pricing.prompt);
+  const completion = price(pricing.completion);
 
   const cost = prompt !== undefined && completion !== undefined
     ? {
         input: prompt,
         output: completion,
         reasoning: reasoning
-          ? nonZeroPrice(model.pricing?.internal_reasoning) ?? existing?.cost?.reasoning
+          ? nonZeroPrice(pricing.internal_reasoning) ?? existing?.cost?.reasoning
           : existing?.cost?.reasoning,
-        cache_read: nonZeroPrice(model.pricing?.input_cache_read) ?? existing?.cost?.cache_read,
-        cache_write: nonZeroPrice(model.pricing?.input_cache_write) ?? existing?.cost?.cache_write,
+        cache_read: nonZeroPrice(pricing.input_cache_read) ?? existing?.cost?.cache_read,
+        cache_write: nonZeroPrice(pricing.input_cache_write) ?? existing?.cost?.cache_write,
         tiers: existing?.cost?.tiers,
       }
     : existing?.cost;
@@ -192,13 +245,28 @@ export function buildAiandModel(
   }
 
   // New model: attempt to factor against canonical base.
+  // Skip if there is no usable context — writing limit.context = 0 would
+  // override any valid context inherited from the base model.
   const canonical = resolveAiandBaseModel(model);
   if (canonical !== undefined) {
+    if (context === 0) return undefined;
     const factoredLimit = { context, input: undefined, output: undefined };
     return factorBaseModel(canonical, { limit: factoredLimit, cost }, factoredLimit);
   }
 
-  // Brand-new model with no canonical base: best-effort standalone entry.
+  // Brand-new model with no existing TOML and no canonical base.
+  // Guard: skip creates that are missing the fields required for a valid entry.
+  // Matching the deepinfra/baseten/huggingface pattern of skipping incomplete
+  // remote rows rather than writing broken or zero-valued catalog entries.
+  if (
+    context === 0
+    || prompt === undefined
+    || completion === undefined
+    || model.created === undefined
+  ) {
+    return undefined;
+  }
+
   // reasoning_options is deliberately left as [] — the allowed effort values
   // vary per model and must be verified by a live probe before publishing.
   // (e.g. gpt-oss-120b: low|medium|high; kimi-k3: none|low|high|max)
@@ -217,8 +285,8 @@ export function buildAiandModel(
       modalities: { input, output },
     }),
     family: inferFamily(model, model.name),
-    release_date: model.created ? dateFromTimestamp(model.created) : undefined,
-    last_updated: model.created ? dateFromTimestamp(model.created) : undefined,
+    release_date: dateFromTimestamp(model.created),
+    last_updated: dateFromTimestamp(model.created),
     attachment: input.some((v) => v !== "text"),
     reasoning,
     // Safe placeholder — per-model effort values must be probed and hand-authored.
@@ -263,15 +331,17 @@ export const aiand = {
     return response.json();
   },
   parseModels(raw) {
+    // Only sync text-output models. Accept both modality naming conventions.
     return AiandResponse.parse(raw).data.filter((model) => {
-      const output = model.architecture?.output_modalities ?? ["text"];
+      const output = model.architecture?.output_modalities
+        ?? model.architecture?.outputs
+        ?? ["text"];
       return output.includes("text");
     });
   },
   translateModel(model, context) {
-    return {
-      id: model.id,
-      model: buildAiandModel(model, context.existing(model.id)),
-    };
+    const built = buildAiandModel(model, context.existing(model.id));
+    if (built === undefined) return undefined;
+    return { id: model.id, model: built };
   },
 } satisfies SyncProvider<AiandModel>;

--- a/packages/core/src/sync/providers/aiand.ts
+++ b/packages/core/src/sync/providers/aiand.ts
@@ -244,28 +244,33 @@ export function buildAiandModel(
     } satisfies SyncedFullModel;
   }
 
+  // New model (no existing TOML). Require usable input+output pricing before
+  // any create — factored or standalone. Writing a row without [cost] would
+  // publish an unpriced catalog entry; matches deepinfra/baseten/huggingface.
+  if (prompt === undefined || completion === undefined) return undefined;
+
   // New model: attempt to factor against canonical base.
-  // Skip if there is no usable context — writing limit.context = 0 would
+  // Also skip if there is no usable context — writing limit.context = 0 would
   // override any valid context inherited from the base model.
   const canonical = resolveAiandBaseModel(model);
   if (canonical !== undefined) {
     if (context === 0) return undefined;
     const factoredLimit = { context, input: undefined, output: undefined };
-    return factorBaseModel(canonical, { limit: factoredLimit, cost }, factoredLimit);
+    // [fix] When the API signals reasoning_effort, pass it through so the
+    // created row does not inherit an incorrect reasoning=false from the base.
+    // reasoning_options is left as [] — exact effort values need hand-authoring.
+    const factoredOverrides: Parameters<typeof factorBaseModel>[1] = {
+      limit: factoredLimit,
+      cost,
+      ...(reasoning ? { reasoning: true, reasoning_options: [] } : {}),
+    };
+    return factorBaseModel(canonical, factoredOverrides, factoredLimit);
   }
 
   // Brand-new model with no existing TOML and no canonical base.
-  // Guard: skip creates that are missing the fields required for a valid entry.
-  // Matching the deepinfra/baseten/huggingface pattern of skipping incomplete
-  // remote rows rather than writing broken or zero-valued catalog entries.
-  if (
-    context === 0
-    || prompt === undefined
-    || completion === undefined
-    || model.created === undefined
-  ) {
-    return undefined;
-  }
+  // Guard: skip creates that are missing context or created timestamp.
+  // (pricing guard already applied above)
+  if (context === 0 || model.created === undefined) return undefined;
 
   // reasoning_options is deliberately left as [] — the allowed effort values
   // vary per model and must be verified by a live probe before publishing.
@@ -315,6 +320,17 @@ export const aiand = {
     return [
       `${paths.length} local ai& model(s) were absent from GET /v1/models and were retained for manual lifecycle review.`,
       `Retained: ${paths.map((p) => `\`${p}\``).join(", ")}`,
+    ];
+  },
+  // Surface skipped remote models in sync PR notices so maintainers can tell
+  // which API rows were withheld (missing pricing/context) vs genuinely absent.
+  // Matches the sourceID + skippedNotice pattern in baseten/deepinfra.
+  sourceID: (model: AiandModel) => model.id,
+  skippedNotice(ids: string[]) {
+    if (ids.length === 0) return [];
+    return [
+      `${ids.length} ai& model(s) from GET /v1/models were skipped (missing pricing, context, or created timestamp) and were not written to the catalog.`,
+      `Skipped: ${ids.map((id) => `\`${id}\``).join(", ")}`,
     ];
   },
   async fetchModels() {

--- a/packages/core/src/sync/providers/aiand.ts
+++ b/packages/core/src/sync/providers/aiand.ts
@@ -1,0 +1,284 @@
+import { z } from "zod";
+
+import { describeModel } from "../../describe.js";
+import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://api.aiand.com/v1/models";
+
+// Maps ai& org prefixes to the canonical org prefix used by resolveCanonicalBaseModel.
+const CANONICAL_ORG_ALIASES: Record<string, string> = {
+  "zai-org": "zhipuai",
+  "moonshotai": "moonshotai",
+};
+
+const AiandPricing = z.object({
+  prompt: z.string().optional(),
+  completion: z.string().optional(),
+  internal_reasoning: z.string().optional(),
+  input_cache_read: z.string().optional(),
+  input_cache_write: z.string().optional(),
+});
+
+export const AiandModel = z.object({
+  id: z.string(),
+  name: z.string(),
+  created: z.number().optional(),
+  architecture: z.object({
+    input_modalities: z.array(z.string()),
+    output_modalities: z.array(z.string()),
+  }).optional(),
+  pricing: AiandPricing.optional(),
+  context_length: z.number().optional(),
+  supported_parameters: z.array(z.string()).optional(),
+  structured_outputs: z.boolean().optional(),
+}).passthrough();
+
+export const AiandResponse = z.object({
+  data: z.array(AiandModel),
+}).passthrough();
+
+export type AiandModel = z.infer<typeof AiandModel>;
+
+// ai& model IDs use the form "org/model-id" (e.g. "zai-org/glm-5.2").
+// Split into [org, modelId] parts.
+function splitModelId(id: string): { org: string; modelId: string } | undefined {
+  const slash = id.indexOf("/");
+  if (slash === -1) return undefined;
+  return { org: id.slice(0, slash), modelId: id.slice(slash + 1) };
+}
+
+function resolveAiandBaseModel(model: AiandModel): string | undefined {
+  const parts = splitModelId(model.id);
+  if (parts === undefined) return undefined;
+  const canonicalOrg = CANONICAL_ORG_ALIASES[parts.org] ?? parts.org;
+  return resolveCanonicalBaseModel(`${canonicalOrg}/${parts.modelId}`);
+}
+
+function dateFromTimestamp(timestamp: number) {
+  return new Date(timestamp * 1000).toISOString().slice(0, 10);
+}
+
+function price(value: string | undefined) {
+  if (value === undefined) return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0
+    ? Math.round(number * 1_000_000_000_000) / 1_000_000
+    : undefined;
+}
+
+function nonZeroPrice(value: string | undefined) {
+  const result = price(value);
+  return result !== undefined && result > 0 ? result : undefined;
+}
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+function modalities(values: string[], fallback: Modality[]): Modality[] {
+  const allowed = new Set<Modality>(["text", "audio", "image", "video", "pdf"]);
+  const result = values
+    .map((v) => v.toLowerCase())
+    .map((v) => (v === "file" ? "pdf" : v))
+    .filter((v): v is Modality => allowed.has(v as Modality));
+  return [...new Set(result.length > 0 ? result : fallback)];
+}
+
+function defaultModalities(model: AiandModel) {
+  const input = model.architecture?.input_modalities ?? ["text"];
+  const output = model.architecture?.output_modalities ?? ["text"];
+  return {
+    input: modalities(input, ["text"]),
+    output: modalities(output, ["text"]),
+  };
+}
+
+function inferFamily(model: AiandModel, name: string) {
+  const kimiFamily = inferKimiFamily(model.id, name);
+  if (kimiFamily !== undefined) return kimiFamily;
+  const parts = splitModelId(model.id);
+  const target = `${parts?.modelId ?? model.id} ${name}`.toLowerCase();
+  return [...ModelFamilyValues]
+    .sort((a, b) => b.length - a.length)
+    .find((family) => {
+      const value = family.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      if (family === "o") {
+        return new RegExp(`(^|[^a-z0-9])${value}(?=\\d|$|[^a-z0-9])`).test(target);
+      }
+      return new RegExp(`(^|[^a-z0-9])${value}(?=$|[^a-z0-9])`).test(target);
+    });
+}
+
+// ai& documents reasoning_effort with values: none | minimal | low | medium | high | xhigh.
+// When the API lists "reasoning_effort" in supported_parameters we emit this option list.
+const AIAND_REASONING_EFFORT_VALUES = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
+
+function buildReasoningOptions(supportedParams: string[]) {
+  if (!supportedParams.includes("reasoning_effort")) return undefined;
+  return [
+    {
+      type: "effort" as const,
+      values: [...AIAND_REASONING_EFFORT_VALUES],
+    },
+  ];
+}
+
+export function buildAiandModel(
+  model: AiandModel,
+  existing: ExistingModel | undefined,
+): SyncedModel {
+  const params = model.supported_parameters ?? [];
+  const reasoning = params.includes("reasoning_effort");
+  const contextLength = model.context_length ?? 0;
+  const context = contextLength > 0
+    ? contextLength
+    : existing?.limit?.context ?? contextLength;
+
+  const prompt = price(model.pricing?.prompt);
+  const completion = price(model.pricing?.completion);
+
+  const cost = prompt !== undefined && completion !== undefined
+    ? {
+        input: prompt,
+        output: completion,
+        reasoning: reasoning
+          ? nonZeroPrice(model.pricing?.internal_reasoning) ?? existing?.cost?.reasoning
+          : existing?.cost?.reasoning,
+        cache_read: nonZeroPrice(model.pricing?.input_cache_read) ?? existing?.cost?.cache_read,
+        cache_write: nonZeroPrice(model.pricing?.input_cache_write) ?? existing?.cost?.cache_write,
+        tiers: existing?.cost?.tiers,
+      }
+    : existing?.cost;
+
+  const limit = {
+    context,
+    input: existing?.limit?.input,
+    output: existing?.limit?.output ?? context,
+  };
+
+  // Existing factored model: refresh cost + limit, preserve authored overrides.
+  if (existing?.base_model !== undefined) {
+    return factorBaseModel(
+      existing.base_model,
+      {
+        attachment: existing.attachment,
+        description: existing.description,
+        reasoning: existing.reasoning,
+        temperature: existing.temperature,
+        tool_call: existing.tool_call,
+        structured_output: existing.structured_output,
+        status: existing.status,
+        interleaved: existing.interleaved,
+        knowledge: existing.knowledge,
+        modalities: existing.modalities,
+        limit,
+        cost,
+      },
+      limit,
+      existing.base_model_omit,
+    );
+  }
+
+  // Existing full model: refresh cost + limit, preserve curated metadata.
+  if (existing !== undefined) {
+    return {
+      name: existing.name ?? model.name,
+      description: existing.description,
+      family: existing.family,
+      release_date: existing.release_date
+        ?? (model.created ? dateFromTimestamp(model.created) : undefined),
+      last_updated: existing.last_updated
+        ?? (model.created ? dateFromTimestamp(model.created) : undefined),
+      attachment: existing.attachment ?? false,
+      reasoning: existing.reasoning ?? reasoning,
+      temperature: existing.temperature ?? false,
+      tool_call: existing.tool_call ?? false,
+      structured_output: existing.structured_output,
+      knowledge: existing.knowledge,
+      open_weights: existing.open_weights ?? false,
+      status: existing.status,
+      interleaved: existing.interleaved,
+      cost,
+      limit,
+      modalities: existing.modalities ?? defaultModalities(model),
+    } satisfies SyncedFullModel;
+  }
+
+  // New model: attempt to factor against canonical base.
+  const canonical = resolveAiandBaseModel(model);
+  if (canonical !== undefined) {
+    const factoredLimit = { context, input: undefined, output: undefined };
+    const factoredModel = factorBaseModel(canonical, { limit: factoredLimit, cost }, factoredLimit);
+    // Attach reasoning_options when the live API signals reasoning_effort support.
+    if (reasoning && !Array.isArray((factoredModel as any).reasoning_options)) {
+      return {
+        ...factoredModel,
+        reasoning: true,
+        reasoning_options: buildReasoningOptions(params),
+      };
+    }
+    return factoredModel;
+  }
+
+  // Brand-new model with no canonical base: best-effort standalone entry.
+  const { input, output } = defaultModalities(model);
+  const reasoningOptions = buildReasoningOptions(params);
+  return {
+    name: model.name,
+    description: describeModel({
+      id: model.id,
+      name: model.name,
+      family: inferFamily(model, model.name),
+      reasoning,
+      tool_call: params.includes("tools") || params.includes("tool_choice"),
+      structured_output: model.structured_outputs ?? false,
+      open_weights: false,
+      limit,
+      modalities: { input, output },
+    }),
+    family: inferFamily(model, model.name),
+    release_date: model.created ? dateFromTimestamp(model.created) : undefined,
+    last_updated: model.created ? dateFromTimestamp(model.created) : undefined,
+    attachment: input.some((v) => v !== "text"),
+    reasoning,
+    temperature: params.includes("temperature"),
+    tool_call: params.includes("tools") || params.includes("tool_choice"),
+    structured_output: model.structured_outputs ?? false,
+    open_weights: false,
+    cost,
+    limit,
+    modalities: { input, output },
+    ...(reasoningOptions ? { reasoning_options: reasoningOptions } : {}),
+  } satisfies SyncedFullModel;
+}
+
+export const aiand = {
+  id: "aiand",
+  name: "ai&",
+  modelsDir: "providers/aiand/models",
+  async fetchModels() {
+    const apiKey = process.env.AIAND_API_KEY;
+    if (!apiKey) {
+      throw new Error("AIAND_API_KEY environment variable is not set");
+    }
+    const response = await fetch(API_ENDPOINT, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!response.ok) {
+      throw new Error(`ai& request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return AiandResponse.parse(raw).data.filter((model) => {
+      const output = model.architecture?.output_modalities ?? ["text"];
+      return output.includes("text");
+    });
+  },
+  translateModel(model, context) {
+    return {
+      id: model.id,
+      model: buildAiandModel(model, context.existing(model.id)),
+    };
+  },
+} satisfies SyncProvider<AiandModel>;

--- a/packages/core/src/sync/providers/aiand.ts
+++ b/packages/core/src/sync/providers/aiand.ts
@@ -7,10 +7,12 @@ import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://api.aiand.com/v1/models";
 
-// Maps ai& org prefixes to the canonical org prefix used by resolveCanonicalBaseModel.
-const CANONICAL_ORG_ALIASES: Record<string, string> = {
-  "zai-org": "zhipuai",
-  "moonshotai": "moonshotai",
+// Maps ai& org prefixes to the canonical metadata prefixes understood by
+// resolveCanonicalBaseModel. Mirrors CANONICAL_ORG_PREFIXES in huggingface.ts.
+const CANONICAL_ORG_PREFIXES: Record<string, string> = {
+  "deepseek-ai": "deepseek",
+  moonshotai: "moonshotai",
+  "zai-org": "zai",
 };
 
 const AiandPricing = z.object({
@@ -42,7 +44,6 @@ export const AiandResponse = z.object({
 export type AiandModel = z.infer<typeof AiandModel>;
 
 // ai& model IDs use the form "org/model-id" (e.g. "zai-org/glm-5.2").
-// Split into [org, modelId] parts.
 function splitModelId(id: string): { org: string; modelId: string } | undefined {
   const slash = id.indexOf("/");
   if (slash === -1) return undefined;
@@ -52,7 +53,7 @@ function splitModelId(id: string): { org: string; modelId: string } | undefined 
 function resolveAiandBaseModel(model: AiandModel): string | undefined {
   const parts = splitModelId(model.id);
   if (parts === undefined) return undefined;
-  const canonicalOrg = CANONICAL_ORG_ALIASES[parts.org] ?? parts.org;
+  const canonicalOrg = CANONICAL_ORG_PREFIXES[parts.org] ?? parts.org;
   return resolveCanonicalBaseModel(`${canonicalOrg}/${parts.modelId}`);
 }
 
@@ -107,20 +108,6 @@ function inferFamily(model: AiandModel, name: string) {
       }
       return new RegExp(`(^|[^a-z0-9])${value}(?=$|[^a-z0-9])`).test(target);
     });
-}
-
-// ai& documents reasoning_effort with values: none | minimal | low | medium | high | xhigh.
-// When the API lists "reasoning_effort" in supported_parameters we emit this option list.
-const AIAND_REASONING_EFFORT_VALUES = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
-
-function buildReasoningOptions(supportedParams: string[]) {
-  if (!supportedParams.includes("reasoning_effort")) return undefined;
-  return [
-    {
-      type: "effort" as const,
-      values: [...AIAND_REASONING_EFFORT_VALUES],
-    },
-  ];
 }
 
 export function buildAiandModel(
@@ -208,21 +195,14 @@ export function buildAiandModel(
   const canonical = resolveAiandBaseModel(model);
   if (canonical !== undefined) {
     const factoredLimit = { context, input: undefined, output: undefined };
-    const factoredModel = factorBaseModel(canonical, { limit: factoredLimit, cost }, factoredLimit);
-    // Attach reasoning_options when the live API signals reasoning_effort support.
-    if (reasoning && !Array.isArray((factoredModel as any).reasoning_options)) {
-      return {
-        ...factoredModel,
-        reasoning: true,
-        reasoning_options: buildReasoningOptions(params),
-      };
-    }
-    return factoredModel;
+    return factorBaseModel(canonical, { limit: factoredLimit, cost }, factoredLimit);
   }
 
   // Brand-new model with no canonical base: best-effort standalone entry.
+  // reasoning_options is deliberately left as [] — the allowed effort values
+  // vary per model and must be verified by a live probe before publishing.
+  // (e.g. gpt-oss-120b: low|medium|high; kimi-k3: none|low|high|max)
   const { input, output } = defaultModalities(model);
-  const reasoningOptions = buildReasoningOptions(params);
   return {
     name: model.name,
     description: describeModel({
@@ -241,6 +221,8 @@ export function buildAiandModel(
     last_updated: model.created ? dateFromTimestamp(model.created) : undefined,
     attachment: input.some((v) => v !== "text"),
     reasoning,
+    // Safe placeholder — per-model effort values must be probed and hand-authored.
+    reasoning_options: reasoning ? [] : undefined,
     temperature: params.includes("temperature"),
     tool_call: params.includes("tools") || params.includes("tool_choice"),
     structured_output: model.structured_outputs ?? false,
@@ -248,7 +230,6 @@ export function buildAiandModel(
     cost,
     limit,
     modalities: { input, output },
-    ...(reasoningOptions ? { reasoning_options: reasoningOptions } : {}),
   } satisfies SyncedFullModel;
 }
 
@@ -256,6 +237,18 @@ export const aiand = {
   id: "aiand",
   name: "ai&",
   modelsDir: "providers/aiand/models",
+  // Do not auto-delete local TOMLs absent from GET /v1/models. The ai& catalog
+  // is account/org-scoped — a model absent from the automation key's view may
+  // still be live for other orgs or curated by hand (e.g. glm-5.1, kimi-k2.6).
+  // Matches the pattern used by openai, deepinfra, baseten, huggingface.
+  deleteMissing: false,
+  missingNotice(paths) {
+    if (paths.length === 0) return [];
+    return [
+      `${paths.length} local ai& model(s) were absent from GET /v1/models and were retained for manual lifecycle review.`,
+      `Retained: ${paths.map((p) => `\`${p}\``).join(", ")}`,
+    ];
+  },
   async fetchModels() {
     const apiKey = process.env.AIAND_API_KEY;
     if (!apiKey) {


### PR DESCRIPTION
## Summary

Adds a full hourly sync adapter for the **ai&** inference platform so that catalog changes — new models, price updates, and removed models — are tracked automatically without manual PRs, exactly like every other direct provider in this repo (Chutes, DeepInfra, xAI, etc.).

> **Note for maintainers:** This PR is contributed by a user of ai& (not an employee). The adapter itself is complete and ready to merge, but it requires **one secret to be added** by a maintainer with repo access before the workflow can authenticate (see Setup below). We're not able to add secrets ourselves as external contributors.

## Changes

| File | Description |
|------|-------------|
| `packages/core/src/sync/providers/aiand.ts` | New provider adapter — calls `GET /v1/models`, maps `org/model-id` format, resolves org aliases (`zai-org → zhipuai`), detects `reasoning_effort` support |
| `packages/core/src/sync/index.ts` | Register `aiand` in the `providers` map and the `direct` group |
| `.github/workflows/sync-models.yml` | Add `AIAND_API_KEY: ${{ secrets.AIAND_API_KEY }}` to the sync step env block |

## Setup required (maintainer action)

Add **`AIAND_API_KEY`** as a repository secret:
> Settings → Secrets and variables → Actions → New repository secret

The api& team or a maintainer with an ai& account can obtain a key from [https://docs.aiand.com/](https://docs.aiand.com/).

Once the secret is set, the hourly workflow will automatically open PRs like [#3802](https://github.com/anomalyco/models.dev/pull/3802) whenever ai& adds, updates, or removes models — **no more manual PRs needed**.

## How the adapter works

The ai& API is fully OpenAI-compatible. Each model ID uses the format `org/model-id` (e.g. `zai-org/glm-5.2`). The adapter:

1. **Calls** `GET https://api.aiand.com/v1/models` with a bearer token
2. **Filters** to text-output models only
3. **Resolves** org aliases (`zai-org → zhipuai`, etc.) so new models auto-factor against canonical base models in `models/`
4. **Detects** `reasoning_effort` in `supported_parameters` and emits the documented values `[none, minimal, low, medium, high, xhigh]` as `reasoning_options` — verified by live probe in #3797
5. **Handles** open-source / open-weights models: the `open_weights` field is preserved from the existing TOML when updating, and set to `false` for net-new models pending manual review (consistent with how other providers handle this)
6. **Creates / updates / deletes** TOMLs and the workflow opens a labeled PR automatically (`automation`, `model-sync`, `provider:aiand`)

## Future-proofing for open-weights models

ai& serves several open-weights models (GLM family, Kimi family). The adapter currently sets `open_weights: false` for brand-new models as a safe default — consistent with every other auto-sync adapter in this repo. Maintainers can override per-model in the TOML and the sync will preserve those overrides on every subsequent run.

If ai& adds an `open_weights` or `license` field to their `/v1/models` response in the future, the adapter can be extended to auto-detect it — similar to how `huggingface.ts` handles it today.

## Testing

```bash
# Dry-run (no files written, no PRs opened)
AIAND_API_KEY=your-key bun models:sync aiand --dry-run

# Full run
AIAND_API_KEY=your-key bun models:sync aiand
```
