### PR TITLE
feat(opencode-go): add DeepSeek vision model

### DIFF
--- a/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,0 +1,19 @@
+name = "DeepSeek V4 Flash Vision Exp"
+description = "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work"
+family = "deepseek-flash"
+release_date = "2026-08-21"
+last_updated = "2026-08-21"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/opencode-go/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/opencode-go/models/deepseek-v4-flash-vision-exp.toml
@@ -1,0 +1,13 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-21)
+base_model = "deepseek/deepseek-v4-flash-vision-exp"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.22
+output = 0.66
+cache_read = 0.007


### PR DESCRIPTION
## Summary
- add DeepSeek V4 Flash Vision Exp metadata
- expose the model through OpenCode Go

## Testing
- `bun validate`