### PR TITLE
fix(nebius): set cache_read price for Kimi-K3

### DIFF
--- a/providers/nebius/models/moonshotai/Kimi-K3.toml
+++ b/providers/nebius/models/moonshotai/Kimi-K3.toml
@@ -7,6 +7,12 @@
 # The gateway's generic schema accepts none/minimal/low/medium/high/xhigh/max (422 on other
 # input), but the model backend itself (sglang) rejects "minimal" and "xhigh" with a 400:
 # "Input should be 'none', 'low', 'medium', 'high' or 'max'". Only those 5 actually work.
+# Nebius does not offer a discounted prompt-cache tier for Kimi-K3: the models_info API has
+# no cache fields, the docs have no cache pricing for this model, and the public endpoint
+# page (tokenfactory.nebius.com) lists only "$3.00 / 1M In" and "$15.00 / 1M Out" with no
+# cache-hit rate. cache_read is set equal to input to reflect that cached and fresh input
+# tokens are billed identically, instead of leaving it unset (which downstream consumers
+# such as opencode were treating as $0/M, undercounting cost by ~18x on cache-heavy sessions).
 base_model = "moonshotai/kimi-k3"
 attachment = false
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
@@ -17,6 +23,7 @@ field = "reasoning_content"
 [cost]
 input = 3
 output = 15
+cache_read = 3
 
 [limit]
 context = 1_048_576


### PR DESCRIPTION
## Problem

`providers/nebius/models/moonshotai/Kimi-K3.toml` has no `cache_read` price. Consumers of models.dev pricing (e.g. opencode) treat a missing `cache_read` as `$0/M`, so cached input tokens are reported as free.

## Reality

Nebius Token Factory does not offer a discounted prompt-cache tier for Kimi-K3:

- `/api/public/models_info` (authoritative pricing source) has no cache-related fields for this model.
- `model-catalog.md` lists only `input_price_per_million_tokens` / `output_price_per_million_tokens`.
- The public model endpoint page on tokenfactory.nebius.com shows only `$3.00 / 1M In` and `$15.00 / 1M Out`, no cache-hit rate.

So cached and fresh input tokens are billed identically at the full input rate.

## Fix

Set `cache_read = 3`, equal to `input`, instead of leaving it unset. This reflects that there's no caching discount on Nebius for this model, rather than implying it's free, which was undercounting real cost by roughly 18x on cache-heavy sessions.