### PR TITLE
feat(cortecs): add deepseek-v4-flash-0731

### DIFF
--- a/providers/cortecs/models/deepseek-v4-flash-0731.toml
+++ b/providers/cortecs/models/deepseek-v4-flash-0731.toml
@@ -1,3 +1,6 @@
+# Cost converted from EUR at 1 EUR = 1.1515 USD (rate 2026-08-04).
+# EUR list: input €0.224 / output €0.269 / cache_read €0.056 per MTok.
+# https://api.cortecs.ai/v1/models (accessed 2026-08-04)
 base_model = "deepseek/deepseek-v4-flash-0731"
 base_model_omit = ["structured_output"]
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
@@ -5,7 +8,6 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 [interleaved]
 field = "reasoning_content"
 
-# Cost converted from EUR at 1 EUR = 1.1515 USD (rate 2026-08-04).
 [cost]
 input = 0.258
 output = 0.310

--- a/providers/cortecs/models/deepseek-v4-flash-0731.toml
+++ b/providers/cortecs/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+base_model_omit = ["structured_output"]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+# Cost converted from EUR at 1 EUR = 1.1515 USD (rate 2026-08-04).
+[cost]
+input = 0.258
+output = 0.310
+cache_read = 0.0645
+
+[limit]
+context = 1_048_576


### PR DESCRIPTION
Adds `deepseek-v4-flash-0731` to the cortecs provider.

Mirrors the override-only structure already used for `deepseek-v4-flash` in
`providers/cortecs/models/deepseek-v4-flash.toml`