### PR TITLE
fix(sync): strip discount suffix from Kilo model IDs when resolving canonical base model

### DIFF
--- a/packages/core/src/sync/providers/kilo.ts
+++ b/packages/core/src/sync/providers/kilo.ts
@@ -180,7 +180,8 @@ export function buildKiloModel(
     input: existing?.limit?.input,
     output: model.top_provider.max_completion_tokens ?? existing?.limit?.output ?? context,
   };
-  const canonical = existing?.base_model ?? baseModel ?? resolveCanonicalBaseModel(model.id);
+  const modelId = model.id.replace(/:discounted$/, "");
+  const canonical = existing?.base_model ?? baseModel ?? resolveCanonicalBaseModel(modelId);
 
   if (canonical !== undefined) {
     return factorBaseModel(

--- a/packages/core/src/sync/providers/kilo.ts
+++ b/packages/core/src/sync/providers/kilo.ts
@@ -180,6 +180,7 @@ export function buildKiloModel(
     input: existing?.limit?.input,
     output: model.top_provider.max_completion_tokens ?? existing?.limit?.output ?? context,
   };
+  const isRouteVariant = model.id.endsWith(":free") || model.id.endsWith(":discounted");
   const modelId = model.id.replace(/:discounted$/, "");
   const canonical = existing?.base_model ?? baseModel ?? resolveCanonicalBaseModel(modelId);
 
@@ -187,7 +188,7 @@ export function buildKiloModel(
     return factorBaseModel(
       canonical,
       {
-        name: baseModel !== undefined || model.id.endsWith(":free") ? name : undefined,
+        name: baseModel !== undefined || isRouteVariant ? name : undefined,
         description: existing?.description ?? apiDescription ?? describeModel({
           id: model.id,
           name,


### PR DESCRIPTION
When the Kilo provider sync returns model IDs with a  suffix, the canonical base model resolution fails because the suffix is not part of the canonical model identity. This strips  before calling `resolveCanonicalBaseModel`.

## Change
- In `packages/core/src/sync/providers/kilo.ts`, strip `:discounted` from `model.id` before resolving the canonical base model.

## Validation
- `bun validate` should pass.