### PR TITLE
fix(cloudflare-workers-ai): correct GLM 5.2 token limits

### DIFF
--- a/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-5.2.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-5.2.toml
@@ -1,4 +1,4 @@
-# Output limit verified against Cloudflare Workers AI OpenAI-compatible endpoint.
+# Context and output limits verified against Cloudflare Workers AI's OpenAI-compatible endpoint.
 # https://developers.cloudflare.com/workers-ai/models/glm-5.2/
 base_model = "zhipuai/glm-5.2"
 name = "Glm 5.2"
@@ -10,5 +10,5 @@ output = 4.4
 cache_read = 0.26
 
 [limit]
-context = 262_144
+context = 256_000
 output = 256_000

--- a/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-5.2.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-5.2.toml
@@ -1,3 +1,5 @@
+# Output limit verified against Cloudflare Workers AI OpenAI-compatible endpoint.
+# https://developers.cloudflare.com/workers-ai/models/glm-5.2/
 base_model = "zhipuai/glm-5.2"
 name = "Glm 5.2"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
@@ -9,4 +11,4 @@ cache_read = 0.26
 
 [limit]
 context = 262_144
-output = 262_144
+output = 256_000


### PR DESCRIPTION
## Summary

Correct Cloudflare Workers AI's GLM 5.2 context and output limits from 262,144 to 256,000 tokens.

## Evidence mapped to each change

### `limit.output`: 262,144 → 256,000

A direct request to the Workers AI OpenAI-compatible endpoint with `max_completion_tokens: 262144` returned:

> max_completion_tokens is too large: 262144. This model supports at most 256000 completion tokens.

### `limit.context`: 262,144 → 256,000

A direct request to the same endpoint with 31,216 input tokens and `max_completion_tokens: 225662` (256,878 total) returned:

> Requested token count exceeds the model's maximum context length of 256000 tokens. You requested a total of 256878 tokens: 31216 tokens from the input messages and 225662 tokens for the completion.

Both responses came from `POST /client/v4/accounts/{account}/ai/v1/chat/completions` using `@cf/zai-org/glm-5.2`.

The incorrect values cause clients such as OpenCode and pi to fail before inference. I verified text streaming and complete tool-call round trips in both clients after applying the corrected limits.

Source: https://developers.cloudflare.com/workers-ai/models/glm-5.2/

## Validation

- `bun validate`
- `git diff --check`
- live `/ai/v1/chat/completions` probes
- pi text and tool-call smoke tests
- OpenCode text and tool-call smoke tests
