### PR TITLE
baseten: refresh reasoning_effort values from Baseten's docs

### DIFF
--- a/providers/baseten/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/baseten/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,16 +1,15 @@
-# Baseten overview documents DeepSeek V4 Flash 0731 reasoning as "Enabled by
-# default". Mirroring the DeepSeek V4 Pro entry, reasoning_effort accepts
-# low | medium | high | xhigh; no toggle or budget field is documented.
-# https://docs.baseten.co/inference/model-apis/overview (accessed 2026-08-01)
+# Baseten's model matrix documents DeepSeek V4 Flash 0731 reasoning as "Enabled
+# by default", but the model is absent from the "Control reasoning depth" table
+# on the reasoning page, and that page warns that models outside it accept
+# reasoning_effort and ignore it. So it reasons with no addressable depth.
+# https://docs.baseten.co/inference/model-apis/overview
+# https://docs.baseten.co/inference/model-apis/reasoning
 base_model = "deepseek/deepseek-v4-flash-0731"
 name = "Deepseek V4 Flash 0731"
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
-
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh"]
 
 [cost]
 input = 0.13

--- a/providers/baseten/models/deepseek-ai/DeepSeek-V4-Pro.toml
+++ b/providers/baseten/models/deepseek-ai/DeepSeek-V4-Pro.toml
@@ -1,5 +1,6 @@
-# Baseten documents top-level reasoning_effort = low | medium | high | xhigh
-# for DeepSeek V4 Pro; no toggle or reasoning-token budget field is documented.
+# Baseten now documents top-level reasoning_effort = none | minimal | low |
+# medium (default) | high | xhigh | max for DeepSeek V4 Pro; no toggle or
+# reasoning-token budget field is documented.
 # https://docs.baseten.co/inference/model-apis/reasoning
 
 base_model = "deepseek/deepseek-v4-pro"
@@ -10,7 +11,7 @@ field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 1.74

--- a/providers/baseten/models/moonshotai/Kimi-K3.toml
+++ b/providers/baseten/models/moonshotai/Kimi-K3.toml
@@ -1,7 +1,15 @@
+# Baseten documents Kimi K3 reasoning as enabled by default, with top-level
+# reasoning_effort = none | low | high | max (default). It also accepts
+# chat_template_args.enable_thinking=false. No reasoning-token budget is
+# documented.
+# https://docs.baseten.co/inference/model-apis/reasoning
 base_model = "moonshotai/kimi-k3"
 description = "Kimi multimodal agent model for visual understanding, coding, and planning"
 temperature = true
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "high", "max"]
 
 [cost]
 input = 3

--- a/providers/baseten/models/openai/gpt-oss-120b.toml
+++ b/providers/baseten/models/openai/gpt-oss-120b.toml
@@ -1,5 +1,6 @@
-# Baseten documents top-level reasoning_effort = low | medium | high for GPT OSS
-# 120B; reasoning is otherwise enabled by default. No toggle or budget exists.
+# Baseten now documents top-level reasoning_effort = none | minimal | low |
+# medium (default) | high | xhigh | max for GPT OSS 120B; reasoning is
+# otherwise enabled by default. No toggle or budget exists.
 # https://docs.baseten.co/inference/model-apis/reasoning
 
 name = "OpenAI GPT 120B"
@@ -17,7 +18,7 @@ open_weights = true
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.1

--- a/providers/baseten/models/zai-org/GLM-5.2-Fast.toml
+++ b/providers/baseten/models/zai-org/GLM-5.2-Fast.toml
@@ -1,6 +1,8 @@
 # Fast tier of GLM 5.2: same weights/API as zai-org/GLM-5.2, dedicated
 # higher-throughput capacity. Opt in with chat_template_args.enable_thinking=true.
-# Baseten documents no explicit false behavior, effort values, or reasoning-token budget.
+# Baseten now documents reasoning_effort = none | high | max for GLM 5.2 Fast,
+# and returns a 400 for any value outside that set. No reasoning-token budget
+# is documented.
 # https://docs.baseten.co/inference/model-apis/overview
 # https://docs.baseten.co/inference/model-apis/reasoning
 base_model = "zhipuai/glm-5.2"
@@ -10,7 +12,8 @@ name = "GLM 5.2 Fast"
 field = "reasoning_content"
 
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "high", "max"]
 
 [cost]
 input = 2.1

--- a/providers/baseten/models/zai-org/GLM-5.2.toml
+++ b/providers/baseten/models/zai-org/GLM-5.2.toml
@@ -1,5 +1,7 @@
-# Opt in with chat_template_args.enable_thinking=true. Baseten documents no
-# explicit false behavior, effort values, or reasoning-token budget.
+# Opt in with chat_template_args.enable_thinking=true. Baseten now documents
+# reasoning_effort = none | high | max for GLM 5.2, and returns a 400 for any
+# value outside that set. GLM 5.2 honors reasoning_effort both top-level and
+# inside chat_template_args. No reasoning-token budget is documented.
 # https://docs.baseten.co/inference/model-apis/reasoning
 base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
@@ -8,7 +10,8 @@ name = "GLM 5.2"
 field = "reasoning_content"
 
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "high", "max"]
 
 [cost]
 input = 1.4


### PR DESCRIPTION
Baseten's reasoning page has grown a **Control reasoning depth** table since these entries were written. Each entry already cites that page, and the values it now publishes differ from what we ship.

| model | current | Baseten's docs |
| --- | --- | --- |
| `zai-org/GLM-5.2` | `toggle` | `effort`: `none, high, max` |
| `zai-org/GLM-5.2-Fast` | `toggle` | `effort`: `none, high, max` |
| `openai/gpt-oss-120b` | `low, medium, high` | `none, minimal, low, medium, high, xhigh, max` |
| `deepseek-ai/DeepSeek-V4-Pro` | `low, medium, high, xhigh` | `none, minimal, low, medium, high, xhigh, max` |
| `moonshotai/Kimi-K3` | `reasoning_options = []` | `effort`: `none, low, high, max` |

The two GLM 5.2 routes are the ones that bite. The docs state the endpoint **returns a 400 for any value outside its supported set**, so describing them as a toggle both hides the two depths that do work and leaves a consumer no way to learn that the usual ladder is rejected. A client offering `minimal`/`low`/`medium`/`xhigh` there gets four guaranteed 400s, and `max` never becomes reachable.

Every value in the table above is read from the **Supported values** table at https://docs.baseten.co/inference/model-apis/reasoning.

### Second commit, separated on purpose

`deepseek-ai/DeepSeek-V4-Flash-0731` is a judgment call rather than a citation, so it is its own commit and can be dropped without touching the rest. Its comment says the values were reached by *"mirroring the DeepSeek V4 Pro entry"*, and that mirror does not hold: V4 Flash is absent from the depth table, and the same page warns that models outside it accept `reasoning_effort` and ignore it. The model matrix does list its reasoning as "Enabled by default", so the commit leaves it reasoning with an empty `reasoning_options` rather than removing reasoning altogether.

### Checks

Each changed file parses, and `reasoning_options` round-trips to the shape the API serves. `none` is included wherever Baseten lists it, matching the existing convention in the Inkling entries.
