### PR TITLE
feat(providers/azure): add Kimi K2.7 Code

### DIFF
--- a/providers/azure/models/kimi-k2.7-code.toml
+++ b/providers/azure/models/kimi-k2.7-code.toml
@@ -1,0 +1,21 @@
+# Pricing source: https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/ (accessed 2026-08-05)
+base_model = "moonshotai/kimi-k2.7-code"
+
+attachment = false
+reasoning_options = []
+
+[modalities]
+input = ["text", "image"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4.0
+cache_read = 0.19
+
+[provider]
+shape = "completions"
+npm = "@ai-sdk/openai-compatible"
+api = "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/models"

--- a/providers/azure/models/kimi-k2.7-code.toml
+++ b/providers/azure/models/kimi-k2.7-code.toml
@@ -1,7 +1,6 @@
 # Pricing source: https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/ (accessed 2026-08-05)
 base_model = "moonshotai/kimi-k2.7-code"
 
-attachment = false
 reasoning_options = []
 
 [modalities]


### PR DESCRIPTION
Adds Azure pricing and provider metadata for `Kimi K2.7 Code`.

- Source: https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/
- Pricing (commercial region): input $0.95, output $4.00, cache_read $0.19 per 1M tokens
- Uses `moonshotai/kimi-k2.7-code` lab metadata via `base_model`
- `reasoning_options = []` — no caller-facing reasoning controls on the Azure endpoint; consistent with the Moonshot first-party entry
- `bun validate` passes