### PR TITLE
Neon: correct the output-token limit on eleven models

### DIFF
--- a/providers/neon/models/gemma-3-12b.toml
+++ b/providers/neon/models/gemma-3-12b.toml
@@ -17,7 +17,7 @@ output = 0.5
 
 [limit]
 context = 131_072
-output = 16_384
+output = 8_192
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neon/models/glm-5-2.toml
+++ b/providers/neon/models/glm-5-2.toml
@@ -8,3 +8,8 @@ reasoning_options = [
 input = 1.4
 output = 4.4
 cache_read = 0.26
+
+# The Neon gateway caps output below the upstream entry: `max_tokens` one above
+# 65_536 returns 400. Measured at the boundary 2026-08-08. `context` is inherited.
+[limit]
+output = 65_536

--- a/providers/neon/models/gpt-oss-120b.toml
+++ b/providers/neon/models/gpt-oss-120b.toml
@@ -4,3 +4,8 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 [cost]
 input = 0.072
 output = 0.28
+
+# The Neon gateway caps output below the upstream entry: `max_tokens` one above
+# 25_000 returns 400. Measured at the boundary 2026-08-08. `context` is inherited.
+[limit]
+output = 25_000

--- a/providers/neon/models/gpt-oss-20b.toml
+++ b/providers/neon/models/gpt-oss-20b.toml
@@ -17,7 +17,7 @@ output = 0.20
 
 [limit]
 context = 131_072
-output = 32_768
+output = 25_000
 
 [modalities]
 input = ["text"]

--- a/providers/neon/models/inkling.toml
+++ b/providers/neon/models/inkling.toml
@@ -3,3 +3,8 @@ reasoning_options = [
   { type = "toggle" },                                                              # API: {"thinking": {"type": "enabled"|"disabled"}}
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] }, # API: {"reasoning_effort": <v>}
 ]
+
+# The Neon gateway caps output below the upstream entry: `max_tokens` one above
+# 65_536 returns 400. Measured at the boundary 2026-08-08. `context` is inherited.
+[limit]
+output = 65_536

--- a/providers/neon/models/kimi-k3.toml
+++ b/providers/neon/models/kimi-k3.toml
@@ -11,3 +11,8 @@ reasoning_options = [
 input = 3
 output = 15
 cache_read = 0.3
+
+# The Neon gateway caps output below the upstream entry: `max_tokens` one above
+# 65_536 returns 400. Measured at the boundary 2026-08-08. `context` is inherited.
+[limit]
+output = 65_536

--- a/providers/neon/models/llama-4-maverick.toml
+++ b/providers/neon/models/llama-4-maverick.toml
@@ -3,3 +3,8 @@ base_model = "meta/llama-4-maverick-17b-instruct"
 [cost]
 input = 0.5
 output = 1.5
+
+# The Neon gateway caps output below the upstream entry: `max_tokens` one above
+# 8_192 returns 400. Measured at the boundary 2026-08-08. `context` is inherited.
+[limit]
+output = 8_192

--- a/providers/neon/models/meta-llama-3-1-8b-instruct.toml
+++ b/providers/neon/models/meta-llama-3-1-8b-instruct.toml
@@ -17,7 +17,7 @@ output = 0.45
 
 [limit]
 context = 131_072
-output = 16_384
+output = 8_192
 
 [modalities]
 input = ["text"]

--- a/providers/neon/models/meta-llama-3-3-70b-instruct.toml
+++ b/providers/neon/models/meta-llama-3-3-70b-instruct.toml
@@ -4,3 +4,8 @@ attachment = false
 [cost]
 input = 0.5
 output = 1.5
+
+# The Neon gateway serves more than the upstream entry claims: this is the
+# largest accepted `max_tokens`. Measured at the boundary 2026-08-08.
+[limit]
+output = 8_192

--- a/providers/neon/models/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/neon/models/qwen3-next-80b-a3b-instruct.toml
@@ -3,3 +3,8 @@ base_model = "alibaba/qwen3-next-80b-a3b-instruct"
 [cost]
 input = 0.15
 output = 1.2
+
+# The Neon gateway caps output below the upstream entry: `max_tokens` one above
+# 10_000 returns 400. Measured at the boundary 2026-08-08. `context` is inherited.
+[limit]
+output = 10_000

--- a/providers/neon/models/qwen35-122b-a10b.toml
+++ b/providers/neon/models/qwen35-122b-a10b.toml
@@ -8,7 +8,7 @@ output = 2.2
 
 [limit]
 context = 262_144
-output = 8_000
+output = 25_000
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Eleven `neon` models publish a `limit.output` that does not match what the gateway serves. Each value came from the upstream maker's entry — Moonshot really does serve `kimi-k3` at 131,072 — rather than from the serving layer, which caps most of them lower and two of them higher.

```
max_tokens (65537) cannot exceed 65536. Please reduce the length of max output tokens generated.
```

**Overstated** — the published value returns 400:

| Model | Was | Now | |
| --- | ---: | ---: | --- |
| `inkling` | 1,048,576 | 65,536 | had the context window as the output limit |
| `glm-5-2` | 131,072 | 65,536 | |
| `kimi-k3` | 131,072 | 65,536 | |
| `qwen3-next-80b-a3b-instruct` | 32,768 | 10,000 | |
| `gpt-oss-120b` | 32,768 | 25,000 | |
| `gpt-oss-20b` | 32,768 | 25,000 | |
| `gemma-3-12b` | 16,384 | 8,192 | |
| `llama-4-maverick` | 16,384 | 8,192 | |
| `meta-llama-3-1-8b-instruct` | 16,384 | 8,192 | |

**Understated** — the gateway serves more than the entry claims:

| Model | Was | Now |
| --- | ---: | ---: |
| `qwen35-122b-a10b` | 8,000 | 25,000 |
| `meta-llama-3-3-70b-instruct` | 4,096 | 8,192 |

Entries inheriting through `base_model` get a partial `[limit]` carrying only `output`, so `context` keeps inheriting; the standalone entries were edited in place. Verified through `generateCatalog`: all eleven resolve to the new `output` with `context` unchanged, and `output <= context` holds across every `neon` model.

Measured by posting `max_tokens` at the published value and at one above it, then confirming each candidate at its boundary. Every one is exact — the new value returns 200, one token above returns 400. Probing only at the published value is what hid the two understated entries initially, since a 200 there is equally consistent with the claim being exact and with it being too low.

Only the output side was measured. `context` is untouched here and unverified.