### PR TITLE
Add Kimi K3 to GitHub Copilot

### DIFF
--- a/providers/github-copilot/models/kimi-k3.toml
+++ b/providers/github-copilot/models/kimi-k3.toml
@@ -1,0 +1,14 @@
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.95
+output = 4.0
+cache_read = 0.19
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Adds Kimi K3 to GitHub Copilot.

Sources:
- GitHub Changelog: https://github.blog/changelog/2026-08-06-kimi-k3-is-now-available-in-github-copilot/
- VS Code Kimi K3 support: https://github.com/microsoft/vscode/blob/fec2ccde919d61474327b36fb58b8f0753506a9e/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
- VS Code reasoning levels (`low`, `high`, `max`): https://github.com/microsoft/vscode/blob/fec2ccde919d61474327b36fb58b8f0753506a9e/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts#L487-L489

Validation: `bun validate`
