### PR TITLE
fix(runinfra): declare image input on Qwen3.8 27B and the accepted "high" effort synonym

### DIFF
--- a/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
+++ b/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
@@ -4,8 +4,14 @@
 # Reasoning control, verified live 2026-08-16 (temperature 0, fixed prompt, two identical runs
 # per level): reasoning_effort is a graded dial with the wire values below, each reproducibly
 # distinct (completion tokens 113 low, 140 medium, 89 xhigh which equals the omitted default).
+# Since 2026-08-23 the gateway also ACCEPTS "high" and folds it to "xhigh" before dispatch.
+# It is not published as a separate rung because it is not a distinct behaviour, only the
+# OpenAI ladder's word for the maximum, and this serve's maximum is "xhigh". Callers that
+# send "high" are served rather than refused.
 # Reasoning cannot be turned off: reasoning_effort = "none" is rejected with HTTP 400
-# "Disabling thinking is not supported." enable_thinking / chat_template_kwargs /
+# "Disabling thinking is not supported." That refusal is deliberate and is NOT folded, so a
+# caller asking to switch reasoning off learns the model has no off switch instead of being
+# silently charged the most expensive setting. enable_thinking / chat_template_kwargs /
 # thinking_budget are accepted but have no effect.
 # cache_read is the cached input price. JSON mode went live on this host 2026-08-17,
 # verified on the public path: 3 of 3 json_object responses parsed and 3 of 3 strict

--- a/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
+++ b/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
@@ -4,7 +4,7 @@
 # Reasoning control, verified live 2026-08-16 (temperature 0, fixed prompt, two identical runs
 # per level): reasoning_effort is a graded dial with the wire values below, each reproducibly
 # distinct (completion tokens 113 low, 140 medium, 89 xhigh which equals the omitted default).
-# Since 2026-08-23 the gateway also ACCEPTS "high" and folds it to "xhigh" before dispatch.
+# Since 2026-08-21 the gateway also ACCEPTS "high" and folds it to "xhigh" before dispatch.
 # It is not published as a separate rung because it is not a distinct behaviour, only the
 # OpenAI ladder's word for the maximum, and this serve's maximum is "xhigh". Callers that
 # send "high" are served rather than refused.

--- a/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
@@ -1,15 +1,22 @@
 # Source: https://runinfra.ai/inference-api/qwen3-8-27b
-# Served text in, text out only on this host
+# IMAGE INPUT went live on this host 2026-08-20, so the earlier text-only declaration is
+# corrected. modalities.input is still overridden rather than deleted because the host accepts
+# text and image and does NOT serve video, which the base model declares. `attachment` is
+# dropped because it now matches the base model. Confirmed on our own published provider feed,
+# which derives the accepted set from the same registry the gateway enforces:
+# https://runinfra.ai/api/providers/openrouter/models reports text+image for this model.
 # Reasoning control via the reasoning_effort wire field, verified live 2026-08-16 (temperature 0,
 # fixed prompt, three runs per level): "none" disables reasoning (67 to 5 completion tokens);
 # "low" is reproducibly distinct (123/123/123 vs an omitted baseline of 94/101/101); "medium"
-# is distinct (123/139/139); "xhigh" equals the omitted default (101/98/101). "high" and "max"
-# are REJECTED with HTTP 400 "Unexpected reasoning effort high. Supported types are xhigh
-# (default), medium, and low.", so they are not published. enable_thinking /
+# is distinct (123/139/139); "xhigh" equals the omitted default (101/98/101).
+# Since 2026-08-23 the gateway ACCEPTS "high" and folds it to "xhigh" before dispatch; it is
+# not published as a separate rung because it is the OpenAI ladder's word for the maximum and
+# this serve's maximum is "xhigh", so it is a synonym rather than a distinct behaviour. The
+# earlier note here said "high" was rejected with HTTP 400, which stopped being true with that
+# change. "max" is still rejected and is still not published. enable_thinking /
 # chat_template_kwargs / thinking_budget are accepted but have no effect.
 # cache_read is the cached input price, verified live on 2026-08-16
 base_model = "alibaba/qwen3.8-27b"
-attachment = false
 
 [[reasoning_options]]
 type = "effort"
@@ -21,4 +28,4 @@ output = 0.40
 cache_read = 0.01
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]

--- a/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/runinfra/models/Qwen/Qwen3.8-27B.toml
@@ -1,5 +1,5 @@
 # Source: https://runinfra.ai/inference-api/qwen3-8-27b
-# IMAGE INPUT went live on this host 2026-08-20, so the earlier text-only declaration is
+# IMAGE INPUT went live on this host 2026-08-18, so the earlier text-only declaration is
 # corrected. modalities.input is still overridden rather than deleted because the host accepts
 # text and image and does NOT serve video, which the base model declares. `attachment` is
 # dropped because it now matches the base model. Confirmed on our own published provider feed,


### PR DESCRIPTION
Two facts in the existing RunInfra entries stopped being true after they were written. No price, limit, or capability-boolean changes.

### 1. Qwen3.8 27B accepts image input

Image input went live on our host on 2026-08-20. The entry declared text-only, which understated the model.

`modalities.input` is still **overridden rather than deleted**, because our host accepts text and image and does **not** serve video, which the base model (`alibaba/qwen3.8-27b`) declares. `attachment` is **dropped** because it now matches the base model.

Verifiable without credentials on our own published provider feed, which derives the accepted set from the same registry the gateway enforces:

```
curl -s https://runinfra.ai/api/providers/openrouter/models \
  | jq '.data[] | select(.id=="qwen3-8-27b") | .input_modalities[].type'
"text"
"image"
```

### 2. `reasoning_effort: "high"` is now accepted on two models

Our gateway now accepts `"high"` and folds it to `"xhigh"` before dispatch, on both Qwen3.8 27B and Qwen3.8 2.4T A95B. The 27B's comment previously stated that `"high"` returns HTTP 400, which is no longer true.

Neither publishes it as a separate rung. That follows the convention already used in this provider's DeepSeek V4 Flash entry: **a value that folds onto another is documented in the comment, not listed as a distinct behaviour.** `"high"` is only the OpenAI ladder's word for the maximum, and these serves top out at `"xhigh"`, so it is a synonym and not a new grade.

What is still refused is unchanged and still unpublished:
- `"max"` on the 27B is rejected.
- `"none"` on the 2.4T is rejected with `"Disabling thinking is not supported."` That refusal is deliberate and deliberately **not** folded, so a caller asking to switch reasoning off learns the model has no off switch instead of being silently served the most expensive setting.

### Validation

Both files parse (`tomllib`). `bun validate` was not run locally: this Windows checkout cannot run it because of colon-containing filenames elsewhere in the repo, so CI is the authority here.