### PR TITLE
fix(opencode-go): add 1M context limit to deepseek-v4-flash

### DIFF
--- a/providers/opencode-go/models/deepseek-v4-flash.toml
+++ b/providers/opencode-go/models/deepseek-v4-flash.toml
@@ -14,3 +14,7 @@ field = "reasoning_content"
 input = 0.22
 output = 0.66
 cache_read = 0.007
+
+[limit]
+context = 1_000_000
+output = 384_000


### PR DESCRIPTION
## Summary

`deepseek-v4-flash` natively supports a **1M context window** (see `models/deepseek/deepseek-v4-flash-0731.toml`, which registers `[limit] context = 1_000_000`). However, the **opencode-go** provider entry for `deepseek-v4-flash` has no `[limit]` section, so clients that read models.dev metadata (e.g. Claude Code) fall back to a **200K default** and start compacting at ~100K.

`deepseek-v4-pro` on the same provider already carries an explicit `[limit]` block and correctly surfaces 1M. This change mirrors that block for flash.

## Change

`providers/opencode-go/models/deepseek-v4-flash.toml`:

```toml
[limit]
context = 1_000_000
output = 384_000
```

Values match the canonical model file `models/deepseek/deepseek-v4-flash-0731.toml`.

## Evidence the gateway supports it

The OpenCode Go gateway itself is not the limiter — a request of ~214K tokens to `deepseek-v4-flash` via `/zen/go/v1/messages` returned 200 OK.

## Related

- opencode issue: https://github.com/anomalyco/opencode/issues/43272
- #40958 (free-tier flash capped at 200K is intentional for cost control; this is the **paid** Go plan)