### PR TITLE
fix(amazon-bedrock): pin Mantle model endpoints to us-east-1

### DIFF
--- a/providers/amazon-bedrock/models/openai.gpt-5.4.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.4.toml
@@ -14,5 +14,5 @@ output = 128_000
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"
-api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+api = "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
 shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-5.5.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.5.toml
@@ -14,5 +14,5 @@ output = 128_000
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"
-api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+api = "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
 shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-luna.toml
@@ -21,5 +21,5 @@ cache_write = 0.55
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"
-api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+api = "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
 shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
@@ -21,5 +21,5 @@ cache_write = 13.75
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"
-api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+api = "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
 shape = "responses"

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-terra.toml
@@ -21,5 +21,5 @@ cache_write = 5.50
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"
-api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+api = "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
 shape = "responses"

--- a/providers/amazon-bedrock/models/xai.grok-4.3.toml
+++ b/providers/amazon-bedrock/models/xai.grok-4.3.toml
@@ -16,5 +16,5 @@ input = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"
-api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+api = "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
 shape = "responses"


### PR DESCRIPTION
Closes part of #4818.

These six Mantle entries template their endpoint on `${AWS_REGION}`, but Mantle only serves them in some US regions. Outside those, the URL resolves to a host that 404s with no hint that region is the cause:

```
POST bedrock-mantle.eu-west-1.api.aws/openai/v1/responses {"model":"openai.gpt-5.6-terra"}
  → 404 The model 'openai.gpt-5.6-terra' does not exist
POST bedrock-mantle.us-east-1.api.aws/openai/v1/responses  (same body)
  → 200
```

I checked all six against both regions and they show the same split: `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.6-sol`, `openai.gpt-5.4`, `openai.gpt-5.5` and `xai.grok-4.3`.

us-east-1 serves every Mantle model, so it's the most compatible pin, and it matches the US East in-region pricing these files already declare ([Bedrock pricing](https://aws.amazon.com/bedrock/pricing/)). The cost is a bit of routing loss for anyone currently in us-east-2 or us-west-2.

The `openai.gpt-oss-*` entries are untouched — `gpt-oss-120b` answers in both regions, so `${AWS_REGION}` is right there.

`bun validate` passes.
