### PR TITLE
Add Sakana Namazu model

### DIFF
--- a/labs/sakana/lab.toml
+++ b/labs/sakana/lab.toml
@@ -1,1 +1,1 @@
-description = "Sakana AI develops Japanese-specialized language models and multi-agent systems for research, coding, and business workflows."
+description = "Sakana AI turns model routing into a product, exposing multi-agent systems through a single API for research, coding, and hard analysis."

--- a/labs/sakana/lab.toml
+++ b/labs/sakana/lab.toml
@@ -1,1 +1,1 @@
-description = "Sakana AI turns model routing into a product, exposing multi-agent systems through a single API for research, coding, and hard analysis."
+description = "Sakana AI develops Japanese-specialized language models and multi-agent systems for research, coding, and business workflows."

--- a/models/sakana/sakana-namazu.toml
+++ b/models/sakana/sakana-namazu.toml
@@ -1,0 +1,59 @@
+name = "Sakana Namazu"
+description = "Japanese-specialized reasoning model based on Kimi K2.6 and tuned for Japanese language, culture, and business workflows"
+family = "sakana-namazu"
+release_date = "2026-08-03"
+last_updated = "2026-08-03"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]
+
+[[links]]
+label = "Official product page"
+url = "https://sakana.ai/namazu/"
+type = "announcement"
+
+[[links]]
+label = "Official model documentation"
+url = "https://console.sakana.ai/models?model=sakana-namazu"
+type = "docs"
+
+[[benchmarks]]
+name = "AIME26"
+score = 96.67
+source = "https://console.sakana.ai/models?model=sakana-namazu"
+
+[[benchmarks]]
+name = "MMLU-Pro"
+score = 90.33
+source = "https://console.sakana.ai/models?model=sakana-namazu"
+
+[[benchmarks]]
+name = "LiveCodeBench v6"
+score = 90.33
+source = "https://console.sakana.ai/models?model=sakana-namazu"
+
+[[benchmarks]]
+name = "JFBench"
+score = 37.40
+source = "https://console.sakana.ai/models?model=sakana-namazu"
+
+[[benchmarks]]
+name = "Translation"
+score = 52.20
+source = "https://console.sakana.ai/models?model=sakana-namazu"
+
+[[benchmarks]]
+name = "FairPoliticsQA"
+score = 56.30
+source = "https://console.sakana.ai/models?model=sakana-namazu"

--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -366,6 +366,9 @@ export const ModelFamilyValues = [
   // Conductor
   "fugu",
 
+  // Sakana Namazu
+  "sakana-namazu",
+
   // V0
   "v0",
 

--- a/providers/sakana/models/sakana-namazu.toml
+++ b/providers/sakana/models/sakana-namazu.toml
@@ -6,6 +6,3 @@ reasoning_options = [{ type = "toggle" }]
 input = 0.95
 output = 4
 cache_read = 0.15
-
-[provider]
-shape = "responses"

--- a/providers/sakana/models/sakana-namazu.toml
+++ b/providers/sakana/models/sakana-namazu.toml
@@ -1,0 +1,11 @@
+# Toggle: chat_template_kwargs.thinking = true|false
+base_model = "sakana/sakana-namazu"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.15
+
+[provider]
+shape = "responses"


### PR DESCRIPTION
## Summary

Add Sakana Namazu model metadata, including its capabilities, limits, modalities, and benchmarks. Register `sakana-namazu` under the first-party Sakana AI provider with official pricing and reasoning configuration.

## Sources

- https://sakana.ai/namazu/
- https://console.sakana.ai/models?model=sakana-namazu
