### PR TITLE
feat(aixy): add gateway provider

### DIFF
--- a/providers/aixy/logo.svg
+++ b/providers/aixy/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="currentColor">
+  <path d="M18 47 30.6 16h4.6L48 47h-8.2l-2.6-7.2H27L24.2 47H16zm13.8-22.4-2.7 8.2h6l-2.8-8.2h-.5z"/>
+  <circle cx="47" cy="17" r="4"/>
+</svg>

--- a/providers/aixy/models/openai/gpt-4.1-mini.toml
+++ b/providers/aixy/models/openai/gpt-4.1-mini.toml
@@ -1,0 +1,7 @@
+# Aixy's public quickstart documents this provider-qualified model ID.
+base_model = "openai/gpt-4.1-mini"
+
+[cost]
+input = 0.40
+output = 1.60
+cache_read = 0.10

--- a/providers/aixy/provider.toml
+++ b/providers/aixy/provider.toml
@@ -1,0 +1,7 @@
+name = "Aixy"
+env = ["AIXY_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# Aixy is a BYOK gateway. Model availability is tenant-specific and returned by
+# authenticated GET /v1/models; direct IDs use provider/model.
+api = "https://api.aixy-gateway.com/v1"
+doc = "https://docs.aixy-gateway.com/integrations/overview"


### PR DESCRIPTION
## Summary

- register Aixy as an OpenAI-compatible provider at `https://api.aixy-gateway.com/v1`
- add the Aixy logo using the catalog-required square `viewBox` and `currentColor`
- add the publicly documented `openai/gpt-4.1-mini` route via canonical `base_model` metadata and its public OpenAI token prices

## Catalog scope

Aixy is a BYOK gateway: the authenticated `GET /v1/models` result is tenant-specific and depends on the provider credentials connected to that project. This initial entry therefore seeds only the exact provider-qualified model ID used in the public quickstart instead of claiming that every upstream model is globally available.

Sources:

- [Aixy integration details](https://docs.aixy-gateway.com/integrations/overview) document the base URL, `AIXY_API_KEY` authentication, provider-qualified model IDs, and authenticated model discovery.
- [Aixy quickstart](https://docs.aixy-gateway.com/quickstart) documents `openai/gpt-4.1-mini` through the production gateway.
- [OpenAI GPT-4.1 announcement](https://openai.com/index/gpt-4-1/) documents the $0.40 input, $0.10 cached-input, and $1.60 output prices per million tokens.

## Validation

- `bun validate`
- `cd packages/sdk && bun run test` (23 passed)