### PR TITLE
feat(aihubmix): add Qwen3.8 Max and Claude Opus 5

### DIFF
--- a/providers/aihubmix/models/claude-opus-5.toml
+++ b/providers/aihubmix/models/claude-opus-5.toml
@@ -1,3 +1,4 @@
+# AIHubMix Anthropic-compatible /v1/messages: $.thinking.type = "disabled"|"adaptive" (toggle) and $.output_config.effort = "low"|"medium"|"high"|"xhigh"|"max"; verified live 2026-08-11. https://docs.aihubmix.com/cn/api-reference/anthropic-compatible/create-a-message
 base_model = "anthropic/claude-opus-5"
 structured_output = true
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/aihubmix/models/claude-opus-5.toml
+++ b/providers/aihubmix/models/claude-opus-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-5"
+structured_output = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+interleaved = true
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/qwen3.8-max.toml
+++ b/providers/aihubmix/models/qwen3.8-max.toml
@@ -1,4 +1,5 @@
 # AIHubMix OpenAI-compatible /v1/chat/completions: $.enable_thinking = true|false (toggle) and $.reasoning_effort = "low"|"medium"|"xhigh"; verified live 2026-08-11. https://docs.aihubmix.com/cn/api/unified-inference
+# AIHubMix Models API (queried 2026-08-11T09:45:11Z): input 1.69, output 5.07, cache_read 0.169, cache_write 2.1125 USD/MTok. https://aihubmix.com/api/v1/models?model=qwen3.8-max
 base_model = "alibaba/qwen3.8-max"
 attachment = false
 structured_output = true

--- a/providers/aihubmix/models/qwen3.8-max.toml
+++ b/providers/aihubmix/models/qwen3.8-max.toml
@@ -1,0 +1,24 @@
+base_model = "alibaba/qwen3.8-max"
+attachment = false
+structured_output = true
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.69
+output = 5.07
+cache_read = 0.169
+cache_write = 2.1125
+
+[limit]
+context = 991_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aihubmix/models/qwen3.8-max.toml
+++ b/providers/aihubmix/models/qwen3.8-max.toml
@@ -1,3 +1,4 @@
+# AIHubMix OpenAI-compatible /v1/chat/completions: $.enable_thinking = true|false (toggle) and $.reasoning_effort = "low"|"medium"|"xhigh"; verified live 2026-08-11. https://docs.aihubmix.com/cn/api/unified-inference
 base_model = "alibaba/qwen3.8-max"
 attachment = false
 structured_output = true


### PR DESCRIPTION
## Summary

Add Qwen3.8 Max and Claude Opus 5 to the AIHubMix provider catalog.

## Changes

- Add `qwen3.8-max` using the existing `alibaba/qwen3.8-max` base model.
- Add `claude-opus-5` using the existing `anthropic/claude-opus-5` base model.
- Add AIHubMix pricing, cache pricing, service limits, and input modalities.
- Add provider-specific reasoning controls, structured output, and interleaved reasoning metadata.
- Restrict the AIHubMix Qwen3.8 Max entry to text input and disable attachments to match the Models API service surface.
- Document each toggle's exact AIHubMix wire path in a leading TOML comment.

## Reasoning controls

AIHubMix is a multi-model relay. Its SDK routes `claude-*` models through the Anthropic-compatible Messages surface and Qwen3.8 Max through the OpenAI-compatible Chat Completions surface.

- Qwen3.8 Max toggle: `$.enable_thinking = true|false`; effort: `$.reasoning_effort = low|medium|xhigh`.
- Claude Opus 5 toggle: `$.thinking.type = disabled|adaptive`; effort: `$.output_config.effort = low|medium|high|xhigh|max`.

## Validation

- AIHubMix Models API validator `2026.08.11.1` passed for both model IDs on 2026-08-11.
- The exact [`qwen3.8-max` Models API query](https://aihubmix.com/api/v1/models?model=qwen3.8-max) returned `input=1.69`, `output=5.07`, `cache_read=0.169`, and `cache_write=2.1125` USD/MTok at `2026-08-11T09:51:06Z`.
- Paid Chat Completions validation for `qwen3.8-max` completed at `2026-08-11T09:30:23Z`: `reasoning_effort` values `low`, `medium`, and `xhigh` each returned HTTP 200; `response_format=json_schema` returned HTTP 200.
- Paid Chat Completions validation for `claude-opus-5` completed at `2026-08-11T09:30:54Z`: `reasoning_effort` values `low`, `medium`, `high`, `xhigh`, and `max` each returned HTTP 200; `response_format=json_schema` returned HTTP 200.
- Paid wire-level validation on 2026-08-11 confirmed Qwen3.8 Max with `enable_thinking=false` and `enable_thinking=true`; both returned HTTP 200.
- Paid Anthropic Messages validation on 2026-08-11 confirmed Claude Opus 5 with `thinking.type=disabled` and with `thinking.type=adaptive` combined separately with all five configured `output_config.effort` values; all six calls returned HTTP 200.
- `bun validate` passed after both review fixes.
- The models.dev web registry build passed.
- The generated `_api.json` contains both merged AIHubMix entries with the expected pricing, limits, modalities, and reasoning options.
- OpenCode loaded the same combined local registry and listed both `aihubmix/qwen3.8-max` and `aihubmix/claude-opus-5`.
- Actual OpenCode calls using `--variant low` succeeded for both models: each returned exactly `OK` with exit code 0. Explicit titles were supplied to avoid ancillary title-generation model calls.
