### PR TITLE
feat(ollama-cloud): add deepseek-v4-flash:0731-cloud

### DIFF
--- a/providers/ollama-cloud/models/deepseek-v4-flash:0731-cloud.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-flash:0731-cloud.toml
@@ -1,9 +1,9 @@
 # OpenAI POST /v1/chat/completions: top-level `reasoning_effort` or
-# `reasoning.effort` with "high"|"max"; "none" disables reasoning (toggle).
+# `reasoning.effort` with "none"|"high"|"max"; "none" disables reasoning.
 base_model = "deepseek/deepseek-v4-flash-0731"
 name = "deepseek-v4-flash:0731-cloud"
 
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
 
 [limit]
 context = 1048576

--- a/providers/ollama-cloud/models/deepseek-v4-flash:0731-cloud.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-flash:0731-cloud.toml
@@ -1,0 +1,18 @@
+name = "deepseek-v4-flash:0731-cloud"
+description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
+family = "deepseek-flash"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+tool_call = true
+release_date = "2026-07-31"
+last_updated = "2026-07-31"
+open_weights = true
+
+[limit]
+context = 1048576
+output = 1048576
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ollama-cloud/models/deepseek-v4-flash:0731-cloud.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-flash:0731-cloud.toml
@@ -1,18 +1,10 @@
+# OpenAI POST /v1/chat/completions: top-level `reasoning_effort` or
+# `reasoning.effort` with "high"|"max"; "none" disables reasoning (toggle).
+base_model = "deepseek/deepseek-v4-flash-0731"
 name = "deepseek-v4-flash:0731-cloud"
-description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
-family = "deepseek-flash"
-attachment = false
-reasoning = true
+
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
-tool_call = true
-release_date = "2026-07-31"
-last_updated = "2026-07-31"
-open_weights = true
 
 [limit]
 context = 1048576
 output = 1048576
-
-[modalities]
-input = ["text"]
-output = ["text"]


### PR DESCRIPTION
## Summary
- adds Ollama Cloud `deepseek-v4-flash:0731-cloud` to the `ollama-cloud` provider catalog
- self-contained model definition mirroring the existing `deepseek-v4-flash.toml` entry, with `:0731-cloud` as the tagged revision ID
- `release_date` / `last_updated` set to `2026-07-31` matching the 0731 post-training revision
- advertises native `high` / `max` effort controls (plus toggle) for the OpenAI-compatible endpoint, consistent with sibling `deepseek-v4-flash.toml`

## Sources
- https://ollama.com/library/deepseek-v4-flash

## Verification
- `bun validate`
