### PR TITLE
feat(llmgateway): add reasoning effort levels for kimi-k3

### DIFF
--- a/providers/llmgateway/models/kimi-k3.toml
+++ b/providers/llmgateway/models/kimi-k3.toml
@@ -1,5 +1,17 @@
+# Moonshot mapping lists $.reasoning_effort / $.reasoning.effort =
+# none|minimal|low|medium|high|xhigh|max. Verified 2026-07-29: every value is
+# accepted and returns a thinking trace in $.choices[].message.reasoning;
+# depth scales low < medium < high ~= max. There is NO working off switch:
+# "none", reasoning.enabled=false, thinking.type=disabled, and
+# reasoning.exclude=true all still reason, so "none" is not listed and no
+# toggle is declared (the model always thinks on this gateway).
+# https://docs.llmgateway.io/features/reasoning
+# https://api.llmgateway.io/v1/models providers[].reasoning_efforts
 base_model = "moonshotai/kimi-k3"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort" # API: {"reasoning_effort": "<v>"} or {"reasoning": {"effort": "<v>"}}
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 3

--- a/providers/llmgateway/models/kimi-k3.toml
+++ b/providers/llmgateway/models/kimi-k3.toml
@@ -1,16 +1,18 @@
 # Moonshot mapping lists $.reasoning_effort / $.reasoning.effort =
-# none|minimal|low|medium|high|xhigh|max. Verified 2026-07-29: every value is
-# accepted and returns a thinking trace in $.choices[].message.reasoning;
-# depth scales low < medium < high ~= max. There is NO working off switch:
-# "none", reasoning.enabled=false, thinking.type=disabled, and
-# reasoning.exclude=true all still reason, so "none" is not listed and no
-# toggle is declared (the model always thinks on this gateway).
+# none|minimal|low|medium|high|xhigh|max. Effort is sent as
+# {"reasoning_effort": "<v>"} or {"reasoning": {"effort": "<v>"}}.
+# Verified 2026-07-29: every value is accepted and returns a thinking trace
+# in $.choices[].message.reasoning; depth scales low < medium < high ~= max.
+# There is NO working off switch: "none", reasoning.enabled=false,
+# thinking.type=disabled, and reasoning.exclude=true all still reason, so
+# "none" is not listed and no toggle is declared (the model always thinks on
+# this gateway).
 # https://docs.llmgateway.io/features/reasoning
 # https://api.llmgateway.io/v1/models providers[].reasoning_efforts
 base_model = "moonshotai/kimi-k3"
 
 [[reasoning_options]]
-type = "effort" # API: {"reasoning_effort": "<v>"} or {"reasoning": {"effort": "<v>"}}
+type = "effort"
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]


### PR DESCRIPTION
## Problem

The `llmgateway/kimi-k3` entry declares `reasoning_options = []`, so catalog consumers see no way to control thinking for this model even though the gateway exposes reasoning controls for it.

## Change

Add an effort list to `providers/llmgateway/models/kimi-k3.toml`: `minimal`, `low`, `medium`, `high`, `xhigh`, `max` (sent as `reasoning_effort` / `reasoning.effort`).

`none` is deliberately **not** listed and no `toggle` is declared: the model always reasons on this gateway (see below), so consumers infer always-thinking from the level list alone.

## Verification (live gateway, 2026-07-29)

Probed `POST /v1/chat/completions` with `model: kimi-k3`:

- Every documented effort value (`none|minimal|low|medium|high|xhigh|max`) is accepted without error, and every response carries a thinking trace in `choices[].message.reasoning`.
- Reasoning depth scales with the level (`reasoning_tokens` on a fixed hard prompt: low ≈ 279, medium ≈ 539, high ≈ 811, max ≈ 722).
- No off switch works — all of these still return thinking traces with comparable reasoning-token counts:
  - `reasoning_effort: "none"` (and `reasoning: {"effort": "none"}`)
  - `reasoning: {"enabled": false}`
  - `thinking: {"type": "disabled"}`
  - `reasoning: {"exclude": true}`
- `reasoning: {"max_tokens": 0}` errors.
- `https://api.llmgateway.io/v1/models` advertises these values in `providers[].reasoning_efforts` for kimi-k3.

Sources: https://docs.llmgateway.io/features/reasoning

## Validation

- `bun validate` passes; the generated catalog lists the six effort levels for `llmgateway/kimi-k3`.

Note: direct provider routing is unavailable on the plan used for testing, so the fireworks-routed path specifically could not be exercised; all observations above are for the routes the gateway serves by default. If a maintainer can confirm `none` is honored on a specific route, it can be added back in a follow-up.
