### PR TITLE
feat(nvidia): add muse-glimmer-30b model

### DIFF
--- a/providers/nvidia/models/meta/muse-glimmer-30b.toml
+++ b/providers/nvidia/models/meta/muse-glimmer-30b.toml
@@ -1,0 +1,15 @@
+base_model = "meta/muse-glimmer-30b"
+
+# NIM Chat schema: `reasoning_effort = none|minimal|low|medium|high|max`
+# (off = none; graded levels, no separate toggle).
+# https://docs.api.nvidia.com/nim/reference/meta-muse-glimmer-30b-infer
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+# NVIDIA API catalog is free for prototyping (no published per-token price).
+# Matches other NVIDIA-hosted Meta models (e.g. llama-3.2-*).
+[cost]
+input = 0.00
+output = 0.00


### PR DESCRIPTION
## Description

Adds `meta/muse-glimmer-30b` to the NVIDIA provider using `base_model` to inherit the existing model metadata.

## Pricing

- Input: $0
- Output: $0

## Reasoning

Uses NVIDIA NIM `reasoning_effort` values:
`none`, `minimal`, `low`, `medium`, `high`, `max`.

Reasoning traces are exposed through `reasoning_content`.

## References

- https://docs.api.nvidia.com/nim/reference/meta-muse-glimmer-30b-infer
- https://build.nvidia.com/meta/muse-glimmer-30b
- https://huggingface.co/meta-models/Muse-Glimmer-30B