### PR TITLE
feat(vivgrid): add gemini-3.7-flash

### DIFF
--- a/providers/vivgrid/models/gemini-3.7-flash.toml
+++ b/providers/vivgrid/models/gemini-3.7-flash.toml
@@ -1,0 +1,11 @@
+# Source: https://vivgrid.com/docs/models/gemini-3.7-flash
+base_model = "google/gemini-3.7-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+
+[provider]
+npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
Adds `gemini-3.7-flash` for Vivgrid using the `base_model` override pattern.

- **Docs / Dashboard Source:** https://vivgrid.com/docs/models/gemini-3.7-flash
- **Context Window:** 1,000,000 tokens
- **Max Output:** 65,536 tokens
- **Pricing:** $0.75 / 1M input, $3.75 / 1M output, $0.075 / 1M cache read
- **Reasoning Controls:** Graded reasoning effort (`low`, `medium`, `high`) matching Google and peer relay configurations.