### PR TITLE
feat(sync): add Nvidia model catalog sync

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -24,6 +24,7 @@ import { kilo } from "./providers/kilo.js";
 import { llmgateway } from "./providers/llmgateway.js";
 import { mergeGateway } from "./providers/merge-gateway.js";
 import { nanoGpt } from "./providers/nano-gpt.js";
+import { nvidia } from "./providers/nvidia.js";
 import { openai } from "./providers/openai.js";
 import { ofox } from "./providers/ofox.js";
 import { openrouter } from "./providers/openrouter.js";
@@ -133,6 +134,7 @@ export const providers: {
   llmgateway: SyncProvider<any>;
   "merge-gateway": SyncProvider<any>;
   "nano-gpt": SyncProvider<any>;
+  nvidia: SyncProvider<any>;
   ofox: SyncProvider<any>;
   openai: SyncProvider<any>;
   openrouter: SyncProvider<any>;
@@ -164,6 +166,7 @@ export const providers: {
   llmgateway,
   "merge-gateway": mergeGateway,
   "nano-gpt": nanoGpt,
+  nvidia,
   ofox,
   openai,
   openrouter,
@@ -194,7 +197,7 @@ export const groups = {
     "vercel",
   ],
   cloudflare: ["cloudflare-workers-ai"],
-  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
+  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "google", "hyper", "nvidia", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;

--- a/packages/core/src/sync/providers/nvidia.ts
+++ b/packages/core/src/sync/providers/nvidia.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+import { AuthoredModel } from "../../schema.js";
+import type { ExistingModel, SyncProvider, SyncedBaseModel, SyncedModel } from "../index.js";
+
+const API_ENDPOINT = "https://integrate.api.nvidia.com/v1/models";
+
+export const NvidiaModel = z.object({
+  id: z.string().min(1),
+  object: z.literal("model"),
+  created: z.number().int().nonnegative(),
+  owned_by: z.string(),
+}).passthrough();
+
+const NvidiaResponse = z.object({
+  object: z.literal("list"),
+  data: z.array(NvidiaModel),
+}).passthrough();
+
+export type NvidiaModel = z.infer<typeof NvidiaModel>;
+
+export function parseNvidiaModels(raw: unknown) {
+  return NvidiaResponse.parse(raw).data;
+}
+
+function preserveAuthoredModel(id: string, authored: ExistingModel): SyncedModel {
+  if (authored.base_model !== undefined) return authored as SyncedBaseModel;
+
+  const parsed = AuthoredModel.safeParse({ id, ...authored });
+  if (!parsed.success) {
+    parsed.error.cause = { provider: "nvidia", model: id };
+    throw parsed.error;
+  }
+  const { id: _id, ...model } = parsed.data;
+  return model;
+}
+
+export async function fetchNvidiaModels(fetcher: typeof fetch = fetch) {
+  const response = await fetcher(API_ENDPOINT);
+  if (!response.ok) {
+    throw new Error(`Nvidia models request failed: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export const nvidia = {
+  id: "nvidia",
+  name: "Nvidia",
+  modelsDir: "providers/nvidia/models",
+  skipCreates: true,
+  // /v1/models is a public availability listing with no lifecycle or pricing
+  // metadata. Mirror the OpenAI sync: preserve hand-authored TOMLs byte for
+  // byte, never create or delete, and surface remote/local deltas as notices.
+  trackMissingModels: false,
+  deleteMissing: false,
+  sourceID(model) {
+    return model.id;
+  },
+  skippedNotice(ids) {
+    if (ids.length === 0) return [];
+    return [
+      `${ids.length} Nvidia models are served by the API but missing from the local catalog and require hand-authored metadata.`,
+      `Missing remote IDs: ${ids.map((id) => `\`${id}\``).join(", ")}`,
+    ];
+  },
+  async fetchModels() {
+    return fetchNvidiaModels();
+  },
+  parseModels: parseNvidiaModels,
+  translateModel(model, context) {
+    const authored = context.authored(model.id);
+    if (authored === undefined) return undefined;
+    return { id: model.id, model: preserveAuthoredModel(model.id, authored) };
+  },
+} satisfies SyncProvider<NvidiaModel>;

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -72,6 +72,7 @@ import {
   resolveNanoGptBaseModel,
   type NanoGptModel,
 } from "../src/sync/providers/nano-gpt.js";
+import { nvidia, parseNvidiaModels } from "../src/sync/providers/nvidia.js";
 import { openai, parseOpenAIModels } from "../src/sync/providers/openai.js";
 import { ofox } from "../src/sync/providers/ofox.js";
 import { pioneer } from "../src/sync/providers/pioneer.js";
@@ -1050,6 +1051,31 @@ test("OpenAI availability sync preserves authored metadata", () => {
   )).toEqual({ id: "gpt-5.5", model: authored });
 });
 
+test("Nvidia availability sync preserves authored metadata", () => {
+  const authored = {
+    base_model: "nvidia/llama-3.1-nemotron-70b-instruct",
+    cost: { input: 0, output: 0 },
+  };
+  expect(nvidia.translateModel(
+    { id: "nvidia/llama-3.1-nemotron-70b-instruct", object: "model", created: 1, owned_by: "nvidia" },
+    { existing: () => authored as never, authored: () => authored },
+  )).toEqual({ id: "nvidia/llama-3.1-nemotron-70b-instruct", model: authored });
+});
+
+test("Nvidia availability sync parses the public models listing", () => {
+  const models = parseNvidiaModels({
+    object: "list",
+    data: [
+      { id: "nvidia/nemotron-3-nano-30b-a3b", object: "model", created: 1, owned_by: "nvidia" },
+      { id: "deepseek-ai/deepseek-v4-flash-0731", object: "model", created: 1, owned_by: "deepseek-ai" },
+    ],
+  });
+  expect(models).toEqual([
+    { id: "nvidia/nemotron-3-nano-30b-a3b", object: "model", created: 1, owned_by: "nvidia" },
+    { id: "deepseek-ai/deepseek-v4-flash-0731", object: "model", created: 1, owned_by: "deepseek-ai" },
+  ]);
+});
+
 test("OpenAI availability sync retains models absent from a scoped response", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "sync-openai-"));
   const modelsDir = path.join(dir, "providers", "openai", "models");
@@ -1100,6 +1126,8 @@ test("tracks missing models except for unreliable first-party inventories", () =
   expect(google.trackMissingModels).toBe(false);
   expect(openai.skipCreates).toBe(true);
   expect(openai.trackMissingModels).toBe(false);
+  expect(nvidia.skipCreates).toBe(true);
+  expect(nvidia.trackMissingModels).toBe(false);
   expect(pioneer.skipCreates).toBe(true);
   expect(pioneer.trackMissingModels).toBe(true);
   expect(ofox.skipCreates).toBe(true);


### PR DESCRIPTION
## Summary
- add a non-destructive Nvidia availability monitor backed by the public `GET /v1/models` endpoint
- preserve authored metadata and retain local models absent from the API listing
- report remote-only Nvidia models as notices for manual review instead of auto-creating incomplete TOMLs
- register Nvidia in the hourly model sync automation

## Why
The Nvidia NIM API exposes models that are missing from the catalog (e.g. `deepseek-ai/deepseek-v4-flash-0731`, `nvidia/nemotron-4-340b-instruct`, `nvidia/nemotron-3.5-content-safety`), and several catalog entries are no longer served. The public listing carries no pricing, limit, or lifecycle metadata, so the sync mirrors the OpenAI approach: preserve hand-authored TOMLs byte-for-byte, never create or delete, and surface deltas as notices so stale entries stay a human decision.

## Testing
- `bun test packages/core/test/sync.test.ts`
- `bun test` (196 pass; 4 pre-existing failures unrelated to this change)
- `bun validate`
- `bun models:sync nvidia --dry-run` -> 0 created, 0 updated, 0 removed, 100 unchanged
- `bun models:sync nvidia` -> 0 created, 0 updated, 0 removed, 100 unchanged

## Source
- https://integrate.api.nvidia.com/v1/models (public, no authentication required)

No new repository or organization Actions secrets are required: the endpoint is unauthenticated.