### PR TITLE
feat(bytedance-seed): add Seed 2.0 Code metadata

### DIFF
--- a/models/bytedance-seed/seed-2.0-code.toml
+++ b/models/bytedance-seed/seed-2.0-code.toml
@@ -1,0 +1,23 @@
+# Sources (accessed 2026-08-11):
+# - https://seed.bytedance.com/en/blog/seed-2-0-official-launch
+# - https://seed.bytedance.com/en/seed2
+# - https://www.volcengine.com/docs/82379/1330310
+name = "Seed 2.0 Code"
+description = "ByteDance Seed coding model for multimodal software engineering and long-running agents"
+family = "seed"
+release_date = "2026-02-14"
+last_updated = "2026-02-14"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 262_144
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/packages/core/src/sync/providers/deepinfra.ts
+++ b/packages/core/src/sync/providers/deepinfra.ts
@@ -372,6 +372,7 @@ export function buildDeepInfraModel(
 // catalog's canonical metadata namespace so new models can inherit via
 // `base_model` whenever a `models/` entry already exists.
 const DEEPINFRA_PREFIXES: Record<string, string> = {
+  ByteDance: "bytedance-seed",
   "deepseek-ai": "deepseek",
   "meta-llama": "meta",
   google: "google",

--- a/packages/core/src/sync/providers/empiriolabs.ts
+++ b/packages/core/src/sync/providers/empiriolabs.ts
@@ -8,6 +8,7 @@ import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
 const API_ENDPOINT = "https://api.empiriolabs.ai/v1/models";
 
 const CANONICAL_BASE_MODELS: Record<string, string> = {
+  "seed-2-0-code": "bytedance-seed/seed-2.0-code",
   "fugu-ultra": "sakana/fugu-ultra",
   "deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash-0731",
   "gemma-4-26b-a4b": "google/gemma-4-26b-a4b-it",

--- a/packages/core/src/sync/providers/nano-gpt.ts
+++ b/packages/core/src/sync/providers/nano-gpt.ts
@@ -96,6 +96,7 @@ const BASE_MODEL_ALIASES: Record<string, string | undefined> = {
   "claude-opus-4": "anthropic/claude-opus-4-0",
   "claude-sonnet-4": "anthropic/claude-sonnet-4-0",
   "cohere/north-mini-code": "cohere/north-mini-code-1-0",
+  "doubao-seed-2-0-code-preview-260215": "bytedance-seed/seed-2.0-code",
 };
 
 const NANO_GPT_VARIANT_SUFFIX = /(?::(?:thinking|none|minimal|low|medium|high|xhigh|max|\d+)|-thinking)$/i;

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -23,6 +23,7 @@ const CANONICAL_BASE_MODEL_OVERRIDES = {
 const CANONICAL_PROVIDER_PREFIXES = {
   alibaba: { provider: "alibaba", metadata: "alibaba" },
   anthropic: { provider: "anthropic", metadata: "anthropic" },
+  "bytedance-seed": { provider: "bytedance-seed", metadata: "bytedance-seed" },
   cohere: { provider: "cohere", metadata: "cohere" },
   deepseek: { provider: "deepseek", metadata: "deepseek" },
   google: { provider: "google", metadata: "google" },

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -13,6 +13,7 @@ const modelMetadataFilesByProvider = new Map<string, Set<string>>();
 let allModelMetadataIDs: string[] | undefined;
 
 const CANONICAL_BASE_MODEL_OVERRIDES = {
+  "bytedance/dola-seed-2.0-code": "bytedance-seed/seed-2.0-code",
   "openai/gpt-5.6-luna-pro": "openai/gpt-5.6-luna",
   "openai/gpt-5.6-sol-pro": "openai/gpt-5.6-sol",
   "openai/gpt-5.6-terra-pro": "openai/gpt-5.6-terra",

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -2259,6 +2259,7 @@ test("factors OpenRouter Pro routes against canonical OpenAI metadata", () => {
 // Ensures Merge Gateway namespaces reuse the matching canonical model metadata.
 test("resolves Merge Gateway provider aliases to canonical metadata", () => {
   expect([
+    resolveCanonicalBaseModel("bytedance-seed/seed-2.0-code"),
     resolveCanonicalBaseModel("moonshot/kimi-k2.5"),
     resolveCanonicalBaseModel("moonshot/kimi-k2.6"),
     resolveCanonicalBaseModel("moonshot/kimi-k2.7-code"),
@@ -2266,6 +2267,7 @@ test("resolves Merge Gateway provider aliases to canonical metadata", () => {
     resolveCanonicalBaseModel("sakana/fugu-ultra"),
     resolveCanonicalBaseModel("meta/muse-glimmer-30b"),
   ]).toEqual([
+    "bytedance-seed/seed-2.0-code",
     "moonshotai/kimi-k2.5",
     "moonshotai/kimi-k2.6",
     "moonshotai/kimi-k2.7-code",

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -15,7 +15,11 @@ import {
   buildCrossModel,
   type CrossModelModel,
 } from "../src/sync/providers/crossmodel.js";
-import { buildDeepInfraModel, type DeepInfraModel } from "../src/sync/providers/deepinfra.js";
+import {
+  buildDeepInfraModel,
+  resolveDeepInfraBaseModel,
+  type DeepInfraModel,
+} from "../src/sync/providers/deepinfra.js";
 import {
   buildDigitalOceanModel,
   digitalocean,
@@ -274,6 +278,8 @@ test("factors NanoGPT variants against canonical models without retaining wrong 
   expect(resolveNanoGptBaseModel("TEE/gpt-oss-120b")).toBe("openai/gpt-oss-120b");
   expect(resolveNanoGptBaseModel("TEE/gemma-4-31b-it")).toBe("google/gemma-4-31b-it");
   expect(resolveNanoGptBaseModel("cohere/north-mini-code")).toBe("cohere/north-mini-code-1-0");
+  expect(resolveNanoGptBaseModel("doubao-seed-2-0-code-preview-260215"))
+    .toBe("bytedance-seed/seed-2.0-code");
   expect(resolveNanoGptBaseModel("xiaomi/mimo-v2.5-pro-ultraspeed"))
     .toBe("xiaomi/mimo-v2.5-pro-ultraspeed");
   expect(resolveNanoGptBaseModel("claude-haiku-4-5-20251001-thinking"))
@@ -2044,6 +2050,11 @@ test("formats provider overrides and experimental modes", () => {
   });
 });
 
+test("resolves DeepInfra ByteDance IDs to canonical metadata", () => {
+  expect(resolveDeepInfraBaseModel("ByteDance/Seed-2.0-code"))
+    .toBe("bytedance-seed/seed-2.0-code");
+});
+
 test("DeepInfra preserves live modalities for new base models", () => {
   const model = buildDeepInfraModel(
     deepInfraModel("Qwen/Qwen3.5-9B", ["multimodal", "input-video"]),
@@ -2260,6 +2271,7 @@ test("factors OpenRouter Pro routes against canonical OpenAI metadata", () => {
 test("resolves Merge Gateway provider aliases to canonical metadata", () => {
   expect([
     resolveCanonicalBaseModel("bytedance-seed/seed-2.0-code"),
+    resolveCanonicalBaseModel("bytedance/dola-seed-2.0-code"),
     resolveCanonicalBaseModel("moonshot/kimi-k2.5"),
     resolveCanonicalBaseModel("moonshot/kimi-k2.6"),
     resolveCanonicalBaseModel("moonshot/kimi-k2.7-code"),
@@ -2267,6 +2279,7 @@ test("resolves Merge Gateway provider aliases to canonical metadata", () => {
     resolveCanonicalBaseModel("sakana/fugu-ultra"),
     resolveCanonicalBaseModel("meta/muse-glimmer-30b"),
   ]).toEqual([
+    "bytedance-seed/seed-2.0-code",
     "bytedance-seed/seed-2.0-code",
     "moonshotai/kimi-k2.5",
     "moonshotai/kimi-k2.6",
@@ -3190,6 +3203,7 @@ test("syncs EmpirioLabs pricing tiers and reasoning controls", () => {
 
 test("maps EmpirioLabs aliases to canonical model metadata", () => {
   expect(resolveEmpiriolabsBaseModel("fugu-ultra")).toBe("sakana/fugu-ultra");
+  expect(resolveEmpiriolabsBaseModel("seed-2-0-code")).toBe("bytedance-seed/seed-2.0-code");
   expect(resolveEmpiriolabsBaseModel("muse-spark-1-1")).toBe("meta/muse-spark-1.1");
   expect(resolveEmpiriolabsBaseModel("step-3-5-flash")).toBe("stepfun/step-3.5-flash");
 });


### PR DESCRIPTION
## Summary

- add complete shared metadata for `bytedance-seed/seed-2.0-code`
- register the ByteDance Seed namespace with the common canonical resolver
- normalize the live DeepInfra, EmpirioLabs, NanoGPT, and Merge Gateway aliases
- verify each public provider ID resolves to the new base model

## Why

Kilo #4514 and OpenRouter #4511 both discovered `bytedance-seed/seed-2.0-code`, but emitted full inline definitions because no shared lab metadata or canonical namespace mapping existed. Other hosts expose the same model under host-specific IDs that also require normalization:

- DeepInfra: `ByteDance/Seed-2.0-code`
- EmpirioLabs: `seed-2-0-code`
- NanoGPT: `doubao-seed-2-0-code-preview-260215`
- Merge Gateway: `bytedance/dola-seed-2.0-code`

The base uses the exact common Kilo/OpenRouter slug. The explicit aliases let all currently known sync sources produce override-only provider entries.

## Sources

- ByteDance Seed launch: https://seed.bytedance.com/en/blog/seed-2-0-official-launch
- ByteDance Seed model page: https://seed.bytedance.com/en/seed2
- Volcano Engine model catalog: https://www.volcengine.com/docs/82379/1330310
- OpenRouter live catalog: https://openrouter.ai/api/v1/models

The live OpenRouter entry confirms text/image/video input, reasoning, tool calling, structured output, 262,144 context, and 131,072 maximum completion tokens.

## Validation

- `bun validate`
- focused resolver tests for OpenRouter/Kilo, DeepInfra, EmpirioLabs, NanoGPT, and Merge Gateway

Follow-up: rerun affected syncs after merge to factor their generated provider files.