### PR TITLE
perplexity: mark sonar models as deprecated (hold until 2026-09-27 sunset)

### DIFF
--- a/providers/perplexity/models/sonar-deep-research.toml
+++ b/providers/perplexity/models/sonar-deep-research.toml
@@ -16,6 +16,7 @@ temperature = false
 tool_call = false
 knowledge = "2025-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 2.0

--- a/providers/perplexity/models/sonar-pro.toml
+++ b/providers/perplexity/models/sonar-pro.toml
@@ -9,6 +9,7 @@ temperature = true
 tool_call = false
 knowledge = "2025-09-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 3.00

--- a/providers/perplexity/models/sonar-reasoning-pro.toml
+++ b/providers/perplexity/models/sonar-reasoning-pro.toml
@@ -17,6 +17,7 @@ temperature = true
 tool_call = false
 knowledge = "2025-09-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 2.00

--- a/providers/perplexity/models/sonar.toml
+++ b/providers/perplexity/models/sonar.toml
@@ -9,6 +9,7 @@ temperature = true
 tool_call = false
 knowledge = "2025-09-01"
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 1.00


### PR DESCRIPTION
## Summary

Marks all four Perplexity Sonar model entries as deprecated:

- `sonar`
- `sonar-pro`
- `sonar-reasoning-pro`
- `sonar-deep-research`

## Background

Perplexity has announced that the `/chat/completions` Sonar endpoint (and the `sonar*` model IDs served through it) will be sunset on **2026-09-27**, after which the provider will no longer serve those models via its public API. New integrations should target the Agent API (`/v1/responses`) and the `perplexity-agent` models instead.

## Why this PR is a draft

The README defines `status = "deprecated"` as "no longer served by the provider's public API". Between now and 2026-09-27 the Sonar endpoint is still live and still serving these models, so setting `deprecated` today would be inaccurate by the field's own definition and would cause downstream catalogs (opencode, Vercel AI SDK, Mastra, and others) to steer users off a model that still works.

The PR is being opened as a draft now so the diff is visible, review can start, and the flip on the sunset date is a one-click change rather than a race. It will be marked **ready for review on 2026-09-27**, the day the deprecation definition becomes true.

## Diff

Adds one line (`status = "deprecated"`) to each of the four model TOMLs. No other fields are changed.

## Related upstream context

- Perplexity Agent API migration overview: https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar/overview
- Agent API reference: https://docs.perplexity.ai/api-reference

Filed independently from any perplexity-agent additions, which will land in a separate PR.