### PR TITLE
feat: add InferenceSaver provider with keyless catalog sync

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -78,6 +78,7 @@ jobs:
           DIGITALOCEAN_API_TOKEN: ${{ secrets.DIGITALOCEAN_API_TOKEN }}
           DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          INFERENCESAVER_API_KEY: ${{ secrets.INFERENCESAVER_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}

--- a/models/xiaomi/mimo-v2.5-tts.toml
+++ b/models/xiaomi/mimo-v2.5-tts.toml
@@ -1,0 +1,18 @@
+name = "MiMo-V2.5-TTS"
+description = "Speech generation model for controllable voice, narration, and audio delivery"
+family = "mimo"
+release_date = "2026-04-22"
+last_updated = "2026-04-22"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+open_weights = true
+
+[limit]
+context = 8_192
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -18,6 +18,7 @@ import { empiriolabs } from "./providers/empiriolabs.js";
 import { google } from "./providers/google.js";
 import { hyper } from "./providers/hyper.js";
 import { huggingface } from "./providers/huggingface.js";
+import { inferencesaver } from "./providers/inferencesaver.js";
 import { kilo } from "./providers/kilo.js";
 import { llmgateway } from "./providers/llmgateway.js";
 import { mergeGateway } from "./providers/merge-gateway.js";
@@ -125,6 +126,7 @@ export const providers: {
   google: SyncProvider<any>;
   hyper: SyncProvider<any>;
   huggingface: SyncProvider<any>;
+  inferencesaver: SyncProvider<any>;
   kilo: SyncProvider<any>;
   llmgateway: SyncProvider<any>;
   "merge-gateway": SyncProvider<any>;
@@ -154,6 +156,7 @@ export const providers: {
   google,
   hyper,
   huggingface,
+  inferencesaver,
   kilo,
   llmgateway,
   "merge-gateway": mergeGateway,
@@ -176,6 +179,7 @@ export const groups = {
     "crossmodel",
     "empiriolabs",
     "huggingface",
+    "inferencesaver",
     "kilo",
     "llmgateway",
     "merge-gateway",

--- a/packages/core/src/sync/providers/inferencesaver.ts
+++ b/packages/core/src/sync/providers/inferencesaver.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import type { SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
 import { factorBaseModel } from "./openrouter.js";
 
 // ========================================
@@ -87,6 +87,7 @@ const BASE_MODELS: Record<string, string> = {
   "grok-4.5": "xai/grok-4.5",
   "grok-imagine-video": "xai/grok-imagine-video-1.5",
   "kimi-k3": "moonshotai/kimi-k3",
+  "mimo-v2.5-tts": "xiaomi/mimo-v2.5-tts",
   "Nano-Banana": "google/gemini-2.5-flash-image",
   "nano-banana-2": "google/gemini-3.1-flash-image",
   "veo-3.1": "google/veo-3.1-generate-preview",
@@ -100,18 +101,14 @@ const BASE_MODELS: Record<string, string> = {
 // toggles via enable_thinking plus effort.
 const REASONING_OPTIONS: Record<string, NonNullable<SyncedFullModel["reasoning_options"]>> = {
   "claude-fable-5": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
-  "claude-haiku-4-5-20251001": [{ type: "budget_tokens", min: 1_024 }],
-  "claude-opus-4-6": [
-    { type: "effort", values: ["low", "medium", "high", "max"] },
-    { type: "budget_tokens", min: 1_024 },
-  ],
+  // OpenAI-compatible surface: no proven budget field on this API path, so
+  // match same-surface peers (llmgateway) — effort-only / no controls.
+  "claude-haiku-4-5-20251001": [],
+  "claude-opus-4-6": [{ type: "effort", values: ["low", "medium", "high", "max"] }],
   "claude-opus-4-7": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
   "claude-opus-4-8": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
   "claude-opus-5": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
-  "claude-sonnet-4-6": [
-    { type: "effort", values: ["low", "medium", "high", "max"] },
-    { type: "budget_tokens", min: 1_024 },
-  ],
+  "claude-sonnet-4-6": [{ type: "effort", values: ["low", "medium", "high", "max"] }],
   "claude-sonnet-5": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
   "deepseek-v4-flash": [
     { type: "toggle" },
@@ -142,7 +139,6 @@ const UNIQUE_MODELS: Record<string, { name: string; description: string; family?
   "agnes-image-2.1-flash": { name: "Agnes Image 2.1 Flash", description: "Image generation model served by InferenceSaver over an OpenAI-compatible API." },
   "agnes-video-v2.0": { name: "Agnes Video 2.0", description: "Video generation model served by InferenceSaver over an OpenAI-compatible API." },
   "Hunyuan-MT": { name: "Hunyuan MT", description: "Multilingual chat model served by InferenceSaver over an OpenAI-compatible API.", family: "hunyuan" },
-  "mimo-v2.5-tts": { name: "MiMo 2.5 TTS", description: "Text-to-speech model served by InferenceSaver over an OpenAI-compatible API.", family: "mimo" },
   "music-2.6": { name: "Music 2.6", description: "Music generation model served by InferenceSaver over an OpenAI-compatible API." },
   "music-2.6-free": { name: "Music 2.6 Free", description: "Music generation model served by InferenceSaver over an OpenAI-compatible API." },
   "music-cover": { name: "Music Cover", description: "Music cover generation model served by InferenceSaver over an OpenAI-compatible API." },
@@ -185,7 +181,8 @@ export async function fetchInferenceSaverCatalog(
 
 export function buildInferenceSaverModel(
   model: InferenceSaverModel,
-  releaseDate: string,
+  existing: ExistingModel | undefined,
+  today = new Date().toISOString().slice(0, 10),
 ): SyncedModel {
   const base = BASE_MODELS[model.rawName];
   const capability = model.capability ?? "chat";
@@ -211,9 +208,17 @@ export function buildInferenceSaverModel(
     // for many models (image/video generation included). When it matches
     // that filler exactly, the lab metadata is authoritative, so omit the
     // limit override and let the lab limit inherit.
+    // The catalog's contextWindow for GPT models (272k/400k) matches the
+    // pricing-tier input band (e.g. gpt-5.4-mini lab input = 272_000), not
+    // the full context the lab publishes (1.05M / 400k mini). Treat those as
+    // non-authoritative and let the lab limits inherit, per the sync review.
     const isFillerLimit =
       model.contextWindow === FILLER_CONTEXT && model.maxOutputTokens === FILLER_OUTPUT;
-    const limit = isFillerLimit
+    const isGPTInputBand =
+      model.rawName.startsWith("gpt-5.4") ||
+      model.rawName.startsWith("gpt-5.5") ||
+      model.rawName.startsWith("gpt-5.6");
+    const limit = isFillerLimit || isGPTInputBand
       ? undefined
       : {
           ...(model.contextWindow !== undefined ? { context: model.contextWindow } : {}),
@@ -238,14 +243,11 @@ export function buildInferenceSaverModel(
     throw new Error(`No models.dev definition for ${model.rawName}; add it to BASE_MODELS or UNIQUE_MODELS`);
   }
   const defaults = CAPABILITY_MODALITIES[capability] ?? CAPABILITY_MODALITIES.chat;
-  // Chat uniques keep the catalog's limits; generation uniques are
-  // non-token endpoints so 0/0 mirrors same-surface peers.
-  const limit = defaults.generation
-    ? { context: 0, output: 0 }
-    : {
-        ...(model.contextWindow !== undefined ? { context: model.contextWindow } : {}),
-        ...(model.maxOutputTokens !== undefined ? { output: model.maxOutputTokens } : {}),
-      };
+  // The catalog reports the same 200k/16k pair for every unique chat model,
+  // which is a placeholder, not a measured host window. Unique models have
+  // no lab entry to inherit from, so serialize the non-token 0/0 default
+  // (same convention as generation uniques) instead of the filler.
+  const limit = { context: 0, output: 0 };
   return {
     name: facts.name,
     description: facts.description,
@@ -253,8 +255,8 @@ export function buildInferenceSaverModel(
     attachment: defaults.attachment,
     reasoning: false,
     tool_call: defaults.tool_call,
-    release_date: releaseDate,
-    last_updated: releaseDate,
+    release_date: existing?.release_date ?? today,
+    last_updated: existing?.last_updated ?? existing?.release_date ?? today,
     open_weights: false,
     ...(Object.keys(cost).length > 0 ? { cost } : {}),
     limit,
@@ -277,9 +279,11 @@ export const inferencesaver = {
   parseModels(raw) {
     return InferenceSaverResponse.parse(raw);
   },
-  translateModel(model) {
-    const releaseDate = new Date().toISOString().slice(0, 10);
-    return { id: model.rawName, model: buildInferenceSaverModel(model, releaseDate) };
+  translateModel(model, context) {
+    return {
+      id: model.rawName,
+      model: buildInferenceSaverModel(model, context.existing(model.rawName)),
+    };
   },
 } satisfies SyncProvider<InferenceSaverModel>;
 

--- a/packages/core/src/sync/providers/inferencesaver.ts
+++ b/packages/core/src/sync/providers/inferencesaver.ts
@@ -1,0 +1,285 @@
+import { z } from "zod";
+
+import type { SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel } from "./openrouter.js";
+
+// ========================================
+// Endpoints
+// ========================================
+
+// Public pricing + capability catalog (no auth). This is the source of
+// truth for the sync: every model InferenceSaver serves, with pricing,
+// context window, output limit, and modality capability. A gateway key
+// (INFERENCESAVER_API_KEY) is optional and only adds account-scoped
+// availability; the public catalog works without it.
+const PUBLIC_CATALOG_URL = "https://inferencesaver.com/api/public/models";
+
+const BROWSER_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+// Catalog-wide default context/output reported for models whose real limits
+// InferenceSaver does not expose. The lab metadata for those models (tiny
+// non-token contexts, e.g. gpt-image-2, veo-3.1-generate-preview,
+// grok-imagine-video-1.5) is authoritative, so we omit the override and let
+// the lab limits inherit.
+const FILLER_CONTEXT = 200_000;
+const FILLER_OUTPUT = 16_384;
+
+// ========================================
+// Schemas
+// ========================================
+
+export const InferenceSaverModel = z
+  .object({
+    rawName: z.string().min(1),
+    label: z.string().min(1),
+    provider: z.string().optional(),
+    family: z.string().optional(),
+    tier: z.string().optional(),
+    capability: z.string().optional(),
+    supportedEndpoints: z.array(z.string()).optional(),
+    contextWindow: z.number().optional(),
+    maxOutputTokens: z.number().optional(),
+    inputPricePerMillionUsd: z.number().optional(),
+    outputPricePerMillionUsd: z.number().optional(),
+    originalInputPricePerMillionUsd: z.number().optional(),
+    originalOutputPricePerMillionUsd: z.number().optional(),
+    savingsPercent: z.number().optional(),
+    cacheReadPricePerMillionUsd: z.number().optional(),
+    cacheWritePricePerMillionUsd: z.number().optional(),
+    enableGroups: z.array(z.string()).optional(),
+    pricingVersion: z.string().nullish(),
+    slug: z.string().optional(),
+    route: z.string().optional(),
+  })
+  .passthrough();
+
+// The public catalog endpoint returns a bare array of models.
+export const InferenceSaverResponse = z.array(InferenceSaverModel);
+
+export type InferenceSaverModel = z.infer<typeof InferenceSaverModel>;
+
+// ========================================
+// Gateway model id -> models.dev lab model
+// ========================================
+
+const BASE_MODELS: Record<string, string> = {
+  "claude-fable-5": "anthropic/claude-fable-5",
+  "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4-5-20251001",
+  "claude-opus-4-6": "anthropic/claude-opus-4-6",
+  "claude-opus-4-7": "anthropic/claude-opus-4-7",
+  "claude-opus-4-8": "anthropic/claude-opus-4-8",
+  "claude-opus-5": "anthropic/claude-opus-5",
+  "claude-sonnet-4-6": "anthropic/claude-sonnet-4-6",
+  "claude-sonnet-5": "anthropic/claude-sonnet-5",
+  "deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+  "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview",
+  "gemini-3.5-flash": "google/gemini-3.5-flash",
+  "glm-5.2": "zhipuai/glm-5.2",
+  "gpt-5.4": "openai/gpt-5.4",
+  "gpt-5.4-mini": "openai/gpt-5.4-mini",
+  "gpt-5.5": "openai/gpt-5.5",
+  "gpt-5.5-openai-compact": "openai/gpt-5.5",
+  "gpt-5.6-luna": "openai/gpt-5.6-luna",
+  "gpt-5.6-sol": "openai/gpt-5.6-sol",
+  "gpt-5.6-terra": "openai/gpt-5.6-terra",
+  "gpt-image-2": "openai/gpt-image-2",
+  "grok-4.5": "xai/grok-4.5",
+  "grok-imagine-video": "xai/grok-imagine-video-1.5",
+  "kimi-k3": "moonshotai/kimi-k3",
+  "Nano-Banana": "google/gemini-2.5-flash-image",
+  "nano-banana-2": "google/gemini-3.1-flash-image",
+  "veo-3.1": "google/veo-3.1-generate-preview",
+};
+
+// Reasoning controls required by the strict provider refine when the merged
+// base model declares reasoning = true. Each set is copied from the
+// underlying model's lab metadata / first-party provider entry (not a
+// blanket shape). Claude 4.7+/5/Fable are effort-only (AGENTS forbids budget
+// on 4.7+ adaptive); GPT/Gemini/GLM/Kimi/Grok use effort; DeepSeek Flash
+// toggles via enable_thinking plus effort.
+const REASONING_OPTIONS: Record<string, NonNullable<SyncedFullModel["reasoning_options"]>> = {
+  "claude-fable-5": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "claude-haiku-4-5-20251001": [{ type: "budget_tokens", min: 1_024 }],
+  "claude-opus-4-6": [
+    { type: "effort", values: ["low", "medium", "high", "max"] },
+    { type: "budget_tokens", min: 1_024 },
+  ],
+  "claude-opus-4-7": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "claude-opus-4-8": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "claude-opus-5": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "claude-sonnet-4-6": [
+    { type: "effort", values: ["low", "medium", "high", "max"] },
+    { type: "budget_tokens", min: 1_024 },
+  ],
+  "claude-sonnet-5": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "deepseek-v4-flash": [
+    { type: "toggle" },
+    { type: "effort", values: ["low", "high", "max"] },
+  ],
+  "gemini-3.1-pro-preview": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "gemini-3.5-flash": [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "glm-5.2": [{ type: "effort", values: ["high", "max"] }],
+  "gpt-5.4": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "gpt-5.4-mini": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "gpt-5.5": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "gpt-5.5-openai-compact": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "gpt-5.6-luna": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }],
+  "gpt-5.6-sol": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }],
+  "gpt-5.6-terra": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }],
+  "grok-4.5": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "kimi-k3": [{ type: "effort", values: ["low", "high", "max"] }],
+  // google/gemini-3.1-flash-image first-party: effort minimal|high
+  "nano-banana-2": [{ type: "effort", values: ["minimal", "high"] }],
+};
+
+// Unique-to-InferenceSaver models with no models.dev lab counterpart get a
+// full inline definition. Facts the catalog cannot provide are conservative
+// defaults; maintainers should review before merging.
+const UNIQUE_MODELS: Record<string, { name: string; description: string; family?: string }> = {
+  "agnes-2.0-flash": { name: "Agnes 2.0 Flash", description: "Fast general chat model served by InferenceSaver over an OpenAI-compatible API." },
+  "agnes-2.5-flash": { name: "Agnes 2.5 Flash", description: "Fast general chat model served by InferenceSaver over an OpenAI-compatible API." },
+  "agnes-image-2.1-flash": { name: "Agnes Image 2.1 Flash", description: "Image generation model served by InferenceSaver over an OpenAI-compatible API." },
+  "agnes-video-v2.0": { name: "Agnes Video 2.0", description: "Video generation model served by InferenceSaver over an OpenAI-compatible API." },
+  "Hunyuan-MT": { name: "Hunyuan MT", description: "Multilingual chat model served by InferenceSaver over an OpenAI-compatible API.", family: "hunyuan" },
+  "mimo-v2.5-tts": { name: "MiMo 2.5 TTS", description: "Text-to-speech model served by InferenceSaver over an OpenAI-compatible API.", family: "mimo" },
+  "music-2.6": { name: "Music 2.6", description: "Music generation model served by InferenceSaver over an OpenAI-compatible API." },
+  "music-2.6-free": { name: "Music 2.6 Free", description: "Music generation model served by InferenceSaver over an OpenAI-compatible API." },
+  "music-cover": { name: "Music Cover", description: "Music cover generation model served by InferenceSaver over an OpenAI-compatible API." },
+  "music-cover-free": { name: "Music Cover Free", description: "Music cover generation model served by InferenceSaver over an OpenAI-compatible API." },
+};
+
+// Capability-derived defaults for host-only models: generation endpoints do
+// not expose tool calling, and image/video/audio modalities map to the
+// corresponding output type. Limits for generation uniques default to
+// non-token (0/0) like same-surface peers (stepfun TTS, chatgpt-image).
+const CAPABILITY_MODALITIES: Record<string, { input: Array<"text" | "image" | "video" | "audio">; output: Array<"text" | "image" | "video" | "audio">; tool_call: boolean; attachment: boolean; generation: boolean }> = {
+  chat: { input: ["text"], output: ["text"], tool_call: true, attachment: false, generation: false },
+  image: { input: ["text"], output: ["image"], tool_call: false, attachment: true, generation: true },
+  video: { input: ["text"], output: ["video"], tool_call: false, attachment: false, generation: true },
+  audio: { input: ["text"], output: ["audio"], tool_call: false, attachment: false, generation: true },
+};
+
+// Round float noise from the catalog (e.g. 0.30000000000000004) to clean
+// USD/MTok values.
+function roundPrice(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+// ========================================
+// Fetch + translate
+// ========================================
+
+export async function fetchInferenceSaverCatalog(
+  fetcher: typeof fetch = fetch,
+  url = PUBLIC_CATALOG_URL,
+) {
+  const response = await fetcher(url, {
+    headers: { Accept: "application/json", "User-Agent": BROWSER_UA },
+  });
+  if (!response.ok) {
+    throw new Error(`InferenceSaver catalog request failed: ${response.status} ${response.statusText}`);
+  }
+  return InferenceSaverResponse.parse(await response.json());
+}
+
+export function buildInferenceSaverModel(
+  model: InferenceSaverModel,
+  releaseDate: string,
+): SyncedModel {
+  const base = BASE_MODELS[model.rawName];
+  const capability = model.capability ?? "chat";
+  const isGeneration = CAPABILITY_MODALITIES[capability]?.generation ?? false;
+  const cost = {
+    ...(model.inputPricePerMillionUsd !== undefined
+      ? { input: roundPrice(model.inputPricePerMillionUsd) }
+      : {}),
+    ...(model.outputPricePerMillionUsd !== undefined
+      ? { output: roundPrice(model.outputPricePerMillionUsd) }
+      : {}),
+    ...(model.cacheReadPricePerMillionUsd !== undefined && model.cacheReadPricePerMillionUsd > 0
+      ? { cache_read: roundPrice(model.cacheReadPricePerMillionUsd) }
+      : {}),
+    ...(model.cacheWritePricePerMillionUsd !== undefined && model.cacheWritePricePerMillionUsd > 0
+      ? { cache_write: roundPrice(model.cacheWritePricePerMillionUsd) }
+      : {}),
+  };
+  const costOverrides = cost.input !== undefined || cost.output !== undefined ? { cost } : {};
+
+  if (base !== undefined) {
+    // The catalog reports 200k context / 16k output as a uniform fallback
+    // for many models (image/video generation included). When it matches
+    // that filler exactly, the lab metadata is authoritative, so omit the
+    // limit override and let the lab limit inherit.
+    const isFillerLimit =
+      model.contextWindow === FILLER_CONTEXT && model.maxOutputTokens === FILLER_OUTPUT;
+    const limit = isFillerLimit
+      ? undefined
+      : {
+          ...(model.contextWindow !== undefined ? { context: model.contextWindow } : {}),
+          ...(model.maxOutputTokens !== undefined ? { output: model.maxOutputTokens } : {}),
+        };
+    return factorBaseModel(
+      base,
+      {
+        ...costOverrides,
+        ...(limit !== undefined ? { limit } : {}),
+        ...(model.rawName === "gpt-5.5-openai-compact" ? { name: "GPT-5.5 OpenAI Compact" } : {}),
+        ...(REASONING_OPTIONS[model.rawName] !== undefined
+          ? { reasoning_options: REASONING_OPTIONS[model.rawName] }
+          : {}),
+      },
+      limit,
+    );
+  }
+
+  const facts = UNIQUE_MODELS[model.rawName];
+  if (facts === undefined) {
+    throw new Error(`No models.dev definition for ${model.rawName}; add it to BASE_MODELS or UNIQUE_MODELS`);
+  }
+  const defaults = CAPABILITY_MODALITIES[capability] ?? CAPABILITY_MODALITIES.chat;
+  // Chat uniques keep the catalog's limits; generation uniques are
+  // non-token endpoints so 0/0 mirrors same-surface peers.
+  const limit = defaults.generation
+    ? { context: 0, output: 0 }
+    : {
+        ...(model.contextWindow !== undefined ? { context: model.contextWindow } : {}),
+        ...(model.maxOutputTokens !== undefined ? { output: model.maxOutputTokens } : {}),
+      };
+  return {
+    name: facts.name,
+    description: facts.description,
+    ...(facts.family !== undefined ? { family: facts.family } : {}),
+    attachment: defaults.attachment,
+    reasoning: false,
+    tool_call: defaults.tool_call,
+    release_date: releaseDate,
+    last_updated: releaseDate,
+    open_weights: false,
+    ...(Object.keys(cost).length > 0 ? { cost } : {}),
+    limit,
+    modalities: { input: defaults.input, output: defaults.output },
+  } satisfies SyncedFullModel;
+}
+
+export const inferencesaver = {
+  id: "inferencesaver",
+  name: "InferenceSaver",
+  modelsDir: "providers/inferencesaver/models",
+  deleteMissing: true,
+  preserveDescriptions: false,
+  sourceID(model) {
+    return model.rawName;
+  },
+  fetchModels() {
+    return fetchInferenceSaverCatalog();
+  },
+  parseModels(raw) {
+    return InferenceSaverResponse.parse(raw);
+  },
+  translateModel(model) {
+    const releaseDate = new Date().toISOString().slice(0, 10);
+    return { id: model.rawName, model: buildInferenceSaverModel(model, releaseDate) };
+  },
+} satisfies SyncProvider<InferenceSaverModel>;
+

--- a/providers/inferencesaver/logo.svg
+++ b/providers/inferencesaver/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <!-- Placeholder logo for the InferenceSaver provider. Replace with the
+       official mark before submitting (currentColor only, no fixed size). -->
+  <path d="M12 2 3 14h6l-1 8L19 10h-6l-1-8z"/>
+</svg>

--- a/providers/inferencesaver/models/Hunyuan-MT.toml
+++ b/providers/inferencesaver/models/Hunyuan-MT.toml
@@ -1,0 +1,22 @@
+name = "Hunyuan MT"
+description = "Multilingual chat model served by InferenceSaver over an OpenAI-compatible API."
+family = "hunyuan"
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.02
+output = 0.04
+cache_read = 0.002
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/inferencesaver/models/Hunyuan-MT.toml
+++ b/providers/inferencesaver/models/Hunyuan-MT.toml
@@ -14,8 +14,8 @@ output = 0.04
 cache_read = 0.002
 
 [limit]
-context = 200_000
-output = 16_384
+context = 0
+output = 0
 
 [modalities]
 input = ["text"]

--- a/providers/inferencesaver/models/Nano-Banana.toml
+++ b/providers/inferencesaver/models/Nano-Banana.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-flash-image"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.1

--- a/providers/inferencesaver/models/agnes-2.0-flash.toml
+++ b/providers/inferencesaver/models/agnes-2.0-flash.toml
@@ -12,8 +12,8 @@ input = 0
 output = 0
 
 [limit]
-context = 200_000
-output = 16_384
+context = 0
+output = 0
 
 [modalities]
 input = ["text"]

--- a/providers/inferencesaver/models/agnes-2.0-flash.toml
+++ b/providers/inferencesaver/models/agnes-2.0-flash.toml
@@ -1,0 +1,20 @@
+name = "Agnes 2.0 Flash"
+description = "Fast general chat model served by InferenceSaver over an OpenAI-compatible API."
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/inferencesaver/models/agnes-2.5-flash.toml
+++ b/providers/inferencesaver/models/agnes-2.5-flash.toml
@@ -1,0 +1,20 @@
+name = "Agnes 2.5 Flash"
+description = "Fast general chat model served by InferenceSaver over an OpenAI-compatible API."
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = false
+reasoning = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 200_000
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/inferencesaver/models/agnes-2.5-flash.toml
+++ b/providers/inferencesaver/models/agnes-2.5-flash.toml
@@ -12,8 +12,8 @@ input = 0
 output = 0
 
 [limit]
-context = 200_000
-output = 16_384
+context = 0
+output = 0
 
 [modalities]
 input = ["text"]

--- a/providers/inferencesaver/models/agnes-image-2.1-flash.toml
+++ b/providers/inferencesaver/models/agnes-image-2.1-flash.toml
@@ -1,0 +1,20 @@
+name = "Agnes Image 2.1 Flash"
+description = "Image generation model served by InferenceSaver over an OpenAI-compatible API."
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = true
+reasoning = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["image"]

--- a/providers/inferencesaver/models/agnes-video-v2.0.toml
+++ b/providers/inferencesaver/models/agnes-video-v2.0.toml
@@ -1,0 +1,20 @@
+name = "Agnes Video 2.0"
+description = "Video generation model served by InferenceSaver over an OpenAI-compatible API."
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["video"]

--- a/providers/inferencesaver/models/claude-fable-5.toml
+++ b/providers/inferencesaver/models/claude-fable-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-fable-5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1

--- a/providers/inferencesaver/models/claude-haiku-4-5-20251001.toml
+++ b/providers/inferencesaver/models/claude-haiku-4-5-20251001.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-haiku-4-5-20251001"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25
+
+[limit]
+output = 8_192

--- a/providers/inferencesaver/models/claude-haiku-4-5-20251001.toml
+++ b/providers/inferencesaver/models/claude-haiku-4-5-20251001.toml
@@ -1,8 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5-20251001"
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
+reasoning_options = []
 
 [cost]
 input = 1

--- a/providers/inferencesaver/models/claude-opus-4-6.toml
+++ b/providers/inferencesaver/models/claude-opus-4-6.toml
@@ -1,0 +1,19 @@
+base_model = "anthropic/claude-opus-4-6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/inferencesaver/models/claude-opus-4-6.toml
+++ b/providers/inferencesaver/models/claude-opus-4-6.toml
@@ -4,10 +4,6 @@ base_model = "anthropic/claude-opus-4-6"
 type = "effort"
 values = ["low", "medium", "high", "max"]
 
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
-
 [cost]
 input = 5
 output = 25

--- a/providers/inferencesaver/models/claude-opus-4-7.toml
+++ b/providers/inferencesaver/models/claude-opus-4-7.toml
@@ -1,0 +1,15 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/inferencesaver/models/claude-opus-4-8.toml
+++ b/providers/inferencesaver/models/claude-opus-4-8.toml
@@ -1,0 +1,15 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/inferencesaver/models/claude-opus-5.toml
+++ b/providers/inferencesaver/models/claude-opus-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/inferencesaver/models/claude-sonnet-4-6.toml
+++ b/providers/inferencesaver/models/claude-sonnet-4-6.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+
+[limit]
+context = 400_000

--- a/providers/inferencesaver/models/claude-sonnet-4-6.toml
+++ b/providers/inferencesaver/models/claude-sonnet-4-6.toml
@@ -4,10 +4,6 @@ base_model = "anthropic/claude-sonnet-4-6"
 type = "effort"
 values = ["low", "medium", "high", "max"]
 
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
-
 [cost]
 input = 3
 output = 15

--- a/providers/inferencesaver/models/claude-sonnet-5.toml
+++ b/providers/inferencesaver/models/claude-sonnet-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-sonnet-5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+
+[limit]
+context = 400_000
+output = 64_000

--- a/providers/inferencesaver/models/deepseek-v4-flash.toml
+++ b/providers/inferencesaver/models/deepseek-v4-flash.toml
@@ -1,0 +1,20 @@
+# Toggle: OpenAI-compatible `enable_thinking` true/false disables/enables
+# chain-of-thought; `reasoning_effort` accepts low/high/max (per DeepSeek
+# Chat Completions API, same as alibaba-token-plan peer).
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.25
+output = 0.5
+cache_read = 0.05
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/inferencesaver/models/gemini-3.1-pro-preview.toml
+++ b/providers/inferencesaver/models/gemini-3.1-pro-preview.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[limit]
+context = 1_000_000

--- a/providers/inferencesaver/models/gemini-3.5-flash.toml
+++ b/providers/inferencesaver/models/gemini-3.5-flash.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3.5-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+
+[limit]
+context = 1_000_000

--- a/providers/inferencesaver/models/glm-5.2.toml
+++ b/providers/inferencesaver/models/glm-5.2.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26

--- a/providers/inferencesaver/models/gpt-5.4-mini.toml
+++ b/providers/inferencesaver/models/gpt-5.4-mini.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.4-mini"
-base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"
@@ -9,7 +8,3 @@ values = ["none", "low", "medium", "high", "xhigh"]
 input = 0.75
 output = 4.5
 cache_read = 0.075
-
-[limit]
-context = 272_000
-output = 65_536

--- a/providers/inferencesaver/models/gpt-5.4-mini.toml
+++ b/providers/inferencesaver/models/gpt-5.4-mini.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-5.4-mini"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+
+[limit]
+context = 272_000
+output = 65_536

--- a/providers/inferencesaver/models/gpt-5.4.toml
+++ b/providers/inferencesaver/models/gpt-5.4.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.4"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[limit]
+context = 272_000

--- a/providers/inferencesaver/models/gpt-5.4.toml
+++ b/providers/inferencesaver/models/gpt-5.4.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.4"
-base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"
@@ -9,6 +8,3 @@ values = ["none", "low", "medium", "high", "xhigh"]
 input = 2.5
 output = 15
 cache_read = 0.25
-
-[limit]
-context = 272_000

--- a/providers/inferencesaver/models/gpt-5.5-openai-compact.toml
+++ b/providers/inferencesaver/models/gpt-5.5-openai-compact.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.5"
-base_model_omit = ["limit.input"]
 name = "GPT-5.5 OpenAI Compact"
 
 [[reasoning_options]]
@@ -10,7 +9,3 @@ values = ["none", "low", "medium", "high", "xhigh"]
 input = 5
 output = 40
 cache_read = 0.5
-
-[limit]
-context = 400_000
-output = 65_536

--- a/providers/inferencesaver/models/gpt-5.5-openai-compact.toml
+++ b/providers/inferencesaver/models/gpt-5.5-openai-compact.toml
@@ -1,0 +1,16 @@
+base_model = "openai/gpt-5.5"
+base_model_omit = ["limit.input"]
+name = "GPT-5.5 OpenAI Compact"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 5
+output = 40
+cache_read = 0.5
+
+[limit]
+context = 400_000
+output = 65_536

--- a/providers/inferencesaver/models/gpt-5.5.toml
+++ b/providers/inferencesaver/models/gpt-5.5.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.5"
-base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"
@@ -9,6 +8,3 @@ values = ["none", "low", "medium", "high", "xhigh"]
 input = 5
 output = 40
 cache_read = 0.5
-
-[limit]
-context = 400_000

--- a/providers/inferencesaver/models/gpt-5.5.toml
+++ b/providers/inferencesaver/models/gpt-5.5.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.5"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 5
+output = 40
+cache_read = 0.5
+
+[limit]
+context = 400_000

--- a/providers/inferencesaver/models/gpt-5.6-luna.toml
+++ b/providers/inferencesaver/models/gpt-5.6-luna.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.6-luna"
-base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"
@@ -9,6 +8,3 @@ values = ["none", "low", "medium", "high", "xhigh", "max"]
 input = 1
 output = 8
 cache_read = 0.1
-
-[limit]
-context = 272_000

--- a/providers/inferencesaver/models/gpt-5.6-luna.toml
+++ b/providers/inferencesaver/models/gpt-5.6-luna.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.6-luna"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 1
+output = 8
+cache_read = 0.1
+
+[limit]
+context = 272_000

--- a/providers/inferencesaver/models/gpt-5.6-sol.toml
+++ b/providers/inferencesaver/models/gpt-5.6-sol.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.6-sol"
-base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"
@@ -9,6 +8,3 @@ values = ["none", "low", "medium", "high", "xhigh", "max"]
 input = 5
 output = 40
 cache_read = 0.5
-
-[limit]
-context = 272_000

--- a/providers/inferencesaver/models/gpt-5.6-sol.toml
+++ b/providers/inferencesaver/models/gpt-5.6-sol.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.6-sol"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 40
+cache_read = 0.5
+
+[limit]
+context = 272_000

--- a/providers/inferencesaver/models/gpt-5.6-terra.toml
+++ b/providers/inferencesaver/models/gpt-5.6-terra.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.6-terra"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2.5
+output = 20
+cache_read = 0.25
+
+[limit]
+context = 272_000

--- a/providers/inferencesaver/models/gpt-5.6-terra.toml
+++ b/providers/inferencesaver/models/gpt-5.6-terra.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-5.6-terra"
-base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"
@@ -9,6 +8,3 @@ values = ["none", "low", "medium", "high", "xhigh", "max"]
 input = 2.5
 output = 20
 cache_read = 0.25
-
-[limit]
-context = 272_000

--- a/providers/inferencesaver/models/gpt-image-2.toml
+++ b/providers/inferencesaver/models/gpt-image-2.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-image-2"
+
+[cost]
+input = 0.4
+output = 0.4

--- a/providers/inferencesaver/models/grok-4.5.toml
+++ b/providers/inferencesaver/models/grok-4.5.toml
@@ -1,0 +1,10 @@
+base_model = "xai/grok-4.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5

--- a/providers/inferencesaver/models/grok-imagine-video.toml
+++ b/providers/inferencesaver/models/grok-imagine-video.toml
@@ -1,0 +1,5 @@
+base_model = "xai/grok-imagine-video-1.5"
+
+[cost]
+input = 1
+output = 1

--- a/providers/inferencesaver/models/kimi-k3.toml
+++ b/providers/inferencesaver/models/kimi-k3.toml
@@ -1,0 +1,10 @@
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 3.5
+output = 17.5
+cache_read = 0.35

--- a/providers/inferencesaver/models/mimo-v2.5-tts.toml
+++ b/providers/inferencesaver/models/mimo-v2.5-tts.toml
@@ -1,0 +1,21 @@
+name = "MiMo 2.5 TTS"
+description = "Text-to-speech model served by InferenceSaver over an OpenAI-compatible API."
+family = "mimo"
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/inferencesaver/models/mimo-v2.5-tts.toml
+++ b/providers/inferencesaver/models/mimo-v2.5-tts.toml
@@ -1,21 +1,5 @@
-name = "MiMo 2.5 TTS"
-description = "Text-to-speech model served by InferenceSaver over an OpenAI-compatible API."
-family = "mimo"
-release_date = "2026-08-11"
-last_updated = "2026-08-11"
-attachment = false
-reasoning = false
-tool_call = false
-open_weights = false
+base_model = "xiaomi/mimo-v2.5-tts"
 
 [cost]
 input = 0
 output = 0
-
-[limit]
-context = 0
-output = 0
-
-[modalities]
-input = ["text"]
-output = ["audio"]

--- a/providers/inferencesaver/models/music-2.6-free.toml
+++ b/providers/inferencesaver/models/music-2.6-free.toml
@@ -1,0 +1,20 @@
+name = "Music 2.6 Free"
+description = "Music generation model served by InferenceSaver over an OpenAI-compatible API."
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.3
+output = 0.3
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/inferencesaver/models/music-2.6.toml
+++ b/providers/inferencesaver/models/music-2.6.toml
@@ -1,0 +1,20 @@
+name = "Music 2.6"
+description = "Music generation model served by InferenceSaver over an OpenAI-compatible API."
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.3
+output = 0.3
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/inferencesaver/models/music-cover-free.toml
+++ b/providers/inferencesaver/models/music-cover-free.toml
@@ -1,0 +1,20 @@
+name = "Music Cover Free"
+description = "Music cover generation model served by InferenceSaver over an OpenAI-compatible API."
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.3
+output = 0.3
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/inferencesaver/models/music-cover.toml
+++ b/providers/inferencesaver/models/music-cover.toml
@@ -1,0 +1,20 @@
+name = "Music Cover"
+description = "Music cover generation model served by InferenceSaver over an OpenAI-compatible API."
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = false
+reasoning = false
+tool_call = false
+open_weights = false
+
+[cost]
+input = 0.3
+output = 0.3
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["audio"]

--- a/providers/inferencesaver/models/nano-banana-2.toml
+++ b/providers/inferencesaver/models/nano-banana-2.toml
@@ -1,0 +1,9 @@
+base_model = "google/gemini-3.1-flash-image"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "high"]
+
+[cost]
+input = 0.16
+output = 0.16

--- a/providers/inferencesaver/models/veo-3.1.toml
+++ b/providers/inferencesaver/models/veo-3.1.toml
@@ -1,0 +1,5 @@
+base_model = "google/veo-3.1-generate-preview"
+
+[cost]
+input = 1.2
+output = 1.2

--- a/providers/inferencesaver/provider.toml
+++ b/providers/inferencesaver/provider.toml
@@ -1,0 +1,5 @@
+name = "InferenceSaver"
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.inferencesaver.com/v1"
+doc = "https://inferencesaver.com/en/models"
+env = ["INFERENCESAVER_API_KEY"]


### PR DESCRIPTION
## Summary

Adds **InferenceSaver** as a synced provider on models.dev: 36 models with pricing, context windows, output limits, and capability modalities, kept current by the hourly catalog automation.

## What's included

- `providers/inferencesaver/provider.toml` — OpenAI-compatible provider (`@ai-sdk/openai-compatible`, `https://api.inferencesaver.com/v1`, `INFERENCESAVER_API_KEY`)
- `providers/inferencesaver/logo.svg` — placeholder; official mark to follow
- `providers/inferencesaver/models/*.toml` — 36 model files
  - **26** link to existing lab entries via `base_model` (override-only: cost, limits, `reasoning_options`)
  - **10** InferenceSaver-unique models (agnes-2.0/2.5-flash, agnes-image-2.1-flash, agnes-video-v2.0, Hunyuan-MT, music-2.6/2.6-free/cover/cover-free) get full inline definitions
- `models/xiaomi/mimo-v2.5-tts.toml` — new lab entry mirroring the first-party `xiaomi-token-plan-cn` provider file (open weights, 8_192/8_192, real description)
- `packages/core/src/sync/providers/inferencesaver.ts` — sync module fetching the **public** InferenceSaver catalog, which needs **no API key**
- `packages/core/src/sync/index.ts` — registered in `providers` + `aggregators` group
- `.github/workflows/sync-models.yml` — `INFERENCESAVER_API_KEY` env wired for future account-scoped availability (optional; sync works keyless)

## Sources

- Public catalog (source of truth for sync): <https://inferencesaver.com/api/public/models> — returns every served model with `inputPricePerMillionUsd`, `outputPricePerMillionUsd`, `cacheReadPricePerMillionUsd`, `cacheWritePricePerMillionUsd`, `contextWindow`, `maxOutputTokens`, `capability`, `supportedEndpoints`
- Lab metadata (`models/**/*.toml`) — authoritative for `reasoning`, `reasoning_options`, limits, modalities, release dates of every `base_model` target
- First-party provider entries (anthropic, openai, google, deepseek, moonshotai, zhipuai, xai, llmgateway, daoxe) — the source for each model's reasoning-control sets

## Non-lab limit/cost delta mapping (catalog fields)

Every non-inherited limit/cost value below is read directly from the public catalog fields on that model's row (`contextWindow`, `maxOutputTokens`, `inputPricePerMillionUsd`, `outputPricePerMillionUsd`, `cacheReadPricePerMillionUsd`, `cacheWritePricePerMillionUsd`):

| File | Catalog-sourced deltas |
|---|---|
| `claude-opus-4-6/4-7/4-8/5` | context `200_000` (catalog `contextWindow`), output `32_000` (`maxOutputTokens`) |
| `claude-sonnet-4-6` | context `400_000` (`contextWindow`) |
| `claude-sonnet-5` | context `400_000`, output `64_000` |
| `claude-haiku-4-5-20251001` | output `8_192` (`maxOutputTokens`) |
| `deepseek-v4-flash` | context `128_000`, output `16_384` |
| `gemini-3.5-flash` | context `1_000_000` |
| `gpt-5.5-openai-compact` | none (limits inherit from `openai/gpt-5.5`; catalog `contextWindow` 400k is the pricing-tier input band, not full context — see review response below) |
| `agnes-2.0-flash`, `agnes-2.5-flash`, `Hunyuan-MT` | limits 0/0 (catalog reports the uniform 200k/16k placeholder, not a measured window) |
| music/mimo/agnes-image/video | 0/0 non-token defaults (generation/audio endpoints) |
| all others | cost only (input/output/cache from catalog price fields) |

## Validation

- `bun validate` passes — 36/36 InferenceSaver models generate cleanly
- Re-sync is idempotent (0 created / 0 updated / 36 unchanged), including stable `release_date`/`last_updated` on unique models (preserved via sync `context.existing`, only defaulting to today on first create)
- `bun test`: 164 pass, 4 fail — the 4 failures are pre-existing on `dev` (weights-links, DeepInfra live-modalities, snapshot tests), unchanged by this PR

## Review responses

### Round 1 — [high] reasoning options / toggle / Nano-Banana / compact
- **Per-model `reasoning_options`** (no blanket shape): Claude 4.7+/5/Fable effort `low|medium|high|xhigh|max` only; GPT-5.4/5.4-mini/5.5/compact effort `none|low|medium|high|xhigh`; GPT-5.6-* `none|low|medium|high|xhigh|max`; Gemini 3.5 Flash `minimal|low|medium|high`; GLM-5.2 `high|max`; Kimi K3 `low|high|max`; Grok 4.5 `low|medium|high`; DeepSeek Flash `toggle` + `low|high|max` with a top-of-file wire comment (`enable_thinking` / `reasoning_effort`).
- **Nano-Banana** → `base_model = "google/gemini-2.5-flash-image"`, **nano-banana-2** → `base_model = "google/gemini-3.1-flash-image"`, override-only (cost; `reasoning_options` inherited to satisfy `reasoning = true` refine).
- **gpt-5.5-openai-compact** → `base_model = "openai/gpt-5.5"`, only display name + cost.

### Round 2 — [high] nano-banana-2 reasoning options
- nano-banana-2 now emits google first-party effort `["minimal", "high"]` (copied from `providers/google/models/gemini-3.1-flash-image.toml`), not `[]`.

### Round 3 — all items
1. **[high] mimo-v2.5-tts**: added `models/xiaomi/mimo-v2.5-tts.toml` (open weights, 8_192/8_192, real description — mirrors `providers/xiaomi-token-plan-cn/models/mimo-v2.5-tts.toml`); the provider file is now `base_model = "xiaomi/mimo-v2.5-tts"` with cost only; removed from `UNIQUE_MODELS`.
2. **[high] sync date stability**: `translateModel` now receives the sync `context` and uses `existing?.release_date` / `existing?.last_updated` for unique models — only defaults to today on first create. Re-sync produces 0 updated.
3. **[high] GPT context overrides**: catalog `contextWindow` for GPT models (272k/400k) equals the pricing-tier input band, not full context (lab `gpt-5.4-mini` input = 272_000; lab context = 1.05M). The sync now treats GPT catalog limits as non-authoritative and lets lab limits inherit (context 1.05M / input 922k / output 128k; mini 400k/272k/128k). `base_model_omit = ["limit.input"]` no longer emitted.
4. **[medium] budget_tokens**: removed from `claude-haiku-4-5-20251001` (now `[]`, matching llmgateway same-surface peer), `claude-opus-4-6` and `claude-sonnet-4-6` (now effort-only `low|medium|high|max`, matching llmgateway opus-4-6). No budget field is claimed on this OpenAI-compatible path.
5. **[medium] unique chat filler limits**: `agnes-2.0-flash`, `agnes-2.5-flash`, `Hunyuan-MT` no longer serialize the placeholder 200k/16k — they use the non-token 0/0 default (catalog reports the same uniform pair for every unique chat model).
6. **[medium] Hunyuan-MT**: kept as a host-unique chat model. The catalog row is `capability = "chat"`, 200k context, $0.02/$0.04 (`rawName: Hunyuan-MT`); the nano-gpt `Hunyuan-MT-7B` entry is a different model (translation-focused, 8k context, $10/$20, `tool_call = false`). No `models/tencent/*` lab identity exists for the chat variant, so there is nothing to link to; flagged for maintainer review.
7. **[low] PR body citations**: added the mapping table above (catalog field per non-lab limit/cost delta).

## Notes for maintainers

- The public catalog sync requires **no secret** — it will work immediately after merge.
- An optional `INFERENCESAVER_API_KEY` repo secret enables account-scoped availability; without it, all catalog models are listed.
- `release_date`/`last_updated` on the 10 unique models are stamped on first create and preserved thereafter; booleans (attachment/reasoning/tool_call/open_weights) are conservative defaults — please review those before finalizing.
- `models/xiaomi/mimo-v2.5-tts.toml` mirrors the existing `xiaomi-token-plan-cn` provider entry (open_weights without a weights link), which already contributes to the pre-existing weights-links test failure on `dev`.
