### PR TITLE
fix(amazon-bedrock): correct OpenAI model pricing and metadata

### DIFF
--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-luna.toml
@@ -1,20 +1,21 @@
 # Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
 # Verified from eu-west-1: returns 200 with reasoning effort set.
-# Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-luna: https://aws.amazon.com/bedrock/pricing/
+# Global pricing and Runtime capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
 base_model = "openai/gpt-5.6-luna"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-5.6 Luna (Global)"
+structured_output = false
 
 [cost]
-input = 0.22
-output = 1.32
-cache_read = 0.022
-cache_write = 0.275
+input = 0.20
+output = 1.20
+cache_read = 0.02
+cache_write = 0.25
 
 [[cost.tiers]]
 tier = { size = 272_000 }
-input = 0.44
-output = 1.98
-cache_read = 0.044
-cache_write = 0.55
+input = 0.40
+output = 1.80
+cache_read = 0.04
+cache_write = 0.50

--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-sol.toml
@@ -1,20 +1,21 @@
 # Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
 # Verified from eu-west-1: returns 200 with reasoning effort set.
-# Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-sol: https://aws.amazon.com/bedrock/pricing/
+# Global pricing and Runtime capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
 base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-5.6 Sol (Global)"
+structured_output = false
 
 [cost]
-input = 5.50
-output = 33.00
-cache_read = 0.55
-cache_write = 6.875
+input = 4.00
+output = 20.00
+cache_read = 0.40
+cache_write = 5.00
 
 [[cost.tiers]]
 tier = { size = 272_000 }
-input = 11.00
-output = 49.50
-cache_read = 1.10
-cache_write = 13.75
+input = 8.00
+output = 30.00
+cache_read = 0.80
+cache_write = 10.00

--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-terra.toml
@@ -1,20 +1,21 @@
 # Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
 # Verified from eu-west-1: effort none|low|medium|high|xhigh|max all return 200.
-# Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-terra: https://aws.amazon.com/bedrock/pricing/
+# Global pricing and Runtime capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html
 base_model = "openai/gpt-5.6-terra"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-5.6 Terra (Global)"
+structured_output = false
 
 [cost]
-input = 2.20
-output = 13.20
-cache_read = 0.22
-cache_write = 2.75
+input = 2.00
+output = 12.00
+cache_read = 0.20
+cache_write = 2.50
 
 [[cost.tiers]]
 tier = { size = 272_000 }
-input = 4.40
-output = 19.80
-cache_read = 0.44
-cache_write = 5.50
+input = 4.00
+output = 18.00
+cache_read = 0.40
+cache_write = 5.00

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
@@ -1,23 +1,23 @@
 # Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
 # Bedrock context window: https://developers.openai.com/api/docs/guides/amazon-bedrock
-# In-region on-demand pricing (US East N. Virginia & Ohio): https://aws.amazon.com/bedrock/pricing/
+# In-region on-demand pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
 # Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
 base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 
 [cost]
-input = 5.50
-output = 33.00
-cache_read = 0.55
-cache_write = 6.875
+input = 4.40
+output = 22.00
+cache_read = 0.44
+cache_write = 5.50
 
 [[cost.tiers]]
 tier = { size = 272_000 }
-input = 11.00
-output = 49.50
-cache_read = 1.10
-cache_write = 13.75
+input = 8.80
+output = 33.00
+cache_read = 0.88
+cache_write = 11.00
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
@@ -9,7 +9,7 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.15

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b.toml
@@ -9,7 +9,7 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.15

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
@@ -9,7 +9,7 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.07

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b.toml
@@ -9,7 +9,7 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.07

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
@@ -8,7 +8,7 @@ reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.15

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
@@ -8,7 +8,7 @@ reasoning = false
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [cost]
 input = 0.07


### PR DESCRIPTION
## Summary
- correct global GPT-5.6 Luna, Terra, and Sol pricing for both standard and long-context tiers, and correct stale regional GPT-5.6 Sol pricing
- mark global Bedrock Runtime GPT-5.6 profiles as not supporting structured outputs
- identify all six GPT-OSS and GPT-OSS Safeguard entries as open-weight models
- preserve the existing intentional transport split: global inference profiles use Bedrock Runtime/Converse, while unprefixed GPT-5.6 models use Mantle Responses

## AWS documentation
- GPT-5.6 Sol model card, pricing, supported APIs, and features: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
- GPT-5.6 Terra model card, pricing, supported APIs, and features: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html
- GPT-5.6 Luna model card, pricing, supported APIs, and features: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
- GPT-OSS 120B model card: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html
- GPT-OSS Safeguard 120B model card: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-safeguard-120b.html

## Validation
- `bun validate`
- inspected generated catalog entries to verify corrected pricing and capabilities while retaining the original provider package for each transport