### PR TITLE
Update GreenPT: cached-token rates, compression variants, kimi-k3

### DIFF
--- a/providers/greenpt/models/deepseek-v4-flash-0731.toml
+++ b/providers/greenpt/models/deepseek-v4-flash-0731.toml
@@ -6,6 +6,8 @@
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek V4 Flash 0731"
+release_date = "2026-07-31"
+last_updated = "2026-07-31"
 reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]

--- a/providers/greenpt/models/deepseek-v4-flash-0731.toml
+++ b/providers/greenpt/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,14 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash 0731"
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.1596
+cache_read = 0.0456
+output = 0.399

--- a/providers/greenpt/models/gemma4.toml
+++ b/providers/greenpt/models/gemma4.toml
@@ -1,7 +1,7 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
-# reasoning_effort: thinking is enabled by default, "none" disables it, and
-# minimal/low/medium/high are accepted. See https://docs.greenpt.ai/chat-completion
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 base_model = "google/gemma-4-26b-a4b-it"
 name = "gemma4"
 reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]

--- a/providers/greenpt/models/glm-5.1.toml
+++ b/providers/greenpt/models/glm-5.1.toml
@@ -1,6 +1,7 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
 base_model = "zhipuai/glm-5.1"
+status = "deprecated"
 reasoning_options = []
 
 [cost]

--- a/providers/greenpt/models/glm-5.2-caveman-lite.toml
+++ b/providers/greenpt/models/glm-5.2-caveman-lite.toml
@@ -1,0 +1,13 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Caveman Lite"
+description = "glm-5.2 carrying a built-in ruleset that compresses prose, keeping code and technical detail verbatim. The gentlest tier: it cuts filler only and keeps the explanation intact. Same upstream model and price per token as glm-5.2, with fewer output tokens."
+reasoning_options = []
+
+[cost]
+input = 1.254
+cache_read = 0.3135
+output = 5.016

--- a/providers/greenpt/models/glm-5.2-caveman-lite.toml
+++ b/providers/greenpt/models/glm-5.2-caveman-lite.toml
@@ -1,11 +1,13 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Caveman Lite"
 description = "glm-5.2 carrying a built-in ruleset that compresses prose, keeping code and technical detail verbatim. The gentlest tier: it cuts filler only and keeps the explanation intact. Same upstream model and price per token as glm-5.2, with fewer output tokens."
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/glm-5.2-caveman-ultra.toml
+++ b/providers/greenpt/models/glm-5.2-caveman-ultra.toml
@@ -1,0 +1,13 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Caveman Ultra"
+description = "glm-5.2 carrying a built-in ruleset that compresses prose, keeping code and technical detail verbatim. The most aggressive tier, close to answer-only. Same upstream model and price per token as glm-5.2, with fewer output tokens."
+reasoning_options = []
+
+[cost]
+input = 1.254
+cache_read = 0.3135
+output = 5.016

--- a/providers/greenpt/models/glm-5.2-caveman-ultra.toml
+++ b/providers/greenpt/models/glm-5.2-caveman-ultra.toml
@@ -1,11 +1,13 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Caveman Ultra"
 description = "glm-5.2 carrying a built-in ruleset that compresses prose, keeping code and technical detail verbatim. The most aggressive tier, close to answer-only. Same upstream model and price per token as glm-5.2, with fewer output tokens."
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/glm-5.2-caveman.toml
+++ b/providers/greenpt/models/glm-5.2-caveman.toml
@@ -1,0 +1,13 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Caveman"
+description = "glm-5.2 carrying a built-in ruleset that compresses prose, keeping code and technical detail verbatim. The middle tier, and the ruleset as its authors wrote it. Same upstream model and price per token as glm-5.2, with fewer output tokens."
+reasoning_options = []
+
+[cost]
+input = 1.254
+cache_read = 0.3135
+output = 5.016

--- a/providers/greenpt/models/glm-5.2-caveman.toml
+++ b/providers/greenpt/models/glm-5.2-caveman.toml
@@ -1,11 +1,13 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Caveman"
 description = "glm-5.2 carrying a built-in ruleset that compresses prose, keeping code and technical detail verbatim. The middle tier, and the ruleset as its authors wrote it. Same upstream model and price per token as glm-5.2, with fewer output tokens."
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/glm-5.2-honey-lite.toml
+++ b/providers/greenpt/models/glm-5.2-honey-lite.toml
@@ -1,0 +1,13 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Honey Lite"
+description = "glm-5.2 carrying a built-in ruleset that compresses both generated code and prose. The gentlest tier: it cuts filler only and keeps the explanation intact. Same upstream model and price per token as glm-5.2, with fewer output tokens."
+reasoning_options = []
+
+[cost]
+input = 1.254
+cache_read = 0.3135
+output = 5.016

--- a/providers/greenpt/models/glm-5.2-honey-lite.toml
+++ b/providers/greenpt/models/glm-5.2-honey-lite.toml
@@ -1,11 +1,13 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Honey Lite"
 description = "glm-5.2 carrying a built-in ruleset that compresses both generated code and prose. The gentlest tier: it cuts filler only and keeps the explanation intact. Same upstream model and price per token as glm-5.2, with fewer output tokens."
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/glm-5.2-honey-ultra.toml
+++ b/providers/greenpt/models/glm-5.2-honey-ultra.toml
@@ -1,0 +1,13 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Honey Ultra"
+description = "glm-5.2 carrying a built-in ruleset that compresses both generated code and prose. The most aggressive tier, close to answer-only. Same upstream model and price per token as glm-5.2, with fewer output tokens."
+reasoning_options = []
+
+[cost]
+input = 1.254
+cache_read = 0.3135
+output = 5.016

--- a/providers/greenpt/models/glm-5.2-honey-ultra.toml
+++ b/providers/greenpt/models/glm-5.2-honey-ultra.toml
@@ -1,11 +1,13 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Honey Ultra"
 description = "glm-5.2 carrying a built-in ruleset that compresses both generated code and prose. The most aggressive tier, close to answer-only. Same upstream model and price per token as glm-5.2, with fewer output tokens."
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/glm-5.2-honey.toml
+++ b/providers/greenpt/models/glm-5.2-honey.toml
@@ -1,0 +1,13 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Honey"
+description = "glm-5.2 carrying a built-in ruleset that compresses both generated code and prose. The middle tier, and the ruleset as its authors wrote it. Same upstream model and price per token as glm-5.2, with fewer output tokens."
+reasoning_options = []
+
+[cost]
+input = 1.254
+cache_read = 0.3135
+output = 5.016

--- a/providers/greenpt/models/glm-5.2-honey.toml
+++ b/providers/greenpt/models/glm-5.2-honey.toml
@@ -1,11 +1,13 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Honey"
 description = "glm-5.2 carrying a built-in ruleset that compresses both generated code and prose. The middle tier, and the ruleset as its authors wrote it. Same upstream model and price per token as glm-5.2, with fewer output tokens."
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/glm-5.2-ponytail-lite.toml
+++ b/providers/greenpt/models/glm-5.2-ponytail-lite.toml
@@ -1,0 +1,13 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Ponytail Lite"
+description = "glm-5.2 carrying a built-in ruleset that compresses generated code, preferring platform features over custom code. The gentlest tier: it cuts filler only and keeps the explanation intact. Same upstream model and price per token as glm-5.2, with fewer output tokens."
+reasoning_options = []
+
+[cost]
+input = 1.254
+cache_read = 0.3135
+output = 5.016

--- a/providers/greenpt/models/glm-5.2-ponytail-lite.toml
+++ b/providers/greenpt/models/glm-5.2-ponytail-lite.toml
@@ -1,11 +1,13 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Ponytail Lite"
 description = "glm-5.2 carrying a built-in ruleset that compresses generated code, preferring platform features over custom code. The gentlest tier: it cuts filler only and keeps the explanation intact. Same upstream model and price per token as glm-5.2, with fewer output tokens."
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/glm-5.2-ponytail-ultra.toml
+++ b/providers/greenpt/models/glm-5.2-ponytail-ultra.toml
@@ -1,0 +1,13 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Ponytail Ultra"
+description = "glm-5.2 carrying a built-in ruleset that compresses generated code, preferring platform features over custom code. The most aggressive tier, close to answer-only. Same upstream model and price per token as glm-5.2, with fewer output tokens."
+reasoning_options = []
+
+[cost]
+input = 1.254
+cache_read = 0.3135
+output = 5.016

--- a/providers/greenpt/models/glm-5.2-ponytail-ultra.toml
+++ b/providers/greenpt/models/glm-5.2-ponytail-ultra.toml
@@ -1,11 +1,13 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Ponytail Ultra"
 description = "glm-5.2 carrying a built-in ruleset that compresses generated code, preferring platform features over custom code. The most aggressive tier, close to answer-only. Same upstream model and price per token as glm-5.2, with fewer output tokens."
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/glm-5.2-ponytail.toml
+++ b/providers/greenpt/models/glm-5.2-ponytail.toml
@@ -1,0 +1,13 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Ponytail"
+description = "glm-5.2 carrying a built-in ruleset that compresses generated code, preferring platform features over custom code. The middle tier, and the ruleset as its authors wrote it. Same upstream model and price per token as glm-5.2, with fewer output tokens."
+reasoning_options = []
+
+[cost]
+input = 1.254
+cache_read = 0.3135
+output = 5.016

--- a/providers/greenpt/models/glm-5.2-ponytail.toml
+++ b/providers/greenpt/models/glm-5.2-ponytail.toml
@@ -1,11 +1,13 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Ponytail"
 description = "glm-5.2 carrying a built-in ruleset that compresses generated code, preferring platform features over custom code. The middle tier, and the ruleset as its authors wrote it. Same upstream model and price per token as glm-5.2, with fewer output tokens."
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/glm-5.2.toml
+++ b/providers/greenpt/models/glm-5.2.toml
@@ -1,8 +1,11 @@
-# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
 reasoning_options = []
 
 [cost]
 input = 1.254
+cache_read = 0.3135
 output = 5.016

--- a/providers/greenpt/models/glm-5.2.toml
+++ b/providers/greenpt/models/glm-5.2.toml
@@ -1,9 +1,11 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 1.254

--- a/providers/greenpt/models/gpt-oss-120b.toml
+++ b/providers/greenpt/models/gpt-oss-120b.toml
@@ -1,8 +1,11 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: this endpoint accepts only the values below; the remaining
+# documented values are rejected with a 400. Verified against the production API.
+# See https://docs.greenpt.ai/chat-completion
 base_model = "openai/gpt-oss-120b"
 attachment = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.228

--- a/providers/greenpt/models/green-r-raw.toml
+++ b/providers/greenpt/models/green-r-raw.toml
@@ -1,11 +1,12 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
-# reasoning_effort: thinking is enabled by default, "none" disables it, and
-# minimal/low/medium/high are accepted. See https://docs.greenpt.ai/chat-completion
+# reasoning_effort: this endpoint accepts only the values below; the remaining
+# documented values are rejected with a 400. Verified against the production API.
+# See https://docs.greenpt.ai/chat-completion
 base_model = "openai/gpt-oss-120b"
 name = "Green R Raw"
 attachment = true
-reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.399

--- a/providers/greenpt/models/green-r.toml
+++ b/providers/greenpt/models/green-r.toml
@@ -1,11 +1,12 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
-# reasoning_effort: thinking is enabled by default, "none" disables it, and
-# minimal/low/medium/high are accepted. See https://docs.greenpt.ai/chat-completion
+# reasoning_effort: this endpoint accepts only the values below; the remaining
+# documented values are rejected with a 400. Verified against the production API.
+# See https://docs.greenpt.ai/chat-completion
 base_model = "openai/gpt-oss-120b"
 name = "Green R"
 attachment = true
-reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.399

--- a/providers/greenpt/models/holo2-30b-a3b.toml
+++ b/providers/greenpt/models/holo2-30b-a3b.toml
@@ -6,7 +6,7 @@ release_date = "2025-11"
 last_updated = "2025-11"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = false

--- a/providers/greenpt/models/kimi-k2.6-fast.toml
+++ b/providers/greenpt/models/kimi-k2.6-fast.toml
@@ -2,6 +2,7 @@
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
 base_model = "moonshotai/kimi-k2.6"
 name = "Kimi K2.6 Fast"
+status = "deprecated"
 reasoning_options = []
 
 [cost]

--- a/providers/greenpt/models/kimi-k2.6.toml
+++ b/providers/greenpt/models/kimi-k2.6.toml
@@ -1,11 +1,14 @@
-# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "moonshotai/kimi-k2.6"
 reasoning_options = []
 
 [cost]
-input = 0.828
-output = 4.389
+input = 0.7524
+cache_read = 0.2508
+output = 4.275
 
 [modalities]
 input = ["text", "image"]

--- a/providers/greenpt/models/kimi-k2.6.toml
+++ b/providers/greenpt/models/kimi-k2.6.toml
@@ -1,9 +1,11 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "moonshotai/kimi-k2.6"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.7524

--- a/providers/greenpt/models/kimi-k2.7-code.toml
+++ b/providers/greenpt/models/kimi-k2.7-code.toml
@@ -1,11 +1,14 @@
-# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "moonshotai/kimi-k2.7-code"
 attachment = false
 reasoning_options = []
 
 [cost]
-input = 0.941
+input = 0.9006
+cache_read = 0.1881
 output = 4.389
 
 [modalities]

--- a/providers/greenpt/models/kimi-k2.7-code.toml
+++ b/providers/greenpt/models/kimi-k2.7-code.toml
@@ -1,10 +1,12 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "moonshotai/kimi-k2.7-code"
 attachment = false
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.9006

--- a/providers/greenpt/models/kimi-k3.toml
+++ b/providers/greenpt/models/kimi-k3.toml
@@ -1,0 +1,14 @@
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
+base_model = "moonshotai/kimi-k3"
+reasoning_options = []
+
+[cost]
+input = 3.762
+cache_read = 0.9405
+output = 18.81
+
+[modalities]
+input = ["text", "image"]

--- a/providers/greenpt/models/kimi-k3.toml
+++ b/providers/greenpt/models/kimi-k3.toml
@@ -1,9 +1,11 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "moonshotai/kimi-k3"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 3.762

--- a/providers/greenpt/models/minimax-m2.5.toml
+++ b/providers/greenpt/models/minimax-m2.5.toml
@@ -1,8 +1,11 @@
-# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
+# Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# cache_read: discounted rate for cached prompt tokens. Cache writes are not
+# charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "minimax/MiniMax-M2.5"
 reasoning_options = []
 
 [cost]
-input = 0.188
+input = 0.1938
+cache_read = 0.0627
 output = 1.129

--- a/providers/greenpt/models/minimax-m2.5.toml
+++ b/providers/greenpt/models/minimax-m2.5.toml
@@ -1,9 +1,11 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-08-01).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 # cache_read: discounted rate for cached prompt tokens. Cache writes are not
 # charged. See https://docs.greenpt.ai/prompt-caching
 base_model = "minimax/MiniMax-M2.5"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.1938

--- a/providers/greenpt/models/mistral-medium-3.5-128b.toml
+++ b/providers/greenpt/models/mistral-medium-3.5-128b.toml
@@ -1,7 +1,10 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: this endpoint accepts only the values below; the remaining
+# documented values are rejected with a 400. Verified against the production API.
+# See https://docs.greenpt.ai/chat-completion
 base_model = "mistral/mistral-medium-2604"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
 
 [cost]
 input = 2.052

--- a/providers/greenpt/models/qwen3.5-397b-a17b.toml
+++ b/providers/greenpt/models/qwen3.5-397b-a17b.toml
@@ -1,8 +1,10 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 base_model = "alibaba/qwen3.5-397b-a17b"
 attachment = false
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.798

--- a/providers/greenpt/models/qwen3.6-35b-a3b.toml
+++ b/providers/greenpt/models/qwen3.6-35b-a3b.toml
@@ -1,7 +1,9 @@
 # Cost: converted from GreenPT's EUR list price at 1.14 USD/EUR (rate captured 2026-07-24).
 # Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# reasoning_effort: thinking is enabled by default and "none" disables it.
+# Values verified against the production API. See https://docs.greenpt.ai/chat-completion
 base_model = "alibaba/qwen3.6-35b-a3b"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
 
 [cost]
 input = 0.342


### PR DESCRIPTION
Refreshes the GreenPT catalog added in #3726. Four things changed on our side since that merged: prompt caching shipped, nine compression ids went GA, one model was withdrawn upstream, and a few list prices moved.

No entries are removed and nothing outside `providers/greenpt/` is touched. Costs remain USD, converted from GreenPT's EUR list price at **1.14 USD/EUR**; files whose price was re-verified for this update carry the later capture date in their top-of-file comment, untouched files keep the original one.

### 1. Cached prompt tokens (`cost.cache_read`)

GreenPT now bills prompt-cache hits at a reduced input rate. `cost.cache_write` is **omitted rather than zeroed**: cache writes are not charged at all.

| entry | EUR cached | `cache_read` |
|---|---|---|
| `glm-5.2` and all nine compression variants | 0.275 | **0.3135** |
| `kimi-k3` | 0.825 | **0.9405** |
| `kimi-k2.6` | 0.22 | **0.2508** |
| `kimi-k2.7-code` | 0.165 | **0.1881** |
| `minimax-m2.5` | 0.055 | **0.0627** |

These are the only models that discount cache hits; every other GreenPT entry bills input at its normal rate and is left without the field.

### 2. Price corrections

Our upstream list prices were re-read from the gateway's own catalogue rather than its marketing page, which had been quoting higher figures:

| entry | field | was | now | EUR |
|---|---|---|---|---|
| `kimi-k2.6` | input | 0.828 | **0.7524** | 0.66 |
| `kimi-k2.6` | output | 4.389 | **4.275** | 3.75 |
| `kimi-k2.7-code` | input | 0.941 | **0.9006** | 0.79 |
| `minimax-m2.5` | input | 0.188 | **0.1938** | 0.17 |

`glm-5.2` prices are unchanged; it only gains `cache_read`. Untouched entries were deliberately not re-rounded, to keep the diff limited to real changes.

### 3. New: `kimi-k3`

GA on GreenPT at 3.762 / 18.81, cached 0.9405. Declared through `base_model = "moonshotai/kimi-k3"`, inheriting the 1,048,576 context. GreenPT serves it with text and image input, so the inherited `video` modality is overridden away, consistent with how `kimi-k2.6` is already declared here.

### 4. New: nine compression variants of `glm-5.2`

`glm-5.2-{caveman,honey,ponytail}` each in `-lite`, unsuffixed and `-ultra`. They are the same upstream model carrying a built-in output-compression ruleset: `caveman` compresses prose, `ponytail` compresses generated code, `honey` compresses both, and the suffix selects intensity. Same price per token (including the cached rate) and the same context; the saving comes purely from generating fewer output tokens.

All nine are declared through `base_model = "zhipuai/glm-5.2"`, so their cost and limits cannot drift from the base entry.

### 5. Deprecated: `kimi-k2.6-fast`

Withdrawn by the upstream provider; GreenPT no longer serves the id and requests for it fail. Marked `status = "deprecated"` rather than deleted, so existing configurations still resolve. Its prices are untouched.

### Reasoning controls

Unchanged from #3726 and applied to the new entries too: the documented effort enum stays limited to the GreenPT-hosted models whose control is documented first-party (`gemma4`, `green-r`, `green-r-raw`). `kimi-k3` and all nine variants are pass-through endpoints whose accepted values we have not verified, so they declare `reasoning_options = []`.

### Verification

`bun validate` is green. `bun test` shows no failures beyond the 3 pre-existing `packages/sdk/src/snapshot.js` module-resolution errors that also fail on a clean `dev`. Diffing the resolved catalog against the published `models.dev/api.json` confirms exactly the 10 additions, the 4 repriced fields, the 15 `cache_read` values and the one status change, with nothing else moved.

### Evidence

| Claim | Source |
|---|---|
| Every cached rate, and which models discount cache hits | https://docs.greenpt.ai/prompt-caching |
| The nine compression ids, their families and intensities | https://docs.greenpt.ai/compression-models |
| Token prices, context windows, modalities | https://docs.greenpt.ai/model-cards |
| Full price table including the cached-input column | https://docs.greenpt.ai/pricing |
| `reasoning_effort` values on GreenPT-hosted models | https://docs.greenpt.ai/chat-completion |
