### PR TITLE
feat(schema): support time-of-day cost tiers

### DIFF
--- a/packages/core/script/compare-model-migrations.ts
+++ b/packages/core/script/compare-model-migrations.ts
@@ -304,21 +304,27 @@ function normalizeCost(model: Record<string, unknown>) {
   }
 
   const tiers = (cost as { tiers?: unknown }).tiers;
-  if (!Array.isArray(tiers) || tiers.length !== 1) {
+  if (!Array.isArray(tiers)) {
     return model;
   }
 
-  const contextOver200k = tiers.find((tier) => {
+  // Only context tiers feed the legacy field; a time tier alongside them must
+  // not suppress it.
+  const contextTiers = tiers.filter((tier): tier is { tier: Record<string, unknown> } => {
     if (tier === null || typeof tier !== "object" || Array.isArray(tier)) return false;
     const tierConfig = (tier as { tier?: unknown }).tier;
     if (tierConfig === null || typeof tierConfig !== "object" || Array.isArray(tierConfig)) return false;
     const type = (tierConfig as { type?: unknown }).type;
-    const size = (tierConfig as { size?: unknown }).size;
-    return (
-      (type === undefined || type === "context") &&
-      typeof size === "number" &&
-      size >= 200_000
-    );
+    return type === undefined || type === "context";
+  });
+
+  if (contextTiers.length !== 1) {
+    return model;
+  }
+
+  const contextOver200k = contextTiers.find((tier) => {
+    const size = (tier.tier as { size?: unknown }).size;
+    return typeof size === "number" && size >= 200_000;
   });
 
   if (contextOver200k === undefined) {

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -241,6 +241,14 @@ function normalizeModelCost(model: z.infer<typeof AuthoredModel>): Model {
   return normalizeCost(model) as Model;
 }
 
+function isContextTier(tier: unknown): tier is { tier: Record<string, unknown> } {
+  if (tier === null || typeof tier !== "object" || Array.isArray(tier)) return false;
+  const tierConfig = (tier as { tier?: unknown }).tier;
+  if (tierConfig === null || typeof tierConfig !== "object" || Array.isArray(tierConfig)) return false;
+  const type = (tierConfig as { type?: unknown }).type;
+  return type === undefined || type === "context";
+}
+
 function normalizeCost(model: Record<string, unknown>) {
   const cost = model.cost;
   if (cost === undefined || cost === null || typeof cost !== "object" || Array.isArray(cost)) {
@@ -252,23 +260,19 @@ function normalizeCost(model: Record<string, unknown>) {
     return model;
   }
 
-  if (tiers.length !== 1) {
+  // Only context tiers feed the legacy field; a time tier alongside them must
+  // not suppress it.
+  const contextTiers = tiers.filter(isContextTier);
+
+  if (contextTiers.length !== 1) {
     return model;
   }
 
-  const contextOver200k = tiers.find((tier) => {
-    if (tier === null || typeof tier !== "object" || Array.isArray(tier)) return false;
-    const tierConfig = (tier as { tier?: unknown }).tier;
-    if (tierConfig === null || typeof tierConfig !== "object" || Array.isArray(tierConfig)) return false;
-    const type = (tierConfig as { type?: unknown }).type;
-    const size = (tierConfig as { size?: unknown }).size;
+  const contextOver200k = contextTiers.find((tier) => {
+    const size = (tier.tier as { size?: unknown }).size;
     // context_over_200k is a legacy compatibility field. It intentionally
     // includes higher thresholds; cost.tiers carries the exact threshold.
-    return (
-      (type === undefined || type === "context") &&
-      typeof size === "number" &&
-      size >= 200_000
-    );
+    return typeof size === "number" && size >= 200_000;
   });
 
   if (contextOver200k === undefined) {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -114,6 +114,10 @@ const TimeWindow = z
 // Time-of-day pricing: the tier's rates apply inside `windows`, and the base
 // cost applies outside all of them. Providers that bill peak/off-peak (DeepSeek
 // V4 since 2026-08-16) put the peak rate here and the off-peak rate in `[cost]`.
+// When a context tier and a time tier both match a request, the context tier
+// wins and the time tier is ignored — tiers replace the base cost, they never
+// compose. A provider that charges a combined long-context peak rate cannot be
+// expressed with one tier of each kind.
 const TimeTier = z
   .object({
     type: z.literal("time"),

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -91,14 +91,59 @@ const Cost = z.object({
     .optional(),
 }).strict();
 
+const ContextTier = z
+  .object({
+    type: z.literal("context").default("context"),
+    size: z.number().int().min(0, "Context tier size cannot be negative"),
+  })
+  .strict();
+
+// UTC "HH:MM-HH:MM" range, start inclusive and end exclusive. An end that
+// precedes its start wraps past midnight ("22:00-02:00").
+const TimeWindow = z
+  .string()
+  .regex(
+    /^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$/,
+    "Must be a UTC time range in HH:MM-HH:MM format",
+  )
+  .refine((window) => {
+    const [start, end] = window.split("-");
+    return start !== end;
+  }, "Time window cannot start and end at the same minute");
+
+// Time-of-day pricing: the tier's rates apply inside `windows`, and the base
+// cost applies outside all of them. Providers that bill peak/off-peak (DeepSeek
+// V4 since 2026-08-16) put the peak rate here and the off-peak rate in `[cost]`.
+const TimeTier = z
+  .object({
+    type: z.literal("time"),
+    windows: z
+      .array(TimeWindow)
+      .min(1, "Time tier must list at least one window"),
+  })
+  .strict();
+
+// A plain union rather than z.discriminatedUnion: authored context tiers omit
+// `type` and lean on the default, which a discriminated union cannot match.
 const CostTier = Cost.extend({
-  tier: z
-    .object({
-      type: z.literal("context").default("context"),
-      size: z.number().int().min(0, "Context tier size cannot be negative"),
-    })
-    .strict(),
+  tier: z.union([ContextTier, TimeTier]),
 }).strict();
+
+function toMinutes(time: string): number {
+  const [hours = 0, minutes = 0] = time.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+/** Expands a window into [start, end) minute intervals, splitting midnight wraps. */
+function toIntervals(window: string): Array<[number, number]> {
+  const [start = 0, end = 0] = window.split("-").map(toMinutes);
+  return start < end
+    ? [[start, end]]
+    : [
+        [start, 24 * 60],
+        [0, end],
+      ];
+}
 
 const AuthoredCost = Cost.extend({
   context_over_200k: z.never().optional(),
@@ -344,13 +389,34 @@ function refineModel<
         const tiers = data.cost?.tiers;
         if (tiers === undefined) return true;
 
-        const sizes = tiers.map(
-          (tier: { tier: { size: number } }) => tier.tier.size,
+        const sizes = tiers.flatMap((entry: z.infer<typeof CostTier>) =>
+          entry.tier.type === "context" ? [entry.tier.size] : [],
         );
         return new Set(sizes).size === sizes.length;
       },
       {
         message: "Cost context tiers must not have duplicate sizes",
+        path: ["cost", "tiers"],
+      },
+    )
+    .refine(
+      (data) => {
+        const tiers = data.cost?.tiers;
+        if (tiers === undefined) return true;
+
+        const intervals = tiers.flatMap((entry: z.infer<typeof CostTier>) =>
+          entry.tier.type === "time"
+            ? entry.tier.windows.flatMap(toIntervals)
+            : [],
+        );
+        return intervals.every(([start, end], index) =>
+          intervals
+            .slice(index + 1)
+            .every(([other, otherEnd]) => start >= otherEnd || other >= end),
+        );
+      },
+      {
+        message: "Cost time tier windows must not overlap",
         path: ["cost", "tiers"],
       },
     );

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -949,7 +949,9 @@ export function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
 
     for (const tier of model.cost.tiers ?? []) {
       lines.push("", "[[cost.tiers]]");
-      if (tier.tier?.size !== undefined) {
+      if (tier.tier?.type === "time") {
+        lines.push(`tier = { type = "time", windows = [${tier.tier.windows.map(quote).join(", ")}] }`);
+      } else if (tier.tier?.size !== undefined) {
         lines.push(`tier = { type = ${quote(tier.tier.type ?? "context")}, size = ${formatInteger(tier.tier.size)} }`);
       }
       if (tier.input !== undefined) lines.push(`input = ${formatNumber(tier.input)}`);

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -45,6 +45,47 @@ describe("catalog generation", () => {
     });
   });
 
+  test("time tiers generate alongside the legacy context_over_200k field", async () => {
+    await withFixture(async (root) => {
+      await write(root, "providers/provider/provider.toml", providerToml("Provider"));
+      await write(root, "models/lab/model.toml", modelMetadataToml());
+      await write(
+        root,
+        "providers/provider/models/model.toml",
+        `base_model = "lab/model"
+reasoning_options = []
+
+[cost]
+input = 0.22
+output = 0.66
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 0.33
+output = 0.99
+
+[[cost.tiers]]
+tier = { type = "time", windows = ["01:00-04:00", "06:00-10:00"] }
+input = 0.44
+output = 1.32
+`,
+      );
+
+      const providers = await generate(path.join(root, "providers"));
+      const cost = providers.provider?.models.model?.cost;
+
+      expect(cost?.tiers).toEqual([
+        { tier: { type: "context", size: 200_000 }, input: 0.33, output: 0.99 },
+        {
+          tier: { type: "time", windows: ["01:00-04:00", "06:00-10:00"] },
+          input: 0.44,
+          output: 1.32,
+        },
+      ]);
+      expect(cost?.context_over_200k).toEqual({ input: 0.33, output: 0.99 });
+    });
+  });
+
   test("base_model can factor metadata without changing provider JSON", async () => {
     await withFixture(async (root) => {
       await write(root, "providers/direct/provider.toml", providerToml("Direct"));

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -109,6 +109,133 @@ describe("model schema", () => {
   });
 });
 
+describe("cost tiers", () => {
+  function withTiers(tiers: unknown) {
+    return AuthoredModel.safeParse({
+      ...baseModel({}),
+      cost: { input: 1, output: 2, tiers },
+    });
+  }
+
+  test("keeps accepting context tiers authored without an explicit type", () => {
+    const result = withTiers([{ tier: { size: 200_000 }, input: 2, output: 4 }]);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.cost?.tiers?.[0]?.tier).toEqual({
+      type: "context",
+      size: 200_000,
+    });
+  });
+
+  test("accepts time tiers with UTC windows", () => {
+    expect(
+      withTiers([
+        {
+          tier: { type: "time", windows: ["01:00-04:00", "06:00-10:00"] },
+          input: 0.44,
+          output: 1.32,
+          cache_read: 0.014,
+        },
+      ]).success,
+    ).toBe(true);
+  });
+
+  test("accepts a window that wraps past midnight", () => {
+    expect(
+      withTiers([
+        { tier: { type: "time", windows: ["22:00-02:00"] }, input: 2, output: 4 },
+      ]).success,
+    ).toBe(true);
+  });
+
+  test("rejects malformed windows", () => {
+    for (const window of [
+      "1:00-4:00",
+      "24:00-25:00",
+      "01:00",
+      "01:00-04:60",
+      "01:00 - 04:00",
+    ]) {
+      expect(
+        withTiers([
+          { tier: { type: "time", windows: [window] }, input: 2, output: 4 },
+        ]).success,
+      ).toBe(false);
+    }
+  });
+
+  test("rejects a window that starts and ends at the same minute", () => {
+    expect(
+      withTiers([
+        { tier: { type: "time", windows: ["01:00-01:00"] }, input: 2, output: 4 },
+      ]).success,
+    ).toBe(false);
+  });
+
+  test("rejects a time tier with no windows", () => {
+    expect(
+      withTiers([{ tier: { type: "time", windows: [] }, input: 2, output: 4 }])
+        .success,
+    ).toBe(false);
+  });
+
+  test("rejects overlapping windows within one tier", () => {
+    expect(
+      withTiers([
+        {
+          tier: { type: "time", windows: ["01:00-04:00", "03:00-06:00"] },
+          input: 2,
+          output: 4,
+        },
+      ]).success,
+    ).toBe(false);
+  });
+
+  test("rejects overlapping windows across tiers, including midnight wraps", () => {
+    expect(
+      withTiers([
+        { tier: { type: "time", windows: ["22:00-02:00"] }, input: 2, output: 4 },
+        { tier: { type: "time", windows: ["01:00-03:00"] }, input: 3, output: 5 },
+      ]).success,
+    ).toBe(false);
+  });
+
+  test("accepts adjacent windows, since the end is exclusive", () => {
+    expect(
+      withTiers([
+        {
+          tier: { type: "time", windows: ["01:00-04:00", "04:00-06:00"] },
+          input: 2,
+          output: 4,
+        },
+      ]).success,
+    ).toBe(true);
+  });
+
+  test("rejects duplicate context sizes alongside a time tier", () => {
+    expect(
+      withTiers([
+        { tier: { size: 200_000 }, input: 2, output: 4 },
+        { tier: { size: 200_000 }, input: 3, output: 5 },
+        { tier: { type: "time", windows: ["01:00-04:00"] }, input: 4, output: 6 },
+      ]).success,
+    ).toBe(false);
+  });
+
+  test("rejects unknown keys inside a tier", () => {
+    expect(
+      withTiers([
+        {
+          tier: { type: "time", windows: ["01:00-04:00"], timezone: "UTC" },
+          input: 2,
+          output: 4,
+        },
+      ]).success,
+    ).toBe(false);
+  });
+});
+
 describe("provider schema", () => {
   const mergeGatewayProvider = {
     id: "merge-gateway",

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -2461,6 +2461,37 @@ test("formats interleaved as a root field before reasoning option tables", () =>
   });
 });
 
+test("round-trips context and time cost tiers through TOML", () => {
+  const tiers = [
+    { tier: { type: "context" as const, size: 200_000 }, input: 0.33, output: 0.99 },
+    {
+      tier: { type: "time" as const, windows: ["01:00-04:00", "06:00-10:00"] },
+      input: 0.44,
+      output: 1.32,
+      cache_read: 0.014,
+    },
+  ];
+
+  const content = formatToml({
+    id: "example/model",
+    name: "Example Model",
+    description: "Example model for sync formatting regression tests",
+    release_date: "2026-01-01",
+    last_updated: "2026-01-01",
+    attachment: false,
+    reasoning: false,
+    tool_call: true,
+    open_weights: false,
+    cost: { input: 0.22, output: 0.66, cache_read: 0.007, tiers },
+    limit: { context: 1_000, output: 100 },
+    modalities: { input: ["text"], output: ["text"] },
+  });
+
+  // A sync that carries authored tiers forward must not drop the tier header:
+  // a time tier written as bare prices no longer parses as a tier at all.
+  expect(Bun.TOML.parse(content)).toMatchObject({ cost: { tiers } });
+});
+
 test("formats empty reasoning options outside the interleaved table", () => {
   const content = formatToml({
     id: "example/model",

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -57,20 +57,34 @@ export interface Cost {
   output_audio?: number
 }
 
-/** Pricing that applies from a given context size upward. */
-export interface CostTier extends Cost {
-  tier: {
-    type: "context"
-    /** Context size (in tokens) at which this tier starts to apply. */
-    size: number
-  }
+/** Band that applies from a given context size upward. */
+export interface ContextTier {
+  type: "context"
+  /** Context size (in tokens) at which this tier starts to apply. */
+  size: number
 }
 
-/** Pricing for a provider's model, including context-size tiers. */
+/** Band that applies during given times of day. */
+export interface TimeTier {
+  type: "time"
+  /**
+   * UTC `HH:MM-HH:MM` ranges, start inclusive and end exclusive. An end that
+   * precedes its start wraps past midnight. The model's base cost applies
+   * outside every window.
+   */
+  windows: string[]
+}
+
+/** Pricing for one context-size band or time-of-day band. */
+export interface CostTier extends Cost {
+  tier: ContextTier | TimeTier
+}
+
+/** Pricing for a provider's model, including context-size and time-of-day tiers. */
 export interface ModelCost extends Cost {
   /** Legacy compatibility field: pricing applied beyond 200K context. Prefer `tiers`. */
   context_over_200k?: Cost
-  /** Context-size-based pricing tiers. */
+  /** Context-size and time-of-day pricing tiers. */
   tiers?: CostTier[]
 }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -70,7 +70,9 @@ export interface TimeTier {
   /**
    * UTC `HH:MM-HH:MM` ranges, start inclusive and end exclusive. An end that
    * precedes its start wraps past midnight. The model's base cost applies
-   * outside every window.
+   * outside every window. When a context tier and a time tier both match a
+   * request, the context tier wins — tiers replace the base cost, they never
+   * compose.
    */
   windows: string[]
 }


### PR DESCRIPTION
Adds a `time` variant to `cost.tiers[]`, so providers that bill by time of day can be expressed as data. Follow-up to #4891, which had to flatten DeepSeek V4's peak/off-peak rates into a single number because the schema has no way to say "this rate applies between these hours".

```toml
[cost]
input = 0.22
output = 0.66
cache_read = 0.007

[[cost.tiers]]
tier = { type = "time", windows = ["01:00-04:00", "06:00-10:00"] }
input = 0.44
output = 1.32
cache_read = 0.014
```

Windows are UTC `HH:MM-HH:MM`, start inclusive and end exclusive; an end that precedes its start wraps past midnight (`22:00-02:00`). The base `[cost]` applies outside every window — same override relationship context tiers already have.

DeepSeek is the immediate case (V4 moved to peak/off-peak on 2026-08-16), but the pattern isn't new — Chinese labs have run off-peak discount windows for a while, and this stops each one from silently becoming a wrong flat number in the catalog.

### Notes on the implementation

**`z.union`, not `z.discriminatedUnion`.** The obvious move is a discriminated union on `tier.type`, but it breaks every tier already in the repo: authored context tiers omit `type` and rely on `z.literal("context").default("context")`, and a discriminated union can't match a missing discriminator — it fails with "No matching discriminator" before the default is ever applied. A plain union keeps existing data valid, at the cost of slightly noisier error messages. There's a test pinning that behaviour.

**Validation.** Windows must be well-formed, must not start and end at the same minute, must be non-empty, and must not overlap each other — including across separate time tiers, and including wrap-around windows. Adjacent windows (`01:00-04:00` and `04:00-06:00`) are allowed since the end is exclusive.

**The duplicate-size check.** It did `tiers.map((tier) => tier.tier.size)` unconditionally, which yields `undefined` for a time tier and would fire spuriously on two of them. Now it only looks at context tiers.

**Legacy `context_over_200k`.** Both `generate.ts` and `compare-model-migrations.ts` bailed out unless there was exactly one tier, so adding a time tier to a model would have silently dropped the legacy field. They now count context tiers only — behaviour is unchanged for every model without a time tier.

**SDK types.** `CostTier.tier` becomes `ContextTier | TimeTier`. The drift-protection assertions in `packages/sdk/test/types.ts` pin these to the inferred Zod types, and they pass.

### Verification

- `bun test` — 206 pass, 12 of them new. The 4 failures (`repository open-weight model metadata includes weights links`, `DeepInfra preserves live modalities for new base models`, and two `snapshot` module-resolution failures) reproduce identically on an unmodified `dev`.
- `bun run validate` — passes.
- `tsc --noEmit` in `packages/sdk` — clean.

No data uses the new variant yet. If this lands I'll follow up by converting the DeepSeek entries to carry both rates.
