### PR TITLE
fix(modelis): declare reasoning_options per model from measurements

### DIFF
--- a/providers/modelis/models/claude-fable-5.toml
+++ b/providers/modelis/models/claude-fable-5.toml
@@ -1,7 +1,9 @@
+# Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
+#   Effort:        {"reasoning_effort": "<value>"}
 base_model = "anthropic/claude-fable-5"
 
 [[reasoning_options]]
-type = "effort" # API: {"reasoning_effort": "<value>"}
+type = "effort"
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]

--- a/providers/modelis/models/claude-fable-5.toml
+++ b/providers/modelis/models/claude-fable-5.toml
@@ -1,10 +1,7 @@
-# reasoning_effort verified live on 2026-08-02: all six values accepted and
-# reflected in usage.completion_tokens_details.reasoning_tokens.
-# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "anthropic/claude-fable-5"
 
 [[reasoning_options]]
-type = "effort"
+type = "effort" # API: {"reasoning_effort": "<value>"}
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]

--- a/providers/modelis/models/claude-fable-5.toml
+++ b/providers/modelis/models/claude-fable-5.toml
@@ -4,7 +4,7 @@ base_model = "anthropic/claude-fable-5"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 10

--- a/providers/modelis/models/claude-opus-4-8.toml
+++ b/providers/modelis/models/claude-opus-4-8.toml
@@ -1,11 +1,11 @@
-# reasoning_effort verified live on 2026-08-02: all six values accepted and
-# reflected in usage.completion_tokens_details.reasoning_tokens.
-# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "anthropic/claude-opus-4-8"
 
 [[reasoning_options]]
-type = "effort"
+type = "effort" # API: {"reasoning_effort": "<value>"}
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+
+[[reasoning_options]]
+type = "toggle" # API: {"reasoning": {"enabled": true|false}}
 
 [cost]
 input = 5

--- a/providers/modelis/models/claude-opus-4-8.toml
+++ b/providers/modelis/models/claude-opus-4-8.toml
@@ -5,7 +5,7 @@ base_model = "anthropic/claude-opus-4-8"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "max"]
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/modelis/models/claude-opus-4-8.toml
+++ b/providers/modelis/models/claude-opus-4-8.toml
@@ -1,11 +1,14 @@
+# Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
+#   Effort:        {"reasoning_effort": "<value>"}
+#   Toggle:        {"reasoning": {"enabled": true|false}}
 base_model = "anthropic/claude-opus-4-8"
 
 [[reasoning_options]]
-type = "effort" # API: {"reasoning_effort": "<value>"}
+type = "effort"
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [[reasoning_options]]
-type = "toggle" # API: {"reasoning": {"enabled": true|false}}
+type = "toggle"
 
 [cost]
 input = 5

--- a/providers/modelis/models/claude-opus-4-8.toml
+++ b/providers/modelis/models/claude-opus-4-8.toml
@@ -5,7 +5,7 @@ base_model = "anthropic/claude-opus-4-8"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/modelis/models/claude-sonnet-4-6.toml
+++ b/providers/modelis/models/claude-sonnet-4-6.toml
@@ -1,11 +1,11 @@
-# reasoning_effort verified live on 2026-08-02: all six values accepted and
-# reflected in usage.completion_tokens_details.reasoning_tokens.
-# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "anthropic/claude-sonnet-4-6"
 
 [[reasoning_options]]
-type = "effort"
+type = "effort" # API: {"reasoning_effort": "<value>"}
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+
+[[reasoning_options]]
+type = "toggle" # API: {"reasoning": {"enabled": true|false}}
 
 [cost]
 input = 3

--- a/providers/modelis/models/claude-sonnet-4-6.toml
+++ b/providers/modelis/models/claude-sonnet-4-6.toml
@@ -1,11 +1,14 @@
+# Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
+#   Effort:        {"reasoning_effort": "<value>"}
+#   Toggle:        {"reasoning": {"enabled": true|false}}
 base_model = "anthropic/claude-sonnet-4-6"
 
 [[reasoning_options]]
-type = "effort" # API: {"reasoning_effort": "<value>"}
+type = "effort"
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [[reasoning_options]]
-type = "toggle" # API: {"reasoning": {"enabled": true|false}}
+type = "toggle"
 
 [cost]
 input = 3

--- a/providers/modelis/models/claude-sonnet-4-6.toml
+++ b/providers/modelis/models/claude-sonnet-4-6.toml
@@ -5,7 +5,7 @@ base_model = "anthropic/claude-sonnet-4-6"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "max"]
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/modelis/models/deepseek-v4-flash.toml
+++ b/providers/modelis/models/deepseek-v4-flash.toml
@@ -1,9 +1,10 @@
 # Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
-#   Toggle:        {"reasoning_effort": "none"} to disable; omit to enable
+#   Effort:        {"reasoning_effort": "none"|"high"|"max"} — "none" disables reasoning
 base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "high", "max"]
 
 [cost]
 input = 0.0983

--- a/providers/modelis/models/deepseek-v4-flash.toml
+++ b/providers/modelis/models/deepseek-v4-flash.toml
@@ -1,11 +1,7 @@
-# reasoning_effort verified live on 2026-08-02: all six values accepted and
-# reflected in usage.completion_tokens_details.reasoning_tokens.
-# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]
-type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+type = "toggle" # API: {"reasoning_effort": "none"} disables; omit to enable
 
 [cost]
 input = 0.0983

--- a/providers/modelis/models/deepseek-v4-flash.toml
+++ b/providers/modelis/models/deepseek-v4-flash.toml
@@ -1,7 +1,9 @@
+# Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
+#   Toggle:        {"reasoning_effort": "none"} to disable; omit to enable
 base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]
-type = "toggle" # API: {"reasoning_effort": "none"} disables; omit to enable
+type = "toggle"
 
 [cost]
 input = 0.0983

--- a/providers/modelis/models/deepseek-v4-pro.toml
+++ b/providers/modelis/models/deepseek-v4-pro.toml
@@ -1,7 +1,9 @@
+# Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
+#   Toggle:        {"reasoning_effort": "none"} to disable; omit to enable
 base_model = "deepseek/deepseek-v4-pro"
 
 [[reasoning_options]]
-type = "toggle" # API: {"reasoning_effort": "none"} disables; omit to enable
+type = "toggle"
 
 [cost]
 input = 0.435

--- a/providers/modelis/models/deepseek-v4-pro.toml
+++ b/providers/modelis/models/deepseek-v4-pro.toml
@@ -1,9 +1,10 @@
 # Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
-#   Toggle:        {"reasoning_effort": "none"} to disable; omit to enable
+#   Effort:        {"reasoning_effort": "none"|"high"|"max"} — "none" disables reasoning
 base_model = "deepseek/deepseek-v4-pro"
 
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "high", "max"]
 
 [cost]
 input = 0.435

--- a/providers/modelis/models/deepseek-v4-pro.toml
+++ b/providers/modelis/models/deepseek-v4-pro.toml
@@ -1,11 +1,7 @@
-# reasoning_effort verified live on 2026-08-02: all six values accepted and
-# reflected in usage.completion_tokens_details.reasoning_tokens.
-# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "deepseek/deepseek-v4-pro"
 
 [[reasoning_options]]
-type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+type = "toggle" # API: {"reasoning_effort": "none"} disables; omit to enable
 
 [cost]
 input = 0.435

--- a/providers/modelis/models/gemini-2.5-flash.toml
+++ b/providers/modelis/models/gemini-2.5-flash.toml
@@ -6,7 +6,7 @@ base_model = "google/gemini-2.5-flash"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+values = ["minimal", "low", "medium", "high", "max"]
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/modelis/models/gemini-2.5-flash.toml
+++ b/providers/modelis/models/gemini-2.5-flash.toml
@@ -1,11 +1,14 @@
-# reasoning_effort verified live on 2026-08-02: all six values accepted and
-# reflected in usage.completion_tokens_details.reasoning_tokens.
-# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "google/gemini-2.5-flash"
 
 [[reasoning_options]]
-type = "effort"
+type = "effort" # API: {"reasoning_effort": "<value>"}
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+
+[[reasoning_options]]
+type = "toggle" # API: {"reasoning": {"enabled": true|false}}
+
+[[reasoning_options]]
+type = "budget_tokens" # API: {"reasoning": {"max_tokens": <n>}}
 
 [cost]
 input = 0.3

--- a/providers/modelis/models/gemini-2.5-flash.toml
+++ b/providers/modelis/models/gemini-2.5-flash.toml
@@ -1,14 +1,18 @@
+# Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
+#   Effort:        {"reasoning_effort": "<value>"}
+#   Toggle:        {"reasoning": {"enabled": true|false}}
+#   Budget tokens: {"reasoning": {"max_tokens": <n>}}
 base_model = "google/gemini-2.5-flash"
 
 [[reasoning_options]]
-type = "effort" # API: {"reasoning_effort": "<value>"}
+type = "effort"
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [[reasoning_options]]
-type = "toggle" # API: {"reasoning": {"enabled": true|false}}
+type = "toggle"
 
 [[reasoning_options]]
-type = "budget_tokens" # API: {"reasoning": {"max_tokens": <n>}}
+type = "budget_tokens"
 
 [cost]
 input = 0.3

--- a/providers/modelis/models/gemini-2.5-pro.toml
+++ b/providers/modelis/models/gemini-2.5-pro.toml
@@ -1,11 +1,14 @@
+# Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
+#   Effort:        {"reasoning_effort": "<value>"}
+#   Budget tokens: {"reasoning": {"max_tokens": <n>}}
 base_model = "google/gemini-2.5-pro"
 
 [[reasoning_options]]
-type = "effort" # API: {"reasoning_effort": "<value>"}
+type = "effort"
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [[reasoning_options]]
-type = "budget_tokens" # API: {"reasoning": {"max_tokens": <n>}}
+type = "budget_tokens"
 
 [cost]
 input = 1.25

--- a/providers/modelis/models/gemini-2.5-pro.toml
+++ b/providers/modelis/models/gemini-2.5-pro.toml
@@ -5,7 +5,7 @@ base_model = "google/gemini-2.5-pro"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "max"]
 
 [[reasoning_options]]
 type = "budget_tokens"

--- a/providers/modelis/models/gemini-2.5-pro.toml
+++ b/providers/modelis/models/gemini-2.5-pro.toml
@@ -1,11 +1,11 @@
-# reasoning_effort verified live on 2026-08-02: all six values accepted and
-# reflected in usage.completion_tokens_details.reasoning_tokens.
-# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "google/gemini-2.5-pro"
 
 [[reasoning_options]]
-type = "effort"
+type = "effort" # API: {"reasoning_effort": "<value>"}
 values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens" # API: {"reasoning": {"max_tokens": <n>}}
 
 [cost]
 input = 1.25

--- a/providers/modelis/models/qwen/qwen3.7-max.toml
+++ b/providers/modelis/models/qwen/qwen3.7-max.toml
@@ -1,11 +1,10 @@
-# reasoning_effort verified live on 2026-08-02: all six values accepted and
-# reflected in usage.completion_tokens_details.reasoning_tokens.
-# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "alibaba/qwen3.7-max"
 
 [[reasoning_options]]
-type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+type = "toggle" # API: {"reasoning": {"enabled": true|false}}
+
+[[reasoning_options]]
+type = "budget_tokens" # API: {"reasoning": {"max_tokens": <n>}}
 
 [cost]
 input = 3

--- a/providers/modelis/models/qwen/qwen3.7-max.toml
+++ b/providers/modelis/models/qwen/qwen3.7-max.toml
@@ -1,10 +1,13 @@
+# Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
+#   Toggle:        {"reasoning": {"enabled": true|false}}
+#   Budget tokens: {"reasoning": {"max_tokens": <n>}}
 base_model = "alibaba/qwen3.7-max"
 
 [[reasoning_options]]
-type = "toggle" # API: {"reasoning": {"enabled": true|false}}
+type = "toggle"
 
 [[reasoning_options]]
-type = "budget_tokens" # API: {"reasoning": {"max_tokens": <n>}}
+type = "budget_tokens"
 
 [cost]
 input = 3

--- a/providers/modelis/models/qwen/qwen3.7-plus.toml
+++ b/providers/modelis/models/qwen/qwen3.7-plus.toml
@@ -1,11 +1,10 @@
-# reasoning_effort verified live on 2026-08-02: all six values accepted and
-# reflected in usage.completion_tokens_details.reasoning_tokens.
-# API: {"reasoning_effort": "minimal"|"low"|"medium"|"high"|"xhigh"|"max"}
 base_model = "alibaba/qwen3.7-plus"
 
 [[reasoning_options]]
-type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+type = "toggle" # API: {"reasoning": {"enabled": true|false}}
+
+[[reasoning_options]]
+type = "budget_tokens" # API: {"reasoning": {"max_tokens": <n>}}
 
 [cost]
 input = 0.768

--- a/providers/modelis/models/qwen/qwen3.7-plus.toml
+++ b/providers/modelis/models/qwen/qwen3.7-plus.toml
@@ -1,10 +1,13 @@
+# Reasoning controls verified against https://modelishub.com/v1 on 2026-08-02.
+#   Toggle:        {"reasoning": {"enabled": true|false}}
+#   Budget tokens: {"reasoning": {"max_tokens": <n>}}
 base_model = "alibaba/qwen3.7-plus"
 
 [[reasoning_options]]
-type = "toggle" # API: {"reasoning": {"enabled": true|false}}
+type = "toggle"
 
 [[reasoning_options]]
-type = "budget_tokens" # API: {"reasoning": {"max_tokens": <n>}}
+type = "budget_tokens"
 
 [cost]
 input = 0.768


### PR DESCRIPTION
Follow-up to #3932, which merged before I could push this correction.

That PR landed with the identical six-value `effort` list on all nine models. The review
bot flagged that as over-broad, and it was right — re-measuring showed it is also
**incomplete**: two controls this gateway exposes were missing from every file, and the
header comment claiming all six values are "reflected in `reasoning_tokens`" holds for
five models, not nine.

This PR replaces those declarations with per-model ones derived from measurement. All nine
now differ. Full evidence below (also posted on #3932).

Disclosure: I maintain Modelis.

---

The check was right that a uniform six-value effort list was over-broad. It was also
*under*-broad in a way neither of us flagged: two controls this gateway does expose
were missing from every file.

I re-tested each model per control against `https://modelishub.com/v1` and rewrote the
nine files from the measurements. All nine now differ. Numbers below so you can check
the reasoning rather than take my word for it.

## Method

- Metric: `usage.completion_tokens_details.reasoning_tokens`.
- `temperature: 0`, 2–3 samples per cell. Single samples were the main weakness of my
  previous comment.
- **Two prompts, deliberately** — an easy one (three switches / three bulbs) and a hard
  one (derive and prove a recurrence for 3×n domino tilings, compute f(12)). This
  turned out to matter more than anything else; see below.
- Cells that errored were re-run, not recorded as "unsupported". One earlier `ERR` was
  my own test key hitting its quota limit, which would have read as a rejection.

## Negative controls

Acceptance is weak evidence on an OpenAI-compatible gateway, so:

| Request | Result |
| --- | --- |
| `reasoning_effort: "banana"` | `400` — `Invalid option: expected one of "max"\|"xhigh"\|"high"\|"medium"\|"low"\|"minimal"\|"none"` |
| `reasoning: {enabled: "yes-please"}` | `400` — `enabled: Invalid input: expected boolean, received string` |
| `reasoning: {nonsense_field: 7}` | `200`, silently ignored |
| `reasoning: {max_tokens: 0}` on `gemini-2.5-pro` | `400` — `Reasoning is mandatory for this endpoint and cannot be disabled.` |

Row 3 is the load-bearing one: unknown keys under `reasoning` *are* dropped silently,
so the typed `400`s show `reasoning_effort` and `reasoning.enabled` are genuinely
parsed rather than accidentally tolerated.

## 1. Is `reasoning_effort` honoured?

Mean `reasoning_tokens` per effort value. `F` compares the spread *between* effort
levels against the spread *between repeats of the same level* — a flat model with one
noisy spike scores near 1.

| model | minimal | low | medium | high | xhigh | max | F | honoured |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `claude-opus-4-8` † | 108 | 70 | 822 | 914 | 800 | 862 | 62.7 | yes |
| `claude-sonnet-4-6` | 0 | 0 | 6 | 80 | 85 | 158 | 49.3 | yes |
| `claude-fable-5` | 0 | 0 | 11 | 21 | 37 | 68 | 14.6 | yes |
| `gemini-2.5-pro` | 70 | 74 | 234 | 408 | 565 | 567 | 173.2 | yes |
| `gemini-2.5-flash` | 37 | 107 | 304 | 448 | 355 | 355 | ∞ ‡ | yes |
| `deepseek-v4-pro` | 136 | 141 | 118 | 149 | 377 | 181 | 5.2 | **no** |
| `deepseek-v4-flash` | 116 | 96 | 63 | 86 | 62 | 88 | 1.4 | **no** |
| `qwen/qwen3.7-max` | 1529 | 1650 | 1597 | 1791 | 1457 | 1433 | 0.9 | **no** |
| `qwen/qwen3.7-plus` | 1238 | 1362 | 1285 | 1309 | 1471 | 1264 | 0.6 | **no** |

† hard prompt. ‡ repeats at a given level were identical, so within-level variance was
zero.

`deepseek-v4-pro` at F = 5.2 is the one judgement call: the apparent rise is a single
cell (`xhigh` samples 243 / 324 / **564**) and the curve is otherwise flat, so I read it
as noise and did not declare effort. Raw numbers are here in case you read it differently.

The four DeepSeek/Qwen models accept every effort value and return `200`, but the value
does not change what the model does — "accepted" is not "meaningful", so they get no
effort declaration.

## What the easy prompt got wrong

Worth stating, because measuring only the easy prompt would have produced a confidently
wrong PR **twice, in opposite directions**:

- On the easy prompt `claude-opus-4-8` returned **0** reasoning tokens at every effort
  except `max` — which reads as "only `max` does anything". On the hard prompt: 108 / 70 /
  822 / 914 / 800 / 862.
- On the easy prompt `reasoning: {enabled: true}` on `claude-opus-4-8` returned **0**,
  which reads as "no toggle". On the hard prompt it returns **370** against an
  `enabled: false` result of **0**.

The easy puzzle simply did not require thinking. Any per-value claim measured on a task
the model finds trivial is measuring the task, not the API.

## 2. Is there a toggle?

Same prompt, both states caller-selected, so the default behaviour is not part of the claim.

| model | off | on | mechanism | toggle |
| --- | --- | --- | --- | --- |
| `claude-opus-4-8` † | 0 | 370 | `reasoning.enabled` | yes |
| `claude-sonnet-4-6` † | 0 | 648 | `reasoning.enabled` | yes |
| `claude-fable-5` | `400` | — | — | **no** — `Reasoning is mandatory for this endpoint and cannot be disabled.` |
| `gemini-2.5-pro` | `400` | — | — | **no** — same error |
| `gemini-2.5-flash` | 0 | 979 | `reasoning.enabled` | yes |
| `deepseek-v4-pro` † | 0 via `reasoning_effort: "none"` | 2000\* | `reasoning_effort` | yes |
| `deepseek-v4-flash` † | 0 via `reasoning_effort: "none"` | 2000\* | `reasoning_effort` | yes |
| `qwen/qwen3.7-max` | 0 | 1655 | `reasoning.enabled` | yes |
| `qwen/qwen3.7-plus` | 0 | 1319 | `reasoning.enabled` | yes |

† hard prompt. \* clipped by that run's `max_tokens: 2000`; the exact figure is unknown but
it is unambiguously non-zero, which is all the "on" state needs to show.

Two different mechanisms, which is why the `# API:` comment differs per file:

- `claude-opus-4-8`, `claude-sonnet-4-6`, `gemini-2.5-flash` and both Qwen models toggle
  reasoning with `reasoning.enabled` set to `true` or `false`.
- Both DeepSeek models **ignore** `reasoning.enabled` (off → 121 against a baseline of 185)
  but do honour `reasoning_effort: "none"`, which takes them from 2000 reasoning tokens to
  0, reproducibly, on the hard prompt.

I declared the DeepSeek pair as `toggle` rather than `effort` with `values = ["none"]`:
on/off is what a caller actually gets, and a one-entry effort list would render as a
control that doesn't exist. Happy to switch if you'd rather the declaration mirror the
field name.

## 3. Is `budget_tokens` honoured?

`reasoning: {max_tokens: n}`, measured with a high `max_tokens` so the output ceiling is
not mistaken for the model's behaviour — an earlier pass capped output at 900 and produced
a suspicious run of `863`s that were just the ceiling.

| model | requested budget → observed `reasoning_tokens` | tracks budget |
| --- | --- | --- |
| `gemini-2.5-pro` | 128 → 70 · 1024 → 914 · 4096 → 3526 | **yes** |
| `gemini-2.5-flash` | 128 → 98 · 1024 → 787 · 4096 → 748 (saturates) | **yes** |
| `qwen/qwen3.7-max` | 128 → **128 exactly** · 2048 → 1564 | **yes** |
| `qwen/qwen3.7-plus` | 128 → **128 exactly** · 2048 → 1142 | **yes** |
| `claude-opus-4-8` † | 256 → 738 · 3072 → 879 | no — a 256 budget produced 738 |
| `claude-sonnet-4-6` † | 256 → 441 · 3072 → 775 | no — high variance, no tracking |
| `claude-fable-5` † | 256 → 463 · 3072 → 382 | no — 12× the budget gave *fewer* tokens |
| `deepseek-v4-pro` † | 256 → 2000\* · 3072 → 2000\* | no — a 256 budget ran to the output cap |
| `deepseek-v4-flash` † | 256 → 2000\* · 3072 → 2000\* | no — same |

\* clipped: that run set `max_tokens: 2000`, and reasoning consumed all of it. The exact
value is unknown, but "≥ 2000 when 256 was requested" is enough to show the budget is
ignored.

The Qwen rows are the cleanest evidence in the set: a 128-token budget returns exactly 128
reasoning tokens, twice, on both models.

No `min`/`max` is declared anywhere — I never probed a boundary, and unverified bounds
should be omitted rather than inferred from `limit.output`.

## Resulting declarations

| model | declared |
| --- | --- |
| `claude-opus-4-8` | `effort` (6 values) + `toggle` |
| `claude-sonnet-4-6` | `effort` (6 values) + `toggle` |
| `claude-fable-5` | `effort` (6 values) |
| `gemini-2.5-pro` | `effort` (6 values) + `budget_tokens` |
| `gemini-2.5-flash` | `effort` (6 values) + `toggle` + `budget_tokens` |
| `deepseek-v4-pro` | `toggle` |
| `deepseek-v4-flash` | `toggle` |
| `qwen/qwen3.7-max` | `toggle` + `budget_tokens` |
| `qwen/qwen3.7-plus` | `toggle` + `budget_tokens` |

`"none"` is deliberately absent from every effort list: it's an off switch, not an effort
level, and where it works it's declared as `toggle` instead.

Prices are unchanged and were re-checked against the live `/api/pricing` today — all nine
still match.
