### PR TITLE
fix(inkling): add output token limit

### DIFF
--- a/models/thinkingmachines/inkling.toml
+++ b/models/thinkingmachines/inkling.toml
@@ -17,6 +17,7 @@ license = "Apache-2.0"
 
 [limit]
 context = 1_048_576
+output = 1_048_576
 
 [modalities]
 input = ["text", "image", "audio"]


### PR DESCRIPTION
## Summary

- add Inkling’s missing canonical output token limit
- allow DeepInfra and Hugging Face sync output to inherit a valid `limit.output`

## Validation

- `bun validate`

## Sources

- Failed sync run: https://github.com/anomalyco/models.dev/actions/runs/30510915163
- Inkling model card (1M-token context): https://thinkingmachines.ai/model-card/inkling/
- Hugging Face config (`model_max_length: 1048576`): https://huggingface.co/thinkingmachines/Inkling/blob/main/config.json