### PR TITLE
feat: add DeepSeek V4 Pro 0813 to Alibaba plans

### DIFF
--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-flash.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-flash.toml
@@ -1,14 +1,13 @@
 base_model = "deepseek/deepseek-v4-flash"
-# Reasoning HTTP format (accessed 2026-06-25):
+# Reasoning HTTP format (accessed 2026-08-15):
 # This model toggles with `enable_thinking`: true or false. Chat Completions
 # `reasoning_effort` accepts high (default) or max; low/medium map to high and
 # xhigh maps to max. Anthropic Messages defaults `reasoning_effort` to max.
 # Sources:
-# https://www.alibabacloud.com/help/en/model-studio/deepseek-api
+# https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
 
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-pro-0813.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-pro-0813.toml
@@ -6,11 +6,10 @@ base_model = "deepseek/deepseek-v4-pro-0813"
 # Model availability: authenticated Alibaba Token Plan model selector.
 # Sources:
 # https://help.aliyun.com/zh/model-studio/token-plan-overview
-# https://www.alibabacloud.com/help/en/model-studio/deepseek-api
+# https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
 
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-pro-0813.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-pro-0813.toml
@@ -1,0 +1,22 @@
+base_model = "deepseek/deepseek-v4-pro-0813"
+# Reasoning HTTP format (accessed 2026-08-15):
+# This model toggles with `enable_thinking`: true or false. Chat Completions
+# `reasoning_effort` accepts high (default) or max; low/medium map to high and
+# xhigh maps to max. Anthropic Messages defaults `reasoning_effort` to max.
+# Model availability: authenticated Alibaba Token Plan model selector.
+# Sources:
+# https://help.aliyun.com/zh/model-studio/token-plan-overview
+# https://www.alibabacloud.com/help/en/model-studio/deepseek-api
+# https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/alibaba-token-plan-cn/models/deepseek-v4-pro.toml
+++ b/providers/alibaba-token-plan-cn/models/deepseek-v4-pro.toml
@@ -1,14 +1,13 @@
 base_model = "deepseek/deepseek-v4-pro"
-# Reasoning HTTP format (accessed 2026-06-25):
+# Reasoning HTTP format (accessed 2026-08-15):
 # This model toggles with `enable_thinking`: true or false. Chat Completions
 # `reasoning_effort` accepts high (default) or max; low/medium map to high and
 # xhigh maps to max. Anthropic Messages defaults `reasoning_effort` to max.
 # Sources:
-# https://www.alibabacloud.com/help/en/model-studio/deepseek-api
+# https://platform.qianwenai.com/docs/api-reference/chat/openai-chat
 # https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
 
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/alibaba-token-plan/models/deepseek-v4-pro-0813.toml
+++ b/providers/alibaba-token-plan/models/deepseek-v4-pro-0813.toml
@@ -1,0 +1,21 @@
+base_model = "deepseek/deepseek-v4-pro-0813"
+# Reasoning HTTP format (accessed 2026-08-15):
+# This model toggles with `enable_thinking`: true or false. Chat Completions
+# `reasoning_effort` accepts high (default) or max; low/medium map to high and
+# xhigh maps to max. Anthropic Messages defaults `reasoning_effort` to max.
+# Model availability: authenticated Alibaba Token Plan model selector.
+# Sources:
+# https://www.alibabacloud.com/help/en/model-studio/token-plan-overview
+# https://www.alibabacloud.com/help/en/model-studio/deepseek-api
+# https://www.alibabacloud.com/help/en/model-studio/anthropic-api-messages
+
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
## Summary

- add `deepseek-v4-pro-0813` to the international Alibaba Token Plan catalog
- add the same model ID to the China Alibaba Token Plan catalog
- inherit the existing canonical `deepseek/deepseek-v4-pro-0813` metadata and preserve the plans' zero subscription cost
- align China `deepseek-v4-pro`, `deepseek-v4-pro-0813`, and `deepseek-v4-flash` with the documented `toggle` plus `high`/`max` effort controls

## Why

The authenticated Alibaba Token Plan model selectors for both Singapore and Beijing now list `deepseek-v4-pro-0813`, but the two provider catalogs do not expose it yet. The China catalog also retained older toggle-only metadata even though the current China API documentation defines `reasoning_effort=high|max` for the DeepSeek V4 series.

## Sources

- [Alibaba Token Plan international overview](https://www.alibabacloud.com/help/en/model-studio/token-plan-overview)
- [Alibaba Token Plan China overview](https://help.aliyun.com/zh/model-studio/token-plan-overview)
- [Qwen AI Platform OpenAI Chat API](https://platform.qianwenai.com/docs/api-reference/chat/openai-chat)
- [Alibaba Model Studio DeepSeek API](https://www.alibabacloud.com/help/en/model-studio/deepseek-api)
- [Canonical models.dev metadata](https://github.com/anomalyco/models.dev/blob/dev/models/deepseek/deepseek-v4-pro-0813.toml)

## Validation

- `npx --yes --cache /tmp/models-dev-npm-cache bun@1.3.0 ./packages/core/script/validate.ts`
- verified the generated `alibaba-token-plan` and `alibaba-token-plan-cn` entries both resolve as `deepseek-v4-pro-0813`
- verified all four China DeepSeek V4 entries resolve with `toggle` and `effort` values `high`/`max`
- `git diff --cached --check`
