### PR TITLE
feat: add Nous Portal provider with free-tier models

### DIFF
--- a/models/inclusionai/ring-2.6-1t.toml
+++ b/models/inclusionai/ring-2.6-1t.toml
@@ -7,11 +7,11 @@ temperature = true
 tool_call = true
 release_date = "2026-05-08"
 last_updated = "2026-05-08"
-open_weights = true
+open_weights = false
 
 [limit]
 context = 262_144
-output = 66_000
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/models/inclusionai/ring-2.6-1t.toml
+++ b/models/inclusionai/ring-2.6-1t.toml
@@ -1,0 +1,18 @@
+name = "Ring-2.6-1T"
+description = "InclusionAI Ring-2.6-1T, a 1T-parameter-scale thinking model with 63B active parameters, built for coding agents and long-horizon tool-using workflows"
+family = "ring"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+release_date = "2026-05-08"
+last_updated = "2026-05-08"
+open_weights = true
+
+[limit]
+context = 262_144
+output = 66_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/nous/logo.svg
+++ b/providers/nous/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M5 19V5h2.7l8.6 10.1V5H19v14h-2.7L7.7 8.9V19H5z"/>
+</svg>

--- a/providers/nous/models/inclusionai/ring-2.6-1t:free.toml
+++ b/providers/nous/models/inclusionai/ring-2.6-1t:free.toml
@@ -1,6 +1,6 @@
 base_model = "inclusionai/ring-2.6-1t"
 name = "Ring-2.6-1T (free)"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["high", "xhigh"] }]
 
 [cost]
 input = 0

--- a/providers/nous/models/inclusionai/ring-2.6-1t:free.toml
+++ b/providers/nous/models/inclusionai/ring-2.6-1t:free.toml
@@ -1,0 +1,8 @@
+base_model = "inclusionai/ring-2.6-1t"
+name = "Ring-2.6-1T (free)"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/nous/models/meituan/longcat-2.0:free.toml
+++ b/providers/nous/models/meituan/longcat-2.0:free.toml
@@ -1,0 +1,8 @@
+base_model = "meituan/longcat-2.0"
+name = "LongCat-2.0 (free)"
+reasoning_options = [{ type = "toggle" }]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/nous/models/meituan/longcat-2.0:free.toml
+++ b/providers/nous/models/meituan/longcat-2.0:free.toml
@@ -1,6 +1,10 @@
+# Toggle wire path: the Portal relays third-party models through OpenRouter, so
+# reasoning is controlled via OpenRouter's reasoning.budget_tokens field.
 base_model = "meituan/longcat-2.0"
 name = "LongCat-2.0 (free)"
-reasoning_options = [{ type = "toggle" }]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 0

--- a/providers/nous/models/meituan/longcat-2.0:free.toml
+++ b/providers/nous/models/meituan/longcat-2.0:free.toml
@@ -1,5 +1,6 @@
-# Toggle wire path: the Portal relays third-party models through OpenRouter, so
-# reasoning is controlled via OpenRouter's reasoning.budget_tokens field.
+# Reasoning budget wire path: the Portal relays third-party models through
+# OpenRouter, so the budget is set via the reasoning.max_tokens request field
+# (OpenAI-compatible chat convention).
 base_model = "meituan/longcat-2.0"
 name = "LongCat-2.0 (free)"
 

--- a/providers/nous/provider.toml
+++ b/providers/nous/provider.toml
@@ -1,0 +1,5 @@
+name = "Nous Portal"
+env = ["NOUS_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://inference-api.nousresearch.com/v1"
+doc = "https://hermes-agent.nousresearch.com/docs/integrations/nous-portal"


### PR DESCRIPTION
## Summary

Adds a `nous` provider (Nous Portal, https://portal.nousresearch.com) with its zero-cost free-tier catalog:

- `meituan/longcat-2.0:free` — base_model `meituan/longcat-2.0` + free cost override
- `inclusionai/ring-2.6-1t:free` — new lab entry `models/inclusionai/ring-2.6-1t.toml` + free cost override

Nous Portal is Nous Research's subscription gateway (launched 2026-04-27) serving a rotating free-model catalog on its $0 tier (50 RPM / 500K TPM). Its third-party catalog is OpenRouter-powered, and the portal emits OpenRouter-style slugs (`vendor/model:free`). These two slugs are verified from production usage logs (Hermes Agent / opencode against `inference-api.nousresearch.com/v1`); the free rotation also includes time-limited promos (Step 3.5 Flash etc.), which I deliberately left out since they are not standing catalog entries.

Deliberately excluded: `openrouter/owl-alpha` and `openrouter/elephant-alpha` (stealth previews, no authoritative identity/limits to satisfy the schema honestly).

## Why it matters downstream

[tokscale](https://github.com/junhoyeo/tokscale) prices usage via provider-hinted exact matching against this catalog (plus LiteLLM/OpenRouter). Today every Hermes Agent / Nous Portal user's free-model usage is excluded from tokscale's leaderboard submissions as unpriced because no dataset carries these IDs; this entry fixes that for everyone (provider id `nous` matches both opencode custom-provider configs and Hermes billing rows).

## Validation

- `bun validate` passes.
- Provider follows the openai-compatible template (`NOUS_API_KEY`, api endpoint per official docs).
- Free-model files are override-only via `base_model`; the new lab file carries complete required metadata.