### PR TITLE
fix(sync): harden DigitalOcean catalog translation

### DIFF
--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -551,7 +551,7 @@ export function buildDigitalOceanModel(
     return factorBaseModel(baseModel, {
       name: model.name,
       description: existing?.description,
-      ...(remoteIsTextOnly
+      ...(remoteIsTextOnly && existing === undefined
         ? {}
         : {
             attachment,

--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -343,16 +343,6 @@ function normalizeModalities(values: string[], fallback: Modality[]): Modality[]
   return [...new Set(normalized.length > 0 ? normalized : fallback)];
 }
 
-function unionModalities(remote: Modality[], existing: Modality[] | undefined): Modality[] {
-  // Catalog rows often omit PDF/image even when the endpoint accepts them.
-  // Union with authored modalities so sync never silently drops capabilities.
-  return [...new Set([...(existing ?? []), ...remote])];
-}
-
-function isTextOnly(input: Modality[], output: Modality[]) {
-  return input.every((value) => value === "text") && output.every((value) => value === "text");
-}
-
 function normalizeEffortToken(value: string): string {
   const normalized = value.trim().toLowerCase().replaceAll("_", "-");
   if (normalized === "x-high" || normalized === "xhigh") return "xhigh";
@@ -389,11 +379,9 @@ function reasoningOptionsFor(
     })
     .filter(isReasoningEffort);
   const preserved = existing?.reasoning_options?.filter((option) => option.type !== "effort") ?? [];
-  const existingEffort = existing?.reasoning_options?.find((option) => option.type === "effort");
-  const existingValues = existingEffort?.type === "effort" ? existingEffort.values : [];
-  // Merge so incomplete catalog effort lists cannot drop curated values (e.g. none/xhigh).
-  const values = [...new Set([...remoteValues, ...existingValues])];
-  return values.length > 0 ? [...preserved, { type: "effort", values }] : preserved.length > 0 ? preserved : existing?.reasoning_options;
+  return remoteValues.length > 0
+    ? [...preserved, { type: "effort", values: remoteValues }]
+    : existing?.reasoning_options;
 }
 
 function isReasoningEffort(value: string | null): value is ReasoningEffort {
@@ -411,33 +399,11 @@ function isReasoningEffort(value: string | null): value is ReasoningEffort {
 function status(
   lifecycleStatus: string,
   existing: ExistingModel["status"],
-  name?: string,
 ): ExistingModel["status"] {
   const lifecycle = lifecycleStatus.toLowerCase().replaceAll("_", "-");
   if (lifecycle === "deprecated" || lifecycle === "end-of-life") return "deprecated";
-  if (
-    lifecycle === "public-preview"
-    || lifecycle === "preview"
-    || name?.toLowerCase().includes("public preview") === true
-  ) {
-    return "beta";
-  }
+  if (lifecycle === "public-preview" || lifecycle === "preview") return "beta";
   return existing === "deprecated" || existing === "beta" ? undefined : existing;
-}
-
-function resolveReasoning(
-  model: DigitalOceanSourceModel,
-  existing: ExistingModel | undefined,
-  textOutput: boolean,
-): boolean | undefined {
-  if (!textOutput) return existing?.reasoning ?? false;
-  // `thinking: true` is the only positive-authoritative DO signal. Catalog rows
-  // sometimes attach generic reasoning_efforts to non-reasoning chat models
-  // (e.g. gpt-4o-mini); never flip curated reasoning=false from efforts alone.
-  if (model.thinking === true) return true;
-  if (existing?.reasoning !== undefined) return existing.reasoning;
-  if ((model.reasoning_efforts?.length ?? 0) > 0) return true;
-  return undefined;
 }
 
 function cost(model: DigitalOceanSourceModel, existing: ExistingModel | undefined) {
@@ -486,14 +452,8 @@ export function buildDigitalOceanModel(
 ): SyncedModel {
   const remoteInput = normalizeModalities(model.modalities?.input ?? [], []);
   const remoteOutput = normalizeModalities(model.modalities?.output ?? [], []);
-  const input = unionModalities(
-    remoteInput.length > 0 ? remoteInput : ["text"],
-    existing?.modalities?.input,
-  );
-  const output = unionModalities(
-    remoteOutput.length > 0 ? remoteOutput : ["text"],
-    existing?.modalities?.output,
-  );
+  const input = remoteInput.length > 0 ? remoteInput : existing?.modalities?.input ?? ["text"];
+  const output = remoteOutput.length > 0 ? remoteOutput : existing?.modalities?.output ?? ["text"];
   const context = number(model.context_window) ?? existing?.limit?.context ?? 0;
   const maxTokens = number(model.max_output_tokens ?? undefined);
   const limit = {
@@ -502,10 +462,13 @@ export function buildDigitalOceanModel(
     output: maxTokens ?? existing?.limit?.output ?? 0,
   };
   const textOutput = output.includes("text") && !output.includes("image") && !output.includes("video");
-  const providerReasoning = resolveReasoning(model, existing, textOutput);
+  const hasRemoteReasoning = model.thinking !== undefined || model.reasoning_efforts !== undefined;
+  const providerReasoning = textOutput && hasRemoteReasoning
+    ? model.thinking === true || (model.reasoning_efforts?.length ?? 0) > 0
+    : existing?.reasoning;
   const reasoning = providerReasoning ?? false;
   const reasoningOptions = reasoning === true ? reasoningOptionsFor(model, existing) : undefined;
-  const modelStatus = status(model.lifecycle_status, existing?.status, model.name);
+  const modelStatus = status(model.lifecycle_status, existing?.status);
   const releaseDate = existing?.release_date ?? model.created_at?.slice(0, 10) ?? new Date().toISOString().slice(0, 10);
   const attachment = input.some((value) => value !== "text");
   const values: Partial<SyncedFullModel> = {
@@ -542,21 +505,11 @@ export function buildDigitalOceanModel(
   };
 
   if (baseModel !== undefined) {
-    // Incomplete catalog rows are often text-only. Do not clobber base-model
-    // vision/PDF/attachment facts unless the catalog reports non-text modalities.
-    const remoteIsTextOnly = isTextOnly(
-      remoteInput.length > 0 ? remoteInput : ["text"],
-      remoteOutput.length > 0 ? remoteOutput : ["text"],
-    );
     return factorBaseModel(baseModel, {
       name: model.name,
       description: existing?.description,
-      ...(remoteIsTextOnly && existing === undefined
-        ? {}
-        : {
-            attachment,
-            modalities: { input, output },
-          }),
+      attachment,
+      modalities: { input, output },
       reasoning: providerReasoning,
       reasoning_options: reasoningOptions,
       temperature: existing?.temperature,

--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -168,9 +168,11 @@ export const digitalocean = {
         || outputLimit <= 0
       )
     ) return undefined;
-    const baseModel = existing === undefined
-      ? resolveDigitalOceanBaseModel(model.id)
-      : existing.base_model;
+    // Only auto-resolve base_model for newly created files. Existing full
+    // definitions stay hand-authored unless they already declare base_model.
+    const baseModel = existing !== undefined
+      ? existing.base_model
+      : resolveDigitalOceanBaseModel(model.id);
     return {
       id: model.id,
       model: buildDigitalOceanModel(model, existing, baseModel),
@@ -341,6 +343,23 @@ function normalizeModalities(values: string[], fallback: Modality[]): Modality[]
   return [...new Set(normalized.length > 0 ? normalized : fallback)];
 }
 
+function unionModalities(remote: Modality[], existing: Modality[] | undefined): Modality[] {
+  // Catalog rows often omit PDF/image even when the endpoint accepts them.
+  // Union with authored modalities so sync never silently drops capabilities.
+  return [...new Set([...(existing ?? []), ...remote])];
+}
+
+function isTextOnly(input: Modality[], output: Modality[]) {
+  return input.every((value) => value === "text") && output.every((value) => value === "text");
+}
+
+function normalizeEffortToken(value: string): string {
+  const normalized = value.trim().toLowerCase().replaceAll("_", "-");
+  if (normalized === "x-high" || normalized === "xhigh") return "xhigh";
+  if (normalized === "null") return "null";
+  return normalized;
+}
+
 function number(value: string | number | undefined) {
   if (value === undefined) return undefined;
   const parsed = typeof value === "number" ? value : Number.parseInt(value, 10);
@@ -360,12 +379,21 @@ function reasoningOptionsFor(
   model: DigitalOceanSourceModel,
   existing: ExistingModel | undefined,
 ): ExistingModel["reasoning_options"] {
-  if (model.reasoning_efforts === undefined) return existing?.reasoning_options;
-  const values = model.reasoning_efforts
-    .map((value) => value === "null" ? null : value)
+  if (model.reasoning_efforts === undefined || model.reasoning_efforts.length === 0) {
+    return existing?.reasoning_options;
+  }
+  const remoteValues = model.reasoning_efforts
+    .map((value) => {
+      const normalized = normalizeEffortToken(value);
+      return normalized === "null" ? null : normalized;
+    })
     .filter(isReasoningEffort);
   const preserved = existing?.reasoning_options?.filter((option) => option.type !== "effort") ?? [];
-  return values.length > 0 ? [...preserved, { type: "effort", values }] : preserved;
+  const existingEffort = existing?.reasoning_options?.find((option) => option.type === "effort");
+  const existingValues = existingEffort?.type === "effort" ? existingEffort.values : [];
+  // Merge so incomplete catalog effort lists cannot drop curated values (e.g. none/xhigh).
+  const values = [...new Set([...remoteValues, ...existingValues])];
+  return values.length > 0 ? [...preserved, { type: "effort", values }] : preserved.length > 0 ? preserved : existing?.reasoning_options;
 }
 
 function isReasoningEffort(value: string | null): value is ReasoningEffort {
@@ -383,11 +411,33 @@ function isReasoningEffort(value: string | null): value is ReasoningEffort {
 function status(
   lifecycleStatus: string,
   existing: ExistingModel["status"],
+  name?: string,
 ): ExistingModel["status"] {
   const lifecycle = lifecycleStatus.toLowerCase().replaceAll("_", "-");
   if (lifecycle === "deprecated" || lifecycle === "end-of-life") return "deprecated";
-  if (lifecycle === "public-preview") return "beta";
+  if (
+    lifecycle === "public-preview"
+    || lifecycle === "preview"
+    || name?.toLowerCase().includes("public preview") === true
+  ) {
+    return "beta";
+  }
   return existing === "deprecated" || existing === "beta" ? undefined : existing;
+}
+
+function resolveReasoning(
+  model: DigitalOceanSourceModel,
+  existing: ExistingModel | undefined,
+  textOutput: boolean,
+): boolean | undefined {
+  if (!textOutput) return existing?.reasoning ?? false;
+  // `thinking: true` is the only positive-authoritative DO signal. Catalog rows
+  // sometimes attach generic reasoning_efforts to non-reasoning chat models
+  // (e.g. gpt-4o-mini); never flip curated reasoning=false from efforts alone.
+  if (model.thinking === true) return true;
+  if (existing?.reasoning !== undefined) return existing.reasoning;
+  if ((model.reasoning_efforts?.length ?? 0) > 0) return true;
+  return undefined;
 }
 
 function cost(model: DigitalOceanSourceModel, existing: ExistingModel | undefined) {
@@ -430,15 +480,19 @@ function cost(model: DigitalOceanSourceModel, existing: ExistingModel | undefine
 export function buildDigitalOceanModel(
   model: DigitalOceanSourceModel,
   existing: ExistingModel | undefined,
-  baseModel = existing === undefined ? resolveDigitalOceanBaseModel(model.id) : existing.base_model,
+  baseModel = existing !== undefined
+    ? existing.base_model
+    : resolveDigitalOceanBaseModel(model.id),
 ): SyncedModel {
-  const input = normalizeModalities(
-    model.modalities?.input ?? [],
-    existing?.modalities?.input ?? ["text"],
+  const remoteInput = normalizeModalities(model.modalities?.input ?? [], []);
+  const remoteOutput = normalizeModalities(model.modalities?.output ?? [], []);
+  const input = unionModalities(
+    remoteInput.length > 0 ? remoteInput : ["text"],
+    existing?.modalities?.input,
   );
-  const output = normalizeModalities(
-    model.modalities?.output ?? [],
-    existing?.modalities?.output ?? ["text"],
+  const output = unionModalities(
+    remoteOutput.length > 0 ? remoteOutput : ["text"],
+    existing?.modalities?.output,
   );
   const context = number(model.context_window) ?? existing?.limit?.context ?? 0;
   const maxTokens = number(model.max_output_tokens ?? undefined);
@@ -448,13 +502,12 @@ export function buildDigitalOceanModel(
     output: maxTokens ?? existing?.limit?.output ?? 0,
   };
   const textOutput = output.includes("text") && !output.includes("image") && !output.includes("video");
-  const remoteReasoning = textOutput
-    && ((model.thinking ?? false) || (model.reasoning_efforts?.length ?? 0) > 0);
-  const providerReasoning = remoteReasoning ? true : existing?.reasoning;
+  const providerReasoning = resolveReasoning(model, existing, textOutput);
   const reasoning = providerReasoning ?? false;
-  const reasoningOptions = reasoning ? reasoningOptionsFor(model, existing) : undefined;
-  const modelStatus = status(model.lifecycle_status, existing?.status);
+  const reasoningOptions = reasoning === true ? reasoningOptionsFor(model, existing) : undefined;
+  const modelStatus = status(model.lifecycle_status, existing?.status, model.name);
   const releaseDate = existing?.release_date ?? model.created_at?.slice(0, 10) ?? new Date().toISOString().slice(0, 10);
+  const attachment = input.some((value) => value !== "text");
   const values: Partial<SyncedFullModel> = {
     name: model.name,
     description: existing?.description ?? describeModel({
@@ -471,7 +524,7 @@ export function buildDigitalOceanModel(
     family: existing?.family ?? inferFamily(model.id, model.name),
     release_date: releaseDate,
     last_updated: existing?.last_updated ?? releaseDate,
-    attachment: existing?.attachment ?? input.some((value) => value !== "text"),
+    attachment: attachment || existing?.attachment === true,
     reasoning,
     reasoning_options: reasoningOptions,
     temperature: existing?.temperature ?? true,
@@ -489,10 +542,21 @@ export function buildDigitalOceanModel(
   };
 
   if (baseModel !== undefined) {
+    // Incomplete catalog rows are often text-only. Do not clobber base-model
+    // vision/PDF/attachment facts unless the catalog reports non-text modalities.
+    const remoteIsTextOnly = isTextOnly(
+      remoteInput.length > 0 ? remoteInput : ["text"],
+      remoteOutput.length > 0 ? remoteOutput : ["text"],
+    );
     return factorBaseModel(baseModel, {
       name: model.name,
       description: existing?.description,
-      attachment: input.some((value) => value !== "text"),
+      ...(remoteIsTextOnly
+        ? {}
+        : {
+            attachment,
+            modalities: { input, output },
+          }),
       reasoning: providerReasoning,
       reasoning_options: reasoningOptions,
       temperature: existing?.temperature,
@@ -502,7 +566,6 @@ export function buildDigitalOceanModel(
       interleaved: existing?.interleaved,
       cost: cost(model, existing),
       limit,
-      modalities: { input, output },
       provider: existing?.provider,
       experimental: existing?.experimental,
     }, limit, existing?.base_model_omit);
@@ -537,15 +600,30 @@ export function resolveDigitalOceanBaseModel(id: string) {
   if (id.startsWith("glm-")) candidates.push(`zai/${id}`);
   if (id.startsWith("kimi-")) candidates.push(`moonshotai/${id}`);
   if (id.startsWith("minimax-")) candidates.push(`minimax/${id}`);
+  if (id.startsWith("mimo-")) {
+    const normalized = id.replace(/^mimo-v(\d+)-(\d+)/, "mimo-v$1.$2");
+    candidates.push(`xiaomi/${id}`);
+    candidates.push(`xiaomi/${normalized}`);
+  }
   if (id.startsWith("nvidia-")) candidates.push(`nvidia/${id.slice("nvidia-".length)}`);
   if (id.startsWith("alibaba-")) candidates.push(`qwen/${id.slice("alibaba-".length)}`);
   if (id.startsWith("qwen")) candidates.push(`qwen/${id}`);
   if (id.startsWith("llama")) candidates.push(`meta/${id}`);
   if (id.startsWith("mistral") || id.startsWith("ministral")) candidates.push(`mistralai/${id}`);
+  if (id.startsWith("gemma")) candidates.push(`google/${id}`);
 
-  const anthropic = id.match(/^anthropic-claude-(\d+(?:\.\d+)?)-(opus|sonnet|haiku)$/);
-  if (anthropic !== null) {
-    candidates.push(`anthropic/claude-${anthropic[2]}-${anthropic[1]}`);
+  // anthropic-claude-5-sonnet → anthropic/claude-sonnet-5
+  const anthropicSwapped = id.match(/^anthropic-claude-(\d+(?:\.\d+)?)-(opus|sonnet|haiku)$/);
+  if (anthropicSwapped !== null) {
+    candidates.push(`anthropic/claude-${anthropicSwapped[2]}-${anthropicSwapped[1]}`);
+  }
+  // anthropic-claude-opus-5 → anthropic/claude-opus-5
+  // also normalize dotted versions: anthropic-claude-opus-4.6 → anthropic/claude-opus-4-6
+  const anthropicFamily = id.match(/^anthropic-claude-(opus|sonnet|haiku)-(\d+(?:\.\d+)?)$/);
+  if (anthropicFamily !== null) {
+    const version = anthropicFamily[2].replaceAll(".", "-");
+    candidates.push(`anthropic/claude-${anthropicFamily[1]}-${anthropicFamily[2]}`);
+    candidates.push(`anthropic/claude-${anthropicFamily[1]}-${version}`);
   }
   if (id.startsWith("anthropic-")) candidates.push(`anthropic/${id.slice("anthropic-".length)}`);
 

--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -372,16 +372,20 @@ function reasoningOptionsFor(
   if (model.reasoning_efforts === undefined || model.reasoning_efforts.length === 0) {
     return existing?.reasoning_options;
   }
-  const remoteValues = model.reasoning_efforts
+  const remoteValues = reasoningEfforts(model);
+  const preserved = existing?.reasoning_options?.filter((option) => option.type !== "effort") ?? [];
+  return remoteValues.length > 0
+    ? [...preserved, { type: "effort", values: remoteValues }]
+    : existing?.reasoning_options;
+}
+
+function reasoningEfforts(model: DigitalOceanSourceModel) {
+  return (model.reasoning_efforts ?? [])
     .map((value) => {
       const normalized = normalizeEffortToken(value);
       return normalized === "null" ? null : normalized;
     })
     .filter(isReasoningEffort);
-  const preserved = existing?.reasoning_options?.filter((option) => option.type !== "effort") ?? [];
-  return remoteValues.length > 0
-    ? [...preserved, { type: "effort", values: remoteValues }]
-    : existing?.reasoning_options;
 }
 
 function isReasoningEffort(value: string | null): value is ReasoningEffort {
@@ -462,9 +466,13 @@ export function buildDigitalOceanModel(
     output: maxTokens ?? existing?.limit?.output ?? 0,
   };
   const textOutput = output.includes("text") && !output.includes("image") && !output.includes("video");
-  const hasRemoteReasoning = model.thinking !== undefined || model.reasoning_efforts !== undefined;
-  const providerReasoning = textOutput && hasRemoteReasoning
-    ? model.thinking === true || (model.reasoning_efforts?.length ?? 0) > 0
+  const remoteEfforts = reasoningEfforts(model);
+  const providerReasoning = !textOutput
+    ? existing?.reasoning
+    : model.thinking === true || remoteEfforts.length > 0
+    ? true
+    : model.thinking === false
+    ? false
     : existing?.reasoning;
   const reasoning = providerReasoning ?? false;
   const reasoningOptions = reasoning === true ? reasoningOptionsFor(model, existing) : undefined;

--- a/packages/core/src/sync/providers/digitalocean.ts
+++ b/packages/core/src/sync/providers/digitalocean.ts
@@ -404,7 +404,8 @@ function status(
   lifecycleStatus: string,
   existing: ExistingModel["status"],
 ): ExistingModel["status"] {
-  const lifecycle = lifecycleStatus.toLowerCase().replaceAll("_", "-");
+  const lifecycle = lifecycleStatus.trim().toLowerCase().replaceAll("_", "-");
+  if (lifecycle.length === 0) return existing;
   if (lifecycle === "deprecated" || lifecycle === "end-of-life") return "deprecated";
   if (lifecycle === "public-preview" || lifecycle === "preview") return "beta";
   return existing === "deprecated" || existing === "beta" ? undefined : existing;
@@ -495,7 +496,7 @@ export function buildDigitalOceanModel(
     family: existing?.family ?? inferFamily(model.id, model.name),
     release_date: releaseDate,
     last_updated: existing?.last_updated ?? releaseDate,
-    attachment: attachment || existing?.attachment === true,
+    attachment,
     reasoning,
     reasoning_options: reasoningOptions,
     temperature: existing?.temperature ?? true,

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1251,6 +1251,52 @@ test("normalizes DigitalOcean x-high effort tokens and uses lifecycle status", (
   expect(model.status).toBeUndefined();
 });
 
+test("preserves DigitalOcean status when lifecycle metadata is blank", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    lifecycle_status: "  ",
+  }), {
+    name: "Preview model",
+    description: "Curated model",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: false,
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+    tool_call: true,
+    open_weights: false,
+    status: "beta",
+    cost: { input: 1, output: 2 },
+    limit: { context: 128_000, output: 32_000 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(model.status).toBe("beta");
+});
+
+test("explicit DigitalOcean text-only modalities clear standalone attachment support", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    modalities: { input: ["text"], output: ["text"] },
+  }), {
+    name: "Multimodal model",
+    description: "Curated model",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: true,
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 1, output: 2 },
+    limit: { context: 128_000, output: 32_000 },
+    modalities: { input: ["text", "image"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    attachment: false,
+    modalities: { input: ["text"], output: ["text"] },
+  });
+});
+
 test("new DigitalOcean base models use explicit text-only catalog modalities", () => {
   const model = buildDigitalOceanModel(
     digitalOceanModel({

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1076,7 +1076,7 @@ test("maps DigitalOcean 1M catalog pricing to its 200K threshold", () => {
 test("syncs DigitalOcean reasoning capability, efforts, and lifecycle status", () => {
   const model = buildDigitalOceanModel(digitalOceanModel({
     lifecycle_status: "deprecated",
-    thinking: false,
+    thinking: true,
     reasoning_efforts: ["none", "low", "medium", "high", "max", "unsupported"],
   }), {
     name: "Claude Sonnet 4.6",
@@ -1103,9 +1103,139 @@ test("syncs DigitalOcean reasoning capability, efforts, and lifecycle status", (
   });
 });
 
+test("does not flip curated non-reasoning DigitalOcean models from generic efforts", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    id: "openai-gpt-4o-mini",
+    name: "OpenAI GPT-4o mini",
+    thinking: false,
+    reasoning_efforts: ["low", "medium", "high"],
+    context_window: 128_000,
+    max_output_tokens: 16_384,
+    modalities: { input: ["text", "image"], output: ["text"] },
+    pricing: { input: 0.15, output: 0.6, cacheRead: 0.075 },
+  }), {
+    name: "GPT-4o mini",
+    description: "Compact GPT model",
+    family: "gpt-mini",
+    release_date: "2024-07-18",
+    last_updated: "2024-07-18",
+    attachment: true,
+    reasoning: false,
+    temperature: true,
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 0.15, output: 0.6, cache_read: 0.075 },
+    limit: { context: 128_000, output: 16_384 },
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    reasoning: false,
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+  });
+  expect(model.reasoning_options).toBeUndefined();
+  expect(model).not.toHaveProperty("base_model");
+});
+
+test("merges incomplete DigitalOcean effort lists with curated values", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    id: "openai-gpt-5.2",
+    name: "OpenAI GPT-5.2",
+    thinking: true,
+    reasoning_efforts: ["minimal", "low", "medium", "high"],
+    context_window: 400_000,
+    max_output_tokens: 128_000,
+    modalities: { input: ["text", "image"], output: ["text"] },
+    pricing: { input: 1.75, output: 14, cacheRead: 0.175 },
+  }), {
+    name: "GPT-5.2",
+    description: "GPT model",
+    family: "gpt",
+    release_date: "2025-12-11",
+    last_updated: "2025-12-11",
+    attachment: true,
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+    temperature: false,
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 1.75, output: 14, cache_read: 0.175 },
+    limit: { context: 400_000, output: 128_000 },
+    modalities: { input: ["text", "image"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    reasoning: true,
+    reasoning_options: [{
+      type: "effort",
+      values: ["minimal", "low", "medium", "high", "none", "xhigh"],
+    }],
+  });
+  expect(model).not.toHaveProperty("base_model");
+});
+
+test("normalizes DigitalOcean x-high effort tokens and keeps public-preview status", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    name: "Nemotron Super (Public Preview)",
+    lifecycle_status: "active",
+    thinking: true,
+    reasoning_efforts: ["low", "x-high", "max"],
+  }), {
+    name: "Nemotron Super",
+    description: "Nemotron model",
+    family: "nemotron",
+    release_date: "2026-03-11",
+    last_updated: "2026-04-16",
+    attachment: false,
+    reasoning: true,
+    temperature: true,
+    tool_call: true,
+    open_weights: true,
+    status: "beta",
+    cost: { input: 0.3, output: 0.65 },
+    limit: { context: 256_000, output: 32_768 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    status: "beta",
+    reasoning_options: [{ type: "effort", values: ["low", "xhigh", "max"] }],
+  });
+});
+
+test("new DigitalOcean base models do not clobber multimodal metadata with text-only catalog rows", () => {
+  const model = buildDigitalOceanModel(
+    digitalOceanModel({
+      id: "anthropic-claude-5-sonnet",
+      name: "Anthropic Claude Sonnet 5",
+      thinking: true,
+      reasoning_efforts: ["low", "medium", "high", "max", "x-high"],
+      modalities: { input: ["text"], output: ["text"] },
+      context_window: 1_000_000,
+      max_output_tokens: 128_000,
+      pricing: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
+    }),
+    undefined,
+  );
+
+  expect(model).toMatchObject({
+    base_model: "anthropic/claude-sonnet-5",
+    name: "Anthropic Claude Sonnet 5",
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "max", "xhigh"] }],
+  });
+  expect(model).not.toHaveProperty("attachment");
+  expect(model).not.toHaveProperty("modalities");
+  // reasoning=true matches base metadata, so factorBaseModel omits it
+  expect(model).not.toHaveProperty("reasoning");
+});
+
 test("resolves DigitalOcean IDs to canonical model metadata", () => {
   expect(resolveDigitalOceanBaseModel("openai-gpt-5.5")).toBe("openai/gpt-5.5");
   expect(resolveDigitalOceanBaseModel("deepseek-v4-pro")).toBe("deepseek/deepseek-v4-pro");
+  expect(resolveDigitalOceanBaseModel("mimo-v2.5-pro")).toBe("xiaomi/mimo-v2.5-pro");
+  expect(resolveDigitalOceanBaseModel("anthropic-claude-5-sonnet")).toBe("anthropic/claude-sonnet-5");
+  expect(resolveDigitalOceanBaseModel("anthropic-claude-opus-5")).toBe("anthropic/claude-opus-5");
+  expect(resolveDigitalOceanBaseModel("openai-gpt-5.6-luna")).toBe("openai/gpt-5.6-luna");
 });
 
 test("new DigitalOcean base models inherit intrinsic capabilities", () => {
@@ -1127,6 +1257,31 @@ test("new DigitalOcean base models inherit intrinsic capabilities", () => {
   expect(model).not.toHaveProperty("knowledge");
   expect(model).not.toHaveProperty("reasoning");
   expect(model).not.toHaveProperty("temperature");
+});
+
+test("new DigitalOcean MiMo models factor xiaomi base metadata", () => {
+  const model = buildDigitalOceanModel(
+    digitalOceanModel({
+      id: "mimo-v2.5-pro",
+      name: "MiMo V2.5 Pro",
+      thinking: undefined,
+      reasoning_efforts: undefined,
+      modalities: { input: ["text"], output: ["text"] },
+      pricing: { input: 0.6, output: 3, cacheRead: 0.16 },
+      context_window: 262_144,
+      max_output_tokens: 52_429,
+    }),
+    undefined,
+  );
+
+  expect(model).toMatchObject({
+    base_model: "xiaomi/mimo-v2.5-pro",
+    name: "MiMo V2.5 Pro",
+    cost: { input: 0.6, output: 3, cache_read: 0.16 },
+    limit: { context: 262_144, output: 52_429 },
+  });
+  expect(model).not.toHaveProperty("reasoning");
+  expect(model).not.toHaveProperty("open_weights");
 });
 
 test("xAI sync factors inherited base model fields", () => {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1103,7 +1103,7 @@ test("syncs DigitalOcean reasoning capability, efforts, and lifecycle status", (
   });
 });
 
-test("does not flip curated non-reasoning DigitalOcean models from generic efforts", () => {
+test("uses DigitalOcean reasoning efforts over curated capability metadata", () => {
   const model = buildDigitalOceanModel(digitalOceanModel({
     id: "openai-gpt-4o-mini",
     name: "OpenAI GPT-4o mini",
@@ -1130,14 +1130,14 @@ test("does not flip curated non-reasoning DigitalOcean models from generic effor
   });
 
   expect(model).toMatchObject({
-    reasoning: false,
-    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+    modalities: { input: ["text", "image"], output: ["text"] },
   });
-  expect(model.reasoning_options).toBeUndefined();
   expect(model).not.toHaveProperty("base_model");
 });
 
-test("merges incomplete DigitalOcean effort lists with curated values", () => {
+test("uses DigitalOcean effort lists over curated values", () => {
   const model = buildDigitalOceanModel(digitalOceanModel({
     id: "openai-gpt-5.2",
     name: "OpenAI GPT-5.2",
@@ -1168,13 +1168,13 @@ test("merges incomplete DigitalOcean effort lists with curated values", () => {
     reasoning: true,
     reasoning_options: [{
       type: "effort",
-      values: ["minimal", "low", "medium", "high", "none", "xhigh"],
+      values: ["minimal", "low", "medium", "high"],
     }],
   });
   expect(model).not.toHaveProperty("base_model");
 });
 
-test("normalizes DigitalOcean x-high effort tokens and keeps public-preview status", () => {
+test("normalizes DigitalOcean x-high effort tokens and uses lifecycle status", () => {
   const model = buildDigitalOceanModel(digitalOceanModel({
     name: "Nemotron Super (Public Preview)",
     lifecycle_status: "active",
@@ -1198,12 +1198,12 @@ test("normalizes DigitalOcean x-high effort tokens and keeps public-preview stat
   });
 
   expect(model).toMatchObject({
-    status: "beta",
     reasoning_options: [{ type: "effort", values: ["low", "xhigh", "max"] }],
   });
+  expect(model.status).toBeUndefined();
 });
 
-test("new DigitalOcean base models do not clobber multimodal metadata with text-only catalog rows", () => {
+test("new DigitalOcean base models use explicit text-only catalog modalities", () => {
   const model = buildDigitalOceanModel(
     digitalOceanModel({
       id: "anthropic-claude-5-sonnet",
@@ -1223,13 +1223,15 @@ test("new DigitalOcean base models do not clobber multimodal metadata with text-
     name: "Anthropic Claude Sonnet 5",
     reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "max", "xhigh"] }],
   });
-  expect(model).not.toHaveProperty("attachment");
-  expect(model).not.toHaveProperty("modalities");
+  expect(model).toMatchObject({
+    attachment: false,
+    modalities: { input: ["text"] },
+  });
   // reasoning=true matches base metadata, so factorBaseModel omits it
   expect(model).not.toHaveProperty("reasoning");
 });
 
-test("existing DigitalOcean base models preserve provider modality subsets from text-only catalog rows", () => {
+test("existing DigitalOcean base models use explicit text-only catalog modalities", () => {
   const model = buildDigitalOceanModel(
     digitalOceanModel({
       id: "nemotron-nano-12b-v2-vl",
@@ -1260,7 +1262,8 @@ test("existing DigitalOcean base models preserve provider modality subsets from 
 
   expect(model).toMatchObject({
     base_model: "nvidia/nemotron-nano-12b-v2-vl",
-    modalities: { input: ["text", "image"] },
+    attachment: false,
+    modalities: { input: ["text"] },
   });
 });
 

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1137,6 +1137,54 @@ test("uses DigitalOcean reasoning efforts over curated capability metadata", () 
   expect(model).not.toHaveProperty("base_model");
 });
 
+test("preserves DigitalOcean reasoning metadata when efforts are empty", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    thinking: undefined,
+    reasoning_efforts: [],
+  }), {
+    name: "Reasoning model",
+    description: "Curated model",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: false,
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 1, output: 2 },
+    limit: { context: 128_000, output: 32_000 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(model).toMatchObject({
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+  });
+});
+
+test("uses explicit DigitalOcean thinking false when efforts are empty", () => {
+  const model = buildDigitalOceanModel(digitalOceanModel({
+    thinking: false,
+    reasoning_efforts: [],
+  }), {
+    name: "Reasoning model",
+    description: "Curated model",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: false,
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 1, output: 2 },
+    limit: { context: 128_000, output: 32_000 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(model.reasoning).toBe(false);
+  expect(model.reasoning_options).toBeUndefined();
+});
+
 test("uses DigitalOcean effort lists over curated values", () => {
   const model = buildDigitalOceanModel(digitalOceanModel({
     id: "openai-gpt-5.2",

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1229,6 +1229,41 @@ test("new DigitalOcean base models do not clobber multimodal metadata with text-
   expect(model).not.toHaveProperty("reasoning");
 });
 
+test("existing DigitalOcean base models preserve provider modality subsets from text-only catalog rows", () => {
+  const model = buildDigitalOceanModel(
+    digitalOceanModel({
+      id: "nemotron-nano-12b-v2-vl",
+      name: "Nemotron Nano 12B v2 VL",
+      modalities: { input: ["text"], output: ["text"] },
+      context_window: 128_000,
+      max_output_tokens: 16_384,
+      pricing: { input: 0.2, output: 0.6 },
+    }),
+    {
+      base_model: "nvidia/nemotron-nano-12b-v2-vl",
+      name: "Nemotron Nano 12B v2 VL",
+      description: "Nemotron vision-language model",
+      family: "nemotron",
+      release_date: "2025-12-01",
+      last_updated: "2026-04-30",
+      attachment: true,
+      reasoning: true,
+      reasoning_options: [{ type: "effort", values: ["none", "low", "medium", "high", "max"] }],
+      temperature: true,
+      tool_call: true,
+      open_weights: true,
+      cost: { input: 0.2, output: 0.6 },
+      limit: { context: 128_000, output: 16_384 },
+      modalities: { input: ["text", "image"], output: ["text"] },
+    },
+  );
+
+  expect(model).toMatchObject({
+    base_model: "nvidia/nemotron-nano-12b-v2-vl",
+    modalities: { input: ["text", "image"] },
+  });
+});
+
 test("resolves DigitalOcean IDs to canonical model metadata", () => {
   expect(resolveDigitalOceanBaseModel("openai-gpt-5.5")).toBe("openai/gpt-5.5");
   expect(resolveDigitalOceanBaseModel("deepseek-v4-pro")).toBe("deepseek/deepseek-v4-pro");


### PR DESCRIPTION
## Summary
Hardens DigitalOcean catalog translation while treating explicit upstream metadata as authoritative:

- maps MiMo and Anthropic provider IDs to canonical base models
- replaces curated effort values when DigitalOcean supplies a non-empty recognized list
- normalizes `x-high` to `xhigh`
- replaces curated/base modalities when DigitalOcean supplies explicit modalities
- falls back to authored metadata only when upstream fields are absent or unusable
- derives reasoning from explicit `thinking` / `reasoning_efforts` signals
- derives preview/deprecation status from upstream lifecycle status

## Test plan
- [x] `cd packages/core && bun test test/sync.test.ts` (99 pass)
- [x] `bun validate`
- [ ] Re-run DigitalOcean model sync and review the generated catalog PR