### PR TITLE
mixlayer: add glm 5.2 and kimi k2.7 code

### DIFF
--- a/providers/mixlayer/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/mixlayer/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,17 @@
+# Mixlayer model ID and pricing: https://www.mixlayer.com/ (accessed 2026-07-28)
+# Kimi K2.7 Code forces thinking, so Mixlayer exposes no reasoning control:
+# https://huggingface.co/moonshotai/Kimi-K2.7-Code (accessed 2026-07-28)
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+temperature = true
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.75
+output = 3.5
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/mixlayer/models/z-ai/glm-5.2.toml
+++ b/providers/mixlayer/models/z-ai/glm-5.2.toml
@@ -1,0 +1,14 @@
+# Mixlayer model ID and pricing: https://www.mixlayer.com/ (accessed 2026-07-28)
+# Reasoning API: {"reasoning_effort": "none"|"low"|"high"|"max"}
+base_model = "zhipuai/glm-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+
+[limit]
+context = 262_144


### PR DESCRIPTION
Adds support for GLM 5.2 and Kimi K2.7 Code on Mixlayer. 

Supercedes, incorporates feedback from #2628 