### PR TITLE
chore(ci): use OpenCode app credentials for ci-fixer and model sync

### DIFF
--- a/.github/actions/setup-git-committer/action.yml
+++ b/.github/actions/setup-git-committer/action.yml
@@ -1,0 +1,43 @@
+name: "Setup Git Committer"
+description: "Create app token and configure git user"
+inputs:
+  opencode-app-id:
+    description: "OpenCode GitHub App ID"
+    required: true
+  opencode-app-secret:
+    description: "OpenCode GitHub App private key"
+    required: true
+outputs:
+  token:
+    description: "GitHub App token"
+    value: ${{ steps.apptoken.outputs.token }}
+  app-slug:
+    description: "GitHub App slug"
+    value: ${{ steps.apptoken.outputs.app-slug }}
+runs:
+  using: "composite"
+  steps:
+    - name: Create app token
+      id: apptoken
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+      with:
+        app-id: ${{ inputs.opencode-app-id }}
+        private-key: ${{ inputs.opencode-app-secret }}
+        owner: ${{ github.repository_owner }}
+
+    - name: Configure git user
+      run: |
+        slug="${{ steps.apptoken.outputs.app-slug }}"
+        git config --global user.name "${slug}[bot]"
+        git config --global user.email "${slug}[bot]@users.noreply.github.com"
+      shell: bash
+
+    - name: Clear checkout auth
+      run: |
+        git config --local --unset-all http.https://github.com/.extraheader || true
+      shell: bash
+
+    - name: Configure git remote
+      run: |
+        git remote set-url origin https://x-access-token:${{ steps.apptoken.outputs.token }}@github.com/${{ github.repository }}
+      shell: bash

--- a/.github/workflows/ci-fixer.yml
+++ b/.github/workflows/ci-fixer.yml
@@ -28,14 +28,23 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}
-      GH_TOKEN: ${{ github.token }}
       FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
       FAILED_RUN_URL: ${{ github.event.workflow_run.html_url }}
       FAILED_WORKFLOW: ${{ github.event.workflow_run.name }}
 
     steps:
+      - name: Create app token
+        id: apptoken
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.OPENCODE_APP_ID }}
+          private-key: ${{ secrets.OPENCODE_APP_SECRET }}
+          owner: ${{ github.repository_owner }}
+
       - name: Check run budget
         id: budget
+        env:
+          GH_TOKEN: ${{ steps.apptoken.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -92,6 +101,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: dev
+          persist-credentials: false
+
+      - name: Setup git committer
+        id: committer
+        if: steps.budget.outputs.run == 'true' && steps.budget-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-git-committer
+        with:
+          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
 
       - name: Install opencode
         if: steps.budget.outputs.run == 'true' && steps.budget-cache.outputs.cache-hit != 'true'
@@ -99,6 +117,8 @@ jobs:
 
       - name: Collect failed logs
         if: steps.budget.outputs.run == 'true' && steps.budget-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
         run: |
           set -euo pipefail
           LOG_FILE="$RUNNER_TEMP/dev-ci-failure.log"
@@ -159,6 +179,7 @@ jobs:
       - name: Create pull request
         if: steps.budget.outputs.run == 'true' && steps.budget-cache.outputs.cache-hit != 'true'
         env:
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
           BRANCH: ci-fixer-${{ github.event.workflow_run.id || github.run_id }}
           TITLE: "fix: dev CI failure"
         run: |
@@ -169,8 +190,6 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$BRANCH"
           git add -A
           git commit -m "$TITLE"

--- a/.github/workflows/issue-fixer.yml
+++ b/.github/workflows/issue-fixer.yml
@@ -23,7 +23,6 @@ jobs:
       && github.event.client_payload.provider != 'pioneer'
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
       ISSUE_NUMBER: ${{ github.event.issue.number || github.event.client_payload.issue_number }}
 
     steps:
@@ -31,8 +30,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: dev
+          persist-credentials: false
+
+      - name: Setup git committer
+        id: committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
 
       - name: Load issue
+        env:
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
         run: |
           set -euo pipefail
           ISSUE_FILE="$RUNNER_TEMP/issue.json"
@@ -83,6 +92,7 @@ jobs:
       - name: Create pull request
         if: success()
         env:
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
           BRANCH: issue-${{ github.event.issue.number || github.event.client_payload.issue_number }}
         run: |
           set -euo pipefail
@@ -95,8 +105,6 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$BRANCH"
           git add -A
           TITLE="fix: ${ISSUE_TITLE:0:200}"

--- a/.github/workflows/issue-fixer.yml
+++ b/.github/workflows/issue-fixer.yml
@@ -23,6 +23,7 @@ jobs:
       && github.event.client_payload.provider != 'pioneer'
     runs-on: ubuntu-latest
     env:
+      GH_TOKEN: ${{ github.token }}
       ISSUE_NUMBER: ${{ github.event.issue.number || github.event.client_payload.issue_number }}
 
     steps:
@@ -30,18 +31,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: dev
-          persist-credentials: false
-
-      - name: Setup git committer
-        id: committer
-        uses: ./.github/actions/setup-git-committer
-        with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
 
       - name: Load issue
-        env:
-          GH_TOKEN: ${{ steps.committer.outputs.token }}
         run: |
           set -euo pipefail
           ISSUE_FILE="$RUNNER_TEMP/issue.json"
@@ -92,7 +83,6 @@ jobs:
       - name: Create pull request
         if: success()
         env:
-          GH_TOKEN: ${{ steps.committer.outputs.token }}
           BRANCH: issue-${{ github.event.issue.number || github.event.client_payload.issue_number }}
         run: |
           set -euo pipefail
@@ -105,6 +95,8 @@ jobs:
             exit 0
           fi
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$BRANCH"
           git add -A
           TITLE="fix: ${ISSUE_TITLE:0:200}"

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -51,6 +51,14 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: dev
+          persist-credentials: false
+
+      - name: Setup git committer
+        id: committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7
@@ -63,7 +71,7 @@ jobs:
       - name: Sync model catalogs
         run: bun models:sync ${{ matrix.provider }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
           DEEPINFRA_API_KEY: ${{ secrets.DEEPINFRA_API_KEY }}
@@ -88,7 +96,7 @@ jobs:
 
       - name: Report changes
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
           BRANCH: automation/sync-models-${{ matrix.provider }}
           LABELS: automation,model-sync,provider:${{ matrix.provider }}
           TITLE: "chore(sync): update ${{ matrix.name }} model catalog"
@@ -107,8 +115,6 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --no-tags --depth=1 origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || true
           git checkout -B "$BRANCH"
           git add models providers

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Sync model catalogs
         run: bun models:sync ${{ matrix.provider }}
         env:
-          GH_TOKEN: ${{ steps.committer.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
           DEEPINFRA_API_KEY: ${{ secrets.DEEPINFRA_API_KEY }}


### PR DESCRIPTION
## Summary
- Add `setup-git-committer` composite action (same pattern as opencode) to mint a GitHub App token from `OPENCODE_APP_ID` / `OPENCODE_APP_SECRET`
- Wire **ci-fixer** and **sync-models** to commit/push/open PRs as the app bot so CI runs on those PRs (and auto-merge is possible)
- Leave **issue-fixer** on `GITHUB_TOKEN`

## Test plan
- [ ] Confirm `OPENCODE_APP_ID` (var) and `OPENCODE_APP_SECRET` (secret) are set on `anomalyco/models.dev`
- [ ] Confirm the OpenCode GitHub App is installed with contents + pull requests (+ actions read for ci-fixer log fetch)
- [ ] Dispatch Sync Model Catalogs or Dev CI Fixer and verify the PR author is the app bot and CI runs