### PR TITLE
feat(provider): add TokenBay provider and 16 supported models

### DIFF
--- a/providers/tokenbay/logo.svg
+++ b/providers/tokenbay/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 458 458" fill="currentColor" role="img" aria-labelledby="tokenbay-logo-title">
+  <title id="tokenbay-logo-title">TokenBay</title>
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M111 0h236c61.3 0 111 49.7 111 111v236c0 61.3-49.7 111-111 111H111C49.7 458 0 408.3 0 347V111C0 49.7 49.7 0 111 0Zm43 342 24-194h-70l11-40h147c20 0 39 8 53 24 12 15 17 36 11 69-12-6-25-11-42-14 0-18-4-28-17-36-5-3-12-4-19-4h-36l-23 195h-39Zm56 1 5-41 70-2c13-1 22-8 28-20 5-10 3-23-10-31-8-6-18-9-32-9h-49l5-38h67c21 2 39 14 50 35 10 18 11 43 0 67-12 25-32 38-56 38l-78 1Z"
+  />
+</svg>

--- a/providers/tokenbay/models/claude-opus-4.8.toml
+++ b/providers/tokenbay/models/claude-opus-4.8.toml
@@ -1,3 +1,5 @@
+# Anthropic Messages: POST https://api.tokenbay.com/v1/messages
+# https://www.tokenbay.com/docs/reference/text/anthropic/messages
 base_model = "anthropic/claude-opus-4-8"
 structured_output = true
 
@@ -13,6 +15,4 @@ cache_write = 5.3125
 
 [provider]
 npm = "@ai-sdk/anthropic"
-# Anthropic Messages: POST https://api.tokenbay.com/v1/messages
-# https://www.tokenbay.com/docs/reference/text/anthropic/messages
 api = "https://api.tokenbay.com/v1"

--- a/providers/tokenbay/models/claude-opus-4.8.toml
+++ b/providers/tokenbay/models/claude-opus-4.8.toml
@@ -13,3 +13,6 @@ cache_write = 5.3125
 
 [provider]
 npm = "@ai-sdk/anthropic"
+# Anthropic Messages: POST https://api.tokenbay.com/v1/messages
+# https://www.tokenbay.com/docs/reference/text/anthropic/messages
+api = "https://api.tokenbay.com/v1"

--- a/providers/tokenbay/models/claude-opus-4.8.toml
+++ b/providers/tokenbay/models/claude-opus-4.8.toml
@@ -10,3 +10,6 @@ input = 4.25
 output = 21.25
 cache_read = 0.425
 cache_write = 5.3125
+
+[provider]
+npm = "@ai-sdk/anthropic"

--- a/providers/tokenbay/models/claude-opus-4.8.toml
+++ b/providers/tokenbay/models/claude-opus-4.8.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-8"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 4.25
+output = 21.25
+cache_read = 0.425
+cache_write = 5.3125

--- a/providers/tokenbay/models/claude-sonnet-4.6.toml
+++ b/providers/tokenbay/models/claude-sonnet-4.6.toml
@@ -5,6 +5,10 @@ structured_output = true
 type = "effort"
 values = ["low", "medium", "high", "max"]
 
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
 [limit]
 output = 128_000
 

--- a/providers/tokenbay/models/claude-sonnet-4.6.toml
+++ b/providers/tokenbay/models/claude-sonnet-4.6.toml
@@ -5,10 +5,6 @@ structured_output = true
 type = "effort"
 values = ["low", "medium", "high", "max"]
 
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
-
 [limit]
 output = 128_000
 
@@ -20,3 +16,6 @@ cache_write = 3.1875
 
 [provider]
 npm = "@ai-sdk/anthropic"
+# Anthropic Messages: POST https://api.tokenbay.com/v1/messages
+# https://www.tokenbay.com/docs/reference/text/anthropic/messages
+api = "https://api.tokenbay.com/v1"

--- a/providers/tokenbay/models/claude-sonnet-4.6.toml
+++ b/providers/tokenbay/models/claude-sonnet-4.6.toml
@@ -17,3 +17,6 @@ input = 2.55
 output = 12.75
 cache_read = 0.255
 cache_write = 3.1875
+
+[provider]
+npm = "@ai-sdk/anthropic"

--- a/providers/tokenbay/models/claude-sonnet-4.6.toml
+++ b/providers/tokenbay/models/claude-sonnet-4.6.toml
@@ -1,0 +1,19 @@
+base_model = "anthropic/claude-sonnet-4-6"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[limit]
+output = 128_000
+
+[cost]
+input = 2.55
+output = 12.75
+cache_read = 0.255
+cache_write = 3.1875

--- a/providers/tokenbay/models/claude-sonnet-4.6.toml
+++ b/providers/tokenbay/models/claude-sonnet-4.6.toml
@@ -1,3 +1,5 @@
+# Anthropic Messages: POST https://api.tokenbay.com/v1/messages
+# https://www.tokenbay.com/docs/reference/text/anthropic/messages
 base_model = "anthropic/claude-sonnet-4-6"
 structured_output = true
 
@@ -20,6 +22,4 @@ cache_write = 3.1875
 
 [provider]
 npm = "@ai-sdk/anthropic"
-# Anthropic Messages: POST https://api.tokenbay.com/v1/messages
-# https://www.tokenbay.com/docs/reference/text/anthropic/messages
 api = "https://api.tokenbay.com/v1"

--- a/providers/tokenbay/models/deepseek-v4-flash.toml
+++ b/providers/tokenbay/models/deepseek-v4-flash.toml
@@ -1,0 +1,16 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.119
+output = 0.238
+cache_read = 0.00238

--- a/providers/tokenbay/models/deepseek-v4-flash.toml
+++ b/providers/tokenbay/models/deepseek-v4-flash.toml
@@ -1,9 +1,6 @@
 base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
 values = ["high", "max"]
 

--- a/providers/tokenbay/models/deepseek-v4-flash.toml
+++ b/providers/tokenbay/models/deepseek-v4-flash.toml
@@ -1,7 +1,7 @@
-base_model = "deepseek/deepseek-v4-flash"
-
 # TokenBay Chat Completions documents reasoning_effort but not thinking.type.
 # https://www.tokenbay.com/docs/reference/text/openai/chat-completions
+base_model = "deepseek/deepseek-v4-flash"
+
 [[reasoning_options]]
 type = "effort"
 values = ["high", "max"]

--- a/providers/tokenbay/models/deepseek-v4-flash.toml
+++ b/providers/tokenbay/models/deepseek-v4-flash.toml
@@ -1,7 +1,10 @@
-# TokenBay Chat Completions documents reasoning_effort = low|high|max but not
-# thinking.type.
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
 # https://www.tokenbay.com/docs/reference/text/openai/chat-completions
 base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/tokenbay/models/deepseek-v4-flash.toml
+++ b/providers/tokenbay/models/deepseek-v4-flash.toml
@@ -1,10 +1,11 @@
-# TokenBay Chat Completions documents reasoning_effort but not thinking.type.
+# TokenBay Chat Completions documents reasoning_effort = low|high|max but not
+# thinking.type.
 # https://www.tokenbay.com/docs/reference/text/openai/chat-completions
 base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["low", "high", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/tokenbay/models/deepseek-v4-flash.toml
+++ b/providers/tokenbay/models/deepseek-v4-flash.toml
@@ -1,5 +1,7 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+# TokenBay Chat Completions documents reasoning_effort but not thinking.type.
+# https://www.tokenbay.com/docs/reference/text/openai/chat-completions
 [[reasoning_options]]
 type = "effort"
 values = ["high", "max"]

--- a/providers/tokenbay/models/deepseek-v4-pro.toml
+++ b/providers/tokenbay/models/deepseek-v4-pro.toml
@@ -1,5 +1,7 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+# TokenBay Chat Completions documents reasoning_effort but not thinking.type.
+# https://www.tokenbay.com/docs/reference/text/openai/chat-completions
 [[reasoning_options]]
 type = "effort"
 values = ["high", "max"]

--- a/providers/tokenbay/models/deepseek-v4-pro.toml
+++ b/providers/tokenbay/models/deepseek-v4-pro.toml
@@ -1,7 +1,7 @@
-base_model = "deepseek/deepseek-v4-pro"
-
 # TokenBay Chat Completions documents reasoning_effort but not thinking.type.
 # https://www.tokenbay.com/docs/reference/text/openai/chat-completions
+base_model = "deepseek/deepseek-v4-pro"
+
 [[reasoning_options]]
 type = "effort"
 values = ["high", "max"]

--- a/providers/tokenbay/models/deepseek-v4-pro.toml
+++ b/providers/tokenbay/models/deepseek-v4-pro.toml
@@ -1,0 +1,16 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.36975
+output = 0.7395
+cache_read = 0.003081

--- a/providers/tokenbay/models/deepseek-v4-pro.toml
+++ b/providers/tokenbay/models/deepseek-v4-pro.toml
@@ -1,9 +1,6 @@
 base_model = "deepseek/deepseek-v4-pro"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
 values = ["high", "max"]
 

--- a/providers/tokenbay/models/deepseek-v4-pro.toml
+++ b/providers/tokenbay/models/deepseek-v4-pro.toml
@@ -1,6 +1,10 @@
-# TokenBay Chat Completions documents reasoning_effort but not thinking.type.
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high|max
 # https://www.tokenbay.com/docs/reference/text/openai/chat-completions
 base_model = "deepseek/deepseek-v4-pro"
+
+[[reasoning_options]]
+type = "toggle"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/tokenbay/models/gemini-2.5-flash.toml
+++ b/providers/tokenbay/models/gemini-2.5-flash.toml
@@ -1,0 +1,15 @@
+base_model = "google/gemini-2.5-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 24_576
+
+[cost]
+input = 0.30
+output = 2.50
+cache_read = 0.03
+input_audio = 1.00

--- a/providers/tokenbay/models/gemini-2.5-flash.toml
+++ b/providers/tokenbay/models/gemini-2.5-flash.toml
@@ -1,5 +1,14 @@
+# Toggle/budget: generationConfig.thinkingConfig.thinkingBudget = 0 disables
+# thinking; positive values up to 24_576 set the reasoning-token budget.
 base_model = "google/gemini-2.5-flash"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 24_576
 
 [cost]
 input = 0.30

--- a/providers/tokenbay/models/gemini-2.5-flash.toml
+++ b/providers/tokenbay/models/gemini-2.5-flash.toml
@@ -1,3 +1,4 @@
+# Native Gemini: POST https://api.tokenbay.com/v1beta/models/{model}:generateContent
 # Toggle/budget: generationConfig.thinkingConfig.thinkingBudget = 0 disables
 # thinking; positive values up to 24_576 set the reasoning-token budget.
 base_model = "google/gemini-2.5-flash"
@@ -15,3 +16,7 @@ input = 0.30
 output = 2.50
 cache_read = 0.03
 input_audio = 1.00
+
+[provider]
+npm = "@ai-sdk/google"
+api = "https://api.tokenbay.com/v1beta"

--- a/providers/tokenbay/models/gemini-2.5-flash.toml
+++ b/providers/tokenbay/models/gemini-2.5-flash.toml
@@ -1,12 +1,5 @@
 base_model = "google/gemini-2.5-flash"
-
-[[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 0
-max = 24_576
+reasoning_options = []
 
 [cost]
 input = 0.30

--- a/providers/tokenbay/models/gemini-2.5-pro.toml
+++ b/providers/tokenbay/models/gemini-2.5-pro.toml
@@ -1,0 +1,17 @@
+base_model = "google/gemini-2.5-pro"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 128
+max = 32_768
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125
+
+[[cost.tiers]]
+tier = { size = 200_000 }
+input = 2.50
+output = 15.00
+cache_read = 0.25

--- a/providers/tokenbay/models/gemini-2.5-pro.toml
+++ b/providers/tokenbay/models/gemini-2.5-pro.toml
@@ -7,7 +7,7 @@ output = 10.00
 cache_read = 0.125
 
 [[cost.tiers]]
-tier = { size = 200_000 }
+tier = { type = "context", size = 200_000 }
 input = 2.50
 output = 15.00
 cache_read = 0.25

--- a/providers/tokenbay/models/gemini-2.5-pro.toml
+++ b/providers/tokenbay/models/gemini-2.5-pro.toml
@@ -1,3 +1,4 @@
+# Native Gemini: POST https://api.tokenbay.com/v1beta/models/{model}:generateContent
 # Budget: generationConfig.thinkingConfig.thinkingBudget = 128..32_768.
 base_model = "google/gemini-2.5-pro"
 
@@ -16,3 +17,7 @@ tier = { type = "context", size = 200_000 }
 input = 2.50
 output = 15.00
 cache_read = 0.25
+
+[provider]
+npm = "@ai-sdk/google"
+api = "https://api.tokenbay.com/v1beta"

--- a/providers/tokenbay/models/gemini-2.5-pro.toml
+++ b/providers/tokenbay/models/gemini-2.5-pro.toml
@@ -1,9 +1,5 @@
 base_model = "google/gemini-2.5-pro"
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 128
-max = 32_768
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/tokenbay/models/gemini-2.5-pro.toml
+++ b/providers/tokenbay/models/gemini-2.5-pro.toml
@@ -1,5 +1,10 @@
+# Budget: generationConfig.thinkingConfig.thinkingBudget = 128..32_768.
 base_model = "google/gemini-2.5-pro"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 128
+max = 32_768
 
 [cost]
 input = 1.25

--- a/providers/tokenbay/models/glm-5.2.toml
+++ b/providers/tokenbay/models/glm-5.2.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.91
+output = 2.86
+cache_read = 0.169

--- a/providers/tokenbay/models/gpt-5.2-codex.toml
+++ b/providers/tokenbay/models/gpt-5.2-codex.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-5.2-codex"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.4875
+output = 11.90
+cache_read = 0.14875
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/tokenbay/models/gpt-5.2-codex.toml
+++ b/providers/tokenbay/models/gpt-5.2-codex.toml
@@ -8,3 +8,4 @@ cache_read = 0.14875
 
 [provider]
 npm = "@ai-sdk/openai"
+api = "https://api.tokenbay.com/v1"

--- a/providers/tokenbay/models/gpt-5.2-codex.toml
+++ b/providers/tokenbay/models/gpt-5.2-codex.toml
@@ -8,4 +8,3 @@ cache_read = 0.14875
 
 [provider]
 npm = "@ai-sdk/openai"
-shape = "responses"

--- a/providers/tokenbay/models/gpt-5.6-luna.toml
+++ b/providers/tokenbay/models/gpt-5.6-luna.toml
@@ -1,0 +1,17 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0.85
+output = 5.10
+cache_read = 0.085
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 1.70
+output = 7.65
+cache_read = 0.17
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/tokenbay/models/gpt-5.6-luna.toml
+++ b/providers/tokenbay/models/gpt-5.6-luna.toml
@@ -14,4 +14,3 @@ cache_read = 0.17
 
 [provider]
 npm = "@ai-sdk/openai"
-shape = "responses"

--- a/providers/tokenbay/models/gpt-5.6-luna.toml
+++ b/providers/tokenbay/models/gpt-5.6-luna.toml
@@ -14,3 +14,4 @@ cache_read = 0.17
 
 [provider]
 npm = "@ai-sdk/openai"
+api = "https://api.tokenbay.com/v1"

--- a/providers/tokenbay/models/gpt-5.6-luna.toml
+++ b/providers/tokenbay/models/gpt-5.6-luna.toml
@@ -1,3 +1,6 @@
+# TokenBay lists Luna at $1/$6/$0.10 before its 15% discount, rather than the
+# current OpenAI lab list; its public catalog exposes no cache-write SKU.
+# https://www.tokenbay.com/models (accessed 2026-08-12)
 base_model = "openai/gpt-5.6-luna"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/tokenbay/models/gpt-5.6-luna.toml
+++ b/providers/tokenbay/models/gpt-5.6-luna.toml
@@ -7,7 +7,7 @@ output = 5.10
 cache_read = 0.085
 
 [[cost.tiers]]
-tier = { size = 272_000 }
+tier = { type = "context", size = 272_000 }
 input = 1.70
 output = 7.65
 cache_read = 0.17

--- a/providers/tokenbay/models/gpt-5.6-sol.toml
+++ b/providers/tokenbay/models/gpt-5.6-sol.toml
@@ -14,3 +14,4 @@ cache_read = 0.85
 
 [provider]
 npm = "@ai-sdk/openai"
+api = "https://api.tokenbay.com/v1"

--- a/providers/tokenbay/models/gpt-5.6-sol.toml
+++ b/providers/tokenbay/models/gpt-5.6-sol.toml
@@ -1,3 +1,6 @@
+# TokenBay's public catalog exposes input, output, and cache-read pricing for
+# Sol, but no cache-write SKU at either the base or long-context tier.
+# https://www.tokenbay.com/models (accessed 2026-08-12)
 base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 

--- a/providers/tokenbay/models/gpt-5.6-sol.toml
+++ b/providers/tokenbay/models/gpt-5.6-sol.toml
@@ -7,7 +7,7 @@ output = 25.50
 cache_read = 0.425
 
 [[cost.tiers]]
-tier = { size = 272_000 }
+tier = { type = "context", size = 272_000 }
 input = 8.50
 output = 38.25
 cache_read = 0.85

--- a/providers/tokenbay/models/gpt-5.6-sol.toml
+++ b/providers/tokenbay/models/gpt-5.6-sol.toml
@@ -1,0 +1,17 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 4.25
+output = 25.50
+cache_read = 0.425
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 8.50
+output = 38.25
+cache_read = 0.85
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/tokenbay/models/gpt-5.6-sol.toml
+++ b/providers/tokenbay/models/gpt-5.6-sol.toml
@@ -14,4 +14,3 @@ cache_read = 0.85
 
 [provider]
 npm = "@ai-sdk/openai"
-shape = "responses"

--- a/providers/tokenbay/models/gpt-5.6-terra.toml
+++ b/providers/tokenbay/models/gpt-5.6-terra.toml
@@ -8,7 +8,7 @@ cache_read = 0.2125
 cache_write = 2.65625
 
 [[cost.tiers]]
-tier = { size = 272_000 }
+tier = { type = "context", size = 272_000 }
 input = 4.25
 output = 19.125
 cache_read = 0.425

--- a/providers/tokenbay/models/gpt-5.6-terra.toml
+++ b/providers/tokenbay/models/gpt-5.6-terra.toml
@@ -16,3 +16,4 @@ cache_write = 5.3125
 
 [provider]
 npm = "@ai-sdk/openai"
+api = "https://api.tokenbay.com/v1"

--- a/providers/tokenbay/models/gpt-5.6-terra.toml
+++ b/providers/tokenbay/models/gpt-5.6-terra.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 4.25
+output = 19.125
+cache_read = 0.2125
+cache_write = 2.65625
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 4.25
+output = 19.125
+cache_read = 0.425
+cache_write = 5.3125
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/tokenbay/models/gpt-5.6-terra.toml
+++ b/providers/tokenbay/models/gpt-5.6-terra.toml
@@ -2,8 +2,8 @@ base_model = "openai/gpt-5.6-terra"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 4.25
-output = 19.125
+input = 2.125
+output = 12.75
 cache_read = 0.2125
 cache_write = 2.65625
 
@@ -16,4 +16,3 @@ cache_write = 5.3125
 
 [provider]
 npm = "@ai-sdk/openai"
-shape = "responses"

--- a/providers/tokenbay/models/kimi-k2.6.toml
+++ b/providers/tokenbay/models/kimi-k2.6.toml
@@ -1,7 +1,5 @@
 base_model = "moonshotai/kimi-k2.6"
-
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/tokenbay/models/kimi-k2.6.toml
+++ b/providers/tokenbay/models/kimi-k2.6.toml
@@ -1,5 +1,8 @@
+# Toggle: thinking.type = enabled|disabled
 base_model = "moonshotai/kimi-k2.6"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/tokenbay/models/kimi-k2.6.toml
+++ b/providers/tokenbay/models/kimi-k2.6.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.8075
+output = 3.40
+cache_read = 0.136

--- a/providers/tokenbay/models/kimi-k3.toml
+++ b/providers/tokenbay/models/kimi-k3.toml
@@ -1,5 +1,13 @@
+# Toggle: thinking.type = enabled|disabled|adaptive
+# Effort: output_config.effort = low|high|max
 base_model = "moonshotai/kimi-k3"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
 
 [cost]
 input = 3.00

--- a/providers/tokenbay/models/kimi-k3.toml
+++ b/providers/tokenbay/models/kimi-k3.toml
@@ -1,11 +1,5 @@
 base_model = "moonshotai/kimi-k3"
-
-[[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "effort"
-values = ["low", "high", "max"]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/tokenbay/models/kimi-k3.toml
+++ b/providers/tokenbay/models/kimi-k3.toml
@@ -1,7 +1,11 @@
+# Toggle: thinking.type = enabled|disabled
 # TokenBay Chat Completions: reasoning_effort = low|high|max
 # Responses: message.reasoning_content carries the reasoning side channel.
 # https://www.tokenbay.com/docs/reference/text/openai/chat-completions
 base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "toggle"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/tokenbay/models/kimi-k3.toml
+++ b/providers/tokenbay/models/kimi-k3.toml
@@ -1,0 +1,16 @@
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30

--- a/providers/tokenbay/models/kimi-k3.toml
+++ b/providers/tokenbay/models/kimi-k3.toml
@@ -1,5 +1,6 @@
 # Toggle: thinking.type = enabled|disabled|adaptive
 # Effort: output_config.effort = low|high|max
+# Responses: reasoning_content carries the reasoning side channel.
 base_model = "moonshotai/kimi-k3"
 
 [[reasoning_options]]
@@ -8,6 +9,9 @@ type = "toggle"
 [[reasoning_options]]
 type = "effort"
 values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 3.00

--- a/providers/tokenbay/models/kimi-k3.toml
+++ b/providers/tokenbay/models/kimi-k3.toml
@@ -1,9 +1,6 @@
 base_model = "moonshotai/kimi-k3"
 reasoning_options = []
 
-[interleaved]
-field = "reasoning_content"
-
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/tokenbay/models/kimi-k3.toml
+++ b/providers/tokenbay/models/kimi-k3.toml
@@ -1,10 +1,7 @@
-# Toggle: thinking.type = enabled|disabled|adaptive
-# Effort: output_config.effort = low|high|max
-# Responses: reasoning_content carries the reasoning side channel.
+# TokenBay Chat Completions: reasoning_effort = low|high|max
+# Responses: message.reasoning_content carries the reasoning side channel.
+# https://www.tokenbay.com/docs/reference/text/openai/chat-completions
 base_model = "moonshotai/kimi-k3"
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/tokenbay/models/minimax-m3.toml
+++ b/providers/tokenbay/models/minimax-m3.toml
@@ -1,0 +1,19 @@
+base_model = "minimax/MiniMax-M3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+
+[[cost.tiers]]
+tier = { size = 512_000 }
+input = 0.60
+output = 2.40
+cache_read = 0.12

--- a/providers/tokenbay/models/minimax-m3.toml
+++ b/providers/tokenbay/models/minimax-m3.toml
@@ -1,7 +1,8 @@
 base_model = "minimax/MiniMax-M3"
+reasoning_options = []
 
-[[reasoning_options]]
-type = "toggle"
+[interleaved]
+field = "reasoning_content"
 
 [limit]
 context = 1_000_000

--- a/providers/tokenbay/models/minimax-m3.toml
+++ b/providers/tokenbay/models/minimax-m3.toml
@@ -11,7 +11,7 @@ output = 1.20
 cache_read = 0.06
 
 [[cost.tiers]]
-tier = { size = 512_000 }
+tier = { type = "context", size = 512_000 }
 input = 0.60
 output = 2.40
 cache_read = 0.12

--- a/providers/tokenbay/models/minimax-m3.toml
+++ b/providers/tokenbay/models/minimax-m3.toml
@@ -1,5 +1,8 @@
+# Toggle: chat_template_kwargs.thinking_mode = enabled|disabled
 base_model = "minimax/MiniMax-M3"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [limit]
 context = 1_000_000

--- a/providers/tokenbay/models/minimax-m3.toml
+++ b/providers/tokenbay/models/minimax-m3.toml
@@ -6,7 +6,6 @@ type = "toggle"
 
 [limit]
 context = 1_000_000
-output = 128_000
 
 [cost]
 input = 0.30

--- a/providers/tokenbay/models/minimax-m3.toml
+++ b/providers/tokenbay/models/minimax-m3.toml
@@ -1,9 +1,6 @@
 base_model = "minimax/MiniMax-M3"
 reasoning_options = []
 
-[interleaved]
-field = "reasoning_content"
-
 [limit]
 context = 1_000_000
 output = 128_000

--- a/providers/tokenbay/models/qwen3.7-max.toml
+++ b/providers/tokenbay/models/qwen3.7-max.toml
@@ -1,5 +1,14 @@
+# Toggle: enable_thinking = true|false
+# Budget: thinking_budget = 1..262_144 reasoning tokens
 base_model = "alibaba/qwen3.7-max"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 262_144
 
 [cost]
 input = 1.50

--- a/providers/tokenbay/models/qwen3.7-max.toml
+++ b/providers/tokenbay/models/qwen3.7-max.toml
@@ -1,0 +1,13 @@
+base_model = "alibaba/qwen3.7-max"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 1.50
+output = 4.50
+cache_read = 0.30
+cache_write = 1.875

--- a/providers/tokenbay/models/qwen3.7-max.toml
+++ b/providers/tokenbay/models/qwen3.7-max.toml
@@ -1,10 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
-
-[[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 1.50

--- a/providers/tokenbay/models/qwen3.7-plus.toml
+++ b/providers/tokenbay/models/qwen3.7-plus.toml
@@ -1,10 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
-
-[[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
+reasoning_options = []
 
 [cost]
 input = 0.34

--- a/providers/tokenbay/models/qwen3.7-plus.toml
+++ b/providers/tokenbay/models/qwen3.7-plus.toml
@@ -8,7 +8,7 @@ cache_read = 0.068
 cache_write = 0.425
 
 [[cost.tiers]]
-tier = { size = 256_000 }
+tier = { type = "context", size = 256_000 }
 input = 1.02
 output = 4.08
 cache_read = 0.204

--- a/providers/tokenbay/models/qwen3.7-plus.toml
+++ b/providers/tokenbay/models/qwen3.7-plus.toml
@@ -1,5 +1,14 @@
+# Toggle: enable_thinking = true|false
+# Budget: thinking_budget = 1..262_144 reasoning tokens
 base_model = "alibaba/qwen3.7-plus"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 262_144
 
 [cost]
 input = 0.34

--- a/providers/tokenbay/models/qwen3.7-plus.toml
+++ b/providers/tokenbay/models/qwen3.7-plus.toml
@@ -1,0 +1,20 @@
+base_model = "alibaba/qwen3.7-plus"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.34
+output = 1.36
+cache_read = 0.068
+cache_write = 0.425
+
+[[cost.tiers]]
+tier = { size = 256_000 }
+input = 1.02
+output = 4.08
+cache_read = 0.204
+cache_write = 1.275

--- a/providers/tokenbay/provider.toml
+++ b/providers/tokenbay/provider.toml
@@ -1,0 +1,5 @@
+name = "TokenBay"
+env = ["TOKENBAY_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.tokenbay.com/v1"
+doc = "https://www.tokenbay.com/docs"


### PR DESCRIPTION
## Summary

Add TokenBay as an OpenAI-compatible provider with 16 supported models.

- Add `providers/tokenbay/provider.toml`
- Add a theme-compatible SVG logo using `currentColor`
- Configure the TokenBay API endpoint and API key environment variable
- Reuse canonical model metadata through `base_model`
- Add TokenBay-specific USD pricing and context-based pricing tiers
- Prefer active discounted prices, falling back to standard prices
- Preserve reasoning capabilities and parameters from the original model providers

## Provider

- API: `https://api.tokenbay.com/v1`
- Documentation: https://www.tokenbay.com/docs
- Model catalog: https://www.tokenbay.com/models
- Environment variable: `TOKENBAY_API_KEY`
- AI SDK package: `@ai-sdk/openai-compatible`

## Models

- GLM-5.2
- GPT-5.6 Terra
- GPT-5.6 Luna
- Claude Sonnet 4.6
- Claude Opus 4.8
- Gemini 2.5 Pro
- DeepSeek V4 Pro
- Qwen3.7 Max
- Kimi K3
- MiniMax M3
- GPT-5.2 Codex
- GPT-5.6 Sol
- DeepSeek V4 Flash
- Gemini 2.5 Flash
- Qwen3.7 Plus
- Kimi K2.6

## Pricing

All prices are expressed in USD per million tokens.

Pricing is sourced from the TokenBay model catalog. Active discounted prices are used when available; otherwise, standard prices are used.

For models with context-based pricing, the corresponding `cost.tiers` entries are included.

For Claude models, `cost.cache_write` represents the 5-minute cache-write price, following the existing models.dev convention. The separate 1-hour cache-write price is not represented because the current schema exposes only one `cache_write` field.

## Model metadata

Provider-independent fields are inherited from the canonical models.dev metadata, including:

- Model capabilities
- Modalities
- Context and output limits
- Release and knowledge dates
- Tool-calling support
- Structured-output support
- Reasoning options and budgets

No mock model metadata or pricing values are included.

## Validation

```bash
bun validate
```
