### PR TITLE
fix: add cache_read (cached input price) for abliteration-ai models

### DIFF
--- a/providers/abliteration-ai/models/abliterated-model-large.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large.toml
@@ -31,6 +31,7 @@ type = "toggle" # API: {"thinking": false} on /v1/messages (legacy alias on /v1/
 [cost]
 input = 5.00
 output = 5.00
+cache_read = 0.50
 
 [limit]
 context = 1_000_000

--- a/providers/abliteration-ai/models/abliterated-model.toml
+++ b/providers/abliteration-ai/models/abliterated-model.toml
@@ -25,6 +25,7 @@ type = "toggle" # API: {"thinking": false} on /v1/messages (legacy alias on /v1/
 [cost]
 input = 3.00
 output = 3.00
+cache_read = 0.30
 
 [limit]
 context = 150_000


### PR DESCRIPTION
Fix input cache prices for abliteration.ai
- abliterated-model: cache_read = 0.30
- abliterated-model-large: cache_read = 0.50
Pricing info: https://abliteration.ai/pricing#api-pricing