### PR TITLE
feat(sap-ai-core): add GPT-5.6 models

### DIFF
--- a/providers/sap-ai-core/models/gpt-5.6-luna.toml
+++ b/providers/sap-ai-core/models/gpt-5.6-luna.toml
@@ -1,0 +1,17 @@
+# Azure OpenAI deployment adapter: raw Chat uses top-level $.reasoning_effort = "none"|"low"|"medium"|"high"|"xhigh"|"max"; "none" is off. https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning (accessed 2026-07-09)
+
+base_model = "openai/gpt-5.6-luna"
+
+name = "gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 1.00
+output = 6.00
+cache_read = 0.10
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 2.00
+output = 9.00
+cache_read = 0.20

--- a/providers/sap-ai-core/models/gpt-5.6-sol.toml
+++ b/providers/sap-ai-core/models/gpt-5.6-sol.toml
@@ -1,0 +1,17 @@
+# Azure OpenAI deployment adapter: raw Chat uses top-level $.reasoning_effort = "none"|"low"|"medium"|"high"|"xhigh"|"max"; "none" is off. https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning (accessed 2026-07-09)
+
+base_model = "openai/gpt-5.6-sol"
+
+name = "gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10.00
+output = 45.00
+cache_read = 1.00

--- a/providers/sap-ai-core/models/gpt-5.6-terra.toml
+++ b/providers/sap-ai-core/models/gpt-5.6-terra.toml
@@ -1,0 +1,17 @@
+# Azure OpenAI deployment adapter: raw Chat uses top-level $.reasoning_effort = "none"|"low"|"medium"|"high"|"xhigh"|"max"; "none" is off. https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning (accessed 2026-07-09)
+
+base_model = "openai/gpt-5.6-terra"
+
+name = "gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5.00
+output = 22.50
+cache_read = 0.50


### PR DESCRIPTION
## What

Adds the three GPT-5.6 models now available through SAP AI Core:

- `gpt-5.6-luna`
- `gpt-5.6-terra`
- `gpt-5.6-sol`

Each wrapper uses `base_model = "openai/gpt-5.6-*"` so provider-agnostic metadata stays inherited from `models/openai/`.

## Details

- Preserves SAP AI Core deployment IDs as lowercase `name` values.
- Uses the Azure OpenAI adapter reasoning surface already used by existing SAP GPT wrappers: `reasoning_effort = none | low | medium | high | xhigh | max`.
- Mirrors the Azure/Azure Cognitive Services GPT-5.6 pricing shape already present in this repo: standard pricing plus `context` tier at `272_000` input tokens.
- Omits OpenAI-only `cache_write` and `experimental.modes` fields, matching the SAP/Azure adapter convention.

## Evidence

- SAP AI Core Generative AI Hub model availability is tracked in SAP Note 3437766.
- SAP AI Core routes GPT models through Azure OpenAI-compatible deployments; existing wrappers document the request surface in `providers/sap-ai-core/provider.toml` and the GPT 5.x model headers.
- Azure OpenAI reasoning API: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning
- Cross-checked against existing repo entries:
  - `providers/azure/models/gpt-5.6-{luna,terra,sol}.toml`
  - `providers/azure-cognitive-services/models/gpt-5.6-{luna,terra,sol}.toml`
  - `providers/openai/models/gpt-5.6-{luna,terra,sol}.toml`

## Verification

- `bun validate` -> exit 0
- `git diff --check HEAD~1..HEAD` -> pass
- `generateCatalog()` smoke check confirms all three SAP models resolve with inherited OpenAI metadata, SAP lowercase names, expected cost tiers, and reasoning options.