### PR TITLE
fix: adds low effort deepseek-v4-flash-0731 to the fireworks-ai provider

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash-0731.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash-0731.toml
@@ -5,7 +5,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["low", "high", "max"]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Adds low effort to the fireworks-ai provider of model DeepSeek-V4-Flash-0731.

Sources: the [Hugging Face model card](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) and config.json states that reasoning efforts are: low, high, max. Using its "Playground" I confirm that the low effort option works as intended.

I've tried to be careful in my sourcing, if there is any issue with the config tell me and I will correct it (or you can modify it yourself).

I recommend squashing the merge because I've had to resolve conflicts.