### PR TITLE
provider(upstage): add Solar Pro 4

### DIFF
--- a/providers/upstage/models/solar-pro4.toml
+++ b/providers/upstage/models/solar-pro4.toml
@@ -1,0 +1,26 @@
+name = "Solar Pro 4"
+description = "Upstage's flagship model, specialized for agentic use"
+family = "solar-pro"
+release_date = "2026-08-06"
+last_updated = "2026-08-06"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
+temperature = true
+knowledge = "2026-02"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+
+[limit]
+context = 524_288
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Adds Upstage **Solar Pro 4** (`solar-pro4`, alias of `solar-pro4-260806`).

Specs from the [Upstage console model catalog](https://console.upstage.ai/docs/models/solar-pro-4) and [reasoning docs](https://console.upstage.ai/docs/capabilities/generate/reasoning), verified against the live `/v1/models` API:

- Released 2026-08-06, knowledge cutoff Feb 2026
- 512K context, 128K max output tokens
- Reasoning on by default; `reasoning_effort` accepts `none`/`minimal` (off) and `low`/`medium`/`high`/`xhigh`/`max` (on)
- Tool calling and structured outputs supported
- Text in/out (English, Korean, Japanese)
- Pricing: $0.30 input / $1.20 output per 1M tokens, $0.06 cached input
- `bun run validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)