### PR TITLE
feat(github-copilot): add Gemini 3.7 Flash

### DIFF
--- a/providers/github-copilot/models/gemini-3.7-flash.toml
+++ b/providers/github-copilot/models/gemini-3.7-flash.toml
@@ -1,0 +1,18 @@
+# Sources:
+# - https://api.githubcopilot.com/models
+# - https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
+base_model = "google/gemini-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+
+[limit]
+context = 1_000_000
+input = 936_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
## Summary

- add Gemini 3.7 Flash to the GitHub Copilot provider
- use Copilot-specific reasoning levels, token limits, and image input support
- use GitHub's promotional token pricing through December 31, 2026

## Validation

- `bun validate`
- `git diff --check`

## Sources

- https://api.githubcopilot.com/models
- https://docs.github.com/en/copilot/reference/ai-models/supported-models
- https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
