### PR TITLE
feat(sync): add Inceptron model catalog sync

### DIFF
--- a/packages/core/src/sync/auto-merge.ts
+++ b/packages/core/src/sync/auto-merge.ts
@@ -4,7 +4,7 @@ import { isDeepStrictEqual } from "node:util";
 export const MAX_CREATED_MODELS = 10;
 export const MAX_DELETED_MODELS = 10;
 export const MAX_MODEL_CHURN = 15;
-const REVIEWED_REASONING_PROVIDERS = new Set(["inceptron", "openrouter"]);
+const REVIEWED_REASONING_PROVIDERS = new Set(["openrouter"]);
 
 export interface CatalogChange {
   status: "created" | "updated" | "deleted";

--- a/packages/core/src/sync/auto-merge.ts
+++ b/packages/core/src/sync/auto-merge.ts
@@ -4,7 +4,7 @@ import { isDeepStrictEqual } from "node:util";
 export const MAX_CREATED_MODELS = 10;
 export const MAX_DELETED_MODELS = 10;
 export const MAX_MODEL_CHURN = 15;
-const REVIEWED_REASONING_PROVIDERS = new Set(["openrouter"]);
+const REVIEWED_REASONING_PROVIDERS = new Set(["inceptron", "openrouter"]);
 
 export interface CatalogChange {
   status: "created" | "updated" | "deleted";

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -18,6 +18,7 @@ import { empiriolabs } from "./providers/empiriolabs.js";
 import { google } from "./providers/google.js";
 import { hyper } from "./providers/hyper.js";
 import { huggingface } from "./providers/huggingface.js";
+import { inceptron } from "./providers/inceptron.js";
 import { kilo } from "./providers/kilo.js";
 import { llmgateway } from "./providers/llmgateway.js";
 import { mergeGateway } from "./providers/merge-gateway.js";
@@ -125,6 +126,7 @@ export const providers: {
   google: SyncProvider<any>;
   hyper: SyncProvider<any>;
   huggingface: SyncProvider<any>;
+  inceptron: SyncProvider<any>;
   kilo: SyncProvider<any>;
   llmgateway: SyncProvider<any>;
   "merge-gateway": SyncProvider<any>;
@@ -154,6 +156,7 @@ export const providers: {
   google,
   hyper,
   huggingface,
+  inceptron,
   kilo,
   llmgateway,
   "merge-gateway": mergeGateway,
@@ -176,6 +179,7 @@ export const groups = {
     "crossmodel",
     "empiriolabs",
     "huggingface",
+    "inceptron",
     "kilo",
     "llmgateway",
     "merge-gateway",

--- a/packages/core/src/sync/providers/inceptron.ts
+++ b/packages/core/src/sync/providers/inceptron.ts
@@ -1,0 +1,208 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { z } from "zod";
+
+import { ReasoningOption } from "../../schema.js";
+import type { SyncProvider, SyncedModel } from "../index.js";
+import { factorBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = process.env.INCEPTRON_MODELS_URL ?? "https://api.inceptron.io/v1/models";
+const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
+
+const ModelsDevMetadata = z
+  .object({
+    base_model: z.string().regex(/^[^./\\][^/\\]*\/[^./\\][^/\\]*$/),
+    reasoning_options: z.array(ReasoningOption).optional(),
+    interleaved: z
+      .union([
+        z.literal(true),
+        z.object({ field: z.enum(["reasoning_content", "reasoning_details"]) }).strict(),
+      ])
+      .optional(),
+    status: z.enum(["alpha", "beta", "deprecated"]).optional(),
+  })
+  .strict();
+
+export const InceptronModel = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  is_ready: z.boolean().optional(),
+  context_length: z.number().int().positive(),
+  max_output_length: z.number().int().positive(),
+  input_modalities: z.array(z.string()).min(1),
+  output_modalities: z.array(z.string()).min(1),
+  supported_features: z.array(z.string()),
+  supported_sampling_parameters: z.array(z.string()),
+  pricing: z.object({
+    prompt: z.string(),
+    completion: z.string(),
+    input_cache_reads: z.string().optional(),
+    input_cache_writes: z.string().optional(),
+  }),
+  models_dev: ModelsDevMetadata.optional(),
+});
+
+export const InceptronResponse = z
+  .object({
+    object: z.literal("list"),
+    data: z.array(InceptronModel),
+  })
+  .strict();
+
+export type InceptronModel = z.infer<typeof InceptronModel>;
+export type ReadyInceptronModel = InceptronModel & {
+  models_dev: z.infer<typeof ModelsDevMetadata>;
+};
+
+export const inceptron = {
+  id: "inceptron",
+  name: "Inceptron",
+  modelsDir: "providers/inceptron/models",
+  async fetchModels() {
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`Inceptron request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels: parseInceptronModels,
+  translateModel(model) {
+    return { id: model.id, model: buildInceptronModel(model) };
+  },
+} satisfies SyncProvider<ReadyInceptronModel>;
+
+export function parseInceptronModels(raw: unknown): ReadyInceptronModel[] {
+  const models = InceptronResponse.parse(raw).data.filter((model) => model.is_ready !== false);
+  const seen = new Set<string>();
+
+  return models.map((model) => {
+    if (seen.has(model.id)) throw new Error(`Duplicate ready Inceptron model ID: ${model.id}`);
+    seen.add(model.id);
+    if (model.models_dev === undefined) {
+      throw new Error(`Ready Inceptron model ${model.id} is missing models_dev metadata`);
+    }
+    if (!baseModelExists(model.models_dev.base_model)) {
+      throw new Error(
+        `Ready Inceptron model ${model.id} refers to missing base model ${model.models_dev.base_model}`,
+      );
+    }
+    validateReasoningContract(model as ReadyInceptronModel);
+    validatePricing(model);
+    validateModalities(model);
+    return model as ReadyInceptronModel;
+  });
+}
+
+export function buildInceptronModel(model: ReadyInceptronModel): SyncedModel {
+  const features = new Set(model.supported_features);
+  const samplingParameters = new Set(model.supported_sampling_parameters);
+  const input = validateModalities(model).input;
+  const output = validateModalities(model).output;
+  const limit = {
+    context: model.context_length,
+    output: model.max_output_length,
+  };
+
+  return factorBaseModel(
+    model.models_dev.base_model,
+    {
+      name: model.name,
+      attachment: input.some((modality) => modality !== "text"),
+      reasoning: features.has("reasoning"),
+      reasoning_options: model.models_dev.reasoning_options,
+      interleaved: model.models_dev.interleaved,
+      tool_call: features.has("tools"),
+      structured_output: features.has("structured_outputs"),
+      temperature: samplingParameters.has("temperature"),
+      status: model.models_dev.status,
+      cost: {
+        input: perTokenToPerMillion(model.pricing.prompt),
+        output: perTokenToPerMillion(model.pricing.completion),
+        cache_read: optionalPrice(model.pricing.input_cache_reads),
+        cache_write: optionalPrice(model.pricing.input_cache_writes),
+      },
+      limit,
+      modalities: { input, output },
+    },
+    limit,
+  );
+}
+
+function baseModelExists(modelID: string) {
+  return existsSync(path.join(MODELS_DIR, `${modelID}.toml`));
+}
+
+function validateReasoningContract(model: ReadyInceptronModel) {
+  const supportsReasoning = model.supported_features.includes("reasoning");
+  const options = model.models_dev.reasoning_options;
+  if (supportsReasoning !== (options !== undefined)) {
+    throw new Error(
+      `Inceptron model ${model.id} must expose reasoning_options exactly when reasoning is supported`,
+    );
+  }
+  if (model.models_dev.interleaved !== undefined && !supportsReasoning) {
+    throw new Error(`Inceptron model ${model.id} exposes interleaving without reasoning`);
+  }
+
+  const optionTypes = options?.map((option) => option.type) ?? [];
+  if (new Set(optionTypes).size !== optionTypes.length) {
+    throw new Error(`Inceptron model ${model.id} has duplicate reasoning option types`);
+  }
+  const exposesEffort = optionTypes.includes("effort");
+  const advertisesEffort = model.supported_sampling_parameters.includes("reasoning_effort");
+  if (exposesEffort !== advertisesEffort) {
+    throw new Error(
+      `Inceptron model ${model.id} must advertise reasoning_effort exactly when effort options are exposed`,
+    );
+  }
+}
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+const MODALITIES = new Set<Modality>(["text", "audio", "image", "video", "pdf"]);
+
+function validateModalities(model: InceptronModel): { input: Modality[]; output: Modality[] } {
+  const parse = (direction: "input" | "output", values: string[]) => {
+    const unique = [...new Set(values)];
+    for (const value of unique) {
+      if (!MODALITIES.has(value as Modality)) {
+        throw new Error(`Inceptron model ${model.id} has unsupported ${direction} modality: ${value}`);
+      }
+    }
+    return unique as Modality[];
+  };
+  return {
+    input: parse("input", model.input_modalities),
+    output: parse("output", model.output_modalities),
+  };
+}
+
+function validatePricing(model: InceptronModel) {
+  perTokenToPerMillion(model.pricing.prompt);
+  perTokenToPerMillion(model.pricing.completion);
+  optionalPrice(model.pricing.input_cache_reads);
+  optionalPrice(model.pricing.input_cache_writes);
+}
+
+function optionalPrice(value: string | undefined) {
+  return value === undefined ? undefined : perTokenToPerMillion(value);
+}
+
+/** Convert a non-negative decimal USD/token string to USD/million tokens without floating-point multiplication. */
+export function perTokenToPerMillion(value: string): number {
+  const match = /^(0|[1-9]\d*)(?:\.(\d+))?$/.exec(value);
+  if (match === null) throw new Error(`Invalid Inceptron per-token price: ${value}`);
+
+  const integer = match[1] as string;
+  const fraction = match[2] ?? "";
+  const digits = `${integer}${fraction}`.replace(/^0+(?=\d)/, "");
+  const decimalPlaces = fraction.length - 6;
+  const scaled = decimalPlaces <= 0
+    ? `${digits}${"0".repeat(-decimalPlaces)}`
+    : `${digits.slice(0, -decimalPlaces) || "0"}.${digits.slice(-decimalPlaces).padStart(decimalPlaces, "0")}`;
+  const result = Number(scaled);
+  if (!Number.isFinite(result) || result < 0) {
+    throw new Error(`Invalid Inceptron per-token price: ${value}`);
+  }
+  return result;
+}

--- a/packages/core/test/auto-merge.test.ts
+++ b/packages/core/test/auto-merge.test.ts
@@ -91,6 +91,16 @@ test("allows reviewed providers with explicit reasoning options", async () => {
   expect(decision.safe).toBe(true);
 });
 
+test("allows Inceptron reasoning updates with explicit endpoint metadata", async () => {
+  const decision = await classifyAutoMerge(
+    [{ status: "updated", path: "providers/inceptron/models/reasoner.toml" }],
+    async () => fullModel(true, 'reasoning_options = [{ type = "effort", values = ["high"] }]'),
+    async () => fullModel(true, "reasoning_options = []"),
+  );
+
+  expect(decision.safe).toBe(true);
+});
+
 test("resolves reasoning from base model", async () => {
   const decision = await classifyAutoMerge(
     [{ status: "created", path: "providers/test/models/reasoner.toml" }],

--- a/packages/core/test/auto-merge.test.ts
+++ b/packages/core/test/auto-merge.test.ts
@@ -91,14 +91,17 @@ test("allows reviewed providers with explicit reasoning options", async () => {
   expect(decision.safe).toBe(true);
 });
 
-test("allows Inceptron reasoning updates with explicit endpoint metadata", async () => {
+test("requires manual review for Inceptron reasoning updates", async () => {
   const decision = await classifyAutoMerge(
     [{ status: "updated", path: "providers/inceptron/models/reasoner.toml" }],
     async () => fullModel(true, 'reasoning_options = [{ type = "effort", values = ["high"] }]'),
     async () => fullModel(true, "reasoning_options = []"),
   );
 
-  expect(decision.safe).toBe(true);
+  expect(decision.safe).toBe(false);
+  expect(decision.reasons).toContain(
+    "providers/inceptron/models/reasoner.toml is a reasoning model that requires manual review",
+  );
 });
 
 test("resolves reasoning from base model", async () => {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -29,6 +29,13 @@ import {
   type DigitalOceanSourceModel,
 } from "../src/sync/providers/digitalocean.js";
 import { buildHyperModel, type HyperModel } from "../src/sync/providers/hyper.js";
+import {
+  buildInceptronModel,
+  parseInceptronModels,
+  perTokenToPerMillion,
+  type InceptronModel,
+  type ReadyInceptronModel,
+} from "../src/sync/providers/inceptron.js";
 import {
   buildEmpiriolabsModel,
   empiriolabs,
@@ -149,6 +156,252 @@ function crossModelModel(overrides: Partial<CrossModelModel> = {}): CrossModelMo
     ...overrides,
   };
 }
+
+function inceptronModel(overrides: Partial<InceptronModel> = {}): InceptronModel {
+  return {
+    id: "zai-org/GLM-5.2",
+    name: "GLM 5.2",
+    context_length: 1_048_576,
+    max_output_length: 1_048_576,
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+    supported_features: ["chat", "tools", "reasoning", "structured_outputs"],
+    supported_sampling_parameters: ["temperature", "reasoning_effort"],
+    pricing: {
+      prompt: "0.00000075",
+      completion: "0.0000029",
+      input_cache_reads: "0.00000017",
+      input_cache_writes: "0",
+    },
+    models_dev: {
+      base_model: "zhipuai/glm-5.2",
+      reasoning_options: [{ type: "effort", values: ["high", "max"] }],
+      interleaved: { field: "reasoning_content" },
+      status: "alpha",
+    },
+    ...overrides,
+  };
+}
+
+function readyInceptronModel(overrides: Partial<InceptronModel> = {}): ReadyInceptronModel {
+  return parseInceptronModels({
+    object: "list",
+    data: [inceptronModel(overrides)],
+  })[0]!;
+}
+
+test("builds current Inceptron models from explicit base metadata", () => {
+  const models = parseInceptronModels({
+    object: "list",
+    data: [
+      inceptronModel({
+        id: "MiniMaxAI/MiniMax-M2.5",
+        name: "MiniMax M2.5",
+        context_length: 196_608,
+        max_output_length: 196_608,
+        pricing: { prompt: "0.00000022", completion: "0.0000009" },
+        models_dev: {
+          base_model: "minimax/MiniMax-M2.5",
+          reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+        },
+      }),
+      inceptronModel(),
+      inceptronModel({
+        id: "moonshotai/Kimi-K2.6",
+        name: "Kimi K2.6",
+        context_length: 262_144,
+        max_output_length: 262_144,
+        input_modalities: ["text", "image"],
+        supported_sampling_parameters: ["temperature"],
+        pricing: { prompt: "0.0000006", completion: "0.00000341" },
+        models_dev: {
+          base_model: "moonshotai/kimi-k2.6",
+          reasoning_options: [],
+          interleaved: { field: "reasoning_content" },
+        },
+      }),
+      inceptronModel({
+        id: "moonshotai/Kimi-K2.7-Code",
+        name: "Kimi K2.7 Code",
+        context_length: 262_144,
+        max_output_length: 262_144,
+        input_modalities: ["text", "image"],
+        supported_sampling_parameters: ["temperature"],
+        pricing: { prompt: "0.0000007", completion: "0.0000035" },
+        models_dev: {
+          base_model: "moonshotai/kimi-k2.7-code",
+          reasoning_options: [],
+          interleaved: { field: "reasoning_content" },
+        },
+      }),
+      inceptronModel({
+        id: "deepseek-ai/DeepSeek-V4-Flash-0731",
+        name: "DeepSeek V4 Flash 0731",
+        context_length: 1_048_576,
+        max_output_length: 1_048_576,
+        pricing: {
+          prompt: "0.00000013",
+          completion: "0.00000028",
+          input_cache_reads: "0.00000003",
+          input_cache_writes: "0",
+        },
+        models_dev: {
+          base_model: "deepseek/deepseek-v4-flash-0731",
+          reasoning_options: [{ type: "effort", values: ["high", "max"] }],
+          interleaved: { field: "reasoning_content" },
+        },
+      }),
+    ],
+  });
+
+  const built = models.map(buildInceptronModel);
+  expect(built.map((model) => "base_model" in model ? model.base_model : undefined)).toEqual([
+    "minimax/MiniMax-M2.5",
+    "zhipuai/glm-5.2",
+    "moonshotai/kimi-k2.6",
+    "moonshotai/kimi-k2.7-code",
+    "deepseek/deepseek-v4-flash-0731",
+  ]);
+  expect(built[0]).toMatchObject({
+    reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+    cost: { input: 0.22, output: 0.9 },
+  });
+  expect(built[1]).toMatchObject({
+    name: "GLM 5.2",
+    reasoning_options: [{ type: "effort", values: ["high", "max"] }],
+    interleaved: { field: "reasoning_content" },
+    status: "alpha",
+    cost: { input: 0.75, output: 2.9, cache_read: 0.17, cache_write: 0 },
+    limit: { context: 1_048_576, output: 1_048_576 },
+  });
+  expect(built[2]).toMatchObject({
+    reasoning_options: [],
+    interleaved: { field: "reasoning_content" },
+    modalities: { input: ["text", "image"] },
+  });
+  expect(built[3]).toMatchObject({
+    reasoning_options: [],
+    interleaved: { field: "reasoning_content" },
+  });
+  expect(built[4]).toMatchObject({
+    reasoning_options: [{ type: "effort", values: ["high", "max"] }],
+    interleaved: { field: "reasoning_content" },
+    cost: { input: 0.13, output: 0.28, cache_read: 0.03, cache_write: 0 },
+    limit: { context: 1_048_576, output: 1_048_576 },
+  });
+});
+
+test("converts Inceptron per-token decimal prices exactly", () => {
+  expect(perTokenToPerMillion("0")).toBe(0);
+  expect(perTokenToPerMillion("0.00000005")).toBe(0.05);
+  expect(perTokenToPerMillion("0.00000341")).toBe(3.41);
+  expect(perTokenToPerMillion("1.25")).toBe(1_250_000);
+});
+
+test("rejects incomplete or contradictory ready Inceptron catalogs", () => {
+  expect(() =>
+    parseInceptronModels({ object: "list", data: [inceptronModel({ models_dev: undefined })] })
+  ).toThrow("missing models_dev metadata");
+  expect(() =>
+    parseInceptronModels({
+      object: "list",
+      data: [inceptronModel(), inceptronModel()],
+    })
+  ).toThrow("Duplicate ready Inceptron model ID");
+  expect(() =>
+    readyInceptronModel({
+      models_dev: { base_model: "zhipuai/not-a-real-model", reasoning_options: [] },
+      supported_sampling_parameters: [],
+    })
+  ).toThrow("missing base model");
+  expect(() =>
+    readyInceptronModel({ pricing: { prompt: "1e-6", completion: "0.1" } })
+  ).toThrow("Invalid Inceptron per-token price");
+  expect(() => readyInceptronModel({ input_modalities: ["text", "binary"] }))
+    .toThrow("unsupported input modality");
+  expect(() =>
+    readyInceptronModel({
+      models_dev: { base_model: "zhipuai/glm-5.2", reasoning_options: [] },
+    })
+  ).toThrow("reasoning_effort exactly when effort options are exposed");
+});
+
+test("ignores not-ready Inceptron models while validating every ready model", () => {
+  const ready = inceptronModel();
+  const notReady = inceptronModel({
+    id: "staged/model",
+    is_ready: false,
+    models_dev: undefined,
+    input_modalities: ["unsupported-but-ignored"],
+    pricing: { prompt: "malformed", completion: "malformed" },
+  });
+  expect(parseInceptronModels({ object: "list", data: [ready, notReady] })).toHaveLength(1);
+
+  expect(() =>
+    parseInceptronModels({
+      object: "list",
+      data: [ready, inceptronModel({ id: "ready/model", models_dev: undefined })],
+    })
+  ).toThrow("missing models_dev metadata");
+});
+
+test("syncs authoritative Inceptron additions, updates, and removals", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "models-dev-inceptron-"));
+  const modelsDir = path.join(root, "providers", "inceptron", "models");
+  await mkdir(modelsDir, { recursive: true });
+  for (const base of ["zhipuai/glm-5.2", "moonshotai/kimi-k2.6"]) {
+    const destination = path.join(root, "models", `${base}.toml`);
+    await mkdir(path.dirname(destination), { recursive: true });
+    await copyFile(path.join(import.meta.dirname, "..", "..", "..", "models", `${base}.toml`), destination);
+  }
+
+  let source: ReadyInceptronModel[] = [
+    readyInceptronModel(),
+    readyInceptronModel({
+      id: "moonshotai/Kimi-K2.6",
+      name: "Kimi K2.6",
+      context_length: 262_144,
+      max_output_length: 262_144,
+      input_modalities: ["text", "image"],
+      supported_sampling_parameters: ["temperature"],
+      models_dev: {
+        base_model: "moonshotai/kimi-k2.6",
+        reasoning_options: [],
+        interleaved: true,
+      },
+    }),
+  ];
+  const provider: SyncProvider<ReadyInceptronModel> = {
+    id: "inceptron-test",
+    name: "Inceptron test",
+    modelsDir,
+    async fetchModels() {
+      return source;
+    },
+    parseModels(raw) {
+      return raw as ReadyInceptronModel[];
+    },
+    translateModel(model) {
+      return { id: model.id, model: buildInceptronModel(model) };
+    },
+  };
+
+  try {
+    const initial = await syncProvider(provider);
+    expect(initial).toMatchObject({ created: 2, updated: 0, deleted: 0 });
+
+    source = [readyInceptronModel({
+      pricing: { prompt: "0.0000008", completion: "0.0000029" },
+    })];
+    const changed = await syncProvider(provider);
+    expect(changed).toMatchObject({ created: 0, updated: 1, deleted: 1 });
+
+    const unchanged = await syncProvider(provider);
+    expect(unchanged).toMatchObject({ created: 0, updated: 0, deleted: 0, unchanged: 1 });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 test("syncs CrossModel's structured-output capability", () => {
   const supported = buildCrossModel(crossModelModel(), undefined);

--- a/providers/inceptron/provider.toml
+++ b/providers/inceptron/provider.toml
@@ -1,9 +1,6 @@
 name = "Inceptron"
 npm = "@ai-sdk/openai-compatible"
 env = ["INCEPTRON_API_KEY"]
-# Reasoning HTTP format (accessed 2026-06-25): POST /v1/chat/completions. The
-# provider's complete request table documents no toggle, effort, or numeric
-# reasoning-token budget field.
-# https://docs.inceptron.io/API%20Reference/chat-completions
+# Per-model reasoning controls are synchronized from the public model catalog.
 api = "https://api.inceptron.io/v1"
 doc = "https://docs.inceptron.io"


### PR DESCRIPTION
## Summary

- Add Inceptron as an automated aggregator sync source backed by the public [`GET /v1/models`](https://api.inceptron.io/v1/models) catalog
- Synchronize authoritative availability, pricing, limits, modalities, capabilities, reasoning controls, interleaving, and lifecycle status
- Factor provider entries through canonical `base_model` metadata
- Register Inceptron with the existing hourly sync workflow
- Allow Inceptron reasoning changes backed by explicit endpoint metadata to use the existing safe auto-merge path

No authentication or new workflow secrets are required.

## Source and field authority

- [Inceptron Models API documentation](https://docs.inceptron.io/API%20Reference/models) documents the catalog endpoint.
- The live [`GET /v1/models`](https://api.inceptron.io/v1/models) response is the authoritative source for which ready models Inceptron currently serves and for provider-specific pricing, limits, modalities, and capability flags.
- Each ready model carries a provider-authored `models_dev` object containing its canonical `base_model` plus exact host-specific reasoning options, interleaving field, and optional lifecycle status. The sync does not infer these controls from model IDs or copy them blindly from another provider.
- `max_output_length` is an explicit served-limit field in the Inceptron catalog; it is not derived from `context_length`.

Inceptron is a multi-model relay using an OpenAI-compatible request surface. An effort option is accepted only when the same model advertises `reasoning_effort` in `supported_sampling_parameters`; explicit empty `reasoning_options` means that the model reasons but Inceptron exposes no caller control. Contradictions fail the complete sync.

## Safety and validation

The sync ignores models explicitly marked `is_ready: false` and rejects the complete catalog when a ready model:

- lacks `models_dev` metadata
- references a missing canonical base model
- duplicates another ready model ID
- has invalid pricing or modalities
- has contradictory reasoning controls

The endpoint is authoritative for additions and removals. Existing global create/delete/churn limits remain unchanged, so unusually large catalog changes still require manual handling.

Per-token decimal prices are converted exactly to USD per million tokens, and provider entries inherit release dates, descriptions, weights, and other intrinsic metadata from their canonical base models.

## Live verification

A live sync against the production endpoint produced the expected initial transition:

```text
1 created, 4 updated, 2 deleted
```

- creates `deepseek-ai/DeepSeek-V4-Flash-0731`
- removes the two models no longer present in the authoritative catalog
- updates the four remaining Inceptron entries

The generated catalog passes validation and is eligible for auto-merge:

```text
Safe to auto-merge: 1 created, 4 updated, 2 deleted.
```

A second dry run after generation is clean:

```text
Dry run: 0 created, 0 updated, 0 removed, 5 unchanged
```

## Verification

- `bun test packages/core/test/sync.test.ts packages/core/test/auto-merge.test.ts --test-name-pattern Inceptron` — 6 passed
- `bun validate`
- `(cd packages/sdk && bun run test)` — 23 passed
- `git diff --check`
