### PR TITLE
Add Arka-AI provider (OpenAI-compatible model hub)

### DIFF
--- a/providers/arka-ai/logo.svg
+++ b/providers/arka-ai/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 180" fill="none">
+  <path d="M100 8 L185 172 L155 172 L140 155 Q100 115 60 155 L45 172 L15 172 Z" stroke="currentColor" stroke-width="10" stroke-linejoin="round" stroke-linecap="round"/>
+  <path d="M70 116 L100 63 L130 116" stroke="currentColor" stroke-width="8" stroke-linejoin="round" stroke-linecap="round"/>
+  <path d="M66.6 117 L64.8 120 L68.5 120 Z" stroke="currentColor" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
+  <path d="M133.4 117 L131.5 120 L135.2 120 Z" stroke="currentColor" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
+</svg>

--- a/providers/arka-ai/models/DeepSeek-R1.toml
+++ b/providers/arka-ai/models/DeepSeek-R1.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "deepseek/deepseek-r1"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.712923
+output = 2.851693

--- a/providers/arka-ai/models/DeepSeek-V3.toml
+++ b/providers/arka-ai/models/DeepSeek-V3.toml
@@ -1,0 +1,8 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "deepseek/deepseek-v3"
+
+[cost]
+input = 0.356462
+output = 1.425847

--- a/providers/arka-ai/models/DeepSeek-V4-Pro.toml
+++ b/providers/arka-ai/models/DeepSeek-V4-Pro.toml
@@ -1,3 +1,6 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled)
+# Effort: reasoning_effort = high|max (low accepted; maps per DeepSeek lab convention)
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 

--- a/providers/arka-ai/models/DeepSeek-V4-Pro.toml
+++ b/providers/arka-ai/models/DeepSeek-V4-Pro.toml
@@ -1,0 +1,15 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.214748
+output = 4.429496

--- a/providers/arka-ai/models/GLM-4.7-Flash.toml
+++ b/providers/arka-ai/models/GLM-4.7-Flash.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = [
+  { type = "toggle" },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+# No per-token price published for this model.

--- a/providers/arka-ai/models/GLM-4.7-Flash.toml
+++ b/providers/arka-ai/models/GLM-4.7-Flash.toml
@@ -1,3 +1,8 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled,
+# the zhipuai-native wire). First-party providers/zhipuai/models/glm-4.7-flash.toml
+# declares the same toggle. This route returned upstream_error (HTTP 400) at verification
+# time, so the wire is evidenced from Arka's verified GLM siblings (GLM-5, GLM-5.1)
+# served through the same gateway (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 

--- a/providers/arka-ai/models/GLM-5.1.toml
+++ b/providers/arka-ai/models/GLM-5.1.toml
@@ -1,3 +1,6 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled,
+# the zhipuai-native wire)
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 

--- a/providers/arka-ai/models/GLM-5.1.toml
+++ b/providers/arka-ai/models/GLM-5.1.toml
@@ -1,0 +1,14 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "zhipuai/glm-5.1"
+reasoning_options = [
+  { type = "toggle" },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.425847
+output = 4.990464

--- a/providers/arka-ai/models/GLM-5.2.toml
+++ b/providers/arka-ai/models/GLM-5.2.toml
@@ -1,0 +1,14 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "zhipuai/glm-5.2"
+reasoning_options = [
+  { type = "effort", values = ["high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.425847
+output = 4.990464

--- a/providers/arka-ai/models/GLM-5.toml
+++ b/providers/arka-ai/models/GLM-5.toml
@@ -1,3 +1,6 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled,
+# the zhipuai-native wire)
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 

--- a/providers/arka-ai/models/GLM-5.toml
+++ b/providers/arka-ai/models/GLM-5.toml
@@ -1,0 +1,14 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "zhipuai/glm-5"
+reasoning_options = [
+  { type = "toggle" },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.712923
+output = 3.208155

--- a/providers/arka-ai/models/Kimi-K2.7-Code.toml
+++ b/providers/arka-ai/models/Kimi-K2.7-Code.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.1585
+output = 4.812233

--- a/providers/arka-ai/models/MiniMax-M2.5.toml
+++ b/providers/arka-ai/models/MiniMax-M2.5.toml
@@ -1,0 +1,9 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
+
+[cost]
+input = 0.374285
+output = 1.497139

--- a/providers/arka-ai/models/MiniMax-M3.toml
+++ b/providers/arka-ai/models/MiniMax-M3.toml
@@ -1,3 +1,7 @@
+# Toggle: enable_thinking true|false (thinking.type = disabled also accepted).
+# reasoning_content is not exposed; reasoning is visible only via
+# usage.completion_tokens_details.reasoning_tokens.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 

--- a/providers/arka-ai/models/MiniMax-M3.toml
+++ b/providers/arka-ai/models/MiniMax-M3.toml
@@ -1,0 +1,11 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "minimax/MiniMax-M3"
+reasoning_options = [
+  { type = "toggle" },
+]
+
+[cost]
+input = 0.374285
+output = 1.497139

--- a/providers/arka-ai/models/Qwen3-Coder-Flash.toml
+++ b/providers/arka-ai/models/Qwen3-Coder-Flash.toml
@@ -1,0 +1,8 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3-coder-flash"
+
+[cost]
+input = 0.178231
+output = 0.712923

--- a/providers/arka-ai/models/Qwen3-Coder-Next.toml
+++ b/providers/arka-ai/models/Qwen3-Coder-Next.toml
@@ -1,0 +1,8 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3-coder-next"
+
+[cost]
+input = 0.712923
+output = 0.712923

--- a/providers/arka-ai/models/Qwen3.5-27B.toml
+++ b/providers/arka-ai/models/Qwen3.5-27B.toml
@@ -1,10 +1,15 @@
+# Toggle: enable_thinking true|false only; thinking.type = disabled is accepted but has no
+# effect on this model. Reasoning is not exposed separately (no reasoning_content or
+# reasoning_tokens); the toggle is verified via completion length.
+# Budget: thinking_budget is accepted but not enforced, so no budget_tokens control is
+# advertised.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
 base_model = "alibaba/qwen3.5-27b"
 reasoning_options = [
   { type = "toggle" },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/arka-ai/models/Qwen3.5-27B.toml
+++ b/providers/arka-ai/models/Qwen3.5-27B.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3.5-27b"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.106939
+output = 0.855508

--- a/providers/arka-ai/models/Qwen3.5-Flash.toml
+++ b/providers/arka-ai/models/Qwen3.5-Flash.toml
@@ -1,10 +1,13 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled)
+# Budget: thinking_budget is accepted but not enforced (reasoning length unchanged at
+# budget=256 vs no budget), so no budget_tokens control is advertised.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
 base_model = "alibaba/qwen3.5-flash"
 reasoning_options = [
   { type = "toggle" },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/arka-ai/models/Qwen3.5-Flash.toml
+++ b/providers/arka-ai/models/Qwen3.5-Flash.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3.5-flash"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.035646
+output = 0.356462

--- a/providers/arka-ai/models/Qwen3.5-Plus.toml
+++ b/providers/arka-ai/models/Qwen3.5-Plus.toml
@@ -1,10 +1,13 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled)
+# Budget: thinking_budget is accepted but not enforced, so no budget_tokens control is
+# advertised.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
 base_model = "alibaba/qwen3.5-plus"
 reasoning_options = [
   { type = "toggle" },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/arka-ai/models/Qwen3.5-Plus.toml
+++ b/providers/arka-ai/models/Qwen3.5-Plus.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3.5-plus"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.142585
+output = 0.855508

--- a/providers/arka-ai/models/Qwen3.6-Max.toml
+++ b/providers/arka-ai/models/Qwen3.6-Max.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3.6-max-preview"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 1.604078
+output = 9.624465

--- a/providers/arka-ai/models/Qwen3.6-Max.toml
+++ b/providers/arka-ai/models/Qwen3.6-Max.toml
@@ -1,10 +1,13 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled)
+# Budget: thinking_budget is accepted but not enforced, so no budget_tokens control is
+# advertised.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
 base_model = "alibaba/qwen3.6-max-preview"
 reasoning_options = [
   { type = "toggle" },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/arka-ai/models/Qwen3.6-Plus.toml
+++ b/providers/arka-ai/models/Qwen3.6-Plus.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3.6-plus"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 1.425847
+output = 8.55508

--- a/providers/arka-ai/models/Qwen3.6-Plus.toml
+++ b/providers/arka-ai/models/Qwen3.6-Plus.toml
@@ -1,10 +1,13 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled)
+# Budget: thinking_budget is accepted but not enforced, so no budget_tokens control is
+# advertised.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
 base_model = "alibaba/qwen3.6-plus"
 reasoning_options = [
   { type = "toggle" },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/arka-ai/models/Qwen3.7-Max.toml
+++ b/providers/arka-ai/models/Qwen3.7-Max.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3.7-max"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 2.13877
+output = 6.41631

--- a/providers/arka-ai/models/Qwen3.7-Max.toml
+++ b/providers/arka-ai/models/Qwen3.7-Max.toml
@@ -1,10 +1,13 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled)
+# Budget: thinking_budget is accepted but not enforced, so no budget_tokens control is
+# advertised.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
 base_model = "alibaba/qwen3.7-max"
 reasoning_options = [
   { type = "toggle" },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/arka-ai/models/Qwen3.7-Plus.toml
+++ b/providers/arka-ai/models/Qwen3.7-Plus.toml
@@ -1,0 +1,12 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3.7-plus"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.356462
+output = 1.425847

--- a/providers/arka-ai/models/Qwen3.7-Plus.toml
+++ b/providers/arka-ai/models/Qwen3.7-Plus.toml
@@ -1,10 +1,13 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled)
+# Budget: thinking_budget is accepted but not enforced, so no budget_tokens control is
+# advertised.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
 base_model = "alibaba/qwen3.7-plus"
 reasoning_options = [
   { type = "toggle" },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/arka-ai/models/Step-3.7-Flash.toml
+++ b/providers/arka-ai/models/Step-3.7-Flash.toml
@@ -1,0 +1,14 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "stepfun/step-3.7-flash"
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "high"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.240612
+output = 1.44367

--- a/providers/arka-ai/models/deepseek-v4-flash-0731.toml
+++ b/providers/arka-ai/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,15 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "deepseek/deepseek-v4-flash-0731"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.178231
+output = 0.356462

--- a/providers/arka-ai/models/deepseek-v4-flash-0731.toml
+++ b/providers/arka-ai/models/deepseek-v4-flash-0731.toml
@@ -1,10 +1,14 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled)
+# Effort: reasoning_effort = low|high|max (all three levels verified live, matching the
+# first-party deepseek baseline; unlike alibaba's hosted copy, low is not mapped away)
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
 base_model = "deepseek/deepseek-v4-flash-0731"
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["high", "max"] },
+  { type = "effort", values = ["low", "high", "max"] },
 ]
 
 [interleaved]

--- a/providers/arka-ai/models/kimi-k3.toml
+++ b/providers/arka-ai/models/kimi-k3.toml
@@ -1,7 +1,9 @@
 # Reasoning is always on: disabling it (enable_thinking=false or thinking.type=disabled)
-# returns HTTP 400 "invalid temperature: only 0.6 is allowed" from the non-thinking lane,
-# and effort controls (reasoning_effort, output_config.effort) are accepted without any
-# observable change in reasoning depth. No client control is therefore advertised.
+# returns HTTP 400 "invalid temperature: only 0.6 is allowed" from the non-thinking lane
+# even when temperature=0.6 is explicitly set (the value the error demands), so that lane
+# is unusable by callers. Effort controls (reasoning_effort, output_config.effort,
+# thinking.type=adaptive + output_config.effort) are accepted without any observable
+# change in reasoning depth. No client control is therefore advertised.
 # Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.

--- a/providers/arka-ai/models/kimi-k3.toml
+++ b/providers/arka-ai/models/kimi-k3.toml
@@ -1,0 +1,15 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.564617
+output = 17.823084

--- a/providers/arka-ai/models/kimi-k3.toml
+++ b/providers/arka-ai/models/kimi-k3.toml
@@ -1,11 +1,13 @@
+# Reasoning is always on: disabling it (enable_thinking=false or thinking.type=disabled)
+# returns HTTP 400 "invalid temperature: only 0.6 is allowed" from the non-thinking lane,
+# and effort controls (reasoning_effort, output_config.effort) are accepted without any
+# observable change in reasoning depth. No client control is therefore advertised.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
 base_model = "moonshotai/kimi-k3"
-reasoning_options = [
-  { type = "toggle" },
-  { type = "effort", values = ["low", "high", "max"] },
-]
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/arka-ai/models/qwen3.8-max.toml
+++ b/providers/arka-ai/models/qwen3.8-max.toml
@@ -1,0 +1,16 @@
+# Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
+# Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
+
+base_model = "alibaba/qwen3.8-max"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262144 },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.13877
+output = 6.41631

--- a/providers/arka-ai/models/qwen3.8-max.toml
+++ b/providers/arka-ai/models/qwen3.8-max.toml
@@ -1,3 +1,8 @@
+# Toggle: enable_thinking true|false (Arka also accepts thinking.type = enabled|disabled)
+# Effort: reasoning_effort = low|medium|xhigh (high and max accepted as aliases)
+# Budget: thinking_budget is accepted but not enforced (reasoning length unchanged at
+# budget=64 vs budget=16384), so no budget_tokens control is advertised.
+# Verified live on https://api.arka-ai.ru/v1/chat/completions (accessed 2026-08-18).
 # Cost: converted from Arka AI's RUB list price at 82.9977 RUB/USD (CBR rate captured 2026-08-13).
 # Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.
 
@@ -5,7 +10,6 @@ base_model = "alibaba/qwen3.8-max"
 reasoning_options = [
   { type = "toggle" },
   { type = "effort", values = ["low", "medium", "xhigh"] },
-  { type = "budget_tokens", min = 0, max = 262144 },
 ]
 
 [interleaved]

--- a/providers/arka-ai/provider.toml
+++ b/providers/arka-ai/provider.toml
@@ -1,0 +1,5 @@
+name = "Arka-AI"
+npm = "@ai-sdk/openai-compatible"
+env = ["ARKA_API_KEY"]
+api = "https://api.arka-ai.ru/v1"
+doc = "https://arka-ai.ru"


### PR DESCRIPTION
## Summary

Adds **Arka-AI** (https://arka-ai.ru) — an OpenAI-compatible model hub serving `https://api.arka-ai.ru/v1` — with 23 chat/reasoning models from DeepSeek, Qwen (Alibaba), Kimi (Moonshot), MiniMax, GLM (Zhipu), and Step.

- Provider: `name = "Arka-AI"`, `npm = "@ai-sdk/openai-compatible"`, `env = ["ARKA_API_KEY"]`, `api = "https://api.arka-ai.ru/v1"`.
- `logo.svg` is the official Arka AI mark (single `currentColor`, no fixed size).

## Models (23)

All provider files are override-only and `base_model` existing lab entries:

| Arka model id | base_model |
| --- | --- |
| `DeepSeek-V4-Pro` | `deepseek/deepseek-v4-pro` |
| `deepseek-v4-flash-0731` | `deepseek/deepseek-v4-flash-0731` |
| `DeepSeek-V3` | `deepseek/deepseek-v3` |
| `DeepSeek-R1` | `deepseek/deepseek-r1` |
| `GLM-5.2` / `GLM-5.1` / `GLM-5` / `GLM-4.7-Flash` | `zhipuai/*` |
| `Qwen3.5-27B` / `-Plus` / `-Flash`, `Qwen3.6-Plus` / `-Max`, `Qwen3.7-Max` / `-Plus`, `qwen3.8-max`, `Qwen3-Coder-Next` / `-Flash` | `alibaba/*` |
| `MiniMax-M2.5` / `MiniMax-M3` | `minimax/*` |
| `Kimi-K2.7-Code` / `kimi-k3` | `moonshotai/*` |
| `Step-3.7-Flash` | `stepfun/*` |

## Notes

- `reasoning_options` are copied from each underlying lab's first-party provider entry (e.g. DeepSeek V4 = `toggle` + `effort[high,max]`, Qwen = `toggle` + `budget_tokens`, Kimi K3 = `toggle` + `effort[low,high,max]`).
- `interleaved = { field = "reasoning_content" }` where the underlying host exposes it.
- **Cost** is converted from Arka AI's RUB list price at **82.9977 RUB/USD** (CBR rate captured 2026-08-13). Sources: https://arka-ai.ru (pricing) and https://api.arka-ai.ru/v1/models.

`bun validate` passes.