### PR TITLE
feat(alibaba-token-plan): add Qwen3.8 Max

### DIFF
--- a/models/alibaba/qwen3.8-max.toml
+++ b/models/alibaba/qwen3.8-max.toml
@@ -1,0 +1,30 @@
+# Sources (accessed 2026-08-03):
+# https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
+# https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
+# https://docs.qwencloud.com/developer-guides/getting-started/text-generation-models
+# https://platform.qianwenai.com/docs/developer-guides/getting-started/text-generation-models
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/kilo-cli
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/kilo-cli
+# https://github.com/QwenLM/qwen-code/issues/7198
+# https://github.com/QwenLM/qwen-code/pull/7199
+
+name = "Qwen3.8 Max"
+description = "Qwen flagship for million-token multimodal reasoning and long-horizon agentic workflows"
+family = "qwen"
+release_date = "2026-08-03"
+last_updated = "2026-08-03"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/alibaba-token-plan-cn/models/qwen3.8-max.toml
+++ b/providers/alibaba-token-plan-cn/models/qwen3.8-max.toml
@@ -1,0 +1,35 @@
+# Sources (accessed 2026-08-03):
+# https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
+# https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-quickstart
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/opencode
+# https://platform.qianwenai.com/docs/developer-guides/clients-and-developer-tools/kilo-cli
+# https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
+# https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
+# Thinking is always enabled. In thinking mode, temperature defaults to 0.6
+# and values below 0.6 are raised to 0.6. This provider uses the OpenAI-compatible
+# Chat API, whose native qwen3.8 effort values are low/medium/xhigh (default
+# xhigh); the standard high value is accepted as an alias and maps to xhigh.
+# The OpenCode guide labels its tiers low/high/xhigh and configures a 262144-token
+# thinking budget for the China endpoint. `thinking_budget` (0..262144) cannot
+# be combined with `reasoning_effort`. A zero budget maps to low effort; it does
+# not disable thinking. API: {"reasoning_effort":"medium"} or
+# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients must
+# replay every historical `reasoning_content` value unchanged.
+# structured_output: the gateway accepts response_format json_schema (probed
+# 2026-07-24 on the Singapore endpoint; China shares the catalogue).
+
+base_model = "alibaba/qwen3.8-max"
+structured_output = true
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262_144 },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan/models/qwen3.8-max.toml
+++ b/providers/alibaba-token-plan/models/qwen3.8-max.toml
@@ -1,0 +1,35 @@
+# Sources (accessed 2026-08-03):
+# https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
+# https://docs.qwencloud.com/token-plan/personal/token-plan-personal-quickstart
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/opencode
+# https://docs.qwencloud.com/developer-guides/clients-and-developer-tools/kilo-cli
+# https://docs.qwencloud.com/developer-guides/text-generation/thinking
+# https://docs.qwencloud.com/api-reference/chat/openai-chat
+# Thinking is always enabled. In thinking mode, temperature defaults to 0.6
+# and values below 0.6 are raised to 0.6. This provider uses the OpenAI-compatible
+# Chat API, whose native qwen3.8 effort values are low/medium/xhigh (default
+# xhigh); the standard high value is accepted as an alias and maps to xhigh.
+# The OpenCode guide labels its tiers low/high/xhigh and configures a 99072-token
+# thinking budget for the international endpoint. `thinking_budget` (0..262144)
+# cannot be combined with `reasoning_effort`. A zero budget maps to low effort;
+# it does not disable thinking. API: {"reasoning_effort":"medium"} or
+# {"thinking_budget":16384}. `preserve_thinking` defaults to true, so clients must
+# replay every historical `reasoning_content` value unchanged.
+# structured_output: the gateway accepts response_format json_schema (probed
+# 2026-07-24: strict schema request returned {"n": 7}).
+
+base_model = "alibaba/qwen3.8-max"
+structured_output = true
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262_144 },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
## Summary

- add provider-agnostic metadata for the production `qwen3.8-max` model
- add `qwen3.8-max` to the international and China Alibaba Token Plan catalogs
- retain `qwen3.8-max-preview` because it remains separately listed and is still referenced by another provider

## Why

The catalog only contained `qwen3.8-max-preview`, while QwenCloud and the Qianwen AI Platform now list the production model ID `qwen3.8-max`. Without a separate production entry, clients cannot discover or resolve the official model ID.

Alibaba Token Plan is a first-party Alibaba API surface. The production entries keep the native controls already verified for the promoted model family: `reasoning_effort` with `low`, `medium`, and `xhigh`, plus the mutually exclusive `thinking_budget` range from 0 to 262144 tokens. Reasoning is returned through `reasoning_content`.

## Sources

- https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
- https://platform.qianwenai.com/docs/token-plan/personal/token-plan-personal-overview
- https://docs.qwencloud.com/developer-guides/getting-started/text-generation-models
- https://platform.qianwenai.com/docs/developer-guides/getting-started/text-generation-models
- https://docs.qwencloud.com/api-reference/chat/openai-chat
- https://platform.qianwenai.com/docs/api-reference/chat/openai-chat

## Validation

- `bun validate`
- `cd packages/web && bun run build`
