### PR TITLE
Add Standard Compute provider

### DIFF
--- a/providers/standardcompute/logo.svg
+++ b/providers/standardcompute/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="2.5" y="2.5" width="19" height="19" rx="3" stroke="currentColor" stroke-width="1.8"/>
+  <rect x="12.5" y="7" width="5" height="10" fill="currentColor"/>
+  <rect x="6" y="15" width="4.5" height="2" fill="currentColor"/>
+</svg>

--- a/providers/standardcompute/models/standardcompute.toml
+++ b/providers/standardcompute/models/standardcompute.toml
@@ -1,3 +1,11 @@
+# Toggle: reasoning.enabled = true|false
+# Effort: reasoning.effort = "minimal"|"low"|"medium"|"high" (top-level
+# reasoning_effort also accepted)
+# Budget: reasoning.max_tokens = N (no fixed global bounds — the router fans
+# out to different backends; e.g. Gemini-class enforces a small minimum,
+# Anthropic-class requires budget < max_tokens)
+# All three pass through to the routed model; effect depends on which catalog
+# model serves the request (verified per pinned backend 2026-08-22/24).
 # Verified against the live endpoint (https://api.stdcmpt.com/v1/chat/completions):
 # tool_call + structured_output 2026-07-17; reasoning pass-through, image
 # attachment and streaming reasoning_details 2026-08-23/24. limit.context and
@@ -16,7 +24,7 @@ reasoning = true
 # `reasoning_effort`); effect depends on the routed model — true effort
 # levels on OpenAI/Anthropic-class, on/off on open-weight models. Per-model
 # defaults are configurable in the provider dashboard.
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }, { type = "budget_tokens" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/standardcompute/models/standardcompute.toml
+++ b/providers/standardcompute/models/standardcompute.toml
@@ -1,0 +1,41 @@
+# Verified against the live endpoint (https://api.stdcmpt.com/v1/chat/completions):
+# tool_call + structured_output 2026-07-17; reasoning pass-through, image
+# attachment and streaming reasoning_details 2026-08-23/24. limit.context and
+# limit.output are the operator's serving guarantee: every catalog model the
+# router may select serves >= 1M context (enforced as a catalog invariant);
+# 24,576 is the max output cap across plans. release_date is the public
+# launch month as stated by the operator.
+name = "Standard Compute"
+description = "Flat-rate smart-routing gateway: one model id, each request routed across a curated catalog of 1M-context models (DeepSeek, GLM, MiniMax, Qwen, GPT-5.6, Claude 5, Gemini 2.5, Kimi) or pinned to a user-selected model"
+family = "auto"
+release_date = "2026-03-01"
+last_updated = "2026-08-24"
+attachment = true
+reasoning = true
+# Pass-through controls (OpenRouter-style `reasoning` object and top-level
+# `reasoning_effort`); effect depends on the routed model — true effort
+# levels on OpenAI/Anthropic-class, on/off on open-weight models. Per-model
+# defaults are configurable in the provider dashboard.
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_details"
+
+# Subscription pricing (flat monthly tiers, https://standardcompute.com/pricing,
+# accessed 2026-08-24) — no per-token billing, hence cost 0 per the registry
+# convention for subscription providers.
+[cost]
+input = 0.00
+output = 0.00
+
+[limit]
+context = 1_000_000
+output = 24_576
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/standardcompute/models/standardcompute.toml
+++ b/providers/standardcompute/models/standardcompute.toml
@@ -1,11 +1,11 @@
-# Toggle: reasoning.enabled = true|false
-# Effort: reasoning.effort = "minimal"|"low"|"medium"|"high" (top-level
-# reasoning_effort also accepted)
-# Budget: reasoning.max_tokens = N (no fixed global bounds — the router fans
-# out to different backends; e.g. Gemini-class enforces a small minimum,
-# Anthropic-class requires budget < max_tokens)
-# All three pass through to the routed model; effect depends on which catalog
-# model serves the request (verified per pinned backend 2026-08-22/24).
+# Toggle: reasoning.enabled = true|false — the one control verified
+# effective on every backend the auto id can route to (per pinned backend
+# 2026-08-22/24).
+# The endpoint also accepts OpenRouter-style reasoning.effort / top-level
+# reasoning_effort and reasoning.max_tokens as pass-through, but their
+# effect depends on the routed model, so they are intentionally not listed
+# in reasoning_options (auto-router convention: reliable caller controls
+# only).
 # Verified against the live endpoint (https://api.stdcmpt.com/v1/chat/completions):
 # tool_call + structured_output 2026-07-17; reasoning pass-through, image
 # attachment and streaming reasoning_details 2026-08-23/24. limit.context and
@@ -20,11 +20,11 @@ release_date = "2026-03-01"
 last_updated = "2026-08-24"
 attachment = true
 reasoning = true
-# Pass-through controls (OpenRouter-style `reasoning` object and top-level
-# `reasoning_effort`); effect depends on the routed model — true effort
-# levels on OpenAI/Anthropic-class, on/off on open-weight models. Per-model
-# defaults are configurable in the provider dashboard.
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }, { type = "budget_tokens" }]
+# Only the toggle is reliable across every catalog backend; effort and
+# budget pass through with backend-dependent effect (true effort levels on
+# OpenAI/Anthropic-class only), so they are not advertised as options here.
+# Per-model defaults are configurable in the provider dashboard.
+reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true

--- a/providers/standardcompute/provider.toml
+++ b/providers/standardcompute/provider.toml
@@ -6,10 +6,13 @@
 # Reasoning HTTP format (accessed 2026-08-24):
 # POST /v1/chat/completions accepts the OpenRouter-style `reasoning` object
 # ({enabled = bool} | {effort = "minimal"|"low"|"medium"|"high"} |
-# {max_tokens = N}) and top-level `reasoning_effort`; both pass through to
-# the routed model. Requests without reasoning fields use the per-model
-# defaults saved in the customer dashboard. Responses return `reasoning`
-# plus OpenRouter-shape `reasoning_details` (streaming included).
+# {max_tokens = N}) and top-level `reasoning_effort`; all pass through to
+# the routed model. Only `enabled` has a guaranteed effect on every catalog
+# backend; `effort` and `max_tokens` have backend-dependent effect, so the
+# model entry lists only the toggle in reasoning_options. Requests without
+# reasoning fields use the per-model defaults saved in the customer
+# dashboard. Responses return `reasoning` plus OpenRouter-shape
+# `reasoning_details` (streaming included).
 name = "Standard Compute"
 env = ["STANDARDCOMPUTE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/standardcompute/provider.toml
+++ b/providers/standardcompute/provider.toml
@@ -1,0 +1,17 @@
+# Flat-rate smart-routing gateway: per-token cost is $0 because pricing is
+# subscription-based (flat monthly tiers, https://standardcompute.com/pricing,
+# accessed 2026-08-24). The single "standardcompute" model id routes each
+# request across a curated catalog of 1M-context models, or serves the
+# customer's pinned selection.
+# Reasoning HTTP format (accessed 2026-08-24):
+# POST /v1/chat/completions accepts the OpenRouter-style `reasoning` object
+# ({enabled = bool} | {effort = "minimal"|"low"|"medium"|"high"} |
+# {max_tokens = N}) and top-level `reasoning_effort`; both pass through to
+# the routed model. Requests without reasoning fields use the per-model
+# defaults saved in the customer dashboard. Responses return `reasoning`
+# plus OpenRouter-shape `reasoning_details` (streaming included).
+name = "Standard Compute"
+env = ["STANDARDCOMPUTE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.stdcmpt.com/v1"
+doc = "https://standardcompute.com/models"


### PR DESCRIPTION
Adds [Standard Compute](https://standardcompute.com) — an OpenAI-compatible smart-routing gateway on flat monthly plans. One model id; each request is routed across a curated catalog of 1M-context models (DeepSeek, GLM, MiniMax, Qwen, GPT-5.6, Claude 5, Gemini 2.5, Kimi K3) or pinned to a user-selected model.

- `api`: https://api.stdcmpt.com/v1 (OpenAI-compatible chat completions; models listed at [standardcompute.com/models](https://standardcompute.com/models))
- **Verified against the live endpoint**: tool_call + structured_output (2026-07-17); reasoning pass-through, image attachment, and streaming `reasoning_details` (2026-08-23/24) — hence `interleaved.field = "reasoning_details"`
- **Reasoning**: pass-through of the OpenRouter-style `reasoning` object and `reasoning_effort`; effect depends on the routed model, with per-model defaults configurable in the provider dashboard
- **`cost = 0`**: flat subscription, no per-token billing — following the registry's existing convention for subscription providers
- **`limit`**: 1M context / 24,576 output — the serving guarantee across the routed catalog (a catalog admission invariant, not a marketing number)

I operate this provider (co-founder). Happy to adjust anything to registry conventions.