### PR TITLE
fix(deepinfra): derive tiered cache prices from the published multiplier

### DIFF
--- a/packages/core/src/sync/providers/deepinfra.ts
+++ b/packages/core/src/sync/providers/deepinfra.ts
@@ -148,6 +148,33 @@ function cacheCost(inputCost: number, rate: number | null | undefined) {
   return rate == null ? undefined : round(inputCost * rate);
 }
 
+// Within one tier segment the cached price is published twice: as the structured
+// `rate_per_input_token_cached` multiplier, and restated as an absolute price in
+// the free-text `full` string. They normally agree, but the string is
+// hand-written and can drift — `ByteDance/Seed-2.0-mini` currently reads
+// `$0.2 in ... $0.2 cached` above 128K, i.e. cached input priced identically to
+// fresh input, where the multiplier gives $0.04.
+//
+// Derive from the multiplier so that a segment's cached price is computed the
+// same way here as it is on the flat-pricing path below, and warn when the
+// string disagrees so a genuine rate change is visible rather than silent.
+function segmentCacheRead(
+  modelName: string,
+  input: number,
+  stated: number | undefined,
+  rate: number | null | undefined,
+) {
+  if (rate == null) return stated === undefined ? undefined : round(stated);
+  const derived = round(input * rate);
+  if (stated !== undefined && Math.abs(stated - derived) > 1e-9) {
+    console.warn(
+      `Deep Infra: ${modelName} states $${stated}/Mtok cached against a $${input}/Mtok input tier, `
+      + `but rate_per_input_token_cached=${rate} implies $${derived}/Mtok; using $${derived}/Mtok.`,
+    );
+  }
+  return derived;
+}
+
 function buildCost(
   model: DeepInfraModel,
   existing: ExistingModel | undefined,
@@ -157,6 +184,7 @@ function buildCost(
   // No usable API price — leave the curated cost untouched.
   if (inputCost === undefined || outputCost === undefined) return existing?.cost;
 
+  const cacheReadRate = model.pricing?.rate_per_input_token_cached;
   const cacheWriteRate = model.pricing?.rate_per_input_token_cache_write;
   const tiered = parseTieredPricing(model.pricing?.full);
 
@@ -166,13 +194,18 @@ function buildCost(
       input: round(base.input),
       output: round(base.output),
       reasoning: existing?.cost?.reasoning,
-      cache_read: base.cache_read === undefined ? undefined : round(base.cache_read),
-      cache_write: cacheWriteRate == null ? undefined : round(base.input * cacheWriteRate),
+      cache_read: segmentCacheRead(model.model_name, base.input, base.cache_read, cacheReadRate),
+      cache_write: cacheCost(base.input, cacheWriteRate),
       tiers: tiered.tiers.map((tier) => ({
         tier: { type: "context" as const, size: tier.size },
         input: round(tier.input),
         output: round(tier.output),
-        cache_read: tier.cache_read === undefined ? undefined : round(tier.cache_read),
+        cache_read: segmentCacheRead(model.model_name, tier.input, tier.cache_read, cacheReadRate),
+        // Both cache rates are multipliers on the *segment's* input price, so a
+        // context tier that doubles input doubles its cache prices too. Emitting
+        // cache_write only on the base tier would leave a long-context request
+        // priced at the short-context write rate.
+        cache_write: cacheCost(tier.input, cacheWriteRate),
       })),
     };
   }

--- a/packages/core/test/deepinfra.test.ts
+++ b/packages/core/test/deepinfra.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "bun:test";
+
+import {
+  buildDeepInfraModel,
+  type DeepInfraModel,
+} from "../src/sync/providers/deepinfra.js";
+
+function deepinfraModel(overrides: Partial<DeepInfraModel> = {}): DeepInfraModel {
+  return {
+    model_name: "ByteDance/Seed-2.0-pro",
+    type: "text-generation",
+    tags: ["tools", "multimodal"],
+    pricing: {
+      type: "tokens",
+      cents_per_input_token: 5e-5,
+      cents_per_output_token: 3e-4,
+      rate_per_input_token_cached: 0.2,
+      full: "$0.50 in $3 out $0.10 cached <= 128K, $1 in $6 out $0.20 cached",
+    },
+    max_tokens: 256_000,
+    ...overrides,
+  };
+}
+
+test("derives tiered cache_read from the cached-rate multiplier", () => {
+  const built = buildDeepInfraModel(deepinfraModel(), undefined);
+
+  expect(built.cost).toMatchObject({
+    input: 0.5,
+    output: 3,
+    cache_read: 0.1,
+    tiers: [
+      { tier: { type: "context", size: 128_000 }, input: 1, output: 6, cache_read: 0.2 },
+    ],
+  });
+});
+
+test("prefers the cached-rate multiplier over a disagreeing price string", () => {
+  // Live payload for ByteDance/Seed-2.0-mini: the string restates the tier's
+  // cached price as `$0.2`, which is its *input* price — cached input would
+  // cost the same as fresh input. The multiplier gives $0.04, and agrees with
+  // the string on every other segment DeepInfra publishes.
+  const built = buildDeepInfraModel(
+    deepinfraModel({
+      model_name: "ByteDance/Seed-2.0-mini",
+      pricing: {
+        cents_per_input_token: 1e-5,
+        cents_per_output_token: 4e-5,
+        rate_per_input_token_cached: 0.2,
+        full: "$0.10 in $0.40 out $0.02 cached <= 128K, $0.2 in $0.80 out $0.2 cached",
+      },
+    }),
+    undefined,
+  );
+
+  expect(built.cost).toMatchObject({
+    input: 0.1,
+    cache_read: 0.02,
+    tiers: [
+      { tier: { type: "context", size: 128_000 }, input: 0.2, cache_read: 0.04 },
+    ],
+  });
+  // The cached price must stay below the fresh-input price it discounts.
+  const tier = built.cost?.tiers?.[0];
+  expect(tier?.cache_read).toBeLessThan(tier!.input!);
+});
+
+test("keeps the stated cached price when no multiplier is published", () => {
+  const built = buildDeepInfraModel(
+    deepinfraModel({
+      pricing: {
+        cents_per_input_token: 5e-5,
+        cents_per_output_token: 3e-4,
+        rate_per_input_token_cached: null,
+        full: "$0.50 in $3 out $0.10 cached <= 128K, $1 in $6 out $0.20 cached",
+      },
+    }),
+    undefined,
+  );
+
+  expect(built.cost).toMatchObject({
+    cache_read: 0.1,
+    tiers: [{ tier: { type: "context", size: 128_000 }, cache_read: 0.2 }],
+  });
+});
+
+test("scales cache_write per tier instead of only pricing the base tier", () => {
+  const built = buildDeepInfraModel(
+    deepinfraModel({
+      pricing: {
+        cents_per_input_token: 5e-5,
+        cents_per_output_token: 3e-4,
+        rate_per_input_token_cached: 0.2,
+        rate_per_input_token_cache_write: 1.25,
+        full: "$0.50 in $3 out $0.10 cached <= 128K, $1 in $6 out $0.20 cached",
+      },
+    }),
+    undefined,
+  );
+
+  expect(built.cost).toMatchObject({
+    cache_write: 0.625,
+    tiers: [{ tier: { type: "context", size: 128_000 }, cache_write: 1.25 }],
+  });
+});
+
+test("carries every band of a three-tier price string", () => {
+  const built = buildDeepInfraModel(
+    deepinfraModel({
+      model_name: "Qwen/Qwen3.7-Max",
+      pricing: {
+        cents_per_input_token: 2.5e-4,
+        cents_per_output_token: 7.5e-4,
+        rate_per_input_token_cached: 0.2,
+        full:
+          "$2.50 in $7.50 out $0.50 cached <= 32K, $5.0 in $15 out $1.0 cached <= 128K, "
+          + "$6.25 in $18.50 out $1.25 cached > 128K",
+      },
+    }),
+    undefined,
+  );
+
+  expect(built.cost).toMatchObject({
+    input: 2.5,
+    output: 7.5,
+    cache_read: 0.5,
+    tiers: [
+      { tier: { type: "context", size: 32_000 }, input: 5, output: 15, cache_read: 1 },
+      { tier: { type: "context", size: 128_000 }, input: 6.25, output: 18.5, cache_read: 1.25 },
+    ],
+  });
+});

--- a/providers/deepinfra/models/ByteDance/Seed-2.0-mini.toml
+++ b/providers/deepinfra/models/ByteDance/Seed-2.0-mini.toml
@@ -11,7 +11,7 @@ cache_read = 0.02
 tier = { type = "context", size = 128_000 }
 input = 0.2
 output = 0.8
-cache_read = 0.2
+cache_read = 0.04
 
 [modalities]
 input = ["text", "image"]


### PR DESCRIPTION
## The problem

`deepinfra.ts` derives `cache_read` two different ways depending on which branch of `buildCost` runs:

- **flat pricing** → `inputCost * rate_per_input_token_cached` (the structured multiplier)
- **tiered pricing** → the absolute number parsed out of the free-text `full` string

Both are published in the same payload, and normally they agree. Across every tiered model DeepInfra serves today — 7 models, 17 tier segments — **16 segments agree exactly and one doesn't**:

| model | segment | input | `full` says cached | `rate * input` |
| --- | --- | ---: | ---: | ---: |
| `Qwen/Qwen3-Max` | base / 32K / 128K | 1.2 / 2.4 / 3 | 0.24 / 0.48 / 0.6 | 0.24 / 0.48 / 0.6 ✅ |
| `Qwen/Qwen3-Max-Thinking` | base / 32K / 128K | 1.2 / 2.4 / 3 | 0.24 / 0.48 / 0.6 | 0.24 / 0.48 / 0.6 ✅ |
| `Qwen/Qwen3.7-Max` | base / 32K / 128K | 2.5 / 5 / 6.25 | 0.5 / 1 / 1.25 | 0.5 / 1 / 1.25 ✅ |
| `ByteDance/Seed-2.0-pro` | base / 128K | 0.5 / 1 | 0.10 / 0.20 | 0.10 / 0.20 ✅ |
| `ByteDance/Seed-2.0-code` | base / 128K | 0.5 / 1 | 0.10 / 0.20 | 0.10 / 0.20 ✅ |
| `ByteDance/Seed-1.8` | base / 128K | 0.25 / 0.5 | 0.05 / 0.1 | 0.05 / 0.1 ✅ |
| `ByteDance/Seed-2.0-mini` | base | 0.1 | 0.02 | 0.02 ✅ |
| `ByteDance/Seed-2.0-mini` | **128K** | **0.2** | **0.2** | **0.04** ❌ |

The live string is:

```
$0.10 in $0.40 out $0.02 cached <= 128K, $0.2 in $0.80 out $0.2 cached
```

`rate_per_input_token_cached` is `0.2` for all seven of these models, so the second segment's cached price should be `0.2 * 0.2 = $0.04`. What ships today is [`cache_read = 0.2`](providers/deepinfra/models/ByteDance/Seed-2.0-mini.toml) — **5x too high, and exactly equal to the tier's own input price**, i.e. cached input priced identically to fresh input. It's also the same `0.2` as `Seed-2.0-pro`'s top tier, whose input price is 5x higher.

Two independent tells that the string is the wrong source here, not the multiplier: a cached rate can't equal the input rate it discounts, and 16 of 17 segments say the multiplier is authoritative.

## What this changes

**1. One derivation for `cache_read`.** Tier segments now compute it as `segment input * rate_per_input_token_cached`, the same way the flat path already does, and `console.warn` when the string disagrees — so a genuine future rate change surfaces instead of silently overwriting. When no multiplier is published the stated string value is still used, so nothing regresses for a model that only publishes the string.

**2. `cache_write` is now emitted per tier.** It was computed only for the base tier:

```ts
cache_write: cacheWriteRate == null ? undefined : round(base.input * cacheWriteRate),
tiers: tiered.tiers.map((tier) => ({
  input: round(tier.input),
  output: round(tier.output),
  cache_read: ...,          // <- no cache_write
})),
```

Same reasoning as `cache_read`: the file's own comment says these rates are *"multipliers applied to the input price"*, and a context tier that doubles input therefore doubles both cache prices. Leaving `cache_write` off the tiers bills a long-context request at the short-context write rate. This one is **latent, not live** — no tiered DeepInfra model publishes `rate_per_input_token_cache_write` today, so the shipped data is unchanged by it. I've fixed it anyway because the field is already read on the flat path, so the moment DeepInfra populates it on a tiered model the data would go quietly wrong.

Data change is one line: `Seed-2.0-mini`'s 128K tier `cache_read` `0.2 → 0.04`.

## Tests

New `packages/core/test/deepinfra.test.ts`, following the `baseten.test.ts` shape. Five cases, all built from live payloads:

- agreeing case (`Seed-2.0-pro`) — unchanged output, so the fix isn't a blanket rewrite
- disagreeing case (`Seed-2.0-mini`) — pins `0.04`, plus an invariant that a tier's `cache_read` stays below its `input`
- no multiplier published — falls back to the string
- `cache_write` scales per tier
- three-band string (`Qwen3.7-Max`, 32K + 128K) — the multi-tier shape isn't exercised anywhere today

## Verification

```
bun test                # 226 pass, 4 fail
bun run validate        # exit 0
```

The 4 failures are pre-existing on `dev` at `08324a0` and identical before and after this change (`snapshot entrypoint is self-contained`, `snapshot exports providers, models, generatedAt, and a default catalog`, `catalog generation > repository open-weight model metadata includes weights links`, `DeepInfra preserves live modalities for new base models`). Baseline is 221 pass / 4 fail; this adds the 5 new passes and no new failures.

Prices re-read from `https://api.deepinfra.com/models/list?type=text-generation` on 2026-08-22.

## One thing I did not do

I didn't report the `$0.2 cached` string to DeepInfra as a typo, because I can't tell from outside whether it's a formatting slip or a real rate. If it's real, this PR is wrong for that one model and the warning is the thing that would tell you — it fires on exactly that segment and names both numbers. Happy to invert the precedence (trust the string, warn on mismatch) if you'd rather the free text stay authoritative; the helper is one branch either way.
