### PR TITLE
chore(kenari): refresh model catalog from the live endpoint

### DIFF
--- a/models/inclusionai/ling-3.0-flash.toml
+++ b/models/inclusionai/ling-3.0-flash.toml
@@ -1,0 +1,19 @@
+name = "Ling 3.0 Flash"
+description = "124B-parameter Mixture-of-Experts model with roughly 5.1B parameters active per token, tuned for token efficiency and production-scale agentic inference under latency and serving budgets"
+family = "ling"
+release_date = "2026-07-23"
+last_updated = "2026-07-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = false
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kenari/models/claude-opus-5.toml
+++ b/providers/kenari/models/claude-opus-5.toml
@@ -1,0 +1,9 @@
+base_model = "anthropic/claude-opus-5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/claude-sonnet-4-6.toml
+++ b/providers/kenari/models/claude-sonnet-4-6.toml
@@ -1,0 +1,9 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/deepseek-v4-flash.toml
+++ b/providers/kenari/models/deepseek-v4-flash.toml
@@ -1,10 +1,16 @@
+# Sources (accessed 2026-08-10):
+# - https://kenari.id/v1/models (deepseek-v4-flash), public and keyless: publishes
+#   effort ["low","high","max"].
+# The earlier ["high","xhigh"] came from a host defect, since fixed: Kenari derived effort
+# metadata from the openrouter slice of this feed rather than from the model's author.
+# OpenRouter's list describes its own API surface. DeepSeek's own slice in this repo says
+# low, high, max, which is what the host now publishes and serves.
 base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "xhigh"]
+values = ["low", "high", "max"]
 
 [cost]
 input = 0
 output = 0
-

--- a/providers/kenari/models/deepseek-v4-flash:free.toml
+++ b/providers/kenari/models/deepseek-v4-flash:free.toml
@@ -1,9 +1,13 @@
+# Sources (accessed 2026-08-10):
+# - https://kenari.id/v1/models (deepseek-v4-flash:free), public and keyless: publishes
+#   effort ["low","high","max"], same as the paid row.
+# See deepseek-v4-flash.toml for why the earlier ["high","xhigh"] was wrong.
 base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek V4 Flash (Free)"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "xhigh"]
+values = ["low", "high", "max"]
 
 [cost]
 input = 0

--- a/providers/kenari/models/deepseek-v4-pro.toml
+++ b/providers/kenari/models/deepseek-v4-pro.toml
@@ -1,10 +1,14 @@
+# Sources (accessed 2026-08-10):
+# - https://kenari.id/v1/models (deepseek-v4-pro), public and keyless: publishes
+#   effort ["high","max"].
+# See deepseek-v4-flash.toml for why the earlier ["high","xhigh"] was wrong. DeepSeek's
+# own slice in this repo says high, max for this model.
 base_model = "deepseek/deepseek-v4-pro"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "xhigh"]
+values = ["high", "max"]
 
 [cost]
 input = 0
 output = 0
-

--- a/providers/kenari/models/gemini-3-6-flash.toml
+++ b/providers/kenari/models/gemini-3-6-flash.toml
@@ -1,0 +1,9 @@
+base_model = "google/gemini-3.6-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/grok-build-0-1.toml
+++ b/providers/kenari/models/grok-build-0-1.toml
@@ -1,6 +1,0 @@
-base_model = "xai/grok-build-0.1"
-reasoning_options = []
-
-[cost]
-input = 0
-output = 0

--- a/providers/kenari/models/kimi-k2-6:free.toml
+++ b/providers/kenari/models/kimi-k2-6:free.toml
@@ -1,7 +1,0 @@
-base_model = "moonshotai/kimi-k2.6"
-name = "Kimi K2.6 (Free)"
-reasoning_options = []
-
-[cost]
-input = 0
-output = 0

--- a/providers/kenari/models/kimi-k2-7-code:free.toml
+++ b/providers/kenari/models/kimi-k2-7-code:free.toml
@@ -1,7 +1,0 @@
-base_model = "moonshotai/kimi-k2.7-code"
-name = "Kimi K2.7 Code (Free)"
-reasoning_options = []
-
-[cost]
-input = 0
-output = 0

--- a/providers/kenari/models/laguna-s-2-1:free.toml
+++ b/providers/kenari/models/laguna-s-2-1:free.toml
@@ -1,3 +1,11 @@
+# Sources (accessed 2026-08-09):
+# - https://kenari.id/v1/models (laguna-s-2-1:free), public and keyless: publishes
+#   "reasoning_toggle": false for this model.
+# The lab control (chat_template_kwargs.enable_thinking) is not reachable through this
+# host. Kenari implements that shape, but only emits it for a backend configured with
+# one; this model's backend has none, so a caller's reasoning_effort "none" is stripped
+# from the request and nothing replaces it. The [] below is the host's own answer that
+# it exposes no on/off control, not an unfilled catalog field.
 base_model = "poolside/laguna-s-2.1"
 name = "Laguna S 2.1 (Free)"
 reasoning_options = []

--- a/providers/kenari/models/laguna-s-2-1:free.toml
+++ b/providers/kenari/models/laguna-s-2-1:free.toml
@@ -1,0 +1,7 @@
+base_model = "poolside/laguna-s-2.1"
+name = "Laguna S 2.1 (Free)"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/ling-3-0-flash:free.toml
+++ b/providers/kenari/models/ling-3-0-flash:free.toml
@@ -1,22 +1,7 @@
+base_model = "inclusionai/ling-3.0-flash"
 name = "Ling 3.0 Flash (Free)"
-description = "Efficient model for low-latency assistance, extraction, and routine automation"
-family = "ling"
-attachment = false
-reasoning = true
-tool_call = true
-release_date = "2026-07-23"
-last_updated = "2026-07-23"
-open_weights = true
 reasoning_options = []
 
 [cost]
 input = 0
 output = 0
-
-[limit]
-context = 262_144
-output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/kenari/models/ling-3-0-flash:free.toml
+++ b/providers/kenari/models/ling-3-0-flash:free.toml
@@ -1,0 +1,22 @@
+name = "Ling 3.0 Flash (Free)"
+description = "Efficient model for low-latency assistance, extraction, and routine automation"
+family = "ling"
+attachment = false
+reasoning = true
+tool_call = true
+release_date = "2026-07-23"
+last_updated = "2026-07-23"
+open_weights = true
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kenari/models/ling-3-0-flash:free.toml
+++ b/providers/kenari/models/ling-3-0-flash:free.toml
@@ -1,3 +1,10 @@
+# Sources (accessed 2026-08-09):
+# - https://kenari.id/v1/models (ling-3-0-flash:free), public and keyless: publishes
+#   "reasoning_toggle": false and no reasoning_options for this model.
+# Kenari only emits a reasoning disable shape for a backend configured with one, and
+# this model's backend has none, so a caller's reasoning_effort "none" is stripped from
+# the request and nothing replaces it. The [] below is the host's own answer that it
+# exposes no caller control, not an unfilled catalog field.
 base_model = "inclusionai/ling-3.0-flash"
 name = "Ling 3.0 Flash (Free)"
 reasoning_options = []

--- a/providers/kenari/models/longcat-2-0:free.toml
+++ b/providers/kenari/models/longcat-2-0:free.toml
@@ -1,3 +1,11 @@
+# Sources (accessed 2026-08-09):
+# - https://kenari.id/v1/models (longcat-2-0:free), public and keyless: publishes
+#   "reasoning_toggle": false for this model.
+# The lab control (thinking.type enabled|disabled) is not reachable through this host.
+# Kenari implements that shape, but only emits it for a backend configured with one;
+# this model's backend has none, so a caller's reasoning_effort "none" is stripped from
+# the request and nothing replaces it. The [] below is the host's own answer that it
+# exposes no on/off control, not an unfilled catalog field.
 base_model = "meituan/longcat-2.0"
 name = "LongCat-2.0 (Free)"
 reasoning_options = []

--- a/providers/kenari/models/longcat-2-0:free.toml
+++ b/providers/kenari/models/longcat-2-0:free.toml
@@ -1,0 +1,7 @@
+base_model = "meituan/longcat-2.0"
+name = "LongCat-2.0 (Free)"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/mimo-v2-5-pro-ultraspeed.toml
+++ b/providers/kenari/models/mimo-v2-5-pro-ultraspeed.toml
@@ -1,0 +1,6 @@
+base_model = "xiaomi/mimo-v2.5-pro-ultraspeed"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/mimo-v2-5-pro-ultraspeed.toml
+++ b/providers/kenari/models/mimo-v2-5-pro-ultraspeed.toml
@@ -1,3 +1,11 @@
+# Sources (accessed 2026-08-10):
+# - https://kenari.id/v1/models (mimo-v2-5-pro-ultraspeed), public and keyless: publishes
+#   "reasoning_toggle": false and no reasoning_options for this model.
+# The [] below is this host's own answer that it exposes NO caller control, effort or
+# on/off, not an unfilled catalog field. Xiaomi's lab entry carries a first-party toggle,
+# but Kenari emits a disable shape only for a backend configured with one, and this
+# model's backend has none, so a caller's control is stripped from the request and
+# nothing replaces it. Same reading as laguna-s-2-1:free and longcat-2-0:free here.
 base_model = "xiaomi/mimo-v2.5-pro-ultraspeed"
 reasoning_options = []
 

--- a/providers/kenari/models/minimax-m2-7-highspeed.toml
+++ b/providers/kenari/models/minimax-m2-7-highspeed.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/minimax-m2-7.toml
+++ b/providers/kenari/models/minimax-m2-7.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2.7"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/nemotron-3-super-120b-a12b.toml
+++ b/providers/kenari/models/nemotron-3-super-120b-a12b.toml
@@ -1,8 +1,15 @@
+# Sources (accessed 2026-08-10):
+# - https://kenari.id/v1/models (nemotron-3-super-120b-a12b), public and keyless:
+#   publishes "reasoning_toggle": false and no reasoning_options.
+# The [] below is this host's own answer that it exposes NO caller control, effort or
+# on/off. NVIDIA's lab entry carries a first-party toggle, but Kenari emits a disable
+# shape only for a backend configured with one, and this model's backend has none.
+#
+# The earlier effort ["low","medium"] came from the same host defect described in
+# nemotron-3-ultra-550b-a55b.toml: effort metadata derived from the openrouter slice
+# rather than from the model's author.
 base_model = "nvidia/nemotron-3-super-120b-a12b"
-
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium"]
+reasoning_options = []
 
 [cost]
 input = 0

--- a/providers/kenari/models/nemotron-3-super-120b-a12b:free.toml
+++ b/providers/kenari/models/nemotron-3-super-120b-a12b:free.toml
@@ -1,9 +1,11 @@
+# Sources (accessed 2026-08-10):
+# - https://kenari.id/v1/models (nemotron-3-super-120b-a12b:free), public and keyless:
+#   publishes "reasoning_toggle": false and no reasoning_options, same as the paid row.
+# See nemotron-3-super-120b-a12b.toml for the host-control reading and for why the
+# earlier effort ["low","medium"] was wrong.
 base_model = "nvidia/nemotron-3-super-120b-a12b"
 name = "Nemotron 3 Super 120B A12B (Free)"
-
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium"]
+reasoning_options = []
 
 [cost]
 input = 0

--- a/providers/kenari/models/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/kenari/models/nemotron-3-ultra-550b-a55b.toml
@@ -1,8 +1,17 @@
+# Sources (accessed 2026-08-10):
+# - https://kenari.id/v1/models (nemotron-3-ultra-550b-a55b), public and keyless:
+#   publishes "reasoning_toggle": false and no reasoning_options.
+# The [] below is this host's own answer that it exposes NO caller control, effort or
+# on/off. NVIDIA's lab entry carries a first-party toggle, but Kenari emits a disable
+# shape only for a backend configured with one, and this model's backend has none, so a
+# caller's control is stripped from the request and nothing replaces it.
+#
+# The earlier effort ["medium","high"] came from a host defect, since fixed: Kenari
+# derived effort metadata from the openrouter slice of this feed rather than from the
+# model's author. OpenRouter synthesizes an effort list for its own API surface, while
+# NVIDIA publishes a toggle and no levels.
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
-
-[[reasoning_options]]
-type = "effort"
-values = ["medium", "high"]
+reasoning_options = []
 
 [cost]
 input = 0

--- a/providers/kenari/models/nemotron-3-ultra-550b-a55b:free.toml
+++ b/providers/kenari/models/nemotron-3-ultra-550b-a55b:free.toml
@@ -1,9 +1,15 @@
+# Sources (accessed 2026-08-10):
+# - https://kenari.id/v1/models (nemotron-3-ultra-550b-a55b:free), public and keyless:
+#   publishes no reasoning_options for this model.
+# - the nvidia provider slice in this repo, which publishes [{"type":"toggle"}] for
+#   nvidia/nemotron-3-ultra-550b-a55b: a reasoning on/off control and no effort levels.
+# An earlier revision of this file carried effort ["medium","high"], copied from the host
+# while it was deriving effort metadata from the openrouter slice rather than from the
+# model's author. The host corrected that, so the [] below is NVIDIA's own answer that the
+# model exposes no effort control, not an unfilled catalog field.
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 name = "Nemotron 3 Ultra 550B A55B (Free)"
-
-[[reasoning_options]]
-type = "effort"
-values = ["medium", "high"]
+reasoning_options = []
 
 [cost]
 input = 0

--- a/providers/kenari/models/nemotron-3-ultra-550b-a55b:free.toml
+++ b/providers/kenari/models/nemotron-3-ultra-550b-a55b:free.toml
@@ -1,0 +1,10 @@
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+name = "Nemotron 3 Ultra 550B A55B (Free)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/nemotron-3-ultra-550b-a55b:free.toml
+++ b/providers/kenari/models/nemotron-3-ultra-550b-a55b:free.toml
@@ -1,12 +1,16 @@
 # Sources (accessed 2026-08-10):
 # - https://kenari.id/v1/models (nemotron-3-ultra-550b-a55b:free), public and keyless:
-#   publishes no reasoning_options for this model.
-# - the nvidia provider slice in this repo, which publishes [{"type":"toggle"}] for
-#   nvidia/nemotron-3-ultra-550b-a55b: a reasoning on/off control and no effort levels.
-# An earlier revision of this file carried effort ["medium","high"], copied from the host
-# while it was deriving effort metadata from the openrouter slice rather than from the
-# model's author. The host corrected that, so the [] below is NVIDIA's own answer that the
-# model exposes no effort control, not an unfilled catalog field.
+#   publishes "reasoning_toggle": false and no reasoning_options for this model.
+# The [] below is this host's own answer that it exposes NO caller control, effort or
+# on/off. NVIDIA's lab entry carries a first-party toggle, but Kenari only emits a
+# disable shape for a backend configured with one, and this model's backend has none, so
+# a caller's control is stripped from the request and nothing replaces it. Same reading
+# as laguna-s-2-1:free in this branch.
+#
+# An earlier revision carried effort ["medium","high"], copied from the host while it was
+# deriving effort metadata from the openrouter slice of this feed rather than from the
+# model's author. OpenRouter's list describes its own API surface; the host has since
+# corrected that derivation.
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 name = "Nemotron 3 Ultra 550B A55B (Free)"
 reasoning_options = []

--- a/providers/kenari/models/north-mini-code:free.toml
+++ b/providers/kenari/models/north-mini-code:free.toml
@@ -1,3 +1,10 @@
+# Sources (accessed 2026-08-09):
+# - https://kenari.id/v1/models (north-mini-code:free), public and keyless: publishes
+#   "reasoning_toggle": false and no reasoning_options for this model.
+# Kenari only emits a reasoning disable shape for a backend configured with one, and
+# this model's backend has none, so a caller's reasoning_effort "none" is stripped from
+# the request and nothing replaces it. The [] below is the host's own answer that it
+# exposes no caller control, not an unfilled catalog field.
 base_model = "cohere/north-mini-code-1-0"
 name = "North Mini Code (Free)"
 reasoning_options = []

--- a/providers/kenari/models/north-mini-code:free.toml
+++ b/providers/kenari/models/north-mini-code:free.toml
@@ -1,0 +1,7 @@
+base_model = "cohere/north-mini-code-1-0"
+name = "North Mini Code (Free)"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/qwen3-7-flash.toml
+++ b/providers/kenari/models/qwen3-7-flash.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3.7-flash"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/qwen3-7-flash.toml
+++ b/providers/kenari/models/qwen3-7-flash.toml
@@ -1,3 +1,12 @@
+# Sources (accessed 2026-08-10):
+# - https://kenari.id/v1/models (qwen3-7-flash), public and keyless: publishes
+#   "reasoning_toggle": false and no reasoning_options for this model.
+# The [] below is this host's own answer that it exposes NO caller control, effort,
+# budget or on/off, not an unfilled catalog field. Alibaba's first-party paths carry a
+# toggle and budget_tokens, but Kenari emits a disable shape only for a backend
+# configured with one, and this model's backend has none, so a caller's control is
+# stripped from the request and nothing replaces it. Same reading as laguna-s-2-1:free
+# and longcat-2-0:free here.
 base_model = "alibaba/qwen3.7-flash"
 reasoning_options = []
 

--- a/providers/kenari/models/qwen3-8-max.toml
+++ b/providers/kenari/models/qwen3-8-max.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3.8-max"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/step-3-7-flash.toml
+++ b/providers/kenari/models/step-3-7-flash.toml
@@ -1,0 +1,9 @@
+base_model = "stepfun/step-3.7-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/kenari/models/step-3-7-flash:free.toml
+++ b/providers/kenari/models/step-3-7-flash:free.toml
@@ -1,0 +1,10 @@
+base_model = "stepfun/step-3.7-flash"
+name = "Step 3.7 Flash (Free)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0
+output = 0


### PR DESCRIPTION
Data-only refresh of the Kenari catalog against the live endpoint: 15 models added, 3 removed, and 6 already-merged rows corrected. No adapter or sync code in this branch.

The 13 models below were generated by running the sync adapter from #3171 on top of current `dev`. Two more (`ling-3-0-flash:free`, `north-mini-code:free`) were hand-authored afterwards, along with one canonical lab entry they needed; those are called out in their own section. `bun ./packages/core/script/validate.ts` exits 0.

## Added (15)

Every field below comes from `GET https://kenari.id/v1/models`, which is public and needs no key, so it can be checked independently.

| model id | base_model | reasoning_options from the endpoint |
|---|---|---|
| `claude-opus-5` | `anthropic/claude-opus-5` | `["low","medium","high","xhigh","max"]` |
| `claude-sonnet-4-6` | `anthropic/claude-sonnet-4-6` | `["low","medium","high","max"]` |
| `gemini-3-6-flash` | `google/gemini-3.6-flash` | `["minimal","low","medium","high"]` |
| `laguna-s-2-1:free` | `poolside/laguna-s-2.1` | `reasoning: true`, none published |
| `ling-3-0-flash:free` | `inclusionai/ling-3.0-flash` | `reasoning: true`, none published |
| `longcat-2-0:free` | `meituan/longcat-2.0` | `reasoning: true`, none published |
| `mimo-v2-5-pro-ultraspeed` | `xiaomi/mimo-v2.5-pro-ultraspeed` | none |
| `minimax-m2-7` | `minimax/MiniMax-M2.7` | `reasoning: true`, none published |
| `minimax-m2-7-highspeed` | `minimax/MiniMax-M2.7-highspeed` | none |
| `nemotron-3-ultra-550b-a55b:free` | `nvidia/nemotron-3-ultra-550b-a55b` | `reasoning: true`, none published (see below) |
| `north-mini-code:free` | `cohere/north-mini-code-1-0` | `reasoning: true`, none published |
| `qwen3-7-flash` | `alibaba/qwen3.7-flash` | `reasoning: true`, none published |
| `qwen3-8-max` | `alibaba/qwen3.8-max` | `["minimal","low","medium","high","xhigh"]` |
| `step-3-7-flash` | `stepfun/step-3.7-flash` | `["low","medium","high"]` |
| `step-3-7-flash:free` | `stepfun/step-3.7-flash` | `["low","medium","high"]` |

Rows marked "none published" get `reasoning_options = []` from the runner's own preserve path, which is the repo-wide rule for a new reasoning model whose source publishes no efforts. It self-heals: once the endpoint publishes efforts, the list replaces the empty one.

### One row corrected since the table was first written

`nemotron-3-ultra-550b-a55b:free` was listed here with effort `["medium","high"]`, taken from the endpoint at the time. That reading came from a defect on the host side, now fixed: Kenari was deriving effort metadata from the `openrouter` slice of this feed rather than from the model's author, and this repo's own `nvidia` slice publishes `[{"type":"toggle"}]` for `nvidia/nemotron-3-ultra-550b-a55b`, meaning a reasoning on/off control and no effort levels. OpenRouter's `["medium","high"]` describes its own API surface, not the model.

The endpoint now publishes no `reasoning_options` for this model, so the file carries `reasoning_options = []` on the same convention as `laguna-s-2-1:free`. Re-checked against the live endpoint on 2026-08-10: the other fourteen added rows and all three removals are unchanged.

## Corrected (6 existing rows)

These rows were already merged and now disagreed with the endpoint. The host was deriving effort metadata from the `openrouter` slice of this feed rather than from the model's author, so it republished OpenRouter's API surface as if it were the model's own controls. That is fixed upstream, and these rows follow it.

| model id | was | now | why |
|---|---|---|---|
| `deepseek-v4-flash` | `["high","xhigh"]` | `["low","high","max"]` | the `deepseek` slice in this repo publishes low, high, max |
| `deepseek-v4-flash:free` | `["high","xhigh"]` | `["low","high","max"]` | same as the paid row |
| `deepseek-v4-pro` | `["high","xhigh"]` | `["high","max"]` | the `deepseek` slice publishes high, max |
| `nemotron-3-super-120b-a12b` | `["low","medium"]` | `[]` | NVIDIA publishes `[{"type":"toggle"}]`, no effort levels |
| `nemotron-3-super-120b-a12b:free` | `["low","medium"]` | `[]` | same as the paid row |
| `nemotron-3-ultra-550b-a55b` | `["medium","high"]` | `[]` | NVIDIA publishes `[{"type":"toggle"}]`, no effort levels |

Every `[]` in this branch now carries a leading comment citing the host signal that justifies it (`"reasoning_toggle": false` on `GET https://kenari.id/v1/models`), so an empty list reads as an affirmative absence of any caller control rather than unfilled metadata. That also covers `mimo-v2-5-pro-ultraspeed` and `qwen3-7-flash`, which previously carried a bare `[]`.

## Removed (3)

The gateway no longer serves these, and each was confirmed absent from the live response rather than assumed:

`grok-build-0-1`, `kimi-k2-6:free`, `kimi-k2-7-code:free`

## The two the adapter skipped

An earlier revision of this PR left `ling-3-0-flash:free` and `north-mini-code:free` out, because the adapter skips a model whose `base_model` has no canonical entry, and the reasoning given was that inventing name and release-date data is worse than a visible gap. That reasoning still holds. It turned out only one of the two actually needed new data:

- `north-mini-code:free` resolves against `models/cohere/north-mini-code-1-0.toml`, which already exists. Nothing was authored beyond the provider override.
- `ling-3-0-flash:free` needed `models/inclusionai/ling-3.0-flash.toml`, which this PR adds.

Nothing in that lab entry is invented. Four hosts in this repo already carry the model (`openrouter`, `kilo`, `nano-gpt`, `vercel`), so every field is taken from them, using the majority where they disagree: `reasoning = true` (3 of 4), `open_weights = false` (3 of 4), `limit.context = 262144` and `limit.output = 32768` (3 of 4), `release_date = 2026-07-23` (3 of 4). The Kenari endpoint independently reports reasoning, tool calling and a 262144 window. `cost` and `reasoning_options` stay provider-side, per the provider-only rule.

Both Kenari files are override-only on top of `base_model`, matching `laguna-s-2-1:free`.

## Cost stays 0

Kenari bills a prepaid wallet in Indonesian rupiah, so there is no stable USD per-token figure to publish. A converted number would be invented and would drift with the exchange rate. Same treatment as the previous merged refresh.

