### PR TITLE
feat(provider): add Zyloo provider

### DIFF
--- a/providers/zyloo/models/claude-opus-4-7.toml
+++ b/providers/zyloo/models/claude-opus-4-7.toml
@@ -1,0 +1,26 @@
+name = "Claude Opus 4.7"
+description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
+family = "claude-opus"
+release_date = "2026-04-17"
+last_updated = "2026-04-17"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+temperature = false
+tool_call = true
+open_weights = false
+knowledge = "2026-01-31"
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/zyloo/models/claude-sonnet-4-6.toml
+++ b/providers/zyloo/models/claude-sonnet-4-6.toml
@@ -1,0 +1,24 @@
+name = "Claude Sonnet 4.6"
+description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
+family = "claude-sonnet"
+release_date = "2026-02-18"
+last_updated = "2026-03-13"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 1024, max = 63999 }]
+temperature = true
+tool_call = true
+open_weights = false
+knowledge = "2025-08-31"
+
+[cost]
+input = 3.00
+output = 15.00
+
+[limit]
+context = 1_000_000
+output = 64_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/zyloo/models/deepseek-v4-pro.toml
+++ b/providers/zyloo/models/deepseek-v4-pro.toml
@@ -1,0 +1,25 @@
+name = "DeepSeek V4 Pro"
+description = "Advanced open-architecture model for math, coding, and reasoning tasks"
+family = "deepseek"
+release_date = "2026-03-24"
+last_updated = "2026-03-24"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+knowledge = "2025-11"
+
+[cost]
+input = 0.40
+output = 1.60
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zyloo/models/gemini-2.5-flash.toml
+++ b/providers/zyloo/models/gemini-2.5-flash.toml
@@ -1,0 +1,26 @@
+name = "Gemini 2.5 Flash"
+description = "Fast, efficient multimodal model for high-volume tasks and quick reasoning"
+family = "gemini-flash"
+release_date = "2025-06-17"
+last_updated = "2025-06-17"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+knowledge = "2025-01"
+
+[cost]
+input = 0.15
+output = 0.60
+cache_read = 0.0375
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "audio", "video", "pdf"]
+output = ["text"]

--- a/providers/zyloo/models/glm-5.1.toml
+++ b/providers/zyloo/models/glm-5.1.toml
@@ -1,0 +1,27 @@
+name = "GLM 5.1"
+description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+family = "glm"
+release_date = "2026-04-10"
+last_updated = "2026-04-10"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.86
+output = 3.50
+
+[limit]
+context = 200_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/zyloo/models/gpt-5.4.toml
+++ b/providers/zyloo/models/gpt-5.4.toml
@@ -1,0 +1,27 @@
+name = "GPT-5.4"
+description = "Frontier GPT model for professional reasoning, coding, and multimodal work"
+family = "gpt"
+release_date = "2026-03-05"
+last_updated = "2026-03-05"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+knowledge = "2025-08-31"
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/zyloo/models/grok-4.3.toml
+++ b/providers/zyloo/models/grok-4.3.toml
@@ -1,0 +1,24 @@
+name = "Grok 4.3"
+description = "Frontier reasoning model from xAI built for real-time synthesis and reasoning"
+family = "grok"
+release_date = "2026-03-12"
+last_updated = "2026-03-12"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 2.00
+output = 10.00
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/zyloo/provider.toml
+++ b/providers/zyloo/provider.toml
@@ -1,0 +1,5 @@
+name = "Zyloo"
+env = ["ZYLOO_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.zyloo.io/v1"
+doc = "https://zyloo.io"


### PR DESCRIPTION
## Summary

Adds [Zyloo](https://zyloo.io) as an AI model provider with an OpenAI-compatible endpoint (`https://api.zyloo.io/v1`).

### Models Included:
- `claude-opus-4-7`
- `claude-sonnet-4-6`
- `gpt-5.4`
- `gemini-2.5-flash`
- `deepseek-v4-pro`
- `grok-4.3`
- `glm-5.1`

### Verification
- Validated via `bun run validate`.