### PR TITLE
fix(sync): allow safe reasoning model updates

### DIFF
--- a/packages/core/script/check-sync-auto-merge.ts
+++ b/packages/core/script/check-sync-auto-merge.ts
@@ -11,7 +11,16 @@ const diff = Bun.spawnSync(["git", "diff", "--name-status", "--no-renames", base
 
 if (diff.exitCode !== 0) process.exit(diff.exitCode ?? 1);
 
-const decision = await classifyAutoMerge(parseNameStatus(diff.stdout.toString()));
+const loadPrevious = async (path: string) => {
+  const file = Bun.spawnSync(["git", "show", `${base}:${path}`], {
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  if (file.exitCode !== 0) throw new Error(`Failed to read ${path} at ${base}`);
+  return file.stdout.toString();
+};
+
+const decision = await classifyAutoMerge(parseNameStatus(diff.stdout.toString()), undefined, loadPrevious);
 const summary = decision.safe
   ? `Safe to auto-merge: ${decision.created} created, ${decision.updated} updated, ${decision.deleted} deleted.`
   : `Manual review required: ${decision.reasons.join("; ")}.`;

--- a/packages/core/src/sync/auto-merge.ts
+++ b/packages/core/src/sync/auto-merge.ts
@@ -61,9 +61,9 @@ export async function classifyAutoMerge(
   };
 
   for (const change of models) {
-    if (!isProviderModel(change.path)) continue;
+    if (change.status === "deleted" || !isProviderModel(change.path)) continue;
 
-    const current = change.status === "deleted" ? undefined : await reasoningMetadata(change.path, load);
+    const current = await reasoningMetadata(change.path, load);
     const previous = change.status === "created" ? undefined : await reasoningMetadata(change.path, loadPrevious);
     const reasoningChanged = !current || !previous || !isDeepStrictEqual(current, previous);
     if (!reasoningChanged) continue;

--- a/packages/core/src/sync/auto-merge.ts
+++ b/packages/core/src/sync/auto-merge.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
 
 export const MAX_CREATED_MODELS = 10;
 export const MAX_DELETED_MODELS = 10;
@@ -29,6 +30,7 @@ function isProviderModel(path: string) {
 export async function classifyAutoMerge(
   changes: CatalogChange[],
   load = (path: string) => readFile(path, "utf8"),
+  loadPrevious = load,
 ): Promise<AutoMergeDecision> {
   const models = changes.filter((change) => isModel(change.path));
   const created = models.filter((change) => change.status === "created").length;
@@ -42,18 +44,34 @@ export async function classifyAutoMerge(
     reasons.push(`${created + deleted} models created or deleted (limit ${MAX_MODEL_CHURN})`);
   }
 
-  for (const change of models) {
-    if (change.status === "deleted" || !isProviderModel(change.path)) continue;
-
-    const model = Bun.TOML.parse(await load(change.path)) as Record<string, unknown>;
+  const reasoningMetadata = async (path: string, loader: typeof load) => {
+    const model = Bun.TOML.parse(await loader(path)) as Record<string, unknown>;
     let reasoning = model.reasoning;
     if (reasoning === undefined && typeof model.base_model === "string") {
-      const base = Bun.TOML.parse(await load(`models/${model.base_model}.toml`)) as Record<string, unknown>;
+      const base = Bun.TOML.parse(await loader(`models/${model.base_model}.toml`)) as Record<string, unknown>;
       reasoning = base.reasoning;
     }
 
-    if (reasoning === true) {
-      if (!Object.hasOwn(model, "reasoning_options")) {
+    return {
+      reasoning,
+      reasoning_options: model.reasoning_options,
+      interleaved: model.interleaved,
+      base_model: model.base_model,
+    };
+  };
+
+  for (const change of models) {
+    if (!isProviderModel(change.path)) continue;
+
+    const current = change.status === "deleted" ? undefined : await reasoningMetadata(change.path, load);
+    const previous = change.status === "created" ? undefined : await reasoningMetadata(change.path, loadPrevious);
+    const reasoningChanged = !current || !previous || !isDeepStrictEqual(current, previous);
+    if (!reasoningChanged) continue;
+
+    const reasoning = current?.reasoning === true || previous?.reasoning === true;
+
+    if (reasoning) {
+      if (current?.reasoning === true && current.reasoning_options === undefined) {
         reasons.push(`${change.path} is a reasoning model without explicit reasoning_options`);
       } else if (!REVIEWED_REASONING_PROVIDERS.has(change.path.split("/")[1]!)) {
         reasons.push(`${change.path} is a reasoning model that requires manual review`);

--- a/packages/core/test/auto-merge.test.ts
+++ b/packages/core/test/auto-merge.test.ts
@@ -67,14 +67,18 @@ test("requires manual review when reasoning options change", async () => {
   expect(decision.safe).toBe(false);
 });
 
-test("requires manual review when a reasoning model is deleted", async () => {
+test("does not inspect deleted models", async () => {
   const decision = await classifyAutoMerge(
     [{ status: "deleted", path: "providers/test/models/reasoner.toml" }],
-    async () => "",
-    async () => fullModel(true, "reasoning_options = []"),
+    async () => {
+      throw new Error("deleted model should not be loaded");
+    },
+    async () => {
+      throw new Error("deleted model should not be loaded");
+    },
   );
 
-  expect(decision.safe).toBe(false);
+  expect(decision.safe).toBe(true);
 });
 
 test("allows reviewed providers with explicit reasoning options", async () => {

--- a/packages/core/test/auto-merge.test.ts
+++ b/packages/core/test/auto-merge.test.ts
@@ -31,13 +31,13 @@ test("requires manual review for bulk additions", async () => {
   expect(decision.reasons).toContain("11 models created (limit 10)");
 });
 
-test("requires manual review for reasoning provider models", async () => {
+test("requires manual review for added reasoning provider models", async () => {
   const withoutOptions = await classifyAutoMerge(
-    [{ status: "updated", path: "providers/test/models/reasoner.toml" }],
+    [{ status: "created", path: "providers/test/models/reasoner.toml" }],
     async () => fullModel(true),
   );
   const withOptions = await classifyAutoMerge(
-    [{ status: "updated", path: "providers/test/models/reasoner.toml" }],
+    [{ status: "created", path: "providers/test/models/reasoner.toml" }],
     async () => fullModel(true, "reasoning_options = []"),
   );
 
@@ -45,9 +45,42 @@ test("requires manual review for reasoning provider models", async () => {
   expect(withOptions.safe).toBe(false);
 });
 
+test("allows cost and limit updates to existing reasoning models", async () => {
+  const current = `${fullModel(true, "reasoning_options = []")}\n[cost]\ninput = 1\n[limit]\noutput = 100\n`;
+  const previous = `${fullModel(true, "reasoning_options = []")}\n[cost]\ninput = 2\n[limit]\noutput = 50\n`;
+  const decision = await classifyAutoMerge(
+    [{ status: "updated", path: "providers/test/models/reasoner.toml" }],
+    async () => current,
+    async () => previous,
+  );
+
+  expect(decision.safe).toBe(true);
+});
+
+test("requires manual review when reasoning options change", async () => {
+  const decision = await classifyAutoMerge(
+    [{ status: "updated", path: "providers/test/models/reasoner.toml" }],
+    async () => fullModel(true, 'reasoning_options = [{ type = "toggle" }]'),
+    async () => fullModel(true, "reasoning_options = []"),
+  );
+
+  expect(decision.safe).toBe(false);
+});
+
+test("requires manual review when a reasoning model is deleted", async () => {
+  const decision = await classifyAutoMerge(
+    [{ status: "deleted", path: "providers/test/models/reasoner.toml" }],
+    async () => "",
+    async () => fullModel(true, "reasoning_options = []"),
+  );
+
+  expect(decision.safe).toBe(false);
+});
+
 test("allows reviewed providers with explicit reasoning options", async () => {
   const decision = await classifyAutoMerge(
     [{ status: "updated", path: "providers/openrouter/models/reasoner.toml" }],
+    async () => fullModel(true, 'reasoning_options = [{ type = "toggle" }]'),
     async () => fullModel(true, "reasoning_options = []"),
   );
 


### PR DESCRIPTION
## Summary

- compare reasoning metadata before and after model sync updates
- allow cost, limit, and other non-reasoning changes on existing reasoning models to auto-merge
- retain manual review for added reasoning models and reasoning configuration changes on non-allowlisted providers
- preserve existing deletion behavior: deleted models are not inspected and remain subject only to churn limits

Fixes the false manual-review result seen in #4046.

## Validation

- `bun test packages/core/test/auto-merge.test.ts`
- `bun validate`
- `git diff --check`