### PR TITLE
feat(mistral): add Voxtral audio models (transcription, TTS, audio instruct)

### DIFF
--- a/providers/mistral/models/voxtral-mini-latest.toml
+++ b/providers/mistral/models/voxtral-mini-latest.toml
@@ -1,13 +1,22 @@
 # Sources :
+#   GET https://api.mistral.ai/v1/models  (source d'autorite pour l'id courant)
 #   https://docs.mistral.ai/models/model-cards/voxtral-mini-transcribe-25-07
 #   https://mistral.ai/news/voxtral-transcribe-2/  ($0.003 per minute)
+#
+# `voxtral-mini-latest` resout vers `voxtral-mini-2602` et n'expose que la
+# capacite `audio_transcription`. A ne PAS confondre avec les poids ouverts
+# Voxtral Mini 3B, servis en instruct par d'autres providers (cf.
+# providers/amazon-bedrock/models/mistral.voxtral-mini-3b-2507.toml) : meme
+# lignee, surface produit differente. La fiche liee ci-dessus documente la
+# lignee Transcribe, Mistral n'en publiant pas pour la revision 2602.
+#
 # Le bloc [cost] est volontairement absent : la transcription se facture à la
 # MINUTE d'audio ($0.003/min) et non au token, comme les entrées Whisper déjà
 # présentes au catalogue (cf. providers/groq/models/whisper-large-v3-turbo.toml).
-name = "Voxtral Mini Transcribe (latest)"
+name = "Voxtral Mini (latest)"
 description = "Speech transcription model for accurate audio-to-text and captioning workflows"
 family = "voxtral"
-release_date = "2025-07-15"
+release_date = "2026-02-01"
 last_updated = "2026-02-01"
 attachment = false
 reasoning = false

--- a/providers/mistral/models/voxtral-mini-latest.toml
+++ b/providers/mistral/models/voxtral-mini-latest.toml
@@ -1,0 +1,24 @@
+# Sources :
+#   https://docs.mistral.ai/models/model-cards/voxtral-mini-transcribe-25-07
+#   https://mistral.ai/news/voxtral-transcribe-2/  ($0.003 per minute)
+# Le bloc [cost] est volontairement absent : la transcription se facture à la
+# MINUTE d'audio ($0.003/min) et non au token, comme les entrées Whisper déjà
+# présentes au catalogue (cf. providers/groq/models/whisper-large-v3-turbo.toml).
+name = "Voxtral Mini Transcribe (latest)"
+description = "Speech transcription model for accurate audio-to-text and captioning workflows"
+family = "voxtral"
+release_date = "2025-07-15"
+last_updated = "2026-02-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["audio"]
+output = ["text"]

--- a/providers/mistral/models/voxtral-mini-tts-latest.toml
+++ b/providers/mistral/models/voxtral-mini-tts-latest.toml
@@ -1,0 +1,25 @@
+# Sources :
+#   https://mistral.ai/news/voxtral-tts/  ($0.016 per 1k characters)
+#   https://docs.mistral.ai/capabilities/audio/text_to_speech
+# Le bloc [cost] est volontairement absent : la synthèse se facture au CARACTÈRE
+# ($16 per 1M characters) et non au token, unité que le schéma ne modélise pas.
+# Modèle de 4 milliards de paramètres, neuf langues, clonage de voix zero-shot à
+# partir de deux à trois secondes d'audio de référence.
+name = "Voxtral TTS (latest)"
+description = "Multilingual text-to-speech model with zero-shot voice cloning"
+family = "voxtral"
+release_date = "2026-03-01"
+last_updated = "2026-03-01"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/mistral/models/voxtral-mini-tts-latest.toml
+++ b/providers/mistral/models/voxtral-mini-tts-latest.toml
@@ -5,7 +5,7 @@
 # ($16 per 1M characters) et non au token, unité que le schéma ne modélise pas.
 # Modèle de 4 milliards de paramètres, neuf langues, clonage de voix zero-shot à
 # partir de deux à trois secondes d'audio de référence.
-name = "Voxtral TTS (latest)"
+name = "Voxtral Mini TTS (latest)"
 description = "Multilingual text-to-speech model with zero-shot voice cloning"
 family = "voxtral"
 release_date = "2026-03-01"

--- a/providers/mistral/models/voxtral-small-latest.toml
+++ b/providers/mistral/models/voxtral-small-latest.toml
@@ -1,0 +1,27 @@
+# Sources :
+#   https://docs.mistral.ai/models/model-cards/voxtral-small-25-07
+#   https://mistral.ai/news/voxtral/
+# Le bloc [cost] ne porte que le texte ($0.10 / $0.30 per 1M tokens) : l'audio en
+# entrée se facture à la MINUTE ($0.004/min), unité que le schéma ne modélise pas.
+name = "Voxtral Small (latest)"
+description = "Instruct model with native audio input for speech understanding and tool use"
+family = "voxtral"
+release_date = "2025-07-15"
+last_updated = "2025-07-15"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.10
+output = 0.30
+
+[limit]
+context = 32_000
+output = 32_000
+
+[modalities]
+input = ["text", "audio"]
+output = ["text"]


### PR DESCRIPTION
Mistral ships a full audio line that the catalog does not cover yet. This adds the three models exposed by their API today.

| Model | Modalities | Notes |
|---|---|---|
| `voxtral-mini-latest` | `audio` → `text` | Transcription, 13 languages, speaker diarization |
| `voxtral-mini-tts-latest` | `text` → `audio` | 4B params, 9 languages, zero-shot voice cloning from 2–3 s of reference audio |
| `voxtral-small-latest` | `text`+`audio` → `text` | Instruct model with native audio input, tool calling, 32k context |

## On the missing `[cost]` blocks

Transcription and synthesis intentionally omit `[cost]`, because neither bills per token:

- transcription is **$0.003 per minute** of audio
- synthesis is **$0.016 per 1k characters** ($16 per 1M characters)

The schema models `input`/`output` as $/1M **tokens**, so any number I put there would be a fabricated conversion. This follows the treatment already applied to the Whisper entries in the catalog, for instance `providers/groq/models/whisper-large-v3-turbo.toml`, which also omits `[cost]` for per-minute billing.

`voxtral-small-latest` does carry token pricing ($0.10 / $0.30 per 1M) because its **text** side bills that way; its audio input bills per minute ($0.004) and that is documented in the file header rather than forced into the schema.

Per the `AGENTS.md` checklist, every citation lives in a leading comment block so the daily sync does not strip it.

## Sources

- [Voxtral Transcribe 2 announcement](https://mistral.ai/news/voxtral-transcribe-2/) — $0.003/min transcription, $0.006/min realtime
- [Voxtral TTS announcement](https://mistral.ai/news/voxtral-tts/) — $0.016 per 1k characters, 9 languages, zero-shot cloning
- [Voxtral Small model card](https://docs.mistral.ai/models/model-cards/voxtral-small-25-07) — 32k context, $0.10/$0.30 per 1M tokens, $0.004/min audio, tool calling
- [Audio capabilities overview](https://docs.mistral.ai/capabilities/audio_transcription)

Capabilities were also confirmed against the live API: `GET https://api.mistral.ai/v1/models` reports `audio_transcription` for `voxtral-mini-latest`, `audio_speech` for `voxtral-mini-tts-latest`, and `completion_chat` + `function_calling` + `audio` for `voxtral-small-latest`. Both endpoints were exercised end to end (transcription returns the OpenAI-shaped `{text, segments, usage}`; synthesis returns a 22.05 kHz MP3).

## Not included

Mistral also exposes three realtime transcription models (`voxtral-mini-realtime-*`, `audio_transcription_realtime`, $0.006/min). I left them out because their transport is not documented in Mistral's public OpenAPI spec — it declares no realtime endpoint and mentions no WebSocket — so I could not verify their surface the way I did for the other three. Happy to add them in a follow-up if maintainers prefer them listed anyway.

## Validation

`bun validate` passes. Mistral goes from 30 to 33 models, and the three entries resolve with the expected modalities.
