### PR TITLE
feat(hyper): relax base model in autosync

### DIFF
--- a/packages/core/src/sync/providers/hyper.ts
+++ b/packages/core/src/sync/providers/hyper.ts
@@ -2,14 +2,21 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 
+import { describeModel } from "../../describe.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
-import { factorBaseModel } from "./openrouter.js";
+import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://hyper.charm.land/v1/models";
 const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
 
 function baseModelExists(modelID: string) {
   return existsSync(path.join(MODELS_DIR, `${modelID}.toml`));
+}
+
+function resolveHyperBaseModel(modelID: string, existingBase: string | undefined) {
+  if (existingBase !== undefined && baseModelExists(existingBase)) return existingBase;
+  const resolved = resolveModelMetadataBaseModel(modelID);
+  return resolved !== undefined && baseModelExists(resolved) ? resolved : undefined;
 }
 
 const ReasoningEffort = z.enum([
@@ -72,11 +79,9 @@ export const hyper = {
   },
   translateModel(model, context) {
     const existing = context.existing(model.id);
-    const baseModel = existing?.base_model;
-    if (baseModel === undefined || !baseModelExists(baseModel)) return undefined;
     return {
       id: model.id,
-      model: buildHyperModel(model, existing, baseModel),
+      model: buildHyperModel(model, existing),
     };
   },
 } satisfies SyncProvider<HyperModel>;
@@ -131,7 +136,7 @@ function hyperModalities(vision: boolean) {
 export function buildHyperModel(
   model: HyperModel,
   existing: ExistingModel | undefined,
-  baseModel: string,
+  baseModel = existing?.base_model,
   today = new Date().toISOString().slice(0, 10),
 ): SyncedModel {
   const limit = {
@@ -140,17 +145,53 @@ export function buildHyperModel(
     output: model.max_output_tokens,
   };
   const modalities = hyperModalities(model.capabilities?.vision ?? false);
+  const reasoning = model.reasoning != null;
+  const releaseDate = existing?.release_date ?? dateFromTimestamp(model.created);
   const values: Partial<SyncedFullModel> = {
     attachment: modalities.input.some((value) => value !== "text"),
     modalities,
-    reasoning: model.reasoning != null,
-    reasoning_options: model.reasoning != null ? reasoningOptions(model) : undefined,
-    release_date: existing?.release_date ?? dateFromTimestamp(model.created),
+    reasoning,
+    release_date: releaseDate,
     last_updated: existing?.last_updated ?? today,
     interleaved: existing?.interleaved,
     cost: buildCost(model, existing?.cost),
     limit,
   };
+  if (reasoning) values.reasoning_options = reasoningOptions(model);
 
-  return factorBaseModel(baseModel, values, limit, existing?.base_model_omit);
+  const resolvedBase = resolveHyperBaseModel(model.id, baseModel);
+  if (resolvedBase !== undefined) {
+    return factorBaseModel(
+      resolvedBase,
+      values,
+      limit,
+      existing?.base_model === resolvedBase ? existing.base_model_omit : undefined,
+    );
+  }
+
+  const name = existing?.name ?? model.display_name;
+  return {
+    name,
+    description: existing?.description ?? describeModel({
+      id: model.id,
+      name,
+      family: existing?.family,
+      reasoning,
+      tool_call: existing?.tool_call ?? true,
+      structured_output: existing?.structured_output,
+      open_weights: existing?.open_weights ?? false,
+      limit,
+      modalities,
+    }),
+    family: existing?.family,
+    ...values,
+    temperature: existing?.temperature,
+    tool_call: existing?.tool_call ?? true,
+    structured_output: existing?.structured_output,
+    knowledge: existing?.knowledge,
+    open_weights: existing?.open_weights ?? false,
+    status: existing?.status,
+    provider: existing?.provider,
+    experimental: existing?.experimental,
+  };
 }

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1244,6 +1244,41 @@ test("preserves existing Hyper cost when API pricing is missing", () => {
   });
 });
 
+test("creates a full Hyper model when no base_model metadata exists", () => {
+  const model = hyperModel({
+    id: "qwen3.7-flash",
+    display_name: "Qwen3.7-Flash",
+    reasoning: undefined,
+    capabilities: { vision: true },
+    pricing: {
+      input: 0.2,
+      output: 0.8,
+      cache_hit: 0.04,
+      cache_create: 0,
+    },
+  });
+
+  expect(buildHyperModel(model, undefined)).toMatchObject({
+    name: "Qwen3.7-Flash",
+    attachment: true,
+    reasoning: false,
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 0.2, output: 0.8, cache_read: 0.04 },
+    limit: { context: 1_000_000, output: 384_000 },
+    modalities: { input: ["text", "image"], output: ["text"] },
+  });
+  expect(buildHyperModel(model, undefined)).not.toHaveProperty("base_model");
+  expect(buildHyperModel(model, undefined)).not.toHaveProperty("reasoning_options");
+});
+
+test("factors new Hyper models against unique models/ metadata", () => {
+  expect(buildHyperModel(hyperModel({ id: "kimi-k3", reasoning: undefined }), undefined)).toMatchObject({
+    base_model: "moonshotai/kimi-k3",
+    reasoning: false,
+  });
+});
+
 test("formats interleaved as a root field before reasoning option tables", () => {
   const content = formatToml({
     id: "example/model",

--- a/providers/hyper/models/kimi-k3.toml
+++ b/providers/hyper/models/kimi-k3.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k3"
+release_date = "2026-07-27"
+last_updated = "2026-07-30"
+reasoning = false
+
+[cost]
+input = 3.2664
+output = 16.332
+cache_read = 0.32664
+
+[modalities]
+input = ["text", "image"]

--- a/providers/hyper/models/qwen3.7-flash.toml
+++ b/providers/hyper/models/qwen3.7-flash.toml
@@ -1,0 +1,21 @@
+name = "Qwen3.7-Flash"
+description = "Efficient model for low-latency assistance, extraction, and routine automation"
+release_date = "2026-07-27"
+last_updated = "2026-07-30"
+attachment = true
+reasoning = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.8
+cache_read = 0.04
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Problem:
- new Hyper models were not added unless a `base_model` existed. there was no base model for `qwen3.7-flash`

Solution:
- hyper sync script no longer requires the toml with `base-model` before creating models. Works just like openrouter sync
- current logic: check models/ metadata. if no match exists, write a full inline definition with parameters from the API
- this unblocks new entries (qwen3.7-flash)


```
root@8ed8e4850d06:/workspaces/contrib-models.dev# bun test packages/core/test/sync.test.ts -t Hyper
bun test v1.3.14 (0d9b296a)

packages/core/test/sync.test.ts:
✓ syncs Hyper pricing from catalog input/output fields [10.87ms]
✓ rounds Hyper pricing to six decimal places [0.82ms]
✓ sets Hyper reasoning false when API omits reasoning metadata [0.60ms]
✓ preserves existing Hyper cost when API pricing is missing [0.10ms]
✓ creates a full Hyper model when no base_model metadata exists [6.84ms]
✓ factors new Hyper models against unique models/ metadata [0.79ms]

 6 pass
 82 filtered out
 0 fail
 12 expect() calls
Ran 6 tests across 1 file. [454.00ms]
```