### PR TITLE
fix(function): filter inference client user agents

### DIFF
--- a/packages/function/src/worker.ts
+++ b/packages/function/src/worker.ts
@@ -16,7 +16,7 @@ export default {
     const country = request.headers.get("cf-ipcountry") ?? undefined;
     const agent = request.headers.get("user-agent") ?? undefined;
     const time = new Date().toISOString();
-    if (agent?.includes("opencode") || agent?.includes("bun")) {
+    if (isInferenceClient(agent)) {
       ctx.waitUntil(
         fetch("https://us.i.posthog.com/i/v0/e/", {
           method: "POST",
@@ -142,6 +142,10 @@ export default {
     });
   },
 };
+
+export function isInferenceClient(agent: string | undefined) {
+  return /(?:^|[\s;(])(?:opencode|bun)(?:[/\s;)]|$)/i.test(agent ?? "");
+}
 
 function isHtmlRoute(pathname: string) {
   return (

--- a/packages/function/test/worker.test.ts
+++ b/packages/function/test/worker.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+
+import { isInferenceClient } from "../src/worker.js";
+
+test("identifies inference clients without matching Ubuntu browsers", () => {
+  expect(isInferenceClient("Bun/1.3.14")).toBe(true);
+  expect(isInferenceClient("OpenCode/1.0")).toBe(true);
+  expect(
+    isInferenceClient(
+      "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0",
+    ),
+  ).toBe(false);
+});


### PR DESCRIPTION
## Summary

- recognize Bun and OpenCode as complete user-agent tokens
- avoid sending ordinary Ubuntu browser traffic to inference analytics

## Root cause

The previous substring check matched `bun` inside `Ubuntu`, so regular Ubuntu browser requests were recorded as inference-client hits.

## Checks

- `bun test packages/function/test/worker.test.ts`
