### PR TITLE
feat(cline-pass): add missing glm-5.3 and qwen3.8-max models

### DIFF
--- a/providers/cline-pass/models/cline-pass/glm-5.3.toml
+++ b/providers/cline-pass/models/cline-pass/glm-5.3.toml
@@ -1,0 +1,12 @@
+# https://docs.cline.bot/getting-started/clinepass (accessed 2026-08-24)
+# Model ID cline-pass/glm-5.3; reference pricing matches glm-5.2 at $1.4 / $4.4 / $0.26 per 1M tokens (input/output/cache read).
+base_model = "zhipuai/glm-5.3"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26

--- a/providers/cline-pass/models/cline-pass/qwen3.8-max.toml
+++ b/providers/cline-pass/models/cline-pass/qwen3.8-max.toml
@@ -1,0 +1,14 @@
+# https://docs.cline.bot/getting-started/clinepass (accessed 2026-08-24)
+# Model ID cline-pass/qwen3.8-max; reference pricing $2 / $6 / $0.25 per 1M tokens (input/output/cache read), cache write $2.5.
+base_model = "alibaba/qwen3.8-max"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.25
+cache_write = 2.5


### PR DESCRIPTION
Closes #5392

Adds the two clinePass models listed by https://api.cline.bot/api/v1/ai/cline/recommended-models that were missing from providers/cline-pass:

- **cline-pass/glm-5.3** — base_model zhipuai/glm-5.3, interleaved reasoning_content; priced same as glm-5.2 (\.4 / \.4 / \/bin/bash.26 cache read)
- **cline-pass/qwen3.8-max** — base_model alibaba/qwen3.8-max, structured_output, effort reasoning options; \ / \ / \/bin/bash.25 cache read, \.50 cache write (per reference rates used elsewhere in the repo)

Validated with \(bun ./packages/core/script/validate.ts\) (exit 0).