### PR TITLE
feat(runinfra): add DeepSeek V4 Pro

### DIFF
--- a/providers/runinfra/models/deepseek-ai/DeepSeek-V4-Pro-0813.toml
+++ b/providers/runinfra/models/deepseek-ai/DeepSeek-V4-Pro-0813.toml
@@ -1,0 +1,24 @@
+# Source: https://runinfra.ai/inference-api/deepseek-v4-pro
+# Reasoning control, verified live 2026-08-18 on the public path (temperature 0,
+# fixed prompt, three runs per level): reasoning is OFF by default on this host,
+# the omitted field behaves exactly like reasoning_effort = "none" (completion
+# triples 2/2/2), and any other accepted level switches reasoning on with
+# reasoning_content arriving on the message (low/medium/xhigh triples 22/22/22,
+# identical medians, so the control is a toggle, not an effort ladder).
+# json_object and strict json_schema each validated 3 of 3; one tool call
+# round-tripped; the prefix cache hit on an identical repeated prompt; the
+# 32,768 output cap refuses an over-cap request with 400.
+# cache_read is the cached input price (standing rate; no promotional window).
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.60
+output = 1.90
+cache_read = 0.03
+
+[limit]
+context = 1_048_576
+output = 32_768


### PR DESCRIPTION
Adds `deepseek-ai/DeepSeek-V4-Pro-0813` to the runinfra provider, override-only against the existing `deepseek/deepseek-v4-pro-0813` lab entry (no lab files touched).

| | |
|---|---|
| Cost | $0.60 input / $1.90 output / $0.03 cached input read, USD per 1M |
| Context | 1,048,576 (host-served), output capped at 32,768 |
| Reasoning | `toggle`: reasoning is OFF by default on this host (an omitted `reasoning_effort` behaves exactly like `none`, completion triples 2/2/2 at temperature 0), and any other accepted level switches it on with `reasoning_content` on the message; among on-levels the medians are identical (22/22/22), so a toggle rather than an effort ladder |

Everything verified live on the public endpoint on 2026-08-18 before this PR: three runs per reasoning level at temperature 0, `json_object` and strict `json_schema` each 3 of 3, one tool call round-tripped, a prefix-cache hit on a repeated identical prompt (matching the $0.03 cached rate), and the output cap refusing an over-cap request with 400. The file's leading comment carries the evidence summary. `bun validate` passes on the branch.

Disclosure: I work on RunInfra.