### PR TITLE
fix(deepseek): add reasoning token cost for deepseek-v4-pro and deepseek-v4-flash

### DIFF
--- a/providers/deepseek/models/deepseek-reasoner.toml
+++ b/providers/deepseek/models/deepseek-reasoner.toml
@@ -21,6 +21,7 @@ field = "reasoning_content"
 [cost]
 input = 0.14
 output = 0.28
+reasoning = 0.28
 cache_read = 0.0028
 
 [limit]

--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -27,6 +27,7 @@ field = "reasoning_content"
 [cost]
 input = 0.14
 output = 0.28
+reasoning = 0.28
 cache_read = 0.0028
 
 [limit]

--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -1,3 +1,6 @@
+# Reasoning tokens are billed at the output rate (no separate CoT price).
+# `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
 name = "DeepSeek V4 Flash"
 description = "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work"
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -27,6 +27,7 @@ field = "reasoning_content"
 [cost]
 input = 0.435
 output = 0.87
+reasoning = 0.87
 cache_read = 0.003625
 
 [limit]

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -1,3 +1,6 @@
+# Reasoning tokens are billed at the output rate (no separate CoT price).
+# `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
 name = "DeepSeek V4 Pro"
 description = "Open MoE flagship with million-token context for coding and long agent runs"
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.


### PR DESCRIPTION
## Summary

Adds the missing `reasoning` cost to `deepseek/deepseek-v4-pro` and `deepseek/deepseek-v4-flash`, set equal to each model's `output` rate.

## Why

DeepSeek bills chain-of-thought (reasoning) tokens at the standard output token rate — there is no separate reasoning price ([DeepSeek pricing docs](https://api-docs.deepseek.com/quick_start/pricing/)). Both V4 models default to thinking mode, so real API usage routinely reports `reasoning_tokens` in usage.

Because the `[cost]` block currently omits `reasoning`, downstream consumers of this dataset (e.g. Mastra's cost estimator, which fails closed with `no_pricing_for_usage_type` / `partial_cost` when a usage type has no declared rate) cannot price any thinking-mode DeepSeek call, and totals silently exclude reasoning tokens.

This follows the same pattern other providers already use for reasoning-billed-as-output models (e.g. `nebius/deepseek-ai/DeepSeek-V3.2` declares `reasoning = 0.45` equal to `output = 0.45`).

## Changes

- `providers/deepseek/models/deepseek-v4-pro.toml`: `reasoning = 0.87` (= output)
- `providers/deepseek/models/deepseek-v4-flash.toml`: `reasoning = 0.28` (= output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)