### PR TITLE
The Grid: update 9 models

### DIFF
--- a/providers/the-grid-ai/models/agent-max.toml
+++ b/providers/the-grid-ai/models/agent-max.toml
@@ -2,11 +2,11 @@ name = "Agent Max"
 description = "Frontier models for autonomous research, deep multi-step tool chains, and complex long-horizon tasks. Any model that meets the contract spec can serve your request."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
 release_date = "2026-05-04"
-last_updated = "2026-07-06"
-attachment = false
+last_updated = "2026-07-24"
+attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
-temperature = true
+temperature = false
 tool_call = true
 structured_output = true
 status = "beta"

--- a/providers/the-grid-ai/models/agent-prime.toml
+++ b/providers/the-grid-ai/models/agent-prime.toml
@@ -2,7 +2,7 @@ name = "Agent Prime"
 description = "Reliable models for dependable agentic applications, multi-step tool use, and reasoning workflows. Any model that meets the contract spec can serve your request."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
 release_date = "2026-05-04"
-last_updated = "2026-07-06"
+last_updated = "2026-07-15"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/the-grid-ai/models/agent-standard.toml
+++ b/providers/the-grid-ai/models/agent-standard.toml
@@ -2,7 +2,7 @@ name = "Agent Standard"
 description = "Price-optimized models for fast tool calls, simple agent loops, high-throughput automation, and orchestration. Any model that meets the contract spec can serve your request."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
 release_date = "2026-05-04"
-last_updated = "2026-07-06"
+last_updated = "2026-07-15"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/the-grid-ai/models/code-max.toml
+++ b/providers/the-grid-ai/models/code-max.toml
@@ -2,11 +2,11 @@ name = "Code Max"
 description = "Frontier models for complex research, architectural decisions, debugging, and multi-file development. Any model that meets the contract spec can serve your request."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
 release_date = "2026-05-04"
-last_updated = "2026-07-06"
-attachment = false
+last_updated = "2026-07-24"
+attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
-temperature = true
+temperature = false
 tool_call = true
 structured_output = true
 status = "beta"

--- a/providers/the-grid-ai/models/code-prime.toml
+++ b/providers/the-grid-ai/models/code-prime.toml
@@ -2,7 +2,7 @@ name = "Code Prime"
 description = "Reliable models for everyday software tasks, code completion, review, and standard debugging. Any model that meets the contract spec can serve your request."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
 release_date = "2026-05-04"
-last_updated = "2026-07-06"
+last_updated = "2026-07-15"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/the-grid-ai/models/code-standard.toml
+++ b/providers/the-grid-ai/models/code-standard.toml
@@ -2,7 +2,7 @@ name = "Code Standard"
 description = "Price-optimized models for rapid autocomplete, linting, high-frequency suggestions, and batch edits. Any model that meets the contract spec can serve your request."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
 release_date = "2026-05-04"
-last_updated = "2026-07-06"
+last_updated = "2026-07-15"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/the-grid-ai/models/text-max.toml
+++ b/providers/the-grid-ai/models/text-max.toml
@@ -1,12 +1,12 @@
 name = "Text Max"
 description = "Frontier models for deep reasoning, long context, and complex workflows. Any model that meets the contract spec can serve your request."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
-release_date = "2026-03-24"
-last_updated = "2026-07-06"
-attachment = false
+release_date = "2026-02-26"
+last_updated = "2026-07-24"
+attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
-temperature = true
+temperature = false
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/the-grid-ai/models/text-prime.toml
+++ b/providers/the-grid-ai/models/text-prime.toml
@@ -2,7 +2,7 @@ name = "Text Prime"
 description = "Reliable models for everyday text generation, editing, and analysis across diverse workflows. Any model that meets the contract spec can serve your request."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
 release_date = "2026-02-26"
-last_updated = "2026-07-06"
+last_updated = "2026-07-15"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/the-grid-ai/models/text-standard.toml
+++ b/providers/the-grid-ai/models/text-standard.toml
@@ -2,7 +2,7 @@ name = "Text Standard"
 description = "Price-optimized models with low-latency, high-throughput and shorter maximum outputs. Any model that meets the contract spec can serve your request."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
 release_date = "2026-02-26"
-last_updated = "2026-07-06"
+last_updated = "2026-07-15"
 attachment = false
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/the-grid-ai/provider.toml
+++ b/providers/the-grid-ai/provider.toml
@@ -1,5 +1,5 @@
 name = "The Grid AI"
-env = ["THEGRIDAI_API_KEY"]
+env = ["THEGRID_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
 # Raw HTTP reasoning controls (accessed 2026-07-06):
 # - POST https://api.thegrid.ai/v1/chat/completions routes by instrument tier


### PR DESCRIPTION
## Summary

Updates 9 existing model TOMLs under `providers/the-grid-ai/models/` (provider `the-grid-ai`, `providers/the-grid-ai/provider.toml`).

The Grid is an OpenAI-compatible inference platform ([docs](https://docs.thegrid.ai), API base `https://api.thegrid.ai/v1`). These records are generated from the same source of truth that drives our live `/v1/models` endpoint, so the values in this PR match what the API enforces.

## How these values are derived

Grid models differ from single-model providers in ways that affect the values here:

- Each model routes across a pool of underlying models. Published limits are the **guaranteed floor** across that pool — the minimum every pooled model accepts — so requests within the published limits never fail on limit grounds.
- The max input limit is a real, independently enforced cap. It is **not** derivable as `context − max output`.
- **`cost` is intentionally omitted.** Grid tokens trade on an open market, so there is no fixed per-token price to publish. Each model TOML links to its live market instead, matching what is already merged here.
- **`provider.toml` now sets `env = ["THEGRID_API_KEY"]`.** That is the variable named in Grid's own setup documentation and in the LiteLLM provider config ([BerriAI/litellm#35085](https://github.com/BerriAI/litellm/pull/35085)); the previous `THEGRIDAI_API_KEY` does not match the variable Grid documents.
- **Every changed value is sourced from the public catalog** at `GET https://api.thegrid.ai/v1/models` (no auth required): `created` for `release_date`, `grid.updated` for `last_updated`, `architecture.input_modalities` for `attachment`, and `supported_parameters` for `temperature`. Two of these read as capability removals but are corrections: the `*-max` tiers never accepted a `temperature` parameter, and they have always accepted image input, so `attachment` should have been `true` from the start.

## What changed

- `agent-max`
  - `attachment`: false → true
  - `last_updated`: "2026-07-06" → "2026-07-24"
  - `temperature`: true → false
- `agent-prime`
  - `last_updated`: "2026-07-06" → "2026-07-15"
- `agent-standard`
  - `last_updated`: "2026-07-06" → "2026-07-15"
- `code-max`
  - `attachment`: false → true
  - `last_updated`: "2026-07-06" → "2026-07-24"
  - `temperature`: true → false
- `code-prime`
  - `last_updated`: "2026-07-06" → "2026-07-15"
- `code-standard`
  - `last_updated`: "2026-07-06" → "2026-07-15"
- `text-max`
  - `attachment`: false → true
  - `last_updated`: "2026-07-06" → "2026-07-24"
  - `release_date`: "2026-03-24" → "2026-02-26"
  - `temperature`: true → false
- `text-prime`
  - `last_updated`: "2026-07-06" → "2026-07-15"
- `text-standard`
  - `last_updated`: "2026-07-06" → "2026-07-15"

## Verification

- Live values: `GET https://api.thegrid.ai/v1/models`.
- Before submission, every record in this PR was validated against a current entry from this repository (required fields present, matching types).
- `bun validate` passes on a clean checkout with these files applied.

These entries are maintained by an automated generator with daily reconciliation against the published registry, so drift is caught and corrected promptly. Happy to adjust the format or split this PR if you'd prefer.
