### PR TITLE
feat: DeepSeek-V4-Flash-0731, GLM-5.2-NVFP4 and Kimi-K2.7-Code for provider Hetzner

### DIFF
--- a/providers/hetzner/models/DeepSeek-V4-Flash-0731.toml
+++ b/providers/hetzner/models/DeepSeek-V4-Flash-0731.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+reasoning_options = []
+status = "beta"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 512_000

--- a/providers/hetzner/models/DeepSeek-V4-Flash-0731.toml
+++ b/providers/hetzner/models/DeepSeek-V4-Flash-0731.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
 status = "beta"
 
 [cost]

--- a/providers/hetzner/models/GLM-5.2-NVFP4.toml
+++ b/providers/hetzner/models/GLM-5.2-NVFP4.toml
@@ -1,6 +1,6 @@
 name = "GLM-5.2 NVFP4"
 base_model = "zhipuai/glm-5.2"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
 status = "beta"
 
 [cost]

--- a/providers/hetzner/models/GLM-5.2-NVFP4.toml
+++ b/providers/hetzner/models/GLM-5.2-NVFP4.toml
@@ -1,0 +1,12 @@
+name = "GLM-5.2 NVFP4"
+base_model = "zhipuai/glm-5.2"
+reasoning_options = []
+status = "beta"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 512_000

--- a/providers/hetzner/models/Kimi-K2.7-Code.toml
+++ b/providers/hetzner/models/Kimi-K2.7-Code.toml
@@ -9,4 +9,3 @@ cache_read = 0
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/hetzner/models/Kimi-K2.7-Code.toml
+++ b/providers/hetzner/models/Kimi-K2.7-Code.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+status = "beta"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+
+[limit]
+context = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/hetzner/models/Kimi-K2.7-Code.toml
+++ b/providers/hetzner/models/Kimi-K2.7-Code.toml
@@ -7,9 +7,6 @@ input = 0
 output = 0
 cache_read = 0
 
-[limit]
-context = 262_144
-
 [modalities]
 input = ["text", "image"]
 output = ["text"]


### PR DESCRIPTION
## Summary

Adds three models to the experimental Hetzner Inference API catalog:

- `DeepSeek-V4-Flash-0731` with a 512,000-token context window and text input
- `GLM-5.2-NVFP4` with a 512,000-token context window and text input
- `Kimi-K2.7-Code` with a 262,144-token context window and text/image input

Hetzner documents the available model IDs, context lengths, modalities, OpenAI-compatible endpoint, and free experimental pricing at https://experiments.hetzner.com/docs/inference.

## Reasoning options

Hetzner currently does not document reasoning controls, so the request behavior was verified directly against its OpenAI-compatible chat-completions endpoint. The API validates `reasoning_effort` and reports the accepted API-wide values as `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.

For `DeepSeek-V4-Flash-0731`, live requests confirmed that `none` disables reasoning and `max` enables a returned reasoning trace. The catalog exposes the model-effective levels `none`, `low`, `high`, and `max`; a separate toggle is intentionally omitted because `thinking.type` was ignored by Hetzner.

For `GLM-5.2-NVFP4`, live requests likewise confirmed that `none` disables reasoning and `max` enables it. The catalog exposes the effective levels `none`, `high`, and `max`; upstream aliases that collapse to those levels are omitted.

For `Kimi-K2.7-Code`, both `none` and `max` still returned reasoning, so it remains `reasoning_options = []` to represent always-on reasoning with no effective caller control.

## Validation

- `bun validate`
- Live `/models` response confirmed all model IDs and context lengths
- Live chat-completions requests verified the reasoning behavior described above