### PR TITLE
fix(chutes): declare reasoning toggles instead of empty options

### DIFF
--- a/packages/core/src/sync/providers/chutes.ts
+++ b/packages/core/src/sync/providers/chutes.ts
@@ -134,9 +134,11 @@ export function buildChutesModel(
     last_updated: existing?.last_updated ?? today,
     attachment,
     reasoning,
-    // Chutes' /v1/models advertises `reasoning` as a capability but exposes no parameter
-    // to toggle or set its effort, so there is no provider evidence for a reasoning option.
-    reasoning_options: [],
+    // Chutes' /v1/models advertises `reasoning` as a capability but lists no sampling
+    // parameter for it, so the endpoint alone cannot describe the control. The real
+    // control is `chat_template_kwargs`, which is hand-authored per model. Leaving this
+    // field unset lets preserveReasoningOptions keep those authored options and default
+    // only new, unannotated reasoners to an empty list.
     temperature,
     tool_call: toolCall,
     structured_output: structuredOutput ? true : undefined,

--- a/providers/chutes/models/Qwen/Qwen3-32B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3-32B-TEE.toml
@@ -1,7 +1,12 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
+# Source: https://huggingface.co/Qwen/Qwen3-32B (chat template exposes enable_thinking)
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 base_model = "alibaba/qwen3-32b"
 name = "Qwen3 32B TEE"
 structured_output = true
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 0.104

--- a/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.5-397B-A17B-TEE.toml
@@ -1,9 +1,14 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
+# Source: https://huggingface.co/Qwen/Qwen3.5-397B-A17B (chat template exposes enable_thinking)
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 base_model = "alibaba/qwen3.5-397b-a17b"
 name = "Qwen3.5 397B A17B TEE"
-reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 0.45

--- a/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
+++ b/providers/chutes/models/Qwen/Qwen3.6-27B-TEE.toml
@@ -1,6 +1,11 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
+# Source: https://huggingface.co/Qwen/Qwen3.6-27B (chat template exposes enable_thinking)
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 base_model = "alibaba/qwen3.6-27b"
 name = "Qwen3.6 27B TEE"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 0.3

--- a/providers/chutes/models/deepseek-ai/DeepSeek-V3.2-TEE.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V3.2-TEE.toml
@@ -1,3 +1,6 @@
+# Toggle: chat_template_kwargs.thinking = true|false
+# Source: https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp (chat template exposes thinking)
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 name = "DeepSeek V3.2 TEE"
 description = "DeepSeek chat model for instruction following, coding, and analysis"
 family = "deepseek"
@@ -9,10 +12,12 @@ temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
-reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 1

--- a/providers/chutes/models/deepseek-ai/DeepSeek-V4-Flash-0731-TEE.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V4-Flash-0731-TEE.toml
@@ -1,7 +1,11 @@
+# Toggle: chat_template_kwargs.thinking = true|false
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek V4 Flash 0731 TEE"
 last_updated = "2026-08-02"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 0.14

--- a/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
+++ b/providers/chutes/models/google/gemma-4-31B-turbo-TEE.toml
@@ -1,6 +1,11 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
+# Source: https://huggingface.co/google/gemma-4-31b-it (chat template exposes enable_thinking)
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 base_model = "google/gemma-4-31b-it"
 name = "gemma 4 31B turbo TEE"
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 0.12

--- a/providers/chutes/models/moonshotai/Kimi-K2.6-TEE.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K2.6-TEE.toml
@@ -1,10 +1,15 @@
+# Toggle: chat_template_kwargs.thinking = true|false
+# Source: https://huggingface.co/moonshotai/Kimi-K2.6 (chat template exposes thinking)
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 base_model = "moonshotai/kimi-k2.6"
 name = "Kimi K2.6 TEE"
 knowledge = "2025-12"
-reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 0.66

--- a/providers/chutes/models/moonshotai/Kimi-K3-TEE.toml
+++ b/providers/chutes/models/moonshotai/Kimi-K3-TEE.toml
@@ -1,10 +1,14 @@
+# Toggle: chat_template_kwargs.thinking = true|false
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 base_model = "moonshotai/kimi-k3"
 name = "Kimi K3 TEE"
 description = "Kimi multimodal agent model for visual understanding, coding, and planning"
 release_date = "2026-07-29"
 last_updated = "2026-07-29"
 temperature = true
-reasoning_options = []
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 3

--- a/providers/chutes/models/zai-org/GLM-5.1-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-5.1-TEE.toml
@@ -1,9 +1,14 @@
+# Toggle: chat_template_kwargs.thinking = true|false
+# Source: https://huggingface.co/zai-org/GLM-5.1 (chat template exposes thinking)
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 base_model = "zhipuai/glm-5.1"
 name = "GLM 5.1 TEE"
-reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 0.98

--- a/providers/chutes/models/zai-org/GLM-5.2-TEE.toml
+++ b/providers/chutes/models/zai-org/GLM-5.2-TEE.toml
@@ -1,9 +1,14 @@
+# Toggle: chat_template_kwargs.thinking = true|false
+# Source: https://huggingface.co/zai-org/GLM-5.2 (chat template exposes thinking)
+# Verified live on POST https://llm.chutes.ai/v1/chat/completions: reasoning_content present when on, absent when off
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2 TEE"
-reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
 
 [cost]
 input = 1.25

--- a/providers/chutes/provider.toml
+++ b/providers/chutes/provider.toml
@@ -1,11 +1,16 @@
 name = "Chutes"
 env = ["CHUTES_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-# Raw HTTP reasoning controls (sources accessed 2026-06-25):
-# POST https://llm.chutes.ai/v1/chat/completions. GET /v1/models marks models
-# with supported_features including "reasoning", but its advertised sampling
-# parameters contain no toggle, effort, or budget field. The reasoning guide's
-# request surface likewise documents none; reasoning capability is not control.
+# Raw HTTP reasoning controls (sources accessed 2026-08-03):
+# POST https://llm.chutes.ai/v1/chat/completions. GET /v1/models still marks
+# models with supported_features "reasoning" while listing no toggle, effort, or
+# budget among its sampling parameters, so the endpoint alone does not describe
+# the control. The control is `chat_template_kwargs`, forwarded to each model's
+# chat template: `enable_thinking` for Qwen and Gemma checkpoints, `thinking`
+# for Kimi, GLM and DeepSeek. Verified per model against the published chat
+# template and a live request (reasoning_content present when on, absent when
+# off). Authored per model, since it varies by checkpoint rather than by host:
+# Qwen3-235B-A22B-Thinking-2507 exposes no switch and keeps an empty list.
 # https://llm.chutes.ai/v1/models
 # https://chutes.ai/docs/guides/reasoning-models
 api = "https://llm.chutes.ai/v1"

--- a/sync.md
+++ b/sync.md
@@ -261,7 +261,7 @@ Chutes is implemented in `packages/core/src/sync/providers/chutes.ts`.
 - Source endpoint: `https://llm.chutes.ai/v1/models`; no auth required (the model list is public).
 - Model IDs map directly to TOML paths under `providers/chutes/models`.
 - `reasoning`, `tool_call`, and `structured_output` come from `supported_features`; `temperature` comes from `supported_sampling_parameters`.
-- `reasoning_options` is always an empty array: the API advertises a `reasoning` capability but exposes no toggle or effort parameter, so there is no provider evidence for a reasoning option.
+- `reasoning_options` is hand-authored, not derived: the API advertises a `reasoning` capability but no toggle or effort parameter, while the models accept a `chat_template_kwargs` thinking switch (`enable_thinking` for Qwen/Gemma, `thinking` for Kimi/GLM/DeepSeek). The sync leaves the field unset so authored options survive; new reasoners without an entry still default to an empty array.
 - TEE model IDs emit `base_model` references to matching `models/` metadata; checkpoints without a canonical entry (e.g. `Qwen3-235B-A22B-Thinking-2507`, `DeepSeek-V3.2`) are written inline.
 - `attachment` is derived from non-text `input_modalities`, and all models are `open_weights`.
 - `release_date`/`last_updated` default to the API `created` timestamp but preserve existing hand-authored dates; `knowledge`, `family`, `status`, `interleaved`, and `limit.input` are preserved when present.


### PR DESCRIPTION
Every Chutes model with `reasoning = true` currently carries `reasoning_options = []`. Per `AGENTS.md`, that is an affirmative claim that this host exposes **no** caller-facing reasoning control. For ten of the eleven reasoning models that claim is wrong, so callers cannot toggle thinking on a host that does support it.

### Host classification

**Multi-model relay.** Chutes serves other labs' open-weights models on vLLM behind an OpenAI-compatible endpoint (`https://llm.chutes.ai/v1`) and forwards `chat_template_kwargs` to the model's chat template. The thinking switch each lab ships in its template is therefore reachable over this host's wire.

### Toggle wire path

- Qwen and Gemma templates: `chat_template_kwargs.enable_thinking = true|false`
- Kimi, GLM and DeepSeek templates: `chat_template_kwargs.thinking = true|false`

Each changed file carries the exact path as a leading top-of-file comment.

### Models and options

Baseline comes from the underlying lab's published chat template, then confirmed with a live request to this host. `reasoning_content` length is the observable: present when thinking is on, absent when off.

| Model | Wire field | Thinking on | Thinking off | Verdict |
| --- | --- | ---: | ---: | --- |
| `Qwen/Qwen3-32B-TEE` | `enable_thinking` | 193 ch | 0 ch | `toggle` |
| `Qwen/Qwen3.6-27B-TEE` | `enable_thinking` | 178 ch | 0 ch | `toggle` |
| `Qwen/Qwen3.5-397B-A17B-TEE` | `enable_thinking` | 194 ch | 0 ch | `toggle` |
| `moonshotai/Kimi-K2.6-TEE` | `thinking` | 150 ch | 0 ch | `toggle` |
| `moonshotai/Kimi-K3-TEE` | `thinking` | 412 ch | 0 ch | `toggle` |
| `zai-org/GLM-5.1-TEE` | `thinking` | 146 ch | 0 ch | `toggle` |
| `zai-org/GLM-5.2-TEE` | `thinking` | 611 ch | 0 ch | `toggle` |
| `deepseek-ai/DeepSeek-V3.2-TEE` | `thinking` | 641 ch | 0 ch | `toggle` (defaults off) |
| `deepseek-ai/DeepSeek-V4-Flash-0731-TEE` | `thinking` | 507 ch | 0 ch | `toggle` (defaults off) |
| `google/gemma-4-31B-turbo-TEE` | `enable_thinking` | 430 ch | 0 ch | `toggle` (defaults off) |
| `Qwen/Qwen3-235B-A22B-Thinking-2507-TEE` | — | 200 ch | 200 ch | **`[]` kept** |

`Qwen3-235B-A22B-Thinking-2507-TEE` is deliberately left unchanged: its published template exposes no thinking switch, and sending `enable_thinking = false` to this host leaves `reasoning_content` intact. Its existing `[]` is a correct affirmative "no caller control".

Three models are binary on/off with no graded levels advertised, so they get `toggle` alone and no `effort` — per the toggle rules in `AGENTS.md`. No `budget_tokens` is claimed: this host exposes no reasoning-budget field.

### Baseline sources

Chat templates read from the labs' own model repositories:

- https://huggingface.co/Qwen/Qwen3-32B, .../Qwen3.6-27B, .../Qwen3.5-397B-A17B — expose `enable_thinking`
- https://huggingface.co/Qwen/Qwen3-235B-A22B-Thinking-2507 — exposes **no** thinking switch
- https://huggingface.co/moonshotai/Kimi-K2.6 — exposes `thinking`, `preserve_thinking`
- https://huggingface.co/zai-org/GLM-5.1, .../GLM-5.2 — expose `enable_thinking`, `thinking`
- https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp — exposes `thinking`
- https://huggingface.co/google/gemma-4-31b-it — exposes `enable_thinking`, `thinking`

`moonshotai/Kimi-K3` and `deepseek-ai/DeepSeek-V4-Flash-0731` do not publish an accessible chat template, so those two rest on the live host check alone. Neither contradicts its lab's sibling models.

### Formatting

Values use the block form the sync writer emits for non-empty options (`[[reasoning_options]]` after `[interleaved]`), so a later `chutes:sync` reproduces these files unchanged.

### Durability across sync

The first revision of this PR claimed `preserveReasoningOptions` would keep these options. That was wrong, and the review bot was right to flag it. `buildChutesModel` emitted `reasoning_options: []` unconditionally, and `preserveReasoningOptions` returns early whenever the synced model defines the field at all — so the branch that restores authored options was unreachable for this provider, and the next sync would have wiped all ten toggles.

The second commit leaves the field unset in the sync instead. Authored options are then preserved, while reasoners with no entry yet still default to `[]`. Verified by running `bun chutes:sync` against the live endpoint with the toggles in place: `0 created, 0 updated, 0 removed, 13 unchanged`, and all ten toggles still present afterwards.

The same commit rewrites the `provider.toml` header and the Chutes section of `sync.md`. Both still asserted that Chutes exposes no caller-facing reasoning control, which is the reasoning behind the empty lists and now contradicts the model files.

### Validation

`bun validate` passes (exit 0). The generated catalog reports ten Chutes models with `toggle` and `Qwen3-235B-A22B-Thinking-2507-TEE` with `[]`. `bun test` shows 147 pass / 4 fail, the same four failures present on an unmodified `dev` (`DeepInfra preserves live modalities`, `repository open-weight model metadata includes weights links`, and the two snapshot tests).

