### PR TITLE
kimi-for-coding: inherit indicative costs from base models instead of zeroing

### DIFF
--- a/providers/kimi-for-coding/models/k3-256k.toml
+++ b/providers/kimi-for-coding/models/k3-256k.toml
@@ -2,7 +2,9 @@
 # endpoint. Unlike full K3 it accepts no video input (image only).
 # reasoning_options per the Kimi Code docs:
 #   reasoning_effort = "low" | "high" | "max" (default "high")
-# Cost is zeroed per this provider's subscription convention.
+# Kimi For Coding is a fixed-fee subscription plan. The cost is inherited
+# from the base model and is the *indicative* pay-per-token equivalent, for
+# usage tracking only, not the actual billing rate.
 base_model = "moonshotai/kimi-k3"
 name = "Kimi K3-256K"
 description = "256K-context version of Kimi K3, reducing token consumption for shorter coding sessions"
@@ -11,12 +13,6 @@ attachment = false
 [[reasoning_options]]
 type = "effort"
 values = ["low", "high", "max"]
-
-[cost]
-input = 0
-output = 0
-cache_read = 0
-cache_write = 0
 
 [limit]
 context = 262_144

--- a/providers/kimi-for-coding/models/k3.toml
+++ b/providers/kimi-for-coding/models/k3.toml
@@ -1,7 +1,9 @@
 # reasoning_options mirror the Moonshot AI platform API surface:
 #   thinking.type = "enabled" | "disabled" | "adaptive"
 #   output_config.effort = "low" | "high" | "max"
-# Cost is zeroed per this provider's subscription convention.
+# Kimi For Coding is a fixed-fee subscription plan. The cost is inherited
+# from the base model and is the *indicative* pay-per-token equivalent, for
+# usage tracking only, not the actual billing rate.
 base_model = "moonshotai/kimi-k3"
 attachment = false
 
@@ -11,9 +13,3 @@ type = "toggle"
 [[reasoning_options]]
 type = "effort"
 values = ["low", "high", "max"]
-
-[cost]
-input = 0
-output = 0
-cache_read = 0
-cache_write = 0

--- a/providers/kimi-for-coding/models/kimi-for-coding-highspeed.toml
+++ b/providers/kimi-for-coding/models/kimi-for-coding-highspeed.toml
@@ -1,12 +1,9 @@
+# Kimi For Coding is a fixed-fee subscription plan. The cost is inherited
+# from the base model and is the *indicative* pay-per-token equivalent, for
+# usage tracking only, not the actual billing rate.
 base_model = "moonshotai/kimi-k2.7-code-highspeed"
 name = "Kimi For Coding HighSpeed"
 reasoning_options = []
-
-[cost]
-input = 0
-output = 0
-cache_read = 0
-cache_write = 0
 
 [limit]
 output = 32_768

--- a/providers/kimi-for-coding/models/kimi-for-coding.toml
+++ b/providers/kimi-for-coding/models/kimi-for-coding.toml
@@ -1,11 +1,8 @@
+# Kimi For Coding is a fixed-fee subscription plan. The cost is inherited
+# from the base model and is the *indicative* pay-per-token equivalent, for
+# usage tracking only, not the actual billing rate.
 base_model = "moonshotai/kimi-k2.7-code"
 reasoning_options = []
-
-[cost]
-input = 0
-output = 0
-cache_read = 0
-cache_write = 0
 
 [limit]
 output = 32_768


### PR DESCRIPTION
## Summary

The `kimi-for-coding` provider models currently ship with zeroed `[cost]` tables, with the comment "Cost is zeroed per this provider's subscription convention". This makes usage tracking in opencode (and any models.dev consumer) report **$0.00** for all Kimi For Coding traffic, even though the models are billed on the underlying model's token economics.

This PR removes the zeroed `[cost]` tables so each model **inherits the cost of its `base_model`**, keeping the pricing in sync automatically when the underlying model or its price changes.

## What changed

- `providers/kimi-for-coding/models/kimi-for-coding.toml` — no longer zeroes cost; inherits from `moonshotai/kimi-k2.7-code` (input $0.95 / output $4.00 / cache read $0.19)
- `providers/kimi-for-coding/models/kimi-for-coding-highspeed.toml` — inherits from `moonshotai/kimi-k2.7-code-highspeed` (input $1.90 / output $8.00 / cache read $0.38)
- `providers/kimi-for-coding/models/k3.toml` — inherits from `moonshotai/kimi-k3` (input $3.00 / output $15.00 / cache read $0.30)
- `providers/kimi-for-coding/models/k3-256k.toml` — inherits from `moonshotai/kimi-k3`

Each file now carries a comment clarifying that Kimi For Coding is a fixed-fee subscription plan and the inherited cost is the **indicative pay-per-token equivalent, for usage tracking only, not the actual billing rate**.

## Rationale

The `kimi-for-coding` model IDs are rolling aliases that point at the current flagship coding model (e.g. `kimi-for-coding` → `moonshotai/kimi-k2.7-code` today). Because the models use `base_model`, dropping the zeroed `[cost]` tables yields:

- Realistic cost estimates in usage dashboards instead of $0.00
- Automatic price updates when the underlying model or alias changes
- No maintenance of hardcoded numbers per alias

This follows the existing convention for other subscription-billed endpoints already listed in this repo — e.g. `providers/opencode-go/models/kimi-k2.7-code.toml` ships full per-token costs (input $0.95 / output $4.00 / cache read $0.19) without zeroing.

## Notes

- No schema changes; this is purely data.
- If maintainers prefer keeping subscription endpoints at $0, an alternative would be a dedicated `indicative` flag in the schema — happy to discuss.