### PR TITLE
feat: label PRs cleared by automated review

### DIFF
--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -72,10 +72,14 @@ jobs:
           set -euo pipefail
           EVENTS_FILE="$RUNNER_TEMP/pr-reviewer-events.jsonl"
           RESPONSE_FILE="$RUNNER_TEMP/pr-reviewer-response.md"
+          PR_REVIEW_READY_FILE="$RUNNER_TEMP/pr-reviewer-ready"
           echo "RESPONSE_FILE=$RESPONSE_FILE" >> "$GITHUB_ENV"
+          echo "PR_REVIEW_READY_FILE=$PR_REVIEW_READY_FILE" >> "$GITHUB_ENV"
+          export PR_REVIEW_READY_FILE
+          rm -f "$PR_REVIEW_READY_FILE"
 
           opencode run --agent pr-reviewer -m opencode/grok-4.5 --format json <<'EOF' | tee "$EVENTS_FILE"
-          Review this pull request using the trusted reviewer instructions. Start with `.pr-review/pull-request.json`, `.pr-review/diff.patch`, `AGENTS.md`, and the contributing guidance in `README.md`. Read `sync.md`, the reasoning-options audit guide, schema code, and nearby base-revision files when relevant to the changed files. Use only the read, glob, and grep tools. Return only the final review comment in the agent's required output format. Never include progress narration or passed-check summaries.
+          Review this pull request using the trusted reviewer instructions. Start with `.pr-review/pull-request.json`, `.pr-review/diff.patch`, `AGENTS.md`, and the contributing guidance in `README.md`. Read `sync.md`, the reasoning-options audit guide, schema code, and nearby base-revision files when relevant to the changed files. Use only the read, glob, grep, and mark-pr-ready tools. Return only the final review comment in the agent's required output format. Never include progress narration or passed-check summaries.
           EOF
 
           if ! jq -ers 'map(select(.type == "text") | .part.text) | last | select(length > 0)' "$EVENTS_FILE" > "$RESPONSE_FILE"; then
@@ -90,6 +94,6 @@ jobs:
           READY_LABEL: "reviewer: ready"
         run: |
           gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RESPONSE_FILE"
-          if grep -Fxq "No actionable findings." "$RESPONSE_FILE"; then
+          if [[ -f "$PR_REVIEW_READY_FILE" ]]; then
             gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$READY_LABEL"
           fi

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -22,6 +23,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Clear ready label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          READY_LABEL: "reviewer: ready"
+        run: |
+          set -euo pipefail
+          gh label create "$READY_LABEL" --repo "$GITHUB_REPOSITORY" --color "0E8A16" --description "Automated review found no actionable items" --force
+          labels="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name')"
+          if grep -Fxq "$READY_LABEL" <<< "$labels"; then
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$READY_LABEL"
+          fi
+
       - name: Checkout trusted base revision
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -73,4 +87,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RESPONSE_FILE"
+          READY_LABEL: "reviewer: ready"
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RESPONSE_FILE"
+          if grep -Fxq "No actionable findings." "$RESPONSE_FILE"; then
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$READY_LABEL"
+          fi

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run pull request reviewer
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          OPENCODE_PERMISSION: '{"*":"deny","read":"allow","glob":"allow","grep":"allow","external_directory":"deny"}'
+          OPENCODE_PERMISSION: '{"*":"deny","read":"allow","glob":"allow","grep":"allow","mark-pr-ready":"allow","external_directory":"deny"}'
         run: |
           set -euo pipefail
           EVENTS_FILE="$RUNNER_TEMP/pr-reviewer-events.jsonl"

--- a/.opencode/agent/pr-reviewer.md
+++ b/.opencode/agent/pr-reviewer.md
@@ -12,6 +12,7 @@ permission:
     "*.env.*": deny
   glob: allow
   grep: allow
+  mark-pr-ready: allow
   external_directory: deny
 ---
 
@@ -65,6 +66,8 @@ Focus only on actionable problems introduced by the pull request:
 
 Do not report style preferences, speculative concerns, pre-existing problems, or bare schema errors that validation will identify without useful explanation. Do not invent requirements from neighboring files when provider behavior is intentionally different. Do not claim to have run commands, opened links, or performed validation. Do not edit files or attempt to post comments yourself.
 
+Use `mark-pr-ready` only after completing the review and determining there are no action items. Never use it when returning one or more action items.
+
 Every finding must be an action item: the author must need to change something, verify a specific fact, or provide missing evidence. Do not list checks that passed or general observations. If you find action items, list them in severity order and return exactly this structure:
 
 ```markdown
@@ -74,6 +77,6 @@ Every finding must be an action item: the author must need to change something, 
 
 Use `violation` only when the change demonstrably breaks a repository requirement or expected behavior. Use `possible mistake` when the diff provides concrete contradictory or suspicious evidence but external facts must be verified. Use `critical`, `high`, `medium`, or `low` for severity. Reference a changed line whenever possible and keep each action item concise.
 
-If there are no action items, respond with exactly the following text and nothing else. Do not explain what you checked or why it passed:
+If there are no action items, call `mark-pr-ready`, then respond with exactly the following text and nothing else. Do not explain what you checked or why it passed:
 
 `No actionable findings.`

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "mark-pr-ready": "deny"
+  }
+}

--- a/.opencode/tool/mark-pr-ready.ts
+++ b/.opencode/tool/mark-pr-ready.ts
@@ -1,0 +1,16 @@
+import { writeFile } from "node:fs/promises"
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Mark the current pull request as ready after completing a review with no actionable findings.",
+  args: {},
+  async execute(_args, context) {
+    if (context.agent !== "pr-reviewer") throw new Error("This tool is only available to the pr-reviewer agent")
+
+    const readyFile = process.env.PR_REVIEW_READY_FILE
+    if (!readyFile) throw new Error("PR_REVIEW_READY_FILE is not configured")
+
+    await writeFile(readyFile, "")
+    return "Pull request marked ready."
+  },
+})


### PR DESCRIPTION
## Summary

- add a dedicated `mark-pr-ready` tool for the automated reviewer
- expose the tool only to `pr-reviewer`, with both permission scoping and a runtime agent check
- clear stale readiness whenever a new review starts
- apply `reviewer: ready` only when the agent explicitly invokes the tool

The tool writes a workflow-local signal rather than changing GitHub directly. The trusted workflow owns label creation and mutation, and the existing concise review comment remains unchanged. The label indicates automated review only, not human approval.

## Validation

- `bun validate`
- confirmed `mark-pr-ready` is enabled for `pr-reviewer` and disabled for `issue-fixer` and `build`
- exercised successful reviewer invocation and rejection of a non-reviewer invocation
- workflow YAML and OpenCode JSONC parse
- `git diff --check`