### PR TITLE
fix: factor DeepSeek V4 Flash 0731 providers

### DIFF
--- a/models/deepseek/deepseek-v4-flash-0731.toml
+++ b/models/deepseek/deepseek-v4-flash-0731.toml
@@ -1,0 +1,33 @@
+name = "DeepSeek V4 Flash 0731"
+description = "Official DeepSeek V4 Flash release with enhanced agentic capabilities and integrated DSpark speculative decoding"
+family = "deepseek-flash"
+release_date = "2026-07-31"
+last_updated = "2026-07-31"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-05"
+open_weights = true
+license = "MIT"
+
+[limit]
+context = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731"
+
+[[benchmarks]]
+name = "Terminal-Bench"
+score = 82.7
+metric = "pass@1"
+variant = "max"
+version = "2.1"
+source = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731"

--- a/packages/core/src/sync/providers/empiriolabs.ts
+++ b/packages/core/src/sync/providers/empiriolabs.ts
@@ -9,7 +9,7 @@ const API_ENDPOINT = "https://api.empiriolabs.ai/v1/models";
 
 const CANONICAL_BASE_MODELS: Record<string, string> = {
   "fugu-ultra": "sakana/fugu-ultra",
-  "deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash",
+  "deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash-0731",
   "gemma-4-26b-a4b": "google/gemma-4-26b-a4b-it",
   "gemma-4-e4b": "google/gemma-4-E4B-it",
   "mistral-medium-3": "mistral/mistral-medium-2505",

--- a/providers/baseten/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/baseten/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -3,8 +3,7 @@
 # low | medium | high | xhigh; no toggle or budget field is documented.
 # https://docs.baseten.co/inference/model-apis/overview (accessed 2026-08-01)
 
-base_model = "deepseek/deepseek-v4-flash"
-name = "DeepSeek V4 Flash 0731"
+base_model = "deepseek/deepseek-v4-flash-0731"
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/chutes/models/deepseek-ai/DeepSeek-V4-Flash-0731-TEE.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V4-Flash-0731-TEE.toml
@@ -1,14 +1,6 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash 0731 TEE"
-description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
-family = "deepseek"
-release_date = "2026-08-02"
 last_updated = "2026-08-02"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 reasoning_options = []
 
 [cost]
@@ -19,7 +11,3 @@ cache_read = 0.07
 [limit]
 context = 1_048_576
 output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -1,21 +1,11 @@
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
 # https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
+base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash"
-description = "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work"
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.
 # Anthropic: `thinking.type`, `output_config.effort = high|max`; budget ignored.
 # https://api-docs.deepseek.com/api/create-chat-completion (accessed 2026-06-25)
-family = "deepseek-flash"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-attachment = false
-reasoning = true
-temperature = true
-knowledge = "2025-05"
-tool_call = true
-structured_output = true
-open_weights = true
 
 [[reasoning_options]]
 type = "toggle"
@@ -32,11 +22,3 @@ input = 0.14
 output = 0.28
 reasoning = 0.28
 cache_read = 0.0028
-
-[limit]
-context = 1_000_000
-output = 384_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash-0731.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash-0731.toml
@@ -1,8 +1,4 @@
-base_model = "deepseek/deepseek-v4-flash"
-name = "DeepSeek V4 Flash 0731"
-description = "DeepSeek-V4-Flash-0731 is the official release of DeepSeek-V4-Flash, superseding the preview version, with substantially enhanced agentic capabilities. It has the same model structure as DeepSeek-V4-Flash-DSpark, i.e. it comes with a speculative decoding module attached."
-release_date = "2026-07-31"
-last_updated = "2026-07-31"
+base_model = "deepseek/deepseek-v4-flash-0731"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/opencode-go/models/deepseek-v4-flash.toml
+++ b/providers/opencode-go/models/deepseek-v4-flash.toml
@@ -1,4 +1,4 @@
-base_model = "deepseek/deepseek-v4-flash"
+base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash (New)"
 
 [[reasoning_options]]

--- a/providers/opencode/models/deepseek-v4-flash-free.toml
+++ b/providers/opencode/models/deepseek-v4-flash-free.toml
@@ -1,4 +1,4 @@
-base_model = "deepseek/deepseek-v4-flash"
+base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash Free (New)"
 
 [[reasoning_options]]

--- a/providers/opencode/models/deepseek-v4-flash.toml
+++ b/providers/opencode/models/deepseek-v4-flash.toml
@@ -1,4 +1,4 @@
-base_model = "deepseek/deepseek-v4-flash"
+base_model = "deepseek/deepseek-v4-flash-0731"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]

--- a/providers/openrouter/models/deepseek/deepseek-v4-flash-0731.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-flash-0731.toml
@@ -1,14 +1,4 @@
-name = "DeepSeek V4 Flash 0731"
-description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
-family = "deepseek"
-release_date = "2026-07-31"
-last_updated = "2026-07-31"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
+base_model = "deepseek/deepseek-v4-flash-0731"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/venice/models/deepseek-v4-flash-0731.toml
+++ b/providers/venice/models/deepseek-v4-flash-0731.toml
@@ -1,13 +1,5 @@
-name = "DeepSeek V4 Flash 0731"
-description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
-family = "deepseek"
-release_date = "2026-07-31"
+base_model = "deepseek/deepseek-v4-flash-0731"
 last_updated = "2026-08-01"
-attachment = false
-reasoning = true
-tool_call = true
-structured_output = true
-open_weights = false
 reasoning_options = []
 
 [cost]
@@ -16,9 +8,4 @@ output = 0.35
 cache_read = 0.035
 
 [limit]
-context = 1_000_000
 output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/vercel/models/deepseek/deepseek-v4-flash-0731.toml
+++ b/providers/vercel/models/deepseek/deepseek-v4-flash-0731.toml
@@ -1,23 +1,7 @@
-name = "DeepSeek V4 Flash 0731"
-description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
-family = "deepseek"
-release_date = "2026-04-23"
-last_updated = "2026-04-23"
-attachment = false
-reasoning = true
-tool_call = true
-open_weights = false
+base_model = "deepseek/deepseek-v4-flash-0731"
 reasoning_options = []
 
 [cost]
 input = 0.13
 output = 0.26
 cache_read = 0.028
-
-[limit]
-context = 1_000_000
-output = 384_000
-
-[modalities]
-input = ["text"]
-output = ["text"]


### PR DESCRIPTION
## Summary

- add canonical lab metadata for the distinct DeepSeek V4 Flash 0731 release
- factor Baseten, Chutes, DeepSeek, Fireworks AI, OpenCode Zen, OpenCode Go, OpenRouter, Venice, and Vercel entries through `base_model`
- update both paid and free OpenCode Zen routes plus the OpenCode Go route
- update the EmpirioLabs canonical mapping to prevent sync regressions

## Sources

- Model card and release description: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
- DeepSeek API docs confirm the unchanged `deepseek-v4-flash` API ID now serves DeepSeek-V4-Flash-0731: https://api-docs.deepseek.com/quick_start/pricing/
- OpenCode Go lists the undated `deepseek-v4-flash` route and current DeepSeek pricing: https://opencode.ai/docs/go/
- Model card documents `low`, `high`, and `max` reasoning effort levels and recommends up to 384K output for high/max

## Validation

- `bun validate`
- `git diff --check`