### PR TITLE
feat(perplexity-agent): add Moonshot Kimi K3 and K2.7 Code 

### DIFF
--- a/providers/perplexity-agent/models/moonshot-ai/kimi-k2.7-code.toml
+++ b/providers/perplexity-agent/models/moonshot-ai/kimi-k2.7-code.toml
@@ -1,0 +1,18 @@
+# Perplexity Agent API pricing scraped from
+# https://docs.perplexity.ai/docs/agent-api/models (accessed 2026-07-30).
+# Kimi K2.7 Code capability confirmation (force thinking, preserve_thinking,
+# reasoning_content field, instant/non-thinking mode unsupported) sourced from
+# https://huggingface.co/moonshotai/Kimi-K2.7-Code.
+# base_model inherits reasoning = true, so reasoning_options = [] is required
+
+base_model = "moonshotai/kimi-k2.7-code"
+last_updated = "2026-07-30"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4.00
+cache_read = 0.19

--- a/providers/perplexity-agent/models/moonshot-ai/kimi-k3.toml
+++ b/providers/perplexity-agent/models/moonshot-ai/kimi-k3.toml
@@ -1,0 +1,24 @@
+# Perplexity Agent API pricing scraped from
+# https://docs.perplexity.ai/docs/agent-api/models (accessed 2026-07-30).
+# Kimi K3 capability confirmation sourced from
+# https://huggingface.co/moonshotai/Kimi-K3 and https://platform.kimi.ai/docs/overview.
+# Perplexity docs note that Kimi K3 accepts minimal, low, medium, high, xhigh,
+# and max reasoning effort (minimal = low; xhigh and max = max effort) and that
+# reasoning tokens are billed at the output-token rate.
+
+base_model = "moonshotai/kimi-k3"
+last_updated = "2026-07-30"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+# Perplexity docs: minimal/low/medium select low effort; xhigh/max select max effort.
+# Reasoning tokens are billed at the output-token rate.
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30


### PR DESCRIPTION
## Summary

Adds Moonshot AI's Kimi K3 and Kimi K2.7 Code to the Perplexity Agent provider with current pricing and reasoning metadata.

| Model | Input ($/1M) | Output ($/1M) | Cache Read ($/1M) | Reasoning |
| --- | ---: | ---: | ---: | --- |
| `perplexity/kimi-k3` | $3.00 | $15.00 | $0.30 | `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
| `perplexity/kimi-k2.7-code` | $0.95 | $4.00 | $0.19 | Reasoning enabled; no verified effort control |

### Changes

- Adds a new `moonshot-ai` directory under `perplexity-agent/models/`.
- Adds Kimi K3 with Perplexity's documented reasoning effort options.
- Adds Kimi K2.7 Code with `reasoning_options = []`, since the model reasons but Perplexity does not document an effort control for it.
- Uses `reasoning_content` for interleaved reasoning.
- Adds current Perplexity Agent API input, output, and cache-read pricing.
- Reasoning tokens are billed at the output-token rate.

### Sources

- https://docs.perplexity.ai/docs/agent-api/models#moonshot-ai
- https://huggingface.co/moonshotai/Kimi-K3
- https://huggingface.co/moonshotai/Kimi-K2.7-Code
- https://platform.kimi.ai/docs/overview