### PR TITLE
feat(crof): add kimi-k3-eco (cheaper variant)

### DIFF
--- a/providers/crof/models/kimi-k3-eco.toml
+++ b/providers/crof/models/kimi-k3-eco.toml
@@ -1,0 +1,17 @@
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1
+output = 4
+cache_read = 0.1
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[provider]
+npm = "@ai-sdk/openai-compatible"

--- a/providers/crof/models/kimi-k3-eco.toml
+++ b/providers/crof/models/kimi-k3-eco.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 Eco"
 reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
 
 [interleaved]


### PR DESCRIPTION
- Source: https://crof.ai/pricing
- This uses Q2_K quant (instead of original MXFP4) 
- Context window stays on 1M, max output reduced to 131k
- Eco version is priced at $1 input / $0.1 cached / $4 output (per M token)