### PR TITLE
feat(providers): add Kyma

### DIFF
--- a/providers/kyma/logo.svg
+++ b/providers/kyma/logo.svg
@@ -1,0 +1,31 @@
+<!--
+  Kyma API — single-colour mark. Ψ (psi), the brand letterform.
+
+  Redrawn as vector from public/logo.png, which is the real logo and exists only
+  as raster (1024×1024 gold Ψ on a navy tile). There was no vector source in the
+  repo; public/icon.svg holds a different, older mark and is referenced by
+  nothing — do not mistake it for the brand.
+
+  What this keeps from the gold original: the serif letterform — flat caps top
+  and bottom of the stem, arms that sweep outward and taper toward the tips.
+  What it deliberately drops, because a single colour cannot carry them: the
+  metallic gradient, the 3D relief, the concentric wave rings, and the rounded
+  navy tile. Those stay in logo.png for web, social and the app icon. Two assets
+  on purpose — this is the one for surfaces whose background we do not control.
+
+  Required by external catalogs. models.dev's AGENTS.md makes it a hard blocker
+  and an automated reviewer enforces it: "No fixed size or hardcoded colors — use
+  currentColor for fills/strokes so the logo adapts to light/dark themes. Prefer
+  a square viewBox." charmbracelet/catwalk wants the same. Verified legible down
+  to 16px, which is roughly how large it renders in a provider list.
+
+  Also the right asset for READMEs, favicons and badges.
+  If the brand mark ever changes, redraw this from the new original.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M9.2 3.0h5.6v1.05H9.2z"/>
+  <path d="M11.15 3.3h1.7v17.1h-1.7z"/>
+  <path d="M8.5 19.8h7v1.15h-7z"/>
+  <path d="M2.25 4.05c2.6.15 3.75 1.7 3.75 4.6 0 2.85 1.75 4.7 5.15 5.1v1.95C6.35 15.2 3.6 12.4 3.6 8.5c0-2.05-.4-2.95-1.35-3.1z"/>
+  <path d="M21.75 4.05c-2.6.15-3.75 1.7-3.75 4.6 0 2.85-1.75 4.7-5.15 5.1v1.95c4.8-.5 7.55-3.3 7.55-7.2 0-2.05.4-2.95 1.35-3.1z"/>
+</svg>

--- a/providers/kyma/models/claude-haiku-4-5.toml
+++ b/providers/kyma/models/claude-haiku-4-5.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = []
+
+[cost]
+input = 1.35
+output = 6.75

--- a/providers/kyma/models/claude-opus-4-7.toml
+++ b/providers/kyma/models/claude-opus-4-7.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-opus-4-7"
+reasoning_options = []
+
+[cost]
+input = 6.75
+output = 33.75

--- a/providers/kyma/models/claude-opus-5.toml
+++ b/providers/kyma/models/claude-opus-5.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-opus-5"
+reasoning_options = []
+
+[cost]
+input = 6.75
+output = 33.75

--- a/providers/kyma/models/claude-sonnet-4-6.toml
+++ b/providers/kyma/models/claude-sonnet-4-6.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = []
+
+[cost]
+input = 4.05
+output = 20.25

--- a/providers/kyma/models/claude-sonnet-5.toml
+++ b/providers/kyma/models/claude-sonnet-5.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = []
+
+[cost]
+input = 2.7
+output = 13.5

--- a/providers/kyma/models/deepseek-v4-flash.toml
+++ b/providers/kyma/models/deepseek-v4-flash.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
+
+[cost]
+input = 0.187
+output = 0.3741

--- a/providers/kyma/models/deepseek-v4-pro.toml
+++ b/providers/kyma/models/deepseek-v4-pro.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
+
+[cost]
+input = 0.6901
+output = 1.38

--- a/providers/kyma/models/gemini-2.5-flash.toml
+++ b/providers/kyma/models/gemini-2.5-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash"
+reasoning_options = []
+
+[cost]
+input = 0.405
+output = 3.375

--- a/providers/kyma/models/gemini-3-flash.toml
+++ b/providers/kyma/models/gemini-3-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3-flash-preview"
+reasoning_options = []
+
+[cost]
+input = 0.675
+output = 4.05

--- a/providers/kyma/models/gemini-3.5-flash-lite.toml
+++ b/providers/kyma/models/gemini-3.5-flash-lite.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.5-flash-lite"
+reasoning_options = []
+
+[cost]
+input = 0.405
+output = 3.375

--- a/providers/kyma/models/gemini-3.5-flash.toml
+++ b/providers/kyma/models/gemini-3.5-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.5-flash"
+reasoning_options = []
+
+[cost]
+input = 2.025
+output = 12.15

--- a/providers/kyma/models/gemini-3.6-flash.toml
+++ b/providers/kyma/models/gemini-3.6-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.6-flash"
+reasoning_options = []
+
+[cost]
+input = 2.025
+output = 10.125

--- a/providers/kyma/models/gemma-4-31b.toml
+++ b/providers/kyma/models/gemma-4-31b.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemma-4-31b-it"
+reasoning_options = []
+
+[cost]
+input = 0.0702
+output = 0.2006

--- a/providers/kyma/models/glm-4.5-air.toml
+++ b/providers/kyma/models/glm-4.5-air.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.5-air"
+reasoning_options = []
+
+[cost]
+input = 0.176
+output = 1.148

--- a/providers/kyma/models/glm-4.7-flash.toml
+++ b/providers/kyma/models/glm-4.7-flash.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = []
+
+[cost]
+input = 0.081
+output = 0.54

--- a/providers/kyma/models/glm-5.1.toml
+++ b/providers/kyma/models/glm-5.1.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5.1"
+reasoning_options = []
+
+[cost]
+input = 1.89
+output = 5.94

--- a/providers/kyma/models/glm-5.2.toml
+++ b/providers/kyma/models/glm-5.2.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = []
+
+[cost]
+input = 1.459
+output = 4.984

--- a/providers/kyma/models/gpt-5.6-luna.toml
+++ b/providers/kyma/models/gpt-5.6-luna.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = []
+
+[cost]
+input = 0.1373
+output = 0.8231

--- a/providers/kyma/models/gpt-5.6-sol.toml
+++ b/providers/kyma/models/gpt-5.6-sol.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = []
+
+[cost]
+input = 6.75
+output = 40.5

--- a/providers/kyma/models/gpt-5.6-terra.toml
+++ b/providers/kyma/models/gpt-5.6-terra.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = []
+
+[cost]
+input = 1.443
+output = 8.656

--- a/providers/kyma/models/gpt-oss-120b.toml
+++ b/providers/kyma/models/gpt-oss-120b.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-oss-120b"
+reasoning_options = []
+
+[cost]
+input = 0.0527
+output = 0.2565

--- a/providers/kyma/models/grok-4.3.toml
+++ b/providers/kyma/models/grok-4.3.toml
@@ -1,0 +1,6 @@
+base_model = "xai/grok-4.3"
+reasoning_options = []
+
+[cost]
+input = 1.688
+output = 3.375

--- a/providers/kyma/models/grok-4.5.toml
+++ b/providers/kyma/models/grok-4.5.toml
@@ -1,0 +1,6 @@
+base_model = "xai/grok-4.5"
+reasoning_options = []
+
+[cost]
+input = 2.7
+output = 8.1

--- a/providers/kyma/models/grok-build.toml
+++ b/providers/kyma/models/grok-build.toml
@@ -1,0 +1,6 @@
+base_model = "xai/grok-build-0.1"
+reasoning_options = []
+
+[cost]
+input = 1.389
+output = 2.777

--- a/providers/kyma/models/kimi-k2.5.toml
+++ b/providers/kyma/models/kimi-k2.5.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.5"
+reasoning_options = []
+
+[cost]
+input = 0.6075
+output = 3.038

--- a/providers/kyma/models/kimi-k2.6.toml
+++ b/providers/kyma/models/kimi-k2.6.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
+
+[cost]
+input = 0.776
+output = 3.622

--- a/providers/kyma/models/kimi-k2.7-code.toml
+++ b/providers/kyma/models/kimi-k2.7-code.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[cost]
+input = 1.009
+output = 4.774

--- a/providers/kyma/models/kimi-k3.toml
+++ b/providers/kyma/models/kimi-k3.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k3"
+reasoning_options = []
+
+[cost]
+input = 4.05
+output = 20.25

--- a/providers/kyma/models/minimax-m2.5.toml
+++ b/providers/kyma/models/minimax-m2.5.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
+
+[cost]
+input = 0.3826
+output = 1.346

--- a/providers/kyma/models/minimax-m2.7.toml
+++ b/providers/kyma/models/minimax-m2.7.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
+
+[cost]
+input = 0.405
+output = 1.62

--- a/providers/kyma/models/minimax-m3.toml
+++ b/providers/kyma/models/minimax-m3.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M3"
+reasoning_options = []
+
+[cost]
+input = 0.3852
+output = 1.54

--- a/providers/kyma/models/muse-spark-1.1.toml
+++ b/providers/kyma/models/muse-spark-1.1.toml
@@ -1,0 +1,6 @@
+base_model = "meta/muse-spark-1.1"
+reasoning_options = []
+
+[cost]
+input = 1.688
+output = 5.738

--- a/providers/kyma/models/nemotron-3-ultra-550b.toml
+++ b/providers/kyma/models/nemotron-3-ultra-550b.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+reasoning_options = []
+
+[cost]
+input = 0.675
+output = 3.375

--- a/providers/kyma/models/qwen-3-32b.toml
+++ b/providers/kyma/models/qwen-3-32b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-32b"
+reasoning_options = []
+
+[cost]
+input = 0.108
+output = 0.378

--- a/providers/kyma/models/qwen-3.6-plus.toml
+++ b/providers/kyma/models/qwen-3.6-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.6-plus"
+reasoning_options = []
+
+[cost]
+input = 0.4388
+output = 2.633

--- a/providers/kyma/models/qwen-3.7-max.toml
+++ b/providers/kyma/models/qwen-3.7-max.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-max"
+reasoning_options = []
+
+[cost]
+input = 2.56
+output = 7.676

--- a/providers/kyma/models/qwen-3.7-plus.toml
+++ b/providers/kyma/models/qwen-3.7-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-plus"
+reasoning_options = []
+
+[cost]
+input = 0.4482
+output = 1.793

--- a/providers/kyma/models/qwen3.7-flash.toml
+++ b/providers/kyma/models/qwen3.7-flash.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-flash"
+reasoning_options = []
+
+[cost]
+input = 0.0458
+output = 0.1987

--- a/providers/kyma/models/sonar-pro.toml
+++ b/providers/kyma/models/sonar-pro.toml
@@ -1,0 +1,5 @@
+base_model = "perplexity/sonar-pro"
+
+[cost]
+input = 4.05
+output = 20.25

--- a/providers/kyma/models/sonar.toml
+++ b/providers/kyma/models/sonar.toml
@@ -1,0 +1,5 @@
+base_model = "perplexity/sonar"
+
+[cost]
+input = 1.35
+output = 1.35

--- a/providers/kyma/models/step-3.7-flash.toml
+++ b/providers/kyma/models/step-3.7-flash.toml
@@ -1,0 +1,6 @@
+base_model = "stepfun/step-3.7-flash"
+reasoning_options = []
+
+[cost]
+input = 0.27
+output = 1.553

--- a/providers/kyma/provider.toml
+++ b/providers/kyma/provider.toml
@@ -1,0 +1,5 @@
+name = "Kyma"
+env = ["KYMA_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://docs.kymaapi.com"
+api = "https://api.kymaapi.com/v1"


### PR DESCRIPTION
Kyma is an OpenAI-compatible gateway (`https://api.kymaapi.com/v1`). This adds `providers/kyma/` with 41 models.

This supersedes #1417, which I filed in April and let go stale — the stale bot's note said to feel free to reopen, but that payload predates the `base_model` rule and would fail validation today, so this is a clean refile rather than a reopen.

## Shape

Kyma resells; it authors nothing. So every model file is `base_model` plus real overrides only, per `AGENTS.md`:

```toml
base_model = "openai/gpt-oss-120b"
reasoning_options = []

[cost]
input = 0.0527
output = 0.2565
```

- `bun validate` passes.
- `logo.svg` included.
- 41 models across 13 labs, all pointing at existing `models/<lab>/` entries. No new lab files are added by this PR.

## Two things worth flagging to a reviewer

**`reasoning_options = []` is deliberate, not a placeholder.** Kyma accepts `reasoning_effort` and returns 200, but I could not demonstrate that the control reaches upstream on every route — `reasoning_effort: "banana"` also returns 200. Declaring an effort enum would advertise a control that is honoured on some models and dropped on others. `[]` is the schema's own way of saying "this model reasons and the host exposes no control", and it's the most common value in the repo, so it seemed like the honest option rather than a way around the constraint. Happy to publish a real enum once I've audited the passthrough per route.

**11 of Kyma's 52 language models are omitted** because they have no `models/<lab>/` entry yet — mostly very recent releases (`grok-4.20`, the `gpt-5.6-*-pro` variants, `claude-opus-5-fast`). I'd rather leave them out than add lab entries in the same PR as a new provider; happy to file those separately if that's welcome.

## Keeping it fresh

The April entry rotted because it was written by hand. This one is generated from the same catalogue that serves `/v1/models`, so prices here and prices charged can't drift. I noticed `llmgateway:sync`, `nano-gpt:sync` and friends in `package.json` — if a `kyma:sync` script would be useful I'm glad to add one in a follow-up so this never goes stale again.