### PR TITLE
fix(deepseek): update v4-pro/flash pricing to post-promo rates

### DIFF
--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -1,6 +1,8 @@
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
+# Peak rates (01:00-04:00 and 06:00-10:00 UTC); off-peak is half — the launch
+# promo (75% off, $0.14/$0.28) ended; these are the standard list prices.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-21)
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
 # Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
 # Flash maps requested low→low (unlike Pro, which maps low→high). xhigh→high.
@@ -19,7 +21,7 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.14
-output = 0.28
-reasoning = 0.28
-cache_read = 0.0028
+input = 0.44
+output = 1.32
+reasoning = 1.32
+cache_read = 0.014

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -1,6 +1,8 @@
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-12)
+# Peak rates (01:00-04:00 and 06:00-10:00 UTC); off-peak is half — the launch
+# promo (75% off, $0.435/$0.87) ended; these are the standard list prices.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-21)
 base_model = "deepseek/deepseek-v4-pro-0813"
 name = "DeepSeek V4 Pro"
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.
@@ -18,7 +20,7 @@ values = ["high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.435
-output = 0.87
-reasoning = 0.87
-cache_read = 0.003625
+input = 1.32
+output = 3.96
+reasoning = 3.96
+cache_read = 0.044


### PR DESCRIPTION
The DeepSeek V4 launch promo (75% off) has ended. Current entries still carry the promo rates, which under-report cost by ~3-4x in tools that read this catalog.

Updated from the official pricing page (accessed 2026-08-21): https://api-docs.deepseek.com/quick_start/pricing/

Peak hours are 01:00-04:00 and 06:00-10:00 UTC; off-peak rates are half. This PR uses the standard (peak) list prices.

| model | before | after |
|---|---|---|
| deepseek-v4-pro | 0.435 / 0.87 / cache 0.003625 | 1.32 / 3.96 / cache 0.044 |
| deepseek-v4-flash | 0.14 / 0.28 / cache 0.0028 | 0.44 / 1.32 / cache 0.014 |

Reasoning tokens bill at the output rate (unchanged).