### PR TITLE
fix: reject impossible model dates

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -110,9 +110,41 @@ const OutputCost = Cost.extend({
   tiers: z.array(CostTier).optional(),
 });
 
-const DateString = z.string().regex(/^\d{4}-\d{2}(-\d{2})?$/, {
-  message: "Must be in YYYY-MM or YYYY-MM-DD format",
-});
+const DateString = z
+  .string()
+  .regex(/^\d{4}-\d{2}(-\d{2})?$/, {
+    message: "Must be in YYYY-MM or YYYY-MM-DD format",
+  })
+  .refine(
+    (value) => {
+      const [year, month, day] = value.split("-").map(Number);
+      if (month === undefined || month < 1 || month > 12) return false;
+      if (day === undefined) return true;
+
+      const leapYear =
+        year !== undefined &&
+        year % 4 === 0 &&
+        (year % 100 !== 0 || year % 400 === 0);
+      const daysInMonth = [
+        31,
+        leapYear ? 29 : 28,
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+      ];
+      return day >= 1 && day <= daysInMonth[month - 1]!;
+    },
+    {
+      message: "Must be a valid calendar date",
+    },
+  );
 
 const Modality = z.enum(["text", "audio", "image", "video", "pdf"]);
 
@@ -232,12 +264,7 @@ const ModelBase = z.object({
     .optional(),
   structured_output: z.boolean().optional(),
   temperature: z.boolean().optional(),
-  knowledge: z
-    .string()
-    .regex(/^\d{4}-\d{2}(-\d{2})?$/, {
-      message: "Must be in YYYY-MM or YYYY-MM-DD format",
-    })
-    .optional(),
+  knowledge: DateString.optional(),
   release_date: DateString,
   last_updated: DateString,
   modalities: Modalities,

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -5,6 +5,8 @@ import { AuthoredModel } from "../src/index.js";
 
 type AuthoredModelData = z.infer<typeof AuthoredModel>;
 
+const dateFields = ["knowledge", "release_date", "last_updated"] as const;
+
 describe("model schema", () => {
   test("requires reasoning_options when reasoning is true", () => {
     const model = baseModel({ reasoning: true });
@@ -28,6 +30,44 @@ describe("model schema", () => {
     });
 
     expect(AuthoredModel.safeParse(model).success).toBe(false);
+  });
+
+  test("accepts calendar-valid model dates", () => {
+    for (const field of dateFields) {
+      for (const value of [
+        "2026-02",
+        "2024-02-29",
+        "2000-02-29",
+        "2026-12-31",
+      ]) {
+        expect(
+          AuthoredModel.safeParse({
+            ...baseModel({}),
+            [field]: value,
+          }).success,
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("rejects impossible model dates", () => {
+    for (const field of dateFields) {
+      for (const value of [
+        "2026-00",
+        "2026-13",
+        "2025-02-29",
+        "1900-02-29",
+        "2026-02-30",
+        "2026-04-31",
+      ]) {
+        expect(
+          AuthoredModel.safeParse({
+            ...baseModel({}),
+            [field]: value,
+          }).success,
+        ).toBe(false);
+      }
+    }
   });
 });
 

--- a/providers/azure-cognitive-services/models/claude-haiku-4-5.toml
+++ b/providers/azure-cognitive-services/models/claude-haiku-4-5.toml
@@ -10,7 +10,7 @@ reasoning = true
 # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
 reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/azure/models/claude-haiku-4-5.toml
+++ b/providers/azure/models/claude-haiku-4-5.toml
@@ -7,7 +7,7 @@ attachment = true
 reasoning = true
 reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
-knowledge = "2025-02-31"
+knowledge = "2025-02-28"
 tool_call = true
 structured_output = true
 open_weights = false

--- a/providers/scaleway/models/qwen3-embedding-8b.toml
+++ b/providers/scaleway/models/qwen3-embedding-8b.toml
@@ -1,7 +1,7 @@
 name = "Qwen3 Embedding 8B"
 description = "Embedding model for semantic search, retrieval, clustering, and ranking pipelines"
 family = "qwen"
-release_date = "2025-25-11"
+release_date = "2025-06-05"
 last_updated = "2026-03-17"
 attachment = false
 reasoning = false


### PR DESCRIPTION
## Summary

- reject impossible calendar dates while preserving `YYYY-MM` values
- use the shared date validator for provider-model knowledge cutoffs
- correct three invalid dates already present in the catalog

## Root cause

Date fields were checked only by shape, so values such as `2025-02-31` and
`2025-25-11` passed validation. Provider-model `knowledge` also duplicated the
old regex instead of using the shared date schema.

The validator now checks Gregorian month lengths and leap years. Tests cover
all three model date fields, partial dates, leap days, century rules, invalid
months, and invalid month/day combinations.

## Sources

- [Qwen3 Embedding release — June 5, 2025](https://qwenlm.github.io/blog/qwen3-embedding/)
- [Anthropic model overview — Claude Haiku 4.5 reliable knowledge cutoff: February 2025](https://platform.claude.com/docs/en/about-claude/models/overview)
- [Earlier catalog correction establishing the February 28 convention](https://github.com/anomalyco/models.dev/pull/420)

## Validation

- `bun validate`
- `bun test packages/core/test/schema.test.ts` — 5 passed, 33 expectations
- `cd packages/web && bun run build`
- `cd packages/sdk && bun run test` — 23 passed
- `git diff --check`
