### PR TITLE
fix: correct Qwen3.8 Max China pricing

### DIFF
--- a/providers/alibaba-cn/models/qwen3.8-max.toml
+++ b/providers/alibaba-cn/models/qwen3.8-max.toml
@@ -2,9 +2,9 @@
 # https://www.qianwenai.com/models/qwen3.8-max
 # https://help.aliyun.com/zh/model-studio/model-pricing (Beijing: qwen3.8-max ¥12/¥36)
 # https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
+# CNY→USD rate: 6.7513, 2026-08-02, source: https://www.nimbuscalc.com/calculators/financial-calculators/currency-converter/USD-CNY-2026-08-02/
 # CNY list: input ¥12, output ¥36, implicit cache hit ¥1.5, explicit cache create ¥15,
-# explicit cache read ¥1 (per 1M tokens). USD via Alibaba EN Beijing parity for the
-# same CNY list as qwen3.7-max ($1.65/$4.951 for ¥12/¥36); cache scaled from CNY ratios.
+# explicit cache read ¥1 (per 1M tokens).
 # Toggle: enable_thinking true|false (hybrid)
 # Effort: reasoning_effort = low|medium|xhigh (default xhigh); high accepted as alias → xhigh
 # Budget: thinking_budget (0..262144) cannot be combined with reasoning_effort
@@ -21,7 +21,7 @@ reasoning_options = [
 field = "reasoning_content"
 
 [cost]
-input = 1.65
-output = 4.951
-cache_read = 0.206
-cache_write = 2.0625
+input = 1.77744
+output = 5.33231
+cache_read = 0.22218
+cache_write = 2.22179


### PR DESCRIPTION
## Summary

Correct the USD-per-million-token prices for `qwen3.8-max` on Alibaba China.

The merged entry inferred USD values from the older Qwen3.7 Max row. This change instead converts the published Qwen3.8 Max Beijing CNY prices using the documented 2026-08-02 CNY/USD rate.

## Pricing

| Category | CNY/MTok | USD/MTok |
| --- | ---: | ---: |
| Input | ¥12 | $1.77744 |
| Output | ¥36 | $5.33231 |
| Implicit cache read | ¥1.5 | $0.22218 |
| Explicit cache write | ¥15 | $2.22179 |

## Sources

- [Qwen3.8 Max China model page](https://www.qianwenai.com/models/qwen3.8-max)
- [Alibaba Model Studio pricing](https://help.aliyun.com/zh/model-studio/model-pricing)
- [CNY/USD rate for 2026-08-02](https://www.nimbuscalc.com/calculators/financial-calculators/currency-converter/USD-CNY-2026-08-02/)

## Validation

- `bun validate`
- `git diff --check`

Follow-up to #4043.