### PR TITLE
feat(provider): add QwenCloud International

### DIFF
--- a/providers/qwencloud/models/qwen3.6-omni-plus.toml
+++ b/providers/qwencloud/models/qwen3.6-omni-plus.toml
@@ -1,0 +1,31 @@
+name = "Qwen3.6 Omni Plus"
+description = "Qwen omni model for text, vision, audio, and video agent tasks on QwenCloud International"
+family = "qwen"
+release_date = "2026-06-15"
+last_updated = "2026-06-15"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[[reasoning_options]]
+type = "toggle"
+[[reasoning_options]]
+type = "budget_tokens"
+
+# Pricing and limits are best-effort for the QwenCloud International omni tier;
+# adjust once published international rates are confirmed.
+[cost]
+input = 0.50
+output = 1.50
+input_audio = 4.44
+output_audio = 8.89
+
+[limit]
+context = 262_144
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text", "audio"]

--- a/providers/qwencloud/models/qwen3.7-flash.toml
+++ b/providers/qwencloud/models/qwen3.7-flash.toml
@@ -1,0 +1,13 @@
+base_model = "alibaba/qwen3.7-flash"
+[[reasoning_options]]
+type = "toggle"
+[[reasoning_options]]
+type = "budget_tokens"
+
+# Pricing is approximate for the QwenCloud International flash tier; adjust once
+# published international rates are confirmed.
+[cost]
+input = 0.10
+output = 0.40
+cache_read = 0.01
+cache_write = 0.10

--- a/providers/qwencloud/models/qwen3.7-plus.toml
+++ b/providers/qwencloud/models/qwen3.7-plus.toml
@@ -1,0 +1,18 @@
+base_model = "alibaba/qwen3.7-plus"
+[[reasoning_options]]
+type = "toggle"
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.50
+output = 3.00
+cache_read = 0.05
+cache_write = 0.625
+
+[[cost.tiers]]
+tier = { size = 256_000 }
+input = 2.00
+output = 6.00
+cache_read = 0.20
+cache_write = 2.50

--- a/providers/qwencloud/models/qwen3.8-max.toml
+++ b/providers/qwencloud/models/qwen3.8-max.toml
@@ -1,0 +1,16 @@
+base_model = "alibaba/qwen3.8-max"
+structured_output = true
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262_144 },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.00
+output = 6.00
+cache_read = 0.25
+cache_write = 2.5

--- a/providers/qwencloud/provider.toml
+++ b/providers/qwencloud/provider.toml
@@ -1,0 +1,5 @@
+name = "QwenCloud"
+env = ["QWENCLOUD_API_KEY", "DASHSCOPE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+doc = "https://docs.qwencloud.com/developer-guides/getting-started/model-selection"


### PR DESCRIPTION
## Summary
Adds the **QwenCloud International** provider (anomalyco/opencode#43067).

- `provider.toml`: OpenAI-compatible provider at the DashScope International endpoint `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`, auth via `QWENCLOUD_API_KEY` (falls back to `DASHSCOPE_API_KEY`).
- Models: `qwen3.8-max`, `qwen3.7-plus`, `qwen3.7-flash` (thin wrappers reusing the existing `alibaba` base models) and `qwen3.6-omni-plus` (authored from scratch).
- `bun validate` passes; the compiled catalog resolves `qwencloud` to `@ai-sdk/openai-compatible` with the international base URL.

## Test plan
- [x] `bun install && bun validate` (exit 0)
- [ ] Reviewer: confirm the 4 models surface under QwenCloud in the opencode provider picker once this catalog is deployed.

🤖 Generated with [opencode](https://opencode.ai)