### PR TITLE
fix(merge-gateway): tolerate null reasoning metadata

### DIFF
--- a/packages/core/src/sync/providers/merge-gateway.ts
+++ b/packages/core/src/sync/providers/merge-gateway.ts
@@ -165,7 +165,7 @@ export const mergeGateway = {
 export function mergeGatewayReasoningOptions(
   reasoning: MergeGatewayVendor["capabilities"]["reasoning"],
 ): NonNullable<SyncedFullModel["reasoning_options"]> | undefined {
-  if (reasoning === undefined) return undefined;
+  if (reasoning == null) return undefined;
   const options: NonNullable<SyncedFullModel["reasoning_options"]> = [];
 
   if (reasoning.disable_supported === true) {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -2589,6 +2589,23 @@ test("confirms reasoning when any available Merge Gateway route reports supports
   expect(model).not.toMatchObject({ reasoning: false });
 });
 
+// The live catalog emits reasoning: null on some routes even when
+// supports_reasoning is true. Treat that as unknown controls, not a crash.
+test("tolerates a null Merge Gateway reasoning object when reasoning is confirmed", () => {
+  const selected = mergeGatewayVendor();
+  selected.capabilities.supports_reasoning = true;
+  selected.capabilities.reasoning = null;
+  const model = buildMergeGatewayModel(mergeGatewayModel({
+    vendors: { openai: selected },
+  }), {
+    base_model: "openai/gpt-5.6-sol",
+    cost: { input: 5, output: 30 },
+  });
+
+  expect(model).toMatchObject({ reasoning_options: [] });
+  expect(model).not.toMatchObject({ reasoning: false });
+});
+
 // Publishes a toggle only when the selected route explicitly supports disabling reasoning.
 test("derives a Merge Gateway reasoning toggle when the selected route supports disabling", () => {
   const selected = mergeGatewayVendor();


### PR DESCRIPTION
## Summary
- Merge Gateway sync crashed with `TypeError: null is not an object (evaluating 'reasoning.disable_supported')` when `bun models:sync merge-gateway` hit a catalog route whose `capabilities.reasoning` is `null`.
- The schema already allows `reasoning` to be nullable, but `mergeGatewayReasoningOptions` only guarded `undefined`. Treat `null` the same way and fall back to empty `reasoning_options` (reasons, no verified caller control).
- Added a regression test for `supports_reasoning = true` + `reasoning = null`.

## Test plan
- [x] `bun test packages/core/test/sync.test.ts --test-name-pattern "Merge Gateway"`