### PR TITLE
feat: add Command Code and OpenStarry providers

### DIFF
--- a/models/stealth/ox-alpha.toml
+++ b/models/stealth/ox-alpha.toml
@@ -1,0 +1,19 @@
+name = "Ox Alpha"
+description = "Anonymous frontier reasoning model with strong agentic coding performance"
+family = "alpha"
+release_date = "2026-08-20"
+last_updated = "2026-08-20"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -9,6 +9,7 @@ import { ambient } from "./providers/ambient.js";
 import { anthropic } from "./providers/anthropic.js";
 import { baseten } from "./providers/baseten.js";
 import { chutes } from "./providers/chutes.js";
+import { commandcode } from "./providers/commandcode.js";
 import { cloudflareWorkersAi } from "./providers/cloudflare-workers-ai.js";
 import { cortecs } from "./providers/cortecs.js";
 import { crossmodel } from "./providers/crossmodel.js";
@@ -27,6 +28,7 @@ import { nanoGpt } from "./providers/nano-gpt.js";
 import { openai } from "./providers/openai.js";
 import { ofox } from "./providers/ofox.js";
 import { openrouter } from "./providers/openrouter.js";
+import { openstarry } from "./providers/openstarry.js";
 import { ovhcloud } from "./providers/ovhcloud.js";
 import { pioneer } from "./providers/pioneer.js";
 import { requesty } from "./providers/requesty.js";
@@ -128,6 +130,7 @@ export const providers: {
   anthropic: SyncProvider<any>;
   baseten: SyncProvider<any>;
   chutes: SyncProvider<any>;
+  commandcode: SyncProvider<any>;
   "cloudflare-workers-ai": SyncProvider<any>;
   cortecs: SyncProvider<any>;
   crossmodel: SyncProvider<any>;
@@ -147,6 +150,7 @@ export const providers: {
   ofox: SyncProvider<any>;
   openai: SyncProvider<any>;
   openrouter: SyncProvider<any>;
+  openstarry: SyncProvider<any>;
   ovhcloud: SyncProvider<any>;
   pioneer: SyncProvider<any>;
   requesty: SyncProvider<any>;
@@ -160,6 +164,7 @@ export const providers: {
   anthropic,
   baseten,
   chutes,
+  commandcode,
   "cloudflare-workers-ai": cloudflareWorkersAi,
   cortecs,
   crossmodel,
@@ -179,6 +184,7 @@ export const providers: {
   ofox,
   openai,
   openrouter,
+  openstarry,
   ovhcloud,
   pioneer,
   requesty,
@@ -207,7 +213,7 @@ export const groups = {
     "vercel",
   ],
   cloudflare: ["cloudflare-workers-ai"],
-  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
+  direct: ["ambient", "anthropic", "baseten", "chutes", "commandcode", "cortecs", "deepinfra", "digitalocean", "google", "hyper", "openai", "openstarry", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;

--- a/packages/core/src/sync/providers/commandcode.ts
+++ b/packages/core/src/sync/providers/commandcode.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+import { describeModel } from "../../describe.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://api.commandcode.ai/provider/v1/models";
+
+export const CommandCodeModel = z.object({
+  id: z.string(),
+  name: z.string(),
+  created: z.number(),
+  context_length: z.number(),
+}).passthrough();
+
+export const CommandCodeResponse = z.object({
+  data: z.array(CommandCodeModel),
+}).passthrough();
+
+export type CommandCodeModel = z.infer<typeof CommandCodeModel>;
+
+export const commandcode = {
+  id: "commandcode",
+  name: "Command Code",
+  modelsDir: "providers/commandcode/models",
+  async fetchModels() {
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`Command Code request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return CommandCodeResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    return {
+      id: model.id,
+      model: buildCommandCodeModel(model, context.existing(model.id)),
+    };
+  },
+} satisfies SyncProvider<CommandCodeModel>;
+
+function dateFromTimestamp(timestamp: number) {
+  return new Date(timestamp * 1000).toISOString().slice(0, 10);
+}
+
+export function buildCommandCodeModel(
+  model: CommandCodeModel,
+  existing: ExistingModel | undefined,
+  baseModel?: string,
+): SyncedModel {
+  const name = model.name;
+  const reasoning = true;
+  const reasoning_options = existing?.reasoning_options ?? [
+    { type: "effort" as const, values: ["low", "medium", "high"] },
+  ];
+  const context = model.context_length;
+  const limit = {
+    context,
+    output: Math.floor(context / 4),
+  };
+  const releaseDate = dateFromTimestamp(model.created);
+  const canonical = existing?.base_model ?? baseModel ?? resolveModelMetadataBaseModel(model.id);
+
+  if (canonical !== undefined) {
+    return factorBaseModel(
+      canonical,
+      {
+        name: baseModel !== undefined ? name : undefined,
+        description: existing?.description ?? describeModel({
+          id: model.id,
+          name,
+          reasoning,
+          tool_call: true,
+          limit,
+        }),
+        reasoning_options,
+        release_date: releaseDate,
+        last_updated: releaseDate,
+        status: existing?.status,
+        interleaved: existing?.interleaved,
+        limit: { context },
+      },
+      { context },
+      existing?.base_model === canonical ? existing.base_model_omit : undefined,
+    );
+  }
+
+  return {
+    name,
+    description: existing?.description ?? describeModel({
+      id: model.id,
+      name,
+      reasoning,
+      tool_call: true,
+      limit,
+    }),
+    release_date: releaseDate,
+    last_updated: releaseDate,
+    attachment: false,
+    reasoning,
+    reasoning_options,
+    temperature: true,
+    tool_call: true,
+    open_weights: false,
+    status: existing?.status,
+    interleaved: existing?.interleaved,
+    limit,
+    modalities: { input: ["text"], output: ["text"] },
+  } satisfies SyncedFullModel;
+}

--- a/packages/core/src/sync/providers/openstarry.ts
+++ b/packages/core/src/sync/providers/openstarry.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+import { describeModel } from "../../describe.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://api.openstarry.com/v1/models";
+
+export const OpenStarryModel = z.object({
+  id: z.string(),
+  created: z.number(),
+  supported_endpoint_types: z.array(z.string()).optional(),
+}).passthrough();
+
+export const OpenStarryResponse = z.object({
+  data: z.array(OpenStarryModel),
+}).passthrough();
+
+export type OpenStarryModel = z.infer<typeof OpenStarryModel>;
+
+export const openstarry = {
+  id: "openstarry",
+  name: "OpenStarry",
+  modelsDir: "providers/openstarry/models",
+  async fetchModels() {
+    const headers = process.env.OPENSTARRY_API_KEY
+      ? { Authorization: `Bearer ${process.env.OPENSTARRY_API_KEY}` }
+      : undefined;
+    const response = await fetch(API_ENDPOINT, { headers });
+    if (!response.ok) {
+      throw new Error(`OpenStarry request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return OpenStarryResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    return {
+      id: model.id,
+      model: buildOpenStarryModel(model, context.existing(model.id)),
+    };
+  },
+} satisfies SyncProvider<OpenStarryModel>;
+
+function dateFromTimestamp(timestamp: number) {
+  return new Date(timestamp * 1000).toISOString().slice(0, 10);
+}
+
+export function buildOpenStarryModel(
+  model: OpenStarryModel,
+  existing: ExistingModel | undefined,
+  baseModel?: string,
+): SyncedModel {
+  const name = model.id;
+  const reasoning = true;
+  const reasoning_options = existing?.reasoning_options ?? [
+    { type: "effort" as const, values: ["low", "medium", "high"] },
+  ];
+  // OpenStarry returns placeholder timestamps (2021-07-20); keep the authored
+  // release date when present, otherwise fall back to today.
+  const releaseDate = existing?.release_date ?? new Date().toISOString().slice(0, 10);
+  const canonical = existing?.base_model ?? baseModel ?? resolveModelMetadataBaseModel(model.id);
+
+  if (canonical !== undefined) {
+    return factorBaseModel(
+      canonical,
+      {
+        name: baseModel !== undefined ? name : undefined,
+        description: existing?.description ?? describeModel({
+          id: model.id,
+          name,
+          reasoning,
+          tool_call: true,
+        }),
+        reasoning_options,
+        release_date: releaseDate,
+        last_updated: releaseDate,
+        status: existing?.status,
+        interleaved: existing?.interleaved,
+      },
+      undefined,
+      existing?.base_model === canonical ? existing.base_model_omit : undefined,
+    );
+  }
+
+  return {
+    name,
+    description: existing?.description ?? describeModel({
+      id: model.id,
+      name,
+      reasoning,
+      tool_call: true,
+    }),
+    release_date: releaseDate,
+    last_updated: releaseDate,
+    attachment: false,
+    reasoning,
+    reasoning_options,
+    temperature: true,
+    tool_call: true,
+    open_weights: false,
+    status: existing?.status,
+    interleaved: existing?.interleaved,
+    limit: existing?.limit,
+    modalities: { input: ["text"], output: ["text"] },
+  } satisfies SyncedFullModel;
+}

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2.5"
+description = "MiniMax model for chat, coding, office work, and agentic tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 200_000
+output = 50_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M2.7.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M2.7.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M2.7"
+description = "MiniMax model for chat, coding, office work, and agentic tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 200_000
+output = 50_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,0 +1,21 @@
+name = "MiniMax M3"
+description = "MiniMax multimodal coding model for long-context reasoning and agent tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000
+output = 250_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.6-max-preview"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 200_000

--- a/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.6-plus"
+description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 200_000

--- a/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3.7-flash"
+description = "Efficient Qwen model for fast chat, extraction, and high-volume workloads"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3.7-max"
+description = "Flagship Qwen model for complex reasoning, coding, and agentic workflows"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3.7-plus"
+description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3.8-27b"
+description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3.8-max"
+description = "Flagship Qwen model for complex reasoning, coding, and agentic workflows"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/claude-fable-5.toml
+++ b/providers/commandcode/models/claude-fable-5.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-fable-5"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/claude-haiku-4-5-20251001.toml
+++ b/providers/commandcode/models/claude-haiku-4-5-20251001.toml
@@ -1,0 +1,7 @@
+base_model = "anthropic/claude-haiku-4-5-20251001"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/claude-opus-4-7.toml
+++ b/providers/commandcode/models/claude-opus-4-7.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-opus-4-7"
+description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/claude-opus-4-8.toml
+++ b/providers/commandcode/models/claude-opus-4-8.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-opus-4-8"
+description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/claude-opus-5.toml
+++ b/providers/commandcode/models/claude-opus-5.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-opus-5"
+description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/claude-sonnet-4-6.toml
+++ b/providers/commandcode/models/claude-sonnet-4-6.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-sonnet-4-6"
+description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/claude-sonnet-5.toml
+++ b/providers/commandcode/models/claude-sonnet-5.toml
@@ -1,0 +1,8 @@
+base_model = "anthropic/claude-sonnet-5"
+description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-flash-vision-exp"
+description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-flash"
+description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-pro"
+description = "Flagship DeepSeek model for coding, reasoning, and agentic work"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/google/gemini-3.1-flash-lite.toml
+++ b/providers/commandcode/models/google/gemini-3.1-flash-lite.toml
@@ -1,0 +1,10 @@
+base_model = "google/gemini-3.1-flash-lite"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000

--- a/providers/commandcode/models/google/gemini-3.5-flash-lite.toml
+++ b/providers/commandcode/models/google/gemini-3.5-flash-lite.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.5-flash-lite"
+description = "Low-latency Gemini model for high-volume multimodal and agent workloads"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000

--- a/providers/commandcode/models/google/gemini-3.5-flash.toml
+++ b/providers/commandcode/models/google/gemini-3.5-flash.toml
@@ -1,0 +1,10 @@
+base_model = "google/gemini-3.5-flash"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000

--- a/providers/commandcode/models/google/gemini-3.6-flash.toml
+++ b/providers/commandcode/models/google/gemini-3.6-flash.toml
@@ -1,0 +1,10 @@
+base_model = "google/gemini-3.6-flash"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000

--- a/providers/commandcode/models/google/gemini-3.7-flash.toml
+++ b/providers/commandcode/models/google/gemini-3.7-flash.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.7-flash"
+description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/gpt-5.3-codex.toml
+++ b/providers/commandcode/models/gpt-5.3-codex.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-5.3-codex"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/gpt-5.4-mini.toml
+++ b/providers/commandcode/models/gpt-5.4-mini.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.4-mini"
+description = "Compact GPT model for low-latency assistance and high-volume workloads"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/gpt-5.4.toml
+++ b/providers/commandcode/models/gpt-5.4.toml
@@ -1,0 +1,12 @@
+base_model = "openai/gpt-5.4"
+base_model_omit = ["limit.input"]
+description = "Frontier GPT model for professional reasoning, coding, and multimodal work"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 400_000

--- a/providers/commandcode/models/gpt-5.5.toml
+++ b/providers/commandcode/models/gpt-5.5.toml
@@ -1,0 +1,12 @@
+base_model = "openai/gpt-5.5"
+base_model_omit = ["limit.input"]
+description = "Frontier GPT model for professional reasoning, coding, and multimodal work"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 400_000

--- a/providers/commandcode/models/gpt-5.6-luna.toml
+++ b/providers/commandcode/models/gpt-5.6-luna.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.6-luna"
+description = "GPT model for general reasoning, writing, coding, and tool-assisted tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/gpt-5.6-sol.toml
+++ b/providers/commandcode/models/gpt-5.6-sol.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.6-sol"
+description = "GPT model for general reasoning, writing, coding, and tool-assisted tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/gpt-5.6-terra.toml
+++ b/providers/commandcode/models/gpt-5.6-terra.toml
@@ -1,0 +1,8 @@
+base_model = "openai/gpt-5.6-terra"
+description = "GPT model for general reasoning, writing, coding, and tool-assisted tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/meta/muse-spark-1.1.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.1.toml
@@ -1,0 +1,11 @@
+base_model = "meta/muse-spark-1.1"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_048_576

--- a/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
@@ -1,0 +1,21 @@
+name = "Muse Spark 1.2 Contributor"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_048_576
+output = 262_144
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/meta/muse-spark-1.2.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2.toml
@@ -1,0 +1,8 @@
+base_model = "meta/muse-spark-1.2"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.5"
+description = "Kimi model for long-context chat, coding, and agentic reasoning"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 256_000

--- a/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.6"
+description = "Kimi model for long-context chat, coding, and agentic reasoning"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 256_000

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
+description = "Kimi coding model for software agents, refactors, and repository reasoning"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 262_000

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.7-code"
+description = "Kimi coding model for software agents, refactors, and repository reasoning"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 256_000

--- a/providers/commandcode/models/moonshotai/Kimi-K3.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K3.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k3"
+description = "Kimi model for long-context chat, coding, and agentic reasoning"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000

--- a/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,8 @@
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+description = "Flagship Nemotron model for high-throughput reasoning and complex agents"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/poolside/laguna-s-2.1-free.toml
+++ b/providers/commandcode/models/poolside/laguna-s-2.1-free.toml
@@ -1,0 +1,21 @@
+name = "Laguna S 2.1"
+description = "Free provider route for experiments, demos, and cost-sensitive chat workloads"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 256_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/sakana/fugu-ultra.toml
+++ b/providers/commandcode/models/sakana/fugu-ultra.toml
@@ -1,0 +1,7 @@
+base_model = "sakana/fugu-ultra"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/stealth/ox-alpha.toml
+++ b/providers/commandcode/models/stealth/ox-alpha.toml
@@ -1,0 +1,8 @@
+base_model = "stealth/ox-alpha"
+description = "Reasoning model for deliberate analysis, multi-step problem solving, and tool use"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
@@ -1,0 +1,12 @@
+base_model = "stepfun/step-3.5-flash"
+base_model_omit = ["limit.input"]
+description = "StepFun flash model for efficient multimodal reasoning, coding, and tool use"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000

--- a/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
@@ -1,0 +1,8 @@
+base_model = "stepfun/step-3.7-flash"
+description = "StepFun flash model for efficient multimodal reasoning, coding, and tool use"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/tencent/hy3-paid.toml
+++ b/providers/commandcode/models/tencent/hy3-paid.toml
@@ -1,0 +1,21 @@
+name = "Tencent Hy3"
+description = "Tencent Hy reasoning model for coding, instruction following, and agent tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/thinkingmachines/inkling-small.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling-small.toml
@@ -1,0 +1,11 @@
+base_model = "thinkingmachines/inkling-small"
+description = "Efficient model for low-latency assistance, extraction, and routine automation"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000

--- a/providers/commandcode/models/thinkingmachines/inkling.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling.toml
@@ -1,0 +1,11 @@
+base_model = "thinkingmachines/inkling"
+description = "Reasoning model for deliberate analysis, multi-step problem solving, and tool use"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 256_000

--- a/providers/commandcode/models/xai/grok-4.5.toml
+++ b/providers/commandcode/models/xai/grok-4.5.toml
@@ -1,0 +1,8 @@
+base_model = "xai/grok-4.5"
+description = "Grok model for agentic tool use, reasoning, coding, and live assistance"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/xai/grok-4.6.toml
+++ b/providers/commandcode/models/xai/grok-4.6.toml
@@ -1,0 +1,8 @@
+base_model = "xai/grok-4.6"
+description = "Grok model for agentic tool use, reasoning, coding, and live assistance"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,0 +1,11 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+description = "MiMo pro model for strong multimodal reasoning and agent execution"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000

--- a/providers/commandcode/models/xiaomi/mimo-v2.5.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5.toml
@@ -1,0 +1,11 @@
+base_model = "xiaomi/mimo-v2.5"
+description = "MiMo model for long-context reasoning, perception, and agentic tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000

--- a/providers/commandcode/models/zai-org/GLM-5.1.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.1.toml
@@ -1,0 +1,8 @@
+base_model = "zhipuai/glm-5.1"
+description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
@@ -1,0 +1,21 @@
+name = "GLM-5.2 Fast"
+description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 1_000_000
+output = 250_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/zai-org/GLM-5.2.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,8 @@
+base_model = "zhipuai/glm-5.2"
+description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/zai-org/GLM-5.3.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.3.toml
@@ -1,0 +1,8 @@
+base_model = "zhipuai/glm-5.3"
+description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/zai-org/GLM-5.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5"
+description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 200_000

--- a/providers/commandcode/provider.toml
+++ b/providers/commandcode/provider.toml
@@ -1,0 +1,7 @@
+name = "Command Code"
+env = ["COMMAND_CODE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# Reasoning effort is controlled via the `reasoning_effort` request body field
+# (low | medium | high). The model list endpoint is public and requires no key.
+api = "https://api.commandcode.ai/provider/v1"
+doc = "https://commandcode.ai/docs/reference/cli/models"

--- a/providers/openstarry/models/MiniMax-M2.7-highspeed.toml
+++ b/providers/openstarry/models/MiniMax-M2.7-highspeed.toml
@@ -1,0 +1,8 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
+description = "High-speed MiniMax model for low-latency coding and agent workflows"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/models/MiniMax-M2.7.toml
+++ b/providers/openstarry/models/MiniMax-M2.7.toml
@@ -1,0 +1,8 @@
+base_model = "minimax/MiniMax-M2.7"
+description = "MiniMax model for chat, coding, office work, and agentic tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/models/deepseek-v4-flash-0731.toml
+++ b/providers/openstarry/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/models/deepseek-v4-flash.toml
+++ b/providers/openstarry/models/deepseek-v4-flash.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-flash"
+description = "Fast DeepSeek model for efficient chat, coding help, and agent loops"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/models/deepseek-v4-pro-0813.toml
+++ b/providers/openstarry/models/deepseek-v4-pro-0813.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v4-pro-0813"
+description = "Flagship DeepSeek model for coding, reasoning, and agentic work"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/models/glm-5.3.toml
+++ b/providers/openstarry/models/glm-5.3.toml
@@ -1,0 +1,8 @@
+base_model = "zhipuai/glm-5.3"
+description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/models/kimi-k2.6.toml
+++ b/providers/openstarry/models/kimi-k2.6.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.6"
+description = "Kimi model for long-context chat, coding, and agentic reasoning"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/models/kimi-k2.7-code.toml
+++ b/providers/openstarry/models/kimi-k2.7-code.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.7-code"
+description = "Kimi coding model for software agents, refactors, and repository reasoning"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/models/mimo-v2.5.toml
+++ b/providers/openstarry/models/mimo-v2.5.toml
@@ -1,0 +1,8 @@
+base_model = "xiaomi/mimo-v2.5"
+description = "MiMo model for long-context reasoning, perception, and agentic tasks"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/models/qwen3.7-plus.toml
+++ b/providers/openstarry/models/qwen3.7-plus.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3.7-plus"
+description = "Reasoning model for deliberate analysis, multi-step problem solving, and tool use"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/openstarry/provider.toml
+++ b/providers/openstarry/provider.toml
@@ -1,0 +1,7 @@
+name = "OpenStarry"
+env = ["OPENSTARRY_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# Reasoning effort is controlled via the `reasoning_effort` request body field
+# (low | medium | high). The model list endpoint requires an API key.
+api = "https://api.openstarry.com/v1"
+doc = "https://api.openstarry.com/openstarry-docs.html"


### PR DESCRIPTION
## Summary

Add sync providers and model catalogs for two OpenAI-compatible gateways:

- **Command Code** (\pi.commandcode.ai\) — 58 models, public model list endpoint
- **OpenStarry** (\pi.openstarry.com\) — 10 models, key-protected model list endpoint

Also adds base metadata for \stealth/ox-alpha\ (free preview model, 1M context, multimodal input).

## Changes

- \packages/core/src/sync/providers/commandcode.ts\ — sync provider (public endpoint, no auth)
- \packages/core/src/sync/providers/openstarry.ts\ — sync provider (uses \OPENSTARRY_API_KEY\)
- \packages/core/src/sync/index.ts\ — register both providers in \providers\ and \groups.direct\
- \providers/commandcode/\ — provider.toml + 58 generated model TOMLs
- \providers/openstarry/\ — provider.toml + 10 generated model TOMLs
- \models/stealth/ox-alpha.toml\ — base metadata for the free Ox Alpha model

## Notes

- Both catalogs were generated with \un models:sync commandcode\ / \un models:sync openstarry\
- Models that resolve to a canonical base model (deepseek, qwen, glm, kimi, minimax, etc.) use \ase_model\ references; the rest carry full metadata
- Command Code's endpoint is public; OpenStarry's requires an API key (injected via CI secrets)