### PR TITLE
fix(xai): correct Grok 4.5 long-context cached-input price

### DIFF
--- a/providers/openrouter/models/x-ai/grok-4.5.toml
+++ b/providers/openrouter/models/x-ai/grok-4.5.toml
@@ -13,7 +13,7 @@ cache_read = 0.3
 tier = { type = "context", size = 200_000 }
 input = 4
 output = 12
-cache_read = 1
+cache_read = 0.6
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/xai/models/grok-4.5.toml
+++ b/providers/xai/models/grok-4.5.toml
@@ -13,7 +13,7 @@ cache_read = 0.3
 tier = { type = "context", size = 200_000 }
 input = 4
 output = 12
-cache_read = 1
+cache_read = 0.6
 
 [modalities]
 input = ["text", "image", "pdf"]


### PR DESCRIPTION
`grok-4.5`'s `>200K` context tier reports `cache_read = 1`, but xAI publishes **$0.60** for cached input above the threshold.

Per [docs.x.ai/docs/models](https://docs.x.ai/docs/models):

| Mode | ≤200K | >200K |
|---|---|---|
| Input | $2.00 | $4.00 |
| **Cached input** | **$0.30** | **$0.60** |
| Output | $6.00 | $12.00 |

### Why it survived

The base rate self-corrected — `xai.ts`'s `cost()` reads `cached_prompt_text_token_price` straight from the API, so `[cost] cache_read` went `0.5` → `0.3` in `41aed22b`. Tiers don't take that path:

```ts
function preservedCostTiers(existing: ExistingModel) {
  // The xAI models API exposes base pricing only; long-context tiers are curated from xAI docs/console.
  return existing.cost?.tiers;
}
```

So the tier kept `1` — which is `2 × 0.5`, i.e. 2× the *old*, incorrect base rate. It can't self-heal; it needs the hand edit.

### Corroborating

- Within `providers/xai`, `grok-4.5` is the only model whose tier doesn't scale uniformly: `grok-4.3`, `grok-build-0.1`, and all three `grok-4.20-*` double input, output, **and** `cache_read` together. grok-4.5 was doubling input/output but tripling cache_read (3.33×).
- OpenRouter's own API independently reports $0.60 for the same tier:
  ```json
  "pricing": {
    "input_cache_read": "0.0000003",
    "overrides": [
      { "min_prompt_tokens": 200000, "prompt": "0.000004", "completion": "0.000012", "input_cache_read": "0.0000006" }
    ]
  }
  ```
  `openrouter.ts:210` preserves tiers the same way (`tiers: existing?.cost?.tiers`), so `providers/openrouter/models/x-ai/grok-4.5.toml` has the identical stale value and is corrected in the same commit.

Only the `[[cost.tiers]] cache_read` line changes in each file; `[cost] cache_read = 0.3` is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)