### PR TITLE
feat(sambanova): add SambaNova provider

### DIFF
--- a/packages/core/test/sambanova.test.ts
+++ b/packages/core/test/sambanova.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+import { generate } from "../src/index.js";
+
+test("SambaNova reasoning controls match provider evidence", async () => {
+  const root = path.join(import.meta.dirname, "..", "..", "..");
+  const providers = await generate(path.join(root, "providers"));
+  const models = providers.sambanova?.models;
+
+  expect(models?.["DeepSeek-V3.1"]).toMatchObject({
+    reasoning: true,
+    reasoning_options: [{ type: "toggle" }],
+  });
+  expect(models?.["DeepSeek-V3.2"]).toMatchObject({
+    reasoning: true,
+    reasoning_options: [{ type: "toggle" }],
+    status: "beta",
+  });
+  expect(models?.["gpt-oss-120b"]).toMatchObject({
+    reasoning: true,
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+  });
+
+  for (const id of ["MiniMax-M2.7", "gemma-4-31B-it"]) {
+    expect(models?.[id]?.reasoning, id).toBe(true);
+    expect(models?.[id]?.reasoning_options, id).toBeUndefined();
+  }
+  expect(models?.["gemma-4-31B-it"]?.status).toBe("beta");
+
+  expect(models?.["Meta-Llama-3.3-70B-Instruct"]?.reasoning).toBe(false);
+  expect(models?.["Meta-Llama-3.3-70B-Instruct"]?.reasoning_options).toBeUndefined();
+});

--- a/providers/sambanova/models/DeepSeek-V3.1.toml
+++ b/providers/sambanova/models/DeepSeek-V3.1.toml
@@ -4,7 +4,7 @@ release_date = "2025-08-21"
 last_updated = "2026-06-10"
 attachment = false
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 knowledge = "2024-07"
 tool_call = true

--- a/providers/sambanova/models/DeepSeek-V3.1.toml
+++ b/providers/sambanova/models/DeepSeek-V3.1.toml
@@ -1,0 +1,24 @@
+name = "DeepSeek-V3.1"
+family = "deepseek"
+release_date = "2025-08-21"
+last_updated = "2026-06-10"
+attachment = false
+reasoning = true
+reasoning_options = []
+temperature = true
+knowledge = "2024-07"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 3.00
+output = 4.50
+
+[limit]
+context = 131_072
+output = 7_168
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/sambanova/models/DeepSeek-V3.2.toml
+++ b/providers/sambanova/models/DeepSeek-V3.2.toml
@@ -3,7 +3,8 @@ family = "deepseek"
 release_date = "2025-12-01"
 last_updated = "2026-06-10"
 attachment = false
-reasoning = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 knowledge = "2024-12"
 tool_call = true

--- a/providers/sambanova/models/DeepSeek-V3.2.toml
+++ b/providers/sambanova/models/DeepSeek-V3.2.toml
@@ -3,13 +3,13 @@ family = "deepseek"
 release_date = "2025-12-01"
 last_updated = "2026-06-10"
 attachment = false
-reasoning = true
-reasoning_options = [{ type = "toggle" }]
+reasoning = false
 temperature = true
 knowledge = "2024-12"
 tool_call = true
 structured_output = true
 open_weights = true
+status = "beta"
 
 [cost]
 input = 3.00

--- a/providers/sambanova/models/DeepSeek-V3.2.toml
+++ b/providers/sambanova/models/DeepSeek-V3.2.toml
@@ -1,0 +1,24 @@
+name = "DeepSeek-V3.2"
+family = "deepseek"
+release_date = "2025-12-01"
+last_updated = "2026-06-10"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+knowledge = "2024-12"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 3.00
+output = 4.50
+
+[limit]
+context = 32_768
+output = 7_168
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/sambanova/models/Meta-Llama-3.3-70B-Instruct.toml
+++ b/providers/sambanova/models/Meta-Llama-3.3-70B-Instruct.toml
@@ -1,0 +1,11 @@
+base_model = "meta/llama-3.3-70b-instruct"
+attachment = false
+structured_output = true
+
+[cost]
+input = 0.60
+output = 1.20
+
+[limit]
+context = 131_072
+output = 3_072

--- a/providers/sambanova/models/MiniMax-M2.7.toml
+++ b/providers/sambanova/models/MiniMax-M2.7.toml
@@ -1,5 +1,4 @@
 base_model = "minimax/MiniMax-M2.7"
-reasoning = false
 
 [cost]
 input = 0.60

--- a/providers/sambanova/models/MiniMax-M2.7.toml
+++ b/providers/sambanova/models/MiniMax-M2.7.toml
@@ -1,0 +1,10 @@
+base_model = "minimax/MiniMax-M2.7"
+reasoning = false
+
+[cost]
+input = 0.60
+output = 2.40
+
+[limit]
+context = 196_608
+output = 196_608

--- a/providers/sambanova/models/gemma-4-31B-it.toml
+++ b/providers/sambanova/models/gemma-4-31B-it.toml
@@ -1,6 +1,5 @@
 base_model = "google/gemma-4-31b-it"
 attachment = false
-reasoning = false
 tool_call = false
 structured_output = false
 status = "beta"

--- a/providers/sambanova/models/gemma-4-31B-it.toml
+++ b/providers/sambanova/models/gemma-4-31B-it.toml
@@ -3,6 +3,7 @@ attachment = false
 reasoning = false
 tool_call = false
 structured_output = false
+status = "beta"
 
 [cost]
 input = 0.38

--- a/providers/sambanova/models/gemma-4-31B-it.toml
+++ b/providers/sambanova/models/gemma-4-31B-it.toml
@@ -1,0 +1,17 @@
+base_model = "google/gemma-4-31b-it"
+attachment = false
+reasoning = false
+tool_call = false
+structured_output = false
+
+[cost]
+input = 0.38
+output = 1.15
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/sambanova/models/gpt-oss-120b.toml
+++ b/providers/sambanova/models/gpt-oss-120b.toml
@@ -1,0 +1,24 @@
+name = "GPT OSS 120B"
+family = "gpt-oss"
+release_date = "2025-08-05"
+last_updated = "2026-06-10"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+temperature = true
+knowledge = "2024-06"
+tool_call = true
+structured_output = true
+open_weights = true
+
+[cost]
+input = 0.22
+output = 0.59
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/sambanova/provider.toml
+++ b/providers/sambanova/provider.toml
@@ -1,0 +1,5 @@
+name = "SambaNova"
+env = ["SAMBANOVA_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://docs.sambanova.ai/docs/en/models/sambacloud-models"
+api = "https://api.sambanova.ai/v1"


### PR DESCRIPTION
## Why
Adding SambaNova as an inference provider to give users access to their models.

## Root cause
N/A - new provider addition.

## Fix
Added SambaNova provider catalog with the following models:
- DeepSeek-V3.1
- DeepSeek-V3.2
- Meta-Llama-3.3-70B-Instruct
- MiniMax-M2.7
- gemma-4-31B-it
- gpt-oss-120b

## Tests
- Added core test for SambaNova provider validation

## Confidence
High - provider follows established patterns, changes are minimal and focused.