### PR TITLE
fix(sync): accept nullable CrossModel reasoning controls

### DIFF
--- a/packages/core/src/sync/providers/crossmodel.ts
+++ b/packages/core/src/sync/providers/crossmodel.ts
@@ -24,11 +24,13 @@ const API_ENDPOINT = process.env.CROSSMODEL_MODELS_URL ?? "https://www.crossmode
 
 const ReasoningCapability = z
   .object({
-    toggle: z.boolean().optional(),
-    effort: z.array(z.string()).optional(),
+    supported: z.boolean().optional(),
+    toggle: z.boolean().nullish().transform((value) => value ?? undefined),
+    effort: z.array(z.string()).nullish().transform((value) => value ?? undefined),
     budget_tokens: z
       .object({ min: z.number().optional(), max: z.number().optional() })
-      .optional(),
+      .nullish()
+      .transform((value) => value ?? undefined),
   })
   .passthrough();
 
@@ -173,7 +175,7 @@ function isReasoningEffort(value: string): value is ReasoningEffort {
 //   otherwise         -> toggle / effort / budget_tokens entries
 function reasoningOptions(model: CrossModelModel): SyncedModel["reasoning_options"] {
   const reasoning = model.capabilities?.reasoning;
-  if (reasoning === undefined) return undefined;
+  if (reasoning === undefined || reasoning.supported === false) return undefined;
   const options: NonNullable<SyncedModel["reasoning_options"]> = [];
   if (reasoning.toggle === true) options.push({ type: "toggle" });
   if (reasoning.effort !== undefined) {

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -13,6 +13,7 @@ import {
 import { buildCortecsModel, type CortecsModel } from "../src/sync/providers/cortecs.js";
 import {
   buildCrossModel,
+  CrossModelResponse,
   type CrossModelModel,
 } from "../src/sync/providers/crossmodel.js";
 import { buildDeepInfraModel, type DeepInfraModel } from "../src/sync/providers/deepinfra.js";
@@ -174,6 +175,31 @@ test("syncs CrossModel's structured-output capability", () => {
   expect(preserved).toMatchObject({
     base_model: "alibaba/qwen3.8-max",
     structured_output: true,
+  });
+});
+
+test("parses CrossModel's nullable reasoning controls", () => {
+  const parsed = CrossModelResponse.parse({
+    data: [
+      {
+        ...crossModelModel(),
+        capabilities: {
+          reasoning: {
+            supported: true,
+            toggle: null,
+            effort: null,
+            budget_tokens: null,
+          },
+        },
+      },
+    ],
+  });
+
+  expect(parsed.data[0]?.capabilities?.reasoning).toEqual({
+    supported: true,
+    toggle: undefined,
+    effort: undefined,
+    budget_tokens: undefined,
   });
 });
 


### PR DESCRIPTION
## Summary

- normalize nullable CrossModel `toggle`, `effort`, and `budget_tokens` controls to absent values
- honor `capabilities.reasoning.supported = false`
- add regression coverage for the nullable API response shape

## Context

The scheduled CrossModel sync failed because the live catalog now serializes unavailable reasoning controls as `null`, while the sync schema accepted only omitted values: https://github.com/anomalyco/models.dev/actions/runs/31628243295/job/94220189471

Live catalog: https://www.crossmodel.ai/api/models

## Verification

- `bun test packages/core/test/sync.test.ts --test-name-pattern CrossModel`
- `bun validate`
- isolated live CrossModel sync followed by `bun validate`