### PR TITLE
Add SaladCloud AI Gateway provider

### DIFF
--- a/providers/salad-cloud/logo.svg
+++ b/providers/salad-cloud/logo.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-7 0 100 100" fill="currentColor">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4991 37.5006L85.9991 25.0006L64.4991 12.5006V37.5006Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4996 62.4996L42.9996 75.0005L21.4996 87.4996V62.4996Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9996 50.0004L21.4996 62.5004L42.9996 75.0004V50.0004Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4995 87.5005L42.9986 99.9996H42.9995V75.0005L21.4995 87.5005Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 74.9996V75.0005L21.4991 87.4996V62.4996L0 74.9996Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4991 62.5005L85.9991 75.0005V50.0005L64.4991 62.5005Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9996 25.0004L64.4996 37.5004L42.9996 50.0004V25.0004Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 49.9997V50.0006L21.4991 62.5006V37.5006L0 49.9997Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9998 100H43.0015L64.4989 87.5009L42.9998 75V100Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4991 87.5004L85.9991 75.0004L64.4991 62.5004V87.5004Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9998 0.000358582L21.4998 12.5004L42.9998 25.0004V0.000358582Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4996 37.5004L42.9996 50.0004L64.4996 62.5004V37.5004Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4996 62.4996L42.9996 75.0005L64.4996 87.4996V62.4996Z"/>
+</svg>

--- a/providers/salad-cloud/models/qwen3.6-35b-a3b.toml
+++ b/providers/salad-cloud/models/qwen3.6-35b-a3b.toml
@@ -4,7 +4,6 @@
 # https://github.com/SaladTechnologies/ai-sdk-provider (accessed 2026-08-04)
 base_model = "alibaba/qwen3.6-35b-a3b"
 description = "Qwen MoE for agentic tasks, complex reasoning, code generation, and instruction following"
-status = "beta"
 reasoning_options = [{ type = "toggle" }]
 
 [cost]

--- a/providers/salad-cloud/models/qwen3.6-35b-a3b.toml
+++ b/providers/salad-cloud/models/qwen3.6-35b-a3b.toml
@@ -1,0 +1,19 @@
+# Pricing: https://docs.salad.com/ai-gateway/reference/pricing (accessed 2026-08-04)
+# Limits and modalities: https://docs.salad.com/ai-gateway/reference/models (accessed 2026-08-04)
+# Reasoning toggle: chat_template_kwargs.enable_thinking true|false.
+# https://github.com/SaladTechnologies/ai-sdk-provider (accessed 2026-08-04)
+base_model = "alibaba/qwen3.6-35b-a3b"
+description = "Qwen MoE for agentic tasks, complex reasoning, code generation, and instruction following"
+status = "beta"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0.09
+output = 0.60
+
+[limit]
+input = 262_144
+output = 262_144
+
+[modalities]
+input = ["text", "image"]

--- a/providers/salad-cloud/provider.toml
+++ b/providers/salad-cloud/provider.toml
@@ -1,0 +1,4 @@
+name = "SaladCloud AI Gateway"
+env = ["SALAD_CLOUD_API_KEY"]
+npm = "@saladtechnologies-oss/ai-sdk-provider"
+doc = "https://docs.salad.com/ai-gateway/explanation/overview"


### PR DESCRIPTION
## Summary

- add SaladCloud AI Gateway as a provider using its native Vercel AI SDK package
- list only `qwen3.6-35b-a3b`, inheriting the shared Alibaba model metadata
- record Salad-specific per-million-token pricing, limits, modalities, and reasoning toggle
- add a square `currentColor` SaladCloud provider logo

## Why

This makes SaladCloud AI Gateway and its currently promoted agentic model discoverable to Models.dev and downstream consumers while keeping provider-specific overrides separate from the shared Qwen metadata.

## Published data sources

- Pricing: https://docs.salad.com/ai-gateway/reference/pricing
- Model limits and capabilities: https://docs.salad.com/ai-gateway/reference/models
- Gateway overview: https://docs.salad.com/ai-gateway/explanation/overview
- AI SDK package and reasoning behavior: https://github.com/SaladTechnologies/ai-sdk-provider

## Validation

- `bun validate`
- rendered the SVG at 256×256 to verify the square logo asset
