### PR TITLE
feat(provider): add Nexforce Router

### DIFF
--- a/models/alibaba/qwen-2.5-coder-32b.toml
+++ b/models/alibaba/qwen-2.5-coder-32b.toml
@@ -1,0 +1,25 @@
+name = "Qwen2.5-Coder-32B"
+description = "Open instruction-tuned coding model for code generation, repair, and tool-driven workflows"
+family = "qwen"
+release_date = "2024-11-12"
+last_updated = "2024-11-12"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2024-10"
+open_weights = true
+license = "Apache-2.0"
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct"

--- a/models/alibaba/qwen3-30b.toml
+++ b/models/alibaba/qwen3-30b.toml
@@ -1,0 +1,25 @@
+name = "Qwen3 30B A3B"
+description = "Open hybrid-thinking Qwen model for self-hosted chat, reasoning, and coding"
+family = "qwen"
+release_date = "2025-07-31"
+last_updated = "2025-07-31"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2025-04"
+open_weights = true
+license = "Apache-2.0"
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/Qwen3-30B-A3B"

--- a/models/alibaba/qwq-32b.toml
+++ b/models/alibaba/qwq-32b.toml
@@ -1,0 +1,24 @@
+name = "QwQ-32B"
+description = "Open reasoning model for math, science, and deliberate step-by-step problem solving"
+family = "qvq"
+release_date = "2025-03-06"
+last_updated = "2025-03-06"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+knowledge = "2025-01"
+open_weights = true
+license = "Apache-2.0"
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/Qwen/QwQ-32B"

--- a/models/deepseek/deepseek-r1-distill-32b.toml
+++ b/models/deepseek/deepseek-r1-distill-32b.toml
@@ -1,0 +1,23 @@
+name = "DeepSeek-R1-Distill-Qwen-32B"
+description = "Open distilled reasoning model that brings R1's deliberate thinking to a compact dense size"
+family = "deepseek-thinking"
+release_date = "2025-01-20"
+last_updated = "2025-01-20"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = false
+knowledge = "2024-07"
+open_weights = true
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"

--- a/models/meta/llama-3.1-8b.toml
+++ b/models/meta/llama-3.1-8b.toml
@@ -1,0 +1,24 @@
+name = "Llama-3.1-8B"
+description = "Compact open Llama instruction model for efficient chat and on-device workloads"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-03"
+open_weights = true
+license = "Llama 3.1 Community License"
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct"

--- a/models/minimax/MiniMax-M2.1-highspeed.toml
+++ b/models/minimax/MiniMax-M2.1-highspeed.toml
@@ -1,0 +1,18 @@
+name = "MiniMax-M2.1-highspeed"
+description = "High-speed MiniMax model for low-latency coding and agent workflows"
+family = "minimax"
+release_date = "2025-12-23"
+last_updated = "2025-12-23"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = true
+
+[limit]
+context = 204_800
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/mistral/mistral-7b.toml
+++ b/models/mistral/mistral-7b.toml
@@ -1,0 +1,24 @@
+name = "Mistral 7B"
+description = "Early open Mistral model balancing efficiency, fluency, and broad instruction following"
+family = "mistral"
+release_date = "2023-09-27"
+last_updated = "2023-09-27"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+knowledge = "2023-09"
+open_weights = true
+license = "Apache-2.0"
+
+[limit]
+context = 32_768
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2"

--- a/models/openai/gpt-5.3-codex-spark.toml
+++ b/models/openai/gpt-5.3-codex-spark.toml
@@ -1,0 +1,20 @@
+name = "GPT-5.3 Codex Spark"
+description = "Fast coding-optimized GPT model for repository edits, reviews, and agentic software work"
+family = "gpt-codex-spark"
+release_date = "2026-02-05"
+last_updated = "2026-02-05"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2025-08-31"
+open_weights = false
+
+[limit]
+context = 128_000
+output = 32_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/models/openai/gpt-5.6.toml
+++ b/models/openai/gpt-5.6.toml
@@ -1,0 +1,21 @@
+name = "GPT-5.6"
+description = "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows"
+family = "gpt"
+release_date = "2026-07-09"
+last_updated = "2026-07-09"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2026-02-16"
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/models/xai/grok-4.20-multi-agent-0309.toml
+++ b/models/xai/grok-4.20-multi-agent-0309.toml
@@ -1,0 +1,19 @@
+name = "Grok 4.20 Multi-Agent"
+description = "Grok snapshot tuned for multi-agent orchestration and long-horizon collaborative tool use"
+family = "grok"
+release_date = "2026-03-09"
+last_updated = "2026-03-09"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "requesty:sync": "bun ./packages/core/script/sync-models.ts requesty",
     "merge-gateway:sync": "bun ./packages/core/script/sync-models.ts merge-gateway",
     "nano-gpt:sync": "bun ./packages/core/script/sync-models.ts nano-gpt",
+    "nexforce:sync": "bun ./packages/core/script/sync-models.ts nexforce",
     "venice:sync": "bun ./packages/core/script/sync-models.ts venice",
     "tinfoil:sync": "bun ./packages/core/script/sync-models.ts tinfoil",
     "vercel:generate": "bun ./packages/core/script/sync-models.ts vercel",

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -24,6 +24,7 @@ import { kilo } from "./providers/kilo.js";
 import { llmgateway } from "./providers/llmgateway.js";
 import { mergeGateway } from "./providers/merge-gateway.js";
 import { nanoGpt } from "./providers/nano-gpt.js";
+import { nexforce } from "./providers/nexforce.js";
 import { openai } from "./providers/openai.js";
 import { ofox } from "./providers/ofox.js";
 import { openrouter } from "./providers/openrouter.js";
@@ -133,6 +134,7 @@ export const providers: {
   llmgateway: SyncProvider<any>;
   "merge-gateway": SyncProvider<any>;
   "nano-gpt": SyncProvider<any>;
+  nexforce: SyncProvider<any>;
   ofox: SyncProvider<any>;
   openai: SyncProvider<any>;
   openrouter: SyncProvider<any>;
@@ -164,6 +166,7 @@ export const providers: {
   llmgateway,
   "merge-gateway": mergeGateway,
   "nano-gpt": nanoGpt,
+  nexforce,
   ofox,
   openai,
   openrouter,
@@ -188,6 +191,7 @@ export const groups = {
     "llmgateway",
     "merge-gateway",
     "nano-gpt",
+    "nexforce",
     "ofox",
     "requesty",
     "openrouter",

--- a/packages/core/src/sync/providers/nexforce.ts
+++ b/packages/core/src/sync/providers/nexforce.ts
@@ -1,0 +1,234 @@
+import { z } from "zod";
+
+import type { SyncedFullModel, SyncProvider, SyncedModel } from "../index.js";
+import {
+  factorBaseModel,
+  resolveModelMetadataBaseModel,
+} from "./openrouter.js";
+
+const API_ENDPOINT = "https://router.nexforce.ai/v1/models";
+
+/**
+ * Catalog IDs that do not match their canonical metadata filename but describe
+ * the same underlying model. Nexforce serves the branded/streamlined ids;
+ * metadata resolution maps them onto the canonical file.
+ */
+const NEXFORCE_BASE_MODEL_OVERRIDES = {
+  "google/gemma-4-26b": "google/gemma-4-26b-a4b-it",
+  "meta-llama/llama-3.3-70b": "meta/llama-3.3-70b-instruct",
+  "meta-llama/llama-4-scout-17b": "meta/llama-4-scout-17b-instruct",
+  "mistralai/mistral-small-3.1-24b": "mistral/mistral-small-3-1-24b-instruct-2503",
+  "nvidia/nemotron-3-120b": "nvidia/nemotron-3-super-120b-a12b",
+} as const;
+
+/**
+ * Reasoning controls per canonical model, mirroring the underlying model's
+ * OpenAI-compatible surface (first-party labs and same-surface relays:
+ * provider files for deepseek/alibaba/zhipuai/moonshotai/google, OpenRouter and
+ * FastRouter for the OpenAI-compat relay surface). Nexforce passes chat
+ * completion parameters through to the upstream model.
+ */
+const REASONING_OPTIONS: Record<string, SyncedFullModel["reasoning_options"]> = {
+  "anthropic/claude-fable-5": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "anthropic/claude-haiku-4-5": [{ type: "budget_tokens", min: 1_024 }],
+  "anthropic/claude-haiku-4-5-20251001": [{ type: "budget_tokens", min: 1_024 }],
+  "anthropic/claude-opus-4-5": [{ type: "effort", values: ["low", "medium", "high"] }, { type: "budget_tokens", min: 1_024 }],
+  "anthropic/claude-opus-4-5-20251101": [{ type: "effort", values: ["low", "medium", "high"] }, { type: "budget_tokens", min: 1_024 }],
+  "anthropic/claude-opus-4-6": [{ type: "effort", values: ["low", "medium", "high", "max"] }, { type: "budget_tokens", min: 1_024 }],
+  "anthropic/claude-opus-4-7": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "anthropic/claude-opus-4-8": [{ type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "anthropic/claude-opus-5": [{ type: "toggle" }, { type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "anthropic/claude-sonnet-4-5": [{ type: "budget_tokens", min: 1_024 }],
+  "anthropic/claude-sonnet-4-5-20250929": [{ type: "budget_tokens", min: 1_024 }],
+  "anthropic/claude-sonnet-4-6": [{ type: "effort", values: ["low", "medium", "high", "max"] }, { type: "budget_tokens", min: 1_024 }],
+  "anthropic/claude-sonnet-5": [{ type: "toggle" }, { type: "effort", values: ["low", "medium", "high", "xhigh", "max"] }],
+  "deepseek/deepseek-v4-flash": [{ type: "toggle" }, { type: "effort", values: ["high", "max"] }],
+  "deepseek/deepseek-v4-pro": [{ type: "toggle" }, { type: "effort", values: ["high", "max"] }],
+  "deepseek/deepseek-r1-distill-32b": [],
+  "google/deep-research-max-preview-04-2026": [],
+  "google/deep-research-preview-04-2026": [],
+  "google/gemini-2.5-computer-use-preview-10-2025": [],
+  "google/gemini-2.5-flash": [{ type: "toggle" }, { type: "budget_tokens", min: 0, max: 24_576 }],
+  "google/gemini-2.5-flash-image": [],
+  "google/gemini-2.5-flash-lite": [{ type: "toggle" }, { type: "budget_tokens", min: 512, max: 24_576 }],
+  "google/gemini-2.5-pro": [{ type: "budget_tokens", min: 128, max: 32_768 }],
+  "google/gemini-3-flash-preview": [{ type: "toggle" }, { type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "google/gemini-3-pro-image": [],
+  "google/gemini-3-pro-image-preview": [],
+  "google/gemini-3.1-flash-image": [{ type: "toggle" }, { type: "effort", values: ["minimal", "high"] }],
+  "google/gemini-3.1-flash-image-preview": [{ type: "toggle" }, { type: "effort", values: ["minimal", "high"] }],
+  "google/gemini-3.1-flash-lite": [{ type: "toggle" }, { type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "google/gemini-3.1-flash-lite-image": [{ type: "toggle" }, { type: "effort", values: ["minimal", "high"] }],
+  "google/gemini-3.1-flash-lite-preview": [{ type: "toggle" }, { type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "google/gemini-3.1-pro-preview": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "google/gemini-3.1-pro-preview-customtools": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "google/gemini-3.5-flash": [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "google/gemini-3.5-flash-lite": [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "google/gemini-3.6-flash": [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "google/gemini-flash-latest": [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "google/gemini-flash-lite-latest": [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "google/gemini-robotics-er-1.6-preview": [{ type: "toggle" }, { type: "budget_tokens", min: 0 }],
+  "google/gemma-4-26b-a4b-it": [{ type: "toggle" }],
+  "minimax/MiniMax-M2": [],
+  "minimax/MiniMax-M2.1": [],
+  "minimax/MiniMax-M2.1-highspeed": [],
+  "minimax/MiniMax-M2.5": [],
+  "minimax/MiniMax-M2.5-highspeed": [],
+  "minimax/MiniMax-M2.7": [],
+  "minimax/MiniMax-M2.7-highspeed": [],
+  "minimax/MiniMax-M3": [{ type: "toggle" }],
+  "moonshotai/kimi-k2.5": [{ type: "toggle" }],
+  "moonshotai/kimi-k2.6": [{ type: "toggle" }],
+  "moonshotai/kimi-k2.7-code": [],
+  "moonshotai/kimi-k2.7-code-highspeed": [],
+  "moonshotai/kimi-k3": [{ type: "toggle" }, { type: "effort", values: ["low", "high", "max"] }],
+  "nvidia/nemotron-3-super-120b-a12b": [],
+  "openai/gpt-5": [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "openai/gpt-5-mini": [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "openai/gpt-5-nano": [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  "openai/gpt-5-pro": [{ type: "effort", values: ["high"] }],
+  "openai/gpt-5.1": [{ type: "effort", values: ["none", "low", "medium", "high"] }],
+  "openai/gpt-5.2": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "openai/gpt-5.2-chat-latest": [{ type: "effort", values: ["medium"] }],
+  "openai/gpt-5.2-pro": [{ type: "effort", values: ["medium", "high", "xhigh"] }],
+  "openai/gpt-5.3-codex": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "openai/gpt-5.3-codex-spark": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "openai/gpt-5.4": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "openai/gpt-5.4-mini": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "openai/gpt-5.4-nano": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "openai/gpt-5.4-pro": [{ type: "effort", values: ["medium", "high", "xhigh"] }],
+  "openai/gpt-5.5": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh"] }],
+  "openai/gpt-5.5-pro": [{ type: "effort", values: ["medium", "high", "xhigh"] }],
+  "openai/gpt-5.6": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }],
+  "openai/gpt-5.6-luna": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }],
+  "openai/gpt-5.6-sol": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }],
+  "openai/gpt-5.6-terra": [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }],
+  "openai/o1": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "openai/o1-pro": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "openai/o3": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "openai/o3-mini": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "openai/o3-pro": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "openai/o4-mini": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "xai/grok-4.20-0309-reasoning": [],
+  "xai/grok-4.20-multi-agent-0309": [],
+  "xai/grok-4.3": [{ type: "effort", values: ["none", "low", "medium", "high"] }],
+  "xai/grok-4.5": [{ type: "effort", values: ["low", "medium", "high"] }],
+  "xai/grok-build-0.1": [],
+  "zhipuai/glm-4.5": [{ type: "toggle" }],
+  "zhipuai/glm-4.5-air": [{ type: "toggle" }],
+  "zhipuai/glm-4.5-flash": [{ type: "toggle" }],
+  "zhipuai/glm-4.5v": [{ type: "toggle" }],
+  "zhipuai/glm-4.6": [{ type: "toggle" }],
+  "zhipuai/glm-4.6v": [{ type: "toggle" }],
+  "zhipuai/glm-4.7": [{ type: "toggle" }],
+  "zhipuai/glm-4.7-flash": [{ type: "toggle" }],
+  "zhipuai/glm-4.7-flashx": [{ type: "toggle" }],
+  "zhipuai/glm-5": [{ type: "toggle" }],
+  "zhipuai/glm-5-turbo": [{ type: "toggle" }],
+  "zhipuai/glm-5.1": [{ type: "toggle" }],
+  "zhipuai/glm-5.2": [{ type: "effort", values: ["high", "max"] }],
+  "alibaba/qwen3-30b": [{ type: "toggle" }],
+  "alibaba/qwq-32b": [],
+};
+
+const NexforceArchitecture = z
+  .object({
+    input_modalities: z.array(z.string()),
+    output_modalities: z.array(z.string()),
+  })
+  .passthrough()
+  .optional();
+
+export const NexforceModel = z
+  .object({
+    id: z.string().min(1),
+    object: z.literal("model"),
+    kind: z.literal("chat").or(z.literal("embedding")),
+    name: z.string().min(1).optional(),
+    created: z.number().int().nonnegative(),
+    context_length: z.number().int().positive().optional(),
+    max_output_tokens: z.number().int().positive().optional(),
+    architecture: NexforceArchitecture,
+  })
+  .passthrough();
+
+export const NexforceResponse = z
+  .object({
+    object: z.literal("list"),
+    data: z.array(NexforceModel),
+  })
+  .passthrough();
+
+export type NexforceModel = z.infer<typeof NexforceModel>;
+
+export const nexforce = {
+  id: "nexforce",
+  name: "Nexforce",
+  modelsDir: "providers/nexforce/models",
+  async fetchModels() {
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(
+        `Nexforce models request failed: ${response.status} ${response.statusText}`,
+      );
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return NexforceResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    // Embeddings are served on a separate endpoint and are not chat models.
+    if (model.kind !== "chat") return undefined;
+
+    const canonical = resolveNexforceBaseModel(model.id);
+    if (canonical === undefined) {
+      // Host-only surfaces (e.g. `nexforce/smart-route`) stay hand-authored.
+      const authored = context.authored(model.id);
+      return authored === undefined
+        ? undefined
+        : { id: model.id, model: authored as SyncedModel };
+    }
+
+    const existing = context.existing(model.id);
+    const limit = {
+      context: model.context_length,
+      output: model.max_output_tokens,
+    };
+    const values = {
+      name: model.name,
+      reasoning_options:
+        REASONING_OPTIONS[canonical] ?? existing?.reasoning_options,
+      limit,
+      modalities: model.architecture === undefined
+        ? undefined
+        : {
+            input: modalities(model.architecture.input_modalities),
+            output: modalities(model.architecture.output_modalities),
+          },
+    };
+
+    return {
+      id: model.id,
+      model: factorBaseModel(canonical, values, limit),
+    };
+  },
+} satisfies SyncProvider<NexforceModel>;
+
+export function resolveNexforceBaseModel(id: string) {
+  const override = NEXFORCE_BASE_MODEL_OVERRIDES[
+    id as keyof typeof NEXFORCE_BASE_MODEL_OVERRIDES
+  ];
+  return override ?? resolveModelMetadataBaseModel(id);
+}
+
+function modalities(values: string[]): SyncedFullModel["modalities"]["input"] {
+  const allowed = new Set(["text", "audio", "image", "video", "pdf"]);
+  const result = values
+    .map((value) => value.toLowerCase())
+    .map((value) => (value === "file" ? "pdf" : value))
+    .filter((value): value is SyncedFullModel["modalities"]["input"][number] =>
+      allowed.has(value),
+    );
+  return [...new Set(result)];
+}

--- a/providers/nexforce/logo.svg
+++ b/providers/nexforce/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M12 12 6.1 6.1M12 12l5.9-5.9M12 12l-5.9 5.9M12 12l5.9 5.9" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
+  <circle cx="12" cy="12" r="2.3" fill="currentColor"/>
+  <circle cx="5.4" cy="5.4" r="1.4" fill="currentColor"/>
+  <circle cx="18.6" cy="5.4" r="1.4" fill="currentColor"/>
+  <circle cx="5.4" cy="18.6" r="1.4" fill="currentColor"/>
+  <circle cx="18.6" cy="18.6" r="1.4" fill="currentColor"/>
+</svg>

--- a/providers/nexforce/models/anthropic/claude-fable-5.toml
+++ b/providers/nexforce/models/anthropic/claude-fable-5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-fable-5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/nexforce/models/anthropic/claude-haiku-4-5-20251001.toml
+++ b/providers/nexforce/models/anthropic/claude-haiku-4-5-20251001.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-haiku-4-5-20251001"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024

--- a/providers/nexforce/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/nexforce/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-haiku-4-5"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024

--- a/providers/nexforce/models/anthropic/claude-opus-4-5-20251101.toml
+++ b/providers/nexforce/models/anthropic/claude-opus-4-5-20251101.toml
@@ -1,0 +1,9 @@
+base_model = "anthropic/claude-opus-4-5-20251101"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024

--- a/providers/nexforce/models/anthropic/claude-opus-4-5.toml
+++ b/providers/nexforce/models/anthropic/claude-opus-4-5.toml
@@ -1,0 +1,9 @@
+base_model = "anthropic/claude-opus-4-5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024

--- a/providers/nexforce/models/anthropic/claude-opus-4-6.toml
+++ b/providers/nexforce/models/anthropic/claude-opus-4-6.toml
@@ -1,0 +1,9 @@
+base_model = "anthropic/claude-opus-4-6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024

--- a/providers/nexforce/models/anthropic/claude-opus-4-7.toml
+++ b/providers/nexforce/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-7"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/nexforce/models/anthropic/claude-opus-4-8.toml
+++ b/providers/nexforce/models/anthropic/claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/nexforce/models/anthropic/claude-opus-5.toml
+++ b/providers/nexforce/models/anthropic/claude-opus-5.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-opus-5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/nexforce/models/anthropic/claude-sonnet-4-5-20250929.toml
+++ b/providers/nexforce/models/anthropic/claude-sonnet-4-5-20250929.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-sonnet-4-5-20250929"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[limit]
+context = 1_000_000

--- a/providers/nexforce/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/nexforce/models/anthropic/claude-sonnet-4-5.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-sonnet-4-5"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[limit]
+context = 1_000_000

--- a/providers/nexforce/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/nexforce/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[limit]
+output = 128_000

--- a/providers/nexforce/models/anthropic/claude-sonnet-5.toml
+++ b/providers/nexforce/models/anthropic/claude-sonnet-5.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-sonnet-5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/nexforce/models/deepseek/deepseek-r1-distill-32b.toml
+++ b/providers/nexforce/models/deepseek/deepseek-r1-distill-32b.toml
@@ -1,0 +1,3 @@
+base_model = "deepseek/deepseek-r1-distill-32b"
+name = "DeepSeek R1 Distill 32B"
+reasoning_options = []

--- a/providers/nexforce/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/nexforce/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]

--- a/providers/nexforce/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/nexforce/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]

--- a/providers/nexforce/models/google/deep-research-max-preview-04-2026.toml
+++ b/providers/nexforce/models/google/deep-research-max-preview-04-2026.toml
@@ -1,0 +1,6 @@
+base_model = "google/deep-research-max-preview-04-2026"
+name = "Deep Research Max Preview (Apr-21-2026)"
+reasoning_options = []
+
+[limit]
+context = 131_072

--- a/providers/nexforce/models/google/deep-research-preview-04-2026.toml
+++ b/providers/nexforce/models/google/deep-research-preview-04-2026.toml
@@ -1,0 +1,6 @@
+base_model = "google/deep-research-preview-04-2026"
+name = "Deep Research Preview (Apr-21-2026)"
+reasoning_options = []
+
+[limit]
+context = 131_072

--- a/providers/nexforce/models/google/gemini-2.5-computer-use-preview-10-2025.toml
+++ b/providers/nexforce/models/google/gemini-2.5-computer-use-preview-10-2025.toml
@@ -1,0 +1,7 @@
+base_model = "google/gemini-2.5-computer-use-preview-10-2025"
+name = "Gemini 2.5 Computer Use Preview 10-2025"
+reasoning_options = []
+
+[limit]
+context = 131_072
+output = 65_536

--- a/providers/nexforce/models/google/gemini-2.5-flash-image.toml
+++ b/providers/nexforce/models/google/gemini-2.5-flash-image.toml
@@ -1,0 +1,2 @@
+base_model = "google/gemini-2.5-flash-image"
+reasoning_options = []

--- a/providers/nexforce/models/google/gemini-2.5-flash-lite.toml
+++ b/providers/nexforce/models/google/gemini-2.5-flash-lite.toml
@@ -1,0 +1,9 @@
+base_model = "google/gemini-2.5-flash-lite"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 512
+max = 24_576

--- a/providers/nexforce/models/google/gemini-2.5-flash.toml
+++ b/providers/nexforce/models/google/gemini-2.5-flash.toml
@@ -1,0 +1,9 @@
+base_model = "google/gemini-2.5-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 24_576

--- a/providers/nexforce/models/google/gemini-2.5-pro.toml
+++ b/providers/nexforce/models/google/gemini-2.5-pro.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-2.5-pro"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 128
+max = 32_768

--- a/providers/nexforce/models/google/gemini-3-flash-preview.toml
+++ b/providers/nexforce/models/google/gemini-3-flash-preview.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3-flash-preview"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-3-pro-image-preview.toml
+++ b/providers/nexforce/models/google/gemini-3-pro-image-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3-pro-image-preview"
+reasoning_options = []
+
+[limit]
+context = 131_072

--- a/providers/nexforce/models/google/gemini-3-pro-image.toml
+++ b/providers/nexforce/models/google/gemini-3-pro-image.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3-pro-image"
+reasoning_options = []
+
+[limit]
+context = 131_072

--- a/providers/nexforce/models/google/gemini-3.1-flash-image-preview.toml
+++ b/providers/nexforce/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.1-flash-image-preview"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "high"]

--- a/providers/nexforce/models/google/gemini-3.1-flash-image.toml
+++ b/providers/nexforce/models/google/gemini-3.1-flash-image.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-3.1-flash-image"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "high"]
+
+[limit]
+context = 65_536
+output = 65_536

--- a/providers/nexforce/models/google/gemini-3.1-flash-lite-image.toml
+++ b/providers/nexforce/models/google/gemini-3.1-flash-lite-image.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.1-flash-lite-image"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "high"]
+
+[limit]
+output = 65_536

--- a/providers/nexforce/models/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/nexforce/models/google/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/nexforce/models/google/gemini-3.1-flash-lite.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.1-flash-lite"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/nexforce/models/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-pro-preview-customtools"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-3.1-pro-preview.toml
+++ b/providers/nexforce/models/google/gemini-3.1-pro-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-3.5-flash-lite.toml
+++ b/providers/nexforce/models/google/gemini-3.5-flash-lite.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.5-flash-lite"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-3.5-flash.toml
+++ b/providers/nexforce/models/google/gemini-3.5-flash.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.5-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-3.6-flash.toml
+++ b/providers/nexforce/models/google/gemini-3.6-flash.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.6-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-flash-latest.toml
+++ b/providers/nexforce/models/google/gemini-flash-latest.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-flash-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-flash-lite-latest.toml
+++ b/providers/nexforce/models/google/gemini-flash-lite-latest.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-flash-lite-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/google/gemini-robotics-er-1.6-preview.toml
+++ b/providers/nexforce/models/google/gemini-robotics-er-1.6-preview.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-robotics-er-1.6-preview"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0

--- a/providers/nexforce/models/google/gemma-4-26b.toml
+++ b/providers/nexforce/models/google/gemma-4-26b.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemma-4-26b-a4b-it"
+name = "Gemma 4 26B"
+
+[[reasoning_options]]
+type = "toggle"
+
+[limit]
+context = 256_000

--- a/providers/nexforce/models/meta-llama/llama-3.1-8b.toml
+++ b/providers/nexforce/models/meta-llama/llama-3.1-8b.toml
@@ -1,0 +1,2 @@
+base_model = "meta/llama-3.1-8b"
+name = "Llama 3.1 8B"

--- a/providers/nexforce/models/meta-llama/llama-3.2-1b.toml
+++ b/providers/nexforce/models/meta-llama/llama-3.2-1b.toml
@@ -1,0 +1,2 @@
+base_model = "meta/llama-3.2-1b"
+name = "Llama 3.2 1B"

--- a/providers/nexforce/models/meta-llama/llama-3.2-3b.toml
+++ b/providers/nexforce/models/meta-llama/llama-3.2-3b.toml
@@ -1,0 +1,6 @@
+base_model = "meta/llama-3.2-3b"
+name = "Llama 3.2 3B"
+
+[limit]
+context = 128_000
+output = 4_096

--- a/providers/nexforce/models/meta-llama/llama-3.3-70b.toml
+++ b/providers/nexforce/models/meta-llama/llama-3.3-70b.toml
@@ -1,0 +1,2 @@
+base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama 3.3 70B"

--- a/providers/nexforce/models/meta-llama/llama-4-scout-17b.toml
+++ b/providers/nexforce/models/meta-llama/llama-4-scout-17b.toml
@@ -1,0 +1,2 @@
+base_model = "meta/llama-4-scout-17b-instruct"
+name = "Llama 4 Scout 17B"

--- a/providers/nexforce/models/minimax/MiniMax-M2.1-highspeed.toml
+++ b/providers/nexforce/models/minimax/MiniMax-M2.1-highspeed.toml
@@ -1,0 +1,3 @@
+base_model = "minimax/MiniMax-M2.1-highspeed"
+name = "MiniMax M2.1 Highspeed"
+reasoning_options = []

--- a/providers/nexforce/models/minimax/MiniMax-M2.1.toml
+++ b/providers/nexforce/models/minimax/MiniMax-M2.1.toml
@@ -1,0 +1,3 @@
+base_model = "minimax/MiniMax-M2.1"
+name = "MiniMax M2.1"
+reasoning_options = []

--- a/providers/nexforce/models/minimax/MiniMax-M2.5-highspeed.toml
+++ b/providers/nexforce/models/minimax/MiniMax-M2.5-highspeed.toml
@@ -1,0 +1,3 @@
+base_model = "minimax/MiniMax-M2.5-highspeed"
+name = "MiniMax M2.5 Highspeed"
+reasoning_options = []

--- a/providers/nexforce/models/minimax/MiniMax-M2.5.toml
+++ b/providers/nexforce/models/minimax/MiniMax-M2.5.toml
@@ -1,0 +1,3 @@
+base_model = "minimax/MiniMax-M2.5"
+name = "MiniMax M2.5"
+reasoning_options = []

--- a/providers/nexforce/models/minimax/MiniMax-M2.7-highspeed.toml
+++ b/providers/nexforce/models/minimax/MiniMax-M2.7-highspeed.toml
@@ -1,0 +1,3 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
+name = "MiniMax M2.7 Highspeed"
+reasoning_options = []

--- a/providers/nexforce/models/minimax/MiniMax-M2.7.toml
+++ b/providers/nexforce/models/minimax/MiniMax-M2.7.toml
@@ -1,0 +1,3 @@
+base_model = "minimax/MiniMax-M2.7"
+name = "MiniMax M2.7"
+reasoning_options = []

--- a/providers/nexforce/models/minimax/MiniMax-M2.toml
+++ b/providers/nexforce/models/minimax/MiniMax-M2.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M2"
+name = "MiniMax M2"
+reasoning_options = []
+
+[limit]
+context = 204_800

--- a/providers/nexforce/models/minimax/MiniMax-M3.toml
+++ b/providers/nexforce/models/minimax/MiniMax-M3.toml
@@ -1,0 +1,11 @@
+base_model = "minimax/MiniMax-M3"
+name = "MiniMax M3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[limit]
+context = 1_000_000
+
+[modalities]
+input = ["text"]

--- a/providers/nexforce/models/mistralai/mistral-7b.toml
+++ b/providers/nexforce/models/mistralai/mistral-7b.toml
@@ -1,0 +1,1 @@
+base_model = "mistral/mistral-7b"

--- a/providers/nexforce/models/mistralai/mistral-small-3.1-24b.toml
+++ b/providers/nexforce/models/mistralai/mistral-small-3.1-24b.toml
@@ -1,0 +1,1 @@
+base_model = "mistral/mistral-small-3-1-24b-instruct-2503"

--- a/providers/nexforce/models/moonshotai/kimi-k2.5.toml
+++ b/providers/nexforce/models/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[modalities]
+input = ["text"]

--- a/providers/nexforce/models/moonshotai/kimi-k2.6.toml
+++ b/providers/nexforce/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[[reasoning_options]]
+type = "toggle"
+
+[modalities]
+input = ["text"]

--- a/providers/nexforce/models/moonshotai/kimi-k2.7-code-highspeed.toml
+++ b/providers/nexforce/models/moonshotai/kimi-k2.7-code-highspeed.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
+name = "Kimi K2.7 Code HighSpeed"
+reasoning_options = []
+
+[modalities]
+input = ["text", "image"]

--- a/providers/nexforce/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/nexforce/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,5 @@
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[modalities]
+input = ["text", "image"]

--- a/providers/nexforce/models/moonshotai/kimi-k3.toml
+++ b/providers/nexforce/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[modalities]
+input = ["text", "image"]

--- a/providers/nexforce/models/nexforce/smart-route.toml
+++ b/providers/nexforce/models/nexforce/smart-route.toml
@@ -1,0 +1,22 @@
+# Host-only routing alias: Nexforce picks an equivalent model per request,
+# preserving required capabilities (tools, vision). Unique to the Nexforce
+# catalog, so this is authored inline. Served model is reported via
+# X-Nexforce-Served-Model response header.
+# https://router.nexforce.ai/docs (accessed 2026-08-12)
+name = "Nexforce Smart Route"
+description = "Routing alias that lets the Nexforce router pick an equivalent model per request, preserving required capabilities (tools, vision)"
+release_date = "2026-08-12"
+last_updated = "2026-08-12"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/nexforce/models/nvidia/nemotron-3-120b.toml
+++ b/providers/nexforce/models/nvidia/nemotron-3-120b.toml
@@ -1,0 +1,2 @@
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+reasoning_options = []

--- a/providers/nexforce/models/openai/gpt-3.5-turbo.toml
+++ b/providers/nexforce/models/openai/gpt-3.5-turbo.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-3.5-turbo"

--- a/providers/nexforce/models/openai/gpt-4-turbo.toml
+++ b/providers/nexforce/models/openai/gpt-4-turbo.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4-turbo"

--- a/providers/nexforce/models/openai/gpt-4.1-mini.toml
+++ b/providers/nexforce/models/openai/gpt-4.1-mini.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4.1-mini"

--- a/providers/nexforce/models/openai/gpt-4.1-nano.toml
+++ b/providers/nexforce/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4.1-nano"

--- a/providers/nexforce/models/openai/gpt-4.1.toml
+++ b/providers/nexforce/models/openai/gpt-4.1.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4.1"

--- a/providers/nexforce/models/openai/gpt-4.toml
+++ b/providers/nexforce/models/openai/gpt-4.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4"

--- a/providers/nexforce/models/openai/gpt-4o-2024-05-13.toml
+++ b/providers/nexforce/models/openai/gpt-4o-2024-05-13.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4o-2024-05-13"

--- a/providers/nexforce/models/openai/gpt-4o-2024-08-06.toml
+++ b/providers/nexforce/models/openai/gpt-4o-2024-08-06.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4o-2024-08-06"

--- a/providers/nexforce/models/openai/gpt-4o-2024-11-20.toml
+++ b/providers/nexforce/models/openai/gpt-4o-2024-11-20.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4o-2024-11-20"

--- a/providers/nexforce/models/openai/gpt-4o-mini.toml
+++ b/providers/nexforce/models/openai/gpt-4o-mini.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4o-mini"

--- a/providers/nexforce/models/openai/gpt-4o.toml
+++ b/providers/nexforce/models/openai/gpt-4o.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-4o"

--- a/providers/nexforce/models/openai/gpt-5-mini.toml
+++ b/providers/nexforce/models/openai/gpt-5-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5-mini"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/openai/gpt-5-nano.toml
+++ b/providers/nexforce/models/openai/gpt-5-nano.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5-nano"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/openai/gpt-5-pro.toml
+++ b/providers/nexforce/models/openai/gpt-5-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high"]

--- a/providers/nexforce/models/openai/gpt-5.1.toml
+++ b/providers/nexforce/models/openai/gpt-5.1.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.1"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]

--- a/providers/nexforce/models/openai/gpt-5.2-chat-latest.toml
+++ b/providers/nexforce/models/openai/gpt-5.2-chat-latest.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.2-chat-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["medium"]

--- a/providers/nexforce/models/openai/gpt-5.2-pro.toml
+++ b/providers/nexforce/models/openai/gpt-5.2-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.2-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.2.toml
+++ b/providers/nexforce/models/openai/gpt-5.2.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.3-chat-latest.toml
+++ b/providers/nexforce/models/openai/gpt-5.3-chat-latest.toml
@@ -1,0 +1,1 @@
+base_model = "openai/gpt-5.3-chat-latest"

--- a/providers/nexforce/models/openai/gpt-5.3-codex-spark.toml
+++ b/providers/nexforce/models/openai/gpt-5.3-codex-spark.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.3-codex-spark"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.3-codex.toml
+++ b/providers/nexforce/models/openai/gpt-5.3-codex.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.3-codex"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.4-mini.toml
+++ b/providers/nexforce/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-mini"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.4-nano.toml
+++ b/providers/nexforce/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-nano"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.4-pro.toml
+++ b/providers/nexforce/models/openai/gpt-5.4-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.4.toml
+++ b/providers/nexforce/models/openai/gpt-5.4.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.5-pro.toml
+++ b/providers/nexforce/models/openai/gpt-5.5-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.5-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.5.toml
+++ b/providers/nexforce/models/openai/gpt-5.5.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]

--- a/providers/nexforce/models/openai/gpt-5.6-luna.toml
+++ b/providers/nexforce/models/openai/gpt-5.6-luna.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.6-luna"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]

--- a/providers/nexforce/models/openai/gpt-5.6-sol.toml
+++ b/providers/nexforce/models/openai/gpt-5.6-sol.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.6-sol"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]

--- a/providers/nexforce/models/openai/gpt-5.6-terra.toml
+++ b/providers/nexforce/models/openai/gpt-5.6-terra.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.6-terra"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]

--- a/providers/nexforce/models/openai/gpt-5.6.toml
+++ b/providers/nexforce/models/openai/gpt-5.6.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]

--- a/providers/nexforce/models/openai/gpt-5.toml
+++ b/providers/nexforce/models/openai/gpt-5.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]

--- a/providers/nexforce/models/openai/o1-pro.toml
+++ b/providers/nexforce/models/openai/o1-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o1-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/nexforce/models/openai/o1.toml
+++ b/providers/nexforce/models/openai/o1.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o1"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/nexforce/models/openai/o3-mini.toml
+++ b/providers/nexforce/models/openai/o3-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o3-mini"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/nexforce/models/openai/o3-pro.toml
+++ b/providers/nexforce/models/openai/o3-pro.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o3-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/nexforce/models/openai/o3.toml
+++ b/providers/nexforce/models/openai/o3.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/nexforce/models/openai/o4-mini.toml
+++ b/providers/nexforce/models/openai/o4-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/o4-mini"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/nexforce/models/qwen/qwen-2.5-coder-32b.toml
+++ b/providers/nexforce/models/qwen/qwen-2.5-coder-32b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen-2.5-coder-32b"
+name = "Qwen2.5 Coder 32B"
+
+[limit]
+context = 128_000
+output = 8_192

--- a/providers/nexforce/models/qwen/qwen3-30b.toml
+++ b/providers/nexforce/models/qwen/qwen3-30b.toml
@@ -1,0 +1,4 @@
+base_model = "alibaba/qwen3-30b"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/qwen/qwq-32b.toml
+++ b/providers/nexforce/models/qwen/qwq-32b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwq-32b"
+name = "QwQ 32B"
+reasoning_options = []
+
+[limit]
+output = 8_192

--- a/providers/nexforce/models/x-ai/grok-4.20-0309-non-reasoning.toml
+++ b/providers/nexforce/models/x-ai/grok-4.20-0309-non-reasoning.toml
@@ -1,0 +1,5 @@
+base_model = "xai/grok-4.20-0309-non-reasoning"
+name = "Grok 4.20 (non-reasoning)"
+
+[modalities]
+input = ["text", "image"]

--- a/providers/nexforce/models/x-ai/grok-4.20-0309-reasoning.toml
+++ b/providers/nexforce/models/x-ai/grok-4.20-0309-reasoning.toml
@@ -1,0 +1,6 @@
+base_model = "xai/grok-4.20-0309-reasoning"
+name = "Grok 4.20 (reasoning)"
+reasoning_options = []
+
+[modalities]
+input = ["text", "image"]

--- a/providers/nexforce/models/x-ai/grok-4.20-multi-agent-0309.toml
+++ b/providers/nexforce/models/x-ai/grok-4.20-multi-agent-0309.toml
@@ -1,0 +1,2 @@
+base_model = "xai/grok-4.20-multi-agent-0309"
+reasoning_options = []

--- a/providers/nexforce/models/x-ai/grok-4.3.toml
+++ b/providers/nexforce/models/x-ai/grok-4.3.toml
@@ -1,0 +1,8 @@
+base_model = "xai/grok-4.3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[modalities]
+input = ["text", "image"]

--- a/providers/nexforce/models/x-ai/grok-4.5.toml
+++ b/providers/nexforce/models/x-ai/grok-4.5.toml
@@ -1,0 +1,5 @@
+base_model = "xai/grok-4.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/nexforce/models/x-ai/grok-build-0.1.toml
+++ b/providers/nexforce/models/x-ai/grok-build-0.1.toml
@@ -1,0 +1,5 @@
+base_model = "xai/grok-build-0.1"
+reasoning_options = []
+
+[modalities]
+input = ["text", "image"]

--- a/providers/nexforce/models/z-ai/glm-4.5-air.toml
+++ b/providers/nexforce/models/z-ai/glm-4.5-air.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-4.5-air"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-4.5-flash.toml
+++ b/providers/nexforce/models/z-ai/glm-4.5-flash.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-4.5-flash"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-4.5.toml
+++ b/providers/nexforce/models/z-ai/glm-4.5.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-4.5"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-4.5v.toml
+++ b/providers/nexforce/models/z-ai/glm-4.5v.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-4.5v"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-4.6.toml
+++ b/providers/nexforce/models/z-ai/glm-4.6.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-4.6"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-4.6v.toml
+++ b/providers/nexforce/models/z-ai/glm-4.6v.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-4.6v"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-4.7-flash.toml
+++ b/providers/nexforce/models/z-ai/glm-4.7-flash.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-4.7-flash"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-4.7-flashx.toml
+++ b/providers/nexforce/models/z-ai/glm-4.7-flashx.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-4.7-flashx"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-4.7.toml
+++ b/providers/nexforce/models/z-ai/glm-4.7.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-4.7"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-5-turbo.toml
+++ b/providers/nexforce/models/z-ai/glm-5-turbo.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-5-turbo"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-5.1.toml
+++ b/providers/nexforce/models/z-ai/glm-5.1.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-5.1"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/models/z-ai/glm-5.2.toml
+++ b/providers/nexforce/models/z-ai/glm-5.2.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]

--- a/providers/nexforce/models/z-ai/glm-5.toml
+++ b/providers/nexforce/models/z-ai/glm-5.toml
@@ -1,0 +1,4 @@
+base_model = "zhipuai/glm-5"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/nexforce/provider.toml
+++ b/providers/nexforce/provider.toml
@@ -1,0 +1,16 @@
+# OpenAI-compatible Chat Completions pass-through router.
+# Reasoning controls follow the upstream OpenAI-compatible surface per family:
+#   - Anthropic: reasoning.enabled / reasoning.effort / reasoning.budget_tokens (OpenAI-compat)
+#   - DeepSeek: thinking.type = enabled|disabled; reasoning_effort = high|max
+#   - OpenAI / o-series / Grok: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+#   - Google Gemini: thinking = enabled|disabled; thinking_budget (OpenAI-compat)
+#   - Moonshot Kimi / Zhipu GLM / Alibaba Qwen: enable_thinking true|false
+#   - MiniMax / DeepSeek distill / QwQ: no caller controls (host decides)
+# Live catalog: GET /v1/models is public (no key). Prices are Console-only, so
+# no [cost] is authored (request-only).
+# https://router.nexforce.ai/docs (accessed 2026-08-12)
+name = "Nexforce"
+env = ["NEXFORCE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://router.nexforce.ai/v1"
+doc = "https://router.nexforce.ai/docs"

--- a/sync.md
+++ b/sync.md
@@ -287,6 +287,18 @@ Requesty is implemented in `packages/core/src/sync/providers/requesty.ts`.
 - Region variants are written as separate models: `gpt-5.4` and `gpt-5.4@eu` are distinct files that share a `base_model` and differ only in served pricing and limits.
 - Prices are per-token USD and are converted to per-1M-token numbers. `pricing[]` bands become `cost.tiers`, with the first band as the flat `cost`. Price fields are nullable upstream, so a route quoting no prices gets no `[cost]` section rather than a fabricated zero.
 
+## Nexforce Notes
+
+Nexforce is implemented in `packages/core/src/sync/providers/nexforce.ts`.
+
+- Run it with `bun models:sync nexforce` or `bun nexforce:sync`.
+- Source endpoint: `https://router.nexforce.ai/v1/models`; no auth required (the public list needs no key, and a valid key only narrows it to that key's allowed models).
+- Only `kind == "chat"` models are synced; `kind == "embedding"` models are served on a separate endpoint and stay out of the provider catalog.
+- Catalog IDs map onto canonical `models/` metadata through `resolveModelMetadataBaseModel`; branded/streamlined IDs that resolve to a differently named canonical file use `NEXFORCE_BASE_MODEL_OVERRIDES`.
+- API-authoritative fields: display `name`, `context_length`, `max_output_tokens`, and `architecture` modalities. Models without a canonical entry (e.g. the host-only `nexforce/smart-route` alias) remain hand-authored and are preserved as-is.
+- `reasoning_options` is authored from a curated per-model map mirroring each model's OpenAI-compatible surface (first-party lab entries plus OpenRouter and FastRouter relays); authored options are preserved on re-sync.
+- No `[cost]` is authored: the API does not expose prices (they live in the Console), so all entries are request-only. `base_model_omit` is not needed for pricing.
+
 ## Venice Notes
 
 Venice is implemented in `packages/core/src/sync/providers/venice.ts`.


### PR DESCRIPTION
## Summary

Adds Nexforce as a new aggregator provider for its OpenAI-compatible inference router at `https://router.nexforce.ai/v1`.

- add a Nexforce sync module reading the public `GET /v1/models` catalog (no auth; prices are Console-only and not exposed, so all entries are request-only with no `[cost]`)
- wire the provider into the `aggregators` sync group and add a `nexforce:sync` script
- author 122 chat models as `base_model`-factored entries across 9 vendors (Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, xAI, MiniMax, Meta, Mistral, NVIDIA, Qwen), with `base_model` overrides for branded IDs (`google/gemma-4-26b`, `meta-llama/llama-3.3-70b`, `meta-llama/llama-4-scout-17b`, `mistralai/mistral-small-3.1-24b`, `nvidia/nemotron-3-120b`)
- add 10 canonical lab entries under `models/` so the host entries stay override-only (`openai/gpt-5.6`, `openai/gpt-5.3-codex-spark`, `alibaba/qwen3-30b`, `alibaba/qwq-32b`, `alibaba/qwen-2.5-coder-32b`, `deepseek/deepseek-r1-distill-32b`, `meta/llama-3.1-8b`, `mistral/mistral-7b`, `minimax/MiniMax-M2.1-highspeed`, `xai/grok-4.20-multi-agent-0309`)
- keep the host-only `nexforce/smart-route` routing alias as a hand-authored inline entry; embedding-kind models are skipped (separate endpoint)
- author `reasoning_options` per model from each model's OpenAI-compatible surface (`thinking.type`/`reasoning_effort` for DeepSeek, `enable_thinking` for Kimi/GLM/Qwen, `thinking`/`thinking_budget` for Gemini, `reasoning_effort` for GPT/o-series/Grok; no caller controls for MiniMax, QwQ, and the R1 distill) — wire-paths documented in `providers/nexforce/provider.toml`

Sources:
- https://router.nexforce.ai/docs
- https://router.nexforce.ai/v1/models

## Validation

- `bun validate` passes
- `bun models:sync nexforce` followed by a re-run `--dry-run` is a no-op (idempotent)
- `bun test`: 183 pass, 4 fail — the same 4 failures (snapshot build artifact, live-API-dependent tests) occur on clean `dev`
- chat roundtrip not executed: requires an `nfc_...` API key not available in this environment