### PR TITLE
Add DeepSeek-V4-Flash-0731 to Scaleway Inference API catalog

### DIFF
--- a/providers/scaleway/models/deepseek-v4-flash-0731.toml
+++ b/providers/scaleway/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,16 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek-V4-Flash-0731"
+description = "DeepSeek-V4-Flash-0731 is DeepSeek's fast, cost-efficient 1M-context model, retaining the Preview model's architecture and size while receiving additional post-training for substantially improved agent capabilities."
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "high", "max"]
+
+[cost]
+input = 0.4
+output = 0.8
+cache_read = 0.08
+
+[limit]
+context = 256_000
+output = 32_768

--- a/providers/scaleway/models/deepseek-v4-flash-0731.toml
+++ b/providers/scaleway/models/deepseek-v4-flash-0731.toml
@@ -1,6 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
 name = "DeepSeek-V4-Flash-0731"
-description = "DeepSeek-V4-Flash-0731 is DeepSeek's fast, cost-efficient 1M-context model, retaining the Preview model's architecture and size while receiving additional post-training for substantially improved agent capabilities."
 
 [[reasoning_options]]
 type = "effort"


### PR DESCRIPTION
## Summary

Adds one model to the Scaleway Inference API catalog:

- `DeepSeek-V4-Flash-0731` with a 256k-token context window

## Resources

- Pricing page: https://www.scaleway.com/en/pricing/model-as-a-service/#managed-inference

## Validation

`bun run validate` outputs correct data for the added model.