### PR TITLE
fix(merge-gateway): tolerate evolving modality values

### DIFF
--- a/packages/core/src/sync/providers/merge-gateway.ts
+++ b/packages/core/src/sync/providers/merge-gateway.ts
@@ -17,8 +17,10 @@ const VendorReasoning = z.object({
 }).passthrough();
 
 const VendorCapabilities = z.object({
-  input: z.array(z.enum(["text", "audio", "image", "document", "embedding"])),
-  output: z.array(z.enum(["text", "audio", "tool_use", "embedding"])),
+  // Keep the API boundary forward-compatible; `modalities()` filters the
+  // evolving Gateway vocabulary to values supported by models.dev.
+  input: z.array(z.string()),
+  output: z.array(z.string()),
   supports_tool_calling: z.boolean(),
   supports_tool_choice: z.boolean().default(false),
   supports_structured_outputs: z.boolean(),

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1765,6 +1765,49 @@ test("accepts audio modalities from the Merge Gateway catalog", () => {
   }).data[0]?.vendors.openai.capabilities.input).toContain("audio");
 });
 
+// Prevents a valid multimodal route from rejecting the entire live catalog.
+test("accepts video modalities from the Merge Gateway catalog", () => {
+  const model = mergeGatewayModel();
+  model.vendors.openai.capabilities.input.push("video");
+
+  const parsed = MergeGatewayResponse.parse({
+    object: "list",
+    data: [model],
+    has_more: false,
+    next_cursor: null,
+  }).data[0]!;
+
+  expect(parsed.vendors.openai.capabilities.input).toContain("video");
+  expect(buildMergeGatewayModel(parsed, undefined)).toMatchObject({
+    modalities: {
+      input: ["text", "image", "pdf", "video"],
+    },
+  });
+});
+
+// Keeps the API boundary forward-compatible while output normalization remains strict.
+test("filters unknown Merge Gateway modalities without rejecting the catalog", () => {
+  const model = mergeGatewayModel();
+  model.vendors.openai.capabilities.input.push("future_modality");
+  model.vendors.openai.capabilities.output.push("future_output_modality");
+
+  const parsed = MergeGatewayResponse.parse({
+    object: "list",
+    data: [model],
+    has_more: false,
+    next_cursor: null,
+  }).data[0]!;
+  const synced = buildMergeGatewayModel(parsed, undefined);
+
+  expect(synced).toEqual({
+    base_model: "openai/gpt-5.6-sol",
+    cost: {
+      input: 5,
+      output: 30,
+    },
+  });
+});
+
 // Emits only route-specific overrides when canonical metadata already matches.
 test("factors Merge Gateway GPT-5.6 Sol against canonical metadata", () => {
   const model = buildMergeGatewayModel(mergeGatewayModel(), undefined);


### PR DESCRIPTION
## Summary

- accept evolving Merge Gateway modality strings at the API boundary
- keep models.dev output constrained through the existing modality allow-list
- add regression coverage for video input and unknown future input/output modalities

## Root cause

The live Merge Gateway catalog began returning `video` for five Google and Vertex AI vendor routes. The closed Zod modality enum rejected the entire response before the existing normalizer could handle those values. This change follows the resilient boundary pattern already used by the OpenRouter sync.

## Validation

- `bun test packages/core/test/sync.test.ts` — 90 passed, 0 failed
- `bun validate` — passed
- `bun models:sync merge-gateway` against the live API — completed without schema errors
- live contract verification — 248 models, 380 vendor routes, 1,265 assertions, including all five current video routes and injected future modalities
- generated catalog changes were isolated from this PR

Failure reproduced from: https://github.com/anomalyco/models.dev/actions/runs/30571917187/job/90970520594