### PR TITLE
feat(scaleway): add DeepSeek V4 Flash 0731

### DIFF
--- a/providers/scaleway/models/deepseek-v4-flash-0731.toml
+++ b/providers/scaleway/models/deepseek-v4-flash-0731.toml
@@ -4,8 +4,7 @@ base_model = "deepseek/deepseek-v4-flash-0731"
 reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
 status = "beta"
 
-[interleaved]
-field = "reasoning"
+interleaved = true
 
 [cost]
 # Scaleway pricing: https://www.scaleway.com/en/pricing/model-as-a-service/ (accessed 2026-08-21)
@@ -15,6 +14,7 @@ field = "reasoning"
 # chain-of-thought in `reasoning` and counts it inside completion_tokens.
 input = 0.468
 output = 0.936
+reasoning = 0.936
 cache_read = 0.0936
 
 [limit]

--- a/providers/scaleway/models/deepseek-v4-flash-0731.toml
+++ b/providers/scaleway/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,22 @@
+# see: https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/#deepseek-v4-flash-0731
+# last update: 2026-08-21
+base_model = "deepseek/deepseek-v4-flash-0731"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+status = "beta"
+
+[interleaved]
+field = "reasoning"
+
+[cost]
+# Scaleway pricing: https://www.scaleway.com/en/pricing/model-as-a-service/ (accessed 2026-08-21)
+# Billed in EUR: €0.40 input / €0.08 cached input / €0.80 output per 1M tokens.
+# Converted at 1 EUR = 1.17 USD on 2026-08-21 (models.dev publishes USD).
+# Reasoning tokens bill as output: verified empirically — the API returns
+# chain-of-thought in `reasoning` and counts it inside completion_tokens.
+input = 0.468
+output = 0.936
+cache_read = 0.0936
+
+[limit]
+context = 256_000
+output = 16_384


### PR DESCRIPTION
Adds Scaleway's DeepSeek V4 Flash 0731 catalog entry.

Scaleway lists this model in its Generative APIs supported models: https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/#deepseek-v4-flash-0731