### PR TITLE
feat(providers/azure): add Claude Opus 4.7

### DIFF
--- a/providers/azure/models/claude-opus-4-7.toml
+++ b/providers/azure/models/claude-opus-4-7.toml
@@ -1,0 +1,23 @@
+# Azure AI Foundry serves Claude Opus 4.7 at Anthropic list pricing:
+# https://platform.claude.com/docs/en/about-claude/pricing
+# Claude 4.6+ bills the full 1M context window at standard rates (no long-context
+# premium), so no [[cost.tiers]] here — the tiers on azure's claude-opus-4-6/4-8
+# entries predate that policy. Model availability:
+# https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/claude-models?tabs=pay-go#available-claude-models
+base_model = "anthropic/claude-opus-4-7"
+# Possible values described at https://platform.claude.com/docs/en/build-with-claude/effort#effort-levels
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5.00
+output = 25.00
+cache_read = 0.50
+cache_write = 6.25
+
+[limit]
+# Model info described at https://platform.claude.com/docs/en/about-claude/models/overview#latest-models-comparison
+context = 1_000_000
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/anthropic/v1"


### PR DESCRIPTION
## Summary

Adds the missing `claude-opus-4-7` entry to the Azure provider catalog. Claude Opus 4.7 is GA in Microsoft Foundry and already present in most other provider subtrees (anthropic, amazon-bedrock, google-vertex, …); the azure catalog has claude-opus-4-1/4-5/4-6/4-8 but not 4-7.

## Details

- `base_model = "anthropic/claude-opus-4-7"` — inherits name/description/capabilities/modalities/limits from the lab entry; provider file is override-only.
- **Pricing** (verified against https://platform.claude.com/docs/en/about-claude/pricing): input $5.00, output $25.00, cache_read $0.50, cache_write $6.25 per MTok — Anthropic list pricing, which Microsoft Foundry bills at (CCU conversion at standard Claude API rates).
- **No `[[cost.tiers]]`**: Claude 4.6+ bills the full 1M context window at standard rates ("a 900k-token request is billed at the same per-token rate as a 9k-token request"), so there is no long-context premium for this model. The 200k tiers on azure's existing `claude-opus-4-6`/`claude-opus-4-8` entries appear to predate that policy — happy to send a follow-up PR correcting those.
- `reasoning_options`: effort `low`/`medium`/`high`/`xhigh`/`max` — matches Anthropic's first-party 4-7 entry and Microsoft Foundry's documented effort levels for claude-opus-4-7 (https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/claude-models?tabs=pay-go#available-claude-models).
- `[limit] context = 1_000_000` and `[provider]` npm/api mirror the azure `claude-opus-4-8` entry.

## Validation

Merge of `base_model` + provider overrides verified locally (all required post-merge fields present, TOML parses). `bun validate` not run locally (no bun toolchain); relying on CI.