### PR TITLE
Add DeepSeek V4 Pro 0813

### DIFF
--- a/models/deepseek/deepseek-v4-pro-0813.toml
+++ b/models/deepseek/deepseek-v4-pro-0813.toml
@@ -1,0 +1,19 @@
+name = "DeepSeek V4 Pro 0813"
+description = "DeepSeek V4 Pro snapshot with million-token context and support for thinking and non-thinking modes"
+family = "deepseek-thinking"
+release_date = "2026-08-12"
+last_updated = "2026-08-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -1,21 +1,11 @@
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-12)
+base_model = "deepseek/deepseek-v4-pro-0813"
 name = "DeepSeek V4 Pro"
-description = "Open MoE flagship with million-token context for coding and long agent runs"
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.
 # Anthropic: `thinking.type`, `output_config.effort = high|max`; budget ignored.
 # https://api-docs.deepseek.com/api/create-chat-completion (accessed 2026-06-25)
-family = "deepseek-thinking"
-release_date = "2026-04-24"
-last_updated = "2026-04-24"
-attachment = false
-reasoning = true
-temperature = true
-knowledge = "2025-05"
-tool_call = true
-structured_output = true
-open_weights = true
 
 [[reasoning_options]]
 type = "toggle"
@@ -32,11 +22,3 @@ input = 0.435
 output = 0.87
 reasoning = 0.87
 cache_read = 0.003625
-
-[limit]
-context = 1_000_000
-output = 384_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/openrouter/models/deepseek/deepseek-v4-pro-0813.toml
+++ b/providers/openrouter/models/deepseek/deepseek-v4-pro-0813.toml
@@ -1,14 +1,5 @@
-name = "DeepSeek V4 Pro 0813"
-description = "Flagship DeepSeek model for coding, reasoning, and agentic work"
-family = "deepseek"
-release_date = "2026-08-12"
-last_updated = "2026-08-12"
-attachment = false
-reasoning = true
-temperature = true
-tool_call = true
+base_model = "deepseek/deepseek-v4-pro-0813"
 structured_output = false
-open_weights = false
 
 [[reasoning_options]]
 type = "toggle"
@@ -24,8 +15,3 @@ cache_read = 0.003625
 
 [limit]
 context = 1_048_576
-output = 384_000
-
-[modalities]
-input = ["text"]
-output = ["text"]


### PR DESCRIPTION
## Summary

- Add canonical metadata for DeepSeek V4 Pro 0813.
- Point DeepSeek's `deepseek-v4-pro` route to the new snapshot.
- Link OpenRouter's synced `deepseek/deepseek-v4-pro-0813` entry to the canonical model while keeping its provider-specific overrides.

Official weights for the 0813 snapshot have not been published, so `open_weights` is set to `false`.

## Sources

- https://api-docs.deepseek.com/quick_start/pricing/
- https://openrouter.ai/api/v1/models
- https://openrouter.ai/api/v1/models/deepseek/deepseek-v4-pro-0813/endpoints

## Validation

- `npx --yes --cache /tmp/models-dev-npm-cache bun@1.3.0 ./packages/core/script/validate.ts`
- `git diff --check`
