### PR TITLE
fix(openrouter): temporarily skip :batch model routes

### DIFF
--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -100,7 +100,8 @@ export const openrouter = {
     return response.json();
   },
   parseModels(raw) {
-    return OpenRouterResponse.parse(raw).data;
+    // Temporarily skip batch routes (`*:batch`) — they are not catalog targets.
+    return OpenRouterResponse.parse(raw).data.filter((model) => !model.id.endsWith(":batch"));
   },
   translateModel(model, context) {
     // OpenRouter serves deprecated/unavailable routes as degraded stubs:


### PR DESCRIPTION
## Summary
- Filter OpenRouter models whose IDs end with `:batch` out of sync `parseModels`
- Batch routes are not catalog targets; this is a temporary skip until we decide how to handle them

## Test plan
- [ ] Confirm OpenRouter sync no longer emits `*:batch` model files
- [ ] Spot-check that non-batch models still sync normally