### PR TITLE
feat(aiand): add automated sync module for ai& provider

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -64,6 +64,7 @@ jobs:
         run: bun models:sync ${{ matrix.provider }}
         env:
           GH_TOKEN: ${{ github.token }}
+          AIAND_API_KEY: ${{ secrets.AIAND_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
           DEEPINFRA_API_KEY: ${{ secrets.DEEPINFRA_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "test": "bun test",
     "validate": "bun ./packages/core/script/validate.ts",
+    "aiand:sync": "bun ./packages/core/script/sync-models.ts aiand",
     "compare:migrations": "bun ./packages/core/script/compare-model-migrations.ts",
     "anthropic:sync": "bun ./packages/core/script/sync-models.ts anthropic",
     "baseten:sync": "bun ./packages/core/script/sync-models.ts baseten",

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { AuthoredModel, AuthoredModelShape, ModelMetadata } from "../schema.js";
 import { openMissingModelIssues } from "./missing-issues.js";
+import { aiand } from "./providers/aiand.js";
 import { ambient } from "./providers/ambient.js";
 import { anthropic } from "./providers/anthropic.js";
 import { baseten } from "./providers/baseten.js";
@@ -105,6 +106,7 @@ export interface SyncResult {
 }
 
 export const providers: {
+  aiand: SyncProvider<any>;
   ambient: SyncProvider<any>;
   anthropic: SyncProvider<any>;
   baseten: SyncProvider<any>;
@@ -128,6 +130,7 @@ export const providers: {
   wandb: SyncProvider<any>;
   xai: SyncProvider<any>;
 } = {
+  aiand,
   ambient,
   anthropic,
   baseten,
@@ -155,7 +158,7 @@ export const providers: {
 export const groups = {
   aggregators: ["crossmodel", "empiriolabs", "huggingface", "kilo", "llmgateway", "openrouter", "vercel"],
   cloudflare: ["cloudflare-workers-ai"],
-  direct: ["ambient", "anthropic", "baseten", "chutes", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "venice", "wandb", "xai"],
+  direct: ["aiand", "ambient", "anthropic", "baseten", "chutes", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "venice", "wandb", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;

--- a/packages/core/src/sync/providers/aiand.ts
+++ b/packages/core/src/sync/providers/aiand.ts
@@ -1,0 +1,360 @@
+import { z } from "zod";
+
+import { describeModel } from "../../describe.js";
+import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { readdirSync } from "node:fs";
+import path from "node:path";
+
+import { factorBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://api.aiand.com/v1/models";
+const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
+
+// ai& serves open-weight models from several labs but prefixes them with its
+// own organization labels. Map those labels to the canonical metadata namespace
+// used in models/ so synced routes can factor onto shared base models.
+const CANONICAL_PREFIX_ALIASES: Record<string, string> = {
+  "deepseek-ai": "deepseek",
+  qwen: "alibaba",
+  "zai-org": "zhipuai",
+};
+
+const AiandModel = z.object({
+  id: z.string(),
+  object: z.literal("model"),
+  name: z.string(),
+  owned_by: z.string(),
+  provider: z.string(),
+  context_window: z.number().int().nonnegative(),
+  capabilities: z.array(z.string()).default([]),
+  description: z.string().nullable().optional(),
+  currency: z.string(),
+  input_per_1m: z.string(),
+  output_per_1m: z.string(),
+  created: z.number().int().nonnegative(),
+}).passthrough();
+
+const AiandResponse = z.object({
+  object: z.literal("list"),
+  data: z.array(AiandModel),
+}).passthrough();
+
+export type AiandModel = z.infer<typeof AiandModel>;
+
+export const aiand = {
+  id: "aiand",
+  name: "ai&",
+  modelsDir: "providers/aiand/models",
+  // The endpoint is too thin to be authoritative for lifecycle (no output limit,
+  // open_weights, temperature, etc.) and existing routes carry hand-probed
+  // overrides. Never delete local TOMLs automatically.
+  deleteMissing: false,
+  sourceID(model) {
+    return model.id;
+  },
+  skippedNotice(ids) {
+    if (ids.length === 0) return [];
+    return [
+      `${ids.length} ai& models were not created because they have no local file and no resolvable \`models/\` entry, and the API does not supply the required curated fields.`,
+      `Skipped remote IDs: ${ids.map((id) => `\`${id}\``).join(", ")}`,
+      "Add a matching `models/<provider>/<model>.toml` entry (or a full provider TOML) to include them in the next sync.",
+    ];
+  },
+  missingNotice(paths) {
+    if (paths.length === 0) return [];
+    return [
+      `${paths.length} local ai& models were absent from the live API and were retained for manual lifecycle review.`,
+      `Retained local paths: ${paths.map((item) => `\`${item}\``).join(", ")}`,
+    ];
+  },
+  async fetchModels() {
+    const key = process.env.AIAND_API_KEY;
+    if (key === undefined) throw new Error("ai& sync requires AIAND_API_KEY");
+    const response = await fetch(API_ENDPOINT, {
+      headers: { Authorization: `Bearer ${key}` },
+    });
+    if (!response.ok) {
+      throw new Error(`ai& models request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return AiandResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    const existing = context.existing(model.id);
+    // ai&'s API is not rich enough to author complete standalone catalog rows
+    // (no output limit, open_weights, temperature, structured_output, or full
+    // reasoning controls). Only update existing routes or create factored routes
+    // against known model metadata.
+    if (existing === undefined && resolveAiandBaseModel(model) === undefined) {
+      return undefined;
+    }
+    return {
+      id: model.id,
+      model: buildAiandModel(model, existing),
+    };
+  },
+} satisfies SyncProvider<AiandModel>;
+
+function dateFromTimestamp(timestamp: number) {
+  return new Date(timestamp * 1000).toISOString().slice(0, 10);
+}
+
+function price(value: string | undefined) {
+  if (value === undefined) return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : undefined;
+}
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+function modalities(capabilities: Set<string>): { input: Modality[]; output: Modality[] } {
+  const input: Modality[] = ["text"];
+  if (capabilities.has("vision")) input.push("image");
+  if (capabilities.has("video")) input.push("video");
+  if (capabilities.has("document")) input.push("pdf");
+  return { input: [...new Set(input)], output: ["text"] };
+}
+
+function resolveAiandBaseModel(model: AiandModel) {
+  const prefix = CANONICAL_PREFIX_ALIASES[model.provider] ?? model.provider;
+  const modelId = model.id.split("/").slice(1).join("/");
+  if (metadataModelExists(prefix, modelId)) return `${prefix}/${modelId}`;
+  return undefined;
+}
+
+const metadataFilesByProvider = new Map<string, Set<string>>();
+
+function metadataModelExists(provider: string, modelId: string) {
+  let files = metadataFilesByProvider.get(provider);
+  if (files === undefined) {
+    try {
+      files = new Set(readdirSync(path.join(MODELS_DIR, provider)));
+    } catch {
+      files = new Set();
+    }
+    metadataFilesByProvider.set(provider, files);
+  }
+  return files.has(`${modelId}.toml`);
+}
+
+function inferFamily(model: AiandModel) {
+  const kimiFamily = inferKimiFamily(model.id, model.name);
+  if (kimiFamily !== undefined) return kimiFamily;
+
+  const target = `${model.id} ${model.name}`.toLowerCase();
+  return [...ModelFamilyValues]
+    .sort((a, b) => b.length - a.length)
+    .find((family) => {
+      const value = family.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      if (family === "o") {
+        return new RegExp(`(^|[^a-z0-9])${value}(?=\\d|$|[^a-z0-9])`).test(target);
+      }
+      return new RegExp(`(^|[^a-z0-9])${value}(?=$|[^a-z0-9])`).test(target);
+    });
+}
+
+export function buildAiandModel(
+  model: AiandModel,
+  existing: ExistingModel | undefined,
+): SyncedModel {
+  const capabilities = new Set(model.capabilities.map((value) => value.toLowerCase()));
+  const apiModalities = modalities(capabilities);
+  const apiAttachment = apiModalities.input.some((value) => value !== "text");
+  const reasoning = capabilities.has("reasoning");
+  const toolCall = capabilities.has("tool_calling");
+  const context = model.context_window;
+  const canonical = resolveAiandBaseModel(model);
+
+  // ai& reports prices in the org's billing currency. Only trust USD figures;
+  // preserve existing cost for any other currency.
+  const isUsd = model.currency.toLowerCase() === "usd";
+  const inputPrice = isUsd ? price(model.input_per_1m) : undefined;
+  const outputPrice = isUsd ? price(model.output_per_1m) : undefined;
+  const cost = inputPrice !== undefined && outputPrice !== undefined
+    ? {
+        input: inputPrice,
+        output: outputPrice,
+        reasoning: existing?.cost?.reasoning,
+        cache_read: existing?.cost?.cache_read,
+        cache_write: existing?.cost?.cache_write,
+        tiers: existing?.cost?.tiers,
+      }
+    : existing?.cost;
+
+  // The API only exposes a combined context window. Never infer input/output
+  // limits from it; preserve authored values so we do not wipe output limits.
+  const limit = {
+    context,
+    input: existing?.limit?.input,
+    output: existing?.limit?.output,
+  };
+
+  const releaseDate = dateFromTimestamp(model.created);
+
+  // Modalities are model-intrinsic and the ai& capability tags are too thin
+  // to be additive authority. Preserve authored/existing values exactly; only
+  // use API-derived modalities for brand-new standalone models.
+  const { modalities: resolvedModalities, attachment: resolvedAttachment } = resolveModalities(
+    existing,
+    apiModalities,
+    apiAttachment,
+    canonical,
+  );
+
+  // Existing factored model: refresh cost and context only; keep all curated
+  // capability/metadata overrides.
+  if (existing?.base_model !== undefined) {
+    return factorBaseModel(
+      existing.base_model,
+      {
+        description: existing.description ?? describeModel({
+          id: model.id,
+          name: existing.name ?? humanizeName(model),
+          family: existing.family,
+          reasoning: existing.reasoning,
+          tool_call: existing.tool_call,
+          structured_output: existing.structured_output,
+          open_weights: existing.open_weights,
+          limit,
+          modalities: resolvedModalities ?? apiModalities,
+        }),
+        reasoning: existing.reasoning,
+        reasoning_options: existing.reasoning_options,
+        temperature: existing.temperature,
+        tool_call: existing.tool_call,
+        structured_output: existing.structured_output,
+        status: existing.status,
+        interleaved: existing.interleaved,
+        knowledge: existing.knowledge,
+        limit,
+        cost,
+        ...(resolvedModalities !== undefined && {
+          attachment: resolvedAttachment,
+          modalities: resolvedModalities,
+        }),
+      },
+      limit,
+      existing.base_model_omit,
+    );
+  }
+
+  // Existing full model: refresh cost and context; preserve all curated
+  // capability/metadata, but merge API capability tags onto authored modalities.
+  if (existing !== undefined) {
+    return {
+      name: existing.name ?? humanizeName(model),
+      description: existing.description ?? model.description ?? describeModel({
+        id: model.id,
+        name: existing.name ?? humanizeName(model),
+        family: existing.family,
+        reasoning: existing.reasoning,
+        tool_call: existing.tool_call,
+        structured_output: existing.structured_output,
+        open_weights: existing.open_weights,
+        limit,
+        modalities: resolvedModalities ?? apiModalities,
+      }),
+      family: existing.family,
+      release_date: existing.release_date ?? releaseDate,
+      last_updated: existing.last_updated ?? releaseDate,
+      attachment: resolvedAttachment ?? apiAttachment,
+      reasoning: existing.reasoning,
+      reasoning_options: existing.reasoning_options,
+      temperature: existing.temperature,
+      tool_call: existing.tool_call,
+      structured_output: existing.structured_output,
+      knowledge: existing.knowledge,
+      open_weights: existing.open_weights,
+      status: existing.status,
+      interleaved: existing.interleaved,
+      cost,
+      limit,
+      modalities: resolvedModalities ?? apiModalities,
+    } satisfies SyncedFullModel;
+  }
+
+  // New model with a reviewed metadata entry: factor it against the canonical
+  // base so name/family/capability facts inherit from models/. Only cost and
+  // context come from the API; everything else stays with the shared metadata.
+  if (canonical !== undefined) {
+    const factoredLimit = { context, input: undefined, output: undefined };
+    return factorBaseModel(
+      canonical,
+      { limit: factoredLimit, cost },
+      factoredLimit,
+    );
+  }
+
+  // Best-effort fallback for unknown standalone models. This path is only
+  // reachable in tests or manual calls; translateModel skips remote IDs with
+  // no local file and no resolvable base_model so the hourly sync does not
+  // author incomplete rows.
+  return {
+    name: humanizeName(model),
+    description: model.description ?? describeModel({
+      id: model.id,
+      name: humanizeName(model),
+      family: inferFamily(model),
+      reasoning,
+      tool_call: toolCall,
+      structured_output: false,
+      open_weights: false,
+      limit,
+      modalities: apiModalities,
+    }),
+    family: inferFamily(model),
+    release_date: releaseDate,
+    last_updated: releaseDate,
+    attachment: apiAttachment,
+    reasoning,
+    reasoning_options: reasoning ? [] : undefined,
+    temperature: false,
+    tool_call: toolCall,
+    structured_output: false,
+    open_weights: false,
+    cost,
+    // The API only exposes a combined context window, so new models have no
+    // authoritative output limit. Fall back to the context window so the model
+    // satisfies AuthoredModel / ProviderModelLimit; this should be reviewed and
+    // corrected by hand when the real output limit is known.
+    limit: { ...limit, output: limit.output ?? context },
+    modalities: apiModalities,
+  } satisfies SyncedFullModel;
+}
+
+function resolveModalities(
+  existing: ExistingModel | undefined,
+  apiModalities: { input: Modality[]; output: Modality[] },
+  apiAttachment: boolean,
+  canonical: string | undefined,
+): { modalities?: { input: Modality[]; output: Modality[] }; attachment?: boolean } {
+  if (existing !== undefined) {
+    // context.existing() returns the base-resolved model, so modalities and
+    // attachment are always present. Pass them through unchanged; factorBaseModel
+    // will strip values that match the shared metadata.
+    return {
+      modalities: existing.modalities,
+      attachment: existing.attachment,
+    };
+  }
+  // Factored routes inherit modalities from the shared base model.
+  if (canonical !== undefined) {
+    return {};
+  }
+  return {
+    modalities: apiModalities,
+    attachment: apiAttachment,
+  };
+}
+
+function humanizeName(model: AiandModel) {
+  const last = model.id.split("/").at(-1) ?? model.id;
+  return last
+    .replace(/[:._-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -38,6 +38,7 @@ import { pioneer } from "../src/sync/providers/pioneer.js";
 import { google, shouldTrackGoogleModel } from "../src/sync/providers/google.js";
 import { resolveVeniceBaseModel } from "../src/sync/providers/venice.js";
 import { buildVercelModel, vercel } from "../src/sync/providers/vercel.js";
+import { aiand, buildAiandModel, type AiandModel } from "../src/sync/providers/aiand.js";
 import { buildWandbModel, type WandbModel } from "../src/sync/providers/wandb.js";
 import { buildXAIModel } from "../src/sync/providers/xai.js";
 
@@ -1534,6 +1535,104 @@ test("maps EmpirioLabs aliases to canonical model metadata", () => {
   expect(resolveEmpiriolabsBaseModel("muse-spark-1-1")).toBe("meta/muse-spark-1.1");
   expect(resolveEmpiriolabsBaseModel("step-3-5-flash")).toBe("stepfun/step-3.5-flash");
 });
+
+test("syncs ai& pricing and context from the OpenAI-shaped models endpoint", () => {
+  const model = buildAiandModel(aiandModel(), undefined);
+
+  expect(model).toMatchObject({
+    base_model: "zhipuai/glm-5.2",
+    cost: { input: 1, output: 4 },
+    limit: { context: 1_048_576 },
+  });
+  expect("name" in model).toBe(false);
+});
+
+test("preserves authored ai& limits and reasoning options on factored models", () => {
+  const model = buildAiandModel(aiandModel({ context_window: 999_000 }), {
+    base_model: "zhipuai/glm-5.2",
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+    cost: { input: 0.5, output: 2 },
+    limit: { context: 1_048_576, output: 131_072 },
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+    attachment: true,
+  });
+
+  expect(model).toMatchObject({
+    base_model: "zhipuai/glm-5.2",
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+    limit: { context: 999_000 },
+  });
+});
+
+test("preserves authored ai& modalities and attachment when API capability tags differ", () => {
+  const model = buildAiandModel(aiandModel({
+    id: "moonshotai/kimi-k2.7-code",
+    provider: "moonshotai",
+    capabilities: ["reasoning", "tool_calling"],
+  }), {
+    name: "Kimi K2.7 Code",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: true,
+    reasoning: true,
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 0.75, output: 3.5 },
+    limit: { context: 262_144, output: 262_144 },
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    attachment: true,
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+});
+
+test("skips ai& remote-only models with no local file and no resolvable base model", () => {
+  const translated = aiand.translateModel(aiandModel({
+    id: "custom-org/custom-model",
+    provider: "custom-org",
+  }), {
+    existing: () => undefined,
+    authored: () => undefined,
+  });
+
+  expect(translated).toBeUndefined();
+});
+
+test("falls back ai& output limit to context for brand-new models", () => {
+  const model = buildAiandModel(aiandModel({
+    id: "custom-org/custom-model",
+    provider: "custom-org",
+    capabilities: ["tool_calling"],
+  }), undefined);
+
+  expect(model).toMatchObject({
+    name: "Custom Model",
+    tool_call: true,
+    attachment: false,
+    limit: { context: 1_048_576, output: 1_048_576 },
+  });
+});
+
+function aiandModel(overrides: Partial<AiandModel> = {}): AiandModel {
+  return {
+    id: "zai-org/glm-5.2",
+    object: "model",
+    name: "zai-org/glm-5.2",
+    owned_by: "ai&",
+    provider: "zai-org",
+    context_window: 1_048_576,
+    capabilities: ["reasoning", "tool_calling"],
+    description: "Zhipu GLM 5.2",
+    currency: "usd",
+    input_per_1m: "1.000000",
+    output_per_1m: "4.000000",
+    created: 1_780_963_200,
+    ...overrides,
+  };
+}
 
 function unavailableStub(): OpenRouterModel {
   return openRouterModel({

--- a/providers/aiand/models/deepseek-ai/deepseek-v4-flash.toml
+++ b/providers/aiand/models/deepseek-ai/deepseek-v4-flash.toml
@@ -17,4 +17,3 @@ output = 0.25
 
 [limit]
 context = 1_048_576
-output = 384_000

--- a/providers/aiand/models/deepseek-ai/deepseek-v4-pro.toml
+++ b/providers/aiand/models/deepseek-ai/deepseek-v4-pro.toml
@@ -11,9 +11,8 @@ type = "effort"
 values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
-input = 1.00
-output = 2.50
+input = 1
+output = 2.5
 
 [limit]
 context = 1_048_576
-output = 384_000

--- a/providers/aiand/models/google/gemma-4-31b-it.toml
+++ b/providers/aiand/models/google/gemma-4-31b-it.toml
@@ -14,9 +14,8 @@ type = "effort"
 values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
-input = 0.20
-output = 0.50
+input = 0.2
+output = 0.5
 
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/aiand/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/aiand/models/moonshotai/kimi-k2.7-code.toml
@@ -13,8 +13,7 @@ values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
 input = 0.75
-output = 3.50
+output = 3.5
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/aiand/models/moonshotai/kimi-k3.toml
+++ b/providers/aiand/models/moonshotai/kimi-k3.toml
@@ -12,13 +12,14 @@
 # with 400 (negative control).
 base_model = "moonshotai/kimi-k3"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "high", "max"]
 
 [cost]
-input = 3.00
-cache_read = 0.50
-output = 12.50
+input = 3
+output = 12.5
+cache_read = 0.5
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/aiand/models/qwen/qwen3.6-27b.toml
+++ b/providers/aiand/models/qwen/qwen3.6-27b.toml
@@ -1,6 +1,7 @@
-# Source: https://docs.aiand.com/models/catalog/ (USD list prices; accessed
-# 2026-07-24) and live probes against api.aiand.com on the same date.
-# Listed as free ("no charges, ideal for evals") in the catalog's Quick picks.
+# Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
+# 2026-07-28). The catalog Quick-picks section still lists this model as free,
+# but the live endpoint reports input = $0.32 / output = $3.20 per 1M tokens,
+# so pricing is taken from the API.
 # ai&'s deployment rejects image input ("does not support image input") and
 # the catalog lists no vision/video/audio capability, so modalities are
 # overridden from the shared base model's text+image+video+audio to text-only,
@@ -8,7 +9,6 @@
 # reasoning_effort verified by live probe on 2026-07-24: all six documented
 # values accepted; invalid values rejected with 400 (negative control).
 base_model = "alibaba/qwen3.6-27b"
-
 attachment = false
 
 [[reasoning_options]]
@@ -16,9 +16,8 @@ type = "effort"
 values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
-input = 0
-output = 0
+input = 0.32
+output = 3.2
 
 [modalities]
 input = ["text"]
-output = ["text"]

--- a/providers/aiand/models/zai-org/glm-5.2.toml
+++ b/providers/aiand/models/zai-org/glm-5.2.toml
@@ -11,9 +11,8 @@ type = "effort"
 values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
-input = 1.00
-output = 4.00
+input = 1
+output = 4
 
 [limit]
 context = 1_048_576
-output = 131_072


### PR DESCRIPTION
## Summary

- Add an automated sync module for the existing [ai&](https://aiand.com/) provider.
- Fetch live model data from ai&'s OpenAI-compatible `GET /v1/models` endpoint.
- Translate API fields into the models.dev schema:
  - `context_window` → `limit.context`
  - `input_per_1m` / `output_per_1m` (USD only) → `cost.input` / `cost.output`
- Map ai& provider prefixes (`zai-org`, `deepseek-ai`, `qwen`) to canonical metadata namespaces (`zhipuai`, `deepseek`, `alibaba`) so models factor onto shared `base_model` entries.
- Preserve curated capability metadata on existing routes; the thin API capability list is only used for brand-new standalone models, which are skipped by the hourly sync.
- Register `aiand` in `packages/core/src/sync/index.ts` and add it to the `direct` sync group.
- Add `AIAND_API_KEY` to `.github/workflows/sync-models.yml` so the scheduled workflow can sync ai& models.
- Add `aiand:sync` script to `package.json` for local runs.
- Add focused unit tests in `packages/core/test/sync.test.ts` covering pricing, capability preservation, base-model factoring, and skipping thin standalone creates.

## Sources

- ai& API endpoint: `GET https://api.aiand.com/v1/models`
- ai& docs: https://docs.aiand.com/models/catalog/
- Existing sync patterns: `packages/core/src/sync/providers/vercel.ts`, `packages/core/src/sync/providers/llmgateway.ts`, `packages/core/src/sync/providers/deepinfra.ts`

## Validation

```bash
bun test packages/core/test/sync.test.ts
```

Tests pass: 60/60.

## Required secret

After merging, ensure the repository has `AIAND_API_KEY` configured as a GitHub secret so the `sync-models.yml` workflow can authenticate against ai&.
