### PR TITLE
Add LLM Tech provider (Qwen3.8-27B NVFP4, EU)

### DIFF
--- a/providers/llmtech/logo.svg
+++ b/providers/llmtech/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor">
+  <rect x="10" y="10" width="8" height="44" rx="2"/>
+  <rect x="10" y="46" width="26" height="8" rx="2"/>
+  <rect x="30" y="10" width="24" height="8" rx="2"/>
+  <rect x="38" y="10" width="8" height="30" rx="2"/>
+</svg>

--- a/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
+++ b/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
@@ -9,7 +9,7 @@ values = ["low", "medium", "xhigh"]
 
 [cost]
 input = 0.25
-output = 2.2
+output = 2.09
 cache_read = 0.04
 
 [limit]

--- a/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
+++ b/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
@@ -5,6 +5,7 @@
 # streaming deltas use `reasoning_content`.
 
 base_model = "alibaba/qwen3.8-27b"
+attachment = false
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
+++ b/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
@@ -1,0 +1,20 @@
+base_model = "alibaba/qwen3.8-27b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
+
+[cost]
+input = 0.25
+output = 2.2
+cache_read = 0.04
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text"]

--- a/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
+++ b/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
@@ -1,3 +1,9 @@
+# Reasoning wire (OpenAI-compatible chat completions at https://api.llmtech.eu/v1):
+# Toggle: chat_template_kwargs.enable_thinking = true | false.
+# Effort: chat_template_kwargs.reasoning_effort = "low" | "medium" | "xhigh".
+# Non-streaming responses carry reasoning text in the `reasoning` field;
+# streaming deltas use `reasoning_content`.
+
 base_model = "alibaba/qwen3.8-27b"
 
 [[reasoning_options]]
@@ -11,10 +17,6 @@ values = ["low", "medium", "xhigh"]
 input = 0.25
 output = 2.09
 cache_read = 0.04
-
-[limit]
-context = 262_144
-output = 32_768
 
 [modalities]
 input = ["text"]

--- a/providers/llmtech/provider.toml
+++ b/providers/llmtech/provider.toml
@@ -1,0 +1,5 @@
+name = "LLM Tech"
+env = ["LLMTECH_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.llmtech.eu/v1"
+doc = "https://llmtech.eu/models/qwen3.8-27b"


### PR DESCRIPTION
Adds LLM Tech (https://llmtech.eu) — an EU-based inference provider.

- `providers/llmtech/provider.toml`: OpenAI-compatible API at `https://api.llmtech.eu/v1`, env `LLMTECH_API_KEY`, `@ai-sdk/openai-compatible`
- `providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml`: linked to `alibaba/qwen3.8-27b`, $0.25/M input, $2.20/M output, $0.04/M cache read, 262,144 context, reasoning toggle + effort
- `providers/llmtech/logo.svg`: currentColor monogram

The endpoint serves production traffic since Aug 22 — live measured status: https://llmtech.eu/status. Pricing is public: https://llmtech.eu/models/qwen3.8-27b