### PR TITLE
fix(sync): clean floating-point decimals

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -818,7 +818,9 @@ function formatInteger(n: number) {
 }
 
 function formatNumber(n: number) {
-  return Number.isInteger(n) ? formatInteger(n) : String(n);
+  if (Number.isInteger(n)) return formatInteger(n);
+  const normalized = Number(n.toPrecision(15));
+  return String(normalized);
 }
 
 function formatKey(value: string) {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1908,6 +1908,21 @@ test("formats interleaved as a root field before reasoning option tables", () =>
   });
 });
 
+test("formats prices without floating-point noise", () => {
+  const content = formatToml({
+    cost: {
+      input: 0.14,
+      output: 0.28,
+      cache_read: 0.14 * 0.1,
+    },
+  });
+
+  expect(content).toContain("cache_read = 0.014");
+  expect(Bun.TOML.parse(content)).toMatchObject({
+    cost: { input: 0.14, output: 0.28, cache_read: 0.014 },
+  });
+});
+
 test("formats empty reasoning options outside the interleaved table", () => {
   const content = formatToml({
     id: "example/model",


### PR DESCRIPTION
## Summary

- normalize fractional TOML values to 15 significant digits during sync serialization
- preserve integer values exactly
- add a regression test for computed pricing such as `0.14 * 0.1`

Fixes noisy decimals seen in #4010, such as `0.013999999999999999` instead of `0.014`.

## Testing

- `bun test test/sync.test.ts --test-name-pattern "formats prices without floating-point noise"`
- `git diff --check`

The complete `sync.test.ts` run currently has one unrelated failure on `dev`: `DeepInfra preserves live modalities for new base models`.