### PR TITLE
feat(ollama-cloud): add deepseek-v4-flash:0731 model

### DIFF
--- a/providers/ollama-cloud/models/deepseek-v4-flash:0731.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-flash:0731.toml
@@ -1,0 +1,12 @@
+# Toggle: native POST /api/chat and /api/generate use `think = true|false`.
+# Effort: OpenAI POST /v1/chat/completions accepts top-level `reasoning_effort`
+# or `reasoning.effort` with high|max (DeepSeek V4 maps low/medium -> high).
+# Sources: https://docs.ollama.com/capabilities/thinking, https://docs.ollama.com/openai
+# API-verified context: https://ollama.com/api/show (deepseek4.context_length = 1048576)
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[limit]
+context = 1048576
+output = 1048576


### PR DESCRIPTION
## Context

Ollama Cloud has been serving `deepseek-v4-flash:0731` since 2026-07-31 (the 0731 snapshot of DeepSeek V4 Flash, with enhanced agentic capabilities and integrated DSpark speculative decoding). The lab metadata already exists on `dev` at [deepseek-v4-flash-0731.toml](https://github.com/anomalyco/models.dev/blob/dev/models/deepseek/deepseek-v4-flash-0731.toml); this PR adds the missing provider entry so the model surfaces under `ollama-cloud` in the generated catalog.

> **Note:** An earlier open PR, #3976, adds the same model. This PR is a corrected alternative — see "Relationship to #3976" below. Happy to defer to the maintainers on which to land.

Confirmed live on the Ollama Cloud API:

```fish
$ curl -s https://ollama.com/api/tags | jq -r '.models[] | .name' | grep deepseek-v4-flash
deepseek-v4-flash
deepseek-v4-flash:0731

$ curl -s https://ollama.com/api/show -d '{"model":"deepseek-v4-flash:0731"}' | jq '.'
{
  "capabilities": ["completion", "tools", "thinking"],
  "details": { "family": "deepseek4", "parameter_size": "304180418494", "quantization_level": "FP8" },
  "model_info": { "deepseek4.context_length": 1048576, "general.architecture": "deepseek4" },
  "modified_at": "2026-07-31T08:00:00-07:00"
}
```

## What changed

- Added `providers/ollama-cloud/models/deepseek-v4-flash:0731.toml`, a `base_model`-factored provider entry that inherits provider-agnostic facts from the existing lab metadata and only declares host-specific overrides.

## Critical Changes

- **New model on `ollama-cloud`:** `deepseek-v4-flash:0731` now resolves in the generated catalog with `limit.context = 1_048_576` / `limit.output = 1_048_576` and `reasoning_options` of `toggle` + `effort: ["high", "max"]`.
- **Override-only:** the provider file uses `base_model = "deepseek/deepseek-v4-flash-0731"` and restates only `reasoning_options` and `[limit]` (real deltas vs. the lab's 1M/384K limits). `name`, `description`, `family`, dates, capabilities, modalities, `open_weights`, `license`, `weights`, and `benchmarks` are inherited from the lab entry.
- **Reasoning controls:** `toggle` + `effort: ["high", "max"]` matches the DeepSeek V4 family on this provider (see [deepseek-v4-flash.toml](https://github.com/anomalyco/models.dev/blob/dev/providers/ollama-cloud/models/deepseek-v4-flash.toml) and [deepseek-v4-pro.toml](https://github.com/anomalyco/models.dev/blob/dev/providers/ollama-cloud/models/deepseek-v4-pro.toml)) and the AGENTS.md DeepSeek V4 guidance (`toggle` + `high`/`max`, not L/M/H).
- **Context override rationale:** the lab's `1_000_000` is a rounded figure; Ollama Cloud's `/api/show` exposes the real `deepseek4.context_length = 1_048_576`. `output = context` follows the established ollama-cloud convention (#1586).

## Expected behavior

- `bun validate` passes (exit 0).
- Resolved provider model:
  - `id`: `deepseek-v4-flash:0731`
  - `name`: `DeepSeek V4 Flash 0731` (inherited from lab)
  - `limit`: `{ context: 1048576, output: 1048576 }`
  - `reasoning_options`: `[{ type: "toggle" }, { type: "effort", values: ["high", "max"] }]`
  - All other fields inherited from `models/deepseek/deepseek-v4-flash-0731.toml`.

## Relationship to #3976

#3976 covers the same model. This PR fixes three issues in that one:

1. **Model ID matches the live API.** #3976 names the file `deepseek-v4-flash:0731-cloud.toml` (and overrides `name` to the same string). The Ollama Cloud API exposes `deepseek-v4-flash:0731` — both `/api/tags` and `/v1/models` — with no `-cloud`/`:cloud` suffix. The suffixed form has been a recurring source of 400/404 errors in downstream consumers (e.g. [NousResearch/hermes-agent#16179](https://github.com/NousResearch/hermes-agent/issues/16179)).
2. **`name` inherited, not restated.** Per AGENTS.md override-only, `name` should not be restated when it doesn't truly differ; if it does, it shouldn't be the raw ID. This PR inherits the lab's display name `"DeepSeek V4 Flash 0731"`.
3. **`reasoning_options` match the DeepSeek V4 siblings.** AGENTS.md specifies `toggle` + `high`/`max` for DeepSeek V4 (no `none`). The existing `deepseek-v4-flash.toml` and `deepseek-v4-pro.toml` both use `[{ toggle }, { effort: ["high","max"] }]`. #3976 drops `toggle` and adds `none`, which contradicts both the policy and the sibling pattern on the same provider.