### PR TITLE
feat(meta): add Muse Spark 1.2

### DIFF
--- a/models/meta/muse-spark-1.2.toml
+++ b/models/meta/muse-spark-1.2.toml
@@ -1,0 +1,23 @@
+# Sources:
+# https://research.meta.ai/blog/introducing-muse-code-and-muse-spark-1-2
+# https://dev.meta.ai/docs/getting-started/models
+
+name = "Muse Spark 1.2"
+description = "Muse Spark 1.2 is a coding-focused update to Muse Spark 1.1 with improvements in code generation, complex debugging, codebase understanding, and end-to-end developer workflows."
+family = "muse"
+release_date = "2026-08-05"
+last_updated = "2026-08-05"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_048_576
+output = 1_048_576
+
+[modalities]
+input = ["text", "image", "video", "pdf", "audio"]
+output = ["text"]

--- a/models/meta/muse-spark-1.2.toml
+++ b/models/meta/muse-spark-1.2.toml
@@ -16,7 +16,7 @@ open_weights = false
 
 [limit]
 context = 1_048_576
-output = 1_048_576
+output = 131_072
 
 [modalities]
 input = ["text", "image", "video", "pdf", "audio"]

--- a/providers/meta/models/muse-spark-1.2-contributor.toml
+++ b/providers/meta/models/muse-spark-1.2-contributor.toml
@@ -1,0 +1,14 @@
+# Sources:
+# https://dev.meta.ai/docs/overview/
+# https://dev.meta.ai/docs/pricing-rate-limits/
+# Contributor tier prompts and completions may be used to improve Meta's products.
+
+base_model = "meta/muse-spark-1.2"
+name = "Muse Spark 1.2 Contributor"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 0.10
+output = 0.20
+cache_read = 0.002

--- a/providers/meta/models/muse-spark-1.2.toml
+++ b/providers/meta/models/muse-spark-1.2.toml
@@ -1,0 +1,12 @@
+# Sources:
+# https://dev.meta.ai/docs/overview/
+# https://dev.meta.ai/docs/pricing-rate-limits/
+
+base_model = "meta/muse-spark-1.2"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.25
+output = 4.25
+cache_read = 0.15

--- a/providers/openrouter/models/meta/muse-spark-1.2.toml
+++ b/providers/openrouter/models/meta/muse-spark-1.2.toml
@@ -8,3 +8,6 @@ values = ["minimal", "low", "medium", "high", "xhigh"]
 input = 1.25
 output = 4.25
 cache_read = 0.15
+
+[limit]
+output = 1_048_576

--- a/providers/openrouter/models/meta/muse-spark-1.2.toml
+++ b/providers/openrouter/models/meta/muse-spark-1.2.toml
@@ -1,14 +1,4 @@
-name = "Muse Spark 1.2"
-description = "Open Llama multimodal model for image understanding and text reasoning"
-family = "muse"
-release_date = "2026-08-05"
-last_updated = "2026-08-05"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = false
+base_model = "meta/muse-spark-1.2"
 
 [[reasoning_options]]
 type = "effort"
@@ -18,11 +8,3 @@ values = ["minimal", "low", "medium", "high", "xhigh"]
 input = 1.25
 output = 4.25
 cache_read = 0.15
-
-[limit]
-context = 1_048_576
-output = 1_048_576
-
-[modalities]
-input = ["text", "image", "video", "pdf", "audio"]
-output = ["text"]


### PR DESCRIPTION
## Summary

- add shared Meta lab metadata for Muse Spark 1.2
- add Meta Model API entries for the standard and Contributor tiers
- point the existing OpenRouter entry at the shared lab model

Meta exposes one underlying Muse Spark 1.2 model through two first-party API IDs. The Contributor ID has lower pricing and permits Meta to use prompts and completions for product improvement.

## Sources

- https://research.meta.ai/blog/introducing-muse-code-and-muse-spark-1-2
- https://dev.meta.ai/docs/overview/
- https://dev.meta.ai/docs/pricing-rate-limits/
- https://dev.meta.ai/docs/getting-started/models

## Validation

- `bun validate`