### PR TITLE
chore(zenmux): mark 20 offline models as deprecated

### DIFF
--- a/providers/zenmux/models/anthropic/claude-3.5-haiku.toml
+++ b/providers/zenmux/models/anthropic/claude-3.5-haiku.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.80
 output = 4.00

--- a/providers/zenmux/models/anthropic/claude-3.5-sonnet.toml
+++ b/providers/zenmux/models/anthropic/claude-3.5-sonnet.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/zenmux/models/anthropic/claude-3.7-sonnet.toml
+++ b/providers/zenmux/models/anthropic/claude-3.7-sonnet.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/zenmux/models/deepseek/deepseek-chat.toml
+++ b/providers/zenmux/models/deepseek/deepseek-chat.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.28
 output = 0.42

--- a/providers/zenmux/models/google/gemini-3-pro-preview.toml
+++ b/providers/zenmux/models/google/gemini-3-pro-preview.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 2.00
 output = 12.00

--- a/providers/zenmux/models/inclusionai/ling-1t.toml
+++ b/providers/zenmux/models/inclusionai/ling-1t.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.56
 output = 2.24

--- a/providers/zenmux/models/inclusionai/ring-1t.toml
+++ b/providers/zenmux/models/inclusionai/ring-1t.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.56
 output = 2.24

--- a/providers/zenmux/models/kuaishou/kat-coder-pro-v1-free.toml
+++ b/providers/zenmux/models/kuaishou/kat-coder-pro-v1-free.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.00
 output = 0.00

--- a/providers/zenmux/models/kuaishou/kat-coder-pro-v1.toml
+++ b/providers/zenmux/models/kuaishou/kat-coder-pro-v1.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.30
 output = 1.20

--- a/providers/zenmux/models/moonshotai/kimi-k2-0905.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-0905.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.60
 output = 2.50

--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 1.15
 output = 8.00

--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.60
 output = 2.50

--- a/providers/zenmux/models/stepfun/step-3.toml
+++ b/providers/zenmux/models/stepfun/step-3.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.21
 output = 0.57

--- a/providers/zenmux/models/volcengine/doubao-seed-code.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-code.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.17
 output = 1.12

--- a/providers/zenmux/models/x-ai/grok-4-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4-fast.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.20
 output = 0.50

--- a/providers/zenmux/models/x-ai/grok-4.1-fast-non-reasoning.toml
+++ b/providers/zenmux/models/x-ai/grok-4.1-fast-non-reasoning.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.20
 output = 0.50

--- a/providers/zenmux/models/x-ai/grok-4.1-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4.1-fast.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.20
 output = 0.50

--- a/providers/zenmux/models/x-ai/grok-4.toml
+++ b/providers/zenmux/models/x-ai/grok-4.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 3.00
 output = 15.00

--- a/providers/zenmux/models/x-ai/grok-code-fast-1.toml
+++ b/providers/zenmux/models/x-ai/grok-code-fast-1.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.20
 output = 1.50

--- a/providers/zenmux/models/xiaomi/mimo-v2-flash-free.toml
+++ b/providers/zenmux/models/xiaomi/mimo-v2-flash-free.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 0.00
 output = 0.00


### PR DESCRIPTION
## Summary

Mark 20 ZenMux provider files as `status = "deprecated"` for models that have been taken offline in ZenMux (visible=2 in DB as of 2026-08-04).

Follows the same pattern as `providers/openai/models/o1.toml` — keeping the file but marking it deprecated rather than deleting it.

## Updated Files

| File |
|------|
| `providers/zenmux/models/anthropic/claude-3.5-haiku.toml` |
| `providers/zenmux/models/anthropic/claude-3.5-sonnet.toml` |
| `providers/zenmux/models/anthropic/claude-3.7-sonnet.toml` |
| `providers/zenmux/models/deepseek/deepseek-chat.toml` |
| `providers/zenmux/models/google/gemini-3-pro-preview.toml` |
| `providers/zenmux/models/inclusionai/ling-1t.toml` |
| `providers/zenmux/models/inclusionai/ring-1t.toml` |
| `providers/zenmux/models/kuaishou/kat-coder-pro-v1-free.toml` |
| `providers/zenmux/models/kuaishou/kat-coder-pro-v1.toml` |
| `providers/zenmux/models/moonshotai/kimi-k2-0905.toml` |
| `providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml` |
| `providers/zenmux/models/moonshotai/kimi-k2-thinking.toml` |
| `providers/zenmux/models/stepfun/step-3.toml` |
| `providers/zenmux/models/volcengine/doubao-seed-code.toml` |
| `providers/zenmux/models/x-ai/grok-4-fast.toml` |
| `providers/zenmux/models/x-ai/grok-4.1-fast-non-reasoning.toml` |
| `providers/zenmux/models/x-ai/grok-4.1-fast.toml` |
| `providers/zenmux/models/x-ai/grok-4.toml` |
| `providers/zenmux/models/x-ai/grok-code-fast-1.toml` |
| `providers/zenmux/models/xiaomi/mimo-v2-flash-free.toml` |
