### PR TITLE
fix(sync): emit toggle + effort for Merge Gateway reasoning controls

### DIFF
--- a/packages/core/src/sync/providers/merge-gateway.ts
+++ b/packages/core/src/sync/providers/merge-gateway.ts
@@ -13,6 +13,7 @@ const VendorReasoning = z.object({
   disable_supported: z.boolean().optional(),
   default_enabled: z.boolean().optional(),
   controls: z.array(z.string()).optional(),
+  effort_values: z.array(z.string()).optional(),
   output_style: z.string().nullable().optional(),
 }).passthrough();
 
@@ -161,6 +162,28 @@ export const mergeGateway = {
   },
 } satisfies SyncProvider<MergeGatewayModel>;
 
+export function mergeGatewayReasoningOptions(
+  reasoning: MergeGatewayVendor["capabilities"]["reasoning"],
+): NonNullable<SyncedFullModel["reasoning_options"]> | undefined {
+  if (reasoning === undefined) return undefined;
+  const options: NonNullable<SyncedFullModel["reasoning_options"]> = [];
+
+  if (reasoning.disable_supported === true) {
+    options.push({ type: "toggle" as const });
+  }
+
+  const controls = (reasoning.controls ?? []).map((control) => control.toLowerCase());
+  const effortValues = reasoning.effort_values ?? [];
+  if (
+    (controls.includes("reasoning.effort") || controls.includes("reasoning_effort"))
+    && effortValues.length > 0
+  ) {
+    options.push({ type: "effort" as const, values: [...effortValues] });
+  }
+
+  return options;
+}
+
 export function selectMergeGatewayVendor(model: MergeGatewayModel) {
   const canonical = model.vendors[model.provider];
   if (canonical?.availability_status === "available") {
@@ -234,8 +257,8 @@ export function buildMergeGatewayModel(
   const reasoning = routeConfirmsReasoning ? true : existing?.reasoning;
   const existingReasoningOptions = existing?.reasoning_options ?? [];
   const reasoningOptions = reasoning === true && existingReasoningOptions.length === 0
-    && selected.info.capabilities.reasoning?.disable_supported === true
-    ? [{ type: "toggle" as const }]
+    ? mergeGatewayReasoningOptions(selected.info.capabilities.reasoning)
+      ?? existingReasoningOptions
     : reasoning === true
       ? existingReasoningOptions
       : existing?.reasoning_options;

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -2559,6 +2559,69 @@ test("derives a Merge Gateway reasoning toggle when the selected route supports 
   expect(model).toMatchObject({ reasoning_options: [{ type: "toggle" }] });
 });
 
+// Effort control yields toggle + effort, not a bare toggle (claude-opus-5 regression).
+test("derives Merge Gateway toggle + effort from an effort control", () => {
+  const selected = mergeGatewayVendor({
+    pricing: { currency: "USD", input_per_million: 5, output_per_million: 25 },
+  });
+  selected.capabilities.reasoning = {
+    configurable: true,
+    disable_supported: true,
+    default_enabled: true,
+    controls: ["reasoning.effort"],
+    effort_values: ["low", "medium", "high", "xhigh", "max"],
+    output_style: "hidden",
+  };
+  const model = buildMergeGatewayModel(mergeGatewayModel({
+    model: "anthropic/claude-opus-5",
+    provider: "anthropic",
+    display_name: "Claude Opus 5",
+    vendors: { anthropic: selected },
+  }), {
+    base_model: "anthropic/claude-opus-5",
+    reasoning: true,
+    reasoning_options: [],
+    cost: { input: 5, output: 25 },
+  });
+
+  expect(model).toMatchObject({
+    reasoning_options: [
+      { type: "toggle" },
+      { type: "effort", values: ["low", "medium", "high", "xhigh", "max"] },
+    ],
+  });
+});
+
+// Effort control without disable support yields effort only.
+test("derives Merge Gateway effort without a toggle when disable is unsupported", () => {
+  const selected = mergeGatewayVendor({
+    pricing: { currency: "USD", input_per_million: 5, output_per_million: 25 },
+  });
+  selected.capabilities.reasoning = {
+    configurable: true,
+    disable_supported: false,
+    default_enabled: true,
+    controls: ["reasoning.effort"],
+    effort_values: ["low", "medium", "high", "xhigh", "max"],
+    output_style: "hidden",
+  };
+  const model = buildMergeGatewayModel(mergeGatewayModel({
+    model: "anthropic/claude-sonnet-5",
+    provider: "anthropic",
+    display_name: "Claude Sonnet 5",
+    vendors: { anthropic: selected },
+  }), {
+    base_model: "anthropic/claude-sonnet-5",
+    reasoning: true,
+    reasoning_options: [],
+    cost: { input: 3, output: 15 },
+  });
+
+  expect(model).toMatchObject({
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  });
+});
+
 // Prevents deprecated routes from contributing capabilities to an available model.
 test("ignores supports_reasoning = true on unavailable Merge Gateway routes", () => {
   const selected = mergeGatewayVendor();

--- a/providers/merge-gateway/models/anthropic/claude-opus-5.toml
+++ b/providers/merge-gateway/models/anthropic/claude-opus-5.toml
@@ -1,8 +1,8 @@
+# Source: https://api-gateway.merge.dev/v1/models?model=anthropic%2Fclaude-opus-5 (accessed 2026-08-04)
+
 base_model = "anthropic/claude-opus-5"
 structured_output = true
-
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5


### PR DESCRIPTION
## Summary

The daily Merge Gateway model sync synthesized a **bare reasoning toggle** for any newly-added model whose route advertises `disable_supported: true` — ignoring `reasoning.controls` entirely. That's how `anthropic/claude-opus-5` (added 2026-08-02, no pre-existing `reasoning_options`) got:

```toml
[[reasoning_options]]
type = "toggle"
```

...when the route actually advertises a graded **`reasoning.effort`** control. The rest of the Claude family (`claude-opus-4-6/4-7/4-8`, `claude-sonnet-4-6/5`) carries `toggle` + `effort` because their options were **hand-authored** in #3249 — opus-5 hit the uncurated auto-fallback.

## Root cause

`packages/core/src/sync/providers/merge-gateway.ts` only read `reasoning.disable_supported` when synthesizing options and never read `reasoning.controls`. Per AGENTS.md, a relay that advertises `reasoning.effort` should emit an `effort` option alongside the toggle.

## What changed

- **`merge-gateway.ts`**: `mergeGatewayReasoningOptions()` maps `reasoning.controls` + `reasoning.effort_values` into synthesized options:
  - `toggle` when `disable_supported: true`
  - `effort` when controls include `reasoning.effort` / `reasoning_effort`, using `effort_values` from the API
- **`claude-opus-5.toml`**: authored to `toggle` + `effort [low..max]` (matches the family; effort values sourced from the first-party lab baseline for now).
- **Tests**: two new cases (toggle+effort; effort-only without disable).

## Dependency

`effort_values` is a new field the merge-gateway `/v1/models` API will send — landing in **merge-api/merge-gateway#854**. This PR makes the sync **ready** to consume it; the opus-5 TOML edit pins the correct values until the API ships.

## Validation

- `bun test packages/core/test/sync.test.ts -t "Merge Gateway"` → 24 pass
- `bun validate` → exit 0
- 4 pre-existing test failures (DeepInfra, catalog gen, sdk snapshot) also fail on clean `dev`.