### PR TITLE
fix(ofox): add GLM-5V-Turbo

### DIFF
--- a/providers/ofox/models/z-ai/glm-5v-turbo.toml
+++ b/providers/ofox/models/z-ai/glm-5v-turbo.toml
@@ -1,0 +1,11 @@
+# Sources:
+# - https://ofox.ai/models/z-ai/glm-5v-turbo (pricing $1.2/$4 per MTok, cache_read $0.24; context 200K; output 128K)
+# - https://docs.z.ai/guides/overview/concept-param (thinking.type for GLM-5V-Turbo)
+# Toggle: thinking.type = enabled|disabled
+base_model = "zhipuai/glm-5v-turbo"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 1.2
+output = 4
+cache_read = 0.24


### PR DESCRIPTION
Adds the Ofox entry for `z-ai/glm-5v-turbo`.

It reuses the existing ZhipuAI base model and records the Ofox pricing and supported reasoning toggle. `bun validate` passes locally.

Closes #4237