### PR TITLE
nvidia: add kimi-k3 and deepseek-v4-flash-0731 provider entries

### DIFF
--- a/providers/nvidia/models/deepseek-ai/deepseek-v4-flash-0731.toml
+++ b/providers/nvidia/models/deepseek-ai/deepseek-v4-flash-0731.toml
@@ -1,14 +1,17 @@
-base_model = "deepseek/deepseek-v4-flash-0731"
-
 # NIM Chat schema: `reasoning_effort = none|high|max`; `none` disables thinking.
 # https://docs.api.nvidia.com/nim/reference/deepseek-ai-deepseek-v4-flash-infer
+#
+# Pricing: hosted on NVIDIA's API trial tier and currently free — no separate
+# list rate is published for this ID. Source: this model's catalog card,
+# https://build.nvidia.com/deepseek-ai/deepseek-v4-flash-0731 (governed by the
+# NVIDIA API Trial Terms of Service).
+base_model = "deepseek/deepseek-v4-flash-0731"
+
 reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"
 
-# Hosted free on NVIDIA's API trial tier; pricing source is this model's
-# catalog card: https://build.nvidia.com/deepseek-ai/deepseek-v4-flash-0731
 [cost]
 input = 0.0
 output = 0.0

--- a/providers/nvidia/models/deepseek-ai/deepseek-v4-flash-0731.toml
+++ b/providers/nvidia/models/deepseek-ai/deepseek-v4-flash-0731.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+# NIM Chat schema: `reasoning_effort = none|high|max`; `none` disables thinking.
+# https://docs.api.nvidia.com/nim/reference/deepseek-ai-deepseek-v4-flash-0731-infer
+reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/nvidia/models/deepseek-ai/deepseek-v4-flash-0731.toml
+++ b/providers/nvidia/models/deepseek-ai/deepseek-v4-flash-0731.toml
@@ -7,9 +7,8 @@ reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
 [interleaved]
 field = "reasoning_content"
 
-# Hosted on NVIDIA's API trial tier (governed by the NVIDIA API Trial Terms of
-# Service, see this model's build.nvidia.com card); currently free, unlike
-# sibling entries that mirror DeepSeek list pricing.
+# Hosted free on NVIDIA's API trial tier; pricing source is this model's
+# catalog card: https://build.nvidia.com/deepseek-ai/deepseek-v4-flash-0731
 [cost]
 input = 0.0
 output = 0.0

--- a/providers/nvidia/models/deepseek-ai/deepseek-v4-flash-0731.toml
+++ b/providers/nvidia/models/deepseek-ai/deepseek-v4-flash-0731.toml
@@ -1,12 +1,15 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
 
 # NIM Chat schema: `reasoning_effort = none|high|max`; `none` disables thinking.
-# https://docs.api.nvidia.com/nim/reference/deepseek-ai-deepseek-v4-flash-0731-infer
+# https://docs.api.nvidia.com/nim/reference/deepseek-ai-deepseek-v4-flash-infer
 reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"
 
+# Hosted on NVIDIA's API trial tier (governed by the NVIDIA API Trial Terms of
+# Service, see this model's build.nvidia.com card); currently free, unlike
+# sibling entries that mirror DeepSeek list pricing.
 [cost]
 input = 0.0
 output = 0.0

--- a/providers/nvidia/models/moonshotai/kimi-k3.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k3"
+
+# NIM hosted endpoint serves Kimi K3 multimodal (text/image/video input).
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0

--- a/providers/nvidia/models/moonshotai/kimi-k3.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k3.toml
@@ -1,8 +1,8 @@
-base_model = "moonshotai/kimi-k3"
-
 # NIM wire syntax (verified against integrate.api.nvidia.com/v1, 2026-08-22):
 #   on/off: chat_template_kwargs = { "thinking": true | false }  (default: true)
 #   effort: top-level "reasoning_effort" = "low" | "high" | "max"
+base_model = "moonshotai/kimi-k3"
+
 reasoning_options = [
   { type = "toggle" },
   { type = "effort", values = ["low", "high", "max"] },

--- a/providers/nvidia/models/moonshotai/kimi-k3.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k3.toml
@@ -3,11 +3,10 @@ base_model = "moonshotai/kimi-k3"
 # NIM wire syntax (verified against integrate.api.nvidia.com/v1, 2026-08-22):
 #   on/off: chat_template_kwargs = { "thinking": true | false }  (default: true)
 #   effort: top-level "reasoning_effort" = "low" | "high" | "max"
-reasoning_options = [{ type = "toggle" }]
-
-[[reasoning_options]]
-type = "effort"
-values = ["low", "high", "max"]
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "high", "max"] },
+]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/nvidia/models/moonshotai/kimi-k3.toml
+++ b/providers/nvidia/models/moonshotai/kimi-k3.toml
@@ -1,7 +1,13 @@
 base_model = "moonshotai/kimi-k3"
 
-# NIM hosted endpoint serves Kimi K3 multimodal (text/image/video input).
+# NIM wire syntax (verified against integrate.api.nvidia.com/v1, 2026-08-22):
+#   on/off: chat_template_kwargs = { "thinking": true | false }  (default: true)
+#   effort: top-level "reasoning_effort" = "low" | "high" | "max"
 reasoning_options = [{ type = "toggle" }]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Summary

Both models are live on the NVIDIA NIM hosted catalog (`integrate.api.nvidia.com/v1/models`) but were missing from the `nvidia` provider, so consumers (e.g. opencode) show an outdated model picker.

Added override-only provider files per AGENTS.md conventions (`base_model` + `cost` + `reasoning_options` + `interleaved`, no restated lab fields):

- `providers/nvidia/models/moonshotai/kimi-k3.toml`
- `providers/nvidia/models/deepseek-ai/deepseek-v4-flash-0731.toml`

## Notes

- Costs are set to `0.0` consistent with NVIDIA's free trial-tier endpoints; happy to adjust if NIM list pricing differs.
- Broader observation: the nvidia catalog has significant drift from the hosted API (~60 live IDs missing, ~58 listed entries no longer served, incl. rotated IDs like `deepseek-v4-flash` → `deepseek-v4-flash-0731`). Since NIM exposes a catalog API at `/v1/models`, a [sync module](https://github.com/anomalyco/models.dev/blob/dev/sync.md) might be a good fit here — can follow up if maintainers agree.