### PR TITLE
feat(sync): create canonical Merge Gateway models

### DIFF
--- a/packages/core/src/sync/providers/merge-gateway.ts
+++ b/packages/core/src/sync/providers/merge-gateway.ts
@@ -1,10 +1,22 @@
 import { z } from "zod";
 
 import { describeModel } from "../../describe.js";
-import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
-import { factorBaseModel, resolveCanonicalBaseModel } from "./openrouter.js";
+import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedMetadata, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://api-gateway.merge.dev/v1/models";
+
+// Merge's public model IDs use routing namespaces. Shared models.dev metadata
+// uses the model author's namespace, which differs for a few labs.
+const CANONICAL_METADATA_NAMESPACES: Record<string, string> = {
+  "arcee-ai": "arcee",
+  bytedance: "bytedance-seed",
+  moonshot: "moonshotai",
+  qwen: "alibaba",
+  xiaomimimo: "xiaomi",
+  zai: "zhipuai",
+};
 
 const AvailabilityStatus = z.enum(["available", "deprecated"]);
 
@@ -56,6 +68,8 @@ export const MergeGatewayModel = z.object({
   model: z.string().min(1),
   provider: z.string().min(1),
   display_name: z.string().min(1),
+  release_date: z.string().nullable().optional(),
+  open_weights: z.boolean().nullable().optional(),
   vendors: z.record(VendorInfo),
   availability_status: AvailabilityStatus,
   created_at: z.string().nullable().optional(),
@@ -138,7 +152,7 @@ export const mergeGateway = {
   skippedNotice(ids) {
     if (ids.length === 0) return [];
     return [
-      `${ids.length} Merge Gateway models were skipped because they are not text models or lack canonical metadata.`,
+      `${ids.length} Merge Gateway models were skipped because they do not produce text or lack canonical release-date/open-weight metadata.`,
       `Skipped remote IDs: ${ids.map((id) => `\`${id}\``).join(", ")}`,
     ];
   },
@@ -158,9 +172,124 @@ export const mergeGateway = {
   translateModel(model, context) {
     const existing = context.existing(model.model);
     const translated = buildMergeGatewayModel(model, existing, context.authored(model.model));
-    return translated === undefined ? undefined : { id: model.model, model: translated };
+    if (translated !== undefined) return { id: model.model, model: translated };
+
+    const generated = buildMergeGatewayCanonicalFallback(model);
+    return generated === undefined
+      ? undefined
+      : {
+          id: model.model,
+          model: generated.provider,
+          metadata: { id: generated.id, model: generated.metadata },
+        };
   },
 } satisfies SyncProvider<MergeGatewayModel>;
+
+/**
+ * Fallback for a text model that has no reviewed models.dev metadata yet. The
+ * shared metadata contains stable model facts; the Merge
+ * provider record contains only route-specific cost and reasoning controls.
+ *
+ * A release date is deliberately required. Guessing it would make the output
+ * look complete while publishing a false canonical fact.
+ */
+export function buildMergeGatewayCanonicalFallback(model: MergeGatewayModel): {
+  id: string;
+  metadata: SyncedMetadata;
+  provider: SyncedModel;
+} | undefined {
+  const selected = selectMergeGatewayVendor(model);
+  if (selected === undefined || !selected.info.capabilities.output.includes("text")) return undefined;
+
+  const releaseDate = model.release_date;
+  if (releaseDate == null || model.open_weights == null) return undefined;
+  const input = modalities(selected.info.capabilities.input);
+  const output = modalities(selected.info.capabilities.output);
+  const limit = {
+    context: selected.info.context_window,
+    output: selected.info.max_output_tokens || selected.info.context_window,
+  };
+  const routeConfirmsReasoning = Object.values(model.vendors).some(
+    (vendor) => vendor.availability_status === "available" && vendor.capabilities.supports_reasoning === true,
+  );
+  const reasoning = routeConfirmsReasoning || inferReasoning(model);
+  const family = inferFamily(model);
+  const metadataID = canonicalMetadataID(model.model);
+  const metadata = {
+    name: model.display_name,
+    description: describeModel({
+      id: metadataID,
+      name: model.display_name,
+      family,
+      reasoning,
+      tool_call: selected.info.capabilities.supports_tool_calling,
+      structured_output: selected.info.capabilities.supports_structured_outputs,
+      open_weights: model.open_weights,
+      limit,
+      modalities: { input, output },
+    }),
+    family,
+    release_date: releaseDate,
+    attachment: input.some((value) => value !== "text"),
+    reasoning,
+    tool_call: selected.info.capabilities.supports_tool_calling,
+    structured_output: selected.info.capabilities.supports_structured_outputs,
+    open_weights: model.open_weights,
+    limit,
+    modalities: { input, output },
+  } satisfies SyncedMetadata;
+  const cachePricing = mergeGatewayCachePricing(selected.info, undefined);
+  const cost = {
+    input: selected.info.pricing.input_per_million,
+    output: selected.info.pricing.output_per_million,
+    cache_read: cachePricing.read,
+    cache_write: cachePricing.write,
+  };
+  const status = model.availability_status === "deprecated" || selected.info.availability_status === "deprecated"
+    ? "deprecated" as const
+    : undefined;
+  const reasoningOptions = reasoning
+    ? mergeGatewayReasoningOptions(selected.info.capabilities.reasoning) ?? []
+    : undefined;
+
+  return {
+    id: metadataID,
+    metadata,
+    provider: {
+      base_model: metadataID,
+      status,
+      cost,
+      reasoning_options: reasoningOptions,
+    },
+  };
+}
+
+export function canonicalMetadataID(modelID: string) {
+  const [namespace, ...modelParts] = modelID.split("/");
+  if (namespace === undefined || modelParts.length === 0) return modelID;
+  return `${CANONICAL_METADATA_NAMESPACES[namespace] ?? namespace}/${modelParts.join("/")}`;
+}
+
+function inferFamily(model: MergeGatewayModel) {
+  const kimiFamily = inferKimiFamily(model.model, model.display_name);
+  if (kimiFamily !== undefined) return kimiFamily;
+
+  const target = `${model.model} ${model.display_name}`.toLowerCase();
+  return [...ModelFamilyValues]
+    .sort((a, b) => b.length - a.length)
+    .find((family) => {
+      const value = family.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      if (family === "o") {
+        return new RegExp(`(^|[^a-z0-9])${value}(?=\\d|$|[^a-z0-9])`).test(target);
+      }
+      return new RegExp(`(^|[^a-z0-9])${value}(?=$|[^a-z0-9])`).test(target);
+    });
+}
+
+function inferReasoning(model: MergeGatewayModel) {
+  const target = `${model.model} ${model.display_name}`.toLowerCase();
+  return /(^|[-_/ ])(?:r1|reasoning|thinking|think)(?=$|[-_/ .0-9])/.test(target);
+}
 
 export function mergeGatewayReasoningOptions(
   reasoning: MergeGatewayVendor["capabilities"]["reasoning"],
@@ -241,7 +370,7 @@ export function buildMergeGatewayModel(
   const status = model.availability_status === "deprecated" || selected.info.availability_status === "deprecated"
     ? "deprecated" as const
     : undefined;
-  const baseModel = existing?.base_model ?? resolveCanonicalBaseModel(model.model);
+  const baseModel = existing?.base_model ?? resolveModelMetadataBaseModel(model.model);
   // `supports_reasoning` is not part of the documented public schema
   // (PublicVendorModelCapabilities) and is inconsistently populated across
   // vendor routes: the same model can report `true` on one route and `false`

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -3,6 +3,7 @@ import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+import { classifyAutoMerge } from "../src/sync/auto-merge.js";
 import { formatToml, preserveReasoningOptions, syncProvider, type ExistingModel, type SyncProvider } from "../src/sync/index.js";
 import {
   anthropic,
@@ -58,7 +59,9 @@ import {
 } from "../src/sync/providers/openrouter.js";
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
 import {
+  buildMergeGatewayCanonicalFallback,
   buildMergeGatewayModel,
+  canonicalMetadataID,
   fetchMergeGatewayModels,
   mergeGateway,
   MergeGatewayResponse,
@@ -3076,6 +3079,162 @@ test("filters unknown Merge Gateway modalities without rejecting the catalog", (
   });
 });
 
+// Lets a Gateway-only text model enter the catalog without violating the
+// provider/base-model split required by models.dev.
+test("generates canonical metadata for an unconfigured Merge Gateway text model", () => {
+  const parsed = MergeGatewayResponse.parse({
+    object: "list",
+    data: [mergeGatewayModel({
+      model: "google/gemma-3-12b-it",
+      provider: "google",
+      display_name: "Gemma 3 12B",
+      release_date: "2025-03-12",
+      open_weights: true,
+      vendors: { bedrock: mergeGatewayVendor({ launch_date: "2025-04-08" }) },
+    })],
+  }).data[0]!;
+  const generated = buildMergeGatewayCanonicalFallback(parsed);
+
+  expect(generated).toEqual({
+    id: "google/gemma-3-12b-it",
+    metadata: {
+      name: "Gemma 3 12B",
+      description: "Open Gemma instruction model for efficient chat and self-hosted deployments",
+      family: "gemma",
+      release_date: "2025-03-12",
+      attachment: true,
+      reasoning: false,
+      tool_call: true,
+      structured_output: true,
+      open_weights: true,
+      limit: { context: 1_050_000, output: 128_000 },
+      modalities: {
+        input: ["text", "image", "pdf"],
+        output: ["text"],
+      },
+    },
+    provider: {
+      base_model: "google/gemma-3-12b-it",
+      status: undefined,
+      cost: {
+        input: 5,
+        output: 30,
+        cache_read: undefined,
+        cache_write: undefined,
+      },
+      reasoning_options: undefined,
+    },
+  });
+});
+
+test("maps Merge routing namespaces to canonical metadata namespaces", () => {
+  expect(canonicalMetadataID("qwen/qwen3-vl-8b-instruct")).toBe("alibaba/qwen3-vl-8b-instruct");
+  expect(canonicalMetadataID("moonshot/kimi-k2")).toBe("moonshotai/kimi-k2");
+  expect(canonicalMetadataID("zai/glm-5")).toBe("zhipuai/glm-5");
+});
+
+// A generated canonical record must not invent an upstream release date.
+test("does not generate canonical metadata without a Merge Gateway release date", () => {
+  const generated = buildMergeGatewayCanonicalFallback(mergeGatewayModel({
+    model: "qwen/qwen3-14b",
+    provider: "qwen",
+    display_name: "Qwen3 14B",
+    release_date: null,
+    // A vendor onboarding date is not evidence of the upstream release date.
+    vendors: { qwen: mergeGatewayVendor({ launch_date: "2025-06-01" }) },
+  }));
+
+  expect(generated).toBeUndefined();
+});
+
+test("does not generate canonical metadata without explicit Merge Gateway open-weight status", () => {
+  const generated = buildMergeGatewayCanonicalFallback(mergeGatewayModel({
+    model: "qwen/qwen3-14b",
+    provider: "qwen",
+    display_name: "Qwen3 14B",
+    open_weights: null,
+  }));
+
+  expect(generated).toBeUndefined();
+});
+
+test("does not generate canonical metadata for non-text Merge Gateway models", () => {
+  const vendor = mergeGatewayVendor();
+  vendor.capabilities.output = ["image"];
+  const generated = buildMergeGatewayCanonicalFallback(mergeGatewayModel({
+    model: "openai/gpt-image-2",
+    display_name: "GPT Image 2",
+    vendors: { openai: vendor },
+  }));
+
+  expect(generated).toBeUndefined();
+});
+
+test("Merge Gateway sync creates canonical and provider files from discovery metadata", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "sync-merge-gateway-"));
+  const modelsDir = path.join(root, "providers", "merge-gateway", "models");
+  const response = {
+    object: "list" as const,
+    data: [mergeGatewayModel({
+      model: "qwen/qwen3-14b",
+      provider: "qwen",
+      display_name: "Qwen3 14B",
+      release_date: "2025-04-29",
+      open_weights: true,
+    })],
+    has_more: false,
+    next_cursor: null,
+  };
+  const provider: SyncProvider<MergeGatewayModel> = {
+    ...mergeGateway,
+    id: "merge-gateway-test",
+    name: "Merge Gateway test",
+    modelsDir,
+    async fetchModels() {
+      return response;
+    },
+  };
+
+  try {
+    await mkdir(modelsDir, { recursive: true });
+    const result = await syncProvider(provider);
+    expect(result).toMatchObject({ created: 2, updated: 0, deleted: 0 });
+
+    const metadata = await readFile(
+      path.join(root, "models", "alibaba", "qwen3-14b.toml"),
+      "utf8",
+    );
+    expect(metadata).toContain('release_date = "2025-04-29"');
+    expect(metadata).toContain("open_weights = true");
+
+    const providerModel = await readFile(
+      path.join(modelsDir, "qwen", "qwen3-14b.toml"),
+      "utf8",
+    );
+    expect(providerModel).toContain('base_model = "alibaba/qwen3-14b"');
+
+    const decision = await classifyAutoMerge(
+      [
+        { status: "created", path: "models/alibaba/qwen3-14b.toml" },
+        {
+          status: "created",
+          path: "providers/merge-gateway/models/qwen/qwen3-14b.toml",
+        },
+      ],
+      (relativePath) => readFile(path.join(root, relativePath), "utf8"),
+    );
+    expect(decision).toEqual({
+      safe: true,
+      created: 2,
+      updated: 0,
+      deleted: 0,
+      reasons: [],
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 // Emits only route-specific overrides when canonical metadata already matches.
 test("factors Merge Gateway GPT-5.6 Sol against canonical metadata", () => {
   const model = buildMergeGatewayModel(mergeGatewayModel(), undefined);
@@ -3807,6 +3966,8 @@ function mergeGatewayModel(overrides: Partial<MergeGatewayModel> = {}): MergeGat
     model: "openai/gpt-5.6-sol",
     provider: "openai",
     display_name: "GPT-5.6 Sol",
+    release_date: "2026-07-08",
+    open_weights: false,
     vendors: { openai: mergeGatewayVendor() },
     availability_status: "available",
     created_at: "2026-07-09T00:00:00Z",


### PR DESCRIPTION
## Summary

Lets the Merge Gateway sync create previously unknown text models when Gateway discovery supplies the canonical facts models.dev needs.

Today the adapter only updates models that already have reviewed canonical metadata, so valid Gateway-only models are skipped. This aligns Merge with the create-unknown lifecycle used by OpenRouter while failing closed when facts are incomplete.

Gateway-side dependencies:
- https://github.com/merge-api/merge-gateway-control-backend/pull/767
- https://github.com/merge-api/merge-gateway/pull/933

## Safety

A new canonical model is created only when:

- an available route produces text
- release_date is explicitly present at the model level
- open_weights is explicitly true or false

The adapter does not substitute vendor launch dates, does not guess open-weight status, and continues to skip non-text output models. Routing namespaces are mapped to the existing canonical metadata namespaces.

The initial backlog may exceed the repository auto-merge churn limit and require one manual catalog review. Subsequent small refreshes remain eligible for the existing hourly auto-merge workflow.

## Proof

The test runs the actual sync engine for qwen/qwen3-14b and verifies that it creates:

- models/alibaba/qwen3-14b.toml
- providers/merge-gateway/models/qwen/qwen3-14b.toml

It then runs the repository auto-merge classifier over those files and verifies safe: true with two created files and no review reasons.

## Validation

- 30 focused Merge Gateway sync tests passed
- bun validate passed
- full sync.test result: 141 passed and one unrelated DeepInfra Qwen 3.5 failure that reproduces unchanged on origin/dev