### PR TITLE
feat: add qwen3.7-flash model for alibaba-cn provider

### DIFF
--- a/models/alibaba/qwen3.7-flash.toml
+++ b/models/alibaba/qwen3.7-flash.toml
@@ -1,4 +1,5 @@
 name = "Qwen3.7 Flash"
+description = "Lightweight multimodal Qwen model for high-throughput text, image, and video tasks"
 family = "qwen"
 release_date = "2026-07-15"
 last_updated = "2026-07-15"

--- a/models/alibaba/qwen3.7-flash.toml
+++ b/models/alibaba/qwen3.7-flash.toml
@@ -1,0 +1,19 @@
+name = "Qwen3.7 Flash"
+family = "qwen"
+release_date = "2026-07-15"
+last_updated = "2026-07-15"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+input = 991_000
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/alibaba-cn/models/qwen3.7-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.7-flash.toml
@@ -1,0 +1,33 @@
+# CNY→USD rate: 6.7513, 2026-08-02, source: https://www.nimbuscalc.com/calculators/financial-calculators/currency-converter/USD-CNY-2026-08-02/
+# CNY list price source: https://help.aliyun.com/zh/model-studio/model-pricing (Beijing region)
+# Cache pricing: https://help.aliyun.com/zh/model-studio/context-cache (explicit: read 10%, write 125% of input)
+# Toggle: enable_thinking true|false
+# Budget: thinking_budget
+base_model = "alibaba/qwen3.7-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
+[cost]
+input = 0.02962
+output = 0.1185
+cache_read = 0.002962
+cache_write = 0.03703
+
+[[cost.tiers]]
+tier = { type = "context", size = 32_000 }
+input = 0.08887
+output = 0.35549
+cache_read = 0.008887
+cache_write = 0.11109
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 0.17774
+output = 0.71098
+cache_read = 0.017774
+cache_write = 0.22218


### PR DESCRIPTION
Add qwen3.7-flash model definition for Alibaba Cloud Bailian (China) provider.

## Model specs (from Alibaba Cloud Bailian)

- Context: 1M tokens
- Max input: 991K
- Max output: 64K
- Max thinking chain: 256K
- Input modalities: text, image, video
- Output: text
- Supports: thinking mode (enable_thinking), function calling, built-in tools, structured output
- Snapshot: qwen3.7-flash-2026-07-15

## Pricing (Beijing region, CNY per million tokens)

| Token range | Input | Output |
|---|---|---|
| 0–32K | ¥0.2 | ¥0.8 |
| 32K–256K | ¥0.6 | ¥2.4 |
| 256K–1M | ¥1.2 | ¥4.8 |

Cache pricing (explicit): read = 10% of input, write = 125% of input.

## USD conversion

CNY→USD rate: 6.7513, 2026-08-02
Source: https://www.nimbuscalc.com/calculators/financial-calculators/currency-converter/USD-CNY-2026-08-02/

## Files added

- `models/alibaba/qwen3.7-flash.toml` — shared model metadata
- `providers/alibaba-cn/models/qwen3.7-flash.toml` — China provider (base_model reference)

## Sources

- Pricing: https://help.aliyun.com/zh/model-studio/model-pricing
- Model capabilities: https://help.aliyun.com/zh/model-studio/text-generation-model/
- Cache pricing: https://help.aliyun.com/zh/model-studio/context-cache