### PR TITLE
feat(aixy): add curated 50-model catalog

### DIFF
--- a/providers/aixy/models/alibaba/glm-5.2.toml
+++ b/providers/aixy/models/alibaba/glm-5.2.toml
@@ -1,0 +1,20 @@
+# Sources (accessed 2026-08-08):
+# https://www.alibabacloud.com/help/en/model-studio/glm
+# https://www.alibabacloud.com/help/en/model-studio/model-pricing (Singapore list)
+# https://www.qwencloud.com/models/glm-5.2 (implicit cache price)
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# (none disables reasoning, so a separate toggle is not needed).
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.28
+cache_write = 0

--- a/providers/aixy/models/alibaba/qwen3.6-27b.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-27b.toml
@@ -1,0 +1,14 @@
+# Toggle: enable_thinking = true|false
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.6-27b.toml.
+base_model = "alibaba/qwen3.6-27b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.6
+output = 3.6

--- a/providers/aixy/models/alibaba/qwen3.6-flash.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-flash.toml
@@ -1,0 +1,15 @@
+# Toggle: enable_thinking = true|false
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.6-flash.toml.
+base_model = "alibaba/qwen3.6-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.1875
+output = 1.125
+cache_write = 0.234375

--- a/providers/aixy/models/alibaba/qwen3.7-max.toml
+++ b/providers/aixy/models/alibaba/qwen3.7-max.toml
@@ -1,0 +1,16 @@
+# Toggle: enable_thinking = true|false
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.7-max.toml.
+base_model = "alibaba/qwen3.7-max"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 2.5
+output = 7.5
+cache_read = 0.5
+cache_write = 3.125

--- a/providers/aixy/models/alibaba/qwen3.7-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3.7-plus.toml
@@ -1,0 +1,27 @@
+# Toggle: enable_thinking = true|false
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.7-plus.toml.
+base_model = "alibaba/qwen3.7-plus"
+attachment = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+cache_write = 0.625
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 2
+output = 6
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+output = 65_536

--- a/providers/aixy/models/alibaba/qwen3.8-max.toml
+++ b/providers/aixy/models/alibaba/qwen3.8-max.toml
@@ -1,0 +1,34 @@
+# Sources (accessed 2026-08-04):
+# https://www.qwencloud.com/models/qwen3.8-max
+# https://docs.qwencloud.com/developer-guides/text-generation/thinking
+# https://docs.qwencloud.com/developer-guides/getting-started/text-generation-models
+# https://help.aliyun.com/zh/model-studio/model-pricing (Singapore: qwen3.8-max list)
+# Toggle: enable_thinking true|false (hybrid)
+# Effort: reasoning_effort = low|medium|xhigh (default xhigh); high accepted as alias → xhigh
+# Budget: thinking_budget (0..262144) cannot be combined with reasoning_effort
+# API: {"enable_thinking":true,"reasoning_effort":"medium"} or
+# {"enable_thinking":true,"thinking_budget":16384}
+# Pay-as-you-go on DashScope/QwenCloud (not Token Plan only). Cost USD/MTok from model page.
+base_model = "alibaba/qwen3.8-max"
+structured_output = true
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 262_144
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.25
+cache_write = 2.5

--- a/providers/aixy/models/anthropic/claude-fable-5.toml
+++ b/providers/aixy/models/anthropic/claude-fable-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-fable-5"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/aixy/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/aixy/models/anthropic/claude-haiku-4-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-haiku-4-5"
+structured_output = true
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25

--- a/providers/aixy/models/anthropic/claude-opus-4-6.toml
+++ b/providers/aixy/models/anthropic/claude-opus-4-6.toml
@@ -1,0 +1,16 @@
+base_model = "anthropic/claude-opus-4-6"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/anthropic/claude-opus-4-7.toml
+++ b/providers/aixy/models/anthropic/claude-opus-4-7.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-7"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/anthropic/claude-opus-4-8.toml
+++ b/providers/aixy/models/anthropic/claude-opus-4-8.toml
@@ -1,0 +1,16 @@
+base_model = "anthropic/claude-opus-4-8"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[experimental.modes.fast]
+cost = { input = 10, output = 50, cache_read = 1, cache_write = 12.5 }
+provider = { body = { speed = "fast" }, headers = { anthropic-beta = "fast-mode-2026-02-01" } }

--- a/providers/aixy/models/anthropic/claude-opus-5.toml
+++ b/providers/aixy/models/anthropic/claude-opus-5.toml
@@ -1,0 +1,16 @@
+base_model = "anthropic/claude-opus-5"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[experimental.modes.fast]
+cost = { input = 10, output = 50, cache_read = 1, cache_write = 12.5 }
+provider = { body = { speed = "fast" }, headers = { anthropic-beta = "fast-mode-2026-02-01" } }

--- a/providers/aixy/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/aixy/models/anthropic/claude-sonnet-4-6.toml
@@ -1,0 +1,19 @@
+base_model = "anthropic/claude-sonnet-4-6"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+output = 128_000

--- a/providers/aixy/models/anthropic/claude-sonnet-5.toml
+++ b/providers/aixy/models/anthropic/claude-sonnet-5.toml
@@ -1,0 +1,18 @@
+# Toggle: thinking.type = adaptive|disabled
+# Aixy forwards this route to anthropic without translating the model payload.
+# Reasoning controls mirror providers/anthropic/models/claude-sonnet-5.toml.
+base_model = "anthropic/claude-sonnet-5"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/aixy/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/aixy/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,26 @@
+# Toggle: thinking.type = enabled|disabled
+# Reasoning tokens are billed at the output rate (no separate CoT price).
+# `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
+# OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
+# Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
+# Flash maps requested low→low (unlike Pro, which maps low→high). xhigh→high.
+# https://api-docs.deepseek.com/guides/thinking_mode/ (accessed 2026-08-02)
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+reasoning = 0.28
+cache_read = 0.0028

--- a/providers/aixy/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/aixy/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,22 @@
+# Toggle: thinking.type = enabled|disabled
+# Reasoning tokens are billed at the output rate (no separate CoT price).
+# `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-12)
+base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.435
+output = 0.87
+reasoning = 0.87
+cache_read = 0.003625

--- a/providers/aixy/models/gemini/gemini-2.5-pro.toml
+++ b/providers/aixy/models/gemini/gemini-2.5-pro.toml
@@ -1,0 +1,17 @@
+base_model = "google/gemini-2.5-pro"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 128
+max = 32_768
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 15
+cache_read = 0.25

--- a/providers/aixy/models/gemini/gemini-3.1-flash-lite.toml
+++ b/providers/aixy/models/gemini/gemini-3.1-flash-lite.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.1-flash-lite"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+input_audio = 0.5

--- a/providers/aixy/models/gemini/gemini-3.5-flash-lite.toml
+++ b/providers/aixy/models/gemini/gemini-3.5-flash-lite.toml
@@ -1,0 +1,13 @@
+# Sources:
+# - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/
+# - https://ai.google.dev/gemini-api/docs/pricing
+base_model = "google/gemini-3.5-flash-lite"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/aixy/models/gemini/gemini-3.5-flash.toml
+++ b/providers/aixy/models/gemini/gemini-3.5-flash.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.5-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+input_audio = 1.5

--- a/providers/aixy/models/gemini/gemini-3.6-flash.toml
+++ b/providers/aixy/models/gemini/gemini-3.6-flash.toml
@@ -1,0 +1,15 @@
+# Sources:
+# - https://ai.google.dev/gemini-api/docs/pricing#gemini-3.6-flash
+# Introductory Standard pricing applies through 2026-12-31. The published
+# 2027 rates are $1.50 input, $7.50 output, and $0.15 cache read.
+base_model = "google/gemini-3.6-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+input_audio = 0.75

--- a/providers/aixy/models/gemini/gemini-3.7-flash.toml
+++ b/providers/aixy/models/gemini/gemini-3.7-flash.toml
@@ -1,0 +1,15 @@
+# Sources:
+# - https://blog.google/innovation-and-ai/models-and-research/gemini-models/introducing-gemini-3-7-flash/
+# - https://ai.google.dev/gemini-api/docs/pricing
+# - https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thinking
+base_model = "google/gemini-3.7-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+input_audio = 0.75

--- a/providers/aixy/models/meta/llama-3.3-70b-instruct.toml
+++ b/providers/aixy/models/meta/llama-3.3-70b-instruct.toml
@@ -1,0 +1,6 @@
+base_model = "meta/llama-3.3-70b-instruct"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
+++ b/providers/aixy/models/meta/llama-4-maverick-17b-128e-instruct-fp8.toml
@@ -1,0 +1,10 @@
+base_model = "meta/llama-4-maverick-17b-instruct"
+description = "Open multimodal Llama model for strong reasoning and fast responses"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 4_096

--- a/providers/aixy/models/meta/llama-4-scout-17b-16e-instruct-fp8.toml
+++ b/providers/aixy/models/meta/llama-4-scout-17b-16e-instruct-fp8.toml
@@ -1,0 +1,10 @@
+base_model = "meta/llama-4-scout-17b-instruct"
+description = "Open multimodal Llama model for long-context analysis and efficient agents"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 4_096

--- a/providers/aixy/models/mistral/codestral-latest.toml
+++ b/providers/aixy/models/mistral/codestral-latest.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/codestral-latest"
+
+[cost]
+input = 0.3
+output = 0.9

--- a/providers/aixy/models/mistral/magistral-medium-latest.toml
+++ b/providers/aixy/models/mistral/magistral-medium-latest.toml
@@ -1,0 +1,6 @@
+base_model = "mistral/magistral-medium-latest"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 5

--- a/providers/aixy/models/mistral/mistral-large-2512.toml
+++ b/providers/aixy/models/mistral/mistral-large-2512.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-large-2512"
+
+[cost]
+input = 0.5
+output = 1.5

--- a/providers/aixy/models/mistral/mistral-medium-2604.toml
+++ b/providers/aixy/models/mistral/mistral-medium-2604.toml
@@ -1,0 +1,9 @@
+base_model = "mistral/mistral-medium-2604"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 1.5
+output = 7.5

--- a/providers/aixy/models/mistral/mistral-small-2603.toml
+++ b/providers/aixy/models/mistral/mistral-small-2603.toml
@@ -1,0 +1,9 @@
+base_model = "mistral/mistral-small-2603"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/aixy/models/openai/gpt-5.4-mini.toml
+++ b/providers/aixy/models/openai/gpt-5.4-mini.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.4-mini"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+
+[experimental.modes.fast]
+cost = { input = 1.5, output = 9, cache_read = 0.15 }
+provider = { body = { service_tier = "priority" } }

--- a/providers/aixy/models/openai/gpt-5.4-nano.toml
+++ b/providers/aixy/models/openai/gpt-5.4-nano.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-5.4-nano"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02

--- a/providers/aixy/models/openai/gpt-5.4-pro.toml
+++ b/providers/aixy/models/openai/gpt-5.4-pro.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.4-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high", "xhigh"]
+
+[cost]
+input = 30
+output = 180
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 60
+output = 270

--- a/providers/aixy/models/openai/gpt-5.4.toml
+++ b/providers/aixy/models/openai/gpt-5.4.toml
@@ -1,0 +1,20 @@
+base_model = "openai/gpt-5.4"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5
+
+[experimental.modes.fast]
+cost = { input = 5, output = 30, cache_read = 0.5 }
+provider = { body = { service_tier = "priority" } }

--- a/providers/aixy/models/openai/gpt-5.5-pro.toml
+++ b/providers/aixy/models/openai/gpt-5.5-pro.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.5-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high", "xhigh"]
+
+[cost]
+input = 30
+output = 180
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 60
+output = 270

--- a/providers/aixy/models/openai/gpt-5.5.toml
+++ b/providers/aixy/models/openai/gpt-5.5.toml
@@ -1,0 +1,20 @@
+base_model = "openai/gpt-5.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+
+[experimental.modes.fast]
+cost = { input = 12.5, output = 75, cache_read = 1.25 }
+provider = { body = { service_tier = "priority" } }

--- a/providers/aixy/models/openai/gpt-5.6-luna.toml
+++ b/providers/aixy/models/openai/gpt-5.6-luna.toml
@@ -1,0 +1,26 @@
+# Pricing: https://developers.openai.com/api/docs/pricing (Terra/Luna cut 2026-07-30)
+base_model = "openai/gpt-5.6-luna"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.4
+output = 1.8
+cache_read = 0.04
+cache_write = 0.5
+
+[experimental.modes.fast]
+cost = { input = 0.4, output = 2.4, cache_read = 0.04, cache_write = 0.5 }
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }

--- a/providers/aixy/models/openai/gpt-5.6-sol.toml
+++ b/providers/aixy/models/openai/gpt-5.6-sol.toml
@@ -1,0 +1,25 @@
+base_model = "openai/gpt-5.6-sol"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 4
+output = 20
+cache_read = 0.4
+cache_write = 5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 8
+output = 30
+cache_read = 0.8
+cache_write = 10
+
+[experimental.modes.fast]
+cost = { input = 8, output = 40, cache_read = 0.8, cache_write = 10 }
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }

--- a/providers/aixy/models/openai/gpt-5.6-terra.toml
+++ b/providers/aixy/models/openai/gpt-5.6-terra.toml
@@ -1,0 +1,26 @@
+# Pricing: https://developers.openai.com/api/docs/pricing (Terra/Luna cut 2026-07-30)
+base_model = "openai/gpt-5.6-terra"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5
+
+[experimental.modes.fast]
+cost = { input = 4, output = 24, cache_read = 0.4, cache_write = 5 }
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }

--- a/providers/aixy/models/openai/gpt-5.6.toml
+++ b/providers/aixy/models/openai/gpt-5.6.toml
@@ -1,0 +1,26 @@
+base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 4
+output = 20
+cache_read = 0.4
+cache_write = 5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 8
+output = 30
+cache_read = 0.8
+cache_write = 10
+
+[experimental.modes.fast]
+cost = { input = 8, output = 40, cache_read = 0.8, cache_write = 10 }
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }

--- a/providers/aixy/models/openrouter/bytedance-seed/seed-2.0-code.toml
+++ b/providers/aixy/models/openrouter/bytedance-seed/seed-2.0-code.toml
@@ -1,0 +1,21 @@
+# Toggle: reasoning.enabled = true|false
+# Effort: reasoning.effort = low|medium|high
+# https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
+base_model = "bytedance-seed/seed-2.0-code"
+description = "Coding model for repository understanding, refactors, and agentic engineering tasks"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.5
+output = 3
+
+[[cost.tiers]]
+tier = { type = "context", size = 128_000 }
+input = 1
+output = 6

--- a/providers/aixy/models/openrouter/minimax/minimax-m3.toml
+++ b/providers/aixy/models/openrouter/minimax/minimax-m3.toml
@@ -1,0 +1,12 @@
+# Toggle: reasoning.enabled = true|false
+# https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
+base_model = "minimax/MiniMax-M3"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06

--- a/providers/aixy/models/openrouter/moonshotai/kimi-k3.toml
+++ b/providers/aixy/models/openrouter/moonshotai/kimi-k3.toml
@@ -1,0 +1,21 @@
+# Toggle: reasoning.enabled = true|false
+# Aixy forwards this route to openrouter without translating the model payload.
+# Reasoning controls mirror providers/openrouter/models/moonshotai/kimi-k3.toml.
+base_model = "moonshotai/kimi-k3"
+description = "Kimi multimodal agent model for visual understanding, coding, and planning"
+temperature = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+
+[limit]
+output = 943_718

--- a/providers/aixy/models/openrouter/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/aixy/models/openrouter/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,24 @@
+# Toggle: reasoning.enabled = true|false
+# Aixy forwards this route to openrouter without translating the model payload.
+# Reasoning controls mirror providers/openrouter/models/nvidia/nemotron-3-ultra-550b-a55b.toml.
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.6
+output = 3.6
+cache_read = 0.2
+
+[limit]
+context = 512_288
+output = 461_059

--- a/providers/aixy/models/openrouter/z-ai/glm-5.3.toml
+++ b/providers/aixy/models/openrouter/z-ai/glm-5.3.toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5.3"
+description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+structured_output = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 1_048_576

--- a/providers/aixy/models/xai/grok-4.3.toml
+++ b/providers/aixy/models/xai/grok-4.3.toml
@@ -1,0 +1,17 @@
+base_model = "xai/grok-4.3"
+description = "xAI's Grok for chat, coding, agentic tools, and lower hallucination risk"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 5
+cache_read = 0.4

--- a/providers/aixy/models/xai/grok-4.5.toml
+++ b/providers/aixy/models/xai/grok-4.5.toml
@@ -1,0 +1,19 @@
+base_model = "xai/grok-4.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.3
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12
+cache_read = 0.6
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/aixy/models/xai/grok-4.6.toml
+++ b/providers/aixy/models/xai/grok-4.6.toml
@@ -1,0 +1,20 @@
+# Sources: https://docs.x.ai/developers/models/grok-4.6, https://docs.x.ai/developers/pricing, and https://docs.x.ai/developers/model-capabilities/text/reasoning
+base_model = "xai/grok-4.6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12
+cache_read = 1
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/aixy/models/xai/grok-build-0.1.toml
+++ b/providers/aixy/models/xai/grok-build-0.1.toml
@@ -1,0 +1,13 @@
+base_model = "xai/grok-build-0.1"
+reasoning_options = []
+
+[cost]
+input = 1
+output = 2
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2
+output = 4
+cache_read = 0.4


### PR DESCRIPTION
## Summary

- Add 49 curated routes, bringing the Aixy catalog to exactly 50 models including the existing GPT-4.1 Mini entry.
- Cover recent non-deprecated models from 13 labs without mirroring complete upstream inventories.
- Prefer first-party Aixy routes; use a small OpenRouter selection for current models without a direct route.
- Keep availability tenant-specific and BYOK. This PR adds catalog TOMLs only and does not add bulk sync automation.

## Selection

- OpenAI: 11
- Anthropic: 8
- Google: 6
- Zhipu AI / GLM: 2
- Alibaba / Qwen: 5
- DeepSeek: 2
- Mistral: 5
- Meta: 3
- xAI: 4
- ByteDance Seed, MiniMax, Moonshot AI, and NVIDIA: 1 each

## Source mapping

- Model identity, capabilities, and default limits inherit through `base_model` from the canonical lab entries already reviewed in models.dev; the Aixy files keep only host-specific deltas.
- Direct routes mirror the established first-party provider surfaces: [OpenAI](https://platform.openai.com/docs/models), [Anthropic](https://docs.anthropic.com/en/docs/about-claude/models), [Gemini](https://ai.google.dev/gemini-api/docs/models), [Alibaba Model Studio](https://www.alibabacloud.com/help/en/model-studio/models), [DeepSeek](https://api-docs.deepseek.com/quick_start/pricing), [Mistral](https://docs.mistral.ai/getting-started/models/), and [xAI](https://docs.x.ai/docs/models).
- The five OpenRouter-prefixed routes use OpenRouter's authoritative [model API](https://openrouter.ai/docs/api/api-reference/models/get-models) for IDs, pricing, limits, and supported parameters, plus its [reasoning controls](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens).
- The zero-cost Meta Llama routes reflect Meta's officially announced [limited free Llama API preview](https://ai.meta.com/blog/llamacon-llama-news/); availability remains credential- and project-scoped.
- Aixy's integration contract and authenticated catalog behavior are documented in the [Aixy integration guide](https://docs.aixy-gateway.com/integrations/overview).

## Validation

- `bun validate`
- 50 resolved Aixy models
- 0 deprecated or beta routes
- All 44 reasoning models define provider-appropriate `reasoning_options`

This replaces the earlier bulk-generated approach. #5507 remains closed.