### PR TITLE
feat(openai): add pricing for the Codex and chat-latest models

### DIFF
--- a/providers/openai/models/gpt-5-chat-latest.toml
+++ b/providers/openai/models/gpt-5-chat-latest.toml
@@ -1,0 +1,13 @@
+# Pricing and reasoning effort values from OpenAI's published price list and
+# model pages: https://developers.openai.com/api/docs/pricing
+# The model page does not state accepted reasoning effort values, so
+# reasoning_options is left empty per the contribution guidelines.
+
+base_model = "openai/gpt-5-chat-latest"
+
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125

--- a/providers/openai/models/gpt-5-codex.toml
+++ b/providers/openai/models/gpt-5-codex.toml
@@ -1,0 +1,13 @@
+# Pricing and reasoning effort values from OpenAI's published price list and
+# model pages: https://developers.openai.com/api/docs/pricing
+# The model page does not state accepted reasoning effort values, so
+# reasoning_options is left empty per the contribution guidelines.
+
+base_model = "openai/gpt-5-codex"
+
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125

--- a/providers/openai/models/gpt-5.1-chat-latest.toml
+++ b/providers/openai/models/gpt-5.1-chat-latest.toml
@@ -1,0 +1,13 @@
+# Pricing and reasoning effort values from OpenAI's published price list and
+# model pages: https://developers.openai.com/api/docs/pricing
+# The model page does not state accepted reasoning effort values, so
+# reasoning_options is left empty per the contribution guidelines.
+
+base_model = "openai/gpt-5.1-chat-latest"
+
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125

--- a/providers/openai/models/gpt-5.1-codex-max.toml
+++ b/providers/openai/models/gpt-5.1-codex-max.toml
@@ -1,0 +1,13 @@
+# Pricing and reasoning effort values from OpenAI's published price list and
+# model pages: https://developers.openai.com/api/docs/pricing
+# The model page does not state accepted reasoning effort values, so
+# reasoning_options is left empty per the contribution guidelines.
+
+base_model = "openai/gpt-5.1-codex-max"
+
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125

--- a/providers/openai/models/gpt-5.1-codex-mini.toml
+++ b/providers/openai/models/gpt-5.1-codex-mini.toml
@@ -1,0 +1,13 @@
+# Pricing and reasoning effort values from OpenAI's published price list and
+# model pages: https://developers.openai.com/api/docs/pricing
+# The model page does not state accepted reasoning effort values, so
+# reasoning_options is left empty per the contribution guidelines.
+
+base_model = "openai/gpt-5.1-codex-mini"
+
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 2.00
+cache_read = 0.025

--- a/providers/openai/models/gpt-5.1-codex.toml
+++ b/providers/openai/models/gpt-5.1-codex.toml
@@ -1,0 +1,13 @@
+# Pricing and reasoning effort values from OpenAI's published price list and
+# model pages: https://developers.openai.com/api/docs/pricing
+# The model page does not state accepted reasoning effort values, so
+# reasoning_options is left empty per the contribution guidelines.
+
+base_model = "openai/gpt-5.1-codex"
+
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125

--- a/providers/openai/models/gpt-5.2-codex.toml
+++ b/providers/openai/models/gpt-5.2-codex.toml
@@ -1,0 +1,11 @@
+# Pricing and reasoning effort values from OpenAI's published price list and
+# model pages: https://developers.openai.com/api/docs/pricing
+
+base_model = "openai/gpt-5.2-codex"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.75
+output = 14.00
+cache_read = 0.175


### PR DESCRIPTION
## What

Adds provider entries for seven OpenAI models that have `models/openai/` metadata but no `providers/openai/models/` entry, so they never appear under the `openai` provider in `api.json` and consumers have no price for them:

| model | input | cached input | output |
|---|---|---|---|
| `gpt-5-codex` | $1.25 | $0.125 | $10.00 |
| `gpt-5.1-codex` | $1.25 | $0.125 | $10.00 |
| `gpt-5.1-codex-max` | $1.25 | $0.125 | $10.00 |
| `gpt-5.1-codex-mini` | $0.25 | $0.025 | $2.00 |
| `gpt-5.2-codex` | $1.75 | $0.175 | $14.00 |
| `gpt-5-chat-latest` | $1.25 | $0.125 | $10.00 |
| `gpt-5.1-chat-latest` | $1.25 | $0.125 | $10.00 |

The `gpt-5.3` generation onward is already covered — `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2-chat-latest` and `gpt-5.3-chat-latest` all have provider entries. These seven are the ones below that line.

## Source

Prices are from OpenAI's published price list, standard tier: https://developers.openai.com/api/docs/pricing

Each file cites it in a leading comment block, per the guideline that only a leading header survives the sync rewrite.

## Notes

Every entry uses `base_model`, since `models/openai/<id>.toml` exists for all seven — no provider-agnostic facts are duplicated inline.

`reasoning_options` is declared because the inherited metadata sets `reasoning = true` and the schema requires it. Only the `gpt-5.2-codex` model page publishes its accepted effort values (`low`, `medium`, `high`, `xhigh`), so that one is filled in; the other six use `reasoning_options = []` per the guideline to leave it empty rather than assert a control that is not documented. Happy to fill those in if you have a source I missed.

`bun validate` passes.
