### PR TITLE
feat(perplexity-agent): add grok 4.6 and deepseek-v4-flash-0731 models configuration

### DIFF
--- a/providers/perplexity-agent/models/deepseek/deepseek-v4-flash-0731.toml
+++ b/providers/perplexity-agent/models/deepseek/deepseek-v4-flash-0731.toml
@@ -1,0 +1,14 @@
+# Perplexity Agent (OpenAI-compatible relay) pricing per:
+# https://docs.perplexity.ai/docs/agent-api/models#deepseek
+# Reasoning tokens billed at the output rate (no separate CoT price).
+# Effort: reasoning_effort = low|high|max
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.13
+output = 0.26
+cache_read = 0.028

--- a/providers/perplexity-agent/models/xai/grok-4.6.toml
+++ b/providers/perplexity-agent/models/xai/grok-4.6.toml
@@ -1,0 +1,19 @@
+# Pricing per Perplexity Agent API docs:
+# https://docs.perplexity.ai/docs/agent-api/models#xai
+# Context-based tiers: <=200k / >200k.
+base_model = "xai/grok-4.6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2.00
+output = 6.00
+cache_read = 0.50
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4.00
+output = 12.00
+cache_read = 1.00


### PR DESCRIPTION
## Description

Adds `xai/grok-4.6` and `deepseek/deepseek-v4-flash-0731` to the Perplexity Agent provider using `base_model` to inherit shared model metadata and only override provider-specific configuration.

## Cache & Pricing

Source: Perplexity Agent API.

| **Model** | **Input** | **Output** | **Cache Read** |
| --- | ---: | ---: | ---: |
| `xai/grok-4.6` | $2 / $4* | $6 / $12* | $0.50 / $1* |
| `deepseek/deepseek-v4-flash-0731` | $0.13 | $0.26 | $0.028 |

- Pricing is in **USD per 1M tokens**.
- *Grok 4.6 pricing uses a **200,000-token** input threshold; the first value applies to ≤200k and the second to >200k.

## Reasoning

- `xai/grok-4.6` uses the reasoning configuration inherited from its base model.
- `deepseek/deepseek-v4-flash-0731` uses `reasoning_effort` values:
  `low`, `high`, `max`.
- Reasoning tokens for DeepSeek are billed at the output rate.

## References

- Perplexity Agent API: https://docs.perplexity.ai/docs/agent-api/models#xai
- Perplexity Agent API: https://docs.perplexity.ai/docs/agent-api/models#deepseek
- xAI Grok 4.6: https://docs.x.ai/developers/models/grok-4.6
- DeepSeek: https://huggingface.co/deepseek-ai