### PR TITLE
feat: add Omnious provider

### DIFF
--- a/providers/omnious/logo.svg
+++ b/providers/omnious/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144" fill="none">
+  <g stroke="currentColor" stroke-linecap="round">
+    <circle cx="72" cy="72" r="56" stroke-width="3.5" pathLength="100" stroke-dasharray="27.3 6.03"/>
+    <circle cx="72" cy="72" r="40" stroke-width="5.5" pathLength="100" stroke-dasharray="42.5 7.5"/>
+    <circle cx="72" cy="72" r="24" stroke-width="8"/>
+  </g>
+  <circle cx="72" cy="72" r="8.5" fill="currentColor"/>
+</svg>

--- a/providers/omnious/models/auto.toml
+++ b/providers/omnious/models/auto.toml
@@ -8,7 +8,7 @@ release_date = "2026-07-17"
 last_updated = "2026-07-29"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/omnious/models/auto.toml
+++ b/providers/omnious/models/auto.toml
@@ -1,0 +1,23 @@
+# Dynamic catalog: https://api.omnious.xyz/v1/models (accessed 2026-07-29)
+# Auto routing and funded-key setup:
+# https://www.omnious.xyz/integrations?side=customer (accessed 2026-07-29)
+name = "Omnious Auto"
+description = "Live-market router that selects an eligible model and provider for each agent request"
+family = "auto"
+release_date = "2026-07-17"
+last_updated = "2026-07-29"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/omnious/models/glm-5.2.toml
+++ b/providers/omnious/models/glm-5.2.toml
@@ -1,0 +1,12 @@
+# Price metadata is the trailing-30-day p90 of settled daily VWAPs:
+# https://api.omnious.xyz/v1/market/candles?window_ms=2592000000&bucket_ms=86400000
+# Snapshot generated 2026-07-29 from 13 daily samples.
+base_model = "zhipuai/glm-5.2"
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.141015
+output = 3.309797

--- a/providers/omnious/models/kimi-k2.7-code.toml
+++ b/providers/omnious/models/kimi-k2.7-code.toml
@@ -1,0 +1,12 @@
+# Price metadata is the trailing-30-day p90 of settled daily VWAPs:
+# https://api.omnious.xyz/v1/market/candles?window_ms=2592000000&bucket_ms=86400000
+# Snapshot generated 2026-07-29 from 11 daily samples.
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.015237
+output = 4.651478

--- a/providers/omnious/models/kimi-k3.toml
+++ b/providers/omnious/models/kimi-k3.toml
@@ -1,0 +1,12 @@
+# Price metadata is the trailing-30-day p90 of settled daily VWAPs:
+# https://api.omnious.xyz/v1/market/candles?window_ms=2592000000&bucket_ms=86400000
+# Snapshot generated 2026-07-29 from 10 daily samples.
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [{ type = "effort", values = ["max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.3
+output = 16.5

--- a/providers/omnious/models/minimax-m3.toml
+++ b/providers/omnious/models/minimax-m3.toml
@@ -1,0 +1,12 @@
+# Price metadata is the trailing-30-day p90 of settled daily VWAPs:
+# https://api.omnious.xyz/v1/market/candles?window_ms=2592000000&bucket_ms=86400000
+# Snapshot generated 2026-07-29 from 12 daily samples.
+base_model = "minimax/MiniMax-M3"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.33
+output = 1.32

--- a/providers/omnious/models/minimax-m3.toml
+++ b/providers/omnious/models/minimax-m3.toml
@@ -2,7 +2,7 @@
 # https://api.omnious.xyz/v1/market/candles?window_ms=2592000000&bucket_ms=86400000
 # Snapshot generated 2026-07-29 from 12 daily samples.
 base_model = "minimax/MiniMax-M3"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/omnious/provider.toml
+++ b/providers/omnious/provider.toml
@@ -1,0 +1,9 @@
+# OpenAI-compatible inference endpoint and funded-key authentication:
+# https://docs.omnious.xyz/api/authentication (accessed 2026-07-29)
+# Live model catalog:
+# https://api.omnious.xyz/v1/models (accessed 2026-07-29)
+name = "Omnious"
+env = ["OMNIOUS_CREDIT_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.omnious.xyz/v1"
+doc = "https://www.omnious.xyz/integrations?side=customer"


### PR DESCRIPTION
## What

Adds Omnious to the provider registry with:

- `OMNIOUS_CREDIT_KEY` as the spend-capable inference credential
- the OpenAI-compatible `https://api.omnious.xyz/v1` endpoint
- a single-colour `currentColor` Astrolabe logo
- `auto`, GLM-5.2, Kimi K2.7 Code, Kimi K3, and MiniMax M3 model entries
- explicit reasoning/interleaved metadata

Static model costs are a conservative nearest-rank p90 of settled daily input/output VWAPs over the trailing 30-day market window. Comments on each model link to the public candle source and record the sample count. Live request receipts remain authoritative for actual auction clears.

## Why

OpenCode and other models.dev consumers can discover Omnious natively instead of requiring a hand-written custom provider block.

## Impact

This only adds a new provider. It does not change existing provider or base-model metadata.

## Checks

- `bun validate`
- verified generated provider key, credential, endpoint, and five model IDs
- rebased on current `upstream/dev`
