### PR TITLE
Add Riverflow image models and OpenRouter sync support

### DIFF
--- a/models/sourceful/riverflow-2.0-fast.toml
+++ b/models/sourceful/riverflow-2.0-fast.toml
@@ -1,0 +1,32 @@
+# Sources:
+# - https://www.riverflow.ai/research/introducing-riverflow-2-0
+# - https://runware.ai/docs/models/sourceful-riverflow-2-0-fast
+
+name = "Riverflow 2.0 Fast"
+description = "Sourceful's speed-optimized Riverflow 2.0 image generation and editing model for latency-sensitive production pipelines, with product fidelity and font control"
+release_date = "2026-01-30"
+last_updated = "2026-01-30"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+structured_output = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[[links]]
+label = "Announcement"
+url = "https://www.riverflow.ai/research/introducing-riverflow-2-0"
+type = "announcement"
+
+[[links]]
+label = "API documentation"
+url = "https://runware.ai/docs/models/sourceful-riverflow-2-0-fast"
+type = "docs"

--- a/models/sourceful/riverflow-2.0-pro.toml
+++ b/models/sourceful/riverflow-2.0-pro.toml
@@ -1,0 +1,32 @@
+# Sources:
+# - https://www.riverflow.ai/research/introducing-riverflow-2-0
+# - https://runware.ai/docs/models/sourceful-riverflow-2-0-pro
+
+name = "Riverflow 2.0 Pro"
+description = "Sourceful's quality-focused Riverflow 2.0 image generation and editing model for reliable product rendering, font control, and reference-based detail preservation"
+release_date = "2026-01-30"
+last_updated = "2026-01-30"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+structured_output = false
+open_weights = false
+
+[limit]
+context = 8_192
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[[links]]
+label = "Announcement"
+url = "https://www.riverflow.ai/research/introducing-riverflow-2-0"
+type = "announcement"
+
+[[links]]
+label = "API documentation"
+url = "https://runware.ai/docs/models/sourceful-riverflow-2-0-pro"
+type = "docs"

--- a/models/sourceful/riverflow-2.5-fast.toml
+++ b/models/sourceful/riverflow-2.5-fast.toml
@@ -1,0 +1,33 @@
+# Sources:
+# - https://www.riverflow.ai/research/introducing-riverflow-2-5
+# - https://runware.ai/docs/models/sourceful-riverflow-2-5-fast
+# - https://replicate.com/sourceful/riverflow-v2.5-fast
+
+name = "Riverflow 2.5 Fast"
+description = "Sourceful's speed-optimized Riverflow 2.5 image generation and editing model for lower-cost drafts, rapid iteration, and latency-sensitive production workflows"
+release_date = "2026-06-05"
+last_updated = "2026-06-05"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = false
+structured_output = false
+open_weights = false
+
+[limit]
+context = 32_768
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[[links]]
+label = "Announcement"
+url = "https://www.riverflow.ai/research/introducing-riverflow-2-5"
+type = "announcement"
+
+[[links]]
+label = "API documentation"
+url = "https://runware.ai/docs/models/sourceful-riverflow-2-5-fast"
+type = "docs"

--- a/models/sourceful/riverflow-2.5-pro.toml
+++ b/models/sourceful/riverflow-2.5-pro.toml
@@ -1,0 +1,33 @@
+# Sources:
+# - https://www.riverflow.ai/research/introducing-riverflow-2-5
+# - https://runware.ai/docs/models/sourceful-riverflow-2-5-pro
+# - https://replicate.com/sourceful/riverflow-v2.5-pro
+
+name = "Riverflow 2.5 Pro"
+description = "Sourceful's highest-capability Riverflow 2.5 image generation and editing model, with multi-step reasoning, candidate scoring, adjustable thinking effort, and production-focused brand controls"
+release_date = "2026-06-05"
+last_updated = "2026-06-05"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = false
+structured_output = false
+open_weights = false
+
+[limit]
+context = 32_768
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]
+
+[[links]]
+label = "Announcement"
+url = "https://www.riverflow.ai/research/introducing-riverflow-2-5"
+type = "announcement"
+
+[[links]]
+label = "API documentation"
+url = "https://runware.ai/docs/models/sourceful-riverflow-2-5-pro"
+type = "docs"

--- a/packages/core/src/sync/providers/openrouter.ts
+++ b/packages/core/src/sync/providers/openrouter.ts
@@ -6,7 +6,10 @@ import { describeModel } from "../../describe.js";
 import { inferKimiFamily, ModelFamilyValues } from "../../family.js";
 import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
 
-const API_ENDPOINT = "https://openrouter.ai/api/v1/models";
+const API_ENDPOINTS = [
+  "https://openrouter.ai/api/v1/models",
+  "https://openrouter.ai/api/v1/models?output_modalities=image",
+] as const;
 const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
 const modelMetadataByID = new Map<string, Record<string, unknown>>();
 const modelMetadataFilesByProvider = new Map<string, Set<string>>();
@@ -64,6 +67,8 @@ export const OpenRouterModel = z.object({
   pricing: z.object({
     prompt: z.string(),
     completion: z.string(),
+    image_token: z.string().optional(),
+    image_output: z.string().optional(),
     internal_reasoning: z.string().optional(),
     input_cache_read: z.string().optional(),
     input_cache_write: z.string().optional(),
@@ -107,11 +112,14 @@ export const openrouter = {
     const headers = process.env.OPENROUTER_API_KEY
       ? { Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}` }
       : undefined;
-    const response = await fetch(API_ENDPOINT, { headers });
-    if (!response.ok) {
-      throw new Error(`OpenRouter request failed: ${response.status} ${response.statusText}`);
-    }
-    return response.json();
+    const responses = await Promise.all(API_ENDPOINTS.map(async (endpoint) => {
+      const response = await fetch(endpoint, { headers });
+      if (!response.ok) {
+        throw new Error(`OpenRouter request failed: ${response.status} ${response.statusText}`);
+      }
+      return response.json();
+    }));
+    return mergeOpenRouterResponses(responses);
   },
   parseModels(raw) {
     // Temporarily skip batch routes (`*:batch`) — they are not catalog targets.
@@ -133,6 +141,13 @@ export const openrouter = {
     };
   },
 } satisfies SyncProvider<OpenRouterModel>;
+
+export function mergeOpenRouterResponses(responses: unknown[]) {
+  const models = responses.flatMap((raw) => OpenRouterResponse.parse(raw).data);
+  return {
+    data: [...new Map(models.map((model) => [model.id, model])).values()],
+  };
+}
 
 function isUnavailable(model: OpenRouterModel) {
   return (
@@ -209,7 +224,11 @@ export function buildOpenRouterModel(
   const input = modalities(model.architecture.input_modalities, ["text"]);
   const output = modalities(model.architecture.output_modalities, ["text"]);
   const prompt = price(model.pricing.prompt);
-  const completion = price(model.pricing.completion);
+  const completion = price(
+    output.includes("image")
+      ? (model.pricing.image_output ?? model.pricing.image_token ?? model.pricing.completion)
+      : model.pricing.completion,
+  );
   const reasoning = params.has("reasoning") || params.has("include_reasoning");
   // Prefer OpenRouter's live reasoning metadata over authored options so aliases
   // and rotated models pick up new efforts/budget support. Fall back to authored

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -52,6 +52,7 @@ import {
 } from "../src/sync/providers/empiriolabs.js";
 import {
   buildOpenRouterModel,
+  mergeOpenRouterResponses,
   openrouter,
   resolveCanonicalBaseModel,
   type OpenRouterModel,
@@ -2077,6 +2078,46 @@ test("OpenRouter sync maps pricing.overrides into cost tiers", () => {
         cache_read: 0.6,
       }],
     },
+  });
+});
+
+test("OpenRouter sync merges image-only models and deduplicates IDs", () => {
+  const text = openRouterModel();
+  const image = openRouterModel({
+    id: "sourceful/riverflow-v2.5-pro",
+    architecture: {
+      input_modalities: ["text", "image"],
+      output_modalities: ["image"],
+    },
+  });
+
+  expect(mergeOpenRouterResponses([
+    { data: [text] },
+    { data: [image, text] },
+  ]).data.map((model) => model.id)).toEqual([
+    "anthropic/claude-sonnet-5",
+    "sourceful/riverflow-v2.5-pro",
+  ]);
+});
+
+test("OpenRouter sync uses image output pricing for image models", () => {
+  const model = buildOpenRouterModel(openRouterModel({
+    id: "sourceful/riverflow-v2.5-pro",
+    architecture: {
+      input_modalities: ["text", "image"],
+      output_modalities: ["image"],
+    },
+    pricing: {
+      prompt: "0",
+      completion: "0",
+      image_token: "0.000031",
+      image_output: "0.000032",
+    },
+  }), undefined, "sourceful/riverflow-2.5-pro");
+
+  expect(model).toMatchObject({
+    base_model: "sourceful/riverflow-2.5-pro",
+    cost: { input: 0, output: 32 },
   });
 });
 

--- a/providers/openrouter/models/sourceful/riverflow-v2-fast.toml
+++ b/providers/openrouter/models/sourceful/riverflow-v2-fast.toml
@@ -1,0 +1,6 @@
+# Source: https://openrouter.ai/api/v1/models?output_modalities=image (accessed 2026-08-24)
+base_model = "sourceful/riverflow-2.0-fast"
+
+[cost]
+input = 0
+output = 4.790419

--- a/providers/openrouter/models/sourceful/riverflow-v2-pro.toml
+++ b/providers/openrouter/models/sourceful/riverflow-v2-pro.toml
@@ -1,0 +1,6 @@
+# Source: https://openrouter.ai/api/v1/models?output_modalities=image (accessed 2026-08-24)
+base_model = "sourceful/riverflow-2.0-pro"
+
+[cost]
+input = 0
+output = 35.928144

--- a/providers/openrouter/models/sourceful/riverflow-v2.5-fast.toml
+++ b/providers/openrouter/models/sourceful/riverflow-v2.5-fast.toml
@@ -1,0 +1,10 @@
+# Source: https://openrouter.ai/api/v1/models?output_modalities=image (accessed 2026-08-24)
+base_model = "sourceful/riverflow-2.5-fast"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0
+output = 4.550898

--- a/providers/openrouter/models/sourceful/riverflow-v2.5-pro.toml
+++ b/providers/openrouter/models/sourceful/riverflow-v2.5-pro.toml
@@ -1,0 +1,10 @@
+# Source: https://openrouter.ai/api/v1/models?output_modalities=image (accessed 2026-08-24)
+base_model = "sourceful/riverflow-2.5-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+[cost]
+input = 0
+output = 31.137725

--- a/sync.md
+++ b/sync.md
@@ -152,10 +152,10 @@ CrossModel is implemented in `packages/core/src/sync/providers/crossmodel.ts`.
 
 OpenRouter is implemented in `packages/core/src/sync/providers/openrouter.ts`.
 
-- Source endpoint: `https://openrouter.ai/api/v1/models`.
+- Source endpoints: `https://openrouter.ai/api/v1/models` and the same endpoint filtered with `output_modalities=image` so image-only models are included.
 - Optional auth: `OPENROUTER_API_KEY`.
 - Model IDs map directly to TOML paths under `providers/openrouter/models`.
-- API prices are per-token strings and are converted to per-1M-token numbers.
+- API prices are per-token strings and are converted to per-1M-token numbers; image-output models use `image_output` (falling back to `image_token`) for output cost.
 - `structured_output` comes from `supported_parameters.includes("structured_outputs")` only.
 - Existing `status`, `interleaved`, `knowledge`, `limit.input`, and `cost.tiers` may be preserved when OpenRouter is not authoritative enough for those fields.
 - Canonical OpenRouter model IDs should emit `base_model` references to model metadata when a matching `models/` entry exists.


### PR DESCRIPTION
## Summary

- Add canonical metadata for Riverflow 2.0 Fast/Pro and Riverflow 2.5 Fast/Pro so image-generation clients can discover their capabilities, limits, release data, and documentation.
- Publish OpenRouter bindings for all four APIs, including live reasoning-effort controls for Riverflow 2.5 and image-output pricing converted to USD per million tokens.
- Extend the OpenRouter sync to merge its image-only catalog with the default model feed so scheduled syncs retain Riverflow and future image-output models.

## Why

OpenRouter's default models response excludes image-only APIs. Manually adding Riverflow bindings without expanding the sync source would cause the hourly sync to treat them as missing and remove them.

## Risk

The additional fetch is limited to `output_modalities=image`, merged by model ID, and leaves the existing text-model feed unchanged. Image-output routes use OpenRouter's `image_output` price, with `image_token` and the existing completion price as fallbacks.

## Validation

- `bun test packages/core/test/sync.test.ts --test-name-pattern 'OpenRouter sync'` — 5 passed
- `bun validate` — passed
- Parsed the live OpenRouter image catalog snapshot — 45 models, including all four Riverflow APIs
- The full sync test file currently has one unrelated baseline failure in `DeepInfra preserves live modalities for new base models`; all 163 other tests passed, including the new OpenRouter coverage.

## Sources

- [Riverflow 2.0 announcement](https://www.riverflow.ai/research/introducing-riverflow-2-0)
- [Riverflow 2.5 announcement](https://www.riverflow.ai/research/introducing-riverflow-2-5)
- [OpenRouter image model catalog](https://openrouter.ai/api/v1/models?output_modalities=image)
