### PR TITLE
fix(providers/azure): update GPT-5.6 Sol/Terra/Luna pricing

### DIFF
--- a/providers/azure/models/gpt-5.6-luna.toml
+++ b/providers/azure/models/gpt-5.6-luna.toml
@@ -1,17 +1,17 @@
-# Pricing aligned with Azure (no Terra/Luna cut from 2026-07-30): https://learn.microsoft.com/en-us/answers/questions/5962521/pricing-of-openai-gpt-5-6-models-luna-terra
+# Pricing: https://developers.openai.com/api/docs/pricing
 base_model = "openai/gpt-5.6-luna"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 1
-output = 6
-cache_read = 0.1
-cache_write = 1.25
+input = 0.20
+output = 1.20
+cache_read = 0.02
+cache_write = 0.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 2
-output = 9
-cache_read = 0.2
-cache_write = 2.5
+input = 0.40
+output = 1.80
+cache_read = 0.04
+cache_write = 0.50

--- a/providers/azure/models/gpt-5.6-sol.toml
+++ b/providers/azure/models/gpt-5.6-sol.toml
@@ -1,14 +1,17 @@
+# Pricing: https://developers.openai.com/api/docs/pricing
 base_model = "openai/gpt-5.6-sol"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 5
-output = 30
-cache_read = 0.5
+input = 5.00
+output = 30.00
+cache_read = 0.50
+cache_write = 6.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 10
-output = 45
-cache_read = 1
+input = 10.00
+output = 45.00
+cache_read = 1.00
+cache_write = 12.50

--- a/providers/azure/models/gpt-5.6-terra.toml
+++ b/providers/azure/models/gpt-5.6-terra.toml
@@ -1,17 +1,17 @@
-# Pricing aligned with Azure (no Terra/Luna cut from 2026-07-30): https://learn.microsoft.com/en-us/answers/questions/5962521/pricing-of-openai-gpt-5-6-models-luna-terra
+# Pricing: https://developers.openai.com/api/docs/pricing
 base_model = "openai/gpt-5.6-terra"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 2.5
-output = 15
-cache_read = 0.25
-cache_write = 3.125
+input = 2.00
+output = 12.00
+cache_read = 0.20
+cache_write = 2.50
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 5
-output = 22.5
-cache_read = 0.5
-cache_write = 6.25
+input = 4.00
+output = 18.00
+cache_read = 0.40
+cache_write = 5.00


### PR DESCRIPTION
Updates Azure provider pricing for GPT-5.6 Sol, Terra, and Luna to match the current OpenAI standard pricing listed at https://developers.openai.com/api/docs/pricing.

Changes:
- Aligns input/output/cache_read/cache_write costs with the Standard table.
- Adds missing `cache_write` values.
- Keeps the existing 272k context tier threshold and reasoning_options.

Azure availability source: https://azure.microsoft.com/en-us/blog/gpt-5-6-now-available-in-microsoft-foundry/