### PR TITLE
feat: add HAI OpenAI-compatible provider

### DIFF
--- a/providers/hai/logo.svg
+++ b/providers/hai/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="currentColor" opacity="0.12"/>
+  <circle cx="20" cy="32" r="5" fill="currentColor"/>
+  <circle cx="44" cy="20" r="5" fill="currentColor"/>
+  <circle cx="44" cy="44" r="5" fill="currentColor"/>
+  <path d="M24.5 30.5L40 22M24.5 33.5L40 42" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/providers/hai/models/deepseek-v4-flash.toml
+++ b/providers/hai/models/deepseek-v4-flash.toml
@@ -1,0 +1,28 @@
+name = "DeepSeek V4 Flash"
+description = "Fast low-cost model for high-volume workloads"
+family = "deepseek"
+release_date = "2026-08-02"
+last_updated = "2026-08-10"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.14
+output = 0.28
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/hai/models/gemma-4-31b-it.toml
+++ b/providers/hai/models/gemma-4-31b-it.toml
@@ -1,0 +1,22 @@
+name = "Gemma 4 31B"
+description = "Low-cost multimodal model with video input"
+family = "gemma"
+release_date = "2026-08-05"
+last_updated = "2026-08-10"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.24
+output = 0.58
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/hai/models/kimi-k2.6.toml
+++ b/providers/hai/models/kimi-k2.6.toml
@@ -1,0 +1,28 @@
+name = "Kimi K2.6"
+description = "General-purpose model with optional reasoning"
+family = "kimi"
+release_date = "2026-08-03"
+last_updated = "2026-08-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.82
+output = 3.66
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/hai/models/kimi-k3.toml
+++ b/providers/hai/models/kimi-k3.toml
@@ -1,0 +1,28 @@
+name = "Kimi K3"
+description = "Long-context general model with 1M context (TEE-backed)"
+family = "kimi"
+release_date = "2026-07-01"
+last_updated = "2026-08-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 3.00
+output = 15.00
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/hai/models/qwen3.6-35b-a3b-uncensored.toml
+++ b/providers/hai/models/qwen3.6-35b-a3b-uncensored.toml
@@ -1,0 +1,28 @@
+name = "Qwen3.6 35B-A3B Uncensored"
+description = "Uncensored 35B/3B MoE variant that avoids refusal responses"
+family = "qwen"
+release_date = "2026-08-08"
+last_updated = "2026-08-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.24
+output = 1.60
+
+[limit]
+context = 65_536
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/hai/models/qwen3.6-35b-a3b.toml
+++ b/providers/hai/models/qwen3.6-35b-a3b.toml
@@ -1,0 +1,28 @@
+name = "Qwen3.6 35B-A3B"
+description = "Lightweight MoE for agentic coding and video input"
+family = "qwen"
+release_date = "2026-08-08"
+last_updated = "2026-08-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.18
+output = 1.24
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/hai/provider.toml
+++ b/providers/hai/provider.toml
@@ -1,0 +1,5 @@
+name = "HAI"
+npm = "@ai-sdk/openai-compatible"
+env = ["HAI_API_KEY"]
+api = "https://hai-api.hcloud.ltd/v1"
+doc = "https://hai.hcloud.ltd/docs"


### PR DESCRIPTION
## Summary

Add **HAI** (https://hai.hcloud.ltd) as an OpenAI-compatible provider.

HAI is a Japan-based LLM Inference API (JPY billing) that exposes an OpenAI-compatible endpoint at `https://hai-api.hcloud.ltd/v1`.

### Models

| ID | Context | Modalities |
|---|---|---|
| `kimi-k3` | 1,048,576 | text, image |
| `kimi-k2.6` | 262,144 | text, image |
| `gemma-4-31b-it` | 262,144 | text, image, video |
| `qwen3.6-35b-a3b` | 262,144 | text, image, video |
| `qwen3.6-35b-a3b-uncensored` | 65,536 | text, image |
| `deepseek-v4-flash` | 1,048,576 | text |

### Config

```toml
name = "HAI"
npm = "@ai-sdk/openai-compatible"
env = ["HAI_API_KEY"]
api = "https://hai-api.hcloud.ltd/v1"
doc = "https://hai.hcloud.ltd/docs"
```

### Validation

`bun validate` passes locally.

## Test plan

- [x] `bun validate`
- [ ] Confirm provider appears in generated `api.json` after merge