### PR TITLE
fix(openai): gpt-5.6-sol + gpt-5.6 alias still on the pre-2026-08-22 rate ($5/$30 → $4/$20)

### DIFF
--- a/providers/openai/models/gpt-5.6-sol.toml
+++ b/providers/openai/models/gpt-5.6-sol.toml
@@ -2,20 +2,20 @@ base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 2.00
-output = 10.00
-cache_read = 0.20
-cache_write = 2.50
-
-[[cost.tiers]]
-tier = { size = 272_000 }
 input = 4.00
-output = 15.00
+output = 20.00
 cache_read = 0.40
 cache_write = 5.00
 
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 8.00
+output = 30.00
+cache_read = 0.80
+cache_write = 10.00
+
 [experimental.modes.fast]
-cost = { input = 4.00, output = 20.00, cache_read = 0.40, cache_write = 2.50 }
+cost = { input = 8.00, output = 40.00, cache_read = 0.80, cache_write = 10.00 }
 provider = { body = { service_tier = "priority" } }
 
 [experimental.modes.pro]

--- a/providers/openai/models/gpt-5.6-sol.toml
+++ b/providers/openai/models/gpt-5.6-sol.toml
@@ -2,20 +2,20 @@ base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 5.00
-output = 30.00
-cache_read = 0.50
-cache_write = 6.25
+input = 2.00
+output = 10.00
+cache_read = 0.20
+cache_write = 2.50
 
 [[cost.tiers]]
 tier = { size = 272_000 }
-input = 10.00
-output = 45.00
-cache_read = 1.00
-cache_write = 12.50
+input = 4.00
+output = 15.00
+cache_read = 0.40
+cache_write = 5.00
 
 [experimental.modes.fast]
-cost = { input = 10.00, output = 60.00, cache_read = 1.00, cache_write = 12.50 }
+cost = { input = 4.00, output = 20.00, cache_read = 0.40, cache_write = 2.50 }
 provider = { body = { service_tier = "priority" } }
 
 [experimental.modes.pro]

--- a/providers/openai/models/gpt-5.6.toml
+++ b/providers/openai/models/gpt-5.6.toml
@@ -3,20 +3,20 @@ name = "GPT-5.6"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 2.00
-output = 10.00
-cache_read = 0.20
-cache_write = 2.50
-
-[[cost.tiers]]
-tier = { size = 272_000 }
 input = 4.00
-output = 15.00
+output = 20.00
 cache_read = 0.40
 cache_write = 5.00
 
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 8.00
+output = 30.00
+cache_read = 0.80
+cache_write = 10.00
+
 [experimental.modes.fast]
-cost = { input = 4.00, output = 20.00, cache_read = 0.40, cache_write = 2.50 }
+cost = { input = 8.00, output = 40.00, cache_read = 0.80, cache_write = 10.00 }
 provider = { body = { service_tier = "priority" } }
 
 [experimental.modes.pro]

--- a/providers/openai/models/gpt-5.6.toml
+++ b/providers/openai/models/gpt-5.6.toml
@@ -3,20 +3,20 @@ name = "GPT-5.6"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 5.00
-output = 30.00
-cache_read = 0.50
-cache_write = 6.25
+input = 2.00
+output = 10.00
+cache_read = 0.20
+cache_write = 2.50
 
 [[cost.tiers]]
 tier = { size = 272_000 }
-input = 10.00
-output = 45.00
-cache_read = 1.00
-cache_write = 12.50
+input = 4.00
+output = 15.00
+cache_read = 0.40
+cache_write = 5.00
 
 [experimental.modes.fast]
-cost = { input = 10.00, output = 60.00, cache_read = 1.00, cache_write = 12.50 }
+cost = { input = 4.00, output = 20.00, cache_read = 0.40, cache_write = 2.50 }
 provider = { body = { service_tier = "priority" } }
 
 [experimental.modes.pro]


### PR DESCRIPTION
## What

OpenAI repriced `gpt-5.6-sol` on **2026-08-22**. The catalog still holds the pre-change rate, so it currently overbills by **25% on input / cache read / cache write and 50% on output**, and the same staleness sits in the `> 272K` tier and in `[experimental.modes.fast]`.

| | catalog (before) | OpenAI today |
|---|---|---|
| `input` | 5.00 | **4.00** |
| `output` | 30.00 | **20.00** |
| `cache_read` | 0.50 | **0.40** |
| `cache_write` | 6.25 | **5.00** |
| `> 272K` input / output / read / write | 10.00 / 45.00 / 1.00 / 12.50 | **8.00 / 30.00 / 0.80 / 10.00** |
| `modes.fast` input / output / read / write | 10.00 / 60.00 / 1.00 / 12.50 | **8.00 / 40.00 / 0.80 / 10.00** |

Two files, because `providers/openai/models/gpt-5.6.toml` is the alias (`base_model = "openai/gpt-5.6-sol"`) and carries its own copy of the same cost block.

`bun validate` passes.

## Source — OpenAI's own pricing page

<https://developers.openai.com/api/docs/pricing>, columns `Model | Input | Cached input | Cache writes | Output` for short context, then the same four for long context.

**Standard** tab:

```
gpt-5.6-sol    $4.00  $0.40  $5.00  $20.00   $8.00  $0.80  $10.00  $30.00
gpt-5.6-terra  $2.00  $0.20  $2.50  $12.00   $4.00  $0.40  $5.00   $18.00
gpt-5.6-luna   $0.20  $0.02  $0.25  $1.20    $0.40  $0.04  $0.50   $1.80
```

**Fast mode** tab:

```
gpt-5.6-sol    $8.00  $0.80  $10.00  $40.00  $16.00  $1.60  $20.00  $60.00
```

The footnote directly under the Standard table reads: *"GPT-5.6 Sol's promotional pricing is available at least through November 21, 2026."* So the $4/$20 above **is** the promotional rate — it is what the page publishes as Standard today, and the promo has a floor date, not an expiry that has passed.

## When it changed

The current values were correct when they were written; the page moved under them.

- <http://web.archive.org/web/20260820103036/https://developers.openai.com/api/docs/pricing> — Standard `gpt-5.6-sol $5.00 $0.50 $6.25 $30.00 $10.00 $1.00 $12.50 $45.00`, Fast `$10.00 $1.00 $12.50 $60.00`. Exactly the current catalog values, no promo footnote.
- <http://web.archive.org/web/20260822103053/https://developers.openai.com/api/docs/pricing> — Standard `$4.00 $0.40 $5.00 $20.00 $8.00 $0.80 $10.00 $30.00`, and the promo footnote appears.

So this is one un-synced change on 08-21/22, not a transcription problem.

## Not touched

`gpt-5.6-terra` (2 / 12 / 0.20 / 2.50) and `gpt-5.6-luna` (0.20 / 1.20 / 0.02 / 0.25) already match the Standard tab on every field including their long-context tiers. Only Sol moved. Azure and Bedrock still bill the old rate (OpenRouter's endpoint list for `openai/gpt-5.6-sol` shows Azure at 5.00/30.00/0.50/6.25 and Bedrock at 5.50/33.00/0.55/6.875), so anything keyed to those providers should stay where it is — this PR only touches `providers/openai/`.

Happy to split this into two PRs, or to drop the `modes.fast` change if you'd rather handle experimental blocks separately.
