### PR TITLE
feat(baseten): add Inkling Small model API

### DIFF
--- a/models/thinkingmachines/inkling-small.toml
+++ b/models/thinkingmachines/inkling-small.toml
@@ -1,0 +1,27 @@
+# Sources (accessed 2026-08-01):
+# - https://thinkingmachines.ai/news/inkling-small/
+# - https://huggingface.co/thinkingmachines/Inkling-Small
+
+name = "Inkling Small"
+description = "Multimodal MoE reasoning model (276B total, 12B active) for text, image, and audio"
+family = "ling"
+release_date = "2026-07-30"
+last_updated = "2026-07-30"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+license = "Apache-2.0"
+
+[limit]
+context = 1_048_576
+output = 1_048_576
+
+[modalities]
+input = ["text", "image", "audio"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/thinkingmachines/Inkling-Small"

--- a/providers/baseten/models/thinkingmachines/inkling-small.toml
+++ b/providers/baseten/models/thinkingmachines/inkling-small.toml
@@ -1,10 +1,10 @@
-# Baseten documents top-level reasoning_effort for Inkling with values
+# Baseten documents top-level reasoning_effort for Inkling Small with values
 # none | minimal | low | medium | high (default) | xhigh | max. Reasoning is
 # enabled by default; reasoning_effort: "none" disables it (chat_template_args
 # enable_thinking does not). No budget_tokens control.
 # https://docs.baseten.co/inference/model-apis/reasoning (accessed 2026-08-01)
 # API: {"reasoning_effort": "none"|"minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
-base_model = "thinkingmachines/inkling"
+base_model = "thinkingmachines/inkling-small"
 description = "Multimodal reasoning model for visual analysis, planning, and tool use"
 structured_output = true
 
@@ -16,8 +16,9 @@ type = "effort"
 values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 1
-output = 4.05
+input = 0.5
+output = 1.2
+cache_read = 0.1
 
 [limit]
 output = 32_768


### PR DESCRIPTION
Model APIs now include thinkingmachines/inkling-small. Add provider-agnostic metadata so the Baseten sync can map the slug (it was previously skipped), a Baseten entry inheriting via base_model, and refresh Inkling's effort values to include the newly documented "max" level.