### PR TITLE
feat: add glm-5.2-highspeed[1m] to zai-coding-plan and zhipuai-coding-plan

### DIFF
--- a/providers/zai-coding-plan/models/glm-5.2-highspeed[1m].toml
+++ b/providers/zai-coding-plan/models/glm-5.2-highspeed[1m].toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Highspeed"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/zhipuai-coding-plan/models/glm-5.2-highspeed[1m].toml
+++ b/providers/zhipuai-coding-plan/models/glm-5.2-highspeed[1m].toml
@@ -1,0 +1,1 @@
+../../zai-coding-plan/models/glm-5.2-highspeed[1m].toml


### PR DESCRIPTION
## Summary
- add the `glm-5.2-highspeed[1m]` model ID to both GLM coding-plan providers (`zai-coding-plan` and `zhipuai-coding-plan`)
- `zai-coding-plan` holds the entry; `zhipuai-coding-plan` references it via a relative symlink (`../../zai-coding-plan/models/...`), exactly mirroring how `glm-5.2` itself is wired between the two plans
- inherit all GLM-5.2 capabilities via `base_model = "zhipuai/glm-5.2"` — 1M context, reasoning, effort `high`/`max`, interleaved `reasoning_content`
- coding-plan cost 0

## Background
The `glm-5.2-highspeed[1m]` ID was shared by the GLM/Z.ai team via provider contact as a highspeed serving tier of GLM-5.2 exposed under the GLM Coding Plan, on both the Z.AI (`api.z.ai/api/coding/paas/v4`) and Zhipu (`open.bigmodel.cn/api/coding/paas/v4`) endpoints. It is **not** yet listed on the public coding-plan model pages, so this PR is the contact report rather than a docs citation.

### Message from official

<img width="776" height="98" alt="Screenshot 2026-07-31 at 17 19 19" src="https://github.com/user-attachments/assets/ffb41d3c-a915-45d5-a068-d0c4913f1dd1" />

The `[1m]` suffix (1M-context unlock) and the effort mapping are already-documented behaviours, cited below — reused unchanged from the existing `glm-5.2` entries.

## Validation
- `bun validate` passes
- generated the catalog and confirmed both providers expose the literal ID `glm-5.2-highspeed[1m]` with the symlink resolving to the shared definition: 1M context inherited from `zhipuai/glm-5.2`, reasoning effort `[high, max]`, `interleaved.reasoning_content`, cost 0
- `cd packages/web && bun run build` succeeds; the bracketed ID survives the static-site pipeline and appears on both provider pages and in `_catalog.json` / `_api.json`
- `git diff --check` clean

## References
- [Z.AI Coding Plan – How to switch models](https://docs.z.ai/devpack/latest-model) — documents the `[1m]` 1M-context suffix and the GLM-5.2 effort mapping (low/medium/high → high; xhigh/max/ultracode → max)
- [智谱 GLM Coding Plan – 如何切换模型](https://docs.bigmodel.cn/cn/coding-plan/latest-model) — same `[1m]` suffix and effort mapping for the `open.bigmodel.cn` endpoint
