### PR TITLE
feat(zenmux): add custom/deepseek/deepseek-v4-flash

### DIFF
--- a/providers/zenmux/models/custom/deepseek/deepseek-v4-flash.toml
+++ b/providers/zenmux/models/custom/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,14 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"


### PR DESCRIPTION
Add `custom/deepseek/deepseek-v4-flash` to ZenMux provider.

- `base_model = "deepseek/deepseek-v4-flash"`
- Reasoning support with toggle + effort options
- Cost: input $0.14, output $0.28, cache_read $0.0028 per million tokens

Data sourced from https://zenmux.ai/api/anthropic/v1/models