### PR TITLE
add Agnes 2.5 Pro Alpha model

### DIFF
--- a/providers/agnes/models/agnes-2.5-pro-alpha.toml
+++ b/providers/agnes/models/agnes-2.5-pro-alpha.toml
@@ -1,0 +1,29 @@
+name = "Agnes 2.5 Pro Alpha"
+description = "Paid reasoning model for advanced coding, scientific reasoning, long-context analysis, agentic workflows, and multimodal understanding."
+release_date = "2026-07-24"
+last_updated = "2026-07-24"
+attachment = true
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+open_weights = true
+
+[cost]
+input = 0.45
+output = 0.90
+cache_read = 0.0038
+
+[limit]
+context = 1_000_000
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle" # API: {"chat_template_kwargs": {"enable_thinking": true}}


### PR DESCRIPTION
## What does this PR do?

Adds Agnes 2.5 Pro Alpha as a new model under the existing Agnes AI provider.

Agnes 2.5 Pro Alpha is a paid reasoning model designed for advanced coding, scientific reasoning, long-context analysis, agentic workflows, and multimodal understanding.

## Model Details

- Model ID: `agnes-2.5-pro-alpha`
- Context window: 1M tokens
- Max output: 65,536 tokens
- Input modalities: text, image URL
- Reasoning: yes
- Tool calling: yes
- Release date: July 24, 2026

## Pricing

- Input: $0.45 / 1M tokens
- Output: $0.90 / 1M tokens
- Cache read: $0.0038 / 1M tokens

## Sources

- Model doc: https://agnes-ai.com/en/docs/agnes-25-pro-alpha
- Artificial Analysis profile: https://artificialanalysis.ai/models/agnes-2-5-pro-alpha
- Hugging Face profile: https://huggingface.co/Agnes-AI/Agnes-2.5-Pro-Alpha
- API pricing and limits: https://agnes-ai.com/doc

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `providers/agnes/models/agnes-2.5-pro-alpha.toml`: new model file

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature

### Documentation & Housekeeping
- [x] N/A, adding a model TOML under an existing provider