### PR TITLE
fix: add OpenCode models domain

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -49,7 +49,6 @@ export default $config({
         hostname: "models.opencode.ai",
         service: worker.nodes.worker.scriptName,
         zoneId: zone.zoneId,
-        zoneName: zone.name,
       });
     }
 

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -18,13 +18,7 @@ export default $config({
 
     const worker = new sst.cloudflare.Worker("Server", {
       url: true,
-      domain:
-        $app.stage === "dev"
-          ? {
-              name: "models.dev",
-              aliases: ["models.opencode.ai"],
-            }
-          : undefined,
+      domain: $app.stage === "dev" ? "models.dev" : undefined,
       link: [
         new sst.Secret("PosthogToken"),
         new sst.Secret("LakeUrl"),
@@ -40,6 +34,24 @@ export default $config({
         },
       },
     });
+
+    if ($app.stage === "dev") {
+      const zone = cloudflare.getZoneOutput({
+        filter: {
+          account: { id: process.env.CLOUDFLARE_DEFAULT_ACCOUNT_ID! },
+          name: "opencode.ai",
+        },
+      });
+
+      new cloudflare.WorkersCustomDomain("OpenCodeDomain", {
+        accountId: process.env.CLOUDFLARE_DEFAULT_ACCOUNT_ID!,
+        environment: "production",
+        hostname: "models.opencode.ai",
+        service: worker.nodes.worker.scriptName,
+        zoneId: zone.zoneId,
+        zoneName: zone.name,
+      });
+    }
 
     return {
       url: worker.url,


### PR DESCRIPTION
## Summary

- restore the SST 3.17-compatible string configuration for `models.dev`
- route `models.opencode.ai` to the same Cloudflare Worker with a separate custom domain
- pass the Cloudflare lookup's explicit `zoneId` and `zoneName` to the custom domain resource

This replaces the two prior broken attempts: the first passed `zone.id`, which left the required `zoneId` undefined, and the second used the newer SST object-shaped domain API unsupported by the pinned SST 3.17.23.

## Verification

- `bun validate`
- `cd packages/web && bun run build`
- `git diff --check`

A live SST diff requires the Cloudflare credentials available in deployment CI.