### PR TITLE
alibaba-cn/qwen-plus: add published explicit cache rates

### DIFF
--- a/providers/alibaba-cn/models/qwen-plus.toml
+++ b/providers/alibaba-cn/models/qwen-plus.toml
@@ -21,6 +21,8 @@ max = 81_920
 input = 0.115
 output = 0.287
 reasoning = 1.147
+cache_read = 0.012
+cache_write = 0.144
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
`alibaba-cn/qwen-plus` carries `input`, `output` and `reasoning` but no cache rates, even though Alibaba publishes explicit context-cache pricing for the model. Anything pricing a cached qwen-plus turn currently has to fall back to the uncached input rate.

From the [Model Studio pricing page](https://www.alibabacloud.com/help/en/model-studio/qwen-plus) (China Beijing tab; Germany Frankfurt and US Virginia show the same figures under `Scope: Global`), base tier `Input <= 128k`:

| Billing item | USD / 1M tokens |
|---|---|
| Explicit Cache Creation | 0.144 |
| Explicit Cache Read | 0.012 |

Both check out against Alibaba's documented multipliers and the `input` rate this entry already carries. The [context cache guide](https://www.alibabacloud.com/help/en/model-studio/context-cache) states explicit cache creation is billed at **125%** of the standard input price and an explicit cache hit at **10%**:

- `0.115 × 1.25 = 0.14375` → published **0.144**
- `0.115 × 0.10 = 0.0115` → published **0.012**

So two independent sources agree, against a base price this file already had right.

### On which rate `cache_read` carries

I used the **explicit** hit rate (0.012), which is how the other Qwen entries here are populated — `qwen3.7-flash`, `qwen3.6-plus` and `qwen3.7-plus` all sit at exactly 10% of their input.

Worth flagging that Alibaba prices **two different kinds of hit**: an explicit (`cache_control`) hit at 10%, and an implicit prefix-cache hit at 20% — 0.023 for this model, also published on that page. There's one `cache_read` field, and the API reports both kinds in the same `cached_tokens`, so a consumer can't tell which rate applied. I've left that alone here rather than fold a schema question into a data fix; happy to open it separately if that's useful.

### Not included

`qwen-plus` is also published in **three context tiers** (`<= 128k`, `128k–256k`, `256k–1M`) and this entry carries only the first, flat, on a model whose `limit.context` is 1,000,000. I have figures for the upper tiers but only from a rendered read of the page, and they contain an internal inconsistency I couldn't reconcile confidently, so I've deliberately left them out rather than guess. Raising that separately so someone with a cleaner source can do it properly.

---

Verified against the live page on 2026-08-21. Happy to adjust the format or split this differently.
