### PR TITLE
chore(sync): update ai& model catalog

### DIFF
--- a/providers/aiand/models/deepseek-ai/deepseek-v4-flash.toml
+++ b/providers/aiand/models/deepseek-ai/deepseek-v4-flash.toml
@@ -17,4 +17,3 @@ output = 0.25
 
 [limit]
 context = 1_048_576
-output = 384_000

--- a/providers/aiand/models/deepseek-ai/deepseek-v4-pro.toml
+++ b/providers/aiand/models/deepseek-ai/deepseek-v4-pro.toml
@@ -11,9 +11,8 @@ type = "effort"
 values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
-input = 1.00
-output = 2.50
+input = 1
+output = 2.5
 
 [limit]
 context = 1_048_576
-output = 384_000

--- a/providers/aiand/models/google/gemma-4-31b-it.toml
+++ b/providers/aiand/models/google/gemma-4-31b-it.toml
@@ -14,9 +14,8 @@ type = "effort"
 values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
-input = 0.20
-output = 0.50
+input = 0.2
+output = 0.5
 
 [modalities]
 input = ["text", "image", "video", "pdf"]
-output = ["text"]

--- a/providers/aiand/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/aiand/models/moonshotai/kimi-k2.7-code.toml
@@ -13,8 +13,7 @@ values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
 input = 0.75
-output = 3.50
+output = 3.5
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/aiand/models/moonshotai/kimi-k3.toml
+++ b/providers/aiand/models/moonshotai/kimi-k3.toml
@@ -12,13 +12,14 @@
 # with 400 (negative control).
 base_model = "moonshotai/kimi-k3"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "high", "max"]
 
 [cost]
-input = 3.00
-cache_read = 0.50
-output = 12.50
+input = 3
+output = 12.5
+cache_read = 0.5
 
 [modalities]
 input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/aiand/models/motif-technologies/motif-3.toml
+++ b/providers/aiand/models/motif-technologies/motif-3.toml
@@ -1,0 +1,23 @@
+name = "Motif 3"
+description = "Motif 3 is a large-scale, decoder-only Mixture-of-Experts (MoE) language model with 314 billion total parameters and 13.2 billion parameters activated per token."
+release_date = "2026-08-12"
+last_updated = "2026-08-12"
+attachment = false
+reasoning = true
+temperature = false
+tool_call = false
+structured_output = false
+open_weights = false
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 2
+
+[limit]
+context = 262_144
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aiand/models/qwen/qwen3.6-27b.toml
+++ b/providers/aiand/models/qwen/qwen3.6-27b.toml
@@ -1,6 +1,7 @@
-# Source: https://docs.aiand.com/models/catalog/ (USD list prices; accessed
-# 2026-07-24) and live probes against api.aiand.com on the same date.
-# Listed as free ("no charges, ideal for evals") in the catalog's Quick picks.
+# Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
+# 2026-07-28). The catalog Quick-picks section still lists this model as free,
+# but the live endpoint reports input = $0.32 / output = $3.20 per 1M tokens,
+# so pricing is taken from the API.
 # ai&'s deployment rejects image input ("does not support image input") and
 # the catalog lists no vision/video/audio capability, so modalities are
 # overridden from the shared base model's text+image+video+audio to text-only,
@@ -9,16 +10,13 @@
 # values accepted; invalid values rejected with 400 (negative control).
 base_model = "alibaba/qwen3.6-27b"
 
-attachment = false
-
 [[reasoning_options]]
 type = "effort"
 values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
-input = 0
-output = 0
+input = 0.32
+output = 3.2
 
 [modalities]
-input = ["text"]
-output = ["text"]
+input = ["text", "image", "video", "pdf"]

--- a/providers/aiand/models/zai-org/glm-5.2.toml
+++ b/providers/aiand/models/zai-org/glm-5.2.toml
@@ -11,9 +11,8 @@ type = "effort"
 values = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
 [cost]
-input = 1.00
-output = 4.00
+input = 1
+output = 4
 
 [limit]
 context = 1_048_576
-output = 131_072


### PR DESCRIPTION
Updates model TOMLs for the `aiand` sync target.

| Provider | Status | Created | Updated | Deleted |
| --- | --- | ---: | ---: | ---: |
| ai& | changed | 1 | 7 | 0 |

<details><summary>ai& changed files</summary>

- updated: `providers/aiand/models/deepseek-ai/deepseek-v4-flash.toml`
- updated: `providers/aiand/models/deepseek-ai/deepseek-v4-pro.toml`
- updated: `providers/aiand/models/google/gemma-4-31b-it.toml`
- updated: `providers/aiand/models/moonshotai/kimi-k2.7-code.toml`
- updated: `providers/aiand/models/moonshotai/kimi-k3.toml`
- created: `providers/aiand/models/motif-technologies/motif-3.toml`
- updated: `providers/aiand/models/qwen/qwen3.6-27b.toml`
- updated: `providers/aiand/models/zai-org/glm-5.2.toml`
</details>

This PR was created automatically by the daily model sync workflow.
