### PR TITLE
feat(digitalocean): add Kimi K3

### DIFF
--- a/providers/digitalocean/models/kimi-k3.toml
+++ b/providers/digitalocean/models/kimi-k3.toml
@@ -1,0 +1,19 @@
+# DigitalOcean exposes Kimi K3 as serverless with text/image input and $3/$15/$0.30 pricing,
+# but currently omits context and output limits; those inherit from canonical metadata.
+# https://api.digitalocean.com/v2/gen-ai/models/catalog (accessed 2026-08-02)
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
## Summary
- adds DigitalOcean serverless `kimi-k3` using canonical `moonshotai/kimi-k3` metadata
- records DigitalOcean pricing at $3 input, $15 output, and $0.30 cache read per million tokens
- overrides the canonical video modality with DigitalOcean's advertised text/image input subset
- advertises Kimi K3's native `low` / `high` / `max` effort controls and `reasoning_content` side channel

DigitalOcean currently omits context and output limits for this catalog row, so those inherit from canonical metadata.

## Sources
- https://api.digitalocean.com/v2/gen-ai/models/catalog
- https://platform.kimi.ai/docs/pricing/chat-k3

## Verification
- `bun models:sync digitalocean` retained the hand-authored entry unchanged
- `bun validate`