### PR TITLE
Add CoderPlan provider

### DIFF
--- a/providers/coderplan/logo.svg
+++ b/providers/coderplan/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect x="16" y="18" width="88" height="10" rx="5" fill="currentColor"/>
+  <circle cx="26" cy="23" r="3" fill="currentColor"/>
+  <circle cx="36" cy="23" r="3" fill="currentColor"/>
+  <circle cx="46" cy="23" r="3" fill="currentColor"/>
+  <text x="30" y="76" font-family="'SF Mono','Fira Code','Cascadia Code',monospace" font-size="42" font-weight="700" fill="currentColor">$</text>
+  <rect x="68" y="64" width="20" height="5" rx="2.5" fill="currentColor"/>
+</svg>

--- a/providers/coderplan/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/coderplan/models/anthropic/claude-haiku-4-5.toml
@@ -7,5 +7,5 @@ min = 1_024
 
 [cost]
 input = 0.07
-cache_input = 0.007
+cache_read = 0.007
 output = 0.35

--- a/providers/coderplan/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/coderplan/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,10 @@
+# Pricing: converted from CNY catalog (https://coderplan.ai/pricing, 2026-08-18) at 1 USD = 7.15 CNY
+base_model = "anthropic/claude-haiku-4-5"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 0.07
+output = 0.35

--- a/providers/coderplan/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/coderplan/models/anthropic/claude-haiku-4-5.toml
@@ -7,4 +7,5 @@ min = 1_024
 
 [cost]
 input = 0.07
+cache_input = 0.007
 output = 0.35

--- a/providers/coderplan/models/anthropic/claude-opus-4-7.toml
+++ b/providers/coderplan/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,10 @@
+# Pricing: converted from CNY catalog (https://coderplan.ai/pricing, 2026-08-18) at 1 USD = 7.15 CNY
+base_model = "anthropic/claude-opus-4-7"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.35
+output = 1.75

--- a/providers/coderplan/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/coderplan/models/anthropic/claude-sonnet-4-6.toml
@@ -11,5 +11,5 @@ min = 1_024
 
 [cost]
 input = 0.21
-cache_input = 0.014
+cache_read = 0.014
 output = 1.05

--- a/providers/coderplan/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/coderplan/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,14 @@
+# Pricing: converted from CNY catalog (https://coderplan.ai/pricing, 2026-08-18) at 1 USD = 7.15 CNY
+base_model = "anthropic/claude-sonnet-4-6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 0.21
+output = 1.05

--- a/providers/coderplan/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/coderplan/models/anthropic/claude-sonnet-4-6.toml
@@ -11,4 +11,5 @@ min = 1_024
 
 [cost]
 input = 0.21
+cache_input = 0.014
 output = 1.05

--- a/providers/coderplan/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/coderplan/models/deepseek/deepseek-v4-flash.toml
@@ -14,5 +14,5 @@ field = "reasoning_content"
 
 [cost]
 input = 0.34
-cache_input = 0.0112
+cache_read = 0.0112
 output = 1.01

--- a/providers/coderplan/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/coderplan/models/deepseek/deepseek-v4-flash.toml
@@ -14,4 +14,5 @@ field = "reasoning_content"
 
 [cost]
 input = 0.34
+cache_input = 0.0112
 output = 1.01

--- a/providers/coderplan/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/coderplan/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,17 @@
+# Pricing: converted from CNY catalog (https://coderplan.ai/pricing, 2026-08-18) at 1 USD = 7.15 CNY
+# Reasoning toggle wire path: OpenAI-compatible `chat.completions` → `thinking.type = enabled|disabled` (DeepSeek-style passthrough)
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.34
+output = 1.01

--- a/providers/coderplan/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/coderplan/models/deepseek/deepseek-v4-pro.toml
@@ -14,4 +14,5 @@ field = "reasoning_content"
 
 [cost]
 input = 1.01
+cache_input = 0.0336
 output = 3.02

--- a/providers/coderplan/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/coderplan/models/deepseek/deepseek-v4-pro.toml
@@ -14,5 +14,5 @@ field = "reasoning_content"
 
 [cost]
 input = 1.01
-cache_input = 0.0336
+cache_read = 0.0336
 output = 3.02

--- a/providers/coderplan/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/coderplan/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,17 @@
+# Pricing: converted from CNY catalog (https://coderplan.ai/pricing, 2026-08-18) at 1 USD = 7.15 CNY
+# Reasoning toggle wire path: OpenAI-compatible `chat.completions` → `thinking.type = enabled|disabled` (DeepSeek-style passthrough)
+base_model = "deepseek/deepseek-v4-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.01
+output = 3.02

--- a/providers/coderplan/models/openai/gpt-5.4.toml
+++ b/providers/coderplan/models/openai/gpt-5.4.toml
@@ -5,5 +5,5 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 
 [cost]
 input = 0.12
-cache_input = 0.0126
+cache_read = 0.0126
 output = 0.73

--- a/providers/coderplan/models/openai/gpt-5.4.toml
+++ b/providers/coderplan/models/openai/gpt-5.4.toml
@@ -1,0 +1,8 @@
+# Pricing: converted from CNY catalog (https://coderplan.ai/pricing, 2026-08-18) at 1 USD = 7.15 CNY
+base_model = "openai/gpt-5.4"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 0.12
+output = 0.73

--- a/providers/coderplan/models/openai/gpt-5.4.toml
+++ b/providers/coderplan/models/openai/gpt-5.4.toml
@@ -5,4 +5,5 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 
 [cost]
 input = 0.12
+cache_input = 0.0126
 output = 0.73

--- a/providers/coderplan/models/openai/gpt-5.5.toml
+++ b/providers/coderplan/models/openai/gpt-5.5.toml
@@ -1,0 +1,8 @@
+# Pricing: converted from CNY catalog (https://coderplan.ai/pricing, 2026-08-18) at 1 USD = 7.15 CNY
+base_model = "openai/gpt-5.5"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 0.25
+output = 1.47

--- a/providers/coderplan/models/openai/gpt-5.5.toml
+++ b/providers/coderplan/models/openai/gpt-5.5.toml
@@ -5,5 +5,5 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 
 [cost]
 input = 0.25
-cache_input = 0.025
+cache_read = 0.025
 output = 1.47

--- a/providers/coderplan/models/openai/gpt-5.5.toml
+++ b/providers/coderplan/models/openai/gpt-5.5.toml
@@ -5,4 +5,5 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 
 [cost]
 input = 0.25
+cache_input = 0.025
 output = 1.47

--- a/providers/coderplan/provider.toml
+++ b/providers/coderplan/provider.toml
@@ -1,0 +1,5 @@
+name = "CoderPlan"
+env = ["CODERPLAN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.coderplan.ai/v1"
+doc = "https://coderplan.ai/docs/setup"


### PR DESCRIPTION
## Summary

Adds [CoderPlan](https://coderplan.ai) — a pay-as-you-go LLM API relay for coding CLIs (Claude Code / Codex CLI / Gemini CLI) with an OpenAI-compatible endpoint at `https://api.coderplan.ai/v1`.

**Supersedes #2995** — the original author's fork account is no longer available to push fixes, so this PR resubmits with the automated review's feedback fully addressed:

- **reasoning_options** now mirror each `base_model`'s native shape in this repo (e.g. `claude-opus-4-7` → `effort: low/medium/high/xhigh/max` without `budget_tokens`; DeepSeek V4 → `toggle` + `high/max` with `interleaved.reasoning_content`; GPT-5.x → `none/low/medium/high/xhigh`). *Caveat: options mirror the native control surface because CoderPlan proxies the native API; per-level passthrough testing on CoderPlan's endpoint is pending — happy to trim to a provider-proven set if maintainers prefer.*
- **Pricing** re-sourced from the live CNY catalog at https://coderplan.ai/pricing (2026-08-18), converted at 1 USD = 7.15 CNY. All 7 model IDs confirmed live today.
- **Logo**: monochrome `currentColor` (matching the earlier review note on #2995).

## Validation

- [x] `bun run validate` passes locally (repo clone + these files)
- [x] All model IDs match the live pricing catalog (2026-08-18)

## Models included (subset; more can follow)

Claude (Opus 4.7 / Sonnet 4.6 / Haiku 4.5), GPT (5.4 / 5.5), DeepSeek (V4 Pro / Flash)
