### PR TITLE
fix(opencode-go): add low, medium reasoning effort values for deepseek-v4-flash, deepseek-v4-pro, glm-5.2

### DIFF
--- a/providers/opencode-go/models/deepseek-v4-flash.toml
+++ b/providers/opencode-go/models/deepseek-v4-flash.toml
@@ -5,7 +5,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode-go/models/deepseek-v4-pro.toml
+++ b/providers/opencode-go/models/deepseek-v4-pro.toml
@@ -5,7 +5,7 @@ release_date = "2026-04-24"
 last_updated = "2026-04-24"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 temperature = true
 knowledge = "2025-05"
 tool_call = true

--- a/providers/opencode-go/models/glm-5.2.toml
+++ b/providers/opencode-go/models/glm-5.2.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.2"
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
The opencode-go Zen API accepts `reasoning_effort` values `low` and `medium` for `deepseek-v4-flash`, `deepseek-v4-pro`, and `glm-5.2`, but the catalog only lists `high` and `max`. This causes Pi clients to clamp `classifierReasoningLevel: "low"` up to `"high"` (the nearest supported level), which burns through the 512-token fast-classifier budget and fails auto-mode classification.

**Test evidence:**

All requests sent to `POST https://opencode.ai/zen/go/v1/chat/completions`:

| Model | effort | Result |
|---|---|---|
| deepseek-v4-flash | `low` | 200, finish=stop, content="Hi!" |
| deepseek-v4-flash | `medium` | 200, finish=stop, content="Hi!" |
| deepseek-v4-flash | `high` | 200, finish=stop |
| deepseek-v4-flash | `none` | **400** (not supported) |
| deepseek-v4-pro | `low` | 200, finish=stop, content="Hi!" |
| glm-5.2 | `low` | 200, finish=stop, content="Hi!" |

**Context:**
The opencode-go `provider.toml` already carries a caveat that the Zen Go API is undocumented. These values are set per-model (not per-provider) because:
- `hy3` already has `["none", "low", "high"]` (no `medium`, no `max`)
- `grok-4.5` already has `["low", "medium", "high"]` (no `max`)
- `minimax-m3` uses `[{type: "toggle"}]` (no effort at all)