### PR TITLE
feat(openrouter): capture promotional discounts and pre-discount prices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,16 @@ With `base_model`, do not restate fields already correct on the lab entry. Still
 - Convert other currencies and note rate/date in a **top-of-file** comment.
 - Optional keys on cost: `reasoning`, `cache_read`, `cache_write`, `input_audio`, `output_audio`.
 - **Context-based pricing → `[[cost.tiers]]`**, not `context_over_200k`.
+- **Promotional pricing → `discount`** plus the matching `*_list` keys. `discount` is the fraction already taken off (`0.35` = 35% off), and the ordinary price keys stay the price actually billed. `input_list`, `output_list`, `cache_read_list`, and `cache_write_list` record the provider's standard rate before that discount, so a promotion can be told apart from a real price cut. Only author them together — a `*_list` key without a `discount` says nothing.
+
+```toml
+[cost]
+input = 0.091      # billed
+output = 0.182
+discount = 0.35    # 35% off, already reflected above
+input_list = 0.14  # standard rate
+output_list = 0.28
+```
 
 ```toml
 [cost]

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -89,6 +89,36 @@ const Cost = z.object({
     .number()
     .min(0, "Audio output price cannot be negative")
     .optional(),
+  /**
+   * Fraction the prices above are already discounted by (0.25 = 25% off), for
+   * providers quoting a promotional rate. Every other price in this table is the
+   * discounted one actually billed, not the pre-discount rate.
+   */
+  discount: z
+    .number()
+    .min(0, "Discount cannot be negative")
+    .lt(1, "Discount must be below 1")
+    .optional(),
+  /**
+   * The provider's standard rates before `discount` was applied. Only set
+   * alongside a discount, so a price drop can be told apart from a promotion.
+   */
+  input_list: z
+    .number()
+    .min(0, "List input price cannot be negative")
+    .optional(),
+  output_list: z
+    .number()
+    .min(0, "List output price cannot be negative")
+    .optional(),
+  cache_read_list: z
+    .number()
+    .min(0, "List cache read price cannot be negative")
+    .optional(),
+  cache_write_list: z
+    .number()
+    .min(0, "List cache write price cannot be negative")
+    .optional(),
 }).strict();
 
 const CostTier = Cost.extend({

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -946,6 +946,21 @@ export function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
     if (model.cost.output_audio !== undefined) {
       lines.push(`output_audio = ${formatNumber(model.cost.output_audio)}`);
     }
+    if (model.cost.discount !== undefined) {
+      lines.push(`discount = ${formatNumber(model.cost.discount)}`);
+    }
+    if (model.cost.input_list !== undefined) {
+      lines.push(`input_list = ${formatNumber(model.cost.input_list)}`);
+    }
+    if (model.cost.output_list !== undefined) {
+      lines.push(`output_list = ${formatNumber(model.cost.output_list)}`);
+    }
+    if (model.cost.cache_read_list !== undefined) {
+      lines.push(`cache_read_list = ${formatNumber(model.cost.cache_read_list)}`);
+    }
+    if (model.cost.cache_write_list !== undefined) {
+      lines.push(`cache_write_list = ${formatNumber(model.cost.cache_write_list)}`);
+    }
 
     for (const tier of model.cost.tiers ?? []) {
       lines.push("", "[[cost.tiers]]");

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -7,6 +7,13 @@ import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
 
 const API_ENDPOINT = "https://openrouter.ai/api/v1/models";
+const ENDPOINTS_API = "https://openrouter.ai/api/v1/models";
+/**
+ * `/models` is one bulk call; discounts need one `/endpoints` call per model.
+ * Six at a time keeps a full catalog sweep well inside the sync job's budget
+ * without hammering the API.
+ */
+const ENDPOINTS_CONCURRENCY = 6;
 const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
 const modelMetadataByID = new Map<string, Record<string, unknown>>();
 const modelMetadataFilesByProvider = new Map<string, Set<string>>();
@@ -67,6 +74,12 @@ export const OpenRouterModel = z.object({
     internal_reasoning: z.string().optional(),
     input_cache_read: z.string().optional(),
     input_cache_write: z.string().optional(),
+    /**
+     * Not served by `/models`; merged in by `fetchModels` from the per-model
+     * `/endpoints` route. Present means the lookup was conclusive (`0` included);
+     * absent means unknown, and an authored discount should survive the sync.
+     */
+    discount: z.number().optional(),
     overrides: z.array(z.object({
       min_prompt_tokens: z.number().optional(),
       prompt: z.string().optional(),
@@ -97,21 +110,34 @@ export const OpenRouterResponse = z.object({
   data: z.array(OpenRouterModel),
 }).passthrough();
 
+export const OpenRouterEndpoint = z.object({
+  pricing: z.object({
+    prompt: z.string(),
+    completion: z.string(),
+    discount: z.number().optional(),
+  }).passthrough(),
+}).passthrough();
+
+export const OpenRouterEndpointsResponse = z.object({
+  data: z.object({
+    endpoints: z.array(OpenRouterEndpoint),
+  }).passthrough(),
+}).passthrough();
+
 export type OpenRouterModel = z.infer<typeof OpenRouterModel>;
+export type OpenRouterEndpoint = z.infer<typeof OpenRouterEndpoint>;
 
 export const openrouter = {
   id: "openrouter",
   name: "OpenRouter",
   modelsDir: "providers/openrouter/models",
   async fetchModels() {
-    const headers = process.env.OPENROUTER_API_KEY
-      ? { Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}` }
-      : undefined;
-    const response = await fetch(API_ENDPOINT, { headers });
+    const response = await fetch(API_ENDPOINT, { headers: authHeaders() });
     if (!response.ok) {
       throw new Error(`OpenRouter request failed: ${response.status} ${response.statusText}`);
     }
-    return response.json();
+    const raw = await response.json();
+    return mergeEndpointDiscounts(raw);
   },
   parseModels(raw) {
     // Temporarily skip batch routes (`*:batch`) — they are not catalog targets.
@@ -134,6 +160,112 @@ export const openrouter = {
   },
 } satisfies SyncProvider<OpenRouterModel>;
 
+function authHeaders() {
+  return process.env.OPENROUTER_API_KEY
+    ? { Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}` }
+    : undefined;
+}
+
+/**
+ * `/models` quotes a headline price without saying which of a model's provider
+ * routes it came from, and never mentions discounts. The per-model `/endpoints`
+ * route does both, so pair them here: whichever endpoint quotes exactly the
+ * headline price is the route the catalog is recording, and its `discount` is
+ * the one consistent with the `cost.input`/`cost.output` we write.
+ *
+ * Every lookup is fail-soft. A model whose discount cannot be established keeps
+ * `pricing.discount` absent so the sync preserves whatever is already authored
+ * rather than churning a file on a transient API failure.
+ */
+async function mergeEndpointDiscounts(raw: unknown): Promise<unknown> {
+  if (!isPlainObject(raw) || !Array.isArray(raw.data)) return raw;
+
+  const models = raw.data.filter(isPlainObject);
+  const discounts = await mapWithConcurrency(models, ENDPOINTS_CONCURRENCY, async (model) => {
+    const id = model.id;
+    const pricing = model.pricing;
+    if (typeof id !== "string" || !isPlainObject(pricing)) return undefined;
+    if (typeof pricing.prompt !== "string" || typeof pricing.completion !== "string") {
+      return undefined;
+    }
+    // Degraded routes are skipped by translateModel anyway; don't spend a request.
+    if (Number(pricing.prompt) < 0 || Number(pricing.completion) < 0) return undefined;
+
+    const endpoints = await fetchEndpoints(id);
+    if (endpoints === undefined) return undefined;
+    return resolveEndpointDiscount(
+      { prompt: pricing.prompt, completion: pricing.completion },
+      endpoints,
+    );
+  });
+
+  models.forEach((model, index) => {
+    const discount = discounts[index];
+    if (discount !== undefined && isPlainObject(model.pricing)) {
+      model.pricing.discount = discount;
+    }
+  });
+
+  return raw;
+}
+
+async function fetchEndpoints(modelID: string): Promise<OpenRouterEndpoint[] | undefined> {
+  // Variant routes (`:free`, `:nitro`) are served under the base model slug.
+  const slug = modelID.split(":")[0];
+  try {
+    const response = await fetch(`${ENDPOINTS_API}/${slug}/endpoints`, { headers: authHeaders() });
+    if (!response.ok) return undefined;
+    const parsed = OpenRouterEndpointsResponse.safeParse(await response.json());
+    return parsed.success ? parsed.data.data.endpoints : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Discount of the endpoint quoting exactly the headline price, or `undefined`
+ * when no endpoint does — a `:free` variant priced at 0, or a headline that has
+ * moved since the endpoints were read.
+ */
+export function resolveEndpointDiscount(
+  pricing: { prompt: string; completion: string },
+  endpoints: OpenRouterEndpoint[],
+): number | undefined {
+  const prompt = Number(pricing.prompt);
+  const completion = Number(pricing.completion);
+  if (!Number.isFinite(prompt) || !Number.isFinite(completion)) return undefined;
+
+  const matches = endpoints.filter((endpoint) => (
+    Number(endpoint.pricing.prompt) === prompt &&
+    Number(endpoint.pricing.completion) === completion
+  ));
+  if (matches.length === 0) return undefined;
+
+  // Identically priced routes should quote identical discounts. Take the largest
+  // so a promo is never under-reported if they ever diverge.
+  const discount = Math.max(...matches.map((endpoint) => endpoint.pricing.discount ?? 0));
+  if (!Number.isFinite(discount) || discount <= 0) return 0;
+  return Math.round(discount * 1_000_000) / 1_000_000;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<R>,
+): Promise<(R | undefined)[]> {
+  const results: (R | undefined)[] = new Array(items.length).fill(undefined);
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      const item = items[index];
+      if (item !== undefined) results[index] = await worker(item);
+    }
+  });
+  await Promise.all(runners);
+  return results;
+}
+
 function isUnavailable(model: OpenRouterModel) {
   return (
     model.supported_parameters.length === 0 ||
@@ -152,6 +284,18 @@ function price(value: string | undefined) {
   return Number.isFinite(number) && number >= 0
     ? Math.round(number * 1_000_000_000_000) / 1_000_000
     : undefined;
+}
+
+/**
+ * The provider's standard rate before the promotion. OpenRouter serves only the
+ * discounted price, but shows the pre-discount one struck through on the model's
+ * provider table, and it is exactly this quotient — a 35%-off route billing
+ * $0.091/M is posted at $0.14/M. Recording it lets a diff distinguish a real
+ * price cut from a promotion starting.
+ */
+function listPrice(value: number | undefined, discount: number | undefined) {
+  if (value === undefined || discount === undefined || discount <= 0) return undefined;
+  return Math.round((value / (1 - discount)) * 1_000_000) / 1_000_000;
 }
 
 function costTiers(model: OpenRouterModel, existing: ExistingModel | undefined) {
@@ -227,13 +371,26 @@ export function buildOpenRouterModel(
   const structuredOutput = params.has("structured_outputs");
   const knowledge = model.knowledge_cutoff?.slice(0, 10) ?? existing?.knowledge;
   const openWeights = Boolean(model.hugging_face_id);
+  // An absent discount means the endpoints lookup was inconclusive, not that the
+  // promo ended, so keep the authored value. A resolved 0 is authoritative and
+  // clears it.
+  const discount = model.pricing.discount === undefined
+    ? existing?.cost?.discount
+    : model.pricing.discount > 0 ? model.pricing.discount : undefined;
+  const cacheRead = price(model.pricing.input_cache_read);
+  const cacheWrite = price(model.pricing.input_cache_write);
   const cost = prompt !== undefined && completion !== undefined
     ? {
         input: prompt,
         output: completion,
         reasoning: reasoning ? price(model.pricing.internal_reasoning) : undefined,
-        cache_read: price(model.pricing.input_cache_read),
-        cache_write: price(model.pricing.input_cache_write),
+        cache_read: cacheRead,
+        cache_write: cacheWrite,
+        discount,
+        input_list: listPrice(prompt, discount),
+        output_list: listPrice(completion, discount),
+        cache_read_list: listPrice(cacheRead, discount),
+        cache_write_list: listPrice(cacheWrite, discount),
         tiers: costTiers(model, existing),
       }
     : existing?.cost;

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -54,6 +54,7 @@ import {
   buildOpenRouterModel,
   openrouter,
   resolveCanonicalBaseModel,
+  resolveEndpointDiscount,
   type OpenRouterModel,
 } from "../src/sync/providers/openrouter.js";
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
@@ -2081,6 +2082,160 @@ test("OpenRouter sync keeps authored tiers when API omits overrides", () => {
     cost: {
       tiers: [{ tier: { size: 200_000 }, input: 6, output: 22.5 }],
     },
+  });
+});
+
+test("resolves the discount of the OpenRouter endpoint the headline price came from", () => {
+  const discount = resolveEndpointDiscount(
+    { prompt: "0.00000049", completion: "0.00000154" },
+    [
+      { pricing: { prompt: "0.0000007", completion: "0.0000022", discount: 0.5 } },
+      { pricing: { prompt: "0.00000049", completion: "0.00000154", discount: 0.65 } },
+      { pricing: { prompt: "0.00000105", completion: "0.0000033", discount: 0 } },
+    ],
+  );
+
+  expect(discount).toBe(0.65);
+});
+
+test("resolves an OpenRouter discount of zero when the headline endpoint is undiscounted", () => {
+  const discount = resolveEndpointDiscount(
+    { prompt: "0.00000014", completion: "0.00000028" },
+    [
+      { pricing: { prompt: "0.000000091", completion: "0.000000182", discount: 0.35 } },
+      { pricing: { prompt: "0.00000014", completion: "0.00000028", discount: 0 } },
+    ],
+  );
+
+  expect(discount).toBe(0);
+});
+
+test("resolves no OpenRouter discount when the headline price matches no endpoint", () => {
+  const discount = resolveEndpointDiscount(
+    { prompt: "0", completion: "0" },
+    [{ pricing: { prompt: "0.00000009", completion: "0.00000018", discount: 0.1 } }],
+  );
+
+  expect(discount).toBeUndefined();
+});
+
+test("OpenRouter sync records a discount alongside the already-discounted cost", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    id: "upstage/solar-pro4",
+    name: "Upstage: Solar Pro 4",
+    pricing: {
+      prompt: "0.00000003",
+      completion: "0.00000012",
+      discount: 0.9,
+    },
+  }), undefined);
+
+  expect(model).toMatchObject({
+    cost: {
+      input: 0.03,
+      output: 0.12,
+      discount: 0.9,
+    },
+  });
+});
+
+test("OpenRouter sync omits a zero discount instead of writing it", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    pricing: {
+      prompt: "0.000002",
+      completion: "0.00001",
+      discount: 0,
+    },
+  }), {
+    cost: { input: 2, output: 10, discount: 0.5 },
+  });
+
+  expect(model.cost?.discount).toBeUndefined();
+});
+
+test("OpenRouter sync preserves an existing discount when the endpoints lookup is inconclusive", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    pricing: {
+      prompt: "0.000002",
+      completion: "0.00001",
+    },
+  }), {
+    cost: { input: 2, output: 10, discount: 0.25 },
+  });
+
+  expect(model.cost?.discount).toBe(0.25);
+});
+
+test("OpenRouter sync reconstructs pre-discount list prices", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    id: "upstage/solar-pro4",
+    name: "Upstage: Solar Pro 4",
+    pricing: {
+      prompt: "0.00000003",
+      completion: "0.00000012",
+      input_cache_read: "0.000000006",
+      discount: 0.9,
+    },
+  }), undefined);
+
+  expect(model.cost).toMatchObject({
+    input: 0.03,
+    output: 0.12,
+    cache_read: 0.006,
+    discount: 0.9,
+    input_list: 0.3,
+    output_list: 1.2,
+    cache_read_list: 0.06,
+  });
+});
+
+test("OpenRouter sync omits list prices when nothing is discounted", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    pricing: {
+      prompt: "0.000002",
+      completion: "0.00001",
+      discount: 0,
+    },
+  }), undefined);
+
+  expect(model.cost?.input_list).toBeUndefined();
+  expect(model.cost?.output_list).toBeUndefined();
+});
+
+test("OpenRouter list prices stay clean under repeated float division", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    id: "moonshotai/kimi-k2.6",
+    name: "MoonshotAI: Kimi K2.6",
+    pricing: {
+      prompt: "0.0000005795",
+      completion: "0.00000244",
+      discount: 0.39,
+    },
+  }), undefined);
+
+  // 0.5795 / 0.61 is 0.9500000000000001 before rounding.
+  expect(model.cost?.input_list).toBe(0.95);
+  expect(model.cost?.output_list).toBe(4);
+});
+
+test("formats a cost discount into the generated TOML", () => {
+  const content = formatToml({
+    id: "example/model",
+    name: "Example Model",
+    description: "Example model for sync formatting regression tests",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: false,
+    reasoning: false,
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 0.03, output: 0.12, discount: 0.9 },
+    limit: { context: 1_000, output: 100 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  expect(Bun.TOML.parse(content)).toMatchObject({
+    cost: { input: 0.03, output: 0.12, discount: 0.9 },
   });
 });
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -55,6 +55,20 @@ export interface Cost {
   input_audio?: number
   /** Audio output price, USD per 1M tokens. */
   output_audio?: number
+  /**
+   * Fraction the prices above are already discounted by (0.35 = 35% off), for
+   * providers quoting a promotional rate. Every other price here is the
+   * discounted one actually billed, not the pre-discount rate.
+   */
+  discount?: number
+  /** Standard input price before `discount`, USD per 1M tokens. */
+  input_list?: number
+  /** Standard output price before `discount`, USD per 1M tokens. */
+  output_list?: number
+  /** Standard cache read price before `discount`, USD per 1M tokens. */
+  cache_read_list?: number
+  /** Standard cache write price before `discount`, USD per 1M tokens. */
+  cache_write_list?: number
 }
 
 /** Pricing that applies from a given context size upward. */

--- a/sync.md
+++ b/sync.md
@@ -153,9 +153,12 @@ CrossModel is implemented in `packages/core/src/sync/providers/crossmodel.ts`.
 OpenRouter is implemented in `packages/core/src/sync/providers/openrouter.ts`.
 
 - Source endpoint: `https://openrouter.ai/api/v1/models`.
+- Discount source: `https://openrouter.ai/api/v1/models/{author}/{slug}/endpoints`, one call per model at a concurrency of 6.
 - Optional auth: `OPENROUTER_API_KEY`.
 - Model IDs map directly to TOML paths under `providers/openrouter/models`.
 - API prices are per-token strings and are converted to per-1M-token numbers.
+- `/models` quotes an already-discounted headline price without naming the route it came from. `cost.discount` is the discount of the endpoint quoting exactly that headline price, so it always describes the prices written next to it. Prices stay as billed; the pre-discount rate is `input / (1 - discount)`.
+- Discount lookups are fail-soft. A model whose endpoint cannot be matched (a `:free` variant priced at 0, a failed request) keeps its authored `cost.discount` rather than churning the file; a matched endpoint quoting no discount clears it.
 - `structured_output` comes from `supported_parameters.includes("structured_outputs")` only.
 - Existing `status`, `interleaved`, `knowledge`, `limit.input`, and `cost.tiers` may be preserved when OpenRouter is not authoritative enough for those fields.
 - Canonical OpenRouter model IDs should emit `base_model` references to model metadata when a matching `models/` entry exists.


### PR DESCRIPTION
Closes #4580.

## Problem

`GET /api/v1/models` quotes a headline price that is **already discounted** when the route it came from is running a promotion, and the payload never says so. The catalog therefore records promotional rates as if they were standard ones.

`upstage/solar-pro4` is committed today at `input = 0.03`. That is a 90%-off promo on a $0.30/M model. Nothing in the file says so, and when the promo ends the price will appear to have risen 10x for no recorded reason.

That the headline is the discounted price is provable from single-endpoint models, where there is no ambiguity about which route it came from:

| Model | Endpoints | `discount` | Recorded price | Standard rate |
|---|---|---|---|---|
| `upstage/solar-pro4` | 1 | 0.9 | $0.03/M | $0.30/M |
| `inclusionai/ling-2.6-flash` | 1 | 0.9 | $0.01/M | $0.10/M |
| `meituan/longcat-2.0` | 1 | 0.6 | $0.30/M | $0.75/M |

## Approach

`/models` does not report discounts, but the per-model [`/models/{author}/{slug}/endpoints`](https://openrouter.ai/docs/api-reference/list-endpoints-for-a-model) route reports a `discount` fraction per provider endpoint. The two are paired here: **whichever endpoint quotes exactly the headline `(prompt, completion)` is the route the catalog is recording**, so its discount is the one consistent with the `cost.input`/`cost.output` being written.

That rule matters because most models have discounted endpoints that are *not* the recorded one. `deepseek/deepseek-v4-flash-0731` has three discounted providers, but its headline `$0.08/$0.252` is DigitalOcean's undiscounted row — so this PR correctly records **no** discount for it. Across all 350 models the rule produced zero ambiguous matches: 295 matched an undiscounted endpoint, 20 matched a discounted one, 10 matched none (all `:free` variants priced at 0).

## New fields

```toml
[cost]
input = 0.091      # billed, unchanged in meaning
output = 0.182
discount = 0.35    # 35% off, already reflected above
input_list = 0.14  # standard rate
output_list = 0.28
```

Prices keep their current meaning — what you are billed. `discount` says how far below standard that already is, and the `*_list` keys record the standard rate.

The `*_list` values are `price / (1 - discount)`. That is not a guess: OpenRouter displays exactly this number struck through on the model's provider table. From `deepseek-v4-flash-0731`:

| Provider | Shown | `discount` | `*_list` | OpenRouter's struck-through price |
|---|---|---|---|---|
| Decart | $0.081 | 0.10 | $0.09 | $0.09 ✓ |
| StreamLake | $0.091 | 0.35 | $0.14 | $0.14 ✓ |
| GMICloud | $0.112 | 0.20 | $0.14 | $0.14 ✓ |

All 20 affected models reconstruct to clean round numbers ($0.30, $1.40, $0.95, $1.60, $2.00), including cache prices, which are discounted by the same fraction.

`*_list` is derivable from `input` and `discount`, so it is stored for legibility rather than information: it makes a price cut distinguishable from a promotion **in the diff**, without recomputing. When the `solar-pro4` promo ends, the commit reads:

```diff
-input = 0.03
-discount = 0.9
-input_list = 0.3
+input = 0.3
```

Prices return to exactly the previously recorded `input_list`. Since each sync lands as its own commit, the catalog accumulates a readable pricing history.

## Fail-soft

One extra request per model, at a concurrency of 6 — a full sweep of 350 models takes ~13s, and the whole sync runs in ~8s.

Every lookup is fail-soft, which matters because this runs hourly and unattended. A model whose endpoint cannot be matched keeps its authored discount rather than churning; only a *successful* lookup reporting no discount clears it. Verified by pointing the endpoints host at an unreachable domain and running a real sync: `0 updated`, all discounts intact, empty diff.

## Verification

- `bun models:sync openrouter --dry-run` — clean before (`349 unchanged`), `20 updated` after, and clean again on re-run (idempotent)
- Diff is exactly the new keys; no existing field is perturbed
- `bun validate` passes
- `bun test` — 10 new tests, no regressions (4 pre-existing `packages/sdk` snapshot failures are unrelated and present on `dev`)
- Fields reach the generated catalog

## Open questions

1. **Naming.** OpenRouter's own Price History table uses "Listed" for the *discounted* posted price and "Effective" for the usage-weighted average actually paid. So `input_list` here does not match their "listed". `input_undiscounted` may be clearer — happy to rename.
2. **Churn.** A discount flips whenever a promo starts or ends, and `classifyAutoMerge` gates on created/deleted counts and reasoning metadata only — `updated` is computed but never gates anything, so these auto-merge unbounded. If that is unwanted, this needs an update-side gate that does not exist today. (Measured over ~25 min, none of the 20 discounts moved, so the rate may be low in practice.)
3. **Scope.** Wired for OpenRouter only. An authored `discount` on any other synced provider is stripped on its next run, since those modules rebuild `cost` from their own APIs. Making it durable catalog-wide would need a runner-level preserve rule — deliberately out of scope here, per `sync.md`'s preference for small provider-specific PRs.

## Commits

Split so the second can be dropped: the first is code, docs, and tests; the second is `bun models:sync openrouter` output. The promo set is a point-in-time snapshot and will drift, so the hourly sync can produce it instead.

Sources: OpenRouter [`/api/v1/models`](https://openrouter.ai/api/v1/models), [`/endpoints`](https://openrouter.ai/docs/api-reference/list-endpoints-for-a-model), and the [provider table](https://openrouter.ai/deepseek/deepseek-v4-flash-0731#providers).
