### PR TITLE
Add MAI-Code-1.1-Flash to GitHub Copilot

### DIFF
--- a/models/microsoft/mai-code-1.1-flash.toml
+++ b/models/microsoft/mai-code-1.1-flash.toml
@@ -1,0 +1,23 @@
+name = "MAI-Code-1.1-Flash"
+description = "Microsoft coding model with native vision support, optimized for fast and efficient software development"
+family = "mai"
+release_date = "2026-08-11"
+last_updated = "2026-08-11"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 256_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[links]]
+label = "Announcement"
+url = "https://microsoft.ai/news/mai-code-1-1-flash-br-better-faster-at-a-quarter-of-the-cost/"
+type = "announcement"

--- a/providers/github-copilot/models/mai-code-1.1-flash.toml
+++ b/providers/github-copilot/models/mai-code-1.1-flash.toml
@@ -1,0 +1,15 @@
+# Pricing: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
+# Capabilities and limits verified against the GitHub Copilot /models API on 2026-08-12.
+base_model = "microsoft/mai-code-1.1-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.20
+output = 1.20
+cache_read = 0.02
+
+[limit]
+input = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]


### PR DESCRIPTION
Adds MAI-Code-1.1-Flash and its GitHub Copilot provider entry.

Includes the Microsoft base model metadata, native vision support, the Copilot model ID and pricing, reasoning effort levels, PDF input, and served token limits.

Sources:
- GitHub announcement: https://github.blog/changelog/2026-08-11-mai-code-1-1-flash-available-in-github-copilot/
- GitHub Copilot pricing: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
- Microsoft announcement: https://microsoft.ai/news/mai-code-1-1-flash-br-better-faster-at-a-quarter-of-the-cost/
- GitHub Copilot `/models` API for the model ID, capabilities, modalities, reasoning levels, and limits

Validation: `bun validate`
