### PR TITLE
feat(providers): add Model Router OpenAI-compatible gateway

### DIFF
--- a/providers/model-router/logo.svg
+++ b/providers/model-router/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor" role="img" aria-label="Model Router">
+  <path d="M32 8 L44.5 32 L19.5 32 Z" opacity="0.95"/>
+  <path d="M19.5 32 L32 56 L12 56 Z" opacity="0.55"/>
+  <path d="M44.5 32 L52 56 L32 56 Z" opacity="0.75"/>
+</svg>

--- a/providers/model-router/models/plan/claude-fable-5.toml
+++ b/providers/model-router/models/plan/claude-fable-5.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/claude-fable-5 from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/models/plan/claude-opus-4.6.toml
+++ b/providers/model-router/models/plan/claude-opus-4.6.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/claude-opus-4.6 from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "anthropic/claude-opus-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/models/plan/claude-opus-5.toml
+++ b/providers/model-router/models/plan/claude-opus-5.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/claude-opus-5 from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "anthropic/claude-opus-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/models/plan/claude-sonnet-4.6.toml
+++ b/providers/model-router/models/plan/claude-sonnet-4.6.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/claude-sonnet-4.6 from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/models/plan/claude-sonnet-5.toml
+++ b/providers/model-router/models/plan/claude-sonnet-5.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/claude-sonnet-5 from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "anthropic/claude-sonnet-5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/models/plan/gemini-3.1-pro.toml
+++ b/providers/model-router/models/plan/gemini-3.1-pro.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/gemini-3.1-pro from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/models/plan/gemini-3.7-flash.toml
+++ b/providers/model-router/models/plan/gemini-3.7-flash.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/gemini-3.7-flash from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "google/gemini-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/models/plan/gpt-5.5-instant.toml
+++ b/providers/model-router/models/plan/gpt-5.5-instant.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/gpt-5.5-instant from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]

--- a/providers/model-router/models/plan/gpt-5.5-pro.toml
+++ b/providers/model-router/models/plan/gpt-5.5-pro.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/gpt-5.5-pro from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high"] }]

--- a/providers/model-router/models/plan/gpt-5.6-sol.toml
+++ b/providers/model-router/models/plan/gpt-5.6-sol.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/gpt-5.6-sol from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]

--- a/providers/model-router/models/plan/grok-4.3.toml
+++ b/providers/model-router/models/plan/grok-4.3.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/grok-4.3 from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]

--- a/providers/model-router/models/plan/grok-4.5.toml
+++ b/providers/model-router/models/plan/grok-4.5.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/grok-4.5 from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "xai/grok-4.5"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/models/plan/kimi-k2.6.toml
+++ b/providers/model-router/models/plan/kimi-k2.6.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/kimi-k2.6 from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]

--- a/providers/model-router/models/plan/kimi-k3.toml
+++ b/providers/model-router/models/plan/kimi-k3.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/kimi-k3 from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/models/plan/qwen-3.8-max.toml
+++ b/providers/model-router/models/plan/qwen-3.8-max.toml
@@ -1,0 +1,4 @@
+# Catalog id plan/qwen-3.8-max from https://resells.app/api/models/public (2026-08-22).
+# Conservative OpenAI-compat reasoning_effort; no published USD/MTok; cost omitted.
+base_model = "alibaba/qwen3.8-max"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/model-router/provider.toml
+++ b/providers/model-router/provider.toml
@@ -1,0 +1,7 @@
+# Public catalog: https://resells.app/api/models/public (2026-08-22)
+# Clients send plan/<slug>. USD/MTok not on public catalog; cost omitted.
+name = "Model Router"
+npm = "@ai-sdk/openai-compatible"
+env = ["RESELLS_API_KEY"]
+api = "https://resells.app/v1"
+doc = "https://resells.app/docs"


### PR DESCRIPTION
Add Model Router (https://resells.app) as an OpenAI-compatible provider (id model-router). API https://resells.app/v1, env RESELLS_API_KEY, docs https://resells.app/docs. Model ids are plan/<slug> from the public catalog. Includes 15 live models with base_model inheritance and conservative reasoning_options. Cost omitted (no published USD/MTok). Remaining public catalog ids can follow up: older Claude/GPT/Gemini/Grok plus minimax, mistral, muse, o3, o4-mini, qwen-3.6-plus.