### PR TITLE
fix(baseten): correct DeepSeek V4 Flash 0731 output limit

### DIFF
--- a/providers/baseten/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/baseten/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -18,4 +18,4 @@ cache_read = 0.028
 
 [limit]
 context = 1_048_576
-output = 1_048_576
+output = 384_000


### PR DESCRIPTION
Testing against the Baseten API shows the maximum output is 384K.

```text
Error: 400: {"code":400,"message":"Invalid request: ['max_tokens (1032161): Input should be less than or equal to 384000']","type":"Bad Request"}
```
