### PR TITLE
feat(nvidia): add Nemotron 3.5 Lightning

### DIFF
--- a/providers/nvidia/models/nvidia/nemotron-3.5-lightning-30b-a3b.toml
+++ b/providers/nvidia/models/nvidia/nemotron-3.5-lightning-30b-a3b.toml
@@ -1,0 +1,11 @@
+# Sources (accessed 2026-08-11):
+# - https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b
+# - https://integrate.api.nvidia.com/v1/models
+# Toggle: chat_template_kwargs.enable_thinking = true|false
+# https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
+base_model = "nvidia/nemotron-3.5-lightning-30b-a3b"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0.0
+output = 0.0


### PR DESCRIPTION
## Summary

- list `nvidia/nemotron-3.5-lightning-30b-a3b` on the NVIDIA provider
- inherit the existing NVIDIA lab metadata via `base_model`
- expose NVIDIA Nemotron 3.5 Lightning reasoning as a binary toggle

## Sources

- NVIDIA launch post: https://blogs.nvidia.com/blog/nemotron-lightning-switchyard-rtx-dgx/
- NVIDIA NIM model page: https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b
- NVIDIA live model catalog (`nvidia/nemotron-3.5-lightning-30b-a3b`): https://integrate.api.nvidia.com/v1/models
- NVIDIA model card and API examples: https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4

## Reasoning Controls

NVIDIA is the first-party lab and host. The documented wire control is `chat_template_kwargs.enable_thinking = true|false`, so this entry exposes `reasoning_options = [{ type = "toggle" }]`. No effort enum is documented for this model on NVIDIA NIM.

## Validation

- `bun validate`