### PR TITLE
feat(deepseek): use responses api for v4 flash

### DIFF
--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -1,6 +1,8 @@
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
 # https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
+# DeepSeek V4 Flash supports the stateless OpenAI Responses API.
+# https://api-docs.deepseek.com/guides/responses_api (accessed 2026-08-01)
 name = "DeepSeek V4 Flash"
 description = "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work"
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.
@@ -40,3 +42,6 @@ output = 384_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[provider]
+shape = "responses"

--- a/providers/opencode-go/models/deepseek-v4-flash.toml
+++ b/providers/opencode-go/models/deepseek-v4-flash.toml
@@ -1,3 +1,5 @@
+# DeepSeek V4 Flash supports the stateless OpenAI Responses API.
+# https://api-docs.deepseek.com/guides/responses_api (accessed 2026-08-01)
 base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek V4 Flash (New)"
 
@@ -12,3 +14,6 @@ field = "reasoning_content"
 input = 0.14
 output = 0.28
 cache_read = 0.0028
+
+[provider]
+shape = "responses"

--- a/providers/opencode/models/deepseek-v4-flash-free.toml
+++ b/providers/opencode/models/deepseek-v4-flash-free.toml
@@ -1,3 +1,5 @@
+# DeepSeek V4 Flash supports the stateless OpenAI Responses API.
+# https://api-docs.deepseek.com/guides/responses_api (accessed 2026-08-01)
 base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek V4 Flash Free (New)"
 
@@ -16,3 +18,6 @@ cache_read = 0
 [limit]
 context = 200_000
 output = 128_000
+
+[provider]
+shape = "responses"

--- a/providers/opencode/models/deepseek-v4-flash.toml
+++ b/providers/opencode/models/deepseek-v4-flash.toml
@@ -1,3 +1,5 @@
+# DeepSeek V4 Flash supports the stateless OpenAI Responses API.
+# https://api-docs.deepseek.com/guides/responses_api (accessed 2026-08-01)
 base_model = "deepseek/deepseek-v4-flash"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
@@ -8,3 +10,6 @@ field = "reasoning_content"
 input = 0.14
 output = 0.28
 cache_read = 0.028
+
+[provider]
+shape = "responses"


### PR DESCRIPTION
## Summary
- mark direct DeepSeek V4 Flash as a Responses API model
- apply the same shape to OpenCode Zen, Zen Free, and Go catalog entries
- cite DeepSeek's official Responses API documentation

## Context
DeepSeek documents V4 Flash as the only currently supported Responses API model: https://api-docs.deepseek.com/guides/responses_api

Requires anomalyco/opencode#40011 to consume the per-model shape.

## Testing
- `bun validate`
- `git diff --check`
- `bun test`: 131 pass; existing unrelated failures remain for missing open-weight links and ungenerated SDK snapshot/effect artifacts