### PR TITLE
fix(github-copilot): add xhigh effort for Grok 4.6

### DIFF
--- a/providers/github-copilot/models/grok-4.6.toml
+++ b/providers/github-copilot/models/grok-4.6.toml
@@ -2,7 +2,7 @@
 # - https://github.blog/changelog/2026-08-14-grok-4-6-is-now-available-in-github-copilot/
 # - https://docs.x.ai/developers/pricing
 base_model = "xai/grok-4.6"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 
 [cost]
 input = 2


### PR DESCRIPTION
## Summary

Add `xhigh` to the reasoning effort options for Grok 4.6 on GitHub Copilot.

GitHub Copilot's `/models` endpoint reports `low`, `medium`, `high`, and `xhigh` for Grok 4.6.

## Validation

- `bun validate`
- `git diff --check`
