### PR TITLE
fix(ollama-cloud): correct 3 context_lengths, add 3 served-but-missing tags

### DIFF
--- a/providers/ollama-cloud/models/deepseek-v4-flash:preview.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-flash:preview.toml
@@ -1,0 +1,18 @@
+# Preview tag of deepseek-v4-flash, served by Ollama Cloud and listed by GET /v1/models.
+# API-verified context: https://ollama.com/api/show (deepseek4.context_length = 1048576)
+name = "deepseek-v4-flash:preview"
+description = "Preview release of the fast DeepSeek model for efficient chat, coding help, and agent loops"
+family = "deepseek-flash"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+tool_call = true
+open_weights = true
+
+[limit]
+context = 1048576
+output = 1048576
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ollama-cloud/models/deepseek-v4-pro:0813.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-pro:0813.toml
@@ -1,0 +1,18 @@
+# Dated tag of deepseek-v4-pro, served by Ollama Cloud and listed by GET /v1/models.
+# API-verified context: https://ollama.com/api/show (deepseek4.context_length = 1048576)
+name = "deepseek-v4-pro:0813"
+description = "Dated release of the flagship DeepSeek model for coding, reasoning, and agentic work"
+family = "deepseek-thinking"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+tool_call = true
+open_weights = true
+
+[limit]
+context = 1048576
+output = 1048576
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ollama-cloud/models/deepseek-v4-pro:preview.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-pro:preview.toml
@@ -1,0 +1,19 @@
+# Preview tag of deepseek-v4-pro, served by Ollama Cloud and listed by GET /v1/models.
+# NOTE: this tag has HALF the context of the stable tag.
+# API-verified context: https://ollama.com/api/show (deepseek4.context_length = 524288)
+name = "deepseek-v4-pro:preview"
+description = "Preview release of the flagship DeepSeek model for coding, reasoning, and agentic work"
+family = "deepseek-thinking"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+tool_call = true
+open_weights = true
+
+[limit]
+context = 524288
+output = 524288
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/ollama-cloud/models/glm-5.2.toml
+++ b/providers/ollama-cloud/models/glm-5.2.toml
@@ -9,4 +9,4 @@ values = ["high", "max"]
 field = "reasoning_content"
 
 [limit]
-context = 976_000
+context = 1_000_000

--- a/providers/ollama-cloud/models/minimax-m3.toml
+++ b/providers/ollama-cloud/models/minimax-m3.toml
@@ -13,7 +13,7 @@ open_weights = true
 
 
 [limit]
-context = 512_000
+context = 524_288
 output = 131_072
 
 [modalities]

--- a/providers/ollama-cloud/models/nemotron-3-nano:30b.toml
+++ b/providers/ollama-cloud/models/nemotron-3-nano:30b.toml
@@ -10,7 +10,7 @@ last_updated = "2026-01-19"
 open_weights = true
 
 [limit]
-context = 1048576
+context = 262144
 output = 131072
 
 [modalities]


### PR DESCRIPTION
All values read from the provider via `ollama.com/api/show`, the same source the existing `deepseek-v4-flash:0731` entry already cites.

## 1. Corrected `limit.context` (3 models)

| model | current | provider reports |
|---|---|---|
| `glm-5.2` | 976,000 | **1,000,000** |
| `minimax-m3` | 512,000 | **524,288** |
| `nemotron-3-nano:30b` | 1,048,576 | **262,144** |

`nemotron-3-nano:30b` is the one that bites: the recorded window is **4x** the real one, so a client sizing requests from this database overruns the model and the provider rejects the request. I hit exactly that in practice before checking against the API.

## 2. Added 3 tags that are served but not catalogued (new files)

`GET https://ollama.com/v1/models` lists these three; the database had no entry.

| model | context |
|---|---|
| `deepseek-v4-pro:0813` | 1,048,576 |
| `deepseek-v4-pro:preview` | **524,288** — half the stable tag |
| `deepseek-v4-flash:preview` | 1,048,576 |

## How to reproduce

```bash
curl -s https://ollama.com/api/show \
  -H "Authorization: Bearer $OLLAMA_API_KEY" \
  -H "Content-Type: application/json" \
  -d "{\"model\":\"nemotron-3-nano:30b\"}" \
  | jq -r ".model_info | to_entries[] | select(.key|endswith(\"context_length\"))"
```

Observed:

```
glm5.2.context_length            = 1000000
minimax-m3.context_length        =  524288
nemotron-3-nano.context_length   =  262144
deepseek4.context_length         = 1048576   # deepseek-v4-pro:0813
deepseek4.context_length         =  524288   # deepseek-v4-pro:preview
deepseek4.context_length         = 1048576   # deepseek-v4-flash:preview
```

I checked all 17 other `ollama-cloud` entries the same way; they already match and are untouched.

## Scope notes

- Only `providers/ollama-cloud/` is changed.
- `minimax-m3` is deliberately **not** aligned with the MiniMax entries. `minimax/MiniMax-M3` and `minimax-coding-plan/MiniMax-M3` are both 1,000,000, and Ollama genuinely serves a smaller window for the same model — the per-provider split here is correct, only the ollama-cloud number was off.
- `output` on the corrected models is untouched: `api/show` reports no max output, so I have no provider-sourced value. On the three new files `output` mirrors `context`, following every other deepseek entry under this provider; that field is convention, not API-verified.