### PR TITLE
fix(sync): harden NanoGPT reasoning metadata

### DIFF
--- a/packages/core/src/sync/providers/nano-gpt.ts
+++ b/packages/core/src/sync/providers/nano-gpt.ts
@@ -51,7 +51,7 @@ export const NanoGptModel = z.object({
 }).passthrough();
 
 export const NanoGptResponse = z.object({
-  data: z.array(NanoGptModel),
+  data: z.array(NanoGptModel).min(1),
 }).passthrough();
 
 export type NanoGptModel = z.infer<typeof NanoGptModel>;
@@ -138,8 +138,10 @@ export function buildNanoGptModel(
   const inputLimit = sourceContext ?? existing?.limit?.input;
   const outputLimit = sourceOutputLimit ?? existing?.limit?.output;
   const releaseDate = dateFromTimestamp(model.created) ?? existing?.release_date;
-  const inferredSourceReasoning = capabilities.reasoning
-    ?? (model.reasoning_efforts != null ? true : undefined);
+  const hasReasoningEfforts = model.reasoning_efforts != null && model.reasoning_efforts.length > 0;
+  const inferredSourceReasoning = hasReasoningEfforts
+    ? true
+    : capabilities.reasoning ?? (model.reasoning_efforts != null ? true : undefined);
   const reasoning = inferredSourceReasoning ?? existing?.reasoning ?? false;
   const cost = buildCost(model.pricing, existing);
   if (baseModel !== undefined) {
@@ -255,8 +257,11 @@ function reasoningOptions(
   if (reasoning === false) return undefined;
   if (reasoning === undefined) return existing;
   if (model.reasoning_efforts == null) return existing ?? [];
-  if (model.reasoning_efforts.length === 0) return [];
-  return [{ type: "effort", values: [...model.reasoning_efforts] }];
+  if (model.reasoning_efforts.length === 0) return existing ?? [];
+  const order = ReasoningEffort.options;
+  const efforts = [...new Set(model.reasoning_efforts)]
+    .sort((a, b) => order.indexOf(a) - order.indexOf(b));
+  return [{ type: "effort", values: efforts }];
 }
 
 export function resolveNanoGptBaseModel(modelID: string) {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -177,6 +177,30 @@ test("accepts only NanoGPT's supported reasoning effort values", () => {
   expect(NanoGptResponse.safeParse({
     data: [{ ...nanoGptModel(), reasoning_efforts: ["default"] }],
   }).success).toBe(false);
+  expect(NanoGptResponse.safeParse({ data: [] }).success).toBe(false);
+});
+
+test("normalizes authoritative NanoGPT reasoning efforts and preserves incomplete controls", () => {
+  const contradictory = buildNanoGptModel(nanoGptModel({
+    capabilities: { reasoning: false },
+    reasoning_efforts: ["high", "low", "high"],
+  }), undefined);
+  const incomplete = buildNanoGptModel(nanoGptModel({
+    capabilities: { reasoning: true },
+    reasoning_efforts: [],
+  }), {
+    reasoning: true,
+    reasoning_options: [{ type: "toggle" }, { type: "budget_tokens" }],
+  });
+
+  expect(contradictory).toMatchObject({
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+  });
+  expect(incomplete).toMatchObject({
+    reasoning: true,
+    reasoning_options: [{ type: "toggle" }, { type: "budget_tokens" }],
+  });
 });
 
 test("factors NanoGPT variants against canonical models without retaining wrong intrinsic metadata", () => {


### PR DESCRIPTION
## Summary

- reject empty NanoGPT catalog responses before destructive reconciliation
- treat explicit non-empty reasoning efforts as authoritative
- preserve authored controls when the endpoint returns an empty effort list
- deduplicate and canonically order effort values

## Validation

- `bun validate`
- all NanoGPT tests in `bun test packages/core/test/sync.test.ts` pass
- `git diff --check`

The complete sync test file currently has two unrelated failures on `dev` in Hyper and DeepInfra expectations.