### PR TITLE
feat(amazon-bedrock): add global GPT-5.6 inference profiles

### DIFF
--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-luna.toml
@@ -1,0 +1,20 @@
+# Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Verified from eu-west-1: returns 200 with reasoning effort set.
+# Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-luna: https://aws.amazon.com/bedrock/pricing/
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-5.6 Luna (Global)"
+
+[cost]
+input = 0.22
+output = 1.32
+cache_read = 0.022
+cache_write = 0.275
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 0.44
+output = 1.98
+cache_read = 0.044
+cache_write = 0.55

--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-sol.toml
@@ -1,0 +1,20 @@
+# Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Verified from eu-west-1: returns 200 with reasoning effort set.
+# Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-sol: https://aws.amazon.com/bedrock/pricing/
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-5.6 Sol (Global)"
+
+[cost]
+input = 5.50
+output = 33.00
+cache_read = 0.55
+cache_write = 6.875
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 11.00
+output = 49.50
+cache_read = 1.10
+cache_write = 13.75

--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-terra.toml
@@ -1,0 +1,20 @@
+# Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Verified from eu-west-1: effort none|low|medium|high|xhigh|max all return 200.
+# Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-terra: https://aws.amazon.com/bedrock/pricing/
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-5.6 Terra (Global)"
+
+[cost]
+input = 2.20
+output = 13.20
+cache_read = 0.22
+cache_write = 2.75
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 4.40
+output = 19.80
+cache_read = 0.44
+cache_write = 5.50


### PR DESCRIPTION
Closes part of #4818.

AWS added `global.` inference profiles for the GPT-5.6 models on 13th August, so they're now reachable from outside the US. This adds them next to the existing regional entries, the way the `global.anthropic.*` variants do.

Verified from eu-west-1, where the regional Mantle entries 404:

```
POST bedrock-runtime.eu-west-1.amazonaws.com/model/global.openai.gpt-5.6-terra/converse
  → 200   # none, low, medium, high, xhigh and max all accepted
POST bedrock-runtime.eu-west-1.amazonaws.com/model/global.openai.gpt-5.6-luna/converse  → 200
POST bedrock-runtime.eu-west-1.amazonaws.com/model/global.openai.gpt-5.6-sol/converse   → 200
```

One quirk worth flagging: the global profiles are served by Bedrock core (Converse), not Mantle, and Mantle rejects prefixed IDs — so there's deliberately no `[provider]` block and these resolve to the provider default. That's also why they're separate files rather than edits to the existing ones.

`cost` mirrors the US in-region rates already on `openai.gpt-5.6-*` ([Bedrock pricing](https://aws.amazon.com/bedrock/pricing/)), same as the `global.anthropic.*` entries.

`bun validate` passes; resolved output differs from the regional entries only in `id`, `name` and the absent `provider` block.
