### PR TITLE
umans-ai + coding-plan: add DeepSeek V4 Pro (0813 pay-per-token release)

### DIFF
--- a/providers/umans-ai-coding-plan/models/umans-deepseek-v4-pro-0813.toml
+++ b/providers/umans-ai-coding-plan/models/umans-deepseek-v4-pro-0813.toml
@@ -1,0 +1,23 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high|max
+# Live metadata: levels none/high/max, default high, and `can_disable=true`
+# (accessed 2026-08-15): https://api.code.umans.ai/v1/models/info
+# limit.output is cap-1 on purpose: the gateway 400s max_tokens >=
+# max_completion_tokens (393216), so 393215 is the largest value that serves
+# (its advertised `recommended_max_tokens`).
+base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_048_576
+output = 393_215

--- a/providers/umans-ai/models/umans-deepseek-v4-pro-0813.toml
+++ b/providers/umans-ai/models/umans-deepseek-v4-pro-0813.toml
@@ -1,0 +1,24 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high|max
+# Pay-per-token (llm-gateway 00327): Umans AI's public rate, which is what
+# GET /v1/models renders. Live metadata: levels none/high/max, default
+# high, and `can_disable=true` (accessed 2026-08-15):
+# https://api.code.umans.ai/v1/models/info
+# limit.output is cap-1 on purpose: the gateway 400s max_tokens >=
+# max_completion_tokens (393216), so 393215 is the largest value that serves
+# (its advertised `recommended_max_tokens`).
+base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.32
+output = 3.96
+cache_read = 0.044
+
+[limit]
+context = 1_048_576
+output = 393_215


### PR DESCRIPTION
Adds DeepSeek V4 Pro to both Umans AI provider listings, released pay-per-token on 2026-08-15 (llm-gateway 00327):

- `providers/umans-ai/models/umans-deepseek-v4-pro-0813.toml` — pay-per-token at Umans AI's public rate ($1.32 / $3.96 / $0.044 per 1M, input / output / cache read — what GET /v1/models renders).
- `providers/umans-ai-coding-plan/models/umans-deepseek-v4-pro-0813.toml` — included in the coding plan (zero cost, like the other plan entries).

Both reference `base_model = "deepseek/deepseek-v4-pro-0813"` (the GA checkpoint), with the reasoning shape verified live against `GET https://api.code.umans.ai/v1/models/info` (accessed 2026-08-15): toggle (thinking enabled/disabled) + effort `high|max`, default `high`. `limit.output` is cap-1 (393215): the gateway 400s `max_tokens >= max_completion_tokens` (393216), so 393215 is the largest value that serves — the same choice as the V4 Flash entries.

Validation: `bun run validate` passes; `bun test` shows the same 4 failures as clean `dev` (pre-existing, unrelated).
