### PR TITLE
Add Pendra provider (OpenAI-compatible)

### DIFF
--- a/providers/pendra/logo.svg
+++ b/providers/pendra/logo.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 150 150" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <g transform="matrix(1.46991,0,0,1.46991,-151.41,-386.933)">
+    <g transform="matrix(5.96537e-17,0.857236,-3.15843,1.91599e-16,978.649,169.416)">
+      <rect x="123.238" y="248.157" width="88.679" height="26.05" style="fill:none;stroke:currentColor;stroke-width:6.12px;"/>
+    </g>
+    <g transform="matrix(0.680313,0,0,0.680313,98.5276,270.41)">
+      <rect x="99.75" y="76.548" width="24.655" height="24.64" style="fill:currentColor;"/>
+    </g>
+  </g>
+</svg>

--- a/providers/pendra/models/deepseek-v4-flash.toml
+++ b/providers/pendra/models/deepseek-v4-flash.toml
@@ -1,7 +1,8 @@
 base_model = "deepseek/deepseek-v4-flash"
 
-# Reasons by default; Pendra exposes no configurable effort/budget control.
-reasoning_options = []
+# Pendra forwards OpenAI `reasoning_effort` (low|high|max) on chat completions.
+# Effort-only: no thinking on/off toggle is surfaced through Pendra.
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 
 # Self-hosted on your own workers — no per-token charge at the API.
 [cost]

--- a/providers/pendra/models/deepseek-v4-flash.toml
+++ b/providers/pendra/models/deepseek-v4-flash.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+# Reasons by default; Pendra exposes no configurable effort/budget control.
+reasoning_options = []
+
+# Self-hosted on your own workers — no per-token charge at the API.
+[cost]
+input = 0
+output = 0

--- a/providers/pendra/models/glm-4.7-flash.toml
+++ b/providers/pendra/models/glm-4.7-flash.toml
@@ -1,0 +1,9 @@
+base_model = "zhipuai/glm-4.7-flash"
+
+# Hybrid reasoning; Pendra exposes no configurable effort/budget control.
+reasoning_options = []
+
+# Self-hosted on your own workers — no per-token charge at the API.
+[cost]
+input = 0
+output = 0

--- a/providers/pendra/models/gpt-oss:120b.toml
+++ b/providers/pendra/models/gpt-oss:120b.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-oss-120b"
+
+# gpt-oss honours OpenAI-style `reasoning_effort` (low|medium|high), which
+# Pendra forwards on POST /api/v1/chat/completions.
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+# Pendra serves models on your own workers — there is no per-token charge at
+# the API. Billing is by GPU/plan, so token costs are zero here.
+[cost]
+input = 0
+output = 0

--- a/providers/pendra/models/llama3.3:70b.toml
+++ b/providers/pendra/models/llama3.3:70b.toml
@@ -1,0 +1,13 @@
+base_model = "meta/llama-3.3-70b-instruct"
+
+# Pendra serves Llama 3.3 70B as a text-only chat model (no vision).
+attachment = false
+
+# Self-hosted on your own workers — no per-token charge at the API.
+[cost]
+input = 0
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/pendra/models/llama3.3:70b.toml
+++ b/providers/pendra/models/llama3.3:70b.toml
@@ -7,7 +7,3 @@ attachment = false
 [cost]
 input = 0
 output = 0
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/pendra/models/qwen3-coder:30b.toml
+++ b/providers/pendra/models/qwen3-coder:30b.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
+
+# Self-hosted on your own workers — no per-token charge at the API.
+[cost]
+input = 0
+output = 0

--- a/providers/pendra/models/qwen3.6:27b.toml
+++ b/providers/pendra/models/qwen3.6:27b.toml
@@ -1,0 +1,16 @@
+base_model = "alibaba/qwen3.6-27b"
+
+# Hybrid reasoning; Pendra exposes no configurable effort/budget control.
+reasoning_options = []
+
+# Pendra serves Qwen3.6 27B with text + image input (no audio/video).
+attachment = true
+
+# Self-hosted on your own workers — no per-token charge at the API.
+[cost]
+input = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/pendra/models/qwen3.6:27b.toml
+++ b/providers/pendra/models/qwen3.6:27b.toml
@@ -3,9 +3,6 @@ base_model = "alibaba/qwen3.6-27b"
 # Hybrid reasoning; Pendra exposes no configurable effort/budget control.
 reasoning_options = []
 
-# Pendra serves Qwen3.6 27B with text + image input (no audio/video).
-attachment = true
-
 # Self-hosted on your own workers — no per-token charge at the API.
 [cost]
 input = 0

--- a/providers/pendra/provider.toml
+++ b/providers/pendra/provider.toml
@@ -1,0 +1,12 @@
+# Reasoning HTTP format (accessed 2026-08-24):
+# Pendra exposes an OpenAI-compatible surface and forwards chat-completions
+# request fields to the in-process engine, so `reasoning_effort` on
+# POST /api/v1/chat/completions is honoured by models that support it
+# (e.g. gpt-oss). There is no separate reasoning toggle/budget request field.
+# https://pendra.ai/docs/integrations/opencode
+# https://pendra.ai/docs/api/chat-completions
+name = "Pendra"
+env = ["PENDRA_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.pendra.ai/api/v1"
+doc = "https://pendra.ai/docs/integrations/opencode"


### PR DESCRIPTION
Adds [Pendra](https://pendra.ai) as an OpenAI-compatible provider so it can be selected in opencode and looked up via the API.

**About Pendra:** a UK-based GPU inference platform. Users run their own GPU workers and serve open-weight models through them; Pendra exposes an OpenAI-compatible API in front. Because inference runs on the customer's own hardware, there's no per-token API charge (billing is by GPU/plan), so model `[cost]` is `0` — the same convention the self-hosted `lmstudio` provider uses.

**What's included**
- `provider.toml` — `@ai-sdk/openai-compatible`, `api = https://api.pendra.ai/api/v1`, `env = ["PENDRA_API_KEY"]`.
- `logo.svg` — monochrome, `currentColor`.
- Six flagship models as `base_model` wrappers of existing `models/` metadata: `qwen3-coder:30b`, `gpt-oss:120b`, `qwen3.6:27b`, `deepseek-v4-flash`, `glm-4.7-flash`, `llama3.3:70b`.

**Accuracy notes**
- Modalities/attachment are narrowed to what Pendra actually serves — e.g. `qwen3.6:27b` is text+image only (the base lists audio/video), and `llama3.3:70b` is text-only.
- `reasoning_options`: `gpt-oss:120b` exposes OpenAI-style `reasoning_effort` (low/medium/high); the hybrid-reasoning models declare `[]` (reasoning on, no configurable effort/budget surfaced).

Ran `bun run validate` locally — passes.