### PR TITLE
feat(nebius): add DeepSeek-V4-Flash

### DIFF
--- a/providers/nebius/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/nebius/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -6,12 +6,18 @@
 # max_tokens has no documented ceiling other than the context window, so output
 # is set to the context size (same as the other Nebius base_model entries).
 # https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion
-# The gateway's generic schema accepts reasoning_effort =
-# none/minimal/low/medium/high/xhigh/max; the sglang backend rejects "minimal"
-# and "xhigh" (see the Kimi-K3 entry), so only the five below are authored.
+# Reasoning controls are DeepSeek V4's, matching the lab entry for this model and
+# the Nebius DeepSeek-V4-Pro peer; Nebius's request schema permits additional
+# properties, so the model-native fields pass through.
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max (Flash maps low->low, unlike Pro)
+# https://api-docs.deepseek.com/guides/thinking_mode/
 # models_info exposes no cache pricing for this model, so no cache rates are set.
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "high", "max"] },
+]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/nebius/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/nebius/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -19,7 +19,11 @@
 # No toggle: `none` is the off switch, and DeepSeek's native
 # `thinking.type = disabled` is accepted but ignored here (reasoning_content
 # still comes back), so it is not a real caller control on this host.
-# models_info exposes no cache pricing for this model, so no cache rates are set.
+# Nebius has no discounted prompt-cache tier for this model: models_info exposes
+# no cache fields, and cached and fresh input tokens are billed identically at the
+# full input rate. cache_read is therefore set equal to input rather than left
+# unset, which downstream consumers (e.g. opencode) treat as $0/M. Same reasoning
+# as PR #3956 for Kimi-K3.
 base_model = "deepseek/deepseek-v4-flash"
 reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
 
@@ -29,6 +33,7 @@ field = "reasoning_content"
 [cost]
 input = 0.14
 output = 0.28
+cache_read = 0.14
 
 [limit]
 context = 131_072

--- a/providers/nebius/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/nebius/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -6,18 +6,22 @@
 # max_tokens has no documented ceiling other than the context window, so output
 # is set to the context size (same as the other Nebius base_model entries).
 # https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion
-# Reasoning controls are DeepSeek V4's, matching the lab entry for this model and
-# the Nebius DeepSeek-V4-Pro peer; Nebius's request schema permits additional
-# properties, so the model-native fields pass through.
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = low|high|max (Flash maps low->low, unlike Pro)
-# https://api-docs.deepseek.com/guides/thinking_mode/
+# Effort: reasoning_effort. Verified live against
+# api.tokenfactory.nebius.com/v1/chat/completions on 2026-08-09, temperature 0,
+# two prompts. The gateway accepts all seven documented values, but only four
+# distinct behaviours exist on this model, and they line up with lab Flash's
+# low/high/max (https://api-docs.deepseek.com/guides/thinking_mode/) plus a
+# Nebius-side off switch:
+#   none                  -> reasoning_tokens 0, no reasoning_content
+#   minimal = low = medium -> identical output (677 / 133 reasoning tokens)
+#   high = xhigh          -> identical output (490 / 138 reasoning tokens)
+#   max                   -> distinct        (1102 / 154 reasoning tokens)
+# No toggle: `none` is the off switch, and DeepSeek's native
+# `thinking.type = disabled` is accepted but ignored here (reasoning_content
+# still comes back), so it is not a real caller control on this host.
 # models_info exposes no cache pricing for this model, so no cache rates are set.
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = [
-  { type = "toggle" },
-  { type = "effort", values = ["low", "high", "max"] },
-]
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/nebius/models/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/nebius/models/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,0 +1,25 @@
+# Sources:
+# - https://tokenfactory.nebius.com/api/public/models_info (pricing, 131K context)
+# - https://tokenfactory.nebius.com/model-catalog.md
+# Accessed 2026-08-09.
+# Nebius truncates the 1M-context base model to a 131K window.
+# max_tokens has no documented ceiling other than the context window, so output
+# is set to the context size (same as the other Nebius base_model entries).
+# https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion
+# The gateway's generic schema accepts reasoning_effort =
+# none/minimal/low/medium/high/xhigh/max; the sglang backend rejects "minimal"
+# and "xhigh" (see the Kimi-K3 entry), so only the five below are authored.
+# models_info exposes no cache pricing for this model, so no cache rates are set.
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.14
+output = 0.28
+
+[limit]
+context = 131_072
+output = 131_072


### PR DESCRIPTION
Adds `deepseek-ai/DeepSeek-V4-Flash` to Nebius Token Factory (it's live in their playground and catalog, but missing here).

Override-only on top of `models/deepseek/deepseek-v4-flash.toml`.

### Data + sources

All figures from Nebius' public catalog API, accessed 2026-08-09:
- https://tokenfactory.nebius.com/api/public/models_info
- https://tokenfactory.nebius.com/model-catalog.md

| Field | Value | Source |
| --- | --- | --- |
| `cost.input` | `0.14` | `input_price_per_million_tokens: 0.14` |
| `cost.output` | `0.28` | `output_price_per_million_tokens: 0.28` |
| `limit.context` | `131_072` | `context_window_k: 131` / tag `131K context` — Nebius truncates the 1M base window |
| `limit.output` | `131_072` | No documented `max_tokens` ceiling beyond the context window ([API reference](https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion)); same convention as the other Nebius `base_model` entries (`MiniMax-M3`, `GLM-5.2`) |

`reasoning_options`: verified live against the Nebius API on 2026-08-09 (temperature 0, two prompts). The gateway returns 200 for all seven documented `reasoning_effort` values, but only four distinct behaviours exist: `none` (reasoning off), `minimal`=`low`=`medium`, `high`=`xhigh`, and `max`. These line up with lab Flash's `low`/`high`/`max` plus a Nebius-side off switch, so this is authored as `["none", "low", "high", "max"]`. No toggle: `none` is the off switch, and DeepSeek's native `thinking.type = "disabled"` is accepted but ignored here (`reasoning_content` still returns).

`cost.cache_read = 0.14`, equal to `input`: Nebius has no discounted prompt-cache tier for this model, so cached and fresh input tokens bill identically. Set explicitly rather than left unset, which downstream consumers treat as $0/M — same reasoning as #3956 for Kimi-K3.

`bun validate` passes.
