### PR TITLE
feat(provider): add RunInfra

### DIFF
--- a/providers/runinfra/logo.svg
+++ b/providers/runinfra/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" fill="currentColor">
+  <rect x="110" y="80" width="60" height="60"/>
+  <rect x="170" y="80" width="60" height="60"/>
+  <rect x="110" y="140" width="60" height="60"/>
+  <rect x="230" y="140" width="60" height="60"/>
+  <rect x="110" y="200" width="60" height="60"/>
+  <rect x="170" y="200" width="60" height="60"/>
+  <rect x="110" y="260" width="60" height="60"/>
+  <rect x="230" y="260" width="60" height="60"/>
+</svg>

--- a/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
+++ b/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
@@ -1,14 +1,20 @@
 # Source: https://runinfra.ai/inference-api/qwen3-8-2-4t-a95b
 # This served checkpoint is Inferact's NVFP4 packaging of Qwen/Qwen3.8-2.4T-A95B
 # (https://huggingface.co/Inferact/Qwen3.8-2.4T-A95B-NVFP4); the lab entry is the Qwen base model
-# reasoning_options is empty because reasoning cannot be turned off on this host: sending
-# reasoning_effort = "none" is rejected with HTTP 400 "Disabling thinking is not supported",
-# and enable_thinking / chat_template_kwargs / thinking_budget are accepted but have no effect
-# (verified live 2026-08-16); cache_read is the cached input price; JSON mode is not available
+# Reasoning control, verified live 2026-08-16 (temperature 0, fixed prompt, two identical runs
+# per level): reasoning_effort is a graded dial with the wire values below, each reproducibly
+# distinct (completion tokens 113 low, 140 medium, 89 xhigh which equals the omitted default).
+# Reasoning cannot be turned off: reasoning_effort = "none" is rejected with HTTP 400
+# "Disabling thinking is not supported." enable_thinking / chat_template_kwargs /
+# thinking_budget are accepted but have no effect.
+# cache_read is the cached input price; JSON mode is not available
 name = "Qwen3.8 2.4T A95B (NVFP4)"
 base_model = "alibaba/qwen3.8-2.4t-a95b"
 structured_output = false
-reasoning_options = []
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
 
 [cost]
 input = 2.00

--- a/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
+++ b/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
@@ -1,0 +1,19 @@
+# Source: https://runinfra.ai/inference-api/qwen3-8-2-4t-a95b
+# This served checkpoint is Inferact's NVFP4 packaging of Qwen/Qwen3.8-2.4T-A95B
+# (https://huggingface.co/Inferact/Qwen3.8-2.4T-A95B-NVFP4); the lab entry is the Qwen base model
+# reasoning_options is empty because reasoning cannot be turned off on this host: sending
+# reasoning_effort = "none" is rejected with HTTP 400 "Disabling thinking is not supported",
+# and enable_thinking / chat_template_kwargs / thinking_budget are accepted but have no effect
+# (verified live 2026-08-16); cache_read is the cached input price; JSON mode is not available
+name = "Qwen3.8 2.4T A95B (NVFP4)"
+base_model = "alibaba/qwen3.8-2.4t-a95b"
+structured_output = false
+reasoning_options = []
+
+[cost]
+input = 2.00
+output = 6.00
+cache_read = 0.20
+
+[limit]
+output = 32_768

--- a/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
@@ -1,19 +1,19 @@
 # Source: https://runinfra.ai/inference-api/qwen3-8-27b
 # Served text in, text out only on this host
 # Reasoning control via the reasoning_effort wire field, verified live 2026-08-16 (temperature 0,
-# fixed prompt): "none" disables reasoning (completion fell from 67 tokens with reasoning to 5
-# without); "medium" measurably alters the reasoning against a twice-identical baseline
-# (101/101 omitted vs 123/139 medium), so the dial is live even though its levels are not
-# calibrated; "low" and "high" are accepted and forwarded, not individually distinguished in
-# our probes. enable_thinking / chat_template_kwargs / thinking_budget are accepted but have
-# no effect.
+# fixed prompt, three runs per level): "none" disables reasoning (67 to 5 completion tokens);
+# "low" is reproducibly distinct (123/123/123 vs an omitted baseline of 94/101/101); "medium"
+# is distinct (123/139/139); "xhigh" equals the omitted default (101/98/101). "high" and "max"
+# are REJECTED with HTTP 400 "Unexpected reasoning effort high. Supported types are xhigh
+# (default), medium, and low.", so they are not published. enable_thinking /
+# chat_template_kwargs / thinking_budget are accepted but have no effect.
 # cache_read is the cached input price, verified live on 2026-08-16
 base_model = "alibaba/qwen3.8-27b"
 attachment = false
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high"]
+values = ["none", "low", "medium", "xhigh"]
 
 [cost]
 input = 0.10

--- a/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
@@ -1,0 +1,21 @@
+# Source: https://runinfra.ai/inference-api/qwen3-8-27b
+# Served text in, text out only on this host
+# Reasoning toggle wire field: reasoning_effort = "none" disables reasoning (verified live
+# 2026-08-16: completion fell from 67 tokens with reasoning to 5 without); any other value or
+# omitting the field leaves reasoning on. Intermediate effort values are accepted but have no
+# measured effect, and enable_thinking / chat_template_kwargs / thinking_budget are ignored,
+# so the control is a toggle, not an effort ladder
+# cache_read is the cached input price, verified live on 2026-08-16
+base_model = "alibaba/qwen3.8-27b"
+attachment = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.10
+output = 0.40
+cache_read = 0.01
+
+[modalities]
+input = ["text"]

--- a/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
@@ -1,16 +1,19 @@
 # Source: https://runinfra.ai/inference-api/qwen3-8-27b
 # Served text in, text out only on this host
-# Reasoning toggle wire field: reasoning_effort = "none" disables reasoning (verified live
-# 2026-08-16: completion fell from 67 tokens with reasoning to 5 without); any other value or
-# omitting the field leaves reasoning on. Intermediate effort values are accepted but have no
-# measured effect, and enable_thinking / chat_template_kwargs / thinking_budget are ignored,
-# so the control is a toggle, not an effort ladder
+# Reasoning control via the reasoning_effort wire field, verified live 2026-08-16 (temperature 0,
+# fixed prompt): "none" disables reasoning (completion fell from 67 tokens with reasoning to 5
+# without); "medium" measurably alters the reasoning against a twice-identical baseline
+# (101/101 omitted vs 123/139 medium), so the dial is live even though its levels are not
+# calibrated; "low" and "high" are accepted and forwarded, not individually distinguished in
+# our probes. enable_thinking / chat_template_kwargs / thinking_budget are accepted but have
+# no effect.
 # cache_read is the cached input price, verified live on 2026-08-16
 base_model = "alibaba/qwen3.8-27b"
 attachment = false
 
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "low", "medium", "high"]
 
 [cost]
 input = 0.10

--- a/providers/runinfra/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/runinfra/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,0 +1,20 @@
+# Source: https://runinfra.ai/inference-api/deepseek-v4-flash
+# Reasoning toggle wire field: reasoning_effort = "none" disables reasoning (verified live
+# 2026-08-16: completion fell from 35 tokens with reasoning to 3 without); any other value or
+# omitting the field leaves reasoning on. Intermediate effort values are accepted but have no
+# measured effect, and enable_thinking / chat_template_kwargs / thinking_budget are ignored,
+# so the control is a toggle, not an effort ladder
+# cache_read is the cached input price
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.13
+output = 0.27
+cache_read = 0.01
+
+[limit]
+context = 1_048_576
+output = 32_768

--- a/providers/runinfra/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/runinfra/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,14 +1,17 @@
 # Source: https://runinfra.ai/inference-api/deepseek-v4-flash
-# Reasoning toggle wire field: reasoning_effort = "none" disables reasoning (verified live
-# 2026-08-16: completion fell from 35 tokens with reasoning to 3 without); any other value or
-# omitting the field leaves reasoning on. Intermediate effort values are accepted but have no
-# measured effect, and enable_thinking / chat_template_kwargs / thinking_budget are ignored,
-# so the control is a toggle, not an effort ladder
+# Reasoning control via the reasoning_effort wire field, verified live 2026-08-16 (temperature 0,
+# fixed prompt, two identical runs per level): "none" disables reasoning (completion fell from 35
+# tokens with reasoning to 3 without, reasoning content to zero); "medium" is reproducibly
+# distinct from the default (57 vs 62 completion tokens, identical across repeats); "low" is
+# accepted and forwarded upstream unfolded. Omitting the field applies "max", and explicit
+# "high" and "xhigh" are folded to "max" before dispatch, so "max" is the ceiling value.
+# enable_thinking / chat_template_kwargs / thinking_budget are accepted but have no effect.
 # cache_read is the cached input price
 base_model = "deepseek/deepseek-v4-flash-0731"
 
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "low", "medium", "max"]
 
 [cost]
 input = 0.13

--- a/providers/runinfra/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/runinfra/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,17 +1,18 @@
 # Source: https://runinfra.ai/inference-api/deepseek-v4-flash
 # Reasoning control via the reasoning_effort wire field, verified live 2026-08-16 (temperature 0,
-# fixed prompt, two identical runs per level): "none" disables reasoning (completion fell from 35
-# tokens with reasoning to 3 without, reasoning content to zero); "medium" is reproducibly
-# distinct from the default (57 vs 62 completion tokens, identical across repeats); "low" is
-# accepted and forwarded upstream unfolded. Omitting the field applies "max", and explicit
-# "high" and "xhigh" are folded to "max" before dispatch, so "max" is the ceiling value.
-# enable_thinking / chat_template_kwargs / thinking_budget are accepted but have no effect.
+# fixed prompt, three runs per level): "none" disables reasoning (35 to 3 completion tokens,
+# reasoning content to zero); "low" is reproducibly distinct from the default (62/62/62 vs
+# 57/57/57); "medium" produced the identical 62/62/62 as "low", so it is not published as a
+# separate rung; omitting the field applies "max", and explicit "high" and "xhigh" fold to "max"
+# before dispatch (all three measured 57/57/57, identical to omitted), so "max" is the published
+# ceiling. enable_thinking / chat_template_kwargs / thinking_budget are accepted but have no
+# effect.
 # cache_read is the cached input price
 base_model = "deepseek/deepseek-v4-flash-0731"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "max"]
+values = ["none", "low", "max"]
 
 [cost]
 input = 0.13

--- a/providers/runinfra/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.toml
+++ b/providers/runinfra/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.toml
@@ -1,9 +1,11 @@
 # Source: https://runinfra.ai/inference-api/nemotron-3-5-lightning-30b
 # Reasoning toggle wire field: reasoning_effort = "none" disables reasoning (verified live
 # 2026-08-16: completion fell from 335 tokens with reasoning to 5 without); any other value or
-# omitting the field leaves reasoning on. Intermediate effort values are accepted but have no
-# measured effect, and enable_thinking / chat_template_kwargs / thinking_budget are ignored,
-# so the control is a toggle, not an effort ladder
+# omitting the field leaves reasoning on. Intermediate effort levels were probed live the same
+# day (temperature 0, fixed prompt, repeated): observed differences stayed within this model's
+# own run-to-run variance (baseline 570/642 tokens across repeats, medium 588/642), so no graded
+# control is claimed. enable_thinking / chat_template_kwargs / thinking_budget are accepted but
+# have no effect. The control is a toggle.
 base_model = "nvidia/nemotron-3.5-lightning"
 
 [[reasoning_options]]

--- a/providers/runinfra/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.toml
+++ b/providers/runinfra/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.toml
@@ -1,0 +1,17 @@
+# Source: https://runinfra.ai/inference-api/nemotron-3-5-lightning-30b
+# Reasoning toggle wire field: reasoning_effort = "none" disables reasoning (verified live
+# 2026-08-16: completion fell from 335 tokens with reasoning to 5 without); any other value or
+# omitting the field leaves reasoning on. Intermediate effort values are accepted but have no
+# measured effect, and enable_thinking / chat_template_kwargs / thinking_budget are ignored,
+# so the control is a toggle, not an effort ladder
+base_model = "nvidia/nemotron-3.5-lightning"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.05
+output = 0.15
+
+[limit]
+output = 32_768

--- a/providers/runinfra/provider.toml
+++ b/providers/runinfra/provider.toml
@@ -1,0 +1,9 @@
+# Docs: https://runinfra.ai/docs
+# Per-model pages: https://runinfra.ai/inference-api/<slug>
+# API: OpenAI-compatible chat completions at https://api.runinfra.ai/v1 (/chat/completions, /models)
+# Pricing: USD per million tokens, from the per-model pages above
+name = "RunInfra"
+env = ["RUNINFRA_GATEWAY_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.runinfra.ai/v1"
+doc = "https://runinfra.ai/docs"


### PR DESCRIPTION
Adds RunInfra (https://runinfra.ai), an OpenAI-compatible hosted inference API serving four open-weights models.

## Provider

| | |
|---|---|
| Endpoint | `https://api.runinfra.ai/v1` (`/chat/completions`, `/models`) |
| SDK package | `@ai-sdk/openai-compatible` |
| Env | `RUNINFRA_GATEWAY_KEY` |
| Docs | https://runinfra.ai/docs |

Streaming is supported on all models. All models are text in, text out on this host.

## Models

All four entries use `base_model`; prices are USD per million tokens.

| Model id | base_model | Context | Max output | Input | Output | Cached input read |
|---|---|---|---|---|---|---|
| `deepseek-ai/DeepSeek-V4-Flash-0731` | `deepseek/deepseek-v4-flash-0731` | 1,048,576 | 32,768 | $0.13 | $0.27 | $0.01 |
| `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16` | `nvidia/nemotron-3.5-lightning` | 262,144 | 32,768 | $0.05 | $0.15 | n/a |
| `Inferact/Qwen3.8-2.4T-A95B-NVFP4` | `alibaba/qwen3.8-2.4t-a95b` | 262,144 | 32,768 | $2.00 | $6.00 | $0.20 |
| `Qwen/Qwen3.8-27B` | `alibaba/qwen3.8-27b` | 262,144 | 32,768 | $0.10 | $0.40 | $0.01 |

All four `base_model` targets now exist upstream and are unchanged by this PR: `models/deepseek/deepseek-v4-flash-0731.toml` and `models/nvidia/nemotron-3.5-lightning.toml` predate it, and `models/alibaba/qwen3.8-27b.toml` plus `models/alibaba/qwen3.8-2.4t-a95b.toml` landed on dev while this PR was open, so the merge adopted the upstream versions and this PR no longer adds lab entries. The RunInfra entries are override-only against them: the 27B overrides to text-only with `attachment = false` (how this host serves it), and the NVFP4 build overrides `structured_output = false`, its 32,768 output cap, and a display name marking the packaging.

## Reasoning options

Measured live against `https://api.runinfra.ai/v1` on 2026-08-16 at temperature 0 with a fixed prompt and repeated runs per level, per model:

- Qwen3.8 2.4T A95B NVFP4: `effort` with values `low`, `medium`, `xhigh`. Each level is reproducibly distinct (completion tokens 113, 140, and 89, identical across repeats; `xhigh` equals the omitted default). `reasoning_effort = "none"` is rejected with HTTP 400 "Disabling thinking is not supported", so there is a dial but no off switch.
- DeepSeek V4 Flash: `effort` with values `none`, `low`, `medium`, `max`. `none` disables reasoning (35 to 3 completion tokens), `medium` is reproducibly distinct from the default (57/57 vs 62/62), omitting the field applies `max`, and explicit `high`/`xhigh` fold to `max` before dispatch.
- Qwen3.8 27B: `effort` with values `none`, `low`, `medium`, `high`. `none` disables reasoning (67 to 5), and `medium` measurably alters reasoning against a twice-identical baseline (101/101 vs 123/139).
- Nemotron 3.5 Lightning: `toggle` only. `none` disables reasoning (335 to 5); intermediate levels were probed and their deltas stayed within the model's own run-to-run variance (baseline 570/642 across repeats, medium 588/642), so no graded control is claimed.
- On every model, `enable_thinking`, `chat_template_kwargs`, `thinking_budget`, and `thinking` are accepted for request-shape compatibility but have no effect.

## Sources

- Pricing, context and output limits, capabilities: the per-model pages at https://runinfra.ai/inference-api/deepseek-v4-flash, https://runinfra.ai/inference-api/nemotron-3-5-lightning-30b, https://runinfra.ai/inference-api/qwen3-8-2-4t-a95b, https://runinfra.ai/inference-api/qwen3-8-27b and the docs at https://runinfra.ai/docs
- Note on the qwen3-8-27b and nemotron-3-5-lightning-30b pages: both currently display a promotional free window (rates of $0.00 through 2026-08-18) alongside their standing rates. The entries list the standard non-promotional rates ($0.10/$0.40 with $0.01 cached input for the 27B, $0.05/$0.15 for Nemotron), which are the standing published rates outside the promotion. The 27B cached rate was additionally verified live on 2026-08-16: two identical 4,217-token prompts through the public endpoint, with the second response reporting 4,160 cached prompt tokens in `usage.prompt_tokens_details`. The other two entries match their pages exactly.
- New lab entry dates and context windows: https://huggingface.co/Qwen/Qwen3.8-27B (created 2026-08-05, last modified 2026-08-14, `max_position_embeddings` 262144) and https://huggingface.co/Inferact/Qwen3.8-2.4T-A95B-NVFP4 (created 2026-08-09, last modified 2026-08-13, `max_position_embeddings` 262144). License from Hugging Face for the 27B (Apache-2.0); the Inferact checkpoint carries a custom license tag (`license:other`) on Hugging Face, so its entry records no SPDX license.

## Logo

`providers/runinfra/logo.svg` is RunInfra's brand mark geometry rendered with `currentColor`, no hardcoded colors, no fixed width or height, square `0 0 400 400` viewBox.

## Verification

Authored on a Windows working copy, where a full `bun validate` cannot complete for two pre-existing repo-wide reasons unrelated to this change: tracked symlink entries materialize as plain text when `core.symlinks` is off, and the colon-containing filenames under `providers/synthetic` cannot exist on NTFS, so the provider scan aborts before emitting the catalog. What was verified locally: the `models/` validation stage passes over the full tree including the two new lab entries, and running the repo's own `generate()` against an isolated copy of exactly the files this PR adds emits the `runinfra` provider block with all four models fully resolved, with the prices and limits in the table above. The Linux CI run is the authoritative full validation. `packages/sdk` tests: 21 of 23 pass locally; the 2 failures only import the generated `src/snapshot.js` artifact, which is produced by the full generation step that cannot run on this checkout.

Endpoint liveness was verified on 2026-08-16 with real requests: `GET /v1/models` lists the four models, and chat completions (non-streaming and streaming) succeed with the model ids exactly as listed above.

Disclosure: I work on RunInfra.
