### PR TITLE
feat(alibaba-token-plan): add DeepSeek V4 Flash 0731

### DIFF
--- a/providers/alibaba-token-plan/models/deepseek-v4-flash-0731.toml
+++ b/providers/alibaba-token-plan/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,19 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+# Reasoning HTTP format (accessed 2026-06-25):
+# This model toggles with `enable_thinking`: true or false. Chat Completions
+# `reasoning_effort` accepts high (default) or max; low/medium map to high and
+# xhigh maps to max. Anthropic Messages defaults `reasoning_effort` to max.
+# Sources:
+# https://www.alibabacloud.com/help/en/model-studio/deepseek-api
+# https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
+
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
## Summary

- add `deepseek-v4-flash-0731` to the international Alibaba Token Plan provider
- inherit the existing canonical `deepseek/deepseek-v4-flash-0731` metadata
- retain the provider-specific reasoning controls, interleaved reasoning field, and zero-cost subscription accounting

## Evidence

Alibaba Cloud's OpenCode configuration documents `deepseek-v4-flash-0731` as a Token Plan (Team Edition) model:
https://www.alibabacloud.com/help/en/model-studio/opencode

The model was also verified against the international Token Plan endpoint with a successful completion. The existing undated entry is retained because Alibaba's public configuration currently lists both IDs.

## Validation

- `bun validate`