### PR TITLE
feat(openference): add Openference provider and model catalog

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -26,6 +26,7 @@ import { mergeGateway } from "./providers/merge-gateway.js";
 import { nanoGpt } from "./providers/nano-gpt.js";
 import { openai } from "./providers/openai.js";
 import { ofox } from "./providers/ofox.js";
+import { openference } from "./providers/openference.js";
 import { openrouter } from "./providers/openrouter.js";
 import { ovhcloud } from "./providers/ovhcloud.js";
 import { pioneer } from "./providers/pioneer.js";
@@ -135,6 +136,7 @@ export const providers: {
   "nano-gpt": SyncProvider<any>;
   ofox: SyncProvider<any>;
   openai: SyncProvider<any>;
+  openference: SyncProvider<any>;
   openrouter: SyncProvider<any>;
   ovhcloud: SyncProvider<any>;
   pioneer: SyncProvider<any>;
@@ -166,6 +168,7 @@ export const providers: {
   "nano-gpt": nanoGpt,
   ofox,
   openai,
+  openference,
   openrouter,
   ovhcloud,
   pioneer,
@@ -189,6 +192,7 @@ export const groups = {
     "merge-gateway",
     "nano-gpt",
     "ofox",
+    "openference",
     "requesty",
     "openrouter",
     "vercel",

--- a/packages/core/src/sync/providers/openference.ts
+++ b/packages/core/src/sync/providers/openference.ts
@@ -103,7 +103,10 @@ function reasoningOptions(
       (ReasoningEffortOrder.get(b) ?? Number.MAX_SAFE_INTEGER);
     return order || a.localeCompare(b);
   });
-  return [...toggle, ReasoningOption.parse({ type: "effort", values: sorted })];
+  return [
+    ...(sorted.includes("none") ? [] : toggle),
+    ReasoningOption.parse({ type: "effort", values: sorted }),
+  ];
 }
 
 function resolveBaseModel(id: string) {

--- a/packages/core/src/sync/providers/openference.ts
+++ b/packages/core/src/sync/providers/openference.ts
@@ -1,0 +1,168 @@
+import { z } from "zod";
+
+import { ReasoningOption } from "../../schema.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://api.openference.com/v1/models";
+
+// Openference is a curated OpenAI-compatible relay. `/v1/models` is authoritative
+// for pricing (USD per token), served context/output limits, and the reasoning
+// efforts each model accepts. Bare wire IDs resolve to canonical lab metadata in
+// `models/` through the shared resolver; anything without a lab match preserves
+// an existing hand-authored file (e.g. the host's own "Auto" router).
+const BASE_MODEL_ALIASES: Record<string, string> = {
+  // Openference's shorthand for the NVIDIA Super 120B A12B tier.
+  "Nemotron-3-120B": "nvidia/nemotron-3-super-120b-a12b",
+};
+
+// Openference's model listing does not distinguish toggle-capable models from
+// always-on reasoners when supported_efforts is omitted. Keep the documented
+// always-on models explicit so they do not receive a false thinking toggle.
+const ALWAYS_ON_REASONING_MODELS = new Set(["Kimi K2.7 Code", "MiMo-V2.5"]);
+
+const OpenferencePricing = z.object({
+  prompt: z.string(),
+  completion: z.string(),
+  cache_read: z.string().optional(),
+});
+
+type OpenferencePricing = z.infer<typeof OpenferencePricing>;
+
+const OpenferenceReasoning = z
+  .object({
+    supported: z.boolean(),
+    supported_efforts: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+export const OpenferenceModel = z
+  .object({
+    id: z.string(),
+    object: z.string(),
+    created: z.number(),
+    owned_by: z.string(),
+    permission: z.array(z.unknown()),
+    root: z.string(),
+    parent: z.string().nullable(),
+    pricing: OpenferencePricing,
+    context_length: z.number(),
+    max_output_tokens: z.number().optional(),
+    reasoning: OpenferenceReasoning,
+  })
+  .passthrough();
+
+export const OpenferenceResponse = z
+  .object({
+    object: z.string(),
+    data: z.array(OpenferenceModel),
+  })
+  .passthrough();
+
+export type OpenferenceModel = z.infer<typeof OpenferenceModel>;
+
+const ReasoningEffortOrder = new Map(
+  ["none", "minimal", "low", "medium", "high", "xhigh", "max", "default"].map(
+    (effort, index) => [effort, index] as const,
+  ),
+);
+
+function price(value: string | undefined) {
+  if (value === undefined) return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0
+    ? Math.round(number * 1_000_000_000_000) / 1_000_000
+    : undefined;
+}
+
+function buildCost(pricing: OpenferencePricing) {
+  const input = price(pricing.prompt);
+  const output = price(pricing.completion);
+  if (input === undefined || output === undefined) return undefined;
+  return {
+    input,
+    output,
+    cache_read: price(pricing.cache_read),
+  };
+}
+
+function reasoningOptions(
+  model: OpenferenceModel,
+): SyncedFullModel["reasoning_options"] {
+  if (!model.reasoning.supported) return undefined;
+  if (ALWAYS_ON_REASONING_MODELS.has(model.id)) return [];
+  // Toggle-capable reasoning models expose `thinking.type = enabled|disabled`;
+  // graded effort is layered on top when the endpoint advertises
+  // `supported_efforts`.
+  const toggle = [ReasoningOption.parse({ type: "toggle" })];
+  const efforts = model.reasoning.supported_efforts;
+  if (efforts === undefined || efforts.length === 0) return toggle;
+  const sorted = [...efforts].sort((a, b) => {
+    const order =
+      (ReasoningEffortOrder.get(a) ?? Number.MAX_SAFE_INTEGER) -
+      (ReasoningEffortOrder.get(b) ?? Number.MAX_SAFE_INTEGER);
+    return order || a.localeCompare(b);
+  });
+  return [...toggle, ReasoningOption.parse({ type: "effort", values: sorted })];
+}
+
+function resolveBaseModel(id: string) {
+  const alias = BASE_MODEL_ALIASES[id];
+  if (alias !== undefined) return alias;
+  return resolveModelMetadataBaseModel(id.replace(/\s+/g, "-"));
+}
+
+function buildModel(
+  model: OpenferenceModel,
+  base: string,
+  existing: ExistingModel | undefined,
+): SyncedModel {
+  const reasoning = model.reasoning.supported;
+  const limit = {
+    context: model.context_length,
+    output: model.max_output_tokens,
+  };
+  const interleaved = reasoning
+    ? existing?.interleaved ?? { field: "reasoning_content" as const }
+    : undefined;
+  return factorBaseModel(
+    base,
+    {
+      cost: buildCost(model.pricing),
+      limit,
+      reasoning_options: reasoningOptions(model),
+      interleaved,
+    },
+    limit,
+  );
+}
+
+export const openference = {
+  id: "openference",
+  name: "Openference",
+  modelsDir: "providers/openference/models",
+  async fetchModels() {
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(
+        `Openference request failed: ${response.status} ${response.statusText}`,
+      );
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return OpenferenceResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    const base = resolveBaseModel(model.id);
+    if (base === undefined) {
+      // No canonical lab model — preserve a hand-authored file (e.g. the
+      // host's own "Auto" router) and skip models with no metadata at all.
+      const authored = context.authored(model.id);
+      return authored === undefined
+        ? undefined
+        : { id: model.id, model: authored as SyncedModel };
+    }
+    return { id: model.id, model: buildModel(model, base, context.existing(model.id)) };
+  },
+} satisfies SyncProvider<OpenferenceModel>;

--- a/packages/core/src/sync/providers/openference.ts
+++ b/packages/core/src/sync/providers/openference.ts
@@ -123,7 +123,7 @@ function buildModel(
   const reasoning = model.reasoning.supported;
   const limit = {
     context: model.context_length,
-    output: model.max_output_tokens,
+    output: model.max_output_tokens ?? existing?.limit?.output ?? model.context_length,
   };
   const interleaved = reasoning
     ? existing?.interleaved ?? { field: "reasoning_content" as const }
@@ -161,7 +161,7 @@ function buildAuthoredOnlyModel(
   const limit = {
     ...authored.limit,
     context: model.context_length,
-    ...(model.max_output_tokens !== undefined ? { output: model.max_output_tokens } : {}),
+    output: model.max_output_tokens ?? authored.limit?.output ?? model.context_length,
   };
   const reasoning = model.reasoning.supported;
   const apiOptions = reasoningOptions(model);

--- a/packages/core/src/sync/providers/openference.ts
+++ b/packages/core/src/sync/providers/openference.ts
@@ -16,9 +16,9 @@ const BASE_MODEL_ALIASES: Record<string, string> = {
   "Nemotron-3-120B": "nvidia/nemotron-3-super-120b-a12b",
 };
 
-// Openference's model listing does not distinguish toggle-capable models from
-// always-on reasoners when supported_efforts is omitted. Keep the documented
-// always-on models explicit so they do not receive a false thinking toggle.
+// Openference's catalog docs distinguish always-on from toggle-only models by
+// name even when supported_efforts is omitted. Keep the documented always-on
+// models explicit here so they do not receive a false thinking toggle.
 const ALWAYS_ON_REASONING_MODELS = new Set(["Kimi K2.7 Code", "MiMo-V2.5"]);
 
 const OpenferencePricing = z.object({
@@ -140,6 +140,44 @@ function buildModel(
   );
 }
 
+// Host-unique models without a canonical base_model (e.g. the Auto router)
+// still need API-authoritative pricing and limits refreshed onto the
+// hand-authored file. Overlay only the fields /v1/models is authoritative for;
+// preserve everything else from the authored TOML.
+function buildAuthoredOnlyModel(
+  model: OpenferenceModel,
+  authored: ExistingModel,
+): SyncedModel {
+  const { id: _authoredID, ...preserved } = authored;
+  const apiCost = buildCost(model.pricing);
+  const cost = apiCost !== undefined
+    ? {
+        ...authored.cost,
+        input: apiCost.input,
+        output: apiCost.output,
+        ...(apiCost.cache_read !== undefined ? { cache_read: apiCost.cache_read } : {}),
+      }
+    : authored.cost;
+  const limit = {
+    ...authored.limit,
+    context: model.context_length,
+    ...(model.max_output_tokens !== undefined ? { output: model.max_output_tokens } : {}),
+  };
+  const reasoning = model.reasoning.supported;
+  const apiOptions = reasoningOptions(model);
+  const interleaved = reasoning
+    ? authored.interleaved ?? { field: "reasoning_content" as const }
+    : undefined;
+  return {
+    ...preserved,
+    reasoning,
+    cost,
+    limit,
+    ...(apiOptions !== undefined ? { reasoning_options: apiOptions } : {}),
+    interleaved,
+  } as SyncedModel;
+}
+
 export const openference = {
   id: "openference",
   name: "Openference",
@@ -159,12 +197,12 @@ export const openference = {
   translateModel(model, context) {
     const base = resolveBaseModel(model.id);
     if (base === undefined) {
-      // No canonical lab model — preserve a hand-authored file (e.g. the
-      // host's own "Auto" router) and skip models with no metadata at all.
+      // No canonical lab model — refresh API-authoritative fields onto a
+      // hand-authored file (e.g. the host's own "Auto" router) and skip
+      // models with no authored file at all.
       const authored = context.authored(model.id);
-      return authored === undefined
-        ? undefined
-        : { id: model.id, model: authored as SyncedModel };
+      if (authored === undefined) return undefined;
+      return { id: model.id, model: buildAuthoredOnlyModel(model, authored) };
     }
     return { id: model.id, model: buildModel(model, base, context.existing(model.id)) };
   },

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -3741,6 +3741,57 @@ test("converts Openference per-token cache pricing", () => {
   });
 });
 
+test("refreshes API pricing and limits for Openference host-unique models", () => {
+  const authored = {
+    name: "Auto",
+    description: "Openference's auto-routing model",
+    release_date: "2026-07-12",
+    last_updated: "2026-07-12",
+    attachment: false,
+    reasoning: true,
+    temperature: true,
+    tool_call: true,
+    open_weights: false,
+    reasoning_options: [{ type: "toggle" }, { type: "effort", values: ["high"] }],
+    interleaved: { field: "reasoning_content" as const },
+    cost: {
+      input: 0.35,
+      output: 1.0,
+      tiers: [{ tier: { type: "context" as const, size: 200_000 }, input: 0.5, output: 1.5 }],
+    },
+    limit: { context: 250_000, output: 131_072 },
+    modalities: { input: ["text"], output: ["text"] },
+  };
+  const translated = openference.translateModel(
+    openferenceModel("Auto", ["high"]),
+    { existing: () => authored as never, authored: () => authored },
+  );
+
+  expect(translated).toEqual({
+    id: "Auto",
+    model: {
+      name: "Auto",
+      description: "Openference's auto-routing model",
+      release_date: "2026-07-12",
+      last_updated: "2026-07-12",
+      attachment: false,
+      reasoning: true,
+      temperature: true,
+      tool_call: true,
+      open_weights: false,
+      interleaved: { field: "reasoning_content" },
+      cost: {
+        input: 1,
+        output: 2,
+        tiers: authored.cost.tiers,
+      },
+      limit: { context: 128_000, output: 16_384 },
+      reasoning_options: [{ type: "toggle" }, { type: "effort", values: ["high"] }],
+      modalities: { input: ["text"], output: ["text"] },
+    },
+  });
+});
+
 test("parses nullable EmpirioLabs release dates", () => {
   expect(empiriolabs.parseModels({
     data: [{ id: "unknown-text-model", category: "text", model_released_at: null }],

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -3676,7 +3676,11 @@ test("skips an unavailable OpenRouter stub with no authored file", () => {
   expect(translated).toBeUndefined();
 });
 
-function openferenceModel(id: string, supported_efforts?: string[]): OpenferenceModel {
+function openferenceModel(
+  id: string,
+  supported_efforts?: string[],
+  cache_read?: string,
+): OpenferenceModel {
   return {
     id,
     object: "model",
@@ -3685,7 +3689,11 @@ function openferenceModel(id: string, supported_efforts?: string[]): Openference
     permission: [],
     root: id,
     parent: null,
-    pricing: { prompt: "0.000001", completion: "0.000002" },
+    pricing: {
+      prompt: "0.000001",
+      completion: "0.000002",
+      ...(cache_read === undefined ? {} : { cache_read }),
+    },
     context_length: 128_000,
     max_output_tokens: 16_384,
     reasoning: { supported: true, supported_efforts },
@@ -3695,15 +3703,41 @@ function openferenceModel(id: string, supported_efforts?: string[]): Openference
 test("classifies Openference always-on and toggle-only reasoning models", () => {
   const context = { existing: () => undefined, authored: () => undefined };
   const alwaysOn = openference.translateModel(openferenceModel("Kimi K2.7 Code"), context);
+  const alwaysOnMiMo = openference.translateModel(openferenceModel("MiMo-V2.5"), context);
   const toggleOnly = openference.translateModel(openferenceModel("MiniMax M3"), context);
+  const effortWithNone = openference.translateModel(
+    openferenceModel("GLM-5", ["high", "none", "low"]),
+    context,
+  );
 
   expect(alwaysOn?.model).toMatchObject({
     base_model: "moonshotai/kimi-k2.7-code",
     reasoning_options: [],
   });
+  expect(alwaysOnMiMo?.model).toMatchObject({
+    base_model: "xiaomi/mimo-v2.5",
+    reasoning_options: [],
+  });
   expect(toggleOnly?.model).toMatchObject({
     base_model: "minimax/MiniMax-M3",
     reasoning_options: [{ type: "toggle" }],
+  });
+  expect(effortWithNone?.model).toMatchObject({
+    base_model: "zhipuai/glm-5",
+    reasoning_options: [{ type: "effort", values: ["none", "low", "high"] }],
+  });
+});
+
+test("converts Openference per-token cache pricing", () => {
+  const context = { existing: () => undefined, authored: () => undefined };
+  const translated = openference.translateModel(
+    openferenceModel("DeepSeek-V4-Pro-0813", ["high"], "0.000000145"),
+    context,
+  );
+
+  expect(translated?.model).toMatchObject({
+    base_model: "deepseek/deepseek-v4-pro-0813",
+    cost: { input: 1, output: 2, cache_read: 0.145 },
   });
 });
 

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -3792,6 +3792,68 @@ test("refreshes API pricing and limits for Openference host-unique models", () =
   });
 });
 
+test("falls back to context when Openference API omits max_output_tokens", () => {
+  const model: OpenferenceModel = {
+    id: "Nemotron-3-120B",
+    object: "model",
+    created: 0,
+    owned_by: "openference",
+    permission: [],
+    root: "Nemotron-3-120B",
+    parent: null,
+    pricing: { prompt: "0.0000005", completion: "0.0000015" },
+    context_length: 256_000,
+    reasoning: { supported: true, supported_efforts: ["high", "medium", "low"] },
+  };
+  const translated = openference.translateModel(model, {
+    existing: () => undefined,
+    authored: () => undefined,
+  });
+
+  expect(translated?.model).toMatchObject({
+    base_model: "nvidia/nemotron-3-super-120b-a12b",
+    limit: { context: 256_000, output: 256_000 },
+  });
+});
+
+test("falls back to context for authored-only models when API omits max_output_tokens", () => {
+  const authored = {
+    name: "Auto",
+    description: "Openference's auto-routing model",
+    release_date: "2026-07-12",
+    last_updated: "2026-07-12",
+    attachment: false,
+    reasoning: true,
+    temperature: true,
+    tool_call: true,
+    open_weights: false,
+    interleaved: { field: "reasoning_content" as const },
+    cost: { input: 1, output: 2 },
+    limit: { context: 64_000 },
+    modalities: { input: ["text"], output: ["text"] },
+  };
+  const model: OpenferenceModel = {
+    id: "Auto",
+    object: "model",
+    created: 0,
+    owned_by: "openference",
+    permission: [],
+    root: "Auto",
+    parent: null,
+    pricing: { prompt: "0.000001", completion: "0.000002" },
+    context_length: 128_000,
+    reasoning: { supported: true, supported_efforts: ["high"] },
+  };
+  const translated = openference.translateModel(model, {
+    existing: () => authored as never,
+    authored: () => authored,
+  });
+
+  expect(translated?.model).toMatchObject({
+    limit: { context: 128_000, output: 128_000 },
+  });
+});
+
 test("parses nullable EmpirioLabs release dates", () => {
   expect(empiriolabs.parseModels({
     data: [{ id: "unknown-text-model", category: "text", model_released_at: null }],

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -56,6 +56,7 @@ import {
   resolveCanonicalBaseModel,
   type OpenRouterModel,
 } from "../src/sync/providers/openrouter.js";
+import { openference, type OpenferenceModel } from "../src/sync/providers/openference.js";
 import { buildLLMGatewayModel, type LLMGatewayModel } from "../src/sync/providers/llmgateway.js";
 import {
   buildMergeGatewayModel,
@@ -3673,6 +3674,37 @@ test("skips an unavailable OpenRouter stub with no authored file", () => {
   });
 
   expect(translated).toBeUndefined();
+});
+
+function openferenceModel(id: string, supported_efforts?: string[]): OpenferenceModel {
+  return {
+    id,
+    object: "model",
+    created: 0,
+    owned_by: "openference",
+    permission: [],
+    root: id,
+    parent: null,
+    pricing: { prompt: "0.000001", completion: "0.000002" },
+    context_length: 128_000,
+    max_output_tokens: 16_384,
+    reasoning: { supported: true, supported_efforts },
+  };
+}
+
+test("classifies Openference always-on and toggle-only reasoning models", () => {
+  const context = { existing: () => undefined, authored: () => undefined };
+  const alwaysOn = openference.translateModel(openferenceModel("Kimi K2.7 Code"), context);
+  const toggleOnly = openference.translateModel(openferenceModel("MiniMax M3"), context);
+
+  expect(alwaysOn?.model).toMatchObject({
+    base_model: "moonshotai/kimi-k2.7-code",
+    reasoning_options: [],
+  });
+  expect(toggleOnly?.model).toMatchObject({
+    base_model: "minimax/MiniMax-M3",
+    reasoning_options: [{ type: "toggle" }],
+  });
 });
 
 test("parses nullable EmpirioLabs release dates", () => {

--- a/providers/openference/logo.svg
+++ b/providers/openference/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M12 5C15 5 18 7 20 13C18 19 15 21 12 21C9 21 6 19 4 13C6 7 9 5 12 5ZM8.4 11.6A1 1 0 0 1 10.4 11.6L10.4 14.4A1 1 0 0 1 8.4 14.4ZM13.6 11.6A1 1 0 0 1 15.6 11.6L15.6 14.4A1 1 0 0 1 13.6 14.4Z"/>
+  <circle cx="12" cy="4.5" r="1.3"/>
+</svg>

--- a/providers/openference/models/Auto.toml
+++ b/providers/openference/models/Auto.toml
@@ -1,0 +1,36 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high
+# Openference's auto-routing model: no underlying lab identity, so this is a
+# standalone entry rather than a `base_model` override.
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+name = "Auto"
+description = "Automatically selects the optimal model based on performance and speed."
+release_date = "2026-07-12"
+last_updated = "2026-07-12"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high"]
+
+[cost]
+input = 0.35
+output = 1.00
+
+[limit]
+context = 250_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/openference/models/Auto.toml
+++ b/providers/openference/models/Auto.toml
@@ -2,7 +2,7 @@
 # Effort: reasoning_effort = high
 # Openference's auto-routing model: no underlying lab identity, so this is a
 # standalone entry rather than a `base_model` override.
-# https://api.openference.com/v1/models (accessed 2026-08-13)
+# https://api.openference.com/v1/models (accessed 2026-08-14)
 name = "Auto"
 description = "Automatically selects the optimal model based on performance and speed."
 release_date = "2026-07-12"
@@ -24,7 +24,7 @@ type = "effort"
 values = ["high"]
 
 [cost]
-input = 0.35
+input = 0.3675
 output = 1.00
 
 [limit]

--- a/providers/openference/models/DeepSeek-V4-Flash.toml
+++ b/providers/openference/models/DeepSeek-V4-Flash.toml
@@ -1,0 +1,22 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028
+
+[limit]
+context = 920_576

--- a/providers/openference/models/DeepSeek-V4-Pro-0813.toml
+++ b/providers/openference/models/DeepSeek-V4-Pro-0813.toml
@@ -1,0 +1,22 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high|max
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.43
+output = 0.8
+cache_read = 0.145
+
+[limit]
+context = 664_576

--- a/providers/openference/models/DeepSeek-V4-Pro.toml
+++ b/providers/openference/models/DeepSeek-V4-Pro.toml
@@ -1,0 +1,22 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high|max
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "deepseek/deepseek-v4-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.43
+output = 0.8
+cache_read = 0.003625
+
+[limit]
+context = 664_576

--- a/providers/openference/models/GLM-4.7-Flash.toml
+++ b/providers/openference/models/GLM-4.7-Flash.toml
@@ -1,0 +1,22 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|medium|high
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "zhipuai/glm-4.7-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.06
+output = 0.4
+
+[limit]
+context = 131_072
+output = 128_000

--- a/providers/openference/models/GLM-5.1.toml
+++ b/providers/openference/models/GLM-5.1.toml
@@ -1,0 +1,23 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|medium|high
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "zhipuai/glm-5.1"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 202_752
+output = 128_000

--- a/providers/openference/models/GLM-5.2.toml
+++ b/providers/openference/models/GLM-5.2.toml
@@ -1,0 +1,23 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|medium|high
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 524_288
+output = 128_000

--- a/providers/openference/models/GLM-5.toml
+++ b/providers/openference/models/GLM-5.toml
@@ -1,0 +1,23 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|medium|high
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "zhipuai/glm-5"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 1
+output = 3.2
+cache_read = 0.2
+
+[limit]
+context = 202_752
+output = 128_000

--- a/providers/openference/models/Kimi K2.6.toml
+++ b/providers/openference/models/Kimi K2.6.toml
@@ -1,0 +1,17 @@
+# Toggle: thinking.type = enabled|disabled
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "moonshotai/kimi-k2.6"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.16
+
+[limit]
+output = 131_072

--- a/providers/openference/models/Kimi K2.7 Code.toml
+++ b/providers/openference/models/Kimi K2.7 Code.toml
@@ -1,0 +1,15 @@
+# Always-on reasoning: no toggle or effort params (per Openference docs).
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19
+
+[limit]
+output = 131_072

--- a/providers/openference/models/MiMo-V2.5.toml
+++ b/providers/openference/models/MiMo-V2.5.toml
@@ -1,4 +1,5 @@
 # Always-on reasoning: no toggle or effort params (per Openference docs).
+# https://docs.openference.com/api-reference/models#reasoning--thinking (accessed 2026-08-14)
 # https://api.openference.com/v1/models (accessed 2026-08-13)
 base_model = "xiaomi/mimo-v2.5"
 reasoning_options = []

--- a/providers/openference/models/MiMo-V2.5.toml
+++ b/providers/openference/models/MiMo-V2.5.toml
@@ -1,0 +1,15 @@
+# Always-on reasoning: no toggle or effort params (per Openference docs).
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "xiaomi/mimo-v2.5"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028
+
+[limit]
+context = 920_576

--- a/providers/openference/models/MiniMax M3.toml
+++ b/providers/openference/models/MiniMax M3.toml
@@ -1,0 +1,18 @@
+# Toggle: thinking.type = enabled|disabled
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "minimax/MiniMax-M3"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+
+[limit]
+context = 920_576
+output = 131_072

--- a/providers/openference/models/Nemotron-3-120B.toml
+++ b/providers/openference/models/Nemotron-3-120B.toml
@@ -1,0 +1,22 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|medium|high
+# Nemotron-3-120B is Openference's name for NVIDIA's Nemotron 3 Super 120B A12B tier.
+# https://api.openference.com/v1/models (accessed 2026-08-13)
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.5
+output = 1.5
+
+[limit]
+context = 256_000

--- a/providers/openference/models/Nemotron-3-120B.toml
+++ b/providers/openference/models/Nemotron-3-120B.toml
@@ -20,3 +20,4 @@ output = 1.5
 
 [limit]
 context = 256_000
+output = 256_000

--- a/providers/openference/provider.toml
+++ b/providers/openference/provider.toml
@@ -1,0 +1,5 @@
+name = "Openference"
+env = ["OPENFERENCE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.openference.com/v1"
+doc = "https://docs.openference.com/"

--- a/sync.md
+++ b/sync.md
@@ -287,6 +287,18 @@ Requesty is implemented in `packages/core/src/sync/providers/requesty.ts`.
 - Region variants are written as separate models: `gpt-5.4` and `gpt-5.4@eu` are distinct files that share a `base_model` and differ only in served pricing and limits.
 - Prices are per-token USD and are converted to per-1M-token numbers. `pricing[]` bands become `cost.tiers`, with the first band as the flat `cost`. Price fields are nullable upstream, so a route quoting no prices gets no `[cost]` section rather than a fabricated zero.
 
+## Openference Notes
+
+Openference is implemented in `packages/core/src/sync/providers/openference.ts`.
+
+- Run it with `bun models:sync openference`.
+- Source endpoint: `https://api.openference.com/v1/models`; no auth required (the catalog is public).
+- Model IDs are Openference's exact wire IDs (e.g. `DeepSeek-V4-Pro`, `MiniMax M3`, `Qwen3.7 Plus`) and map directly to TOML paths under `providers/openference/models`.
+- Bare wire IDs resolve to canonical lab metadata through `resolveModelMetadataBaseModel` after spaces are normalized to hyphens. `Nemotron-3-120B` aliases to `nvidia/nemotron-3-super-120b-a12b` — Openference's name for NVIDIA's Nemotron 3 Super 120B A12B tier. The host's own `Auto` router has no lab match and is preserved as a hand-authored file.
+- Prices are per-token USD and are converted to per-1M-token numbers. `cost.{input,output,cache_read}` come from `pricing.{prompt,completion,cache_read}`; `limit.context` / `limit.output` come from `context_length` / `max_output_tokens`. Values are authored verbatim and omitted when equal to the lab default.
+- Reasoning models with a documented on/off control accept `thinking.type = enabled|disabled`; always-on models such as `Kimi K2.7 Code` and `MiMo-V2.5` expose no caller control. `reasoning_options` is authored as a `toggle` plus an `effort` option derived from `reasoning.supported_efforts` when present; always-on models get `[]` and toggle-only models get just the `toggle`.
+- Reasoning is delivered in the `reasoning_content` field, so `interleaved` defaults to `reasoning_content` for reasoning models while preserving any existing authored override.
+
 ## Venice Notes
 
 Venice is implemented in `packages/core/src/sync/providers/venice.ts`.


### PR DESCRIPTION
## Summary

Adds Openference as a synced provider backed by its public OpenAI-compatible model catalog.

### Changes

- Register `openference` in the aggregator sync group.
- Add provider metadata, logo, and 13 served model entries.
- Sync pricing, cache-read pricing, context/output limits, and model-specific reasoning controls from `https://api.openference.com/v1/models`.
- Use canonical `base_model` metadata for models with known lab identities while keeping Openference's `Auto` router as a standalone entry.
- Preserve `reasoning_content` interleaving and distinguish toggle-plus-effort, toggle-only, and always-on reasoning models.
- Add sync regression coverage and provider documentation.

Openference docs: https://docs.openference.com/

### Verification

- `bun validate`
- `bun test packages/core/test/sync.test.ts --test-name-pattern 'Openference'`
- `bun run typecheck` from `packages/sdk`