### PR TITLE
fix: add Kimi K3 to Modal

### DIFF
--- a/providers/modal/models/moonshotai/Kimi-K3.toml
+++ b/providers/modal/models/moonshotai/Kimi-K3.toml
@@ -1,0 +1,22 @@
+# Modal Shared API model ID: moonshotai/Kimi-K3.
+# Pricing is USD per 1M tokens: prompt $3.00, cached prompt $0.30,
+# completion $15.00, and reasoning $15.00.
+# Modal documents text and native vision through its OpenAI-compatible Shared API.
+# No Modal-documented reasoning control surface has been verified.
+# https://modal.com/library/moonshot/kimi-k3
+# https://modal.com/blog/kimi-k3-by-moonshot-now-available-on-modal
+# https://modal.com/docs/guide/endpoints
+base_model = "moonshotai/kimi-k3"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+reasoning = 15.0
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
## Summary

- add Modal's `moonshotai/Kimi-K3` Shared API model
- inherit provider-independent metadata from `moonshotai/kimi-k3`
- record Modal's token pricing, native-vision modalities, reasoning response field, and lack of a verified reasoning control surface

## Why

Modal serves Kimi K3 through its OpenAI-compatible Shared API, but the Modal provider directory did not contain a model definition for it. Because the catalog is generated from these provider model files, Kimi K3 was absent from both the Modal provider page and the JSON catalog.

This adds the missing provider entry so the model resolves under its exact Modal API ID while reusing the existing canonical Kimi K3 metadata.

## Validation

- `npx --yes --cache /private/tmp/models-dev-npm-cache bun@1.3.0 validate`
- `git diff --check`

## Sources

- [Modal Kimi K3 model library](https://modal.com/library/moonshot/kimi-k3)
- [Modal Kimi K3 announcement](https://modal.com/blog/kimi-k3-by-moonshot-now-available-on-modal)
- [Modal Endpoints documentation](https://modal.com/docs/guide/endpoints)

Closes #3833
