### PR TITLE
feat(berget): add Kimi K3

### DIFF
--- a/providers/berget/models/moonshotai/Kimi-K3.toml
+++ b/providers/berget/models/moonshotai/Kimi-K3.toml
@@ -1,5 +1,7 @@
-# Kimi K3 always thinks; reasoning_effort controls depth. The Berget API
-# accepts none/low/medium/high/max and maps onto K3's native low/high/max.
+# Kimi K3 always thinks and cannot disable it; reasoning_effort only controls
+# depth. K3's native levels are low/high/max (default max). The Berget API also
+# accepts the other OpenAI effort levels for compatibility and clamps them onto
+# these three, but only the three distinct levels are advertised here.
 # Reasoning is returned in message.reasoning_content, the answer in
 # message.content.
 # https://api.berget.ai/openapi.json
@@ -7,7 +9,7 @@ base_model = "moonshotai/kimi-k3"
 release_date = "2026-07-27"
 last_updated = "2026-07-28"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/berget/models/moonshotai/Kimi-K3.toml
+++ b/providers/berget/models/moonshotai/Kimi-K3.toml
@@ -1,12 +1,12 @@
+# Kimi K3 always thinks; reasoning_effort controls depth. The Berget API
+# accepts none/low/medium/high/max and maps onto K3's native low/high/max.
+# Reasoning is returned in message.reasoning_content, the answer in
+# message.content.
+# https://api.berget.ai/openapi.json
 base_model = "moonshotai/kimi-k3"
 release_date = "2026-07-27"
 last_updated = "2026-07-28"
 
-# Kimi K3 always thinks; reasoning_effort controls depth. The Berget API
-# accepts none/low/medium/high/max and maps onto K3's native low/high/max
-# (none->low, medium->high, xhigh/max->max). Reasoning is returned in
-# message.reasoning_content, the answer in message.content.
-# https://api.berget.ai/openapi.json
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
 
 [interleaved]
@@ -15,7 +15,6 @@ field = "reasoning_content"
 [cost]
 input = 3.0
 output = 15.0
-cache_read = 0.3
 
 [limit]
 context = 327_680

--- a/providers/berget/models/moonshotai/Kimi-K3.toml
+++ b/providers/berget/models/moonshotai/Kimi-K3.toml
@@ -1,0 +1,26 @@
+base_model = "moonshotai/kimi-k3"
+release_date = "2026-07-27"
+last_updated = "2026-07-28"
+
+# Kimi K3 always thinks; reasoning_effort controls depth. The Berget API
+# accepts none/low/medium/high/max and maps onto K3's native low/high/max
+# (none->low, medium->high, xhigh/max->max). Reasoning is returned in
+# message.reasoning_content, the answer in message.content.
+# https://api.berget.ai/openapi.json
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+
+[limit]
+context = 327_680
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Add Kimi K3 to the Berget AI provider.

Moonshot AI's 2.8T-parameter open-weights model (KDA + Gated MLA MoE, native MXFP4, multimodal), served on Berget AI's Swedish infrastructure under EU law.

## Details

- **Reasoning**: K3 always thinks; `reasoning_effort` accepts `none`/`low`/`medium`/`high`/`max`, mapped onto K3's native `low`/`high`/`max`. Reasoning is returned in `message.reasoning_content`, answer in `message.content`.
- **Limits**: 320k context window, 32k max output tokens.
- **Modalities**: text + image input, text output.
- **Pricing**: $3 input / $15 output per 1M tokens.

Verified against the live API at `https://api.berget.ai/v1` (OpenAI-compatible; model id `moonshotai/Kimi-K3`).
