### PR TITLE
feat(merge-gateway): expose OpenAI-compatible API endpoint

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -397,6 +397,7 @@ export const Provider = z
       const isOpenAI = data.npm === "@ai-sdk/openai";
       const isOpenAIcompatible = data.npm === "@ai-sdk/openai-compatible";
       const isOpenrouter = data.npm === "@openrouter/ai-sdk-provider";
+      const isMergeGateway = data.npm === "merge-gateway-ai-sdk-provider";
       const isAnthropic = data.npm === "@ai-sdk/anthropic";
       const isKiro = data.npm === "kiro-acp-ai-provider";
       const hasApi = data.api !== undefined;
@@ -406,6 +407,8 @@ export const Provider = z
         (isOpenAIcompatible && hasApi) ||
         // openrouter: must have api
         (isOpenrouter && hasApi) ||
+        // Merge Gateway: native provider with an OpenAI-compatible fallback
+        (isMergeGateway && hasApi) ||
         // anthropic: api optional (always allowed)
         isAnthropic ||
         // openai: api optional (always allowed)
@@ -416,6 +419,7 @@ export const Provider = z
         (!isOpenAI &&
           !isOpenAIcompatible &&
           !isOpenrouter &&
+          !isMergeGateway &&
           !isAnthropic &&
           !isKiro &&
           !hasApi)
@@ -423,7 +427,7 @@ export const Provider = z
     },
     {
       message:
-        "'api' is required for openai-compatible and openrouter, optional for anthropic, openai, and kiro, forbidden otherwise",
+        "'api' is required for openai-compatible, openrouter, and Merge Gateway; optional for anthropic, openai, and kiro; forbidden otherwise",
       path: ["api"],
     },
   );

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { z } from "zod";
 
-import { AuthoredModel } from "../src/index.js";
+import { AuthoredModel, Provider } from "../src/index.js";
 
 type AuthoredModelData = z.infer<typeof AuthoredModel>;
 
@@ -106,6 +106,28 @@ describe("model schema", () => {
         ).toBe(false);
       }
     }
+  });
+});
+
+describe("provider schema", () => {
+  const mergeGatewayProvider = {
+    id: "merge-gateway",
+    name: "Merge Gateway",
+    env: ["MERGE_GATEWAY_API_KEY"],
+    npm: "merge-gateway-ai-sdk-provider",
+    api: "https://api-gateway.merge.dev/v1/ai-sdk",
+    doc: "https://docs.merge.dev/merge-gateway",
+    models: {},
+  };
+
+  test("accepts Merge Gateway's native package with its OpenAI-compatible API", () => {
+    expect(Provider.safeParse(mergeGatewayProvider).success).toBe(true);
+  });
+
+  test("requires the compatibility API for the Merge Gateway package", () => {
+    const { api: _api, ...providerWithoutApi } = mergeGatewayProvider;
+
+    expect(Provider.safeParse(providerWithoutApi).success).toBe(false);
   });
 });
 

--- a/providers/merge-gateway/provider.toml
+++ b/providers/merge-gateway/provider.toml
@@ -15,4 +15,5 @@
 name = "Merge Gateway"
 env = ["MERGE_GATEWAY_API_KEY"]
 npm = "merge-gateway-ai-sdk-provider"
+api = "https://api-gateway.merge.dev/v1/ai-sdk"
 doc = "https://docs.merge.dev/merge-gateway"


### PR DESCRIPTION
## Summary

- Add Merge Gateway's OpenAI-compatible base URL to its provider metadata
- Allow `merge-gateway-ai-sdk-provider` to declare an `api` URL
- Add schema coverage for the native-package-plus-compatible-API combination

## Why

Merge Gateway supports two integration surfaces:

1. The native `merge-gateway-ai-sdk-provider`, which exposes typed Merge Gateway functionality.
2. An OpenAI-compatible API at `https://api-gateway.merge.dev/v1/ai-sdk`.

models.dev currently records only the native package. Consumers that do not bundle that package but can integrate OpenAI-compatible APIs through the `api` field cannot discover the compatible endpoint and may omit Merge Gateway entirely.

Recording both surfaces makes the provider metadata more complete and portable. This follows the existing OpenRouter pattern: retain the feature-complete native provider while also publishing the compatible API URL for generic consumers.

## Why retain the native package?

Changing `npm` to `@ai-sdk/openai-compatible` would improve generic compatibility but hide the native provider and its Merge Gateway-specific functionality, including routing controls, tags, project association, thinking configuration, and routing metadata.

Publishing both `npm` and `api` preserves the native integration while providing a standards-based fallback.

## Schema change

The provider schema currently permits the native-package-plus-API combination for OpenRouter but forbids `api` for other custom packages. This PR extends that validation to Merge Gateway and requires the compatibility URL whenever `merge-gateway-ai-sdk-provider` is used.

## Compatibility

- Existing consumers can continue using `merge-gateway-ai-sdk-provider`.
- Generic consumers can use the OpenAI-compatible API.
- Model IDs, model metadata, pricing, and catalog synchronization are unchanged.
- The compatibility base URL does not include `/chat/completions`; clients append that path.

## Validation

- `bun test packages/core/test/schema.test.ts` - 8 passed
- `bun validate` - passed; generated Merge Gateway with 164 models and the expected `npm`, `api`, and `env` fields
- `cd packages/sdk && bun run test` - 23 passed
- `git diff --check` - passed
- Verified that `@ai-sdk/openai-compatible` constructs `POST https://api-gateway.merge.dev/v1/ai-sdk/chat/completions` with bearer authentication and Merge Gateway model IDs

## Sources

- https://github.com/merge-api/merge-gateway-ai-sdk-provider
- https://docs.merge.dev/merge-gateway
- https://github.com/anomalyco/models.dev/blob/dev/providers/openrouter/provider.toml
