### PR TITLE
Add Xpersona premium model lineup

### DIFF
--- a/providers/xpersona/models/claude-haiku-4-5.toml
+++ b/providers/xpersona/models/claude-haiku-4-5.toml
@@ -1,15 +1,18 @@
-base_model = "anthropic/claude-fable-5"
-interleaved = { field = "reasoning_content" }
+base_model = "anthropic/claude-haiku-4-5"
 
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 3.00
-output = 18.50
-reasoning = 18.50
-cache_read = 0.30
+input = 0.60
+output = 3.70
+reasoning = 3.70
+cache_read = 0.06
+
+[limit]
+context = 200_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/xpersona/models/claude-haiku-4-5.toml
+++ b/providers/xpersona/models/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/claude-opus-4-8.toml
+++ b/providers/xpersona/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/claude-opus-4-8.toml
+++ b/providers/xpersona/models/claude-opus-4-8.toml
@@ -1,15 +1,18 @@
-base_model = "anthropic/claude-fable-5"
-interleaved = { field = "reasoning_content" }
+base_model = "anthropic/claude-opus-4-8"
 
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 3.00
-output = 18.50
-reasoning = 18.50
-cache_read = 0.30
+input = 1.50
+output = 9.25
+reasoning = 9.25
+cache_read = 0.15
+
+[limit]
+context = 200_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/xpersona/models/claude-sonnet-4-6.toml
+++ b/providers/xpersona/models/claude-sonnet-4-6.toml
@@ -1,15 +1,18 @@
-base_model = "anthropic/claude-fable-5"
-interleaved = { field = "reasoning_content" }
+base_model = "anthropic/claude-sonnet-4-6"
 
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 3.00
-output = 18.50
-reasoning = 18.50
-cache_read = 0.30
+input = 0.90
+output = 5.55
+reasoning = 5.55
+cache_read = 0.09
+
+[limit]
+context = 200_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/xpersona/models/claude-sonnet-4-6.toml
+++ b/providers/xpersona/models/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gemini-3.5-flash.toml
+++ b/providers/xpersona/models/gemini-3.5-flash.toml
@@ -1,15 +1,18 @@
-base_model = "anthropic/claude-fable-5"
-interleaved = { field = "reasoning_content" }
+base_model = "google/gemini-3.5-flash"
 
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 3.00
-output = 18.50
-reasoning = 18.50
-cache_read = 0.30
+input = 1.55
+output = 12.20
+reasoning = 12.20
+cache_read = 0.155
+
+[limit]
+context = 1_000_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/xpersona/models/gemini-3.5-flash.toml
+++ b/providers/xpersona/models/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.4-mini.toml
+++ b/providers/xpersona/models/gpt-5.4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.4-mini.toml
+++ b/providers/xpersona/models/gpt-5.4-mini.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.4-mini"
-base_model_omit = ["limit.input"]
+base_model_omit = ["limit.context", "limit.input"]
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.4-mini.toml
+++ b/providers/xpersona/models/gpt-5.4-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
-base_model_omit = ["limit.context", "limit.input"]
+base_model_omit = ["limit.input"]
 interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]

--- a/providers/xpersona/models/gpt-5.4-mini.toml
+++ b/providers/xpersona/models/gpt-5.4-mini.toml
@@ -1,15 +1,18 @@
-base_model = "anthropic/claude-fable-5"
-interleaved = { field = "reasoning_content" }
+base_model = "openai/gpt-5.4-mini"
 
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 3.00
-output = 18.50
-reasoning = 18.50
-cache_read = 0.30
+input = 0.375
+output = 4.00
+reasoning = 4.00
+cache_read = 0.0375
+
+[limit]
+context = 272_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/xpersona/models/gpt-5.4.toml
+++ b/providers/xpersona/models/gpt-5.4.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4"
+base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.4.toml
+++ b/providers/xpersona/models/gpt-5.4.toml
@@ -1,15 +1,18 @@
-base_model = "anthropic/claude-fable-5"
-interleaved = { field = "reasoning_content" }
+base_model = "openai/gpt-5.4"
 
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 3.00
-output = 18.50
-reasoning = 18.50
-cache_read = 0.30
+input = 0.75
+output = 6.00
+reasoning = 6.00
+cache_read = 0.075
+
+[limit]
+context = 1_050_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/xpersona/models/gpt-5.4.toml
+++ b/providers/xpersona/models/gpt-5.4.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.4"
 base_model_omit = ["limit.input"]
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.5.toml
+++ b/providers/xpersona/models/gpt-5.5.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.5"
 base_model_omit = ["limit.input"]
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.5.toml
+++ b/providers/xpersona/models/gpt-5.5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5"
+base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.5.toml
+++ b/providers/xpersona/models/gpt-5.5.toml
@@ -1,15 +1,18 @@
-base_model = "anthropic/claude-fable-5"
-interleaved = { field = "reasoning_content" }
+base_model = "openai/gpt-5.5"
 
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 3.00
-output = 18.50
-reasoning = 18.50
-cache_read = 0.30
+input = 1.50
+output = 12.00
+reasoning = 12.00
+cache_read = 0.15
+
+[limit]
+context = 1_050_000
+output = 128_000
 
 [modalities]
 input = ["text", "image"]

--- a/providers/xpersona/models/gpt-5.6-sol.toml
+++ b/providers/xpersona/models/gpt-5.6-sol.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.6-sol"
 base_model_omit = ["limit.input"]
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.6-sol.toml
+++ b/providers/xpersona/models/gpt-5.6-sol.toml
@@ -1,0 +1,20 @@
+base_model = "openai/gpt-5.6-sol"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 1.50
+output = 12.00
+reasoning = 12.00
+cache_read = 0.15
+
+[limit]
+context = 372_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/xpersona/models/gpt-5.6-terra.toml
+++ b/providers/xpersona/models/gpt-5.6-terra.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.6-terra"
 base_model_omit = ["limit.input"]
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.6-terra.toml
+++ b/providers/xpersona/models/gpt-5.6-terra.toml
@@ -1,0 +1,20 @@
+base_model = "openai/gpt-5.6-terra"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 1.50
+output = 2.00
+reasoning = 2.00
+cache_read = 0.15
+
+[limit]
+context = 372_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/xpersona/models/gpt-5.6.toml
+++ b/providers/xpersona/models/gpt-5.6.toml
@@ -1,6 +1,7 @@
 base_model = "openai/gpt-5.6-sol"
 base_model_omit = ["limit.input"]
 name = "GPT-5.6"
+interleaved = { field = "reasoning_content" }
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/xpersona/models/gpt-5.6.toml
+++ b/providers/xpersona/models/gpt-5.6.toml
@@ -1,0 +1,21 @@
+base_model = "openai/gpt-5.6-sol"
+base_model_omit = ["limit.input"]
+name = "GPT-5.6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 1.50
+output = 12.00
+reasoning = 12.00
+cache_read = 0.15
+
+[limit]
+context = 372_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary

- add the ten canonical GPT, Claude, and Gemini routes now served by Xpersona
- inherit provider-agnostic metadata through `base_model`
- keep only Xpersona-specific reasoning controls, prices, and serving-limit overrides
- update the existing Claude Fable 5 output price from $18.00 to the current $18.50

## Sources

- Live model catalog: https://www.xpersona.co/v1/models
- Live pricing catalog: https://www.xpersona.co/v1/pricing
- Xpersona API docs and reasoning control: https://www.xpersona.co/api/v1/openapi/ai-public

## Notes

The provider TOMLs inherit knowledge cutoffs, release dates, capabilities, and other model-owned metadata from the canonical files under `models/`. They override only Xpersona-specific reasoning controls, prices, serving limits, and supported modalities.

The serving-limit and price overrides map directly to the live payload fields as follows:

| Xpersona IDs | `context_length` | `xpersona_max_completion_tokens` | retail input / cache / output (per 1M) |
| --- | ---: | ---: | ---: |
| `gpt-5.6`, `gpt-5.6-sol` | 372000 | 128000 | $1.50 / $0.15 / $12.00 |
| `gpt-5.6-terra` | 372000 | 128000 | $1.50 / $0.15 / $2.00 |
| `gpt-5.5` | 1050000 | 128000 | $1.50 / $0.15 / $12.00 |
| `gpt-5.4` | 1050000 | 128000 | $0.75 / $0.075 / $6.00 |
| `gpt-5.4-mini` | 272000 | 128000 | $0.375 / $0.0375 / $4.00 |
| `claude-opus-4-8` | 200000 | 128000 | $1.50 / $0.15 / $9.25 |
| `claude-sonnet-4-6` | 200000 | 128000 | $0.90 / $0.09 / $5.55 |
| `claude-haiku-4-5` | 200000 | 128000 | $0.60 / $0.06 / $3.70 |
| `gemini-3.5-flash` | 1000000 | 128000 | $1.55 / $0.155 / $12.20 |

The existing `claude-fable-5` entry’s only change is `retail.outputPer1M` and `retail.reasoningPer1M` from $18.00 to $18.50. The `$0.001` request minimum is exposed by Xpersona but is not representable in Models.dev’s cost schema.

The three stable `*-latest` aliases and branded-route cleanup are intentionally outside this PR. This keeps the change limited to canonical upstream model IDs that already have model metadata and can therefore follow the registry's `base_model` convention exactly.
