### PR TITLE
fix(anthropic): drop fast mode from Opus 4.6 and 4.7

### DIFF
--- a/providers/anthropic/models/claude-opus-4-6.toml
+++ b/providers/anthropic/models/claude-opus-4-6.toml
@@ -32,7 +32,3 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-
-[experimental.modes.fast]
-cost = { input = 30, output = 150, cache_read = 3, cache_write = 37.5 }
-provider = { body = { speed = "fast" }, headers = { anthropic-beta = "fast-mode-2026-02-01" } }

--- a/providers/anthropic/models/claude-opus-4-7.toml
+++ b/providers/anthropic/models/claude-opus-4-7.toml
@@ -28,7 +28,3 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
-
-[experimental.modes.fast]
-cost = { input = 30.00, output = 150.00, cache_read = 3.00, cache_write = 37.50 }
-provider = { body = { speed = "fast" }, headers = { anthropic-beta = "fast-mode-2026-02-01" } }


### PR DESCRIPTION
## Summary

`claude-opus-4-6.toml` and `claude-opus-4-7.toml` each declare an `[experimental.modes.fast]` block priced at **$30 / $150 / $3 / $37.50**. Anthropic does not offer fast mode on either model, and those figures appear nowhere in its current documentation.

A consumer pricing an Opus 4.6 fast request overstates it by **6×**. For Opus 4.7 the declared request shape (`speed = "fast"` plus the `fast-mode-2026-02-01` beta header) does not work at all — the API rejects it.

These almost certainly date from the February 2026 fast-mode launch and were simply never retired. The repo already contradicts itself: `claude-opus-4-8.toml` and `claude-opus-5.toml` carry the correct `10 / 50 / 1 / 12.5`.

## Sources

https://platform.claude.com/docs/en/about-claude/pricing — the entire fast-mode price table is two models:

> | Model | Input | Output |
> | Claude Opus 5 / Claude Opus 4.8 | $10 / MTok | $50 / MTok |

and, immediately below it:

> Fast mode is not available on Claude Opus 4.7 (requests with `speed: "fast"` return an error) or Claude Opus 4.6 (requests run at standard speed and are billed at standard rates).

https://platform.claude.com/docs/en/build-with-claude/fast-mode — the supported-models list is those same two entries.

## Changes

Removes the `[experimental.modes.fast]` table from both files. Nothing else is touched — the base `[cost]` block (`input = 5, output = 25, cache_read = 0.5, cache_write = 6.25`) is correct against the vendor's table and stays. `experimental` is an optional provider-only key per `AGENTS.md`, so the removal is schema-safe.

## Validation

Both files parse as TOML after the change, and `[cost]` is intact.

I could not run `bun validate` locally, and I would rather say so than imply I had: this repository cannot be checked out on Windows, because several provider files contain `:` in their filenames (`providers/unorouter/models/gpt-5.5:free.toml`, `amazon-bedrock/…nova-2-lite-v1:0.toml`), which is an invalid path there. I made the edit through the GitHub API instead. Given the change is a pure deletion of an optional table, I rate the validation risk as low — but it is unrun rather than verified, and CI will be the real check.

## Scope

First-party `anthropic` provider only. Fourteen other files copy this fast-mode block (`anyapi`, `auriko`, `databricks`, `github-copilot`, `gmicloud`, `merge-gateway`, `orcarouter`, `snowflake-cortex` variants of 4.6/4.7). Anthropic's documentation is not authoritative for what a third-party relay bills, so I have not touched them — worth a follow-up by someone who can confirm those relays' own published rates.