### PR TITLE
Revert "fix(synthetic): cap GLM-5.2 input at real serving limit 365,178"

### DIFF
--- a/providers/synthetic/models/hf:zai-org/GLM-5.2.toml
+++ b/providers/synthetic/models/hf:zai-org/GLM-5.2.toml
@@ -11,5 +11,4 @@ cache_read = 1.4
 
 [limit]
 context = 524_288
-input = 365_178
 output = 65_536


### PR DESCRIPTION
Reverts anomalyco/models.dev#4372

We support 512k context for GLM-5.2 and the PR author was confused. Like all inference providers, context length includes output tokens, so if you attempt to generate 50k output tokens your input context length is 512-50; if you attempt to generate 100k tokens your input context length is 512-100; etc etc. None of this changes the total context length, which is 512k. 

The PR author claimed that their PR was "confirmed by Synthetic," but we did not confirm it and this was a drive-by surprise when we saw it in our Discord.