### PR TITLE
fix(sync): map CrossModel structured output

### DIFF
--- a/packages/core/src/sync/providers/crossmodel.ts
+++ b/packages/core/src/sync/providers/crossmodel.ts
@@ -55,7 +55,10 @@ export const CrossModelModel = z
       .object({ input: z.array(z.string()), output: z.array(z.string()) })
       .optional(),
     capabilities: z
-      .object({ reasoning: ReasoningCapability.optional() })
+      .object({
+        json: z.boolean().optional(),
+        reasoning: ReasoningCapability.optional(),
+      })
       .passthrough()
       .nullable()
       .optional(),
@@ -186,7 +189,7 @@ function reasoningOptions(model: CrossModelModel): SyncedModel["reasoning_option
   return options;
 }
 
-function buildCrossModel(
+export function buildCrossModel(
   model: CrossModelModel,
   existing: ExistingModel | undefined,
 ): SyncedModel | undefined {
@@ -247,7 +250,7 @@ function buildCrossModel(
       reasoning: existing?.reasoning,
       temperature: existing?.temperature,
       tool_call: existing?.tool_call,
-      structured_output: existing?.structured_output,
+      structured_output: model.capabilities?.json ?? existing?.structured_output,
       knowledge: existing?.knowledge,
       modalities: modality,
       reasoning_options,

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -10,6 +10,10 @@ import {
   parseAnthropicPricing,
   type AnthropicModel,
 } from "../src/sync/providers/anthropic.js";
+import {
+  buildCrossModel,
+  type CrossModelModel,
+} from "../src/sync/providers/crossmodel.js";
 import { buildDeepInfraModel, type DeepInfraModel } from "../src/sync/providers/deepinfra.js";
 import {
   buildDigitalOceanModel,
@@ -113,6 +117,63 @@ function nanoGptModel(overrides: Partial<NanoGptModel> = {}): NanoGptModel {
     ...overrides,
   };
 }
+
+function crossModelModel(overrides: Partial<CrossModelModel> = {}): CrossModelModel {
+  return {
+    id: "qwen/qwen3.8-max",
+    vendor_code: "qwen",
+    display_name: "Qwen3.8 Max",
+    context_window_tokens: 1_000_000,
+    max_output_tokens: 131_072,
+    modalities: { input: ["text", "image", "video"], output: ["text"] },
+    capabilities: {
+      json: true,
+      reasoning: { toggle: true },
+    },
+    currency: "USD",
+    pricing: {
+      tiers: [
+        {
+          threshold: 0,
+          input_micro_per_1m: 1_880_000,
+          output_micro_per_1m: 5_630_000,
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+test("syncs CrossModel's structured-output capability", () => {
+  const supported = buildCrossModel(crossModelModel(), undefined);
+  const unsupported = buildCrossModel(
+    crossModelModel({
+      id: "qwen/qwen3.7-flash",
+      capabilities: { json: false, reasoning: { toggle: true } },
+    }),
+    undefined,
+  );
+  const preserved = buildCrossModel(
+    crossModelModel({ capabilities: { reasoning: { toggle: true } } }),
+    {
+      base_model: "alibaba/qwen3.8-max",
+      structured_output: true,
+    },
+  );
+
+  expect(supported).toMatchObject({
+    base_model: "alibaba/qwen3.8-max",
+    structured_output: true,
+  });
+  expect(unsupported).toMatchObject({
+    base_model: "alibaba/qwen3.7-flash",
+    structured_output: false,
+  });
+  expect(preserved).toMatchObject({
+    base_model: "alibaba/qwen3.8-max",
+    structured_output: true,
+  });
+});
 
 test("syncs NanoGPT's verified reasoning, pricing, limits, and open-weight metadata", () => {
   const model = buildNanoGptModel(nanoGptModel({

--- a/providers/crossmodel/models/anthropic/claude-fable-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-fable-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-fable-5"
+structured_output = true
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/crossmodel/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+structured_output = true
 
 [[reasoning_options]]
 type = "budget_tokens"

--- a/providers/crossmodel/models/anthropic/claude-opus-4-7.toml
+++ b/providers/crossmodel/models/anthropic/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+structured_output = true
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/crossmodel/models/anthropic/claude-opus-4-8.toml
+++ b/providers/crossmodel/models/anthropic/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+structured_output = true
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/crossmodel/models/anthropic/claude-opus-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-opus-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-5"
+structured_output = true
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/crossmodel/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/crossmodel/models/anthropic/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+structured_output = true
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/crossmodel/models/anthropic/claude-sonnet-5.toml
+++ b/providers/crossmodel/models/anthropic/claude-sonnet-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/crossmodel/models/minimax/minimax-m2.7.toml
+++ b/providers/crossmodel/models/minimax/minimax-m2.7.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M2.7"
+structured_output = true
 reasoning_options = []
 
 [cost]

--- a/providers/crossmodel/models/minimax/minimax-m3.toml
+++ b/providers/crossmodel/models/minimax/minimax-m3.toml
@@ -1,4 +1,5 @@
 base_model = "minimax/MiniMax-M3"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/crossmodel/models/qwen/qwen3.6-plus.toml
+++ b/providers/crossmodel/models/qwen/qwen3.6-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.6-plus"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/crossmodel/models/qwen/qwen3.7-max.toml
+++ b/providers/crossmodel/models/qwen/qwen3.7-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-max"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/crossmodel/models/qwen/qwen3.7-plus.toml
+++ b/providers/crossmodel/models/qwen/qwen3.7-plus.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.7-plus"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/crossmodel/models/qwen/qwen3.8-max.toml
+++ b/providers/crossmodel/models/qwen/qwen3.8-max.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3.8-max"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"
@@ -11,7 +12,3 @@ input = 1.88
 output = 5.63
 cache_read = 0.23
 cache_write = 2.35
-
-[modalities]
-input = ["text", "image", "video", "audio"]
-output = ["text", "audio"]

--- a/providers/crossmodel/models/tencent/hy3-preview.toml
+++ b/providers/crossmodel/models/tencent/hy3-preview.toml
@@ -1,4 +1,5 @@
 base_model = "tencent/hy3-preview"
+structured_output = true
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/crossmodel/models/tencent/hy3.toml
+++ b/providers/crossmodel/models/tencent/hy3.toml
@@ -1,4 +1,5 @@
 base_model = "tencent/hy3"
+structured_output = true
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/crossmodel/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/crossmodel/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5-pro"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/crossmodel/models/xiaomi/mimo-v2.5.toml
+++ b/providers/crossmodel/models/xiaomi/mimo-v2.5.toml
@@ -1,4 +1,5 @@
 base_model = "xiaomi/mimo-v2.5"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/crossmodel/models/z-ai/glm-4.7.toml
+++ b/providers/crossmodel/models/z-ai/glm-4.7.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/crossmodel/models/z-ai/glm-5.toml
+++ b/providers/crossmodel/models/z-ai/glm-5.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5"
+structured_output = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/sync.md
+++ b/sync.md
@@ -139,6 +139,15 @@ CI automatically picks up providers registered in `providers` in `packages/core/
 
 Actions are pinned by commit SHA. Keep new workflow actions pinned the same way.
 
+## CrossModel Notes
+
+CrossModel is implemented in `packages/core/src/sync/providers/crossmodel.ts`.
+
+- Source endpoint: `https://www.crossmodel.ai/api/models`.
+- Pricing, context/output limits, modalities, and reasoning controls come from CrossModel's public catalog.
+- `structured_output` comes from `capabilities.json`; when that field is absent, the sync preserves an existing authored override.
+- Other intrinsic model facts remain inherited from the canonical `base_model` metadata.
+
 ## OpenRouter Notes
 
 OpenRouter is implemented in `packages/core/src/sync/providers/openrouter.ts`.


### PR DESCRIPTION
## Summary

- parse CrossModel's public `capabilities.json` flag and map it to models.dev's `structured_output`
- preserve an existing authored override when older source responses omit the capability
- regenerate the 19 CrossModel provider entries that previously rendered `structured` as unknown
- document the CrossModel sync contract and cover true, false, and absent source values

## Root cause

The hourly CrossModel sync already fetched `https://www.crossmodel.ai/api/models`, but its source schema only modeled `capabilities.reasoning`. CrossModel exposes structured/JSON output support as `capabilities.json`, so newly generated provider TOMLs could not emit a provider-specific `structured_output` override when the canonical base model omitted that field.

## Impact

All 50 current CrossModel models now resolve `structured_output = true`, matching the public CrossModel catalog. Future models will receive the field automatically from the hourly sync instead of requiring hand-authored TOML edits.

The regeneration also removes the stale Qwen3.8 Max audio modality override because the current CrossModel catalog now matches the canonical text/image/video input and text output metadata.

## Validation

- `bun test packages/core/test/sync.test.ts -t "syncs CrossModel's structured-output capability"`
- `bun models:sync crossmodel --dry-run --no-issues` (50 unchanged after generation)
- `bun validate`
- generated catalog audit: 50 CrossModel models, 50 `structured_output = true`, 0 source/generated mismatches

The full `packages/core/test/sync.test.ts` run has one unrelated existing failure in `DeepInfra preserves live modalities for new base models`; it reproduces unchanged on `origin/dev` (108 pass, 1 fail there; 109 pass, 1 fail on this branch because this PR adds one passing test).
