### PR TITLE
feat: add GLM-5.3 to zai provider

### DIFF
--- a/providers/zai/models/glm-5.3.toml
+++ b/providers/zai/models/glm-5.3.toml
@@ -1,0 +1,17 @@
+base_model = "zhipuai/glm-5.3"
+# GLM-5.3 always reasons (thinking cannot be disabled); effort levels
+# low|high|max with default max.
+# https://docs.z.ai/guides/llm/glm-5.3
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+cache_write = 0


### PR DESCRIPTION
Adds the missing GLM-5.3 entry to the `zai` provider. The lab metadata already exists (`models/zhipuai/glm-5.3.toml`); this provider entry is override-only, mirroring `providers/zai/models/glm-5.2.toml`.

## Evidence
| Claim | Source |
| --- | --- |
| Model live on the Z.AI API | https://api.z.ai/api/paas/v4 lists `glm-5.3` |
| Effort levels `low`/`high`/`max`, thinking cannot be disabled | https://docs.z.ai/guides/llm/glm-5.3 |
| Pricing $1.40 in / $4.40 out / $0.26 cache read per MTok | https://docs.z.ai/guides/overview/pricing (matches peer entries e.g. edenai, llmgateway) |
| 1M context / 131,072 output | inherited from `zhipuai/glm-5.3` base model |

Validated with `bun ./packages/core/script/validate.ts` (exit 0).

PS: we need this to list glm-5.3 on Hermes Agent, even with coding plan auth