### PR TITLE
feat: add Echo provider

### DIFF
--- a/providers/echo/logo.svg
+++ b/providers/echo/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <rect x="2" y="8" width="3" height="8" rx="1"/>
+  <rect x="6.25" y="3" width="3" height="18" rx="1"/>
+  <rect x="10.5" y="6" width="3" height="12" rx="1"/>
+  <rect x="14.75" y="1" width="3" height="22" rx="1"/>
+  <rect x="19" y="7" width="3" height="10" rx="1"/>
+</svg>

--- a/providers/echo/models/echo.toml
+++ b/providers/echo/models/echo.toml
@@ -1,0 +1,31 @@
+# Sources (accessed 2026-08-16):
+# - API and authentication: https://echo.tracerml.ai/docs/api
+# - Coding-agent setup: https://echo.tracerml.ai/code
+# Echo selects an internal compute level per request. Public rates range from
+# $3/$15 (Quick) to $10/$50 (Deep) per million input/output tokens. Models.dev
+# has no route-based cost shape, so the catalog uses the conservative Deep-rate
+# ceiling instead of incorrectly presenting dynamically routed calls as free.
+name = "Echo"
+description = "Adaptive model for coding, reasoning, and tool-driven agent workflows through one OpenAI-compatible endpoint"
+release_date = "2026-07-19"
+last_updated = "2026-08-16"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = false
+open_weights = false
+status = "beta"
+
+[cost]
+input = 10
+output = 50
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/echo/provider.toml
+++ b/providers/echo/provider.toml
@@ -1,0 +1,5 @@
+name = "Echo"
+env = ["ECHO_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://echo.tracerml.ai/v1"
+doc = "https://echo.tracerml.ai/docs/api"


### PR DESCRIPTION
## Summary

- Add Echo as an OpenAI-compatible provider
- Describe the Echo model with tool use, reasoning controls, context limits, and conservative ceiling pricing
- Add the Echo provider logo

## Validation

- bun validate
- Built the models.dev catalog and resolved echo/echo in OpenCode