### PR TITLE
Neon: declare structured_output where it does not resolve

### DIFF
--- a/providers/neon/models/claude-fable-5.toml
+++ b/providers/neon/models/claude-fable-5.toml
@@ -1,6 +1,7 @@
 # No toggle: "thinking.type.disabled" is rejected for this model, which defaults to
 # adaptive thinking, so effort is the only control the gateway exposes.
 base_model = "anthropic/claude-fable-5"
+structured_output = true
 reasoning_options = [
   { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, # API: {"thinking": {"type": "adaptive"}, "output_config": {"effort": <v>}}
 ]

--- a/providers/neon/models/claude-haiku-4-5.toml
+++ b/providers/neon/models/claude-haiku-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
+structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]

--- a/providers/neon/models/claude-opus-4-1.toml
+++ b/providers/neon/models/claude-opus-4-1.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-1"
+structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 31_999 }]
 
 [cost]

--- a/providers/neon/models/claude-opus-4-5.toml
+++ b/providers/neon/models/claude-opus-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-5"
+structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]

--- a/providers/neon/models/claude-opus-4-6.toml
+++ b/providers/neon/models/claude-opus-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-6"
+structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 127_999 }]
 
 [cost]

--- a/providers/neon/models/claude-opus-4-7.toml
+++ b/providers/neon/models/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-7"
+structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]

--- a/providers/neon/models/claude-opus-4-8.toml
+++ b/providers/neon/models/claude-opus-4-8.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
+structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]

--- a/providers/neon/models/claude-opus-5.toml
+++ b/providers/neon/models/claude-opus-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-5"
+structured_output = true
 reasoning_options = [
   { type = "toggle" },                                                   # API: {"thinking": {"type": "adaptive"|"disabled"}}
   { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, # API: {"thinking": {"type": "adaptive"}, "output_config": {"effort": <v>}}

--- a/providers/neon/models/claude-sonnet-4-5.toml
+++ b/providers/neon/models/claude-sonnet-4-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-5"
+structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]

--- a/providers/neon/models/claude-sonnet-4-6.toml
+++ b/providers/neon/models/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
+structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1_024, max = 63_999 }]
 
 [cost]

--- a/providers/neon/models/claude-sonnet-5.toml
+++ b/providers/neon/models/claude-sonnet-5.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
+structured_output = true
 reasoning_options = [
   { type = "toggle" },                                                   # API: {"thinking": {"type": "adaptive"|"disabled"}}
   { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }, # API: {"thinking": {"type": "adaptive"}, "output_config": {"effort": <v>}}

--- a/providers/neon/models/inkling.toml
+++ b/providers/neon/models/inkling.toml
@@ -1,4 +1,8 @@
 base_model = "thinkingmachines/inkling"
+# The gateway does not honour response_format json_schema here: it answers
+# 200 with finish_reason "abort" and empty content, with strict true or
+# false, at any token budget. Plain requests work. Measured 2026-08-08.
+structured_output = false
 reasoning_options = [
   { type = "toggle" },                                                              # API: {"thinking": {"type": "enabled"|"disabled"}}
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] }, # API: {"reasoning_effort": <v>}

--- a/providers/neon/models/llama-4-maverick.toml
+++ b/providers/neon/models/llama-4-maverick.toml
@@ -1,4 +1,5 @@
 base_model = "meta/llama-4-maverick-17b-instruct"
+structured_output = true
 
 [cost]
 input = 0.5

--- a/providers/neon/models/meta-llama-3-3-70b-instruct.toml
+++ b/providers/neon/models/meta-llama-3-3-70b-instruct.toml
@@ -1,4 +1,5 @@
 base_model = "meta/llama-3.3-70b-instruct"
+structured_output = true
 attachment = false
 
 [cost]

--- a/providers/neon/models/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/neon/models/qwen3-next-80b-a3b-instruct.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+structured_output = true
 
 [cost]
 input = 0.15


### PR DESCRIPTION
Fifteen `neon` entries resolve with no `structured_output` at all, and none of the 42 resolves to
`false`. A consumer filtering for schema-constrained generation therefore gets nothing for the
entire Anthropic family, and cannot tell "does not support it" from "nobody said".

All 42 were probed against a live Neon gateway on 2026-08-08 — not just the fifteen, because the
27 that already resolve to `true` come from the same inherited metadata that turned out to be
wrong about `temperature` on eight models the day before.

**Every one of those 27 held**, so nothing here corrects an existing value; this PR only fills
the gaps.

## Method

`response_format: { type: "json_schema", strict: true }` with a two-field schema, and a pass
requires **both** a 200 **and** content that parses as JSON matching the schema exactly. A model
that accepts the parameter and returns prose has ignored the constraint, not honoured it, so a
status code alone is not the answer. The two Responses-only ids (`gpt-5-3-codex`, `gpt-5-5-pro`)
were probed on `/openai/v1/responses`, where the schema goes under `text.format`.

## Result

Fourteen become `true`: the eleven Claude ids, `llama-4-maverick`,
`meta-llama-3-3-70b-instruct` and `qwen3-next-80b-a3b-instruct`.

`inkling` becomes **`false`**, and its failure is worth stating because it is silent. With
`response_format json_schema` — `strict` true or false — the gateway answers `200` with
`finish_reason: "abort"` and empty content, and no error. It is not a token budget: identical at
3k, 8k and 20k `max_tokens`, with ~103 completion tokens generated and discarded. The same model
answers normally with no `response_format`, and `glm-5-2` under all four conditions returns
conforming JSON, so this is the model on this gateway rather than the probe.

## Scope

Only entries that resolve to absent are touched. The 27 that already inherit `true` correctly are
left alone rather than given a redundant override.

`bun validate` passes; the resolved `neon` provider still has 42 models, and after this every one
carries an explicit `structured_output`.