### PR TITLE
Add Omnious as an inference provider

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -19,6 +19,7 @@ import { hyper } from "./providers/hyper.js";
 import { huggingface } from "./providers/huggingface.js";
 import { kilo } from "./providers/kilo.js";
 import { llmgateway } from "./providers/llmgateway.js";
+import { omnious } from "./providers/omnious.js";
 import { openai } from "./providers/openai.js";
 import { openrouter } from "./providers/openrouter.js";
 import { ovhcloud } from "./providers/ovhcloud.js";
@@ -119,6 +120,7 @@ export const providers: {
   huggingface: SyncProvider<any>;
   kilo: SyncProvider<any>;
   llmgateway: SyncProvider<any>;
+  omnious: SyncProvider<any>;
   openai: SyncProvider<any>;
   openrouter: SyncProvider<any>;
   ovhcloud: SyncProvider<any>;
@@ -142,6 +144,7 @@ export const providers: {
   huggingface,
   kilo,
   llmgateway,
+  omnious,
   openai,
   openrouter,
   ovhcloud,
@@ -153,7 +156,7 @@ export const providers: {
 };
 
 export const groups = {
-  aggregators: ["crossmodel", "empiriolabs", "huggingface", "kilo", "llmgateway", "openrouter", "vercel"],
+  aggregators: ["crossmodel", "empiriolabs", "huggingface", "kilo", "llmgateway", "omnious", "openrouter", "vercel"],
   cloudflare: ["cloudflare-workers-ai"],
   direct: ["ambient", "anthropic", "baseten", "chutes", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "venice", "wandb", "xai"],
 } as const;

--- a/packages/core/src/sync/providers/omnious.ts
+++ b/packages/core/src/sync/providers/omnious.ts
@@ -1,0 +1,168 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import { z } from "zod";
+
+import type { SyncProvider, SyncedModel } from "../index.js";
+
+// Repo-level base-model metadata directory (mirrors openrouter.ts MODELS_DIR).
+const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
+
+// Omnious is an OpenAI-compatible market rather than a fixed-price gateway: every
+// request runs a scoring auction and the winner is paid a second-score price
+// capped by a genuine rival, so the served price for a model class moves with the
+// book. `GET /v1/models` is public (no key required) and reports the current best
+// bid per class, which is the only volatile data we sync — capability, context and
+// modality facts stay inherited from the base model.
+// https://api.omnious.xyz/v1/models
+// OMNIOUS_MODELS_URL overrides the endpoint (e.g. a local router) for testing.
+const API_ENDPOINT = process.env.OMNIOUS_MODELS_URL ?? "https://api.omnious.xyz/v1/models";
+
+export const OmniousModel = z
+  .object({
+    // Classes carry `model_class`; the catalog also lists routing aliases such as
+    // `auto`, which have no class and are filtered out in parseModels.
+    model_class: z.string(),
+    // Best current bid per 1M tokens, in USDC base units (6 dp).
+    best_in: z.number(),
+    best_out: z.number(),
+    // Who made the model, from the router's class catalog. Null for uncataloged
+    // classes, which fall back to a unique-suffix lookup in deriveBaseModel.
+    issuer: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const OmniousResponse = z.object({ data: z.array(z.unknown()) }).passthrough();
+
+export type OmniousModel = z.infer<typeof OmniousModel>;
+
+// Omnious issuer -> models.dev base-model author prefix. Issuers naming a lab
+// models.dev doesn't carry yet (Arcee AI, Liquid AI, …) are absent on purpose:
+// deriveBaseModel skips those classes rather than inventing an author for them.
+const AUTHOR_BY_ISSUER: Record<string, string> = {
+  OpenAI: "openai",
+  Anthropic: "anthropic",
+  Google: "google",
+  Alibaba: "alibaba",
+  "Mistral AI": "mistral",
+  "Z.ai": "zhipuai",
+  MiniMax: "minimax",
+  DeepSeek: "deepseek",
+  Kimi: "moonshotai",
+  Perplexity: "perplexity",
+  "Thinking Machines": "thinkingmachines",
+  Meta: "meta",
+  xAI: "xai",
+  Xiaomi: "xiaomi",
+  Tencent: "tencent",
+  Microsoft: "microsoft",
+  NVIDIA: "nvidia",
+  Cohere: "cohere",
+  Poolside: "poolside",
+  StepFun: "stepfun",
+};
+
+/**
+ * The base models an Omnious entry can inherit from, indexed once per run.
+ *
+ * Both maps are keyed lowercase and resolve back to the ID as authored, because
+ * Omnious class names are lowercase while some base models are not (MiniMax
+ * ships `minimax/MiniMax-M2`). Resolving through this index rather than probing
+ * the filesystem also keeps the lookup honest on a case-insensitive volume,
+ * where an `existsSync` for `minimax/minimax-m2.toml` answers yes and then fails
+ * catalog generation on Linux.
+ *
+ * A base model is indexed only when it declares `limit.output`. Omnious publishes
+ * price, not limits, so an entry here carries `[cost]` and inherits the rest —
+ * which means a base without an output limit would merge into a model that fails
+ * validation. Those classes are skipped rather than given an invented ceiling.
+ *
+ * `bySuffix` is the fallback for classes with no issuer: a class maps only when
+ * exactly one author publishes that model ID, so an ambiguous short name is
+ * skipped rather than attributed to whichever author sorted first.
+ */
+let catalogIndex: { byID: Map<string, string>; bySuffix: Map<string, string[]> } | undefined;
+
+function catalog() {
+  if (catalogIndex !== undefined) return catalogIndex;
+  const byID = new Map<string, string>();
+  const bySuffix = new Map<string, string[]>();
+  for (const author of readdirSync(MODELS_DIR, { withFileTypes: true })) {
+    if (!author.isDirectory()) continue;
+    for (const file of readdirSync(path.join(MODELS_DIR, author.name))) {
+      if (!file.endsWith(".toml")) continue;
+      const short = file.slice(0, -".toml".length);
+      const id = `${author.name}/${short}`;
+      const base = Bun.TOML.parse(
+        readFileSync(path.join(MODELS_DIR, author.name, file), "utf8"),
+      ) as { limit?: { output?: unknown } };
+      if (typeof base.limit?.output !== "number") continue;
+      byID.set(id.toLowerCase(), id);
+      const key = short.toLowerCase();
+      bySuffix.set(key, [...(bySuffix.get(key) ?? []), id]);
+    }
+  }
+  catalogIndex = { byID, bySuffix };
+  return catalogIndex;
+}
+
+function deriveBaseModel(model: OmniousModel): string | undefined {
+  const { byID, bySuffix } = catalog();
+  const issuer = model.issuer ?? undefined;
+  const author = issuer === undefined ? undefined : AUTHOR_BY_ISSUER[issuer];
+  // A known issuer is authoritative: if models.dev doesn't carry that author's
+  // copy of the class, the class is skipped rather than matched to another lab.
+  if (author !== undefined) {
+    return byID.get(`${author}/${model.model_class}`.toLowerCase());
+  }
+  const candidates = bySuffix.get(model.model_class.toLowerCase());
+  return candidates?.length === 1 ? candidates[0] : undefined;
+}
+
+/** USDC base units (6 dp) per 1M tokens -> USD per 1M tokens. */
+function price(units: number): number | undefined {
+  if (!Number.isFinite(units) || units <= 0) return undefined;
+  return Math.round(units) / 1_000_000;
+}
+
+export const omnious = {
+  id: "omnious",
+  name: "Omnious",
+  modelsDir: "providers/omnious/models",
+  async fetchModels() {
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`Omnious request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    // The catalog mixes model classes with routing aliases (`auto`), which carry
+    // no class or price. Parse per entry so one malformed row can't drop the run.
+    return OmniousResponse.parse(raw)
+      .data.map((entry) => OmniousModel.safeParse(entry))
+      .filter((result) => result.success)
+      .map((result) => result.data);
+  },
+  sourceID(model) {
+    return model.model_class;
+  },
+  translateModel(model) {
+    const input = price(model.best_in);
+    const output = price(model.best_out);
+    // A class with no live bid on one side has no served price to publish.
+    if (input === undefined || output === undefined) return undefined;
+
+    // Skip classes we can't attribute, and classes whose base metadata models.dev
+    // doesn't carry yet — those need their author metadata added under models/
+    // first, exactly as for the other aggregators.
+    const baseModel = deriveBaseModel(model);
+    if (baseModel === undefined) return undefined;
+
+    // Only the auction price is provider-specific. Context, modalities and
+    // capability flags are provider-agnostic facts and stay inherited from the
+    // base model, so this entry never contradicts it.
+    const synced: SyncedModel = { base_model: baseModel, cost: { input, output } };
+    return { id: model.model_class, model: synced };
+  },
+} satisfies SyncProvider<OmniousModel>;

--- a/providers/omnious/logo.svg
+++ b/providers/omnious/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 144" width="144" height="144">
+  <g fill="none" stroke-linecap="round">
+    <circle cx="72" cy="72" r="56" stroke="#6c6a64" stroke-width="3.5" pathLength="100" stroke-dasharray="27.3 6.03"/>
+    <circle cx="72" cy="72" r="40" stroke="#a3a19a" stroke-width="5.5" pathLength="100" stroke-dasharray="42.5 7.5"/>
+    <circle cx="72" cy="72" r="24" stroke="#e6e4df" stroke-width="8"/>
+  </g>
+  <circle cx="72" cy="72" r="8.5" fill="#a98e6f"/>
+</svg>

--- a/providers/omnious/models/claude-fable-5.toml
+++ b/providers/omnious/models/claude-fable-5.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-fable-5"
+reasoning_options = []
+
+[cost]
+input = 11
+output = 55

--- a/providers/omnious/models/claude-sonnet-5.toml
+++ b/providers/omnious/models/claude-sonnet-5.toml
@@ -1,0 +1,6 @@
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = []
+
+[cost]
+input = 2.2
+output = 11

--- a/providers/omnious/models/command-r-08-2024.toml
+++ b/providers/omnious/models/command-r-08-2024.toml
@@ -1,0 +1,5 @@
+base_model = "cohere/command-r-08-2024"
+
+[cost]
+input = 0.165
+output = 0.66

--- a/providers/omnious/models/command-r-plus-08-2024.toml
+++ b/providers/omnious/models/command-r-plus-08-2024.toml
@@ -1,0 +1,5 @@
+base_model = "cohere/command-r-plus-08-2024"
+
+[cost]
+input = 2.75
+output = 11

--- a/providers/omnious/models/command-r7b-12-2024.toml
+++ b/providers/omnious/models/command-r7b-12-2024.toml
@@ -1,0 +1,5 @@
+base_model = "cohere/command-r7b-12-2024"
+
+[cost]
+input = 0.04125
+output = 0.165

--- a/providers/omnious/models/deepseek-chat.toml
+++ b/providers/omnious/models/deepseek-chat.toml
@@ -1,0 +1,5 @@
+base_model = "deepseek/deepseek-chat"
+
+[cost]
+input = 0.283142
+output = 1.13157

--- a/providers/omnious/models/deepseek-r1.toml
+++ b/providers/omnious/models/deepseek-r1.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-r1"
+reasoning_options = []
+
+[cost]
+input = 0.77
+output = 2.75

--- a/providers/omnious/models/deepseek-v4-flash.toml
+++ b/providers/omnious/models/deepseek-v4-flash.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = []
+
+[cost]
+input = 0.154
+output = 0.308

--- a/providers/omnious/models/deepseek-v4-pro.toml
+++ b/providers/omnious/models/deepseek-v4-pro.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = []
+
+[cost]
+input = 0.4785
+output = 0.957

--- a/providers/omnious/models/gemini-2.5-flash-lite.toml
+++ b/providers/omnious/models/gemini-2.5-flash-lite.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash-lite"
+reasoning_options = []
+
+[cost]
+input = 0.11
+output = 0.44

--- a/providers/omnious/models/gemini-2.5-flash.toml
+++ b/providers/omnious/models/gemini-2.5-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash"
+reasoning_options = []
+
+[cost]
+input = 0.33
+output = 2.75

--- a/providers/omnious/models/gemini-2.5-pro.toml
+++ b/providers/omnious/models/gemini-2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-pro"
+reasoning_options = []
+
+[cost]
+input = 1.375
+output = 11

--- a/providers/omnious/models/gemini-3-flash-preview.toml
+++ b/providers/omnious/models/gemini-3-flash-preview.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3-flash-preview"
+reasoning_options = []
+
+[cost]
+input = 0.55
+output = 3.3

--- a/providers/omnious/models/gemini-3.1-flash-lite-preview.toml
+++ b/providers/omnious/models/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = []
+
+[cost]
+input = 0.275
+output = 1.65

--- a/providers/omnious/models/gemini-3.1-flash-lite.toml
+++ b/providers/omnious/models/gemini-3.1-flash-lite.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.1-flash-lite"
+reasoning_options = []
+
+[cost]
+input = 0.275
+output = 1.65

--- a/providers/omnious/models/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/omnious/models/gemini-3.1-pro-preview-customtools.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.1-pro-preview-customtools"
+reasoning_options = []
+
+[cost]
+input = 2.2
+output = 13.2

--- a/providers/omnious/models/gemini-3.1-pro-preview.toml
+++ b/providers/omnious/models/gemini-3.1-pro-preview.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = []
+
+[cost]
+input = 2.2
+output = 13.2

--- a/providers/omnious/models/gemini-3.5-flash.toml
+++ b/providers/omnious/models/gemini-3.5-flash.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.5-flash"
+reasoning_options = []
+
+[cost]
+input = 1.65
+output = 9.9

--- a/providers/omnious/models/gemini-flash-latest.toml
+++ b/providers/omnious/models/gemini-flash-latest.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-flash-latest"
+reasoning_options = []
+
+[cost]
+input = 1.65
+output = 8.25

--- a/providers/omnious/models/gemma-4-26b-a4b-it.toml
+++ b/providers/omnious/models/gemma-4-26b-a4b-it.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = []
+
+[cost]
+input = 0.077
+output = 0.374

--- a/providers/omnious/models/gemma-4-31b-it.toml
+++ b/providers/omnious/models/gemma-4-31b-it.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemma-4-31b-it"
+reasoning_options = []
+
+[cost]
+input = 0.11
+output = 0.374

--- a/providers/omnious/models/glm-4.5-air.toml
+++ b/providers/omnious/models/glm-4.5-air.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.5-air"
+reasoning_options = []
+
+[cost]
+input = 0.143
+output = 0.935

--- a/providers/omnious/models/glm-4.5.toml
+++ b/providers/omnious/models/glm-4.5.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.5"
+reasoning_options = []
+
+[cost]
+input = 0.418
+output = 1.76

--- a/providers/omnious/models/glm-4.5v.toml
+++ b/providers/omnious/models/glm-4.5v.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.5v"
+reasoning_options = []
+
+[cost]
+input = 0.66
+output = 1.98

--- a/providers/omnious/models/glm-4.6.toml
+++ b/providers/omnious/models/glm-4.6.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.6"
+reasoning_options = []
+
+[cost]
+input = 0.55
+output = 2.2

--- a/providers/omnious/models/glm-4.6v.toml
+++ b/providers/omnious/models/glm-4.6v.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.6v"
+reasoning_options = []
+
+[cost]
+input = 0.33
+output = 0.99

--- a/providers/omnious/models/glm-4.7-flash.toml
+++ b/providers/omnious/models/glm-4.7-flash.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = []
+
+[cost]
+input = 0.066
+output = 0.44

--- a/providers/omnious/models/glm-4.7-flashx.toml
+++ b/providers/omnious/models/glm-4.7-flashx.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.7-flashx"
+reasoning_options = []
+
+[cost]
+input = 0.077
+output = 0.44

--- a/providers/omnious/models/glm-4.7.toml
+++ b/providers/omnious/models/glm-4.7.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-4.7"
+reasoning_options = []
+
+[cost]
+input = 0.44
+output = 1.925

--- a/providers/omnious/models/glm-5-turbo.toml
+++ b/providers/omnious/models/glm-5-turbo.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5-turbo"
+reasoning_options = []
+
+[cost]
+input = 1.32
+output = 4.4

--- a/providers/omnious/models/glm-5.1.toml
+++ b/providers/omnious/models/glm-5.1.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5.1"
+reasoning_options = []
+
+[cost]
+input = 1.0626
+output = 3.3396

--- a/providers/omnious/models/glm-5.2.toml
+++ b/providers/omnious/models/glm-5.2.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5.2"
+reasoning_options = []
+
+[cost]
+input = 0.64526
+output = 2.027962

--- a/providers/omnious/models/glm-5.toml
+++ b/providers/omnious/models/glm-5.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5"
+reasoning_options = []
+
+[cost]
+input = 0.66
+output = 2.288

--- a/providers/omnious/models/glm-5v-turbo.toml
+++ b/providers/omnious/models/glm-5v-turbo.toml
@@ -1,0 +1,6 @@
+base_model = "zhipuai/glm-5v-turbo"
+reasoning_options = []
+
+[cost]
+input = 1.32
+output = 4.4

--- a/providers/omnious/models/gpt-3.5-turbo.toml
+++ b/providers/omnious/models/gpt-3.5-turbo.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-3.5-turbo"
+
+[cost]
+input = 0.55
+output = 1.65

--- a/providers/omnious/models/gpt-4-turbo.toml
+++ b/providers/omnious/models/gpt-4-turbo.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4-turbo"
+
+[cost]
+input = 11
+output = 33

--- a/providers/omnious/models/gpt-4.1-mini.toml
+++ b/providers/omnious/models/gpt-4.1-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4.1-mini"
+
+[cost]
+input = 0.44
+output = 1.76

--- a/providers/omnious/models/gpt-4.1-nano.toml
+++ b/providers/omnious/models/gpt-4.1-nano.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4.1-nano"
+
+[cost]
+input = 0.11
+output = 0.44

--- a/providers/omnious/models/gpt-4.1.toml
+++ b/providers/omnious/models/gpt-4.1.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4.1"
+
+[cost]
+input = 2.2
+output = 8.8

--- a/providers/omnious/models/gpt-4.toml
+++ b/providers/omnious/models/gpt-4.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4"
+
+[cost]
+input = 33
+output = 66

--- a/providers/omnious/models/gpt-4o-2024-05-13.toml
+++ b/providers/omnious/models/gpt-4o-2024-05-13.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-2024-05-13"
+
+[cost]
+input = 5.5
+output = 16.5

--- a/providers/omnious/models/gpt-4o-2024-08-06.toml
+++ b/providers/omnious/models/gpt-4o-2024-08-06.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-2024-08-06"
+
+[cost]
+input = 2.75
+output = 11

--- a/providers/omnious/models/gpt-4o-2024-11-20.toml
+++ b/providers/omnious/models/gpt-4o-2024-11-20.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-2024-11-20"
+
+[cost]
+input = 2.75
+output = 11

--- a/providers/omnious/models/gpt-4o-mini.toml
+++ b/providers/omnious/models/gpt-4o-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o-mini"
+
+[cost]
+input = 0.165
+output = 0.66

--- a/providers/omnious/models/gpt-4o.toml
+++ b/providers/omnious/models/gpt-4o.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-4o"
+
+[cost]
+input = 2.75
+output = 11

--- a/providers/omnious/models/gpt-5-mini.toml
+++ b/providers/omnious/models/gpt-5-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5-mini"
+reasoning_options = []
+
+[cost]
+input = 0.275
+output = 2.2

--- a/providers/omnious/models/gpt-5-nano.toml
+++ b/providers/omnious/models/gpt-5-nano.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5-nano"
+reasoning_options = []
+
+[cost]
+input = 0.055
+output = 0.44

--- a/providers/omnious/models/gpt-5-pro.toml
+++ b/providers/omnious/models/gpt-5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5-pro"
+reasoning_options = []
+
+[cost]
+input = 16.5
+output = 132

--- a/providers/omnious/models/gpt-5.1-codex-max.toml
+++ b/providers/omnious/models/gpt-5.1-codex-max.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.1-codex-max"
+reasoning_options = []
+
+[cost]
+input = 1.375
+output = 11

--- a/providers/omnious/models/gpt-5.1-codex-mini.toml
+++ b/providers/omnious/models/gpt-5.1-codex-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.1-codex-mini"
+reasoning_options = []
+
+[cost]
+input = 0.275
+output = 2.2

--- a/providers/omnious/models/gpt-5.1-codex.toml
+++ b/providers/omnious/models/gpt-5.1-codex.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.1-codex"
+reasoning_options = []
+
+[cost]
+input = 1.375
+output = 11

--- a/providers/omnious/models/gpt-5.1.toml
+++ b/providers/omnious/models/gpt-5.1.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.1"
+reasoning_options = []
+
+[cost]
+input = 1.375
+output = 11

--- a/providers/omnious/models/gpt-5.2-codex.toml
+++ b/providers/omnious/models/gpt-5.2-codex.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.2-codex"
+reasoning_options = []
+
+[cost]
+input = 1.925
+output = 15.4

--- a/providers/omnious/models/gpt-5.2-pro.toml
+++ b/providers/omnious/models/gpt-5.2-pro.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.2-pro"
+reasoning_options = []
+
+[cost]
+input = 23.1
+output = 184.8

--- a/providers/omnious/models/gpt-5.2.toml
+++ b/providers/omnious/models/gpt-5.2.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.2"
+reasoning_options = []
+
+[cost]
+input = 1.925
+output = 15.4

--- a/providers/omnious/models/gpt-5.3-codex.toml
+++ b/providers/omnious/models/gpt-5.3-codex.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.3-codex"
+reasoning_options = []
+
+[cost]
+input = 1.925
+output = 15.4

--- a/providers/omnious/models/gpt-5.4-mini.toml
+++ b/providers/omnious/models/gpt-5.4-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4-mini"
+reasoning_options = []
+
+[cost]
+input = 0.825
+output = 4.95

--- a/providers/omnious/models/gpt-5.4-nano.toml
+++ b/providers/omnious/models/gpt-5.4-nano.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4-nano"
+reasoning_options = []
+
+[cost]
+input = 0.22
+output = 1.375

--- a/providers/omnious/models/gpt-5.4-pro.toml
+++ b/providers/omnious/models/gpt-5.4-pro.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4-pro"
+reasoning_options = []
+
+[cost]
+input = 33
+output = 198

--- a/providers/omnious/models/gpt-5.4.toml
+++ b/providers/omnious/models/gpt-5.4.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.4"
+reasoning_options = []
+
+[cost]
+input = 2.75
+output = 16.5

--- a/providers/omnious/models/gpt-5.5-pro.toml
+++ b/providers/omnious/models/gpt-5.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.5-pro"
+reasoning_options = []
+
+[cost]
+input = 33
+output = 198

--- a/providers/omnious/models/gpt-5.5.toml
+++ b/providers/omnious/models/gpt-5.5.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.5"
+reasoning_options = []
+
+[cost]
+input = 5.5
+output = 33

--- a/providers/omnious/models/gpt-5.6-luna.toml
+++ b/providers/omnious/models/gpt-5.6-luna.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = []
+
+[cost]
+input = 1.1
+output = 6.6

--- a/providers/omnious/models/gpt-5.6-sol.toml
+++ b/providers/omnious/models/gpt-5.6-sol.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = []
+
+[cost]
+input = 5.5
+output = 33

--- a/providers/omnious/models/gpt-5.toml
+++ b/providers/omnious/models/gpt-5.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-5"
+reasoning_options = []
+
+[cost]
+input = 1.375
+output = 11

--- a/providers/omnious/models/gpt-image-1.toml
+++ b/providers/omnious/models/gpt-image-1.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-image-1"
+
+[cost]
+input = 0.011
+output = 0.044

--- a/providers/omnious/models/gpt-image-2.toml
+++ b/providers/omnious/models/gpt-image-2.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-image-2"
+
+[cost]
+input = 0.011
+output = 0.0583

--- a/providers/omnious/models/gpt-oss-120b.toml
+++ b/providers/omnious/models/gpt-oss-120b.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-oss-120b"
+reasoning_options = []
+
+[cost]
+input = 0.0407
+output = 0.187

--- a/providers/omnious/models/gpt-oss-20b.toml
+++ b/providers/omnious/models/gpt-oss-20b.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-oss-20b"
+reasoning_options = []
+
+[cost]
+input = 0.033
+output = 0.143

--- a/providers/omnious/models/grok-4.3.toml
+++ b/providers/omnious/models/grok-4.3.toml
@@ -1,0 +1,6 @@
+base_model = "xai/grok-4.3"
+reasoning_options = []
+
+[cost]
+input = 1.375
+output = 2.75

--- a/providers/omnious/models/grok-build-0.1.toml
+++ b/providers/omnious/models/grok-build-0.1.toml
@@ -1,0 +1,6 @@
+base_model = "xai/grok-build-0.1"
+reasoning_options = []
+
+[cost]
+input = 1.1
+output = 2.2

--- a/providers/omnious/models/hy3-preview.toml
+++ b/providers/omnious/models/hy3-preview.toml
@@ -1,0 +1,6 @@
+base_model = "tencent/hy3-preview"
+reasoning_options = []
+
+[cost]
+input = 0.0693
+output = 0.231

--- a/providers/omnious/models/hy3.toml
+++ b/providers/omnious/models/hy3.toml
@@ -1,0 +1,6 @@
+base_model = "tencent/hy3"
+reasoning_options = []
+
+[cost]
+input = 0.1452
+output = 0.5808

--- a/providers/omnious/models/kimi-k2-thinking.toml
+++ b/providers/omnious/models/kimi-k2-thinking.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2-thinking"
+reasoning_options = []
+
+[cost]
+input = 0.66
+output = 2.75

--- a/providers/omnious/models/kimi-k2.5.toml
+++ b/providers/omnious/models/kimi-k2.5.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.5"
+reasoning_options = []
+
+[cost]
+input = 0.627002
+output = 3.135

--- a/providers/omnious/models/kimi-k2.6.toml
+++ b/providers/omnious/models/kimi-k2.6.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.6"
+reasoning_options = []
+
+[cost]
+input = 0.6479
+output = 2.728

--- a/providers/omnious/models/kimi-k2.7-code-highspeed.toml
+++ b/providers/omnious/models/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
+reasoning_options = []
+
+[cost]
+input = 2.09
+output = 8.8

--- a/providers/omnious/models/kimi-k2.7-code.toml
+++ b/providers/omnious/models/kimi-k2.7-code.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[cost]
+input = 0.803
+output = 3.85

--- a/providers/omnious/models/kimi-k3.toml
+++ b/providers/omnious/models/kimi-k3.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k3"
+reasoning_options = []
+
+[cost]
+input = 3.3
+output = 16.5

--- a/providers/omnious/models/laguna-xs-2.1.toml
+++ b/providers/omnious/models/laguna-xs-2.1.toml
@@ -1,0 +1,6 @@
+base_model = "poolside/laguna-xs-2.1"
+reasoning_options = []
+
+[cost]
+input = 0.066
+output = 0.132

--- a/providers/omnious/models/llama-3.3-70b-instruct.toml
+++ b/providers/omnious/models/llama-3.3-70b-instruct.toml
@@ -1,0 +1,5 @@
+base_model = "meta/llama-3.3-70b-instruct"
+
+[cost]
+input = 0.11
+output = 0.352

--- a/providers/omnious/models/mimo-v2.5-pro.toml
+++ b/providers/omnious/models/mimo-v2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+reasoning_options = []
+
+[cost]
+input = 0.4785
+output = 0.957

--- a/providers/omnious/models/mimo-v2.5.toml
+++ b/providers/omnious/models/mimo-v2.5.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5"
+reasoning_options = []
+
+[cost]
+input = 0.154
+output = 0.308

--- a/providers/omnious/models/minimax-m2.1.toml
+++ b/providers/omnious/models/minimax-m2.1.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.1"
+reasoning_options = []
+
+[cost]
+input = 0.297
+output = 1.045002

--- a/providers/omnious/models/minimax-m2.5-highspeed.toml
+++ b/providers/omnious/models/minimax-m2.5-highspeed.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.5-highspeed"
+reasoning_options = []
+
+[cost]
+input = 0.66
+output = 2.64

--- a/providers/omnious/models/minimax-m2.5.toml
+++ b/providers/omnious/models/minimax-m2.5.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
+
+[cost]
+input = 0.165
+output = 0.99

--- a/providers/omnious/models/minimax-m2.7-highspeed.toml
+++ b/providers/omnious/models/minimax-m2.7-highspeed.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
+
+[cost]
+input = 0.66
+output = 2.64

--- a/providers/omnious/models/minimax-m2.7.toml
+++ b/providers/omnious/models/minimax-m2.7.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
+
+[cost]
+input = 0.275
+output = 1.1

--- a/providers/omnious/models/minimax-m2.toml
+++ b/providers/omnious/models/minimax-m2.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2"
+reasoning_options = []
+
+[cost]
+input = 0.2794
+output = 1.122

--- a/providers/omnious/models/minimax-m3.toml
+++ b/providers/omnious/models/minimax-m3.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M3"
+reasoning_options = []
+
+[cost]
+input = 0.33
+output = 1.32

--- a/providers/omnious/models/mistral-large-2512.toml
+++ b/providers/omnious/models/mistral-large-2512.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-large-2512"
+
+[cost]
+input = 0.55
+output = 1.65

--- a/providers/omnious/models/mistral-nemo.toml
+++ b/providers/omnious/models/mistral-nemo.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-nemo"
+
+[cost]
+input = 0.020902
+output = 0.033

--- a/providers/omnious/models/mistral-small-2603.toml
+++ b/providers/omnious/models/mistral-small-2603.toml
@@ -1,0 +1,6 @@
+base_model = "mistral/mistral-small-2603"
+reasoning_options = []
+
+[cost]
+input = 0.165
+output = 0.66

--- a/providers/omnious/models/nemotron-3-nano-30b-a3b.toml
+++ b/providers/omnious/models/nemotron-3-nano-30b-a3b.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/nemotron-3-nano-30b-a3b"
+reasoning_options = []
+
+[cost]
+input = 0.055
+output = 0.22

--- a/providers/omnious/models/nemotron-3-super-120b-a12b.toml
+++ b/providers/omnious/models/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+reasoning_options = []
+
+[cost]
+input = 0.0935
+output = 0.44

--- a/providers/omnious/models/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/omnious/models/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+reasoning_options = []
+
+[cost]
+input = 0.66
+output = 3.96

--- a/providers/omnious/models/o1-pro.toml
+++ b/providers/omnious/models/o1-pro.toml
@@ -1,0 +1,6 @@
+base_model = "openai/o1-pro"
+reasoning_options = []
+
+[cost]
+input = 165
+output = 660

--- a/providers/omnious/models/o1.toml
+++ b/providers/omnious/models/o1.toml
@@ -1,0 +1,6 @@
+base_model = "openai/o1"
+reasoning_options = []
+
+[cost]
+input = 16.5
+output = 66

--- a/providers/omnious/models/o3-mini.toml
+++ b/providers/omnious/models/o3-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/o3-mini"
+reasoning_options = []
+
+[cost]
+input = 1.21
+output = 4.84

--- a/providers/omnious/models/o3-pro.toml
+++ b/providers/omnious/models/o3-pro.toml
@@ -1,0 +1,6 @@
+base_model = "openai/o3-pro"
+reasoning_options = []
+
+[cost]
+input = 22
+output = 88

--- a/providers/omnious/models/o3.toml
+++ b/providers/omnious/models/o3.toml
@@ -1,0 +1,6 @@
+base_model = "openai/o3"
+reasoning_options = []
+
+[cost]
+input = 2.2
+output = 8.8

--- a/providers/omnious/models/o4-mini.toml
+++ b/providers/omnious/models/o4-mini.toml
@@ -1,0 +1,6 @@
+base_model = "openai/o4-mini"
+reasoning_options = []
+
+[cost]
+input = 1.21
+output = 4.84

--- a/providers/omnious/models/qwen-plus.toml
+++ b/providers/omnious/models/qwen-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen-plus"
+reasoning_options = []
+
+[cost]
+input = 0.286
+output = 0.858

--- a/providers/omnious/models/qwen3-235b-a22b.toml
+++ b/providers/omnious/models/qwen3-235b-a22b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-235b-a22b"
+reasoning_options = []
+
+[cost]
+input = 0.5005
+output = 2.002

--- a/providers/omnious/models/qwen3-32b.toml
+++ b/providers/omnious/models/qwen3-32b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-32b"
+reasoning_options = []
+
+[cost]
+input = 0.088
+output = 0.308

--- a/providers/omnious/models/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/omnious/models/qwen3-coder-30b-a3b-instruct.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
+
+[cost]
+input = 0.077
+output = 0.297

--- a/providers/omnious/models/qwen3-coder-flash.toml
+++ b/providers/omnious/models/qwen3-coder-flash.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-flash"
+
+[cost]
+input = 0.2145
+output = 1.0725

--- a/providers/omnious/models/qwen3-coder-plus.toml
+++ b/providers/omnious/models/qwen3-coder-plus.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-plus"
+
+[cost]
+input = 0.715
+output = 3.575

--- a/providers/omnious/models/qwen3-max.toml
+++ b/providers/omnious/models/qwen3-max.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-max"
+
+[cost]
+input = 0.858
+output = 4.29

--- a/providers/omnious/models/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/omnious/models/qwen3-next-80b-a3b-instruct.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+
+[cost]
+input = 0.099
+output = 1.21

--- a/providers/omnious/models/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/omnious/models/qwen3-next-80b-a3b-thinking.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-next-80b-a3b-thinking"
+reasoning_options = []
+
+[cost]
+input = 0.165
+output = 1.32

--- a/providers/omnious/models/qwen3.5-122b-a10b.toml
+++ b/providers/omnious/models/qwen3.5-122b-a10b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.5-122b-a10b"
+reasoning_options = []
+
+[cost]
+input = 0.286
+output = 2.288

--- a/providers/omnious/models/qwen3.5-27b.toml
+++ b/providers/omnious/models/qwen3.5-27b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.5-27b"
+reasoning_options = []
+
+[cost]
+input = 0.2145
+output = 1.716

--- a/providers/omnious/models/qwen3.5-35b-a3b.toml
+++ b/providers/omnious/models/qwen3.5-35b-a3b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.5-35b-a3b"
+reasoning_options = []
+
+[cost]
+input = 0.154
+output = 1.1

--- a/providers/omnious/models/qwen3.5-397b-a17b.toml
+++ b/providers/omnious/models/qwen3.5-397b-a17b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.5-397b-a17b"
+reasoning_options = []
+
+[cost]
+input = 0.429
+output = 2.574

--- a/providers/omnious/models/qwen3.5-9b.toml
+++ b/providers/omnious/models/qwen3.5-9b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.5-9b"
+reasoning_options = []
+
+[cost]
+input = 0.11
+output = 0.165

--- a/providers/omnious/models/qwen3.6-27b.toml
+++ b/providers/omnious/models/qwen3.6-27b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.6-27b"
+reasoning_options = []
+
+[cost]
+input = 0.317902
+output = 2.64

--- a/providers/omnious/models/qwen3.6-35b-a3b.toml
+++ b/providers/omnious/models/qwen3.6-35b-a3b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.6-35b-a3b"
+reasoning_options = []
+
+[cost]
+input = 0.154
+output = 1.1

--- a/providers/omnious/models/qwen3.6-flash.toml
+++ b/providers/omnious/models/qwen3.6-flash.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.6-flash"
+reasoning_options = []
+
+[cost]
+input = 0.20625
+output = 1.2375

--- a/providers/omnious/models/qwen3.6-max-preview.toml
+++ b/providers/omnious/models/qwen3.6-max-preview.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.6-max-preview"
+reasoning_options = []
+
+[cost]
+input = 1.129702
+output = 6.7782

--- a/providers/omnious/models/qwen3.6-plus.toml
+++ b/providers/omnious/models/qwen3.6-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.6-plus"
+reasoning_options = []
+
+[cost]
+input = 0.3575
+output = 2.145

--- a/providers/omnious/models/qwen3.7-max.toml
+++ b/providers/omnious/models/qwen3.7-max.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-max"
+reasoning_options = []
+
+[cost]
+input = 1.375
+output = 4.125

--- a/providers/omnious/models/qwen3.7-plus.toml
+++ b/providers/omnious/models/qwen3.7-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-plus"
+reasoning_options = []
+
+[cost]
+input = 0.352
+output = 1.408

--- a/providers/omnious/models/sonar-pro.toml
+++ b/providers/omnious/models/sonar-pro.toml
@@ -1,0 +1,5 @@
+base_model = "perplexity/sonar-pro"
+
+[cost]
+input = 3.3
+output = 16.5

--- a/providers/omnious/models/sonar-reasoning-pro.toml
+++ b/providers/omnious/models/sonar-reasoning-pro.toml
@@ -1,0 +1,6 @@
+base_model = "perplexity/sonar-reasoning-pro"
+reasoning_options = []
+
+[cost]
+input = 2.2
+output = 8.8

--- a/providers/omnious/models/sonar.toml
+++ b/providers/omnious/models/sonar.toml
@@ -1,0 +1,5 @@
+base_model = "perplexity/sonar"
+
+[cost]
+input = 1.1
+output = 1.1

--- a/providers/omnious/models/step-3.5-flash.toml
+++ b/providers/omnious/models/step-3.5-flash.toml
@@ -1,0 +1,6 @@
+base_model = "stepfun/step-3.5-flash"
+reasoning_options = []
+
+[cost]
+input = 0.11
+output = 0.33

--- a/providers/omnious/models/step-3.7-flash.toml
+++ b/providers/omnious/models/step-3.7-flash.toml
@@ -1,0 +1,6 @@
+base_model = "stepfun/step-3.7-flash"
+reasoning_options = []
+
+[cost]
+input = 0.22
+output = 1.265

--- a/providers/omnious/provider.toml
+++ b/providers/omnious/provider.toml
@@ -1,0 +1,14 @@
+# Omnious serves an OpenAI-compatible endpoint over a live per-request auction:
+# providers bid to serve each call and the winner is paid a second-score price
+# capped by a genuine rival, so a model's served price moves with the book
+# rather than sitting on a rate card. `GET /v1/models` is public (no key) and
+# reports the current best bid per model class as `best_in` / `best_out`, in
+# USDC base units per 1M tokens — that endpoint is what the sync module reads,
+# which keeps [cost] here tracking the market instead of freezing at the value
+# it had the day this landed.
+# https://api.omnious.xyz/v1/models (accessed 2026-08-04)
+name = "Omnious"
+env = ["OMNIOUS_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://omnious.xyz/prices"
+api = "https://api.omnious.xyz/v1"


### PR DESCRIPTION
[Omnious](https://omnious.xyz) serves an OpenAI-compatible endpoint over a live per-request auction: providers bid to serve each call, and the winner is paid a second-score price capped by a genuine rival. A class's served price therefore moves with the book rather than sitting on a rate card.

That makes a hand-authored `[cost]` stale on arrival, so this adds a sync module rather than static pricing. `GET /v1/models` is public (no key required) and reports the current best bid per class as `best_in` / `best_out` in USDC base units per 1M tokens; the module converts those to USD and writes them as `[cost]`. It runs in the `aggregators` group so the existing automation keeps it current.

### What each entry carries

Price is the only provider-specific fact Omnious publishes — there's no context, limit or capability data in the catalog. So each entry is `base_model` plus `[cost]` and inherits everything else, which means it can't contradict the base model:

```toml
base_model = "zhipuai/glm-5.2"

[cost]
input = 0.64526
output = 2.027962
```

### Attribution

Classes are attributed by the router's `issuer` field, mapped to a models.dev author. When the router reports no issuer, the module falls back to a suffix match and takes it only when exactly one author publishes that model ID, so an ambiguous short name is skipped rather than assigned to whichever author sorted first.

A class is skipped when models.dev doesn't carry its base model yet, or when that base model has no `limit.output` to inherit (`sakana/fugu-ultra`, `thinkingmachines/inkling`) — inventing a ceiling seemed worse than omitting the row. **128 of 291 classes map today**; the rest need their author metadata added under `models/` first.

Lookups resolve through an index built from `models/`, keyed lowercase and mapped back to the ID as authored, because Omnious class names are lowercase while some base models aren't (`minimax/MiniMax-M2`). That also avoids an `existsSync` probe answering yes on a case-insensitive volume and then failing catalog generation on Linux.

### Verification

- `bun models:sync omnious` → 128 created
- `bun validate` → passes
- Spot-checked generated `[cost]` against the live endpoint (`glm-5.2` → 0.64526 / 2.027962, `kimi-k3` → 3.3 / 16.5)