### PR TITLE
feat(canonn): add Canonn provider and Canonn R1

### DIFF
--- a/providers/canonn/models/canonn-r1.toml
+++ b/providers/canonn/models/canonn-r1.toml
@@ -1,0 +1,22 @@
+name = "Canonn R1"
+description = "Fine-tuned for context faithfulness: answers from the documents it is given, says so when the answer is absent, and flags passages that contradict each other."
+release_date = "2026-07-28"
+last_updated = "2026-07-28"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = false
+open_weights = false
+
+[cost]
+input = 1.20
+output = 6.00
+
+[limit]
+context = 16_384
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/canonn/provider.toml
+++ b/providers/canonn/provider.toml
@@ -1,0 +1,9 @@
+name = "Canonn"
+env = ["CANONN_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# OpenAI-compatible surface (verified 2026-08-24): GET /v1/models returns the
+# served model, POST /v1/chat/completions streams. A public, unauthenticated
+# catalog at https://api.canonn.ai/v1/models/catalog carries pricing, limits
+# and supported sampling parameters, and is the source for the model file.
+doc = "https://canonn.ai/docs/"
+api = "https://api.canonn.ai/v1"


### PR DESCRIPTION
Adds Canonn as a provider with its own model. Canonn hosts the fine-tune it trained behind an OpenAI-compatible API, so per AGENTS.md this is a first-party inline model definition rather than a `base_model` override.

**Draft until the logo lands.** `providers/canonn/logo.svg` is a blocker for new providers and the company's mark exists only as a raster today; the SVG is being produced and will be pushed to this branch. Everything else is complete and `bun validate` passes. Happy to hold the PR closed until then if maintainers prefer.

### Source of the data

Every field comes from the provider's public, unauthenticated catalog, checked 2026-08-24:

```bash
curl https://api.canonn.ai/v1/models/catalog
```

- `input = 1.20` / `output = 6.00` per million - the catalog's per-token strings `0.0000012` / `0.000006`
- `context = 16_384`, `output = 4_096` - `context_length` / `max_output_length`
- text in, text out - `input_modalities` / `output_modalities`
- `tool_call = false`, `reasoning = false`, `attachment = false` - the catalog lists `streaming` as the only supported feature. This one matters: the model answers from supplied documents and cites them, so an agent that selected it as a driving model would fail at the first tool call.
- `release_date` / `last_updated` - the catalog's `created` (1785196800 = 2026-07-28)

`GET /v1/models` and `POST /v1/chat/completions` are live at `https://api.canonn.ai/v1` with a bearer key.

### Notes

`family` is left unset: the enum has no value for this lab, and adding one is a separate change from listing the provider.