### PR TITLE
chore(zenmux): mark 15 offline models as deprecated

### DIFF
--- a/providers/zenmux/models/anthropic/claude-3.5-haiku.toml
+++ b/providers/zenmux/models/anthropic/claude-3.5-haiku.toml
@@ -1,4 +1,5 @@
 name = "Claude 3.5 Haiku"
+description = "Fast Claude model for responsive assistance, classification, and lightweight agents"
 release_date = "2024-11-04"
 last_updated = "2024-11-04"
 attachment = true
@@ -7,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.80
@@ -21,3 +23,7 @@ output = 64_000
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"

--- a/providers/zenmux/models/anthropic/claude-3.7-sonnet.toml
+++ b/providers/zenmux/models/anthropic/claude-3.7-sonnet.toml
@@ -1,12 +1,15 @@
 name = "Claude 3.7 Sonnet"
+description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
 release_date = "2025-02-24"
 last_updated = "2025-02-24"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 3.00
@@ -21,3 +24,7 @@ output = 64_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://zenmux.ai/api/anthropic/v1"

--- a/providers/zenmux/models/deepseek/deepseek-chat.toml
+++ b/providers/zenmux/models/deepseek/deepseek-chat.toml
@@ -1,4 +1,5 @@
 name = "DeepSeek-V3.2 (Non-thinking Mode)"
+description = "DeepSeek chat model for instruction following, coding, and analysis"
 release_date = "2025-12-01"
 last_updated = "2025-12-01"
 attachment = false
@@ -7,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.28

--- a/providers/zenmux/models/inclusionai/ling-1t.toml
+++ b/providers/zenmux/models/inclusionai/ling-1t.toml
@@ -1,4 +1,5 @@
 name = "Ling-1T"
+description = "Tool-capable chat model for instruction following and agentic application workflows"
 release_date = "2025-10-09"
 last_updated = "2025-10-09"
 attachment = false
@@ -7,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.56

--- a/providers/zenmux/models/inclusionai/ring-1t.toml
+++ b/providers/zenmux/models/inclusionai/ring-1t.toml
@@ -1,12 +1,15 @@
 name = "Ring-1T"
+description = "Reasoning model for deliberate analysis, multi-step problem solving, and tool use"
 release_date = "2025-10-12"
 last_updated = "2025-10-12"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.56

--- a/providers/zenmux/models/moonshotai/kimi-k2-0905.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-0905.toml
@@ -1,4 +1,5 @@
 name = "Kimi K2 0905"
+description = "Kimi model for long-context chat, coding, and agentic reasoning"
 release_date = "2025-09-04"
 last_updated = "2025-09-04"
 attachment = false
@@ -7,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.60

--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking-turbo.toml
@@ -1,12 +1,15 @@
 name = "Kimi K2 Thinking Turbo"
+description = "Kimi reasoning model for long-horizon research, planning, and tool use"
 release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 1.15

--- a/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
+++ b/providers/zenmux/models/moonshotai/kimi-k2-thinking.toml
@@ -1,12 +1,15 @@
 name = "Kimi K2 Thinking"
+description = "Kimi reasoning model for long-horizon research, planning, and tool use"
 release_date = "2025-11-06"
 last_updated = "2025-11-06"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.60

--- a/providers/zenmux/models/stepfun/step-3.toml
+++ b/providers/zenmux/models/stepfun/step-3.toml
@@ -1,12 +1,15 @@
 name = "Step-3"
+description = "StepFun flash model for efficient multimodal reasoning, coding, and tool use"
 release_date = "2025-07-31"
 last_updated = "2025-07-31"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.21

--- a/providers/zenmux/models/volcengine/doubao-seed-code.toml
+++ b/providers/zenmux/models/volcengine/doubao-seed-code.toml
@@ -1,12 +1,15 @@
 name = "Doubao-Seed-Code"
+description = "Coding model for repository understanding, refactors, and agentic engineering tasks"
 release_date = "2025-11-11"
 last_updated = "2025-11-11"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.17

--- a/providers/zenmux/models/x-ai/grok-4-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4-fast.toml
@@ -1,12 +1,15 @@
 name = "Grok 4 Fast"
+description = "Fast Grok model for responsive chat, reasoning, and tool-assisted work"
 release_date = "2025-09-19"
 last_updated = "2025-09-19"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.20

--- a/providers/zenmux/models/x-ai/grok-4.1-fast-non-reasoning.toml
+++ b/providers/zenmux/models/x-ai/grok-4.1-fast-non-reasoning.toml
@@ -1,4 +1,5 @@
 name = "Grok 4.1 Fast Non Reasoning"
+description = "Fast Grok model for responsive chat, reasoning, and tool-assisted work"
 release_date = "2025-11-20"
 last_updated = "2025-11-20"
 attachment = true
@@ -7,6 +8,7 @@ temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.20

--- a/providers/zenmux/models/x-ai/grok-4.1-fast.toml
+++ b/providers/zenmux/models/x-ai/grok-4.1-fast.toml
@@ -1,12 +1,15 @@
 name = "Grok 4.1 Fast"
+description = "Fast Grok model for responsive chat, reasoning, and tool-assisted work"
 release_date = "2025-11-20"
 last_updated = "2025-11-20"
 attachment = true
 reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.20

--- a/providers/zenmux/models/x-ai/grok-4.toml
+++ b/providers/zenmux/models/x-ai/grok-4.toml
@@ -1,12 +1,15 @@
 name = "Grok 4"
+description = "Grok model for agentic tool use, reasoning, coding, and live assistance"
 release_date = "2025-07-09"
 last_updated = "2025-07-09"
 attachment = true
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 3.00

--- a/providers/zenmux/models/x-ai/grok-code-fast-1.toml
+++ b/providers/zenmux/models/x-ai/grok-code-fast-1.toml
@@ -1,12 +1,15 @@
 name = "Grok Code Fast 1"
+description = "Fast Grok model for responsive chat, reasoning, and tool-assisted work"
 release_date = "2025-08-26"
 last_updated = "2025-08-26"
 attachment = false
 reasoning = true
+reasoning_options = []
 temperature = true
 tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.20


### PR DESCRIPTION
Mark 15 ZenMux models as `status = "deprecated"` that are no longer available.

Note: 5 models from the original PR #4033 (claude-3.5-sonnet, gemini-3-pro-preview, kat-coder-pro-v1, kat-coder-pro-v1-free, mimo-v2-flash-free) have already been removed from upstream dev, so they are excluded here.

Closes #4033