### PR TITLE
Add WRouter provider

### DIFF
--- a/providers/wrouter/logo.svg
+++ b/providers/wrouter/logo.svg
@@ -1,0 +1,20 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- WSPN brand palette: transparent bg, ink #0C2E26, accent green #5EF1A0 -->
+  <g fill="none" stroke="#0C2E26" stroke-width="2.2" stroke-linecap="round" opacity="0.55">
+    <path d="M 16 22 L 70 50"/>
+    <path d="M 16 36 L 70 50"/>
+    <path d="M 16 50 L 70 50"/>
+    <path d="M 16 64 L 70 50"/>
+    <path d="M 16 78 L 70 50"/>
+  </g>
+  <g fill="#0C2E26">
+    <circle cx="16" cy="22" r="2.2"/>
+    <circle cx="16" cy="36" r="2.2"/>
+    <circle cx="16" cy="50" r="2.2"/>
+    <circle cx="16" cy="64" r="2.2"/>
+    <circle cx="16" cy="78" r="2.2"/>
+  </g>
+  <circle cx="70" cy="50" r="5.5" fill="#5EF1A0"/>
+  <line x1="76" y1="50" x2="88" y2="50" stroke="#5EF1A0" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 84 45 L 89 50 L 84 55" stroke="#5EF1A0" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/providers/wrouter/logo.svg
+++ b/providers/wrouter/logo.svg
@@ -1,20 +1,19 @@
-<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <!-- WSPN brand palette: transparent bg, ink #0C2E26, accent green #5EF1A0 -->
-  <g fill="none" stroke="#0C2E26" stroke-width="2.2" stroke-linecap="round" opacity="0.55">
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <g fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" opacity="0.55">
     <path d="M 16 22 L 70 50"/>
     <path d="M 16 36 L 70 50"/>
     <path d="M 16 50 L 70 50"/>
     <path d="M 16 64 L 70 50"/>
     <path d="M 16 78 L 70 50"/>
   </g>
-  <g fill="#0C2E26">
+  <g fill="currentColor">
     <circle cx="16" cy="22" r="2.2"/>
     <circle cx="16" cy="36" r="2.2"/>
     <circle cx="16" cy="50" r="2.2"/>
     <circle cx="16" cy="64" r="2.2"/>
     <circle cx="16" cy="78" r="2.2"/>
   </g>
-  <circle cx="70" cy="50" r="5.5" fill="#5EF1A0"/>
-  <line x1="76" y1="50" x2="88" y2="50" stroke="#5EF1A0" stroke-width="3" stroke-linecap="round"/>
-  <path d="M 84 45 L 89 50 L 84 55" stroke="#5EF1A0" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="70" cy="50" r="5.5" fill="currentColor"/>
+  <line x1="76" y1="50" x2="88" y2="50" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 84 45 L 89 50 L 84 55" stroke="currentColor" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/providers/wrouter/models/claude-haiku-4-5.toml
+++ b/providers/wrouter/models/claude-haiku-4-5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[cost]
+input = 1
+output = 5

--- a/providers/wrouter/models/claude-haiku-4-5.toml
+++ b/providers/wrouter/models/claude-haiku-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/wrouter/models/claude-haiku-4-5.toml
+++ b/providers/wrouter/models/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 1

--- a/providers/wrouter/models/claude-opus-4-8.toml
+++ b/providers/wrouter/models/claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[cost]
+input = 5
+output = 25

--- a/providers/wrouter/models/claude-opus-4-8.toml
+++ b/providers/wrouter/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 5

--- a/providers/wrouter/models/claude-opus-4-8.toml
+++ b/providers/wrouter/models/claude-opus-4-8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 5

--- a/providers/wrouter/models/claude-sonnet-5.toml
+++ b/providers/wrouter/models/claude-sonnet-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 3

--- a/providers/wrouter/models/claude-sonnet-5.toml
+++ b/providers/wrouter/models/claude-sonnet-5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-sonnet-5"
+
+[cost]
+input = 3
+output = 15

--- a/providers/wrouter/models/claude-sonnet-5.toml
+++ b/providers/wrouter/models/claude-sonnet-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 3

--- a/providers/wrouter/models/gemini-2.5-flash-lite.toml
+++ b/providers/wrouter/models/gemini-2.5-flash-lite.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 0.1

--- a/providers/wrouter/models/gemini-2.5-flash-lite.toml
+++ b/providers/wrouter/models/gemini-2.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.1

--- a/providers/wrouter/models/gemini-2.5-flash-lite.toml
+++ b/providers/wrouter/models/gemini-2.5-flash-lite.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-2.5-flash-lite"
+
+[cost]
+input = 0.1
+output = 0.4

--- a/providers/wrouter/models/gemini-2.5-flash.toml
+++ b/providers/wrouter/models/gemini-2.5-flash.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-2.5-flash"
+
+[cost]
+input = 0.3
+output = 2.5

--- a/providers/wrouter/models/gemini-2.5-flash.toml
+++ b/providers/wrouter/models/gemini-2.5-flash.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-flash"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 0.3

--- a/providers/wrouter/models/gemini-2.5-flash.toml
+++ b/providers/wrouter/models/gemini-2.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.3

--- a/providers/wrouter/models/gemini-2.5-pro.toml
+++ b/providers/wrouter/models/gemini-2.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-pro"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 
 [cost]
 input = 1.25

--- a/providers/wrouter/models/gemini-2.5-pro.toml
+++ b/providers/wrouter/models/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 1.25

--- a/providers/wrouter/models/gemini-2.5-pro.toml
+++ b/providers/wrouter/models/gemini-2.5-pro.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-2.5-pro"
+
+[cost]
+input = 1.25
+output = 5

--- a/providers/wrouter/models/gpt-4.1.toml
+++ b/providers/wrouter/models/gpt-4.1.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4.1"
+
+[cost]
+input = 2
+output = 8

--- a/providers/wrouter/models/gpt-4o-mini.toml
+++ b/providers/wrouter/models/gpt-4o-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-mini"
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/wrouter/models/gpt-4o.toml
+++ b/providers/wrouter/models/gpt-4o.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o"
+
+[cost]
+input = 2.5
+output = 10

--- a/providers/wrouter/models/gpt-5-mini.toml
+++ b/providers/wrouter/models/gpt-5-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5-mini"
+
+[cost]
+input = 0.25
+output = 2

--- a/providers/wrouter/models/gpt-5-mini.toml
+++ b/providers/wrouter/models/gpt-5-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-mini"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.25

--- a/providers/wrouter/models/gpt-5-mini.toml
+++ b/providers/wrouter/models/gpt-5-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.25

--- a/providers/wrouter/models/gpt-5-nano.toml
+++ b/providers/wrouter/models/gpt-5-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.05

--- a/providers/wrouter/models/gpt-5-nano.toml
+++ b/providers/wrouter/models/gpt-5-nano.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-nano"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.05

--- a/providers/wrouter/models/gpt-5-nano.toml
+++ b/providers/wrouter/models/gpt-5-nano.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5-nano"
+
+[cost]
+input = 0.05
+output = 0.4

--- a/providers/wrouter/models/gpt-5.toml
+++ b/providers/wrouter/models/gpt-5.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5"
+
+[cost]
+input = 1.25
+output = 10

--- a/providers/wrouter/models/gpt-5.toml
+++ b/providers/wrouter/models/gpt-5.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5"
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 1.25

--- a/providers/wrouter/models/gpt-5.toml
+++ b/providers/wrouter/models/gpt-5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.25

--- a/providers/wrouter/provider.toml
+++ b/providers/wrouter/provider.toml
@@ -1,0 +1,5 @@
+name = "WRouter"
+env = ["WROUTER_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://wrouter.ai/docs"
+api = "https://wrouter.ai/v1"


### PR DESCRIPTION
Adds [WRouter](https://wrouter.ai), an OpenAI-compatible AI gateway.

## Provider
- Endpoint `https://wrouter.ai/v1` (OpenAI-compatible), env `WROUTER_API_KEY`, `@ai-sdk/openai-compatible`.
- Logo uses `currentColor` only.

## Models
12 headline models referencing canonical `base_model`s (Anthropic Claude, OpenAI GPT, Google Gemini).

### Pricing
Prices are **WRouter's own list prices**, taken from WRouter's public pricing API (https://wrouter.ai/api/pricing) and shown on https://wrouter.ai/pricing . As a gateway, WRouter sets its own USD rates, so some differ from the upstream providers' list prices (e.g. `gemini-2.5-pro` output is $5/M on WRouter). Values verified: `claude-sonnet-5` $3/$15, `claude-opus-4-8` $5/$25, `gpt-4o` $2.5/$10, `gpt-4o-mini` $0.15/$0.60, matching the underlying models.

### Reasoning controls
- GPT-5 / mini / nano: OpenAI `reasoning_effort` (`minimal|low|medium|high`), passed through the OpenAI-compatible endpoint.
- Claude / Gemini: left as `reasoning_options = []` — reasoning-control mapping through the OpenAI-compatible gateway is not yet documented per-model; will add once verified against WRouter's API docs.