### PR TITLE
feat(fireworks-ai): add DeepSeek V4 Pro 0813

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro-0813.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro-0813.toml
@@ -1,0 +1,20 @@
+# Toggle: thinking.type = enabled|disabled (reasoning_effort = none|false also disables)
+# Effort: reasoning_effort = high|max; low/medium promote to high, xhigh to max
+# Reasoning: https://docs.fireworks.ai/api-reference/post-chatcompletions (accessed 2026-08-14)
+# Pricing: https://fireworks.ai/models/deepseek-ai/deepseek-v4-pro-0813 (accessed 2026-08-14)
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.32
+output = 3.96
+cache_read = 0.044


### PR DESCRIPTION
## Summary

Adds `accounts/fireworks/models/deepseek-v4-pro-0813` to the Fireworks AI provider (verified live via the Fireworks models API). Override-only entry pointing at the existing lab metadata `deepseek/deepseek-v4-pro-0813` — no lab files or other providers touched.

## Host classification

Fireworks is a **multi-model relay** for this model (DeepSeek is the lab). Reasoning options copied from the first-party DeepSeek entry (`providers/deepseek/models/deepseek-v4-pro.toml`) and the same-surface Fireworks peer (`deepseek-v4-pro.toml`): `toggle` + `effort ["high", "max"]`.

## Data sources mapped to claims

| Claim | Value | Source |
| --- | --- | --- |
| Input price | $1.32 / MTok | [Fireworks model page](https://fireworks.ai/models/deepseek-ai/deepseek-v4-pro-0813) — "$1.32 / $0.044 / $3.96 per 1M Tokens (input/cached input/output)" (accessed 2026-08-14) |
| Cache read price | $0.044 / MTok | Same |
| Output price | $3.96 / MTok | Same |
| Context 1M / output 384k | inherited from `models/deepseek/deepseek-v4-pro-0813.toml` | Lab metadata, unchanged (page lists "1040k tokens" ≈ 1M serving) |
| Toggle wire path | `thinking.type = enabled\|disabled` (`reasoning_effort = none\|false` also disables) | [Fireworks chat completions API reference](https://docs.fireworks.ai/api-reference/post-chatcompletions) — `thinking` param, `ThinkingConfigDisabled` (accessed 2026-08-14) |
| Effort values `high`, `max` | `reasoning_effort = high\|max` | Same — DeepSeek V4 section: accepts none/low/medium/high/xhigh/max; low/medium silently promoted to high, xhigh to max, default high |
| Interleaved `reasoning_content` | `[interleaved] field = "reasoning_content"` | Same — reasoning delivered via `reasoning_content`; DeepSeek V4 `reasoning_history` default `interleaved` |

## Reasoning options rationale

- `toggle` + `effort ["high", "max"]` per the DeepSeek V4 convention (AGENTS.md): lab maps low/medium→high and xhigh→max, so only `high`/`max` are real caller levels; off is via `thinking.type = disabled`.
- No `xhigh`/`low`/`medium` (no independent effect on this host), no `budget_tokens` (DeepSeek V4 ignores reasoning budgets), not `[]` (host exposes documented caller controls).
- Leading top-of-file wire comments included per review conventions.

## Validation

- [x] `bun validate` passes; merged entry resolves with name/description/limits/modalities from base and cost/reasoning/interleaved overrides.