### PR TITLE
feat(fireworks-ai): add 5 missing Fireworks AI provider models

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/inkling.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/inkling.toml
@@ -1,0 +1,8 @@
+base_model = "thinkingmachines/inkling"
+
+reasoning_options = []
+
+[cost]
+input = 1.00
+output = 4.05
+cache_read = 0.17

--- a/providers/fireworks-ai/models/accounts/fireworks/models/muse-glimmer-30b.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/muse-glimmer-30b.toml
@@ -1,0 +1,10 @@
+base_model = "meta/muse-glimmer-30b"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+[cost]
+input = 0.35
+output = 1.50
+cache_read = 0.04

--- a/providers/fireworks-ai/models/accounts/fireworks/models/nemotron-3-ultra-nvfp4.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/nemotron-3-ultra-nvfp4.toml
@@ -1,0 +1,12 @@
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.60
+output = 2.40
+cache_read = 0.119
+
+[limit]
+context = 262_144

--- a/providers/fireworks-ai/models/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b.toml
@@ -1,0 +1,9 @@
+base_model = "nvidia/nemotron-3.5-lightning"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.05
+output = 0.20
+cache_read = 0.01

--- a/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p8-max.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p8-max.toml
@@ -1,0 +1,18 @@
+base_model = "alibaba/qwen3.8-max"
+
+attachment = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[cost]
+input = 2.00
+output = 6.00
+cache_read = 0.25
+
+[limit]
+context = 262_144


### PR DESCRIPTION
Adds the following models to the fireworks-ai provider:

- [Inkling](https://fireworks.ai/models/fireworks/inkling) (`accounts/fireworks/models/inkling`)
- [Muse Glimmer 30B](https://fireworks.ai/models/fireworks/muse-glimmer-30b) (`accounts/fireworks/models/muse-glimmer-30b`)
- [Nemotron 3 Ultra NVFP4](https://fireworks.ai/models/fireworks/nemotron-3-ultra-nvfp4) (`accounts/fireworks/models/nemotron-3-ultra-nvfp4`)
- [Nemotron Lightning 3.5 30B A3B](https://fireworks.ai/models/fireworks/nemotron-lightning-3p5-30b-a3b) (`accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b`)
- [Qwen3.8 Max](https://fireworks.ai/models/fireworks/qwen3p8-max) (`accounts/fireworks/models/qwen3p8-max`)

All use `base_model` with override-only cost, reasoning options, and modality/pricing deltas. `bun validate` passes.