### PR TITLE
feat(layerx1): add LayerX1 provider with 32 models

### DIFF
--- a/providers/layerx1/logo.svg
+++ b/providers/layerx1/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor">
+  <title>LayerX1</title>
+  <path d="M32 5V59" fill="none" stroke="currentColor" stroke-width="3"/>
+  <path d="M11 21L32 13L53 21L32 29L11 21Z" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <path d="M11 32L32 24L53 32L32 40L11 32Z"/>
+  <path d="M11 43L32 35L53 43L32 51L11 43Z" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <path d="M32 5L36 9L32 13L28 9L32 5Z"/>
+  <path d="M32 51L36 55L32 59L28 55L32 51Z"/>
+</svg>

--- a/providers/layerx1/models/lx1-deepseek-v3.2.toml
+++ b/providers/layerx1/models/lx1-deepseek-v3.2.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v3.2"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.57
+output = 1.71
+cache_read = 0.114
+
+[limit]
+context = 131_072

--- a/providers/layerx1/models/lx1-deepseek-v3.2.toml
+++ b/providers/layerx1/models/lx1-deepseek-v3.2.toml
@@ -1,9 +1,8 @@
 base_model = "deepseek/deepseek-v3.2"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-deepseek-v4-flash.toml
+++ b/providers/layerx1/models/lx1-deepseek-v4-flash.toml
@@ -1,9 +1,8 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-deepseek-v4-flash.toml
+++ b/providers/layerx1/models/lx1-deepseek-v4-flash.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.44
+output = 1.32
+cache_read = 0.014

--- a/providers/layerx1/models/lx1-deepseek-v4-pro.toml
+++ b/providers/layerx1/models/lx1-deepseek-v4-pro.toml
@@ -1,9 +1,8 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-deepseek-v4-pro.toml
+++ b/providers/layerx1/models/lx1-deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 1.32
+output = 3.96
+cache_read = 0.044

--- a/providers/layerx1/models/lx1-devstral-2-123b.toml
+++ b/providers/layerx1/models/lx1-devstral-2-123b.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/devstral-2512"
+
+[cost]
+input = 0.4
+output = 2

--- a/providers/layerx1/models/lx1-gemma-4-26b.toml
+++ b/providers/layerx1/models/lx1-gemma-4-26b.toml
@@ -2,10 +2,9 @@ base_model = "google/gemma-4-26b-a4b-it"
 
 attachment = false
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [modalities]

--- a/providers/layerx1/models/lx1-gemma-4-26b.toml
+++ b/providers/layerx1/models/lx1-gemma-4-26b.toml
@@ -1,0 +1,19 @@
+base_model = "google/gemma-4-26b-a4b-it"
+
+attachment = false
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[modalities]
+input = ["text"]
+
+[cost]
+input = 0.1
+output = 0.3
+
+[limit]
+context = 256_000

--- a/providers/layerx1/models/lx1-gemma-4-31b.toml
+++ b/providers/layerx1/models/lx1-gemma-4-31b.toml
@@ -2,10 +2,9 @@ base_model = "google/gemma-4-31b-it"
 
 attachment = false
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [modalities]

--- a/providers/layerx1/models/lx1-gemma-4-31b.toml
+++ b/providers/layerx1/models/lx1-gemma-4-31b.toml
@@ -1,0 +1,19 @@
+base_model = "google/gemma-4-31b-it"
+
+attachment = false
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[modalities]
+input = ["text"]
+
+[cost]
+input = 0.14
+output = 0.4
+
+[limit]
+context = 256_000

--- a/providers/layerx1/models/lx1-glm-4.7-flash.toml
+++ b/providers/layerx1/models/lx1-glm-4.7-flash.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-4.7-flash"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.0605
+output = 0.4
+
+[limit]
+context = 131_072

--- a/providers/layerx1/models/lx1-glm-4.7-flash.toml
+++ b/providers/layerx1/models/lx1-glm-4.7-flash.toml
@@ -1,9 +1,8 @@
 base_model = "zhipuai/glm-4.7-flash"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-glm-5.2.toml
+++ b/providers/layerx1/models/lx1-glm-5.2.toml
@@ -1,9 +1,8 @@
 base_model = "zhipuai/glm-5.2"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-glm-5.2.toml
+++ b/providers/layerx1/models/lx1-glm-5.2.toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5.2"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 131_072

--- a/providers/layerx1/models/lx1-glm-5.toml
+++ b/providers/layerx1/models/lx1-glm-5.toml
@@ -1,9 +1,8 @@
 base_model = "zhipuai/glm-5"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-glm-5.toml
+++ b/providers/layerx1/models/lx1-glm-5.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 1
+output = 3.2
+
+[limit]
+context = 200_000

--- a/providers/layerx1/models/lx1-gpt-oss-120b.toml
+++ b/providers/layerx1/models/lx1-gpt-oss-120b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-120b"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.35
+output = 0.75
+
+[limit]
+context = 128_000

--- a/providers/layerx1/models/lx1-gpt-oss-120b.toml
+++ b/providers/layerx1/models/lx1-gpt-oss-120b.toml
@@ -1,9 +1,8 @@
 base_model = "openai/gpt-oss-120b"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-gpt-oss-20b.toml
+++ b/providers/layerx1/models/lx1-gpt-oss-20b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-20b"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.2
+output = 0.3
+
+[limit]
+context = 128_000

--- a/providers/layerx1/models/lx1-gpt-oss-20b.toml
+++ b/providers/layerx1/models/lx1-gpt-oss-20b.toml
@@ -1,9 +1,8 @@
 base_model = "openai/gpt-oss-20b"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-grok-4.3.toml
+++ b/providers/layerx1/models/lx1-grok-4.3.toml
@@ -1,0 +1,20 @@
+base_model = "xai/grok-4.3"
+
+attachment = false
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[modalities]
+input = ["text"]
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[limit]
+output = 32_000

--- a/providers/layerx1/models/lx1-grok-4.3.toml
+++ b/providers/layerx1/models/lx1-grok-4.3.toml
@@ -2,10 +2,9 @@ base_model = "xai/grok-4.3"
 
 attachment = false
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [modalities]

--- a/providers/layerx1/models/lx1-kimi-k2-thinking.toml
+++ b/providers/layerx1/models/lx1-kimi-k2-thinking.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2-thinking"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.6
+output = 2.5

--- a/providers/layerx1/models/lx1-kimi-k2-thinking.toml
+++ b/providers/layerx1/models/lx1-kimi-k2-thinking.toml
@@ -1,9 +1,8 @@
 base_model = "moonshotai/kimi-k2-thinking"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-kimi-k2.5.toml
+++ b/providers/layerx1/models/lx1-kimi-k2.5.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.5"
+
+reasoning = false
+attachment = false
+
+[modalities]
+input = ["text"]
+
+[cost]
+input = 0.6
+output = 3

--- a/providers/layerx1/models/lx1-kimi-k2.5.toml
+++ b/providers/layerx1/models/lx1-kimi-k2.5.toml
@@ -1,5 +1,7 @@
 base_model = "moonshotai/kimi-k2.5"
 
+# /v1/models reports no reasoning support for this id: it is absent
+# from both `capabilities.reasoning` and `supported_parameters`.
 reasoning = false
 attachment = false
 

--- a/providers/layerx1/models/lx1-kimi-k2.7-code.toml
+++ b/providers/layerx1/models/lx1-kimi-k2.7-code.toml
@@ -1,0 +1,20 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+attachment = false
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[modalities]
+input = ["text"]
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19
+
+[limit]
+context = 131_072

--- a/providers/layerx1/models/lx1-kimi-k2.7-code.toml
+++ b/providers/layerx1/models/lx1-kimi-k2.7-code.toml
@@ -2,10 +2,9 @@ base_model = "moonshotai/kimi-k2.7-code"
 
 attachment = false
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [modalities]

--- a/providers/layerx1/models/lx1-longcat-2.toml
+++ b/providers/layerx1/models/lx1-longcat-2.toml
@@ -1,0 +1,12 @@
+base_model = "meituan/longcat-2.0"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.75
+output = 2.95
+cache_read = 0.015

--- a/providers/layerx1/models/lx1-longcat-2.toml
+++ b/providers/layerx1/models/lx1-longcat-2.toml
@@ -1,9 +1,8 @@
 base_model = "meituan/longcat-2.0"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-minimax-m2.5.toml
+++ b/providers/layerx1/models/lx1-minimax-m2.5.toml
@@ -1,0 +1,15 @@
+base_model = "minimax/MiniMax-M2.5"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 196_608
+output = 8_192

--- a/providers/layerx1/models/lx1-minimax-m2.5.toml
+++ b/providers/layerx1/models/lx1-minimax-m2.5.toml
@@ -1,9 +1,8 @@
 base_model = "minimax/MiniMax-M2.5"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-mistral-large-3-675b.toml
+++ b/providers/layerx1/models/lx1-mistral-large-3-675b.toml
@@ -1,0 +1,10 @@
+base_model = "mistral/mistral-large-2512"
+
+attachment = false
+
+[modalities]
+input = ["text"]
+
+[cost]
+input = 0.5
+output = 1.5

--- a/providers/layerx1/models/lx1-nemotron-nano-3-30b.toml
+++ b/providers/layerx1/models/lx1-nemotron-nano-3-30b.toml
@@ -1,9 +1,8 @@
 base_model = "nvidia/nemotron-3-nano-30b-a3b"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-nemotron-nano-3-30b.toml
+++ b/providers/layerx1/models/lx1-nemotron-nano-3-30b.toml
@@ -1,0 +1,11 @@
+base_model = "nvidia/nemotron-3-nano-30b-a3b"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.06
+output = 0.24

--- a/providers/layerx1/models/lx1-nemotron-super-3-120b.toml
+++ b/providers/layerx1/models/lx1-nemotron-super-3-120b.toml
@@ -1,9 +1,8 @@
 base_model = "nvidia/nemotron-3-super-120b-a12b"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-nemotron-super-3-120b.toml
+++ b/providers/layerx1/models/lx1-nemotron-super-3-120b.toml
@@ -1,0 +1,11 @@
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.15
+output = 0.65

--- a/providers/layerx1/models/lx1-opus-4.8.toml
+++ b/providers/layerx1/models/lx1-opus-4.8.toml
@@ -1,0 +1,20 @@
+base_model = "anthropic/claude-opus-4-8"
+
+attachment = false
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[modalities]
+input = ["text"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+
+[limit]
+output = 32_000

--- a/providers/layerx1/models/lx1-opus-4.8.toml
+++ b/providers/layerx1/models/lx1-opus-4.8.toml
@@ -2,10 +2,9 @@ base_model = "anthropic/claude-opus-4-8"
 
 attachment = false
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [modalities]

--- a/providers/layerx1/models/lx1-opus-5.toml
+++ b/providers/layerx1/models/lx1-opus-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-5"
+
+attachment = false
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5

--- a/providers/layerx1/models/lx1-opus-5.toml
+++ b/providers/layerx1/models/lx1-opus-5.toml
@@ -1,12 +1,12 @@
 base_model = "anthropic/claude-opus-5"
 
-attachment = false
-
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
+
+[modalities]
+input = ["text", "image"]
 
 [cost]
 input = 5

--- a/providers/layerx1/models/lx1-qwen-turbo.toml
+++ b/providers/layerx1/models/lx1-qwen-turbo.toml
@@ -1,5 +1,7 @@
 base_model = "alibaba/qwen-turbo"
 
+# /v1/models reports no reasoning support for this id: it is absent
+# from both `capabilities.reasoning` and `supported_parameters`.
 reasoning = false
 
 [cost]

--- a/providers/layerx1/models/lx1-qwen-turbo.toml
+++ b/providers/layerx1/models/lx1-qwen-turbo.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen-turbo"
+
+reasoning = false
+
+[cost]
+input = 0.05
+output = 0.2
+cache_read = 0.01
+
+[limit]
+context = 98_304
+output = 8_192

--- a/providers/layerx1/models/lx1-qwen3-235b.toml
+++ b/providers/layerx1/models/lx1-qwen3-235b.toml
@@ -1,0 +1,15 @@
+base_model = "alibaba/qwen3-235b-a22b"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.22
+output = 0.88
+cache_read = 0.022
+
+[limit]
+context = 262_144

--- a/providers/layerx1/models/lx1-qwen3-235b.toml
+++ b/providers/layerx1/models/lx1-qwen3-235b.toml
@@ -1,9 +1,8 @@
 base_model = "alibaba/qwen3-235b-a22b"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-qwen3-coder-30b.toml
+++ b/providers/layerx1/models/lx1-qwen3-coder-30b.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/layerx1/models/lx1-qwen3-coder-480b.toml
+++ b/providers/layerx1/models/lx1-qwen3-coder-480b.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3-coder-480b-a35b-instruct"
+
+[cost]
+input = 0.45
+output = 1.8
+cache_read = 0.045
+
+[limit]
+context = 131_072

--- a/providers/layerx1/models/lx1-qwen3-coder-next.toml
+++ b/providers/layerx1/models/lx1-qwen3-coder-next.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-next"
+
+[cost]
+input = 0.5
+output = 1.2

--- a/providers/layerx1/models/lx1-qwen3-next-80b.toml
+++ b/providers/layerx1/models/lx1-qwen3-next-80b.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+
+[cost]
+input = 0.14
+output = 1.2
+
+[limit]
+context = 262_144

--- a/providers/layerx1/models/lx1-qwen3.8-27b.toml
+++ b/providers/layerx1/models/lx1-qwen3.8-27b.toml
@@ -1,11 +1,8 @@
 base_model = "alibaba/qwen3.8-27b"
 
-attachment = false
-
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-qwen3.8-27b.toml
+++ b/providers/layerx1/models/lx1-qwen3.8-27b.toml
@@ -1,0 +1,13 @@
+base_model = "alibaba/qwen3.8-27b"
+
+attachment = false
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 0.45
+output = 3.2

--- a/providers/layerx1/models/lx1-qwen3.8-max.toml
+++ b/providers/layerx1/models/lx1-qwen3.8-max.toml
@@ -1,0 +1,17 @@
+base_model = "alibaba/qwen3.8-max"
+
+attachment = false
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.25
+
+[limit]
+context = 991_808

--- a/providers/layerx1/models/lx1-qwen3.8-max.toml
+++ b/providers/layerx1/models/lx1-qwen3.8-max.toml
@@ -1,12 +1,12 @@
 base_model = "alibaba/qwen3.8-max"
 
-attachment = false
-
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
+
+[modalities]
+input = ["text", "image", "video"]
 
 [cost]
 input = 2

--- a/providers/layerx1/models/lx1-sonnet-4.6.toml
+++ b/providers/layerx1/models/lx1-sonnet-4.6.toml
@@ -1,9 +1,8 @@
 base_model = "anthropic/claude-sonnet-4-6"
 
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
 
 [cost]

--- a/providers/layerx1/models/lx1-sonnet-4.6.toml
+++ b/providers/layerx1/models/lx1-sonnet-4.6.toml
@@ -1,0 +1,16 @@
+base_model = "anthropic/claude-sonnet-4-6"
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/layerx1/models/lx1-sonnet-5.toml
+++ b/providers/layerx1/models/lx1-sonnet-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-sonnet-5"
+
+attachment = false
+
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
+  { type = "budget_tokens" },
+]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3

--- a/providers/layerx1/models/lx1-sonnet-5.toml
+++ b/providers/layerx1/models/lx1-sonnet-5.toml
@@ -1,12 +1,12 @@
 base_model = "anthropic/claude-sonnet-5"
 
-attachment = false
-
+# reasoning: `reasoning` request field, effort ladder; `none` disables.
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
-  { type = "budget_tokens" },
 ]
+
+[modalities]
+input = ["text", "image"]
 
 [cost]
 input = 3

--- a/providers/layerx1/provider.toml
+++ b/providers/layerx1/provider.toml
@@ -1,0 +1,11 @@
+# LayerX1 is an OpenAI-compatible multi-model gateway. It also speaks the
+# Anthropic Messages and OpenAI Responses wires on the same key.
+# Reasoning is normalized onto one neutral effort ladder across every backend
+# ("none" | "minimal" | "low" | "medium" | "high" | "max"), and `include_reasoning`
+# toggles visibility independently of effort.
+# https://docs.layerx1.com (accessed 2026-08-19)
+name = "LayerX1"
+env = ["LAYERX1_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://docs.layerx1.com"
+api = "https://api.layerx1.com/v1"

--- a/providers/layerx1/provider.toml
+++ b/providers/layerx1/provider.toml
@@ -1,8 +1,9 @@
 # LayerX1 is an OpenAI-compatible multi-model gateway. It also speaks the
 # Anthropic Messages and OpenAI Responses wires on the same key.
-# Reasoning is normalized onto one neutral effort ladder across every backend
-# ("none" | "minimal" | "low" | "medium" | "high" | "max"), and `include_reasoning`
-# toggles visibility independently of effort.
+# Reasoning is requested through a single `reasoning` effort parameter on one
+# neutral ladder ("none" | "minimal" | "low" | "medium" | "high" | "max"),
+# where "none" disables it. Per-model reasoning support is reported by
+# /v1/models in `capabilities.reasoning` and `supported_parameters`.
 # https://docs.layerx1.com (accessed 2026-08-19)
 name = "LayerX1"
 env = ["LAYERX1_API_KEY"]


### PR DESCRIPTION
Adds **LayerX1** ([layerx1.com](https://layerx1.com) · [docs](https://docs.layerx1.com)) as a provider.

LayerX1 is an OpenAI-compatible multi-model gateway. The same key also serves the
Anthropic Messages and OpenAI Responses wires, so `@ai-sdk/openai-compatible` +
`api` is the right entry.

### Contents

- `provider.toml` — `LAYERX1_API_KEY`, `api = https://api.layerx1.com/v1`
- `logo.svg` — `currentColor` only, no hardcoded colors, no fixed `width`/`height`, square `viewBox`
- 32 model TOMLs under `models/`

### How the model files were authored

LayerX1 hosts models it did not create, so **every file uses `base_model`** against
the existing lab entry and is override-only. No lab metadata (`name`,
`description`, dates, `open_weights`, matching `limit`/`modalities`) is restated.

Provider-authored fields are `cost` and `reasoning_options`. Beyond those, the only
values present are genuine deltas where LayerX1's published capability differs from
the lab entry — a smaller served context, or a text-only lane for a model that is
multimodal upstream.

Costs come from the live catalog at `https://api.layerx1.com/v1/models`
(`pricing_usd_per_mtok`), with `cached_input` mapped to `cache_read`.

### `reasoning_options`

These are uniform across the reasoning models, which is intentional rather than
copy-paste. The gateway normalizes every backend onto a single neutral effort
ladder — `none | minimal | low | medium | high | max` — and exposes reasoning
*visibility* separately through `include_reasoning`, independent of effort.
Anthropic-style token budgets are accepted and translated onto the same control.
So the surface a caller sees does not vary per backend:

```toml
reasoning_options = [
  { type = "toggle" },
  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] },
  { type = "budget_tokens" },
]
```

`xhigh` is deliberately absent — the schema permits it but LayerX1 does not
implement it, and the ladder is a documented API surface rather than an inference.

### Deliberately not included

- **7 embedding models** (BGE family, `embeddinggemma-300m`, `qwen3-embed-0.6b`,
  `plamo-embed-1b`). These need lab entries that don't exist yet — there is no
  `models/baai/` at all. Happy to open a follow-up PR authoring complete lab
  metadata for those rather than bundle it here.
- **2 models** whose upstream identity I could not establish with confidence.
  Left out rather than guessed at a `base_model`.

### Validation

`bun validate` passes, and `layerx1` resolves with all 32 models.

### Offer

LayerX1's `/v1/models` is a rich catalog endpoint — it returns pricing, context
window, capabilities, and per-model reasoning support, and it is authoritative
about removals. That fits the sync-module criteria in `sync.md`, so if you'd
prefer this entry be sync-maintained rather than hand-authored, I'm glad to add
the module in a follow-up.
