### PR TITLE
poe: add recent coding models (Kimi K3, Grok 4.6, Gemini 3.7 Flash, GLM-5.2)

### DIFF
--- a/providers/poe/models/alibaba/qwen3.6-plus.toml
+++ b/providers/poe/models/alibaba/qwen3.6-plus.toml
@@ -1,0 +1,15 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Toggle: extra_body.enable_thinking true|false
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "alibaba/qwen3.6-plus"
+name = "Qwen3.6-Plus"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0.5051
+output = 3.0303
+cache_read = 0.101
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/poe/models/alibaba/qwen3.7-plus.toml
+++ b/providers/poe/models/alibaba/qwen3.7-plus.toml
@@ -1,0 +1,15 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Toggle: extra_body.enable_thinking true|false
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "alibaba/qwen3.7-plus"
+name = "Qwen3.7-Plus"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0.404
+output = 1.6162
+cache_read = 0.0808
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/poe/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/poe/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,11 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Toggle: extra_body.enable_thinking true|false
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek-V4-Flash"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0.1414
+output = 0.2828
+cache_read = 0.0283

--- a/providers/poe/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/poe/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,11 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Toggle: extra_body.enable_thinking true|false
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek-V4-Pro"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 1.7576
+output = 3.5152
+cache_read = 0.1465

--- a/providers/poe/models/empiriolabs/kimi-k3-el.toml
+++ b/providers/poe/models/empiriolabs/kimi-k3-el.toml
@@ -1,0 +1,10 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Effort: extra_body.reasoning_effort = low|high|max (thinking always on)
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "moonshotai/kimi-k3"
+name = "Kimi-K3-EL"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[cost]
+input = 3.0303
+output = 15.1515

--- a/providers/poe/models/empiriolabs/qwen3.8-max-el.toml
+++ b/providers/poe/models/empiriolabs/qwen3.8-max-el.toml
@@ -1,0 +1,14 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Toggle: extra_body.enable_thinking true|false
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "alibaba/qwen3.8-max"
+name = "Qwen3.8-Max-EL"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 2.0202
+output = 6.0606
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/poe/models/google/gemini-3.6-flash.toml
+++ b/providers/poe/models/google/gemini-3.6-flash.toml
@@ -1,0 +1,15 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Effort: extra_body.thinking_level = minimal|low|medium|high
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "google/gemini-3.6-flash"
+name = "Gemini-3.6-Flash"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.7576
+output = 3.7879
+cache_read = 0.0758
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/poe/models/google/gemini-3.7-flash.toml
+++ b/providers/poe/models/google/gemini-3.7-flash.toml
@@ -1,0 +1,15 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Effort: extra_body.thinking_level = low|medium|high
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "google/gemini-3.7-flash"
+name = "Gemini-3.7-Flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.7576
+output = 3.7879
+cache_read = 0.0758
+
+[modalities]
+input = ["text", "image", "video", "audio"]
+output = ["text"]

--- a/providers/poe/models/minimax/minimax-m3.toml
+++ b/providers/poe/models/minimax/minimax-m3.toml
@@ -2,7 +2,6 @@
 # Toggle: extra_body.enable_thinking true|false
 # Costs are USD/MTok from Poe pricing fields * 1e6.
 base_model = "minimax/MiniMax-M3"
-name = "MiniMax-M3"
 reasoning_options = [{ type = "toggle" }]
 
 [cost]

--- a/providers/poe/models/minimax/minimax-m3.toml
+++ b/providers/poe/models/minimax/minimax-m3.toml
@@ -1,0 +1,15 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Toggle: extra_body.enable_thinking true|false
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "minimax/MiniMax-M3"
+name = "MiniMax-M3"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0.303
+output = 1.2121
+cache_read = 0.0606
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/poe/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/poe/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,15 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Poe lists no caller reasoning controls for this bot.
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi-K2.7-Code"
+reasoning_options = []
+
+[cost]
+input = 0.9596
+output = 4.0404
+cache_read = 0.1919
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/poe/models/moonshotai/kimi-k3.toml
+++ b/providers/poe/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,15 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Effort: extra_body.reasoning_effort = low|medium|high
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "moonshotai/kimi-k3"
+name = "Kimi-K3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 3.0303
+output = 15.1515
+cache_read = 0.303
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/poe/models/tencent/hy3.toml
+++ b/providers/poe/models/tencent/hy3.toml
@@ -1,0 +1,11 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Toggle: extra_body.enable_thinking true|false
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "tencent/hy3"
+name = "Hy3"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0.1414
+output = 0.5859
+cache_read = 0.0354

--- a/providers/poe/models/tencent/hy3.toml
+++ b/providers/poe/models/tencent/hy3.toml
@@ -2,7 +2,6 @@
 # Toggle: extra_body.enable_thinking true|false
 # Costs are USD/MTok from Poe pricing fields * 1e6.
 base_model = "tencent/hy3"
-name = "Hy3"
 reasoning_options = [{ type = "toggle" }]
 
 [cost]

--- a/providers/poe/models/xai/grok-4.5.toml
+++ b/providers/poe/models/xai/grok-4.5.toml
@@ -1,0 +1,11 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Effort: extra_body.reasoning_effort = low|medium|high
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "xai/grok-4.5"
+name = "Grok-4.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 2.0202
+output = 6.0606
+cache_read = 0.303

--- a/providers/poe/models/xai/grok-4.6.toml
+++ b/providers/poe/models/xai/grok-4.6.toml
@@ -1,0 +1,11 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Effort: extra_body.reasoning_effort = low|medium|high|xhigh
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "xai/grok-4.6"
+name = "Grok-4.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 2.0202
+output = 6.0606
+cache_read = 0.5051

--- a/providers/poe/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/poe/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,0 +1,11 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Poe lists no caller reasoning controls for this bot.
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "xiaomi/mimo-v2.5-pro"
+name = "MiMo-V2.5-Pro"
+reasoning_options = []
+
+[cost]
+input = 1.0101
+output = 3.0303
+cache_read = 0.202

--- a/providers/poe/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/poe/models/xiaomi/mimo-v2.5-pro.toml
@@ -2,7 +2,6 @@
 # Poe lists no caller reasoning controls for this bot.
 # Costs are USD/MTok from Poe pricing fields * 1e6.
 base_model = "xiaomi/mimo-v2.5-pro"
-name = "MiMo-V2.5-Pro"
 reasoning_options = []
 
 [cost]

--- a/providers/poe/models/zhipuai/glm-5.1.toml
+++ b/providers/poe/models/zhipuai/glm-5.1.toml
@@ -1,0 +1,11 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Toggle: extra_body.enable_thinking true|false
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "zhipuai/glm-5.1"
+name = "GLM-5.1"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 1.4141
+output = 4.4444
+cache_read = 0.2626

--- a/providers/poe/models/zhipuai/glm-5.1.toml
+++ b/providers/poe/models/zhipuai/glm-5.1.toml
@@ -2,7 +2,6 @@
 # Toggle: extra_body.enable_thinking true|false
 # Costs are USD/MTok from Poe pricing fields * 1e6.
 base_model = "zhipuai/glm-5.1"
-name = "GLM-5.1"
 reasoning_options = [{ type = "toggle" }]
 
 [cost]

--- a/providers/poe/models/zhipuai/glm-5.2.toml
+++ b/providers/poe/models/zhipuai/glm-5.2.toml
@@ -2,7 +2,6 @@
 # Toggle: extra_body.enable_thinking true|false
 # Costs are USD/MTok from Poe pricing fields * 1e6.
 base_model = "zhipuai/glm-5.2"
-name = "GLM-5.2"
 reasoning_options = [{ type = "toggle" }]
 
 [cost]

--- a/providers/poe/models/zhipuai/glm-5.2.toml
+++ b/providers/poe/models/zhipuai/glm-5.2.toml
@@ -1,0 +1,11 @@
+# Source: Poe GET /v1/models (accessed 2026-08-16).
+# Toggle: extra_body.enable_thinking true|false
+# Costs are USD/MTok from Poe pricing fields * 1e6.
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 1.5152
+output = 4.5455
+cache_read = 0.303


### PR DESCRIPTION
## Summary

Add Poe-hosted coding models that are available on `GET https://api.poe.com/v1/models` but missing from the Poe catalog. Focus is models released in the last two months that are suitable for programming/agent work.

Not listed on the Poe API (so not added):
- GLM-5.3
- GPT-5.6 series

## Models

| Poe ID | Catalog path | Lab | Notes |
| --- | --- | --- | --- |
| `grok-4.6` | `xai/grok-4.6` | xAI | 2026-08-12, `reasoning_effort` low/medium/high/xhigh |
| `grok-4.5` | `xai/grok-4.5` | xAI | 2026-07-08, `reasoning_effort` low/medium/high |
| `gemini-3.7-flash` | `google/gemini-3.7-flash` | Google | 2026-08-13, `thinking_level` low/medium/high |
| `gemini-3.6-flash` | `google/gemini-3.6-flash` | Google | `thinking_level` minimal/low/medium/high |
| `kimi-k3` | `moonshotai/kimi-k3` | Moonshot | 2026-07-16, `reasoning_effort` low/medium/high |
| `kimi-k2.7-code` | `moonshotai/kimi-k2.7-code` | Moonshot | coding specialist, no caller reasoning controls |
| `glm-5.2` | `zhipuai/glm-5.2` | Z.ai | `enable_thinking` toggle |
| `glm-5.1` | `zhipuai/glm-5.1` | Z.ai | `enable_thinking` toggle |
| `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | DeepSeek | official V4 Pro (not the older EL alias) |
| `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | DeepSeek | `enable_thinking` toggle |
| `qwen3.7-plus` | `alibaba/qwen3.7-plus` | Alibaba | `enable_thinking` toggle |
| `qwen3.6-plus` | `alibaba/qwen3.6-plus` | Alibaba | `enable_thinking` toggle |
| `minimax-m3` | `minimax/minimax-m3` | MiniMax | `enable_thinking` toggle |
| `hy3` | `tencent/hy3` | Tencent | `enable_thinking` toggle |
| `mimo-v2.5-pro` | `xiaomi/mimo-v2.5-pro` | Xiaomi | no caller reasoning controls |
| `kimi-k3-el` | `empiriolabs/kimi-k3-el` | EmpirioLabs | `reasoning_effort` low/high/max |
| `qwen3.8-max-el` | `empiriolabs/qwen3.8-max-el` | EmpirioLabs | 2026-08-03 flagship, `enable_thinking` |

## Sources

- Poe OpenAI-compatible API: `GET /v1/models` (accessed 2026-08-16)
- Pricing: Poe `pricing.prompt` / `pricing.completion` / `pricing.input_cache_read` converted to USD per million tokens
- Reasoning controls: Poe `parameters[]` (`reasoning_effort`, `thinking_level`, `enable_thinking`) via `extra_body` on chat completions
- Lab metadata reused via `base_model` (no new `models/` stubs)

`bun validate` passes locally.