### PR TITLE
feat: add GLM-5.3 Highspeed to Zhipu and Z.AI coding plans

### DIFF
--- a/providers/zai-coding-plan/models/glm-5.3-highspeed.toml
+++ b/providers/zai-coding-plan/models/glm-5.3-highspeed.toml
@@ -1,0 +1,17 @@
+base_model = "zhipuai/glm-5.3"
+name = "GLM-5.3 Highspeed"
+
+# Effort levels mirror the base GLM-5.3 (low, high, max).
+# https://docs.bigmodel.cn/cn/coding-plan/latest-model
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/zhipuai-coding-plan/models/glm-5.3-highspeed.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5.3-highspeed.toml
@@ -1,0 +1,17 @@
+base_model = "zhipuai/glm-5.3"
+name = "GLM-5.3 Highspeed"
+
+# Effort levels mirror the base GLM-5.3 (low, high, max).
+# https://docs.bigmodel.cn/cn/coding-plan/latest-model
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
## What

Adds `glm-5.3-highspeed` to both coding-plan providers:

- `providers/zhipuai-coding-plan/models/glm-5.3-highspeed.toml`
- `providers/zai-coding-plan/models/glm-5.3-highspeed.toml`

The entries follow the exact pattern of the existing `glm-5.2-highspeed`: identical fields to the provider's base `glm-5.3.toml`, with the only deltas being the model ID (filename) and `name = "GLM-5.3 Highspeed"`.

## Evidence

Zhipu is rolling out **GLM-5.3-HighSpeed** to GLM Coding Plan users as a 14-day trial (granted to selected accounts; ~8-10x faster than standard GLM-5.3). Grant email screenshot:

<img width="740" height="1074" alt="glm-highspeed" src="https://github.com/user-attachments/assets/d3e94e06-f5d2-4236-86d5-2dd920f2d3e1" />


The `-highspeed` model ID family is established:

- `glm-5.1-highspeed` is officially documented: https://docs.bigmodel.cn/cn/guide/models/text/glm-5.1-highspeed
- `glm-5.2-highspeed` is already registered in this repo for both coding-plan providers
- Base model docs: https://docs.bigmodel.cn/cn/guide/models/text/glm-5.3 and https://docs.bigmodel.cn/cn/coding-plan/latest-model

## Notes

- `reasoning_options` mirrors the base GLM-5.3 (`low`, `high`, `max`); happy to adjust if Zhipu documents different effort levels for the Highspeed variant.
- Cost stays `0` like the other coding-plan models (subscription quota, not per-token billing).
- `bun run validate` passes locally.
