### PR TITLE
fix: drop temperature support from Claude models that reject sampling params

### DIFF
--- a/providers/302ai/models/claude-opus-4-7.toml
+++ b/providers/302ai/models/claude-opus-4-7.toml
@@ -6,7 +6,7 @@ last_updated = "2026-04-17"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
-temperature = true
+temperature = false
 tool_call = true
 open_weights = false
 knowledge = "2026-01-31"

--- a/providers/azure-cognitive-services/models/claude-opus-4-8.toml
+++ b/providers/azure-cognitive-services/models/claude-opus-4-8.toml
@@ -1,5 +1,4 @@
 base_model = "anthropic/claude-opus-4-8"
-temperature = true
 knowledge = "2025-12-31"
 # POST /anthropic/v1/messages uses adaptive thinking with output_config.effort
 # low/medium/high/xhigh/max; Azure catalog availability alone is not a control.

--- a/providers/azure/models/claude-opus-4-8.toml
+++ b/providers/azure/models/claude-opus-4-8.toml
@@ -1,5 +1,4 @@
 base_model = "anthropic/claude-opus-4-8"
-temperature = true
 knowledge = "2025-12-31"
 # Possible values described at https://platform.claude.com/docs/en/build-with-claude/effort#effort-levels
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/digitalocean/models/anthropic-claude-fable-5.toml
+++ b/providers/digitalocean/models/anthropic-claude-fable-5.toml
@@ -6,7 +6,7 @@ last_updated = "2026-06-12"
 attachment = true
 reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
-temperature = true
+temperature = false
 tool_call = true
 open_weights = false
 

--- a/providers/llmgateway/models/claude-sonnet-5.toml
+++ b/providers/llmgateway/models/claude-sonnet-5.toml
@@ -1,5 +1,4 @@
 base_model = "anthropic/claude-sonnet-5"
-temperature = true
 tool_call = false
 structured_output = true
 

--- a/providers/openrouter/models/anthropic/claude-opus-5.toml
+++ b/providers/openrouter/models/anthropic/claude-opus-5.toml
@@ -1,6 +1,5 @@
 base_model = "anthropic/claude-opus-5"
 description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
-temperature = true
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/vercel/models/anthropic/claude-fable-5.toml
+++ b/providers/vercel/models/anthropic/claude-fable-5.toml
@@ -1,6 +1,5 @@
 base_model = "anthropic/claude-fable-5"
 release_date = "2026-07-01"
-temperature = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-5-fast.toml
+++ b/providers/vercel/models/anthropic/claude-opus-5-fast.toml
@@ -1,6 +1,5 @@
 base_model = "anthropic/claude-opus-5"
 name = "Claude Opus 5 (Fast)"
-temperature = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-opus-5.toml
+++ b/providers/vercel/models/anthropic/claude-opus-5.toml
@@ -1,6 +1,5 @@
 base_model = "anthropic/claude-opus-5"
 description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
-temperature = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]

--- a/providers/vercel/models/anthropic/claude-sonnet-5.toml
+++ b/providers/vercel/models/anthropic/claude-sonnet-5.toml
@@ -1,6 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
 release_date = "2026-06-29"
-temperature = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [cost]


### PR DESCRIPTION
Ten provider entries advertise `temperature = true` for Claude models that removed
sampling parameters.

Anthropic dropped `temperature` / `top_p` / `top_k` on Opus 4.7 and later, Sonnet 5 and
Fable 5 — sending any of them returns a `400`. That is a property of the model, not of
the host, so a relay cannot add it back; at best it silently discards the value, which is
still not what `temperature = true` tells a consumer.

The catalog already knows this. `models/anthropic/claude-opus-5.toml` says
`temperature = false`, and eight of these entries declare `base_model` pointing at that
lab entry and then override it back to `true`:

```toml
# providers/vercel/models/anthropic/claude-opus-5.toml
base_model = "anthropic/claude-opus-5"   # lab entry: temperature = false
temperature = true                        # ...overridden back to true
```

AGENTS.md says a provider entry should carry "only real overrides", and this is not a
real override — it contradicts the lab model it inherits from. So those eight lines are
dropped and the lab value is inherited.

`providers/302ai/claude-opus-4-7` and `providers/digitalocean/anthropic-claude-fable-5`
have no `base_model`, so there is nothing to inherit; those two are set to
`temperature = false` explicitly instead.

### Affected

| provider | model |
|---|---|
| vercel | claude-opus-5, claude-opus-5-fast, claude-sonnet-5, claude-fable-5 |
| openrouter | claude-opus-5 |
| azure, azure-cognitive-services | claude-opus-4-8 |
| llmgateway | claude-sonnet-5 |
| digitalocean | claude-fable-5 *(standalone)* |
| 302ai | claude-opus-4-7 *(standalone)* |

Anthropic's migration guide lists the removal under the Opus 4.7 breaking changes, and it
carries forward to 4.8, Opus 5, Sonnet 5 and Fable 5:
https://platform.claude.com/docs/en/about-claude/models/migration-guide

### Checks

`bun validate` passes.

Rechecked the whole catalog afterwards: no remaining entry sets `temperature = true` for
a model in that group.

### Not included

Same sweep also found `xhigh` listed in `reasoning_options` for pre-4.7 models
(`perplexity-agent`, `xpersona`, `llmgateway` — Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6).
`xhigh` was introduced with Opus 4.7, so those look wrong too, but a gateway could
plausibly be mapping `xhigh` onto `max`, and that is a weaker claim than this one. Left
out to keep this change to the part I can state with confidence — happy to open a
separate PR if you want it fixed.

---

Written with AI assistance (Claude Code); I reviewed the change and ran `bun validate`.
