### PR TITLE
fix(sync): preserve OpenRouter reasoning toggles

### DIFF
--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -319,6 +319,9 @@ function openRouterReasoningOptions(reasoning: OpenRouterModel["reasoning"]): Sy
     : reasoning.supported_efforts;
 
   if (efforts !== undefined) {
+    if (!reasoning.mandatory && !efforts.includes("none")) {
+      options.push({ type: "toggle" });
+    }
     options.push({
       type: "effort",
       values: reasoning.mandatory ? efforts.filter((value) => value !== "none") : [...efforts],

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -2201,6 +2201,7 @@ test("syncs OpenRouter reasoning efforts from model metadata", () => {
   expect(model).toMatchObject({
     base_model: "anthropic/claude-sonnet-5",
     reasoning_options: [
+      { type: "toggle" },
       { type: "effort", values: ["max", "xhigh", "high", "medium", "low"] },
     ],
   });
@@ -2314,6 +2315,7 @@ test("prefers OpenRouter API reasoning options over authored ones", () => {
 
   expect(model).toMatchObject({
     reasoning_options: [
+      { type: "toggle" },
       { type: "effort", values: ["max", "xhigh", "high", "medium", "low"] },
     ],
   });
@@ -2366,6 +2368,7 @@ test("upgrades empty OpenRouter reasoning options from model metadata", () => {
 
   expect(model).toMatchObject({
     reasoning_options: [
+      { type: "toggle" },
       { type: "effort", values: ["high", "medium", "low"] },
     ],
   });


### PR DESCRIPTION
## Summary

- emit a reasoning toggle when OpenRouter reports optional reasoning plus graded efforts that do not include `none`
- retain the reported effort levels alongside the separate toggle
- update sync tests for new, existing, and previously empty reasoning metadata

## Why

OpenRouter exposes a separate `reasoning.enabled` control. When a model reports `mandatory = false` and effort values such as `low`, `medium`, and `high`, the current sync emits only the effort selector and loses the on/off control. This affected `bytedance-seed/seed-2.0-code` in #4511 and would overwrite a hand-corrected provider file on the next sync.

If `none` is already part of the effort values, no duplicate toggle is emitted. Mandatory reasoners also remain effort-only.

## Source

- https://openrouter.ai/docs/guides/best-practices/reasoning-tokens

## Validation

- `bun validate`
- focused OpenRouter reasoning sync tests