### PR TITLE
Validate providers have models

### DIFF
--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -89,6 +89,11 @@ async function generateProviders(
     }
 
     const modelsPath = path.join(directory, providerID, "models");
+    if (!existsSync(modelsPath)) {
+      throw new Error(`Provider "${providerID}" has no models`, {
+        cause: { providerPath },
+      });
+    }
     for await (const modelPath of new Bun.Glob("**/*.toml").scan({
       cwd: modelsPath,
       absolute: true,
@@ -123,6 +128,11 @@ async function generateProviders(
         throw model.error;
       }
       provider.data.models[modelID] = normalizeModelCost(model.data);
+    }
+    if (Object.keys(provider.data.models).length === 0) {
+      throw new Error(`Provider "${providerID}" has no models`, {
+        cause: { providerPath },
+      });
     }
     result[providerID] = provider.data;
   }

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -35,6 +35,16 @@ function stable(value: unknown): string {
 }
 
 describe("catalog generation", () => {
+  test("rejects providers with no models", async () => {
+    await withFixture(async (root) => {
+      await write(root, "providers/empty/provider.toml", providerToml("Empty"));
+
+      expect(generate(path.join(root, "providers"))).rejects.toThrow(
+        'Provider "empty" has no models',
+      );
+    });
+  });
+
   test("base_model can factor metadata without changing provider JSON", async () => {
     await withFixture(async (root) => {
       await write(root, "providers/direct/provider.toml", providerToml("Direct"));


### PR DESCRIPTION
## Summary
- fail catalog generation when a provider has no models directory
- fail catalog generation when a provider models directory contains no TOML models
- add regression coverage for an empty provider

## Validation
- `bun test packages/core/test/generate.test.ts --test-name-pattern "rejects providers with no models"`
- `bun validate`