### PR TITLE
fix: Revert Azure GPT-5.6 Terra/Luna pricing to non-discounted values

### DIFF
--- a/providers/azure-cognitive-services/models/gpt-5.6-luna.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.6-luna.toml
@@ -1,15 +1,17 @@
-# Pricing aligned with OpenAI standard (Terra/Luna cut 2026-07-30): https://developers.openai.com/api/docs/pricing
+# Pricing aligned with Azure (no Terra/Luna cut from 2026-07-30): https://learn.microsoft.com/en-us/answers/questions/5962521/pricing-of-openai-gpt-5-6-models-luna-terra
 base_model = "openai/gpt-5.6-luna"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 0.2
-output = 1.2
-cache_read = 0.02
+input = 1
+output = 6
+cache_read = 0.1
+cache_write = 1.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 0.4
-output = 1.8
-cache_read = 0.04
+input = 2
+output = 9
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/azure-cognitive-services/models/gpt-5.6-terra.toml
+++ b/providers/azure-cognitive-services/models/gpt-5.6-terra.toml
@@ -1,15 +1,17 @@
-# Pricing aligned with OpenAI standard (Terra/Luna cut 2026-07-30): https://developers.openai.com/api/docs/pricing
+# Pricing aligned with Azure (no Terra/Luna cut from 2026-07-30): https://learn.microsoft.com/en-us/answers/questions/5962521/pricing-of-openai-gpt-5-6-models-luna-terra
 base_model = "openai/gpt-5.6-terra"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 2.0
-output = 12
-cache_read = 0.2
+input = 2.5
+output = 15
+cache_read = 0.25
+cache_write = 3.125
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 4
-output = 18
-cache_read = 0.4
+input = 5
+output = 22.5
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/azure/models/gpt-5.6-luna.toml
+++ b/providers/azure/models/gpt-5.6-luna.toml
@@ -1,15 +1,17 @@
-# Pricing aligned with OpenAI standard (Terra/Luna cut 2026-07-30): https://developers.openai.com/api/docs/pricing
+# Pricing aligned with Azure (no Terra/Luna cut from 2026-07-30): https://learn.microsoft.com/en-us/answers/questions/5962521/pricing-of-openai-gpt-5-6-models-luna-terra
 base_model = "openai/gpt-5.6-luna"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 0.2
-output = 1.2
-cache_read = 0.02
+input = 1
+output = 6
+cache_read = 0.1
+cache_write = 1.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 0.4
-output = 1.8
-cache_read = 0.04
+input = 2
+output = 9
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/azure/models/gpt-5.6-terra.toml
+++ b/providers/azure/models/gpt-5.6-terra.toml
@@ -1,15 +1,17 @@
-# Pricing aligned with OpenAI standard (Terra/Luna cut 2026-07-30): https://developers.openai.com/api/docs/pricing
+# Pricing aligned with Azure (no Terra/Luna cut from 2026-07-30): https://learn.microsoft.com/en-us/answers/questions/5962521/pricing-of-openai-gpt-5-6-models-luna-terra
 base_model = "openai/gpt-5.6-terra"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 2.0
-output = 12
-cache_read = 0.2
+input = 2.5
+output = 15
+cache_read = 0.25
+cache_write = 3.125
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 4
-output = 18
-cache_read = 0.4
+input = 5
+output = 22.5
+cache_read = 0.5
+cache_write = 6.25


### PR DESCRIPTION
Azure has not adopted the OpenAI GPT-5.6 Terra and Luna price cuts from 2026-07-30 ([announcement](https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/)). For instance, Azure OpenAI's [pricing page](https://azure.microsoft.com/en-us/pricing/details/azure-openai/) and this [Microsoft Learn forum post](https://learn.microsoft.com/en-us/answers/questions/5962521/pricing-of-openai-gpt-5-6-models-luna-terra) both indicate that the prices have not changed from the non-discounted values. I've also tested these API endpoints on Azure and the displayed charges are more consistent with the non-discounted prices. This updates `azure`, and `azure-cognitive-services` catalog costs (standard + long-context tiers) to reflect that. They also add `cache_write`, which shows up in Azure's pricing page.

If I can help find more accurate sources, please let me know!
