### PR TITLE
Neon: correct `temperature` on eight models

### DIFF
--- a/providers/neon/models/gemini-3-6-flash.toml
+++ b/providers/neon/models/gemini-3-6-flash.toml
@@ -1,4 +1,9 @@
 base_model = "google/gemini-3.6-flash"
+# Google's own API takes temperature; the Neon gateway does not, and answers
+# `BAD_REQUEST: Model gemini-3.6-flash does not support the temperature
+# parameter`. Measured 2026-08-07. Inheriting the base value would advertise a
+# parameter every caller gets a 400 for.
+temperature = false
 reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
 
 [cost]

--- a/providers/neon/models/gpt-5-1.toml
+++ b/providers/neon/models/gpt-5-1.toml
@@ -1,4 +1,7 @@
 base_model = "openai/gpt-5.1"
+# The Neon gateway accepts `temperature` on this model; the base entry says
+# otherwise because the upstream provider rejects it. Measured 2026-08-07.
+temperature = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [cost]

--- a/providers/neon/models/gpt-5-2.toml
+++ b/providers/neon/models/gpt-5-2.toml
@@ -1,4 +1,7 @@
 base_model = "openai/gpt-5.2"
+# The Neon gateway accepts `temperature` on this model; the base entry says
+# otherwise because the upstream provider rejects it. Measured 2026-08-07.
+temperature = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]

--- a/providers/neon/models/gpt-5-3-codex.toml
+++ b/providers/neon/models/gpt-5-3-codex.toml
@@ -1,4 +1,7 @@
 base_model = "openai/gpt-5.3-codex"
+# The Neon gateway accepts `temperature` on this model; the base entry says
+# otherwise because the upstream provider rejects it. Measured 2026-08-07.
+temperature = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]

--- a/providers/neon/models/gpt-5-4-mini.toml
+++ b/providers/neon/models/gpt-5-4-mini.toml
@@ -1,4 +1,7 @@
 base_model = "openai/gpt-5.4-mini"
+# The Neon gateway accepts `temperature` on this model; the base entry says
+# otherwise because the upstream provider rejects it. Measured 2026-08-07.
+temperature = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]

--- a/providers/neon/models/gpt-5-4-nano.toml
+++ b/providers/neon/models/gpt-5-4-nano.toml
@@ -1,4 +1,7 @@
 base_model = "openai/gpt-5.4-nano"
+# The Neon gateway accepts `temperature` on this model; the base entry says
+# otherwise because the upstream provider rejects it. Measured 2026-08-07.
+temperature = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]

--- a/providers/neon/models/gpt-5-4.toml
+++ b/providers/neon/models/gpt-5-4.toml
@@ -1,4 +1,7 @@
 base_model = "openai/gpt-5.4"
+# The Neon gateway accepts `temperature` on this model; the base entry says
+# otherwise because the upstream provider rejects it. Measured 2026-08-07.
+temperature = true
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]

--- a/providers/neon/models/kimi-k3.toml
+++ b/providers/neon/models/kimi-k3.toml
@@ -1,4 +1,7 @@
 base_model = "moonshotai/kimi-k3"
+# The Neon gateway accepts `temperature` on this model; the base entry says
+# otherwise because the upstream provider rejects it. Measured 2026-08-07.
+temperature = true
 reasoning_options = [
   { type = "toggle" },                                                              # API: {"thinking": {"type": "enabled"|"disabled"}}
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] }, # API: {"reasoning_effort": <v>}


### PR DESCRIPTION
Eight `neon` entries inherit a `temperature` value that is right for the upstream provider's own
API and wrong for the Neon AI Gateway. Every value below was measured against a live gateway
branch on 2026-08-07 by sending `temperature: 0.2` and recording the status.

| Model | Base says | Gateway | Now |
| --- | --- | --- | --- |
| `gemini-3-6-flash` | `true` | `400 does not support the temperature parameter` | `false` |
| `kimi-k3` | `false` | `200` | `true` |
| `gpt-5-1` | `false` | `200` | `true` |
| `gpt-5-2` | `false` | `200` | `true` |
| `gpt-5-4` | `false` | `200` | `true` |
| `gpt-5-4-mini` | `false` | `200` | `true` |
| `gpt-5-4-nano` | `false` | `200` | `true` |
| `gpt-5-3-codex` | `false` | `200` (Responses) | `true` |

`gemini-3-6-flash` rejects `top_p` the same way, but there is no capability field for it.

## Why this matters more than a metadata nit

Neon publishes this catalog at <https://neon.com/models.json> and the Neon console renders it, so
a wrong `temperature` tells a developer a parameter works when it returns `400`, or that it does
not work when it does.

## Not changed, because the base value is already correct

`gpt-5`, `gpt-5-mini`, `gpt-5-nano` and `gpt-5-5-pro` genuinely reject `temperature` — the
Responses API answers `Unsupported parameter: temperature`. `gpt-5-5-pro` is worth noting because
it reads like the 5.x models above it and behaves like the bare `gpt-5` ones.

Every other Gemini id — `gemini-3-flash`, `gemini-3-5-flash`, `gemini-3-5-flash-lite`,
`gemini-3-1-pro`, `gemini-3-1-flash-lite` — accepts `temperature` and keeps its inherited value.

`bun validate` passes; the resolved `neon` provider still has 42 models and only this field
changes on the eight.