### PR TITLE
feat(cloudflare-ai-gateway): add google-ai-studio, grok, groq, mistral, deepseek providers

### DIFF
--- a/providers/cloudflare-ai-gateway/models/deepseek/deepseek-chat.toml
+++ b/providers/cloudflare-ai-gateway/models/deepseek/deepseek-chat.toml
@@ -1,0 +1,6 @@
+base_model = "deepseek/deepseek-chat"
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028

--- a/providers/cloudflare-ai-gateway/models/deepseek/deepseek-reasoner.toml
+++ b/providers/cloudflare-ai-gateway/models/deepseek/deepseek-reasoner.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-reasoner"
+reasoning_options = []
+
+[cost]
+input = 0.14
+output = 0.28
+reasoning = 0.28
+cache_read = 0.0028
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/cloudflare-ai-gateway/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/cloudflare-ai-gateway/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,25 @@
+# Reasoning tokens are billed at the output rate (no separate CoT price).
+# `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
+# OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
+# Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
+# Flash maps requested low→low (unlike Pro, which maps low→high). xhigh→high.
+# https://api-docs.deepseek.com/guides/thinking_mode/ (accessed 2026-08-02)
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.14
+output = 0.28
+reasoning = 0.28
+cache_read = 0.0028

--- a/providers/cloudflare-ai-gateway/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/cloudflare-ai-gateway/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,24 @@
+# Reasoning tokens are billed at the output rate (no separate CoT price).
+# `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-12)
+base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro"
+# OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.
+# Anthropic: `thinking.type`, `output_config.effort = high|max`; budget ignored.
+# https://api-docs.deepseek.com/api/create-chat-completion (accessed 2026-06-25)
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.435
+output = 0.87
+reasoning = 0.87
+cache_read = 0.003625

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-2.5-flash-lite.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-2.5-flash-lite.toml
@@ -1,0 +1,15 @@
+base_model = "google/gemini-2.5-flash-lite"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 512
+max = 24576
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01
+input_audio = 0.3

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-2.5-flash.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-2.5-flash.toml
@@ -1,0 +1,15 @@
+base_model = "google/gemini-2.5-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 24_576
+
+[cost]
+input = 0.30
+output = 2.50
+cache_read = 0.03
+input_audio = 1.00

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-2.5-pro.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-2.5-pro.toml
@@ -1,0 +1,17 @@
+base_model = "google/gemini-2.5-pro"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 128
+max = 32_768
+
+[cost]
+input = 1.25
+output = 10.00
+cache_read = 0.125
+
+[[cost.tiers]]
+tier = { size = 200_000 }
+input = 2.50
+output = 15.00
+cache_read = 0.25

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3-flash-preview.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3-flash-preview.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3-flash-preview"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+input_audio = 1

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.1-flash-lite.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.1-flash-lite.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.1-flash-lite"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+input_audio = 0.5

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.1-pro-preview.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.1-pro-preview.toml
@@ -1,0 +1,16 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { size = 200000 }
+input = 4
+output = 18
+cache_read = 0.4

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.5-flash-lite.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.5-flash-lite.toml
@@ -1,0 +1,13 @@
+# Sources:
+# - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/
+# - https://ai.google.dev/gemini-api/docs/pricing
+base_model = "google/gemini-3.5-flash-lite"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.30
+output = 2.50
+cache_read = 0.03

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.5-flash.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.5-flash.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.5-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+input_audio = 1.5

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.6-flash.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.6-flash.toml
@@ -1,0 +1,14 @@
+# Sources:
+# - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/
+# - https://ai.google.dev/gemini-api/docs/pricing
+base_model = "google/gemini-3.6-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.50
+output = 7.50
+cache_read = 0.15
+input_audio = 1.50

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.7-flash.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-3.7-flash.toml
@@ -1,0 +1,15 @@
+# Sources:
+# - https://blog.google/innovation-and-ai/models-and-research/gemini-models/introducing-gemini-3-7-flash/
+# - https://ai.google.dev/gemini-api/docs/pricing
+# - https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thinking
+base_model = "google/gemini-3.7-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+input_audio = 0.75

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-flash-latest.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-flash-latest.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-flash-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+input_audio = 1.5

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-flash-lite-latest.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemini-flash-lite-latest.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-flash-lite-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+input_audio = 0.5

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemma-4-26b-a4b-it.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemma-4-26b-a4b-it.toml
@@ -1,0 +1,4 @@
+base_model = "google/gemma-4-26b-a4b-it"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/cloudflare-ai-gateway/models/google-ai-studio/gemma-4-31b-it.toml
+++ b/providers/cloudflare-ai-gateway/models/google-ai-studio/gemma-4-31b-it.toml
@@ -1,0 +1,4 @@
+base_model = "google/gemma-4-31b-it"
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/cloudflare-ai-gateway/models/grok/grok-4.20-0309-non-reasoning.toml
+++ b/providers/cloudflare-ai-gateway/models/grok/grok-4.20-0309-non-reasoning.toml
@@ -1,0 +1,12 @@
+base_model = "xai/grok-4.20-0309-non-reasoning"
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200000 }
+input = 2.5
+output = 5
+cache_read = 0.4

--- a/providers/cloudflare-ai-gateway/models/grok/grok-4.20-0309-reasoning.toml
+++ b/providers/cloudflare-ai-gateway/models/grok/grok-4.20-0309-reasoning.toml
@@ -1,0 +1,13 @@
+base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { size = 200000 }
+input = 2.5
+output = 5
+cache_read = 0.4

--- a/providers/cloudflare-ai-gateway/models/grok/grok-4.3.toml
+++ b/providers/cloudflare-ai-gateway/models/grok/grok-4.3.toml
@@ -1,0 +1,17 @@
+base_model = "xai/grok-4.3"
+description = "xAI's Grok for chat, coding, agentic tools, and lower hallucination risk"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { size = 200000 }
+input = 2.5
+output = 5
+cache_read = 0.4

--- a/providers/cloudflare-ai-gateway/models/grok/grok-4.5.toml
+++ b/providers/cloudflare-ai-gateway/models/grok/grok-4.5.toml
@@ -1,0 +1,19 @@
+base_model = "xai/grok-4.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.3
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12
+cache_read = 0.6
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/cloudflare-ai-gateway/models/grok/grok-4.6.toml
+++ b/providers/cloudflare-ai-gateway/models/grok/grok-4.6.toml
@@ -5,14 +5,6 @@ base_model = "xai/grok-4.6"
 type = "effort"
 values = ["low", "medium", "high", "xhigh"]
 
-[experimental.modes.fast]
-provider = { body = { service_tier = "priority" } }
-
-[experimental.modes.fast.cost]
-input = 4
-output = 12
-cache_read = 1
-
 [cost]
 input = 2
 output = 6

--- a/providers/cloudflare-ai-gateway/models/grok/grok-4.6.toml
+++ b/providers/cloudflare-ai-gateway/models/grok/grok-4.6.toml
@@ -1,0 +1,28 @@
+# Sources: https://docs.x.ai/developers/models/grok-4.6, https://docs.x.ai/developers/pricing, and https://docs.x.ai/developers/model-capabilities/text/reasoning
+base_model = "xai/grok-4.6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+[experimental.modes.fast]
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.fast.cost]
+input = 4
+output = 12
+cache_read = 1
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12
+cache_read = 1
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/cloudflare-ai-gateway/models/grok/grok-build-0.1.toml
+++ b/providers/cloudflare-ai-gateway/models/grok/grok-build-0.1.toml
@@ -1,0 +1,13 @@
+base_model = "xai/grok-build-0.1"
+reasoning_options = []
+
+[cost]
+input = 1
+output = 2
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { size = 200000 }
+input = 2
+output = 4
+cache_read = 0.4

--- a/providers/cloudflare-ai-gateway/models/groq/llama-3.1-8b-instant.toml
+++ b/providers/cloudflare-ai-gateway/models/groq/llama-3.1-8b-instant.toml
@@ -1,0 +1,11 @@
+base_model = "meta/llama-3.1-8b-instruct"
+name = "Llama 3.1 8B"
+description = "Compact Llama instruction model for fast chat and local deployment"
+
+[cost]
+input = 0.05
+output = 0.08
+
+[limit]
+context = 131072
+output = 131072

--- a/providers/cloudflare-ai-gateway/models/groq/llama-3.3-70b-versatile.toml
+++ b/providers/cloudflare-ai-gateway/models/groq/llama-3.3-70b-versatile.toml
@@ -1,0 +1,12 @@
+base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama 3.3 70B"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+attachment = false
+
+[cost]
+input = 0.59
+output = 0.79
+
+[limit]
+context = 131072
+output = 32768

--- a/providers/cloudflare-ai-gateway/models/mistral/codestral-latest.toml
+++ b/providers/cloudflare-ai-gateway/models/mistral/codestral-latest.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/codestral-latest"
+
+[cost]
+input = 0.3
+output = 0.9

--- a/providers/cloudflare-ai-gateway/models/mistral/magistral-medium-latest.toml
+++ b/providers/cloudflare-ai-gateway/models/mistral/magistral-medium-latest.toml
@@ -1,0 +1,7 @@
+base_model = "mistral/magistral-medium-latest"
+open_weights = true
+reasoning_options = []
+
+[cost]
+input = 2
+output = 5

--- a/providers/cloudflare-ai-gateway/models/mistral/magistral-small.toml
+++ b/providers/cloudflare-ai-gateway/models/mistral/magistral-small.toml
@@ -1,0 +1,12 @@
+base_model = "mistral/magistral-small-2506"
+description = "Mistral reasoning model for transparent analysis, math, and complex decisions"
+knowledge = "2025-06"
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 1.5
+
+[limit]
+context = 128000
+output = 128000

--- a/providers/cloudflare-ai-gateway/models/mistral/ministral-8b-latest.toml
+++ b/providers/cloudflare-ai-gateway/models/mistral/ministral-8b-latest.toml
@@ -1,0 +1,12 @@
+base_model = "mistral/ministral-8b-instruct-2410"
+name = "Ministral 8B (latest)"
+description = "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads"
+knowledge = "2024-10"
+
+[cost]
+input = 0.1
+output = 0.1
+
+[limit]
+context = 128000
+output = 128000

--- a/providers/cloudflare-ai-gateway/models/mistral/mistral-large-latest.toml
+++ b/providers/cloudflare-ai-gateway/models/mistral/mistral-large-latest.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-large-latest"
+
+[cost]
+input = 0.5
+output = 1.5

--- a/providers/cloudflare-ai-gateway/models/mistral/mistral-medium-latest.toml
+++ b/providers/cloudflare-ai-gateway/models/mistral/mistral-medium-latest.toml
@@ -1,0 +1,12 @@
+# mistral-medium-latest is Mistral's alias for Mistral Medium 3.5 (mistral-medium-2604).
+# Medium 3.1 (mistral-medium-2508) was deprecated 2026-05-22, retiring 2026-08-31.
+base_model = "mistral/mistral-medium-latest"
+name = "Mistral Medium (latest)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 1.50
+output = 7.50

--- a/providers/cloudflare-ai-gateway/models/mistral/mistral-small-latest.toml
+++ b/providers/cloudflare-ai-gateway/models/mistral/mistral-small-latest.toml
@@ -1,0 +1,9 @@
+base_model = "mistral/mistral-small-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/cloudflare-ai-gateway/models/mistral/pixtral-large-latest.toml
+++ b/providers/cloudflare-ai-gateway/models/mistral/pixtral-large-latest.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/pixtral-large-latest"
+
+[cost]
+input = 2
+output = 6


### PR DESCRIPTION
## Summary

The Cloudflare AI Gateway unified endpoint routes far more providers than the catalog reflected (previously only \`openai/\`, \`anthropic/\`, \`workers-ai/\`). This adds the major missing registered provider prefixes, mirroring each first-party catalog as \`base_model\` stubs. Follows #4674 / #4676.

### Added (34 models)

| Prefix | Source catalog | Models |
|---|---|---|
| \`google-ai-studio/\` | \`providers/google\` | gemini-2.5-pro/flash/flash-lite, gemini-3-flash-preview, 3.1-pro-preview, 3.1-flash-lite, 3.5-flash, 3.5-flash-lite, 3.6-flash, 3.7-flash, flash-latest, flash-lite-latest, gemma-4-26b/31b (14) |
| \`grok/\` | \`providers/xai\` | grok-4.3, 4.5, 4.6, build-0.1, 4.20-0309-reasoning/non-reasoning (6) |
| \`groq/\` | \`providers/groq\` | llama-3.3-70b-versatile, llama-3.1-8b-instant (2) |
| \`mistral/\` | \`providers/mistral\` | large/medium/small/codestral/magistral-medium/pixtral-large -latest, magistral-small, ministral-8b-latest (8) |
| \`deepseek/\` | \`providers/deepseek\` | deepseek-chat, deepseek-reasoner, deepseek-v4-flash, deepseek-v4-pro (4) |

### Curation rules

- Chat-capable, tool-calling, text-out, non-deprecated models only — no image/TTS/STT/embedding/robotics/computer-use variants
- Mistral: \`-latest\` aliases over dated duplicates; 2023-era open-weight legacy models (mixtral, nemo, open-mistral-7b) skipped; \`ministral-3b-latest\` skipped (no lab metadata exists to point at)
- Every entry is an override-only \`base_model\` stub; groq's serving names alias their underlying meta lab models (\`llama-3.3-70b-versatile\` → \`meta/llama-3.3-70b-instruct\`)

### Notes for reviewers

- All of these route through the gateway's OpenAI-compatible unified endpoint (\`ai-gateway-provider\` npm from provider.toml), same as the rest of the catalog today. A native Gemini passthrough in opencode can be layered on later without catalog changes.
- Billing: Cloudflare's docs list Google AI Studio, xAI, and Groq under Unified Billing; Mistral and DeepSeek models may require stored BYOK keys on the gateway. The prefixes themselves are all registered on the unified endpoint.

\`bun run validate\` passes.