### PR TITLE
feat(models): add MiniMax image-01 to minimax providers

### DIFF
--- a/models/minimax/MiniMax-M2-Her.toml
+++ b/models/minimax/MiniMax-M2-Her.toml
@@ -11,8 +11,8 @@ tool_call = true
 open_weights = false
 
 [limit]
-context = 200_000
-output = 131_000
+context = 65_536
+output = 2_048
 
 [modalities]
 input = ["text"]

--- a/models/minimax/MiniMax-M2.toml
+++ b/models/minimax/MiniMax-M2.toml
@@ -10,8 +10,8 @@ tool_call = true
 open_weights = true
 
 [limit]
-context = 196_608
-output = 128_000
+context = 204_800
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/models/minimax/MiniMax-M3.toml
+++ b/models/minimax/MiniMax-M3.toml
@@ -10,8 +10,8 @@ tool_call = true
 open_weights = true
 
 [limit]
-context = 512_000
-output = 128_000
+context = 1_048_576
+output = 512_000
 
 [modalities]
 input = ["text", "image", "video"]

--- a/models/minimax/image-01.toml
+++ b/models/minimax/image-01.toml
@@ -1,0 +1,26 @@
+# Sources:
+# - https://platform.minimax.io/docs/guides/image-generation (text-to-image + subject reference)
+# - https://platform.minimax.io/docs/api-reference/image-generation-t2i (POST /v1/image_generation)
+# - https://platform.minimax.io/docs/guides/pricing-paygo#image ($0.0035 per image)
+# - https://platform.minimax.io/docs/guides/pricing-token-plan (covered by Token Plan; no per-image cost)
+# Note: served on the standalone image endpoint (/v1/image_generation), not the
+# Anthropic-compatible /anthropic/v1 base — hence no provider entry under providers/minimax*.
+
+name = "MiniMax image-01"
+description = "MiniMax text-to-image generation model with reference-image support"
+family = "minimax"
+release_date = "2025-02-15"
+last_updated = "2026-08-25"
+attachment = true
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = false
+
+[limit]
+context = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["image"]

--- a/providers/minimax-cn-coding-plan/models/MiniMax-M2.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M2.toml
@@ -15,8 +15,8 @@ input = 0
 output = 0
 
 [limit]
-context = 196_608
-output = 128_000
+context = 204_800
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-cn-coding-plan/models/MiniMax-M3.toml
@@ -19,8 +19,8 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 1_000_000
-output = 128_000
+context = 1_048_576
+output = 512_000
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/minimax-cn/models/MiniMax-M2.toml
+++ b/providers/minimax-cn/models/MiniMax-M2.toml
@@ -16,8 +16,8 @@ input = 0.30
 output = 1.20
 
 [limit]
-context = 196_608
-output = 128_000
+context = 204_800
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/minimax-cn/models/MiniMax-M3.toml
+++ b/providers/minimax-cn/models/MiniMax-M3.toml
@@ -24,8 +24,8 @@ output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 1_000_000
-output = 128_000
+context = 1_048_576
+output = 512_000
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/minimax-coding-plan/models/MiniMax-M2.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M2.toml
@@ -15,8 +15,8 @@ input = 0
 output = 0
 
 [limit]
-context = 196_608
-output = 128_000
+context = 204_800
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/minimax-coding-plan/models/MiniMax-M3.toml
+++ b/providers/minimax-coding-plan/models/MiniMax-M3.toml
@@ -19,8 +19,8 @@ cache_read = 0
 cache_write = 0
 
 [limit]
-context = 1_000_000
-output = 128_000
+context = 1_048_576
+output = 512_000
 
 [modalities]
 input = ["text", "image", "video"]

--- a/providers/minimax/models/MiniMax-M2.toml
+++ b/providers/minimax/models/MiniMax-M2.toml
@@ -16,8 +16,8 @@ input = 0.30
 output = 1.20
 
 [limit]
-context = 196_608
-output = 128_000
+context = 204_800
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/minimax/models/MiniMax-M3.toml
+++ b/providers/minimax/models/MiniMax-M3.toml
@@ -24,8 +24,8 @@ output = 2.40
 cache_read = 0.12
 
 [limit]
-context = 1_000_000
-output = 128_000
+context = 1_048_576
+output = 512_000
 
 [modalities]
 input = ["text", "image", "video"]


### PR DESCRIPTION
## Summary

MiniMax's catalog entries are text-only — their text-to-image model is missing. `image-01` is MiniMax's image generation model (released 2025-02-15, $0.0035/image, supports text-to-image + reference-image workflows).

Adds `image-01` to `models/minimax/` as catalog metadata only.

**Why no `providers/minimax*` entry:** `image-01` is served on the standalone image endpoint (`POST /v1/image_generation`) and is **not** available on the Anthropic-compatible `/anthropic/v1` base that `providers/minimax*` declare (`@ai-sdk/anthropic`), nor on MiniMax's official AI SDK provider (text M-series only — "For other models, please use the standard MiniMax API interface"). Listing it there would make catalog consumers call it through a chat-only endpoint and fail. This mirrors alibaba-token-plan's image entries (`qwen-image-2.0` / `wan2.7-image`), which are only authored where the host SDK is image-capable.

## Details

- `modalities`: text in, image out (input includes reference images via `subject_reference`)
- `attachment: true`, `reasoning: false`, `temperature: false`, `tool_call: false`
- Pricing: $0.0035 per image (per-image, not per-token); covered by Token Plan at no per-image charge
- Verified live against the MiniMax API: `image-01` works; `minimax-image-01` / `image-pro` / `image-02` rejected with error 2013

## Sources

- Image guide: https://platform.minimax.io/docs/guides/image-generation
- Text-to-image API: https://platform.minimax.io/docs/api-reference/image-generation-t2i
- Pay-as-you-go pricing (image): https://platform.minimax.io/docs/guides/pricing-paygo#image
- Token Plan coverage (image included): https://platform.minimax.io/docs/guides/pricing-token-plan
- AI SDK model list (text-only): https://platform.minimax.io/docs/api-reference/text-ai-sdk

## Also fixes (MiniMax context/output limits)

While adding the model, verified existing entries against official docs and corrected:

- `MiniMax-M3`: context 512K → 1M (512K is the guaranteed minimum, not the limit — https://www.minimax.io/models/text/m3); output 128K → 512,000
- `MiniMax-M2`: context 196,608 → 204,800; output 128,000 → 131,072
- `MiniMax-M2-Her`: context 200,000 → 65,536 (official chat-model doc: https://platform.minimax.io/docs/guides/text-chat); output 131,000 → 2,048

## Verification

- `bun validate` passes
