### PR TITLE
fix(synthetic): correct Kimi-K3 reasoning efforts to low/high/max

### DIFF
--- a/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
+++ b/providers/synthetic/models/hf:moonshotai/Kimi-K3.toml
@@ -2,7 +2,7 @@ base_model = "moonshotai/kimi-k3"
 last_updated = "2026-07-27"
 
 temperature = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
### What does this PR do?

Synthetic's Kimi K3 entry lists reasoning efforts `low, medium, high`, but the live models API reports `low, high, max` for `hf:moonshotai/Kimi-K3`. This corrects `reasoning_options` in the provider TOML to match the API.

### Evidence

- https://api.synthetic.new/openai/v1/models — `hf:moonshotai/Kimi-K3` reports `"reasoning_parameters": { "efforts": ["low", "high", "max"] }` (no `medium`; adds `max`)
- The `syn:large:vision` alias is the same underlying model and reports the same effort set.

### Type of change

- [x] Bug fix (data correction)
- [ ] New model
- [ ] Documentation
