### PR TITLE
fix(runinfra): JSON mode is live on Qwen3.8 2.4T A95B

### DIFF
--- a/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
+++ b/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
@@ -7,10 +7,12 @@
 # Reasoning cannot be turned off: reasoning_effort = "none" is rejected with HTTP 400
 # "Disabling thinking is not supported." enable_thinking / chat_template_kwargs /
 # thinking_budget are accepted but have no effect.
-# cache_read is the cached input price; JSON mode is not available
+# cache_read is the cached input price. JSON mode went live on this host 2026-08-17,
+# verified on the public path: 3 of 3 json_object responses parsed and 3 of 3 strict
+# json_schema responses validated, at 0.35x baseline latency, so structured_output now
+# inherits true from the lab entry
 name = "Qwen3.8 2.4T A95B (NVFP4)"
 base_model = "alibaba/qwen3.8-2.4t-a95b"
-structured_output = false
 
 [[reasoning_options]]
 type = "effort"


### PR DESCRIPTION
One-line change: drops the `structured_output = false` override on `providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml` so the entry inherits `structured_output = true` from the `alibaba/qwen3.8-2.4t-a95b` lab entry, matching what the host now serves.

JSON mode went live on this host today. Verified on the public endpoint before this PR: 3 of 3 `json_object` responses parsed as valid JSON, 3 of 3 strict `json_schema` responses validated against the requested schema (required fields present, no additional properties), warm constrained requests at 0.35x baseline latency, and unconstrained generation unaffected afterward. Unlike our DeepSeek entry, no `reasoning_effort` precondition applies on this model. The file's leading comment carries the evidence summary.

`bun validate` passes on the branch.

Disclosure: I work on RunInfra.