### PR TITLE
ci: run the core test suite on pull requests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Run validation script
         run: bun validate
 
+      - name: Core tests
+        run: bun test
+        working-directory: packages/core
+
       - name: SDK tests
         run: bun run test
         working-directory: packages/sdk

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - **Validate**: `bun validate` - Validates all provider/model configurations
 - **Build web**: `cd packages/web && bun run build` - Builds the web interface
 - **Dev server**: `cd packages/web && bun run dev` - Runs development server
-- **No test framework** - No dedicated test commands found
+- **Test**: `bun test` - Runs the core catalog tests (`packages/core/test`, includes repository-wide data invariants) and SDK unit tests; `cd packages/sdk && bun run test` additionally runs SDK codegen + typecheck
 
 ## Code Style
 - **Runtime**: Bun with TypeScript ESM modules


### PR DESCRIPTION
## What

`validate.yml` runs `bun validate` and the SDK suite on every PR, but the **111 core tests** — including the repository-wide data invariants (`base_model` hygiene, metadata leakage, weights-link coverage, provider-namespace rules) — never execute in CI. Data regressions those tests were written to catch land silently: the weights-link invariant had accumulated 32 violations on `dev` before #3909.

- adds a `Core tests` step (`bun test` in `packages/core`) to `validate.yml`, between validate and the SDK step
- corrects the `AGENTS.md` claim that no test framework exists (which steers both agents and humans away from running the suite)

## Dependency

Needs #3909 (open-weights metadata fixes) to land first — the weights-link invariant is red on current `dev`, so enabling enforcement before the data fix would break every open PR. With #3909 merged, the core suite is fully green (111 pass / 0 fail, verified locally on that branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
