### PR TITLE
feat(provider): add Modelis (OpenAI-compatible gateway)

### DIFF
--- a/providers/modelis/logo.svg
+++ b/providers/modelis/logo.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" fill-rule="evenodd" d="M9 0h14a9 9 0 0 1 9 9v14a9 9 0 0 1-9 9H9a9 9 0 0 1-9-9V9a9 9 0 0 1 9-9ZM8 23V9h3.6l4.4 8.2L20.4 9H24v14h-3v-8.4l-3.8 7h-2.4l-3.8-7V23H8Z"/></svg>

--- a/providers/modelis/models/claude-fable-5.toml
+++ b/providers/modelis/models/claude-fable-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-fable-5"
+
+reasoning_options = []
+
+[cost]
+input = 10
+output = 50

--- a/providers/modelis/models/claude-fable-5.toml
+++ b/providers/modelis/models/claude-fable-5.toml
@@ -1,6 +1,11 @@
+# reasoning_effort verified live on 2026-08-02: all six values accepted and
+# reflected in usage.completion_tokens_details.reasoning_tokens.
+# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "anthropic/claude-fable-5"
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 10

--- a/providers/modelis/models/claude-opus-4-8.toml
+++ b/providers/modelis/models/claude-opus-4-8.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-opus-4-8"
+
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25

--- a/providers/modelis/models/claude-opus-4-8.toml
+++ b/providers/modelis/models/claude-opus-4-8.toml
@@ -1,6 +1,11 @@
+# reasoning_effort verified live on 2026-08-02: all six values accepted and
+# reflected in usage.completion_tokens_details.reasoning_tokens.
+# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "anthropic/claude-opus-4-8"
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5

--- a/providers/modelis/models/claude-sonnet-4-6.toml
+++ b/providers/modelis/models/claude-sonnet-4-6.toml
@@ -1,6 +1,11 @@
+# reasoning_effort verified live on 2026-08-02: all six values accepted and
+# reflected in usage.completion_tokens_details.reasoning_tokens.
+# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "anthropic/claude-sonnet-4-6"
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 3

--- a/providers/modelis/models/claude-sonnet-4-6.toml
+++ b/providers/modelis/models/claude-sonnet-4-6.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+reasoning_options = []
+
+[cost]
+input = 3
+output = 15

--- a/providers/modelis/models/deepseek-v4-flash.toml
+++ b/providers/modelis/models/deepseek-v4-flash.toml
@@ -1,6 +1,11 @@
+# reasoning_effort verified live on 2026-08-02: all six values accepted and
+# reflected in usage.completion_tokens_details.reasoning_tokens.
+# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "deepseek/deepseek-v4-flash"
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.0983

--- a/providers/modelis/models/deepseek-v4-flash.toml
+++ b/providers/modelis/models/deepseek-v4-flash.toml
@@ -1,0 +1,7 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+reasoning_options = []
+
+[cost]
+input = 0.0983
+output = 0.1966

--- a/providers/modelis/models/deepseek-v4-pro.toml
+++ b/providers/modelis/models/deepseek-v4-pro.toml
@@ -1,0 +1,7 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+reasoning_options = []
+
+[cost]
+input = 0.435
+output = 0.87

--- a/providers/modelis/models/deepseek-v4-pro.toml
+++ b/providers/modelis/models/deepseek-v4-pro.toml
@@ -1,6 +1,11 @@
+# reasoning_effort verified live on 2026-08-02: all six values accepted and
+# reflected in usage.completion_tokens_details.reasoning_tokens.
+# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "deepseek/deepseek-v4-pro"
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.435

--- a/providers/modelis/models/gemini-2.5-flash.toml
+++ b/providers/modelis/models/gemini-2.5-flash.toml
@@ -1,6 +1,11 @@
+# reasoning_effort verified live on 2026-08-02: all six values accepted and
+# reflected in usage.completion_tokens_details.reasoning_tokens.
+# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "google/gemini-2.5-flash"
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.3

--- a/providers/modelis/models/gemini-2.5-flash.toml
+++ b/providers/modelis/models/gemini-2.5-flash.toml
@@ -1,0 +1,7 @@
+base_model = "google/gemini-2.5-flash"
+
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.5

--- a/providers/modelis/models/gemini-2.5-pro.toml
+++ b/providers/modelis/models/gemini-2.5-pro.toml
@@ -1,6 +1,11 @@
+# reasoning_effort verified live on 2026-08-02: all six values accepted and
+# reflected in usage.completion_tokens_details.reasoning_tokens.
+# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "google/gemini-2.5-pro"
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 1.25

--- a/providers/modelis/models/gemini-2.5-pro.toml
+++ b/providers/modelis/models/gemini-2.5-pro.toml
@@ -1,0 +1,7 @@
+base_model = "google/gemini-2.5-pro"
+
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 10

--- a/providers/modelis/models/qwen/qwen3.7-max.toml
+++ b/providers/modelis/models/qwen/qwen3.7-max.toml
@@ -1,6 +1,11 @@
+# reasoning_effort verified live on 2026-08-02: all six values accepted and
+# reflected in usage.completion_tokens_details.reasoning_tokens.
+# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "alibaba/qwen3.7-max"
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 3

--- a/providers/modelis/models/qwen/qwen3.7-max.toml
+++ b/providers/modelis/models/qwen/qwen3.7-max.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.7-max"
+
+reasoning_options = []
+
+[cost]
+input = 3
+output = 9

--- a/providers/modelis/models/qwen/qwen3.7-plus.toml
+++ b/providers/modelis/models/qwen/qwen3.7-plus.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.7-plus"
+
+reasoning_options = []
+
+[cost]
+input = 0.768
+output = 3.072

--- a/providers/modelis/models/qwen/qwen3.7-plus.toml
+++ b/providers/modelis/models/qwen/qwen3.7-plus.toml
@@ -1,6 +1,11 @@
+# reasoning_effort verified live on 2026-08-02: all six values accepted and
+# reflected in usage.completion_tokens_details.reasoning_tokens.
+# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "alibaba/qwen3.7-plus"
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.768

--- a/providers/modelis/provider.toml
+++ b/providers/modelis/provider.toml
@@ -1,0 +1,5 @@
+name = "Modelis"
+npm = "@ai-sdk/openai-compatible"
+env = ["MODELIS_API_KEY"]
+api = "https://modelishub.com/v1"
+doc = "https://modelishub.com/pricing"


### PR DESCRIPTION
Adds **Modelis**, an OpenAI-compatible LLM gateway that puts Claude, Gemini, DeepSeek and Qwen coding models behind a single key and base URL.

> **Disclosure: I maintain Modelis.**

### Provider

| | |
|---|---|
| Endpoint | `https://modelishub.com/v1` |
| SDK | `@ai-sdk/openai-compatible` |
| Env | `MODELIS_API_KEY` |
| Docs | https://modelishub.com/pricing |

### Models

Nine coding-relevant models, all inheriting `base_model` from existing `models/` metadata rather than duplicating provider-agnostic facts:

| Model | `base_model` | input $/M | output $/M |
|---|---|---|---|
| `claude-opus-4-8` | `anthropic/claude-opus-4-8` | 5 | 25 |
| `claude-sonnet-4-6` | `anthropic/claude-sonnet-4-6` | 3 | 15 |
| `claude-fable-5` | `anthropic/claude-fable-5` | 10 | 50 |
| `gemini-2.5-pro` | `google/gemini-2.5-pro` | 1.25 | 10 |
| `gemini-2.5-flash` | `google/gemini-2.5-flash` | 0.3 | 2.5 |
| `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | 0.435 | 0.87 |
| `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 0.0983 | 0.1966 |
| `qwen/qwen3.7-max` | `alibaba/qwen3.7-max` | 3 | 9 |
| `qwen/qwen3.7-plus` | `alibaba/qwen3.7-plus` | 0.768 | 3.072 |

### Verification done before opening this PR

- **Every model was called live** against `https://modelishub.com/v1/chat/completions` — 9/9 returned a valid completion.
- **Pricing was not estimated.** It is derived from the gateway's own billing configuration and then cross-checked against a real metered request: a call with 97 prompt + 120 completion tokens on `deepseek-v4-flash` was billed an amount matching the submitted rates to within integer-rounding. The Claude rates independently reproduce Anthropic's public list prices.
- **`reasoning_options = []`** on the reasoning models: they reason upstream, but Modelis exposes no reasoning control I could verify, and per `AGENTS.md` an empty array is the correct declaration in that case.
- **Logo** is a single path using `currentColor`, no fixed width/height, no hardcoded colors; rendered and checked at 160/96/48 px on light and dark foregrounds.

### Sources

- Pricing page: https://modelishub.com/pricing
- Live model + rate catalog: https://modelishub.com/api/pricing

### Note

I could not run `bun validate` locally — this repo uses 179 symlinked TOMLs plus filenames containing `:`, neither of which a Windows checkout can materialize. I validated the submitted files directly instead (TOML parses under Bun's native loader, field set matches an already-merged peer provider, every `base_model` target exists, costs are non-zero). Relying on CI for the full run — happy to fix anything it flags.
