### PR TITLE
fix(sync): map long-context pricing tiers from xAI and OpenRouter APIs

### DIFF
--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -65,6 +65,14 @@ export const OpenRouterModel = z.object({
     internal_reasoning: z.string().optional(),
     input_cache_read: z.string().optional(),
     input_cache_write: z.string().optional(),
+    overrides: z.array(z.object({
+      min_prompt_tokens: z.number().int().nonnegative(),
+      prompt: z.string().optional(),
+      completion: z.string().optional(),
+      internal_reasoning: z.string().optional(),
+      input_cache_read: z.string().optional(),
+      input_cache_write: z.string().optional(),
+    }).passthrough()).optional(),
   }),
   top_provider: z.object({
     context_length: z.number().nullable(),
@@ -145,6 +153,36 @@ function price(value: string | undefined) {
     : undefined;
 }
 
+function costTiers(model: OpenRouterModel, existing: ExistingModel | undefined) {
+  // OpenRouter exposes long-context (and other threshold) rates via pricing.overrides.
+  // When present, map them to [[cost.tiers]] so stale hand-authored tiers self-heal.
+  // When absent, keep existing tiers — not every route reports overrides yet.
+  const overrides = model.pricing.overrides;
+  if (overrides === undefined || overrides.length === 0) return existing?.cost?.tiers;
+
+  const tiers = [...overrides]
+    .sort((a, b) => a.min_prompt_tokens - b.min_prompt_tokens)
+    .map((override) => {
+      const input = price(override.prompt);
+      const output = price(override.completion);
+      if (input === undefined || output === undefined) return undefined;
+      const cacheRead = price(override.input_cache_read);
+      const cacheWrite = price(override.input_cache_write);
+      const reasoning = price(override.internal_reasoning);
+      return {
+        tier: { type: "context" as const, size: override.min_prompt_tokens },
+        input,
+        output,
+        ...(reasoning === undefined ? {} : { reasoning }),
+        ...(cacheRead === undefined ? {} : { cache_read: cacheRead }),
+        ...(cacheWrite === undefined ? {} : { cache_write: cacheWrite }),
+      };
+    })
+    .filter((tier): tier is NonNullable<typeof tier> => tier !== undefined);
+
+  return tiers.length > 0 ? tiers : existing?.cost?.tiers;
+}
+
 type Modality = "text" | "audio" | "image" | "video" | "pdf";
 
 function modalities(values: string[], fallback: Modality[]): Modality[] {
@@ -207,7 +245,7 @@ export function buildOpenRouterModel(
         reasoning: reasoning ? price(model.pricing.internal_reasoning) : undefined,
         cache_read: price(model.pricing.input_cache_read),
         cache_write: price(model.pricing.input_cache_write),
-        tiers: existing?.cost?.tiers,
+        tiers: costTiers(model, existing),
       }
     : existing?.cost;
   const limit = {

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -66,10 +66,9 @@ export const OpenRouterModel = z.object({
     input_cache_read: z.string().optional(),
     input_cache_write: z.string().optional(),
     overrides: z.array(z.object({
-      min_prompt_tokens: z.number().int().nonnegative(),
+      min_prompt_tokens: z.number(),
       prompt: z.string().optional(),
       completion: z.string().optional(),
-      internal_reasoning: z.string().optional(),
       input_cache_read: z.string().optional(),
       input_cache_write: z.string().optional(),
     }).passthrough()).optional(),
@@ -154,32 +153,20 @@ function price(value: string | undefined) {
 }
 
 function costTiers(model: OpenRouterModel, existing: ExistingModel | undefined) {
-  // OpenRouter exposes long-context (and other threshold) rates via pricing.overrides.
-  // When present, map them to [[cost.tiers]] so stale hand-authored tiers self-heal.
-  // When absent, keep existing tiers — not every route reports overrides yet.
-  const overrides = model.pricing.overrides;
-  if (overrides === undefined || overrides.length === 0) return existing?.cost?.tiers;
-
-  const tiers = [...overrides]
-    .sort((a, b) => a.min_prompt_tokens - b.min_prompt_tokens)
-    .map((override) => {
-      const input = price(override.prompt);
-      const output = price(override.completion);
-      if (input === undefined || output === undefined) return undefined;
-      const cacheRead = price(override.input_cache_read);
-      const cacheWrite = price(override.input_cache_write);
-      const reasoning = price(override.internal_reasoning);
-      return {
-        tier: { type: "context" as const, size: override.min_prompt_tokens },
+  const tiers = (model.pricing.overrides ?? [])
+    .flatMap((o) => {
+      const input = price(o.prompt);
+      const output = price(o.completion);
+      if (input === undefined || output === undefined) return [];
+      return [{
+        tier: { type: "context" as const, size: o.min_prompt_tokens },
         input,
         output,
-        ...(reasoning === undefined ? {} : { reasoning }),
-        ...(cacheRead === undefined ? {} : { cache_read: cacheRead }),
-        ...(cacheWrite === undefined ? {} : { cache_write: cacheWrite }),
-      };
+        cache_read: price(o.input_cache_read),
+        cache_write: price(o.input_cache_write),
+      }];
     })
-    .filter((tier): tier is NonNullable<typeof tier> => tier !== undefined);
-
+    .sort((a, b) => a.tier.size - b.tier.size);
   return tiers.length > 0 ? tiers : existing?.cost?.tiers;
 }
 

--- a/packages/core/src/sync/providers/xai.ts
+++ b/packages/core/src/sync/providers/xai.ts
@@ -145,40 +145,24 @@ function tokenPrice(value: number | undefined) {
   return value / 10_000;
 }
 
-function longContextPrice(value: number | undefined, fallback: number | undefined) {
-  // xAI sends 0 when the long-context rate equals the base rate (or is unused).
-  if (value === undefined) return undefined;
-  if (value > 0) return tokenPrice(value);
-  return fallback;
-}
-
 function costTiers(model: XAIModel, existing: ExistingModel) {
-  const threshold = model.long_context_threshold;
-  // Image/video endpoints omit these fields — keep any hand-authored tiers.
-  if (threshold === undefined) return existing.cost?.tiers;
-  // threshold 0 means the model has no long-context pricing band.
-  if (threshold === 0) return undefined;
+  // 0 = no long-context band; omitted (image/video) = keep authored tiers.
+  // Long-context fields are 0 when they match the base rate.
+  const size = model.long_context_threshold;
+  if (size === undefined) return existing.cost?.tiers;
+  if (size === 0) return undefined;
 
-  const input = longContextPrice(
-    model.prompt_text_token_price_long_context,
-    tokenPrice(model.prompt_text_token_price),
-  );
-  const output = longContextPrice(
-    model.completion_text_token_price_long_context,
-    tokenPrice(model.completion_text_token_price),
-  );
+  const input = tokenPrice(model.prompt_text_token_price_long_context || model.prompt_text_token_price);
+  const output = tokenPrice(model.completion_text_token_price_long_context || model.completion_text_token_price);
   if (input === undefined || output === undefined) return existing.cost?.tiers;
 
-  const cacheRead = longContextPrice(
-    model.cached_prompt_text_token_price_long_context,
-    tokenPrice(model.cached_prompt_text_token_price),
-  );
-
   return [{
-    tier: { type: "context" as const, size: threshold },
+    tier: { type: "context" as const, size },
     input,
     output,
-    ...(cacheRead === undefined ? {} : { cache_read: cacheRead }),
+    cache_read: tokenPrice(
+      model.cached_prompt_text_token_price_long_context || model.cached_prompt_text_token_price,
+    ),
   }];
 }
 

--- a/packages/core/src/sync/providers/xai.ts
+++ b/packages/core/src/sync/providers/xai.ts
@@ -147,13 +147,17 @@ function tokenPrice(value: number | undefined) {
 
 function costTiers(model: XAIModel, existing: ExistingModel) {
   // 0 = no long-context band; omitted (image/video) = keep authored tiers.
-  // Long-context fields are 0 when they match the base rate.
+  // Long-context prices: 0 = same as base; undefined = field omitted, keep authored.
   const size = model.long_context_threshold;
   if (size === undefined) return existing.cost?.tiers;
   if (size === 0) return undefined;
 
-  const input = tokenPrice(model.prompt_text_token_price_long_context || model.prompt_text_token_price);
-  const output = tokenPrice(model.completion_text_token_price_long_context || model.completion_text_token_price);
+  const longInput = model.prompt_text_token_price_long_context;
+  const longOutput = model.completion_text_token_price_long_context;
+  if (longInput === undefined || longOutput === undefined) return existing.cost?.tiers;
+
+  const input = tokenPrice(longInput || model.prompt_text_token_price);
+  const output = tokenPrice(longOutput || model.completion_text_token_price);
   if (input === undefined || output === undefined) return existing.cost?.tiers;
 
   return [{

--- a/packages/core/src/sync/providers/xai.ts
+++ b/packages/core/src/sync/providers/xai.ts
@@ -16,6 +16,10 @@ const XAIModel = z.object({
   prompt_text_token_price: z.number().int().nonnegative().optional(),
   cached_prompt_text_token_price: z.number().int().nonnegative().optional(),
   completion_text_token_price: z.number().int().nonnegative().optional(),
+  prompt_text_token_price_long_context: z.number().int().nonnegative().optional(),
+  cached_prompt_text_token_price_long_context: z.number().int().nonnegative().optional(),
+  completion_text_token_price_long_context: z.number().int().nonnegative().optional(),
+  long_context_threshold: z.number().int().nonnegative().optional(),
   max_prompt_length: z.number().int().nonnegative().optional(),
 }).passthrough();
 
@@ -141,9 +145,41 @@ function tokenPrice(value: number | undefined) {
   return value / 10_000;
 }
 
-function preservedCostTiers(existing: ExistingModel) {
-  // The xAI models API exposes base pricing only; long-context tiers are curated from xAI docs/console.
-  return existing.cost?.tiers;
+function longContextPrice(value: number | undefined, fallback: number | undefined) {
+  // xAI sends 0 when the long-context rate equals the base rate (or is unused).
+  if (value === undefined) return undefined;
+  if (value > 0) return tokenPrice(value);
+  return fallback;
+}
+
+function costTiers(model: XAIModel, existing: ExistingModel) {
+  const threshold = model.long_context_threshold;
+  // Image/video endpoints omit these fields — keep any hand-authored tiers.
+  if (threshold === undefined) return existing.cost?.tiers;
+  // threshold 0 means the model has no long-context pricing band.
+  if (threshold === 0) return undefined;
+
+  const input = longContextPrice(
+    model.prompt_text_token_price_long_context,
+    tokenPrice(model.prompt_text_token_price),
+  );
+  const output = longContextPrice(
+    model.completion_text_token_price_long_context,
+    tokenPrice(model.completion_text_token_price),
+  );
+  if (input === undefined || output === undefined) return existing.cost?.tiers;
+
+  const cacheRead = longContextPrice(
+    model.cached_prompt_text_token_price_long_context,
+    tokenPrice(model.cached_prompt_text_token_price),
+  );
+
+  return [{
+    tier: { type: "context" as const, size: threshold },
+    input,
+    output,
+    ...(cacheRead === undefined ? {} : { cache_read: cacheRead }),
+  }];
 }
 
 function cost(model: XAIModel, existing: ExistingModel) {
@@ -159,7 +195,7 @@ function cost(model: XAIModel, existing: ExistingModel) {
     cache_write: existing.cost?.cache_write,
     input_audio: existing.cost?.input_audio,
     output_audio: existing.cost?.output_audio,
-    tiers: preservedCostTiers(existing),
+    tiers: costTiers(model, existing),
   };
 }
 

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1236,6 +1236,47 @@ test("xAI sync maps long-context API pricing into cost tiers", () => {
   });
 });
 
+test("xAI sync keeps authored tiers when long-context rates are omitted", () => {
+  const model = buildXAIModel(
+    {
+      id: "grok-4.5",
+      created: Date.parse("2026-06-29T00:00:00Z") / 1000,
+      input_modalities: ["text"],
+      output_modalities: ["text"],
+      prompt_text_token_price: 20_000,
+      cached_prompt_text_token_price: 3_000,
+      completion_text_token_price: 60_000,
+      // Positive threshold without long-context rates must not invent a base-priced tier.
+      long_context_threshold: 200_000,
+      max_prompt_length: 500_000,
+    },
+    {
+      name: "Grok 4.5",
+      family: "grok",
+      release_date: "2026-07-08",
+      last_updated: "2026-07-08",
+      attachment: false,
+      reasoning: true,
+      tool_call: true,
+      open_weights: false,
+      cost: {
+        input: 2,
+        output: 6,
+        cache_read: 0.3,
+        tiers: [{ tier: { size: 200_000 }, input: 4, output: 12, cache_read: 0.6 }],
+      },
+      limit: { context: 500_000, output: 500_000 },
+      modalities: { input: ["text"], output: ["text"] },
+    },
+  );
+
+  expect(model).toMatchObject({
+    cost: {
+      tiers: [{ tier: { size: 200_000 }, input: 4, output: 12, cache_read: 0.6 }],
+    },
+  });
+});
+
 test("xAI sync clears cost tiers when API reports no long-context band", () => {
   const model = buildXAIModel(
     {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1183,6 +1183,167 @@ test("xAI sync factors inherited base model fields", () => {
   expect(model).not.toHaveProperty("limit");
 });
 
+test("xAI sync maps long-context API pricing into cost tiers", () => {
+  const model = buildXAIModel(
+    {
+      id: "grok-4.5",
+      created: Date.parse("2026-06-29T00:00:00Z") / 1000,
+      input_modalities: ["text", "image"],
+      output_modalities: ["text"],
+      prompt_text_token_price: 20_000,
+      cached_prompt_text_token_price: 3_000,
+      completion_text_token_price: 60_000,
+      prompt_text_token_price_long_context: 40_000,
+      cached_prompt_text_token_price_long_context: 6_000,
+      completion_text_token_price_long_context: 120_000,
+      long_context_threshold: 200_000,
+      max_prompt_length: 500_000,
+    },
+    {
+      base_model: "xai/grok-4.5",
+      name: "Grok 4.5",
+      family: "grok",
+      release_date: "2026-07-08",
+      last_updated: "2026-07-08",
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      open_weights: false,
+      cost: {
+        input: 2,
+        output: 6,
+        cache_read: 0.3,
+        // Stale hand-authored tier must be overwritten by API long-context rates.
+        tiers: [{ tier: { size: 200_000 }, input: 4, output: 12, cache_read: 1 }],
+      },
+      limit: { context: 500_000, output: 500_000 },
+      modalities: { input: ["text", "image"], output: ["text"] },
+    },
+  );
+
+  expect(model).toMatchObject({
+    cost: {
+      input: 2,
+      output: 6,
+      cache_read: 0.3,
+      tiers: [{
+        tier: { type: "context", size: 200_000 },
+        input: 4,
+        output: 12,
+        cache_read: 0.6,
+      }],
+    },
+  });
+});
+
+test("xAI sync clears cost tiers when API reports no long-context band", () => {
+  const model = buildXAIModel(
+    {
+      id: "grok-code-fast-1",
+      created: Date.parse("2025-01-01T00:00:00Z") / 1000,
+      input_modalities: ["text"],
+      output_modalities: ["text"],
+      prompt_text_token_price: 2_000,
+      cached_prompt_text_token_price: 200,
+      completion_text_token_price: 15_000,
+      prompt_text_token_price_long_context: 0,
+      cached_prompt_text_token_price_long_context: 0,
+      completion_text_token_price_long_context: 0,
+      long_context_threshold: 0,
+      max_prompt_length: 256_000,
+    },
+    {
+      name: "Grok Code Fast 1",
+      family: "grok",
+      release_date: "2025-01-01",
+      last_updated: "2025-01-01",
+      attachment: false,
+      reasoning: true,
+      tool_call: true,
+      open_weights: false,
+      cost: {
+        input: 0.2,
+        output: 1.5,
+        cache_read: 0.02,
+        tiers: [{ tier: { size: 200_000 }, input: 0.4, output: 3 }],
+      },
+      limit: { context: 256_000, output: 256_000 },
+      modalities: { input: ["text"], output: ["text"] },
+    },
+  );
+
+  expect(model).toMatchObject({
+    cost: {
+      input: 0.2,
+      output: 1.5,
+      cache_read: 0.02,
+    },
+  });
+  expect(model.cost?.tiers).toBeUndefined();
+});
+
+test("OpenRouter sync maps pricing.overrides into cost tiers", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    id: "x-ai/grok-4.5",
+    name: "xAI: Grok 4.5",
+    pricing: {
+      prompt: "0.000002",
+      completion: "0.000006",
+      input_cache_read: "0.0000003",
+      overrides: [{
+        min_prompt_tokens: 200_000,
+        prompt: "0.000004",
+        completion: "0.000012",
+        input_cache_read: "0.0000006",
+      }],
+    },
+  }), {
+    cost: {
+      input: 2,
+      output: 6,
+      cache_read: 0.3,
+      tiers: [{ tier: { size: 200_000 }, input: 4, output: 12, cache_read: 1 }],
+    },
+  });
+
+  expect(model).toMatchObject({
+    cost: {
+      input: 2,
+      output: 6,
+      cache_read: 0.3,
+      tiers: [{
+        tier: { type: "context", size: 200_000 },
+        input: 4,
+        output: 12,
+        cache_read: 0.6,
+      }],
+    },
+  });
+});
+
+test("OpenRouter sync keeps authored tiers when API omits overrides", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    pricing: {
+      prompt: "0.000002",
+      completion: "0.00001",
+      input_cache_read: "0.0000002",
+      input_cache_write: "0.0000025",
+    },
+  }), {
+    cost: {
+      input: 3,
+      output: 15,
+      tiers: [{ tier: { size: 200_000 }, input: 6, output: 22.5 }],
+    },
+  });
+
+  expect(model).toMatchObject({
+    cost: {
+      tiers: [{ tier: { size: 200_000 }, input: 6, output: 22.5 }],
+    },
+  });
+});
+
 test("skips new DigitalOcean models with incomplete pricing or limits", () => {
   const translated = digitalocean.translateModel(
     digitalOceanModel({ pricing: undefined }),


### PR DESCRIPTION
## Summary
- **xAI sync** now builds `[[cost.tiers]]` from `long_context_threshold` + `*_long_context` price fields (API already exposes these; the old “base pricing only” path was stale).
- **OpenRouter sync** now maps `pricing.overrides[]` (`min_prompt_tokens` + rates) into `cost.tiers` instead of always keeping hand-authored tiers.
- Falls back to existing tiers only when the API omits tier data (OpenRouter routes without overrides; xAI image/video endpoints that lack the fields). xAI `threshold === 0` clears tiers.
- Unit tests cover mapping, clearing, and fallback.

Follow-up to #3865 — that one-off data fix was correct; this makes the next pricing drift self-heal on sync.

## Test plan
- [x] `cd packages/core && bun test test/sync.test.ts`
- [ ] Next openrouter/xai model sync PR should rewrite stale grok (and other) tier cache rates from live API data