### PR TITLE
Add longwire provider

### DIFF
--- a/providers/longwire/logo.svg
+++ b/providers/longwire/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" fill="none" role="img" aria-label="longwire">
+  <path d="M25 68 H36 C43 68 45.5 58 48 48" pathLength="100" stroke-dasharray="88 12" stroke="currentColor" stroke-width="7.5" stroke-linecap="round"/>
+  <path d="M48 48 C50.5 38 53 28 60 28 H71" pathLength="100" stroke-dasharray="0 12 88" stroke="currentColor" stroke-width="7.5" stroke-linecap="round"/>
+  <circle cx="14" cy="68" r="7.5" stroke="currentColor" stroke-width="5.5"/>
+  <circle cx="82" cy="28" r="7.5" stroke="currentColor" stroke-width="5.5"/>
+  <circle cx="48" cy="48" r="5" fill="currentColor"/>
+</svg>

--- a/providers/longwire/models/alibaba/qwen3.5-9b.toml
+++ b/providers/longwire/models/alibaba/qwen3.5-9b.toml
@@ -1,0 +1,16 @@
+# Self-hosted through longwire: inference runs on the user's own hardware, so
+# there is no per-token price (longwire itself charges nothing per request).
+# Exact model ids vary by serving engine (ollama tags like "gemma4:e4b", HF
+# repo paths on vLLM/sglang) — GET /v1/models returns the account's real ids.
+# Limits/modalities inherit from the base model; engine quantization and
+# --max-model-len can lower the effective context on a given machine.
+# Reasoning control depends on the engine serving this model on the user's
+# machine (ollama `think`, vLLM/sglang reasoning parsers); longwire forwards
+# request fields verbatim, so a plain on/off toggle is the portable surface.
+reasoning_options = [{ type = "toggle" }]
+
+base_model = "alibaba/qwen3.5-9b"
+
+[cost]
+input = 0
+output = 0

--- a/providers/longwire/models/alibaba/qwen3.6-35b-a3b.toml
+++ b/providers/longwire/models/alibaba/qwen3.6-35b-a3b.toml
@@ -1,0 +1,16 @@
+# Self-hosted through longwire: inference runs on the user's own hardware, so
+# there is no per-token price (longwire itself charges nothing per request).
+# Exact model ids vary by serving engine (ollama tags like "gemma4:e4b", HF
+# repo paths on vLLM/sglang) — GET /v1/models returns the account's real ids.
+# Limits/modalities inherit from the base model; engine quantization and
+# --max-model-len can lower the effective context on a given machine.
+# Reasoning control depends on the engine serving this model on the user's
+# machine (ollama `think`, vLLM/sglang reasoning parsers); longwire forwards
+# request fields verbatim, so a plain on/off toggle is the portable surface.
+reasoning_options = [{ type = "toggle" }]
+
+base_model = "alibaba/qwen3.6-35b-a3b"
+
+[cost]
+input = 0
+output = 0

--- a/providers/longwire/models/deepseek/deepseek-v4-flash-0731.toml
+++ b/providers/longwire/models/deepseek/deepseek-v4-flash-0731.toml
@@ -1,0 +1,16 @@
+# Self-hosted through longwire: inference runs on the user's own hardware, so
+# there is no per-token price (longwire itself charges nothing per request).
+# Exact model ids vary by serving engine (ollama tags like "gemma4:e4b", HF
+# repo paths on vLLM/sglang) — GET /v1/models returns the account's real ids.
+# Limits/modalities inherit from the base model; engine quantization and
+# --max-model-len can lower the effective context on a given machine.
+# Reasoning control depends on the engine serving this model on the user's
+# machine (ollama `think`, vLLM/sglang reasoning parsers); longwire forwards
+# request fields verbatim, so a plain on/off toggle is the portable surface.
+reasoning_options = [{ type = "toggle" }]
+
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[cost]
+input = 0
+output = 0

--- a/providers/longwire/models/google/gemma-4-E4B-it.toml
+++ b/providers/longwire/models/google/gemma-4-E4B-it.toml
@@ -1,0 +1,16 @@
+# Self-hosted through longwire: inference runs on the user's own hardware, so
+# there is no per-token price (longwire itself charges nothing per request).
+# Exact model ids vary by serving engine (ollama tags like "gemma4:e4b", HF
+# repo paths on vLLM/sglang) — GET /v1/models returns the account's real ids.
+# Limits/modalities inherit from the base model; engine quantization and
+# --max-model-len can lower the effective context on a given machine.
+# Reasoning control depends on the engine serving this model on the user's
+# machine (ollama `think`, vLLM/sglang reasoning parsers); longwire forwards
+# request fields verbatim, so a plain on/off toggle is the portable surface.
+reasoning_options = [{ type = "toggle" }]
+
+base_model = "google/gemma-4-E4B-it"
+
+[cost]
+input = 0
+output = 0

--- a/providers/longwire/models/poolside/laguna-s-2.1.toml
+++ b/providers/longwire/models/poolside/laguna-s-2.1.toml
@@ -1,0 +1,16 @@
+# Self-hosted through longwire: inference runs on the user's own hardware, so
+# there is no per-token price (longwire itself charges nothing per request).
+# Exact model ids vary by serving engine (ollama tags like "gemma4:e4b", HF
+# repo paths on vLLM/sglang) — GET /v1/models returns the account's real ids.
+# Limits/modalities inherit from the base model; engine quantization and
+# --max-model-len can lower the effective context on a given machine.
+# Reasoning control depends on the engine serving this model on the user's
+# machine (ollama `think`, vLLM/sglang reasoning parsers); longwire forwards
+# request fields verbatim, so a plain on/off toggle is the portable surface.
+reasoning_options = [{ type = "toggle" }]
+
+base_model = "poolside/laguna-s-2.1"
+
+[cost]
+input = 0
+output = 0

--- a/providers/longwire/provider.toml
+++ b/providers/longwire/provider.toml
@@ -1,0 +1,18 @@
+# longwire is a hosted router in front of the user's own machines: a daemon on
+# each machine discovers local engines (ollama, vLLM, sglang, llama.cpp,
+# LM Studio) and tunnels them out through one endpoint. The model catalog is
+# per-account and dynamic — GET https://longwire.ai/v1/models (Bearer lw_sk_
+# key) lists every model the account can reach, addressable as
+# "machine/model" (pinned to one machine) or the bare model name (routed to
+# the least-loaded machine serving it). The entries under models/ are a
+# representative set of commonly-served open-weights models, following the
+# LM Studio convention for bring-your-own-model providers.
+# Besides Chat Completions, completions, and embeddings, the same base URL
+# serves the OpenAI Responses API (/v1/responses) and the Anthropic Messages
+# API (/v1/messages), all streaming.
+# https://longwire.ai/getting-started (accessed 2026-08-10)
+name = "longwire"
+env = ["LONGWIRE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://longwire.ai/v1"
+doc = "https://longwire.ai/getting-started"


### PR DESCRIPTION
## Summary

Adds [longwire](https://longwire.ai) — a hosted router that turns a user's own machines into one OpenAI-compatible endpoint. A daemon on each machine discovers local engines (ollama, vLLM, sglang, llama.cpp, LM Studio) and tunnels them out; requests to `https://longwire.ai/v1` route to the least-loaded machine serving the requested model.

- `providers/longwire/provider.toml` — `@ai-sdk/openai-compatible`, `api = "https://longwire.ai/v1"`, `env = ["LONGWIRE_API_KEY"]`, docs at https://longwire.ai/getting-started
- `providers/longwire/logo.svg` — monochrome `currentColor` mark
- `providers/longwire/models/` — a representative set of commonly-served open-weights models (DeepSeek V4 Flash 0731, Qwen3.5 9B, Qwen3.6 35B-A3B, Gemma 4 E4B, Laguna S 2.1), each inheriting via `base_model` with `cost = 0` (inference runs on the user's own hardware; longwire adds no per-token charge)

## Conventions followed

Like LM Studio and Lynkr (#3212), longwire serves whatever models its users run, so the real catalog is per-account and dynamic: `GET /v1/models` (Bearer key) lists the account's models, addressable as `machine/model` (pinned) or the bare model name (routed). The checked-in entries follow the LM Studio convention of representative popular models rather than an exhaustive list, satisfying the non-empty-models rule from #4014.

`reasoning_options` is declared as a plain toggle on reasoning models: longwire forwards request fields verbatim, so the effective reasoning control surface is the serving engine's — a toggle is the portable common denominator (comment in each TOML).

Beyond Chat Completions/completions/embeddings, the same base URL also serves the OpenAI Responses API (`/v1/responses`) and the Anthropic Messages API (`/v1/messages`), all streaming.

## Validation

- `bun run validate` passes locally
