### PR TITLE
Add Kimi K3 to neuralwatt

### DIFF
--- a/providers/neuralwatt/models/kimi-k3.toml
+++ b/providers/neuralwatt/models/kimi-k3.toml
@@ -1,0 +1,19 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+
+[limit]
+context = 1_048_560
+output = 1_048_560
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds **Kimi K3** to the NeuralWatt provider, inheriting provider-agnostic metadata from `models/moonshotai/kimi-k3.toml` via `base_model`.

## Source

Authenticated `GET https://api.neuralwatt.com/v1/models` (model `kimi-k3`, `pricing_tbd=false`).

## Changes

| Field | Value | Source |
|-------|-------|--------|
| `base_model` | `moonshotai/kimi-k3` | Inherited metadata |
| `cost` | input=3.0 / output=15.0 / cache_read=0.3 (USD per 1M) | NeuralWatt API |
| `limit` | context=1,048,560 / output=1,048,560 | NeuralWatt API |
| `reasoning_options` | `[{ type = "toggle" }]` | `provider.toml`: `chat_template_kwargs.enable_thinking` |
| `[interleaved]` | `field = "reasoning_content"` | NeuralWatt convention (kimi siblings) |
| `[modalities]` | input=`["text", "image"]` | NeuralWatt vision support (API `vision=true`) |

Inherited from `models/moonshotai/kimi-k3.toml`: `description`, `family="kimi-k3"`, `release_date`, `attachment`, `reasoning`, `temperature`, `tool_call`, `structured_output`, `open_weights`.

## Verification

- `bun validate` passes (exit 0)
- `git diff --name-only origin/dev...HEAD` == `providers/neuralwatt/models/kimi-k3.toml` (single file)
- No schema/family/provider/logo changes