### PR TITLE
fix(opencode): include encrypted Muse reasoning

### DIFF
--- a/providers/opencode/models/muse-spark-1.2.toml
+++ b/providers/opencode/models/muse-spark-1.2.toml
@@ -9,3 +9,4 @@ cache_read = 0.15
 
 [provider]
 npm = "@ai-sdk/openai"
+body = { store = false, include = ["reasoning.encrypted_content"] }


### PR DESCRIPTION
## Summary

- request encrypted Muse Spark reasoning content on the OpenCode Zen Responses route
- set `store = false` so stateless clients can replay the opaque reasoning item across turns

## Reasoning audit

- Host: OpenCode Zen, a multi-model relay
- Model: `muse-spark-1.2`
- Existing effort controls remain unchanged: `minimal`, `low`, `medium`, `high`, `xhigh`
- Request fields: `store = false` and `include = ["reasoning.encrypted_content"]`
- Muse readable summaries remain empty by provider design; the encrypted item is replay-only

Meta source: https://github.com/meta-models/meta-model-cookbook/blob/main/01_api_fundamentals/06_reasoning_tokens.ipynb

## Validation

- `bun validate`
- verified generated `provider.body` contains `store: false` and `reasoning.encrypted_content`