### PR TITLE
feat(google-vertex): add Claude Fable 5

### DIFF
--- a/providers/google-vertex-anthropic/models/claude-fable-5@default.toml
+++ b/providers/google-vertex-anthropic/models/claude-fable-5@default.toml
@@ -1,0 +1,9 @@
+# GA on Vertex AI Model Garden: publishers/anthropic/models/claude-fable-5 (versionId: default)
+base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/google-vertex/models/claude-fable-5@default.toml
+++ b/providers/google-vertex/models/claude-fable-5@default.toml
@@ -1,0 +1,12 @@
+# GA on Vertex AI Model Garden: publishers/anthropic/models/claude-fable-5 (versionId: default)
+base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[provider]
+npm = "@ai-sdk/google-vertex/anthropic"


### PR DESCRIPTION
## Summary

Adds `claude-fable-5@default` to the `google-vertex` and `google-vertex-anthropic` providers.

Claude Fable 5 is GA on Vertex AI Model Garden (`publishers/anthropic/models/claude-fable-5`, versionId `default`), verified via the Vertex publisher-models API at both the `global` and `us-central1` locations, but was missing from both Vertex provider catalogs here.

## Details

- Both entries use `base_model = "anthropic/claude-fable-5"` (lab entry already exists) and are override-only, following the existing `claude-opus-5@default` pattern for these providers.
- `reasoning_options`: effort `low`/`medium`/`high`/`xhigh`/`max`, matching the first-party `providers/anthropic/models/claude-fable-5.toml` entry.
- Cost: $10/$50 per MTok (cache read $1, write $12.50), matching Anthropic direct pricing, which Vertex mirrors for Claude models.
- `google-vertex` entry sets `provider.npm = "@ai-sdk/google-vertex/anthropic"`, same as the other Claude entries on that provider.
- `@default` (undated) filename per the Vertex naming convention in AGENTS.md.

## Validation

`bun validate` passes; resolved output for both providers matches the shape of the existing `claude-opus-5@default` entries.