### PR TITLE
feat(xuanshu-api): add XuanShu API provider

### DIFF
--- a/providers/xuanshu-api/logo.svg
+++ b/providers/xuanshu-api/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">玄枢API</title>
+  <defs>
+    <mask id="x-cut">
+      <rect width="64" height="64" fill="white"/>
+      <path d="M24 22 32 30 40 22 42 24 34 32 42 40 40 42 32 34 24 42 22 40 30 32 22 24Z" fill="black"/>
+    </mask>
+  </defs>
+  <g fill="currentColor" mask="url(#x-cut)">
+    <path d="M18 5h28a13 13 0 0 1 13 13v28a13 13 0 0 1-13 13H18A13 13 0 0 1 5 46V18A13 13 0 0 1 18 5Zm0 3v13l7 7 5-5v-7h4v7l5 5 7-7V8Zm38 10H43l-7 7 5 5h7v4h-7l-5 5 7 7h13ZM46 56V43l-7-7-5 5v7h-4v-7l-5-5-7 7v13ZM8 46h13l7-7-5-5h-7v-4h7l5-5-7-7H8Z"/>
+  </g>
+</svg>

--- a/providers/xuanshu-api/models/claude-haiku-4-5.toml
+++ b/providers/xuanshu-api/models/claude-haiku-4-5.toml
@@ -1,0 +1,5 @@
+# Reasoning controls are not documented per-model; the operator publishes a
+# capability matrix that requires per-key verification instead.
+# https://www.xuanshuapi.com/en/docs/model-capabilities (accessed 2026-07-29)
+base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []

--- a/providers/xuanshu-api/models/claude-opus-4-6.toml
+++ b/providers/xuanshu-api/models/claude-opus-4-6.toml
@@ -1,0 +1,5 @@
+# Reasoning controls are not documented per-model; the operator publishes a
+# capability matrix that requires per-key verification instead.
+# https://www.xuanshuapi.com/en/docs/model-capabilities (accessed 2026-07-29)
+base_model = "anthropic/claude-opus-4-6"
+reasoning_options = []

--- a/providers/xuanshu-api/models/claude-opus-4-7.toml
+++ b/providers/xuanshu-api/models/claude-opus-4-7.toml
@@ -1,0 +1,5 @@
+# Reasoning controls are not documented per-model; the operator publishes a
+# capability matrix that requires per-key verification instead.
+# https://www.xuanshuapi.com/en/docs/model-capabilities (accessed 2026-07-29)
+base_model = "anthropic/claude-opus-4-7"
+reasoning_options = []

--- a/providers/xuanshu-api/models/claude-sonnet-4-6.toml
+++ b/providers/xuanshu-api/models/claude-sonnet-4-6.toml
@@ -1,0 +1,5 @@
+# Reasoning controls are not documented per-model; the operator publishes a
+# capability matrix that requires per-key verification instead.
+# https://www.xuanshuapi.com/en/docs/model-capabilities (accessed 2026-07-29)
+base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = []

--- a/providers/xuanshu-api/provider.toml
+++ b/providers/xuanshu-api/provider.toml
@@ -1,0 +1,19 @@
+# XuanShu API (玄枢API) is an OpenAI/Anthropic/Gemini-compatible relay.
+# Registered as @ai-sdk/anthropic: the Messages surface is the one its own docs
+# lead with for coding agents. The SDK appends /messages to `api`.
+# The same host also serves OpenAI Responses and Chat Completions at
+# https://www.xuanshuapi.com/v1 and Gemini native at
+# https://www.xuanshuapi.com/v1beta, which this entry does not model.
+# Note: Claude Code is documented against the ROOT host with no /v1 path;
+# the /v1 value below is the AI SDK baseURL, not the Claude Code Base URL.
+# https://www.xuanshuapi.com/en/docs/claude-code
+# https://www.xuanshuapi.com/en/docs/model-capabilities (accessed 2026-07-29)
+#
+# Costs are omitted deliberately: pricing is a per-group multiplier applied to
+# upstream rates and is set in the operator console, so there is no single
+# public per-model rate to cite.
+name = "XuanShu API"
+env = ["XUANSHU_API_KEY"]
+npm = "@ai-sdk/anthropic"
+api = "https://www.xuanshuapi.com/v1"
+doc = "https://www.xuanshuapi.com/en/docs/models"


### PR DESCRIPTION
Adds `xuanshu-api` — XuanShu API (玄枢API), an Anthropic/OpenAI/Gemini-compatible relay.

### Shape

Registered as `@ai-sdk/anthropic` with `api = "https://www.xuanshuapi.com/v1"`. The Messages
surface is the one the operator's own docs lead with for coding agents, and the SDK appends
`/messages` to `api`. `POST /v1/messages` returns 401 (not 404) unauthenticated, so the route
exists.

The same host also serves OpenAI Responses / Chat Completions at `/v1` and Gemini native at
`/v1beta`. This entry does not model those — one npm per provider entry, and Messages is the
documented primary. Noted in a header comment so a later contributor does not assume the host
is Anthropic-only.

Four models, all inheriting from `models/anthropic/` via `base_model` per the review checklist:
`claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`.

### Two things I deliberately left empty

**`cost` omitted.** Pricing here is a per-group multiplier applied to upstream rates, set in
the operator console. There is no single public per-model rate I can cite, so inventing one
would be worse than omitting it.

**`reasoning_options = []`.** The operator publishes a capability matrix that explicitly says
capabilities are dynamic per key and per group and must be verified with a minimal request
rather than inferred. I could not verify a specific reasoning control surface from public docs,
and the schema's guidance is to use `[]` when a model reasons but exposes no verified control.
Happy to fill both in a follow-up once there is something citable.

### Logo

`providers/xuanshu-api/logo.svg` — square `viewBox="0 0 64 64"`, `fill="currentColor"`, no
hardcoded colors or fixed size. It is the operator's own monochrome brand mark.

### Sources

- https://www.xuanshuapi.com/en/docs/models
- https://www.xuanshuapi.com/en/docs/claude-code
- https://www.xuanshuapi.com/en/docs/model-capabilities

### Checks

`bun validate` — exit 0. Resolved entry inherits limit (1M context / 128K output), modalities,
and `tool_call` from the base model as expected.

### Disclosure

I am affiliated with the provider.
