### PR TITLE
feat(alibaba): add deepseek-v4-flash-0731 and glm-5.2

### DIFF
--- a/providers/alibaba/models/deepseek-v4-flash-0731.toml
+++ b/providers/alibaba/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,20 @@
+# Sources (accessed 2026-08-08):
+# https://www.alibabacloud.com/help/en/model-studio/deepseek-api
+# https://www.alibabacloud.com/help/en/model-studio/model-pricing (Singapore list)
+# https://www.qwencloud.com/models/deepseek-v4-flash-0731 (implicit cache price)
+# Pay-as-you-go on DashScope international, not Token Plan only.
+# Toggle: enable_thinking true|false
+# Effort: reasoning_effort = high (default) | max; low/medium map to high, xhigh maps to max
+base_model = "deepseek/deepseek-v4-flash-0731"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.20
+output = 0.40
+cache_read = 0.04

--- a/providers/alibaba/models/glm-5.2.toml
+++ b/providers/alibaba/models/glm-5.2.toml
@@ -1,0 +1,21 @@
+# Sources (accessed 2026-08-08):
+# https://www.alibabacloud.com/help/en/model-studio/glm
+# https://www.alibabacloud.com/help/en/model-studio/model-pricing (Singapore list)
+# https://www.qwencloud.com/models/glm-5.2 (implicit cache price)
+# Toggle: enable_thinking true|false
+# Effort: reasoning_effort none|minimal skip thinking, low|medium map to high,
+# xhigh maps to max; effective levels are high|max (default: max).
+base_model = "zhipuai/glm-5.2"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.28
+cache_write = 0

--- a/providers/alibaba/models/glm-5.2.toml
+++ b/providers/alibaba/models/glm-5.2.toml
@@ -2,14 +2,10 @@
 # https://www.alibabacloud.com/help/en/model-studio/glm
 # https://www.alibabacloud.com/help/en/model-studio/model-pricing (Singapore list)
 # https://www.qwencloud.com/models/glm-5.2 (implicit cache price)
-# Toggle: enable_thinking true|false
-# Effort: reasoning_effort none|minimal skip thinking, low|medium map to high,
-# xhigh maps to max; effective levels are high|max (default: max).
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# (none disables reasoning, so a separate toggle is not needed).
 base_model = "zhipuai/glm-5.2"
-reasoning_options = [
-  { type = "toggle" },
-  { type = "effort", values = ["high", "max"] },
-]
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Both models are served pay-as-you-go on the international Model Studio endpoint (`dashscope-intl.aliyuncs.com/compatible-mode/v1`), but until now only existed under the plan providers, so callers using the API directly could not resolve them.

Pricing is the Singapore list in USD/MTok:

- `deepseek-v4-flash-0731`: 0.20 input / 0.40 output / 0.04 implicit cache
- `glm-5.2`: 1.40 input / 4.40 output / 0.28 implicit cache

Reasoning controls follow Alibaba Model Studio’s OpenAI-compatible API:

- `deepseek-v4-flash-0731` uses `enable_thinking` plus `reasoning_effort` values `high|max` (`low|medium` map to `high`; `xhigh` maps to `max`).
- `glm-5.2` uses `reasoning_effort` values `none|minimal|low|medium|high|xhigh|max`; `none` disables reasoning, so no separate toggle is needed in `reasoning_options`.

Both models return reasoning through `reasoning_content`.

Sources:

- https://www.alibabacloud.com/help/en/model-studio/deepseek-api
- https://www.alibabacloud.com/help/en/model-studio/glm
- https://www.alibabacloud.com/help/en/model-studio/model-pricing
- https://www.qwencloud.com/models/deepseek-v4-flash-0731
- https://www.qwencloud.com/models/glm-5.2