### PR TITLE
fix(deepseek): update V4 pricing for peak/off-peak billing

### DIFF
--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -1,6 +1,11 @@
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
+# DeepSeek moved V4 to peak/off-peak billing on 2026-08-16 16:00 UTC. Peak hours
+# are 01:00-04:00 and 06:00-10:00 UTC; every other hour is off-peak at half the
+# peak rate (input 0.22, output 0.66, cache_read 0.007). The schema has no time
+# dimension, so `[cost]` carries the peak rate, which the docs present as the
+# list price and off-peak as the discount off it.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17)
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
 # Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
 # Flash maps requested low→low (unlike Pro, which maps low→high). xhigh→high.
@@ -18,12 +23,6 @@ values = ["low", "high", "max"]
 [interleaved]
 field = "reasoning_content"
 
-# DeepSeek moved V4 to peak/off-peak billing on 2026-08-16 16:00 UTC. Peak hours
-# are 01:00-04:00 and 06:00-10:00 UTC; every other hour is off-peak at half the
-# peak rate (input 0.22, output 0.66, cache_read 0.007). The schema has no time
-# dimension, so `[cost]` carries the peak rate, which the docs present as the
-# list price and off-peak as the discount off it.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17)
 [cost]
 input = 0.44
 output = 1.32

--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -18,8 +18,14 @@ values = ["low", "high", "max"]
 [interleaved]
 field = "reasoning_content"
 
+# DeepSeek moved V4 to peak/off-peak billing on 2026-08-16 16:00 UTC. Peak hours
+# are 01:00-04:00 and 06:00-10:00 UTC; every other hour is off-peak at half the
+# peak rate (input 0.22, output 0.66, cache_read 0.007). The schema has no time
+# dimension, so `[cost]` carries the peak rate, which the docs present as the
+# list price and off-peak as the discount off it.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17)
 [cost]
-input = 0.14
-output = 0.28
-reasoning = 0.28
-cache_read = 0.0028
+input = 0.44
+output = 1.32
+reasoning = 1.32
+cache_read = 0.014

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -17,8 +17,14 @@ values = ["high", "max"]
 [interleaved]
 field = "reasoning_content"
 
+# DeepSeek moved V4 to peak/off-peak billing on 2026-08-16 16:00 UTC. Peak hours
+# are 01:00-04:00 and 06:00-10:00 UTC; every other hour is off-peak at half the
+# peak rate (input 0.66, output 1.98, cache_read 0.022). The schema has no time
+# dimension, so `[cost]` carries the peak rate, which the docs present as the
+# list price and off-peak as the discount off it.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17)
 [cost]
-input = 0.435
-output = 0.87
-reasoning = 0.87
-cache_read = 0.003625
+input = 1.32
+output = 3.96
+reasoning = 3.96
+cache_read = 0.044

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -1,6 +1,11 @@
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-12)
+# DeepSeek moved V4 to peak/off-peak billing on 2026-08-16 16:00 UTC. Peak hours
+# are 01:00-04:00 and 06:00-10:00 UTC; every other hour is off-peak at half the
+# peak rate (input 0.66, output 1.98, cache_read 0.022). The schema has no time
+# dimension, so `[cost]` carries the peak rate, which the docs present as the
+# list price and off-peak as the discount off it.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17)
 base_model = "deepseek/deepseek-v4-pro-0813"
 name = "DeepSeek V4 Pro"
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.
@@ -17,12 +22,6 @@ values = ["high", "max"]
 [interleaved]
 field = "reasoning_content"
 
-# DeepSeek moved V4 to peak/off-peak billing on 2026-08-16 16:00 UTC. Peak hours
-# are 01:00-04:00 and 06:00-10:00 UTC; every other hour is off-peak at half the
-# peak rate (input 0.66, output 1.98, cache_read 0.022). The schema has no time
-# dimension, so `[cost]` carries the peak rate, which the docs present as the
-# list price and off-peak as the discount off it.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-17)
 [cost]
 input = 1.32
 output = 3.96


### PR DESCRIPTION
DeepSeek switched V4 to peak/off-peak billing on **2026-08-16 at 16:00 UTC**. The catalog still carries the pre-change flat rates, which are now wrong under either interpretation — `deepseek-v4-flash` is listed at `0.14` input, while the real rates are `0.22` off-peak and `0.44` peak.

Rates from the [official pricing page](https://api-docs.deepseek.com/quick_start/pricing/) (USD per 1M tokens):

| | off-peak | peak |
|---|---|---|
| **v4-flash** input (cache miss) | 0.22 | 0.44 |
| **v4-flash** output | 0.66 | 1.32 |
| **v4-flash** cache read | 0.007 | 0.014 |
| **v4-pro** input (cache miss) | 0.66 | 1.32 |
| **v4-pro** output | 1.98 | 3.96 |
| **v4-pro** cache read | 0.022 | 0.044 |

Peak hours are **01:00–04:00 and 06:00–10:00 UTC**; every other hour is off-peak at exactly half the peak rate.

### Why peak in `[cost]`

The schema has no time dimension, so a single number has to stand in. This PR uses the **peak** rate because the docs present it as the list price and off-peak as a discount off it — the same convention the catalog already follows by listing standard rates rather than batch or promotional discounts. The off-peak rates and the windows are recorded in a comment above `[cost]` in each file so the information isn't lost.

`bun run validate` passes.

### Follow-ups (not in this PR)

- **Time-based cost tiers.** `cost.tiers[]` already has a `tier.type` discriminator, but it's `z.literal("context")` and both `Cost` and `CostTier` are `.strict()`, so this can't be expressed as data today. A `type: "time"` variant with UTC windows would fit the existing shape, and DeepSeek is unlikely to be the last provider to do this. Happy to open that PR if you're open to the schema change — note the duplicate-size check in `schema.ts` does `tiers.map((tier) => tier.tier.size)` unconditionally and would need a guard.
- **Legacy aliases.** `deepseek-chat` and `deepseek-reasoner` still carry `0.14 / 0.28`. If they resolve to V4 Flash they need the same rates, but #3371 proposes deprecating them, so I left them alone to avoid a conflict — happy to fold them in if you'd prefer.
- Unrelated, but `providers/edenai/models/flexai/` contains both `DeepSeek-V4-Flash-0731.toml` and `deepseek-v4-flash-0731.toml`, which can't be checked out together on a case-insensitive filesystem (macOS default) — one always shows as modified.
