### PR TITLE
fix: [missing-model] deepseek: deepseek-v4-flash-vision-exp

### DIFF
--- a/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
@@ -1,0 +1,23 @@
+# DeepSeek-V4-Flash-Vision-Exp is priced the same as DeepSeek V4 Flash.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-22)
+# https://api-docs.deepseek.com/guides/vision (accessed 2026-08-22)
+# OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
+# Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
+base_model = "deepseek/deepseek-v4-flash-vision-exp"
+status = "beta"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.14
+output = 0.28
+reasoning = 0.28
+cache_read = 0.0028


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2><p>Adds the missing first-party DeepSeek provider entry for the experimental multimodal model <code>deepseek-v4-flash-vision-exp</code>.</p><p>The shared lab metadata was already added in #5195, so this PR only adds the first-party <code>providers/deepseek/</code> catalog entry using <code>base_model</code>.</p><h2>Changes</h2><p><strong>New</strong> <code>providers/deepseek/models/deepseek-v4-flash-vision-exp.toml</code>:</p><ul><li><p><code>base_model = "deepseek/deepseek-v4-flash-vision-exp"</code></p></li><li><p><code>status = "beta"</code> for the experimental API model</p></li><li><p>Reasoning controls: <code>toggle</code> + effort <code>low</code> / <code>high</code> / <code>max</code>, matching first-party DeepSeek V4 Flash</p></li><li><p><code>reasoning_content</code> interleaving, matching the existing DeepSeek reasoning API surface</p></li><li><p>Cost (USD/MTok): input <code>0.14</code>, output <code>0.28</code>, reasoning <code>0.28</code>, cache read <code>0.0028</code>, matching first-party DeepSeek V4 Flash</p></li></ul><h2>Evidence</h2>
Claim | Source
-- | --
Model ID deepseek-v4-flash-vision-exp; multimodal / image input | DeepSeek API
Vision API behavior and image input support | DeepSeek Vision guide
Pricing aligned with DeepSeek V4 Flash | DeepSeek Models & Pricing
Thinking toggle and Flash effort mapping | DeepSeek Thinking Mode
Shared lab metadata for the model | #5195

<h2>Validation</h2><ul><li><p>Reuses the existing <code>deepseek/deepseek-v4-flash-vision-exp</code> lab metadata introduced by #5195.</p></li><li><p>Matched pricing, reasoning controls, and interleaving behavior against the existing first-party <code>deepseek-v4-flash</code> provider entry.</p></li><li><p>No duplicate lab metadata or provider-independent fields were added.</p></li></ul><h2>Review notes</h2><ul><li><p>This PR specifically adds the first-party <code>deepseek</code> provider entry that was intentionally left out of #5195.</p></li><li><p><code>status = "beta"</code> follows the model's experimental API status.</p></li><li><p>The provider entry remains override-only and inherits multimodal capabilities, limits, dates, and other model metadata through <code>base_model</code>.</p></li></ul></body></html>## Summary

Adds the missing first-party DeepSeek provider entry for the experimental multimodal model `deepseek-v4-flash-vision-exp`.

The shared lab metadata was already added in #5195, so this PR only adds the first-party `providers/deepseek/` catalog entry using `base_model`.

## Changes

**New** `providers/deepseek/models/deepseek-v4-flash-vision-exp.toml`:

* `base_model = "deepseek/deepseek-v4-flash-vision-exp"`
* `status = "beta"` for the experimental API model
* Reasoning controls: `toggle` + effort `low` / `high` / `max`, matching first-party DeepSeek V4 Flash
* `reasoning_content` interleaving, matching the existing DeepSeek reasoning API surface
* Cost (USD/MTok): input `0.14`, output `0.28`, reasoning `0.28`, cache read `0.0028`, matching first-party DeepSeek V4 Flash

## Evidence

| Claim                                                             | Source                                                                          |
| ----------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| Model ID `deepseek-v4-flash-vision-exp`; multimodal / image input | [[DeepSeek API](https://api-docs.deepseek.com/)](https://api-docs.deepseek.com/)                                  |
| Vision API behavior and image input support                       | [[DeepSeek Vision guide](https://api-docs.deepseek.com/guides/vision)](https://api-docs.deepseek.com/guides/vision)            |
| Pricing aligned with DeepSeek V4 Flash                            | [[DeepSeek Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing/)](https://api-docs.deepseek.com/quick_start/pricing/) |
| Thinking toggle and Flash effort mapping                          | [[DeepSeek Thinking Mode](https://api-docs.deepseek.com/guides/thinking_mode/)](https://api-docs.deepseek.com/guides/thinking_mode/)   |
| Shared lab metadata for the model                                 | #5195                                                                           |

## Validation

* Reuses the existing `deepseek/deepseek-v4-flash-vision-exp` lab metadata introduced by #5195.
* Matched pricing, reasoning controls, and interleaving behavior against the existing first-party `deepseek-v4-flash` provider entry.
* No duplicate lab metadata or provider-independent fields were added.

## Review notes

* This PR specifically adds the first-party `deepseek` provider entry that was intentionally left out of #5195.
* `status = "beta"` follows the model's experimental API status.
* The provider entry remains override-only and inherits multimodal capabilities, limits, dates, and other model metadata through `base_model`.