### PR TITLE
provider(vivgrid): add glm-5.3

### DIFF
--- a/providers/vivgrid/models/glm-5.3.toml
+++ b/providers/vivgrid/models/glm-5.3.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.3"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.2
+output = 4.2
+cache_read = 0.26


### PR DESCRIPTION
Adds `glm-5.3` for Vivgrid using the base_model override pattern.

* **Docs / Dashboard Source:** https://vivgrid.com/docs/models/glm-5.3
* **Context Window:** 1,000,000 tokens
* **Max Output:** 128,000 tokens
* **Pricing:** $1.2 / 1M input, $4.2 / 1M output, $0.3 / 1M cache read