### PR TITLE
fix(synthetic): cap GLM-5.2 input at real serving limit 365,178

### DIFF
--- a/providers/synthetic/models/hf:zai-org/GLM-5.2.toml
+++ b/providers/synthetic/models/hf:zai-org/GLM-5.2.toml
@@ -11,4 +11,5 @@ cache_read = 1.4
 
 [limit]
 context = 524_288
+input = 365_178
 output = 65_536


### PR DESCRIPTION
### What does this PR do?

Synthetic serves GLM-5.2 with a real **input** cap of **365,178 tokens**, but the provider TOML only sets `[limit] context = 524_288` with no `input` override. Clients that use `limit.context` as the compaction trigger (like opencode) let conversations grow past the real cap, then receive a hard 400:

```
Bad Request: Error from inference backend: Input length (369084 tokens) exceeds the maximum allowed length (365178 tokens).
```

This adds `input = 365_178` to the provider TOML so clients compact before the backend rejects.

### Why 365,178? (confirmed by Synthetic)

Synthetic's explanation: the total context window for GLM-5.2 is 524,288, and the model can output up to 163,840 tokens. Because transformers are autoregressive, the input must leave room for output — so the default max input is **524,288 − ~159K ≈ 360K** (their stated "roughly 360k"; the observed error uses 365,178).

They also note the API supports `max_completion_tokens`: requesting a lower output budget can fit more input. However, clients like opencode request only `max_tokens: 32,000`, and the backend still enforces the ~365K input cap — so the *practical* input ceiling for opencode sessions is 365,178 regardless of the client's max_tokens.

### Evidence

- The 365,178 value is from Synthetic's own error message (reproduced in a real session at 369,084 input tokens)
- Empirical boundary tests: 360,645 tokens + 6 tools = accepted (200); 369,084 tokens = rejected with the cap error
- `context = 524_288` retained as the total window — only the *input* serving limit is corrected

### Type of change

- [x] Bug fix (data correction)
- [ ] New model
- [ ] Documentation

### Checklist

- [x] I have verified the data against the provider's actual API behavior
- [x] I have not included unrelated changes