### PR TITLE
Add DeepSeek V4 Flash 0731 to CrofAI

### DIFF
--- a/providers/crof/models/deepseek-v4-flash-0731.toml
+++ b/providers/crof/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,17 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (New)"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.12
+output = 0.21
+cache_read = 0.003
+
+[limit]
+output = 131_072
+
+[provider]
+npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
## What
Adds `deepseek-v4-flash-0731` to the CrofAI provider, mirroring the existing `deepseek-v4-flash` entry.

## Changes
- New `providers/crof/models/deepseek-v4-flash-0731.toml`
  - `base_model = "deepseek/deepseek-v4-flash-0731"` (lab metadata already exists in `models/deepseek/`)
  - Display name: `DeepSeek V4 Flash (New)`
  - Same `reasoning_options`, `interleaved`, `cost`, `limit.output`, and `provider` as the current `deepseek-v4-flash` model

## Validation
- `bun validate` passes