### PR TITLE
fix: map Muse Glimmer hosts onto the Meta lab model

### DIFF
--- a/models/meta/muse-glimmer-30b.toml
+++ b/models/meta/muse-glimmer-30b.toml
@@ -1,0 +1,111 @@
+# Sources:
+# https://research.meta.ai/blog/introducing-muse-glimmer-open-agentic-model
+# https://huggingface.co/meta-models/Muse-Glimmer-30B
+# https://developer.meta.com/ai/models/muse-glimmer/
+
+name = "Muse Glimmer 30B"
+description = "Muse Glimmer is a 30-billion-parameter open-weight multimodal model from Meta Superintelligence Labs, distilled from Muse Spark for always-on local agents, tool use, coding, and image understanding."
+family = "muse"
+release_date = "2026-08-10"
+last_updated = "2026-08-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2026-01-04"
+open_weights = true
+license = "Apache 2.0"
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+
+[[links]]
+label = "Announcement"
+url = "https://research.meta.ai/blog/introducing-muse-glimmer-open-agentic-model"
+type = "announcement"
+
+[[links]]
+label = "Model card"
+url = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+type = "model_card"
+
+[[links]]
+label = "Developer docs"
+url = "https://developer.meta.com/ai/models/muse-glimmer/"
+type = "docs"
+
+[[benchmarks]]
+name = "MCP Atlas"
+score = 75.5
+metric = "success rate"
+variant = "public"
+source = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+date = "2026-08-10"
+
+[[benchmarks]]
+name = "DeepSearch QA"
+score = 74.6
+source = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+date = "2026-08-10"
+
+[[benchmarks]]
+name = "SWE-Bench Pro"
+score = 51.2
+metric = "resolve rate"
+source = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+date = "2026-08-10"
+
+[[benchmarks]]
+name = "SWE-Bench Verified"
+score = 76.0
+metric = "resolve rate"
+source = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+date = "2026-08-10"
+
+[[benchmarks]]
+name = "Terminal-Bench"
+score = 51.7
+metric = "success rate"
+version = "2.1"
+variant = "with terminus2"
+source = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+date = "2026-08-10"
+
+[[benchmarks]]
+name = "OSWorld-Verified"
+score = 65.9
+metric = "success rate"
+source = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+date = "2026-08-10"
+
+[[benchmarks]]
+name = "AIME 2026"
+score = 94.7
+metric = "accuracy"
+source = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+date = "2026-08-10"
+
+[[benchmarks]]
+name = "GPQA Diamond"
+score = 83.5
+metric = "accuracy"
+variant = "AA"
+source = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+date = "2026-08-10"
+
+[[benchmarks]]
+name = "CharXiv Reasoning"
+score = 78.8
+metric = "accuracy"
+source = "https://huggingface.co/meta-models/Muse-Glimmer-30B"
+date = "2026-08-10"

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -2264,12 +2264,14 @@ test("resolves Merge Gateway provider aliases to canonical metadata", () => {
     resolveCanonicalBaseModel("moonshot/kimi-k2.7-code"),
     resolveCanonicalBaseModel("moonshot/kimi-k2.7-code-highspeed"),
     resolveCanonicalBaseModel("sakana/fugu-ultra"),
+    resolveCanonicalBaseModel("meta/muse-glimmer-30b"),
   ]).toEqual([
     "moonshotai/kimi-k2.5",
     "moonshotai/kimi-k2.6",
     "moonshotai/kimi-k2.7-code",
     "moonshotai/kimi-k2.7-code-highspeed",
     "sakana/fugu-ultra",
+    "meta/muse-glimmer-30b",
   ]);
 });
 

--- a/providers/vercel/models/meta/muse-glimmer-30b.toml
+++ b/providers/vercel/models/meta/muse-glimmer-30b.toml
@@ -1,8 +1,9 @@
 # Sources:
-# https://openrouter.ai/meta/muse-glimmer-30b
-# https://openrouter.ai/api/v1/models/meta/muse-glimmer-30b/endpoints
+# https://ai-gateway.vercel.sh/v1/models (meta/muse-glimmer-30b)
 # Effort: reasoning_effort = low|medium|high|xhigh
+# Same controls as OpenRouter/Together and the model card.
 # https://huggingface.co/meta-models/Muse-Glimmer-30B
+# https://openrouter.ai/meta/muse-glimmer-30b
 
 base_model = "meta/muse-glimmer-30b"
 


### PR DESCRIPTION
## Summary

- Depends on #4479 (lab metadata).
- Factor OpenRouter’s existing standalone `meta/muse-glimmer-30b` onto `base_model = "meta/muse-glimmer-30b"`.
- Add Vercel the same way (override-only: cost + reasoning effort). This is the correct form of #4471, which authored a full inline host file because lab metadata was missing.

## Host classification

Relays (OpenRouter, Vercel AI Gateway), not first-party Meta API.

## Reasoning options

- Wire: `reasoning_effort` / OpenAI-compatible `reasoning.effort`
- Values: `low` / `medium` / `high` / `xhigh`
- From the model card and OpenRouter’s live `supported_parameters` (Together backend). No `minimal`; no toggle (`none` is not in the effort list).

## Costs (USD / MTok)

- input `0.35`, output `1.50`, cache_read `0.04`
- OpenRouter, Vercel, and Together public pricing all match.

## Test plan

- [x] `bun validate`
- [x] Merged OpenRouter/Vercel entries inherit lab name, description, modalities, limits, `open_weights = true`

Supersedes the Glimmer file in #4471. That sync PR can be closed or rebased after this lands.