### PR TITLE
fix(sync): dedupe Kilo reasoning efforts

### DIFF
--- a/packages/core/src/sync/providers/kilo.ts
+++ b/packages/core/src/sync/providers/kilo.ts
@@ -270,7 +270,7 @@ function KiloReasoningOptions(opencode: KiloModel["opencode"]): SyncedFullModel[
     .map(([, variant]) => variant.reasoning?.effort)
     .filter((effort): effort is string => effort !== undefined);
   const hasNone = variants.some(([, variant]) => variant.reasoning?.enabled === false);
-  const allEfforts = hasNone ? [...efforts, "none"] : [...efforts];
+  const allEfforts = [...new Set(hasNone ? [...efforts, "none"] : efforts)];
 
   if (allEfforts.length > 0) {
     const orderedEfforts = allEfforts.sort((a, b) => {


### PR DESCRIPTION
## Summary
- deduplicate normalized Kilo reasoning effort values before sorting
- prevent repeated values such as `["none", "low", "medium", "high", "xhigh", "xhigh"]` in generated provider metadata

## Verification
- live `bun models:sync kilo`
- `bun validate`
- checked every generated Kilo reasoning option for duplicate values
- `git diff --check`