### PR TITLE
Neon: add kimi-k3, gemini-3-6-flash, gemini-3-5-flash-lite, and the missing gpt-5-5-pro cost

### DIFF
--- a/providers/neon/models/gemini-3-5-flash-lite.toml
+++ b/providers/neon/models/gemini-3-5-flash-lite.toml
@@ -1,0 +1,7 @@
+base_model = "google/gemini-3.5-flash-lite"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/neon/models/gemini-3-6-flash.toml
+++ b/providers/neon/models/gemini-3-6-flash.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.6-flash"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.5
+output = 7.5
+cache_read = 0.15
+input_audio = 1.5

--- a/providers/neon/models/gpt-5-5-pro.toml
+++ b/providers/neon/models/gpt-5-5-pro.toml
@@ -3,6 +3,15 @@
 base_model = "openai/gpt-5.5-pro"
 reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
+[cost]
+input = 30
+output = 180
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 60
+output = 270
+
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text", "image"]

--- a/providers/neon/models/kimi-k3.toml
+++ b/providers/neon/models/kimi-k3.toml
@@ -1,0 +1,10 @@
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [
+  { type = "toggle" },                                                              # API: {"thinking": {"type": "enabled"|"disabled"}}
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] }, # API: {"reasoning_effort": <v>}
+]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3


### PR DESCRIPTION
Brings the `neon` provider back in line with what the Neon AI Gateway serves: three models were
added, and `gpt-5-5-pro` was missing its `[cost]`. After this change the provider matches
`GET /v1/models` exactly (42 models).

## Added models

| Model | `base_model` |
| --- | --- |
| `kimi-k3` | `moonshotai/kimi-k3` |
| `gemini-3-6-flash` | `google/gemini-3.6-flash` |
| `gemini-3-5-flash-lite` | `google/gemini-3.5-flash-lite` |

## Pricing

Neon publishes that it charges the same per-token rate as the model provider with no markup
(<https://neon.com/docs/ai-gateway/overview#pricing>), so `[cost]` is copied from the first-party
provider entry in this repo — `providers/moonshotai/models/kimi-k3.toml` and
`providers/google/models/gemini-3.{6-flash,5-flash-lite}.toml`. That matches how the existing
`neon` Gemini entries are sourced; `neon/gemini-3-5-flash` carries Google's 1.5/9/0.15 verbatim.

## `gpt-5-5-pro` cost

This entry shipped without a `[cost]` block. That was wrong, and the rate is sourceable two
independent ways that agree exactly:

| | input | output | 272k tier input | 272k tier output |
| --- | --- | --- | --- | --- |
| `providers/openai/models/gpt-5.5-pro.toml` | 30 | 180 | 60 | 270 |
| Databricks published DBU rate × $0.07/DBU | 428.571 → **30.00** | 2571.429 → **180.00** | 857.142 → **60.00** | 3857.144 → **270.00** |

The $0.07/DBU figure is not invented for this PR — it is the rate implied by every `neon` entry
whose model also appears on the Databricks DBU table (`glm-5-2`, `qwen35-122b-a10b`,
`qwen3-next-80b-a3b-instruct`, `llama-4-maverick`, `meta-llama-3-3-70b-instruct`, `gemma-3-12b`,
`meta-llama-3-1-8b-instruct`, `gpt-5-5`), each of which divides out to exactly 0.0700.

Sources: <https://www.databricks.com/product/pricing/proprietary-foundation-model-serving> and
<https://www.databricks.com/product/pricing/foundation-model-serving> (accessed 2026-08-07).

## `reasoning_options`

Measured against a live Neon branch rather than copied, because the gateway does not pass every
upstream control through:

| Model | Accepted |
| --- | --- |
| `kimi-k3` | `reasoning_effort` none, minimal, low, medium, high, max — and the `thinking` toggle |
| `gemini-3-6-flash` | `reasoning_effort` minimal, low, medium, high |
| `gemini-3-5-flash-lite` | `reasoning_effort` minimal, low, medium, high |

`xhigh` is rejected on all three. The Gemini pair matches the values the existing
`neon/gemini-3-5-flash` entry already declares.

## Notes

- Neon now publishes this catalog itself at <https://neon.com/models.json> and treats that as the
  source of truth, so this PR is the `neon` provider here catching up rather than a prerequisite
  for anything on Neon's side. There is no deadline attached to it and nothing downstream is
  waiting — merge it at whatever pace suits the repo.
- None of the three new models carries a `[provider]` block: all are served on the unified chat
  endpoint, so they inherit the provider-level `api`. Only the proprietary OpenAI entries need
  the Responses override.
- `kimi-k3` conforms to the Chat Completions contract. Both Gemini models return `content` as an
  array with the same deviations as the rest of the Gemini 3.x family — `id` null, array `content`
  carrying `thoughtSignature`, and a `usage.total_tokens` that does not equal prompt + completion.
  That is gateway behaviour, not a catalog concern.
- `inkling` remains the one `neon` entry without `[cost]`. It is an open-weights model that
  Databricks does not list on its DBU table and that Thinking Machines does not sell at a retail
  per-token rate — Tinker bills prefill/sample/train meters instead. Several independent hosts
  agree on 1.00/4.05/0.17, but that is their price rather than Neon's, so it stays omitted until
  the real rate is confirmed rather than guessed.
- `bun validate` passes; the generated `neon` provider goes from 39 to 42 models.