### PR TITLE
fix(sync): inherit Hyper reasoning from base models

### DIFF
--- a/packages/core/src/sync/providers/hyper.ts
+++ b/packages/core/src/sync/providers/hyper.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { describeModel } from "../../describe.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
-import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
+import { factorBaseModel, modelMetadata, resolveModelMetadataBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://hyper.charm.land/v1/models";
 const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
@@ -145,7 +145,16 @@ export function buildHyperModel(
     output: model.max_output_tokens,
   };
   const modalities = hyperModalities(model.capabilities?.vision ?? false);
-  const reasoning = model.reasoning != null;
+  const resolvedBase = resolveHyperBaseModel(model.id, baseModel);
+  const advertisedReasoning = model.reasoning != null;
+  // An omitted reasoning object means Hyper advertises no controls, not that a
+  // canonical model's reasoning capability is disabled.
+  const reasoning = resolvedBase !== undefined && !advertisedReasoning
+    ? undefined
+    : advertisedReasoning;
+  const inheritedReasoning = resolvedBase === undefined
+    ? false
+    : modelMetadata(resolvedBase).reasoning === true;
   const releaseDate = existing?.release_date ?? dateFromTimestamp(model.created);
   const values: Partial<SyncedFullModel> = {
     attachment: modalities.input.some((value) => value !== "text"),
@@ -157,9 +166,12 @@ export function buildHyperModel(
     cost: buildCost(model, existing?.cost),
     limit,
   };
-  if (reasoning) values.reasoning_options = reasoningOptions(model);
+  if (advertisedReasoning) {
+    values.reasoning_options = reasoningOptions(model);
+  } else if (inheritedReasoning) {
+    values.reasoning_options = [];
+  }
 
-  const resolvedBase = resolveHyperBaseModel(model.id, baseModel);
   if (resolvedBase !== undefined) {
     return factorBaseModel(
       resolvedBase,

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -541,7 +541,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function modelMetadata(modelID: string) {
+export function modelMetadata(modelID: string) {
   let metadata = modelMetadataByID.get(modelID);
   if (metadata === undefined) {
     const filePath = path.join(MODELS_DIR, `${modelID}.toml`);

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1802,9 +1802,9 @@ test("syncs Hyper pricing from catalog input/output fields", () => {
 
   expect(buildHyperModel(model, undefined, "minimax/MiniMax-M2.7")).toMatchObject({
     cost: { input: 0.3, output: 1.2, cache_read: 0.06, cache_write: 0.03 },
-    reasoning: false,
+    reasoning_options: [],
   });
-  expect(buildHyperModel(model, undefined, "minimax/MiniMax-M2.7")).not.toHaveProperty("reasoning_options");
+  expect(buildHyperModel(model, undefined, "minimax/MiniMax-M2.7")).not.toHaveProperty("reasoning");
 });
 
 test("rounds Hyper pricing to six decimal places", () => {
@@ -1822,7 +1822,7 @@ test("rounds Hyper pricing to six decimal places", () => {
   });
 });
 
-test("sets Hyper reasoning false when API omits reasoning metadata", () => {
+test("inherits Hyper reasoning when API omits reasoning metadata", () => {
   const model = hyperModel({ id: "llama-3.3-70b-instruct", reasoning: undefined });
 
   expect(buildHyperModel(model, undefined, "meta/llama-3.3-70b-instruct")).toMatchObject({
@@ -1832,8 +1832,9 @@ test("sets Hyper reasoning false when API omits reasoning metadata", () => {
   expect(buildHyperModel(model, undefined, "meta/llama-3.3-70b-instruct")).not.toHaveProperty("reasoning_options");
 
   expect(buildHyperModel(hyperModel({ id: "minimax-m2.7", reasoning: undefined }), undefined, "minimax/MiniMax-M2.7")).toMatchObject({
-    reasoning: false,
+    reasoning_options: [],
   });
+  expect(buildHyperModel(hyperModel({ id: "minimax-m2.7", reasoning: undefined }), undefined, "minimax/MiniMax-M2.7")).not.toHaveProperty("reasoning");
 });
 
 test("preserves existing Hyper cost when API pricing is missing", () => {
@@ -1850,8 +1851,8 @@ test("preserves existing Hyper cost when API pricing is missing", () => {
 
 test("creates a full Hyper model when no base_model metadata exists", () => {
   const model = hyperModel({
-    id: "qwen3.7-flash",
-    display_name: "Qwen3.7-Flash",
+    id: "custom-coder",
+    display_name: "Custom Coder",
     reasoning: undefined,
     capabilities: { vision: true },
     pricing: {
@@ -1863,7 +1864,7 @@ test("creates a full Hyper model when no base_model metadata exists", () => {
   });
 
   expect(buildHyperModel(model, undefined)).toMatchObject({
-    name: "Qwen3.7-Flash",
+    name: "Custom Coder",
     attachment: true,
     reasoning: false,
     tool_call: true,
@@ -1879,7 +1880,7 @@ test("creates a full Hyper model when no base_model metadata exists", () => {
 test("factors new Hyper models against unique models/ metadata", () => {
   expect(buildHyperModel(hyperModel({ id: "kimi-k3", reasoning: undefined }), undefined)).toMatchObject({
     base_model: "moonshotai/kimi-k3",
-    reasoning: false,
+    reasoning_options: [],
   });
 });
 


### PR DESCRIPTION
## Summary

- treat an omitted Charm Hyper `reasoning` object as absent control metadata rather than an explicit non-reasoning assertion
- inherit `reasoning` from canonical base models
- emit `reasoning_options = []` for reasoning-capable base models when Hyper advertises no controls
- retain explicit Hyper effort levels when advertised

## Verification

- `bun test packages/core/test/sync.test.ts --test-name-pattern Hyper`
- `bun validate`

The complete sync test file currently has an unrelated pre-existing DeepInfra fixture failure on `dev`: newly available canonical Qwen metadata causes the fixture to factor against a base model.