### PR TITLE
feat(snowflake-cortex): add Claude Opus 5, Sonnet 5, Opus 4.6 and Opus 4.5

### DIFF
--- a/providers/snowflake-cortex/models/claude-opus-4-5.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-5.toml
@@ -1,0 +1,3 @@
+base_model = "anthropic/claude-opus-4-5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]

--- a/providers/snowflake-cortex/models/claude-opus-4-5.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-5.toml
@@ -1,3 +1,3 @@
 base_model = "anthropic/claude-opus-4-5"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "budget_tokens" }]

--- a/providers/snowflake-cortex/models/claude-opus-4-6.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-6.toml
@@ -1,0 +1,3 @@
+base_model = "anthropic/claude-opus-4-6"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]

--- a/providers/snowflake-cortex/models/claude-opus-4-6.toml
+++ b/providers/snowflake-cortex/models/claude-opus-4-6.toml
@@ -1,3 +1,3 @@
 base_model = "anthropic/claude-opus-4-6"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "budget_tokens" }]

--- a/providers/snowflake-cortex/models/claude-opus-5.toml
+++ b/providers/snowflake-cortex/models/claude-opus-5.toml
@@ -1,3 +1,3 @@
 base_model = "anthropic/claude-opus-5"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []

--- a/providers/snowflake-cortex/models/claude-opus-5.toml
+++ b/providers/snowflake-cortex/models/claude-opus-5.toml
@@ -1,0 +1,3 @@
+base_model = "anthropic/claude-opus-5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/snowflake-cortex/models/claude-sonnet-5.toml
+++ b/providers/snowflake-cortex/models/claude-sonnet-5.toml
@@ -1,0 +1,5 @@
+# Toggle: thinking.type = adaptive|disabled
+# Effort: output_config.effort = low|medium|high|xhigh|max
+base_model = "anthropic/claude-sonnet-5"
+
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/snowflake-cortex/models/claude-sonnet-5.toml
+++ b/providers/snowflake-cortex/models/claude-sonnet-5.toml
@@ -1,5 +1,3 @@
-# Toggle: thinking.type = adaptive|disabled
-# Effort: output_config.effort = low|medium|high|xhigh|max
 base_model = "anthropic/claude-sonnet-5"
 
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []


### PR DESCRIPTION
﻿Four Claude models that Snowflake Cortex serves today are missing from this provider's catalog. Cortex has no listing endpoint (`/api/v2/cortex/v1/models` returns 404), so its 21 entries are hand-maintained: the last update was `e205675103` (2026-07-13), and `claude-opus-5` has been added to other providers since 2026-07-24 but never here.

### Verification

Called live against a Snowflake account in `AZURE_WESTEUROPE` with cross-region inference enabled, via `POST /api/v2/cortex/v1/chat/completions`:

| Model | Chat | Tool calling |
| --- | --- | --- |
| `claude-opus-5` | 200 OK | 200 OK |
| `claude-sonnet-5` | 200 OK | 200 OK |
| `claude-opus-4-6` | 200 OK | 200 OK |
| `claude-opus-4-5` | 200 OK | 200 OK |

All four are `base_model` references with no `[cost]`, matching the rest of the provider. `limit` is inherited. No existing file is modified.

### reasoning_options

Values match the corresponding `providers/anthropic/` entries and Anthropic's docs: Opus 5 and Sonnet 5 reject `thinking.type: "enabled"` ([extended thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)) so carry no `budget_tokens`, while Opus 4.6 and Opus 4.5 keep it. `xhigh` is documented for Opus 5 and Sonnet 5 only; `max` also for Opus 4.6 ([effort](https://docs.anthropic.com/en/docs/build-with-claude/effort)).

Existing Claude entries here use `[]` or `budget_tokens` only, following `5c3d9d9d5` ("Limit options to chat completions surface"). Happy to narrow these four to that convention if you prefer.

### Notes

The API caps `max_completion_tokens` at 131072, but that seems a request-parameter ceiling rather than a model output capability, so it is not encoded in `limit`.
