### PR TITLE
fix open-weights metadata: 29 missing weights links, 3 wrong flags

### DIFF
--- a/models/cohere/command-a-plus-05-2026.toml
+++ b/models/cohere/command-a-plus-05-2026.toml
@@ -18,3 +18,7 @@ output = 64_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16"

--- a/models/cohere/north-mini-code-1-0.toml
+++ b/models/cohere/north-mini-code-1-0.toml
@@ -62,3 +62,7 @@ score = 37
 metric = "success rate"
 source = "https://artificialanalysis.ai/articles/north-mini-code-cohere-s-small-coding-focused-moe-model"
 date = "2026-06-09"
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/CohereLabs/North-Mini-Code-1.0"

--- a/models/deepreinforce/ornith-1.0-31b.toml
+++ b/models/deepreinforce/ornith-1.0-31b.toml
@@ -1,3 +1,7 @@
+# open_weights corrected to false: the 31B Dense variant is named in the Ornith 1.0
+# announcement (https://deep-reinforce.com/ornith_1_0.html) but was never published —
+# https://huggingface.co/deepreinforce-ai ships only 9B/35B/397B and no 31B repo or
+# community quantization exists anywhere on Hugging Face.
 # Announced in the Ornith 1.0 family but not yet published on Hugging Face as
 # of 2026-06-28 — no weights URL or benchmark scores available yet. Modalities
 # and context window are provisional, assumed consistent with the rest of the
@@ -12,7 +16,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = true
+open_weights = false
 license = "MIT"
 
 [limit]

--- a/models/moonshotai/kimi-k3.toml
+++ b/models/moonshotai/kimi-k3.toml
@@ -17,3 +17,7 @@ output = 131_072
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/moonshotai/Kimi-K3"

--- a/models/nvidia/llama-3.1-nemotron-70b-instruct.toml
+++ b/models/nvidia/llama-3.1-nemotron-70b-instruct.toml
@@ -16,3 +16,7 @@ output = 8_192
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF"

--- a/models/nvidia/llama-3.1-nemotron-safety-guard-8b-v3.toml
+++ b/models/nvidia/llama-3.1-nemotron-safety-guard-8b-v3.toml
@@ -16,3 +16,7 @@ output = 4_096
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Llama-3.1-Nemotron-Safety-Guard-8B-v3"

--- a/models/nvidia/llama-3.1-nemotron-ultra-253b.toml
+++ b/models/nvidia/llama-3.1-nemotron-ultra-253b.toml
@@ -16,3 +16,7 @@ output = 8_192
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1"

--- a/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
+++ b/models/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Llama-3_3-Nemotron-Super-49B-v1_5"

--- a/models/nvidia/llama-3.3-nemotron-super-49b-v1.toml
+++ b/models/nvidia/llama-3.3-nemotron-super-49b-v1.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Llama-3_3-Nemotron-Super-49B-v1"

--- a/models/nvidia/llama-nemotron-embed-vl-1b-v2.toml
+++ b/models/nvidia/llama-nemotron-embed-vl-1b-v2.toml
@@ -16,3 +16,7 @@ output = 2_048
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2"

--- a/models/nvidia/llama-nemotron-rerank-vl-1b-v2.toml
+++ b/models/nvidia/llama-nemotron-rerank-vl-1b-v2.toml
@@ -16,3 +16,7 @@ output = 4_096
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2"

--- a/models/nvidia/mistral-nemotron.toml
+++ b/models/nvidia/mistral-nemotron.toml
@@ -1,3 +1,6 @@
+# open_weights corrected to false: no public weights exist — nvidia/Mistral-Nemotron is
+# not on Hugging Face (the nvidia org has no *istral* repo) and the model is served
+# API-only via NVIDIA NIM (https://docs.api.nvidia.com/nim/reference/mistralai-mistral-nemotron).
 name = "Mistral Nemotron"
 description = "Mistral model for multilingual chat, reasoning, and tool-assisted workflows"
 family = "nemotron"
@@ -7,7 +10,7 @@ attachment = false
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = true
+open_weights = false
 
 [limit]
 context = 128_000

--- a/models/nvidia/nemotron-3-content-safety.toml
+++ b/models/nvidia/nemotron-3-content-safety.toml
@@ -16,3 +16,7 @@ output = 4_096
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Nemotron-3-Content-Safety"

--- a/models/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/models/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -16,3 +16,7 @@ output = 262_144
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"

--- a/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -16,3 +16,7 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video", "audio"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16"

--- a/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -16,3 +16,7 @@ output = 262_144
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"

--- a/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -99,3 +99,7 @@ score = 46.7
 metric = "wins or ties"
 source = "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
 date = "2026-06-04"
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"

--- a/models/nvidia/nemotron-3.5-content-safety.toml
+++ b/models/nvidia/nemotron-3.5-content-safety.toml
@@ -16,3 +16,7 @@ output = 8_192
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Nemotron-3.5-Content-Safety"

--- a/models/nvidia/nemotron-cascade-2-30b-a3b.toml
+++ b/models/nvidia/nemotron-cascade-2-30b-a3b.toml
@@ -16,3 +16,7 @@ output = 32_768
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B"

--- a/models/nvidia/nemotron-content-safety-reasoning-4b.toml
+++ b/models/nvidia/nemotron-content-safety-reasoning-4b.toml
@@ -16,3 +16,7 @@ output = 4_096
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Nemotron-Content-Safety-Reasoning-4B"

--- a/models/nvidia/nemotron-mini-4b-instruct.toml
+++ b/models/nvidia/nemotron-mini-4b-instruct.toml
@@ -16,3 +16,7 @@ output = 8_192
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/Nemotron-Mini-4B-Instruct"

--- a/models/nvidia/nemotron-nano-12b-v2-vl.toml
+++ b/models/nvidia/nemotron-nano-12b-v2-vl.toml
@@ -16,3 +16,7 @@ output = 128_000
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"

--- a/models/nvidia/nemotron-nano-9b-v2.toml
+++ b/models/nvidia/nemotron-nano-9b-v2.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2"

--- a/models/nvidia/nemotron-voicechat.toml
+++ b/models/nvidia/nemotron-voicechat.toml
@@ -1,3 +1,6 @@
+# open_weights corrected to false: weights are not publicly downloadable — access is an
+# application-only Early Access Program (https://developer.nvidia.com/nemotron-voicechat-early-access)
+# and no Hugging Face repo exists. Revisit if NVIDIA opens general access.
 name = "Nemotron VoiceChat"
 description = "Nemotron multimodal model for visual reasoning and agentic AI workflows"
 family = "nemotron"
@@ -7,7 +10,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
-open_weights = true
+open_weights = false
 
 [limit]
 context = 128_000

--- a/models/openai/whisper-large-v3-turbo.toml
+++ b/models/openai/whisper-large-v3-turbo.toml
@@ -15,3 +15,7 @@ output = 448
 [modalities]
 input = ["audio"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/openai/whisper-large-v3-turbo"

--- a/models/openai/whisper-large-v3.toml
+++ b/models/openai/whisper-large-v3.toml
@@ -15,3 +15,7 @@ output = 4_096
 [modalities]
 input = ["audio"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/openai/whisper-large-v3"

--- a/models/poolside/laguna-m.1.toml
+++ b/models/poolside/laguna-m.1.toml
@@ -17,3 +17,7 @@ output = 32_768
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/poolside/Laguna-M.1"

--- a/models/poolside/laguna-s-2.1.toml
+++ b/models/poolside/laguna-s-2.1.toml
@@ -17,3 +17,7 @@ output = 32_768
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/poolside/Laguna-S-2.1"

--- a/models/poolside/laguna-xs-2.1.toml
+++ b/models/poolside/laguna-xs-2.1.toml
@@ -50,3 +50,7 @@ harness = "Harbor"
 version = "2.0"
 source = "https://poolside.ai/blog/introducing-laguna-xs-2-1"
 date = "2026-07-02"
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/poolside/Laguna-XS-2.1"

--- a/models/poolside/laguna-xs.2.toml
+++ b/models/poolside/laguna-xs.2.toml
@@ -17,3 +17,7 @@ output = 32_768
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/poolside/Laguna-XS.2"

--- a/models/sarvam/sarvam-105b.toml
+++ b/models/sarvam/sarvam-105b.toml
@@ -16,3 +16,7 @@ output = 131_072
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/sarvamai/sarvam-105b"

--- a/models/sarvam/sarvam-30b.toml
+++ b/models/sarvam/sarvam-30b.toml
@@ -16,3 +16,7 @@ output = 128_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/sarvamai/sarvam-30b"


### PR DESCRIPTION
## What

The repository invariant `open_weights = true` ⇒ weights links (`packages/core/test/generate.test.ts`, "repository open-weight model metadata includes weights links") currently fails on **32 registry records**. Every one was verified against Hugging Face individually — each URL below was fetched and confirmed to be that model's official repo.

**29 records were genuinely open but missing links** — each gets its canonical Hugging Face repo as a `[[weights]]` entry (the `label = "Hugging Face"` + `url` form used by all 93 existing entries). Non-obvious repo spellings, all verified live:

- NVIDIA underscore variants: [Llama-3_1-Nemotron-Ultra-253B-v1](https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1), [Llama-3_3-Nemotron-Super-49B-v1_5](https://huggingface.co/nvidia/Llama-3_3-Nemotron-Super-49B-v1_5), [Llama-3_3-Nemotron-Super-49B-v1](https://huggingface.co/nvidia/Llama-3_3-Nemotron-Super-49B-v1)
- The 70B Instruct link points at the [Transformers conversion (-HF)](https://huggingface.co/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF) rather than the NeMo-checkpoint repo, per the model card's own recommendation
- Nemotron 3 BF16-suffixed repos: [Nano-30B-A3B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16), [Super-120B-A12B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16), [Ultra-550B-A55B](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16), [Nano-Omni-Reasoning](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16)
- Cohere publishes under **CohereLabs**: [command-a-plus-05-2026-bf16](https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16), [North-Mini-Code-1.0](https://huggingface.co/CohereLabs/North-Mini-Code-1.0)
- poolside Laguna weights are public: [Laguna-M.1](https://huggingface.co/poolside/Laguna-M.1) (Apache-2.0), [Laguna-S-2.1](https://huggingface.co/poolside/Laguna-S-2.1) / [Laguna-XS-2.1](https://huggingface.co/poolside/Laguna-XS-2.1) (OpenMDW-1.1), [Laguna-XS.2](https://huggingface.co/poolside/Laguna-XS.2)
- Plus sarvam ([105b](https://huggingface.co/sarvamai/sarvam-105b), [30b](https://huggingface.co/sarvamai/sarvam-30b)), whisper ([large-v3](https://huggingface.co/openai/whisper-large-v3), [large-v3-turbo](https://huggingface.co/openai/whisper-large-v3-turbo)), [Kimi-K3](https://huggingface.co/moonshotai/Kimi-K3), and the remaining NVIDIA Nemotron/safety/embed/rerank repos

**3 records had the flag itself wrong** and are corrected to `open_weights = false`, each with a top-of-file citation comment (per AGENTS.md comment placement rules):

- `deepreinforce/ornith-1.0-31b` — the 31B Dense variant is named in the [announcement](https://deep-reinforce.com/ornith_1_0.html) but was never published: [the org](https://huggingface.co/deepreinforce-ai) ships only 9B/35B/397B, and no 31B repo or community quantization exists anywhere on HF
- `nvidia/mistral-nemotron` — no public weights; served API-only via [NVIDIA NIM](https://docs.api.nvidia.com/nim/reference/mistralai-mistral-nemotron), `nvidia/Mistral-Nemotron` does not exist on HF
- `nvidia/nemotron-voicechat` — weights are behind an [application-only Early Access Program](https://developer.nvidia.com/nemotron-voicechat-early-access), not publicly downloadable; no HF repo exists. Worth revisiting if NVIDIA opens general access.

## Verification

`bun validate` passes, and the core test suite goes fully green with this change (111 pass / 0 fail — the weights-link invariant was the only repository-data failure). A follow-up PR proposes running that suite in CI so this class of drift is caught at PR time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
