### PR TITLE
fix(vercel): add Claude Opus 5 Fast with effort options

### DIFF
--- a/providers/vercel/models/anthropic/claude-opus-5-fast.toml
+++ b/providers/vercel/models/anthropic/claude-opus-5-fast.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (Fast)"
+description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5


### PR DESCRIPTION
Supersedes the catalog addition in #4402 with proper `reasoning_options`.

**Host:** Vercel AI Gateway (multi-model relay)

**Model:** `anthropic/claude-opus-5-fast` → `base_model = "anthropic/claude-opus-5"`

**Options:** `effort` `low` / `medium` / `high` / `xhigh` / `max`

Matches first-party Anthropic Opus 5, existing `providers/vercel/models/anthropic/claude-opus-5.toml`, and OpenRouter's Opus 5 Fast peer. Empty `[]` on a relay of a controlled reasoner is invalid.

No toggle (lab has no on/off; off is not `none` in the effort list). No `budget_tokens` (Claude 4.7+ adaptive effort).

Wire on this host: `reasoning.effort` (see `providers/vercel/provider.toml`).