### PR TITLE
Add Telnyx as inference provider

### DIFF
--- a/providers/edenai/models/flexai/deepseek-v4-flash-0731.toml
+++ b/providers/edenai/models/flexai/deepseek-v4-flash-0731.toml
@@ -9,3 +9,6 @@ values = ["none", "low", "high", "max"]
 [cost]
 input = 0.08
 output = 0.18
+
+[limit]
+context = 786_432

--- a/providers/telnyx/logo.svg
+++ b/providers/telnyx/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 2L2 7v10l10 5 10-5V7L12 2zm0 2.3L19.5 8 12 11.7 4.5 8 12 4.3zM4 9.5l7 3.5v7.2l-7-3.5V9.5zm9 10.7v-7.2l7-3.5v7.2l-7 3.5z"/>
+</svg>

--- a/providers/telnyx/models/minimax/MiniMax-M3-MXFP8.toml
+++ b/providers/telnyx/models/minimax/MiniMax-M3-MXFP8.toml
@@ -1,5 +1,8 @@
 base_model = "minimax/MiniMax-M3"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.270
 output = 1.100

--- a/providers/telnyx/models/minimax/MiniMax-M3-MXFP8.toml
+++ b/providers/telnyx/models/minimax/MiniMax-M3-MXFP8.toml
@@ -1,0 +1,6 @@
+base_model = "minimax/MiniMax-M3"
+
+[cost]
+input = 0.270
+output = 1.100
+cache_read = 0.080

--- a/providers/telnyx/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/telnyx/models/moonshotai/Kimi-K2.6.toml
@@ -1,5 +1,11 @@
 base_model = "moonshotai/kimi-k2.6"
 
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
 [cost]
 input = 0.665
 output = 4.000

--- a/providers/telnyx/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/telnyx/models/moonshotai/Kimi-K2.6.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k2.6"
+
+[cost]
+input = 0.665
+output = 4.000
+cache_read = 0.080

--- a/providers/telnyx/models/moonshotai/Kimi-K3.toml
+++ b/providers/telnyx/models/moonshotai/Kimi-K3.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k3"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.700
+output = 13.500
+cache_read = 0.270

--- a/providers/telnyx/models/moonshotai/Kimi-K3.toml
+++ b/providers/telnyx/models/moonshotai/Kimi-K3.toml
@@ -1,5 +1,12 @@
 base_model = "moonshotai/kimi-k3"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/telnyx/models/zai-org/GLM-5.2.toml
+++ b/providers/telnyx/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.000
+output = 4.000
+cache_read = 0.200
+
+[limit]
+context = 1_048_576
+output = 131_072

--- a/providers/telnyx/models/zai-org/GLM-5.2.toml
+++ b/providers/telnyx/models/zai-org/GLM-5.2.toml
@@ -1,5 +1,9 @@
 base_model = "zhipuai/glm-5.2"
 
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
 [interleaved]
 field = "reasoning_content"
 

--- a/providers/telnyx/provider.toml
+++ b/providers/telnyx/provider.toml
@@ -1,0 +1,5 @@
+name = "Telnyx"
+env = ["TELNYX_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.telnyx.com/v2/ai/openai"
+doc = "https://developers.telnyx.com/docs/inference/getting-started"


### PR DESCRIPTION
## Add Telnyx as inference provider

Telnyx hosts open-weight LLMs on owned GPU infrastructure with an OpenAI-compatible API. This PR adds Telnyx as a provider with 4 models:

| Model | Input/1M | Output/1M | Cached/1M |
|-------|----------|-----------|-----------|
| Kimi K3 | $2.700 | $13.500 | $0.270 |
| Kimi K2.6 | $0.665 | $4.000 | $0.080 |
| GLM-5.2 | $1.000 | $4.000 | $0.200 |
| MiniMax-M3 | $0.270 | $1.100 | $0.080 |

API endpoint: `https://api.telnyx.com/v2/ai/openai`
Docs: https://developers.telnyx.com/docs/inference/getting-started