### PR TITLE
Add DeepSeek-V4-Flash-0731, DeepSeek-V4-Pro, and Qwen3.8-Max to SCNet Token Plan

### DIFF
--- a/providers/scnet-token-plan/models/DeepSeek-V4-Flash-0731.toml
+++ b/providers/scnet-token-plan/models/DeepSeek-V4-Flash-0731.toml
@@ -1,0 +1,13 @@
+# Toggle: enable_thinking = true|false
+# Effort: reasoning_effort = high|max
+# https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/api/chat.html (accessed 2026-08-20)
+base_model = "deepseek/deepseek-v4-flash-0731"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/scnet-token-plan/models/DeepSeek-V4-Pro.toml
+++ b/providers/scnet-token-plan/models/DeepSeek-V4-Pro.toml
@@ -1,0 +1,13 @@
+# Toggle: enable_thinking = true|false
+# Effort: reasoning_effort = high|max
+# https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/api/chat.html (accessed 2026-08-20)
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/scnet-token-plan/models/Qwen3.8-Max.toml
+++ b/providers/scnet-token-plan/models/Qwen3.8-Max.toml
@@ -1,0 +1,13 @@
+# Toggle: enable_thinking = true|false
+# Effort: reasoning_effort only applies to DeepSeek-V4 series (high|max); not documented for Qwen3 series.
+# https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/api/chat.html (accessed 2026-08-20)
+base_model = "alibaba/qwen3.8-max"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0


### PR DESCRIPTION
The current model list for the SCNet Token Plan provider was sourced from the doc page at [https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/plans/token-plan.html#可用模型](https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/plans/token-plan.html#%E5%8F%AF%E7%94%A8%E6%A8%A1%E5%9E%8B), but that page is no longer up to date.

The models actually available on the Token Plan can be seen after subscribing at https://www.scnet.cn/ui/console/index.html#/llm/token-plan (maybe need login, screenshot below), which lists three models missing from the catalog:
- DeepSeek-V4-Flash-0731
- DeepSeek-V4-Pro
- Qwen3.8-Max

All three are confirmed working against the SCNet API (https://api.scnet.cn/api/llm/v1) and were added using base_model references to the existing lab models (deepseek/deepseek-v4-flash-0731, deepseek/deepseek-v4-pro, alibaba/qwen3.8-max), with zero-cost entries to match the provider's prepaid-Credits pricing.

<img width="1443" height="738" alt="image" src="https://github.com/user-attachments/assets/4e7ec000-a9d6-49ba-a330-6de22a54815a" />
