### PR TITLE
fix(sdk): reject empty effect responses

### DIFF
--- a/packages/sdk/src/effect/client.ts
+++ b/packages/sdk/src/effect/client.ts
@@ -33,9 +33,17 @@ export const make = (options?: ClientOptions) =>
         })
         .pipe(
           Effect.flatMap(HttpClientResponse.filterStatusOk),
-          Effect.flatMap((response) => response.json),
-          Effect.map((data) => data as A),
+          Effect.flatMap((response) => response.text),
           Effect.mapError((cause) => new ModelsDevError({ cause })),
+          Effect.flatMap((text) =>
+            Effect.try({
+              try: () => {
+                if (text === "") throw new SyntaxError("Unexpected end of JSON input")
+                return JSON.parse(text) as A
+              },
+              catch: (cause) => new ModelsDevError({ cause }),
+            }),
+          ),
         )
 
     return {

--- a/packages/sdk/test/effect.test.ts
+++ b/packages/sdk/test/effect.test.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { Models, ModelsDevError } from "../src/effect.js"
 
-function stubResponse(body: BodyInit | null, init?: ResponseInit) {
+function stubResponse(body: string | null, init?: ResponseInit) {
   const requests: Request[] = []
   const fetch = (async (input: Parameters<typeof globalThis.fetch>[0], requestInit?: RequestInit) => {
     requests.push(new Request(input instanceof URL ? input.href : (input as string), requestInit))
@@ -17,7 +17,7 @@ function stubResponse(body: BodyInit | null, init?: ResponseInit) {
 }
 
 function stub(data: unknown, init?: ResponseInit) {
-  return stubResponse(JSON.stringify(data), init)
+  return stubResponse(JSON.stringify(data) ?? null, init)
 }
 
 test("providers() succeeds through an injected transport", async () => {

--- a/packages/sdk/test/effect.test.ts
+++ b/packages/sdk/test/effect.test.ts
@@ -3,17 +3,21 @@ import { Effect, Layer } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { Models, ModelsDevError } from "../src/effect.js"
 
-function stub(data: unknown, init?: ResponseInit) {
+function stubResponse(body: BodyInit | null, init?: ResponseInit) {
   const requests: Request[] = []
   const fetch = (async (input: Parameters<typeof globalThis.fetch>[0], requestInit?: RequestInit) => {
     requests.push(new Request(input instanceof URL ? input.href : (input as string), requestInit))
-    return new Response(JSON.stringify(data), {
+    return new Response(body, {
       headers: { "content-type": "application/json" },
       ...init,
     })
   }) as typeof globalThis.fetch
   const layer = FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch)(fetch)))
   return { requests, layer }
+}
+
+function stub(data: unknown, init?: ResponseInit) {
+  return stubResponse(JSON.stringify(data), init)
 }
 
 test("providers() succeeds through an injected transport", async () => {
@@ -54,6 +58,17 @@ test("custom headers are sent", async () => {
 
 test("non-2xx fails with ModelsDevError in the error channel", async () => {
   const { layer } = stub({ error: "down" }, { status: 503 })
+  const program = Effect.gen(function* () {
+    const client = yield* Models.make()
+    return yield* client.providers()
+  })
+  const error = await program.pipe(Effect.flip, Effect.provide(layer), Effect.runPromise)
+  expect(error).toBeInstanceOf(ModelsDevError)
+  expect(error._tag).toBe("ModelsDevError")
+})
+
+test("empty body fails with ModelsDevError", async () => {
+  const { layer } = stubResponse("")
   const program = Effect.gen(function* () {
     const client = yield* Models.make()
     return yield* client.providers()


### PR DESCRIPTION
## Summary

- reject empty successful responses in the Effect SDK client
- cover the response-parsing failure channel with an injected transport

## Root cause

Effect's JSON decoder represents an empty response body as `null`; the native SDK treats the same response as malformed.

## Checks

- `bun test test/effect.test.ts`
- `bun run typecheck`
