### PR TITLE
fix(cloudflare-ai-gateway): align reasoning effort options with first-party catalogs

### DIFF
--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-fable-5.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-fable-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-fable-5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 10

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-haiku-4-5.toml
@@ -5,7 +5,7 @@ release_date = "2025-10-15"
 last_updated = "2025-10-15"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-02-28"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-1.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-1.toml
@@ -5,7 +5,7 @@ release_date = "2025-08-05"
 last_updated = "2025-08-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-6.toml
@@ -5,7 +5,7 @@ release_date = "2026-02-05"
 last_updated = "2026-02-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 temperature = true
 tool_call = true
 knowledge = "2025-05-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-8.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4-8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-opus-4.toml
@@ -5,7 +5,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-5.toml
@@ -5,7 +5,7 @@ release_date = "2025-09-29"
 last_updated = "2025-09-29"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-07-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4-6.toml
@@ -5,7 +5,7 @@ release_date = "2026-02-17"
 last_updated = "2026-02-17"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 temperature = true
 tool_call = true
 interleaved = true

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-4.toml
@@ -5,7 +5,7 @@ release_date = "2025-05-22"
 last_updated = "2025-05-22"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
 temperature = true
 tool_call = true
 knowledge = "2025-03-31"

--- a/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-5.toml
+++ b/providers/cloudflare-ai-gateway/models/anthropic/claude-sonnet-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 interleaved = true
 
 [cost]

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-luna.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-luna.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.6-luna"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 1

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-sol.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-sol.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.6-sol"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 5

--- a/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-terra.toml
+++ b/providers/cloudflare-ai-gateway/models/openai/gpt-5.6-terra.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.6-terra"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 2.5


### PR DESCRIPTION
## Summary

The \`cloudflare-ai-gateway\` catalog was built from a one-time snapshot and its \`reasoning_options\` have drifted from the first-party \`anthropic\` and \`openai\` catalogs. Since opencode now routes these gateway models through the native provider passthroughs (OpenAI Responses / Anthropic Messages), reasoning options should mirror what the first-party catalogs record for the same models.

### Effort value alignment

| Model | Before | After (matches first-party) |
|---|---|---|
| \`anthropic/claude-sonnet-4-6\` | low, medium, high | + **max** |
| \`anthropic/claude-opus-4-6\` | low, medium, high | + **max** |
| \`anthropic/claude-opus-4-8\` | low, medium, high | + **xhigh, max** |
| \`anthropic/claude-fable-5\` | low, medium, high | + **xhigh, max** |
| \`anthropic/claude-sonnet-5\` | effort only | + **toggle** option |
| \`openai/gpt-5.6-luna/sol/terra\` | none, low, medium, high | + **xhigh, max** |

### Bogus effort → budget_tokens

These models don't support \`output_config.effort\` upstream (first-party catalog records them as \`budget_tokens\`-only), so sending effort on the native Messages route fails. Switched to \`[{ type = "budget_tokens", min = 1_024 }]\`:

- \`anthropic/claude-haiku-4-5\`
- \`anthropic/claude-sonnet-4-5\`
- \`anthropic/claude-sonnet-4\`
- \`anthropic/claude-opus-4\`
- \`anthropic/claude-opus-4-1\`

## Out of scope (follow-up PR)

Catalog refresh: costs/limits sync, removing dead entries, adding missing models/providers.

Per-model \`npm\` overrides are intentionally untouched; older opencode clients still read them.

\`bun run validate\` passes.