### PR TITLE
feat(amazon-bedrock): add Grok 4.6

### DIFF
--- a/providers/amazon-bedrock/models/xai.grok-4.6.toml
+++ b/providers/amazon-bedrock/models/xai.grok-4.6.toml
@@ -1,0 +1,14 @@
+# Source: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html
+base_model = "xai/grok-4.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+last_updated = "2026-08-18"
+
+[cost]
+input = 2.20
+output = 6.60
+cache_read = 0.55
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"


### PR DESCRIPTION
## Summary

- add Grok 4.6 to Amazon Bedrock through the in-region Mantle endpoint
- include documented reasoning efforts and in-region pricing
- use the Mantle Responses API path so prompt caching is supported

## Sources

- https://x.ai/news/grok-4-6-amazon-bedrock
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html

## Runtime verification

Live calls confirmed that both `us.xai.grok-4.6` and `global.xai.grok-4.6` work through native Bedrock Converse, including `reasoning.effort`. However, adding a Converse `cachePoint` through Cross-Region Inference returned AWS `403`: `You invoked an unsupported model or your request did not allow prompt caching.`

Therefore this entry uses the in-region Mantle endpoint rather than the Runtime Cross-Region Inference profiles so caching remains available.

## Validation

- `bun validate`