### PR TITLE
Neon: use the provider-prefixed dialect paths

### DIFF
--- a/providers/neon/models/gpt-5-1.toml
+++ b/providers/neon/models/gpt-5-1.toml
@@ -12,5 +12,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-2.toml
+++ b/providers/neon/models/gpt-5-2.toml
@@ -12,5 +12,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-3-codex.toml
+++ b/providers/neon/models/gpt-5-3-codex.toml
@@ -12,5 +12,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-4-mini.toml
+++ b/providers/neon/models/gpt-5-4-mini.toml
@@ -12,5 +12,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-4-nano.toml
+++ b/providers/neon/models/gpt-5-4-nano.toml
@@ -12,5 +12,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-4.toml
+++ b/providers/neon/models/gpt-5-4.toml
@@ -18,5 +18,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-5-pro.toml
+++ b/providers/neon/models/gpt-5-5-pro.toml
@@ -9,5 +9,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-5.toml
+++ b/providers/neon/models/gpt-5-5.toml
@@ -18,5 +18,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-6-luna.toml
+++ b/providers/neon/models/gpt-5-6-luna.toml
@@ -18,5 +18,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-6-sol.toml
+++ b/providers/neon/models/gpt-5-6-sol.toml
@@ -18,5 +18,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-6-terra.toml
+++ b/providers/neon/models/gpt-5-6-terra.toml
@@ -18,5 +18,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-mini.toml
+++ b/providers/neon/models/gpt-5-mini.toml
@@ -12,5 +12,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5-nano.toml
+++ b/providers/neon/models/gpt-5-nano.toml
@@ -12,5 +12,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/models/gpt-5.toml
+++ b/providers/neon/models/gpt-5.toml
@@ -12,5 +12,5 @@ output = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"

--- a/providers/neon/provider.toml
+++ b/providers/neon/provider.toml
@@ -3,10 +3,10 @@ npm = "@ai-sdk/openai-compatible"
 # Unified Chat is POST `/v1/chat/completions`. Native routes are POST
 # `/anthropic/v1/messages` (`thinking.type`, `thinking.budget_tokens`), POST
 # `/openai/v1/responses` (`reasoning.effort`), and POST
-# `/v1/gemini/v1beta/models/{model}:generateContent`
-# (`generationConfig.thinkingConfig`). Each also has an equivalent longer
-# `/ai-gateway/<dialect>/...` form; the short paths above are the documented
-# default. Verified 2026-08-05.
+# `/gemini/v1beta/models/{model}:generateContent`
+# (`generationConfig.thinkingConfig`). Verified 2026-08-05, except the Gemini
+# route, which drops its `/v1` prefix to match the provider-prefixed form the
+# other dialects use — see neondatabase/website#5456.
 # https://neon.com/docs/ai-gateway/chat-completions
 # https://neon.com/docs/ai-gateway/anthropic-messages
 # https://neon.com/docs/ai-gateway/openai-responses

--- a/providers/neon/provider.toml
+++ b/providers/neon/provider.toml
@@ -1,11 +1,12 @@
 name = "Neon"
 npm = "@ai-sdk/openai-compatible"
 # Unified Chat is POST `/v1/chat/completions`. Native routes are POST
-# `/ai-gateway/anthropic/v1/messages` (`thinking.type`,
-# `thinking.budget_tokens`), POST `/openai/v1/responses`
-# (`reasoning.effort`), and POST
-# `/ai-gateway/gemini/v1beta/models/{model}:generateContent`
-# (`generationConfig.thinkingConfig`).
+# `/anthropic/v1/messages` (`thinking.type`, `thinking.budget_tokens`), POST
+# `/openai/v1/responses` (`reasoning.effort`), and POST
+# `/v1/gemini/v1beta/models/{model}:generateContent`
+# (`generationConfig.thinkingConfig`). Each also has an equivalent longer
+# `/ai-gateway/<dialect>/...` form; the short paths above are the documented
+# default. Verified 2026-08-05.
 # https://neon.com/docs/ai-gateway/chat-completions
 # https://neon.com/docs/ai-gateway/anthropic-messages
 # https://neon.com/docs/ai-gateway/openai-responses


### PR DESCRIPTION
Neon's AI Gateway addresses each native dialect with a provider prefix at the root. The `neon`
provider pointed its OpenAI Responses entries at a longer `/ai-gateway/openai/v1` form, and its
header comment listed the native routes in three inconsistent shapes.

## Changed

The 14 OpenAI Responses entries:

```diff
 [provider]
 npm = "@ai-sdk/openai"
-api = "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
 shape = "responses"
```

And the `provider.toml` header comment, which now lists all three native routes consistently:

| Dialect | Path |
| --- | --- |
| Chat completions | `POST /v1/chat/completions` |
| OpenAI Responses | `POST /openai/v1/responses` |
| Anthropic Messages | `POST /anthropic/v1/messages` |
| Gemini | `POST /gemini/v1beta/models/{model}:generateContent` |

The `/v1beta` in the Gemini route is Google's own API version, not Neon's.

## Verified

Probed against a live Neon branch on 2026-08-05: `/v1/chat/completions`, `/openai/v1/responses`
and `/anthropic/v1/messages` all return 200, the last on all eleven Claude ids.

**The Gemini route is the exception and lands ahead of the gateway.** `/gemini/v1beta/...`
currently returns 404; `/v1/gemini/v1beta/...` is what serves today. The customer-facing path is
moving to the provider-prefixed form so it matches the other dialects — see
[neondatabase/website#5456](https://github.com/neondatabase/website/pull/5456), which this
follows. Flagging it plainly rather than implying the whole table was measured together.

This only affects the header comment; no Gemini model entry carries a `[provider]` block, so the
generated output for those models is unchanged.

`bun validate` passes — 39 models, and the only diff in the generated provider is the 14 `api`
values.

Docs: <https://neon.com/docs/ai-gateway/models>