### PR TITLE
fix(sync): track missing Pioneer and Ofox models

### DIFF
--- a/.github/workflows/issue-fixer.yml
+++ b/.github/workflows/issue-fixer.yml
@@ -18,9 +18,7 @@ jobs:
     if: >-
       github.repository == 'anomalyco/models.dev'
       && !contains(github.event.issue.labels.*.name, 'provider:openai')
-      && !contains(github.event.issue.labels.*.name, 'provider:pioneer')
       && github.event.client_payload.provider != 'openai'
-      && github.event.client_payload.provider != 'pioneer'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/packages/core/src/sync/providers/ofox.ts
+++ b/packages/core/src/sync/providers/ofox.ts
@@ -55,8 +55,11 @@ export const ofox = {
   name: "Ofox",
   modelsDir: "providers/ofox/models",
   skipCreates: true,
-  trackMissingModels: false,
+  trackMissingModels: true,
   deleteMissing: false,
+  sourceID(model) {
+    return model.mode === "chat" ? model.id : undefined;
+  },
   missingNotice(paths) {
     return paths.map(
       (file) => `Ofox catalog no longer lists ${file}; review for manual deprecation or removal.`,

--- a/packages/core/src/sync/providers/pioneer.ts
+++ b/packages/core/src/sync/providers/pioneer.ts
@@ -141,9 +141,7 @@ export const pioneer = {
   name: "Pioneer",
   modelsDir: "providers/pioneer/models",
   skipCreates: true,
-  // Pioneer reports 2024-01-01 for every model, so its creation dates cannot
-  // support a meaningful age cutoff for remote-only model notifications.
-  trackMissingModels: false,
+  trackMissingModels: true,
   deleteMissing: false,
   async fetchModels() {
     const response = await fetch(API_ENDPOINT);

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -54,13 +54,14 @@ import {
   type NanoGptModel,
 } from "../src/sync/providers/nano-gpt.js";
 import { openai, parseOpenAIModels } from "../src/sync/providers/openai.js";
+import { ofox } from "../src/sync/providers/ofox.js";
 import { pioneer } from "../src/sync/providers/pioneer.js";
 import { google, shouldTrackGoogleModel } from "../src/sync/providers/google.js";
 import { buildTinfoilModel, tinfoil, type TinfoilModel } from "../src/sync/providers/tinfoil.js";
 import { resolveVeniceBaseModel } from "../src/sync/providers/venice.js";
 import { buildVercelModel, vercel } from "../src/sync/providers/vercel.js";
 import { buildWandbModel, type WandbModel } from "../src/sync/providers/wandb.js";
-import { buildXAIModel } from "../src/sync/providers/xai.js";
+import { buildXAIModel, xai } from "../src/sync/providers/xai.js";
 
 function anthropicModel(overrides: Partial<AnthropicModel> = {}): AnthropicModel {
   return {
@@ -802,13 +803,19 @@ test("OpenAI availability sync retains models absent from a scoped response", as
   }
 });
 
-test("does not track unreliable remote-only models", () => {
+test("tracks missing models except for unreliable first-party inventories", () => {
   expect(google.skipCreates).toBe(true);
   expect(google.trackMissingModels).toBe(false);
   expect(openai.skipCreates).toBe(true);
   expect(openai.trackMissingModels).toBe(false);
   expect(pioneer.skipCreates).toBe(true);
-  expect(pioneer.trackMissingModels).toBe(false);
+  expect(pioneer.trackMissingModels).toBe(true);
+  expect(ofox.skipCreates).toBe(true);
+  expect(ofox.trackMissingModels).toBe(true);
+  expect(tinfoil.skipCreates).toBe(true);
+  expect(tinfoil.trackMissingModels).not.toBe(false);
+  expect(xai.skipCreates).toBe(true);
+  expect(xai.trackMissingModels).not.toBe(false);
 });
 
 test("tracks public Google model families but not opaque internal IDs", () => {

--- a/sync.md
+++ b/sync.md
@@ -56,11 +56,11 @@ Providers that cannot safely auto-create TOMLs set `skipCreates: true`. In GitHu
 4. Dispatches the Issue Fixer explicitly so issues created with `GITHUB_TOKEN` can still produce PRs
 5. If listing fails, creates nothing (fail closed)
 
-Requires `GH_TOKEN` on the sync workflow step. Local runs are notice-only unless `--open-issues`. Use `--no-issues` / `--dry-run` to skip creates. Issue-fixer ignores these titles (`[missing-model]…`) — they need hand-authored metadata.
+Requires `GH_TOKEN` on the sync workflow step. Local runs are notice-only unless `--open-issues`. Use `--no-issues` / `--dry-run` to skip creates. Each newly opened issue explicitly dispatches the issue-fixer workflow so an agent can research the missing metadata and open a model PR.
 
 The first Actions run may open a batch of issues per provider, including remote IDs the catalog intentionally omits (e.g. OpenAI whisper/tts/moderation surfaces, dated snapshots). This one-time volume is accepted by design: close unwanted issues once and the closed-title dedupe suppresses them permanently. If the dedupe list window (1000 labeled issues per provider) ever fills, the sync fails closed and creates nothing rather than risk duplicates.
 
-Pioneer sets `trackMissingModels: false`: its API currently assigns the placeholder creation date `2024-01-01` to every model, so neither its timestamps nor an age cutoff can identify meaningful new additions. Existing Pioneer TOMLs are still updated by the sync.
+Pioneer and Ofox track remote-only chat models as missing-model issues. Their APIs are not authoritative enough to create complete TOMLs directly, so the issue-fixer agent researches the missing canonical and provider-specific metadata before opening a PR.
 
 OpenAI also sets `trackMissingModels: false`: `/v1/models` is scoped to the automation account and mixes public models with legacy, internal experiment, dated snapshot, and non-catalog IDs without lifecycle metadata. Existing OpenAI TOMLs are still preserved by the availability sync.
 


### PR DESCRIPTION
## Summary

Enable the existing missing-model issue pipeline for Pioneer and Ofox. Their APIs still cannot directly author complete model TOMLs, but remote-only chat models will now open deduplicated issues and dispatch the issue-fixer agent to research metadata and open focused catalog PRs.

OpenAI and Google remain excluded because their model endpoints are not reliable active public inventories. xAI and Tinfoil already use this issue path.

## Changes

- enable `trackMissingModels` for Pioneer and Ofox
- expose skipped Ofox chat IDs to the shared issue tracker while ignoring non-chat services
- allow Pioneer missing-model dispatches to run the issue-fixer workflow
- update sync policy tests and documentation

## Initial volume

Dry runs against the current public catalogs found:

- 11 remote-only Pioneer models
- 89 remote-only Ofox chat models

The first scheduled run may therefore open and dispatch up to 100 deduplicated missing-model issues. Closed issues remain part of deduplication and will not be reopened on later syncs.

## Validation

- `bun validate`
- `bun test packages/core/test/sync.test.ts --test-name-pattern 'tracks missing models except'`
- `bun models:sync ofox --dry-run --open-issues` reported 89 prospective issues and created no TOMLs
- `bun models:sync pioneer --dry-run --open-issues` reported 11 prospective issues and created no TOMLs
- `git diff --check`

The full `packages/core/test/sync.test.ts` run has one unrelated DeepInfra fixture failure: newly available canonical Qwen metadata causes `factorBaseModel` to omit modalities that the existing assertion expects inline.
