### PR TITLE
fix: OpenAI and Azure GPT-5.6 Terra/Luna pricing

### DIFF
--- a/providers/azure-cognitive-services/models/gpt-5.6-luna.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.6-luna.toml
@@ -1,14 +1,15 @@
+# Pricing aligned with OpenAI standard (Terra/Luna cut 2026-07-30): https://developers.openai.com/api/docs/pricing
 base_model = "openai/gpt-5.6-luna"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 1
-output = 6
-cache_read = 0.1
+input = 0.2
+output = 1.2
+cache_read = 0.02
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 2
-output = 9
-cache_read = 0.2
+input = 0.4
+output = 1.8
+cache_read = 0.04

--- a/providers/azure-cognitive-services/models/gpt-5.6-terra.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.6-terra.toml
@@ -1,14 +1,15 @@
+# Pricing aligned with OpenAI standard (Terra/Luna cut 2026-07-30): https://developers.openai.com/api/docs/pricing
 base_model = "openai/gpt-5.6-terra"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 2.5
-output = 15
-cache_read = 0.25
+input = 2.0
+output = 12
+cache_read = 0.2
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 5
-output = 22.5
-cache_read = 0.5
+input = 4
+output = 18
+cache_read = 0.4

--- a/providers/azure/models/gpt-5.6-luna.toml
+++ b/providers/azure/models/gpt-5.6-luna.toml
@@ -1,14 +1,15 @@
+# Pricing aligned with OpenAI standard (Terra/Luna cut 2026-07-30): https://developers.openai.com/api/docs/pricing
 base_model = "openai/gpt-5.6-luna"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 1
-output = 6
-cache_read = 0.1
+input = 0.2
+output = 1.2
+cache_read = 0.02
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 2
-output = 9
-cache_read = 0.2
+input = 0.4
+output = 1.8
+cache_read = 0.04

--- a/providers/azure/models/gpt-5.6-terra.toml
+++ b/providers/azure/models/gpt-5.6-terra.toml
@@ -1,14 +1,15 @@
+# Pricing aligned with OpenAI standard (Terra/Luna cut 2026-07-30): https://developers.openai.com/api/docs/pricing
 base_model = "openai/gpt-5.6-terra"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 2.5
-output = 15
-cache_read = 0.25
+input = 2.0
+output = 12
+cache_read = 0.2
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 5
-output = 22.5
-cache_read = 0.5
+input = 4
+output = 18
+cache_read = 0.4

--- a/providers/openai/models/gpt-5.6-luna.toml
+++ b/providers/openai/models/gpt-5.6-luna.toml
@@ -1,21 +1,22 @@
+# Pricing: https://developers.openai.com/api/docs/pricing (Terra/Luna cut 2026-07-30)
 base_model = "openai/gpt-5.6-luna"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 1.00
-output = 6.00
-cache_read = 0.10
-cache_write = 1.25
+input = 0.20
+output = 1.20
+cache_read = 0.02
+cache_write = 0.25
 
 [[cost.tiers]]
 tier = { size = 272_000 }
-input = 2.00
-output = 9.00
-cache_read = 0.20
-cache_write = 2.50
+input = 0.40
+output = 1.80
+cache_read = 0.04
+cache_write = 0.50
 
 [experimental.modes.fast]
-cost = { input = 2.00, output = 12.00, cache_read = 0.20, cache_write = 2.50 }
+cost = { input = 0.40, output = 2.40, cache_read = 0.04, cache_write = 0.50 }
 provider = { body = { service_tier = "priority" } }
 
 [experimental.modes.pro]

--- a/providers/openai/models/gpt-5.6-terra.toml
+++ b/providers/openai/models/gpt-5.6-terra.toml
@@ -1,21 +1,22 @@
+# Pricing: https://developers.openai.com/api/docs/pricing (Terra/Luna cut 2026-07-30)
 base_model = "openai/gpt-5.6-terra"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 2.50
-output = 15.00
-cache_read = 0.25
-cache_write = 3.125
+input = 2.00
+output = 12.00
+cache_read = 0.20
+cache_write = 2.50
 
 [[cost.tiers]]
 tier = { size = 272_000 }
-input = 5.00
-output = 22.50
-cache_read = 0.50
-cache_write = 6.25
+input = 4.00
+output = 18.00
+cache_read = 0.40
+cache_write = 5.00
 
 [experimental.modes.fast]
-cost = { input = 5.00, output = 30.00, cache_read = 0.50, cache_write = 6.25 }
+cost = { input = 4.00, output = 24.00, cache_read = 0.40, cache_write = 5.00 }
 provider = { body = { service_tier = "priority" } }
 
 [experimental.modes.pro]


### PR DESCRIPTION
## Summary

- OpenAI reduced GPT-5.6 Terra (−20%) and Luna (−80%) on 2026-07-30 ([announcement](https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/), [API pricing](https://developers.openai.com/api/docs/pricing))
- Update `openai`, `azure`, and `azure-cognitive-services` catalog costs (standard + long-context tiers; OpenAI fast mode)
- Sol pricing unchanged

## Changes

| Model | Field | Old | New |
|-------|-------|-----|-----|
| Terra | input / output | 2.50 / 15.00 | **2.00 / 12.00** |
| | cache_read / cache_write | 0.25 / 3.125 | **0.20 / 2.50** |
| | long-context (>272k) | 5.00 / 22.50 | **4.00 / 18.00** |
| | fast mode (OpenAI) | 5.00 / 30.00 | **4.00 / 24.00** |
| Luna | input / output | 1.00 / 6.00 | **0.20 / 1.20** |
| | cache_read / cache_write | 0.10 / 1.25 | **0.02 / 0.25** |
| | long-context (>272k) | 2.00 / 9.00 | **0.40 / 1.80** |
| | fast mode (OpenAI) | 2.00 / 12.00 | **0.40 / 2.40** |

Azure listings omit `cache_write` (unchanged shape). Values USD per 1M tokens.

## Validation

- `bun validate` passed
- Compared against OpenAI API pricing standard + fast mode tables

## Out of scope

- `opencode` provider (left as-is)
- Other third-party hosts still on pre-cut rates