### PR TITLE
feat(aixy): expand gateway catalog (2/2)

### DIFF
--- a/providers/aixy/.catalog-sync-enabled
+++ b/providers/aixy/.catalog-sync-enabled
@@ -1,0 +1,1 @@
+The complete reviewed first-class provider catalog is present; hourly Aixy sync may own it.

--- a/providers/aixy/models/alibaba/deepseek-v4-flash-0731.toml
+++ b/providers/aixy/models/alibaba/deepseek-v4-flash-0731.toml
@@ -1,0 +1,23 @@
+# Sources (accessed 2026-08-08):
+# https://www.alibabacloud.com/help/en/model-studio/deepseek-api
+# https://www.alibabacloud.com/help/en/model-studio/model-pricing (Singapore list)
+# https://www.qwencloud.com/models/deepseek-v4-flash-0731 (implicit cache price)
+# Pay-as-you-go on DashScope international, not Token Plan only.
+# Toggle: enable_thinking true|false
+# Effort: reasoning_effort = high (default) | max; low/medium map to high, xhigh maps to max
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.2
+output = 0.4
+cache_read = 0.04

--- a/providers/aixy/models/alibaba/glm-5.2.toml
+++ b/providers/aixy/models/alibaba/glm-5.2.toml
@@ -1,0 +1,20 @@
+# Sources (accessed 2026-08-08):
+# https://www.alibabacloud.com/help/en/model-studio/glm
+# https://www.alibabacloud.com/help/en/model-studio/model-pricing (Singapore list)
+# https://www.qwencloud.com/models/glm-5.2 (implicit cache price)
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# (none disables reasoning, so a separate toggle is not needed).
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.28
+cache_write = 0

--- a/providers/aixy/models/alibaba/qwen-flash.toml
+++ b/providers/aixy/models/alibaba/qwen-flash.toml
@@ -1,0 +1,13 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen-flash.toml.
+base_model = "alibaba/qwen-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.05
+output = 0.4

--- a/providers/aixy/models/alibaba/qwen-flash.toml
+++ b/providers/aixy/models/alibaba/qwen-flash.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen-flash.toml.
 base_model = "alibaba/qwen-flash"

--- a/providers/aixy/models/alibaba/qwen-max.toml
+++ b/providers/aixy/models/alibaba/qwen-max.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen-max"
+
+[cost]
+input = 1.6
+output = 6.4

--- a/providers/aixy/models/alibaba/qwen-plus.toml
+++ b/providers/aixy/models/alibaba/qwen-plus.toml
@@ -1,0 +1,14 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen-plus.toml.
+base_model = "alibaba/qwen-plus"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.4
+output = 1.2
+reasoning = 4

--- a/providers/aixy/models/alibaba/qwen-plus.toml
+++ b/providers/aixy/models/alibaba/qwen-plus.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen-plus.toml.
 base_model = "alibaba/qwen-plus"

--- a/providers/aixy/models/alibaba/qwen-turbo.toml
+++ b/providers/aixy/models/alibaba/qwen-turbo.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen-turbo.toml.
 base_model = "alibaba/qwen-turbo"

--- a/providers/aixy/models/alibaba/qwen-turbo.toml
+++ b/providers/aixy/models/alibaba/qwen-turbo.toml
@@ -1,0 +1,14 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen-turbo.toml.
+base_model = "alibaba/qwen-turbo"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.05
+output = 0.2
+reasoning = 0.5

--- a/providers/aixy/models/alibaba/qwen-vl-max.toml
+++ b/providers/aixy/models/alibaba/qwen-vl-max.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen-vl-max"
+
+[cost]
+input = 0.8
+output = 3.2

--- a/providers/aixy/models/alibaba/qwen-vl-plus.toml
+++ b/providers/aixy/models/alibaba/qwen-vl-plus.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen-vl-plus"
+
+[cost]
+input = 0.21
+output = 0.63

--- a/providers/aixy/models/alibaba/qwen2-5-vl-72b-instruct.toml
+++ b/providers/aixy/models/alibaba/qwen2-5-vl-72b-instruct.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen2-5-vl-72b-instruct"
+
+[cost]
+input = 2.8
+output = 8.4

--- a/providers/aixy/models/alibaba/qwen3-235b-a22b.toml
+++ b/providers/aixy/models/alibaba/qwen3-235b-a22b.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3-235b-a22b.toml.
 base_model = "alibaba/qwen3-235b-a22b"

--- a/providers/aixy/models/alibaba/qwen3-235b-a22b.toml
+++ b/providers/aixy/models/alibaba/qwen3-235b-a22b.toml
@@ -1,0 +1,14 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3-235b-a22b.toml.
+base_model = "alibaba/qwen3-235b-a22b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.7
+output = 2.8
+reasoning = 8.4

--- a/providers/aixy/models/alibaba/qwen3-32b.toml
+++ b/providers/aixy/models/alibaba/qwen3-32b.toml
@@ -1,0 +1,14 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3-32b.toml.
+base_model = "alibaba/qwen3-32b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.7
+output = 2.8
+reasoning = 8.4

--- a/providers/aixy/models/alibaba/qwen3-32b.toml
+++ b/providers/aixy/models/alibaba/qwen3-32b.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3-32b.toml.
 base_model = "alibaba/qwen3-32b"

--- a/providers/aixy/models/alibaba/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/aixy/models/alibaba/qwen3-coder-30b-a3b-instruct.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
+
+[cost]
+input = 0.45
+output = 2.25

--- a/providers/aixy/models/alibaba/qwen3-coder-480b-a35b-instruct.toml
+++ b/providers/aixy/models/alibaba/qwen3-coder-480b-a35b-instruct.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-480b-a35b-instruct"
+
+[cost]
+input = 1.5
+output = 7.5

--- a/providers/aixy/models/alibaba/qwen3-coder-flash.toml
+++ b/providers/aixy/models/alibaba/qwen3-coder-flash.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-flash"
+
+[cost]
+input = 0.3
+output = 1.5

--- a/providers/aixy/models/alibaba/qwen3-coder-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3-coder-plus.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-coder-plus"
+
+[cost]
+input = 1
+output = 5

--- a/providers/aixy/models/alibaba/qwen3-max.toml
+++ b/providers/aixy/models/alibaba/qwen3-max.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-max"
+
+[cost]
+input = 1.2
+output = 6

--- a/providers/aixy/models/alibaba/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/aixy/models/alibaba/qwen3-next-80b-a3b-instruct.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+
+[cost]
+input = 0.5
+output = 2

--- a/providers/aixy/models/alibaba/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/aixy/models/alibaba/qwen3-next-80b-a3b-thinking.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3-next-80b-a3b-thinking"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.5
+output = 6

--- a/providers/aixy/models/alibaba/qwen3-vl-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3-vl-plus.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3-vl-plus.toml.
 base_model = "alibaba/qwen3-vl-plus"

--- a/providers/aixy/models/alibaba/qwen3-vl-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3-vl-plus.toml
@@ -1,0 +1,14 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3-vl-plus.toml.
+base_model = "alibaba/qwen3-vl-plus"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.2
+output = 1.6
+reasoning = 4.8

--- a/providers/aixy/models/alibaba/qwen3.5-122b-a10b.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-122b-a10b.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.5-122b-a10b.toml.
 base_model = "alibaba/qwen3.5-122b-a10b"

--- a/providers/aixy/models/alibaba/qwen3.5-122b-a10b.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-122b-a10b.toml
@@ -1,0 +1,13 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.5-122b-a10b.toml.
+base_model = "alibaba/qwen3.5-122b-a10b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.4
+output = 3.2

--- a/providers/aixy/models/alibaba/qwen3.5-27b.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-27b.toml
@@ -1,0 +1,13 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.5-27b.toml.
+base_model = "alibaba/qwen3.5-27b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.3
+output = 2.4

--- a/providers/aixy/models/alibaba/qwen3.5-27b.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-27b.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.5-27b.toml.
 base_model = "alibaba/qwen3.5-27b"

--- a/providers/aixy/models/alibaba/qwen3.5-35b-a3b.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-35b-a3b.toml
@@ -1,0 +1,13 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.5-35b-a3b.toml.
+base_model = "alibaba/qwen3.5-35b-a3b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.25
+output = 2

--- a/providers/aixy/models/alibaba/qwen3.5-35b-a3b.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-35b-a3b.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.5-35b-a3b.toml.
 base_model = "alibaba/qwen3.5-35b-a3b"

--- a/providers/aixy/models/alibaba/qwen3.5-397b-a17b.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-397b-a17b.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.5-397b-a17b.toml.
 base_model = "alibaba/qwen3.5-397b-a17b"

--- a/providers/aixy/models/alibaba/qwen3.5-397b-a17b.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-397b-a17b.toml
@@ -1,0 +1,13 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.5-397b-a17b.toml.
+base_model = "alibaba/qwen3.5-397b-a17b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.6
+output = 3.6

--- a/providers/aixy/models/alibaba/qwen3.5-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-plus.toml
@@ -1,0 +1,14 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.5-plus.toml.
+base_model = "alibaba/qwen3.5-plus"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.4
+output = 2.4
+reasoning = 2.4

--- a/providers/aixy/models/alibaba/qwen3.5-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3.5-plus.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.5-plus.toml.
 base_model = "alibaba/qwen3.5-plus"

--- a/providers/aixy/models/alibaba/qwen3.6-27b.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-27b.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.6-27b.toml.
 base_model = "alibaba/qwen3.6-27b"

--- a/providers/aixy/models/alibaba/qwen3.6-27b.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-27b.toml
@@ -1,0 +1,13 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.6-27b.toml.
+base_model = "alibaba/qwen3.6-27b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.6
+output = 3.6

--- a/providers/aixy/models/alibaba/qwen3.6-35b-a3b.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-35b-a3b.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.6-35b-a3b.toml.
 base_model = "alibaba/qwen3.6-35b-a3b"

--- a/providers/aixy/models/alibaba/qwen3.6-35b-a3b.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-35b-a3b.toml
@@ -1,0 +1,13 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.6-35b-a3b.toml.
+base_model = "alibaba/qwen3.6-35b-a3b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.248
+output = 1.485

--- a/providers/aixy/models/alibaba/qwen3.6-flash.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-flash.toml
@@ -1,0 +1,14 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.6-flash.toml.
+base_model = "alibaba/qwen3.6-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.1875
+output = 1.125
+cache_write = 0.234375

--- a/providers/aixy/models/alibaba/qwen3.6-flash.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-flash.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.6-flash.toml.
 base_model = "alibaba/qwen3.6-flash"

--- a/providers/aixy/models/alibaba/qwen3.6-max-preview.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-max-preview.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.6-max-preview.toml.
 base_model = "alibaba/qwen3.6-max-preview"

--- a/providers/aixy/models/alibaba/qwen3.6-max-preview.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-max-preview.toml
@@ -1,0 +1,15 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.6-max-preview.toml.
+base_model = "alibaba/qwen3.6-max-preview"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 1.3
+output = 7.8
+cache_read = 0.13
+cache_write = 1.625

--- a/providers/aixy/models/alibaba/qwen3.6-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-plus.toml
@@ -1,0 +1,23 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.6-plus.toml.
+base_model = "alibaba/qwen3.6-plus"
+attachment = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+cache_write = 0.625
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 2
+output = 6
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/aixy/models/alibaba/qwen3.6-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3.6-plus.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.6-plus.toml.
 base_model = "alibaba/qwen3.6-plus"

--- a/providers/aixy/models/alibaba/qwen3.7-max.toml
+++ b/providers/aixy/models/alibaba/qwen3.7-max.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.7-max.toml.
 base_model = "alibaba/qwen3.7-max"

--- a/providers/aixy/models/alibaba/qwen3.7-max.toml
+++ b/providers/aixy/models/alibaba/qwen3.7-max.toml
@@ -1,0 +1,15 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.7-max.toml.
+base_model = "alibaba/qwen3.7-max"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 2.5
+output = 7.5
+cache_read = 0.5
+cache_write = 3.125

--- a/providers/aixy/models/alibaba/qwen3.7-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3.7-plus.toml
@@ -1,0 +1,26 @@
+# Aixy forwards this route to alibaba without translating the model payload.
+# Reasoning controls mirror providers/alibaba/models/qwen3.7-plus.toml.
+base_model = "alibaba/qwen3.7-plus"
+attachment = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+cache_write = 0.625
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 2
+output = 6
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+output = 65_536

--- a/providers/aixy/models/alibaba/qwen3.7-plus.toml
+++ b/providers/aixy/models/alibaba/qwen3.7-plus.toml
@@ -1,3 +1,4 @@
+# Toggle: enable_thinking = true|false
 # Aixy forwards this route to alibaba without translating the model payload.
 # Reasoning controls mirror providers/alibaba/models/qwen3.7-plus.toml.
 base_model = "alibaba/qwen3.7-plus"

--- a/providers/aixy/models/alibaba/qwen3.8-max.toml
+++ b/providers/aixy/models/alibaba/qwen3.8-max.toml
@@ -1,0 +1,34 @@
+# Sources (accessed 2026-08-04):
+# https://www.qwencloud.com/models/qwen3.8-max
+# https://docs.qwencloud.com/developer-guides/text-generation/thinking
+# https://docs.qwencloud.com/developer-guides/getting-started/text-generation-models
+# https://help.aliyun.com/zh/model-studio/model-pricing (Singapore: qwen3.8-max list)
+# Toggle: enable_thinking true|false (hybrid)
+# Effort: reasoning_effort = low|medium|xhigh (default xhigh); high accepted as alias → xhigh
+# Budget: thinking_budget (0..262144) cannot be combined with reasoning_effort
+# API: {"enable_thinking":true,"reasoning_effort":"medium"} or
+# {"enable_thinking":true,"thinking_budget":16384}
+# Pay-as-you-go on DashScope/QwenCloud (not Token Plan only). Cost USD/MTok from model page.
+base_model = "alibaba/qwen3.8-max"
+structured_output = true
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 262_144
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.25
+cache_write = 2.5

--- a/providers/aixy/models/alibaba/qwq-plus.toml
+++ b/providers/aixy/models/alibaba/qwq-plus.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwq-plus"
+reasoning_options = []
+
+[cost]
+input = 0.8
+output = 2.4

--- a/providers/aixy/models/azure/claude-fable-5.toml
+++ b/providers/aixy/models/azure/claude-fable-5.toml
@@ -1,0 +1,13 @@
+# Azure catalog: https://ai.azure.com/catalog/models/claude-fable-5
+base_model = "anthropic/claude-fable-5"
+status = "beta"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/aixy/models/azure/claude-haiku-4-5.toml
+++ b/providers/aixy/models/azure/claude-haiku-4-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-haiku-4-5"
+name = "Claude Haiku 4.5"
+description = "Fast Claude model for responsive assistance, classification, and lightweight agents"
+structured_output = true
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25

--- a/providers/aixy/models/azure/claude-mythos-5.toml
+++ b/providers/aixy/models/azure/claude-mythos-5.toml
@@ -1,0 +1,14 @@
+# Azure catalog: https://ai.azure.com/catalog/models/claude-mythos-5
+# Effort: output_config.effort = low|medium|high|xhigh|max; thinking is always on.
+base_model = "anthropic/claude-mythos-5"
+status = "beta"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/aixy/models/azure/claude-opus-4-1.toml
+++ b/providers/aixy/models/azure/claude-opus-4-1.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-opus-4-1"
+name = "Claude Opus 4.1"
+structured_output = true
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 15
+output = 75
+cache_read = 1.5
+cache_write = 18.75

--- a/providers/aixy/models/azure/claude-opus-4-5.toml
+++ b/providers/aixy/models/azure/claude-opus-4-5.toml
@@ -1,0 +1,16 @@
+base_model = "anthropic/claude-opus-4-5"
+name = "Claude Opus 4.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/azure/claude-opus-4-6.toml
+++ b/providers/aixy/models/azure/claude-opus-4-6.toml
@@ -1,0 +1,25 @@
+# Context window: Azure Foundry serves 1M (legacy 200K cap removed).
+# https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/claude-models?tabs=pay-go#available-claude-models
+base_model = "anthropic/claude-opus-4-6"
+description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 10
+output = 37.5
+cache_read = 1
+cache_write = 12.5

--- a/providers/aixy/models/azure/claude-opus-4-7.toml
+++ b/providers/aixy/models/azure/claude-opus-4-7.toml
@@ -1,0 +1,17 @@
+# Azure AI Foundry serves Claude Opus 4.7 at Anthropic list pricing:
+# https://platform.claude.com/docs/en/about-claude/pricing
+# Claude 4.6+ bills the full 1M context window at standard rates (no long-context
+# premium), so no [[cost.tiers]] here — the tiers on azure's claude-opus-4-6/4-8
+# entries predate that policy. Model availability:
+# https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/claude-models?tabs=pay-go#available-claude-models
+base_model = "anthropic/claude-opus-4-7"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/azure/claude-opus-4-8.toml
+++ b/providers/aixy/models/azure/claude-opus-4-8.toml
@@ -1,0 +1,18 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 10
+output = 37.5
+cache_read = 1
+cache_write = 12.5

--- a/providers/aixy/models/azure/claude-opus-5.toml
+++ b/providers/aixy/models/azure/claude-opus-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-5"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/azure/claude-sonnet-4-5.toml
+++ b/providers/aixy/models/azure/claude-sonnet-4-5.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-sonnet-4-5"
+name = "Claude Sonnet 4.5"
+structured_output = true
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/aixy/models/azure/claude-sonnet-4-6.toml
+++ b/providers/aixy/models/azure/claude-sonnet-4-6.toml
@@ -1,0 +1,16 @@
+base_model = "anthropic/claude-sonnet-4-6"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/aixy/models/azure/claude-sonnet-5.toml
+++ b/providers/aixy/models/azure/claude-sonnet-5.toml
@@ -1,0 +1,20 @@
+# Azure catalog and pricing: https://ai.azure.com/catalog/models/claude-sonnet-5
+# Introductory pricing is in effect through August 31, 2026.
+# Toggle: thinking.type = adaptive|disabled
+# Effort: output_config.effort = low|medium|high|xhigh|max
+base_model = "anthropic/claude-sonnet-5"
+structured_output = true
+status = "beta"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/aixy/models/azure/deepseek-r1.toml
+++ b/providers/aixy/models/azure/deepseek-r1.toml
@@ -1,0 +1,13 @@
+base_model = "deepseek/deepseek-r1"
+description = "DeepSeek reasoning model for multi-step analysis, math, coding, and tools"
+tool_call = false
+status = "deprecated"
+reasoning_options = []
+
+[cost]
+input = 1.35
+output = 5.4
+
+[limit]
+context = 163_840
+output = 163_840

--- a/providers/aixy/models/azure/deepseek-v3.2.toml
+++ b/providers/aixy/models/azure/deepseek-v3.2.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-v3.2"
+name = "DeepSeek-V3.2"
+description = "DeepSeek chat model for instruction following, coding, and analysis"
+reasoning_options = []
+
+[cost]
+input = 0.58
+output = 1.68
+
+[limit]
+output = 128_000

--- a/providers/aixy/models/azure/deepseek-v4-flash.toml
+++ b/providers/aixy/models/azure/deepseek-v4-flash.toml
@@ -1,0 +1,11 @@
+# Direct endpoint: POST /models/chat/completions?api-version=2024-05-01-preview.
+# Its published request schema documents no toggle, effort, or reasoning budget.
+# https://learn.microsoft.com/en-us/rest/api/microsoftfoundry/model-inference/get-chat-completions/get-chat-completions (accessed 2026-06-25)
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek-V4-Flash"
+tool_call = false
+reasoning_options = []
+
+[cost]
+input = 0.19
+output = 0.51

--- a/providers/aixy/models/azure/deepseek-v4-pro.toml
+++ b/providers/aixy/models/azure/deepseek-v4-pro.toml
@@ -1,0 +1,11 @@
+# Direct endpoint: POST /models/chat/completions?api-version=2024-05-01-preview.
+# Its published request schema documents no toggle, effort, or reasoning budget.
+# https://learn.microsoft.com/en-us/rest/api/microsoftfoundry/model-inference/get-chat-completions/get-chat-completions (accessed 2026-06-25)
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek-V4-Pro"
+tool_call = false
+reasoning_options = []
+
+[cost]
+input = 1.74
+output = 3.48

--- a/providers/aixy/models/azure/gpt-4-turbo.toml
+++ b/providers/aixy/models/azure/gpt-4-turbo.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-4-turbo"
+base_model_omit = ["structured_output"]
 status = "deprecated"
 
 [cost]

--- a/providers/aixy/models/azure/gpt-4-turbo.toml
+++ b/providers/aixy/models/azure/gpt-4-turbo.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-4-turbo"
+status = "deprecated"
+
+[cost]
+input = 10
+output = 30

--- a/providers/aixy/models/azure/gpt-4.1-mini.toml
+++ b/providers/aixy/models/azure/gpt-4.1-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-4.1-mini"
+base_model_omit = ["structured_output"]
 status = "deprecated"
 
 [cost]

--- a/providers/aixy/models/azure/gpt-4.1-mini.toml
+++ b/providers/aixy/models/azure/gpt-4.1-mini.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-4.1-mini"
+status = "deprecated"
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.1
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/azure/gpt-4.1-nano.toml
+++ b/providers/aixy/models/azure/gpt-4.1-nano.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-4.1-nano"
+status = "deprecated"
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.025

--- a/providers/aixy/models/azure/gpt-4.1-nano.toml
+++ b/providers/aixy/models/azure/gpt-4.1-nano.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-4.1-nano"
+base_model_omit = ["structured_output"]
 status = "deprecated"
 
 [cost]

--- a/providers/aixy/models/azure/gpt-4.1.toml
+++ b/providers/aixy/models/azure/gpt-4.1.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-4.1"
+base_model_omit = ["structured_output"]
 status = "deprecated"
 
 [cost]

--- a/providers/aixy/models/azure/gpt-4.1.toml
+++ b/providers/aixy/models/azure/gpt-4.1.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-4.1"
+status = "deprecated"
+
+[cost]
+input = 2
+output = 8
+cache_read = 0.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/azure/gpt-4o-mini.toml
+++ b/providers/aixy/models/azure/gpt-4o-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-4o-mini"
+base_model_omit = ["structured_output"]
 status = "deprecated"
 
 [cost]

--- a/providers/aixy/models/azure/gpt-4o-mini.toml
+++ b/providers/aixy/models/azure/gpt-4o-mini.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-4o-mini"
+status = "deprecated"
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.075
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/azure/gpt-4o.toml
+++ b/providers/aixy/models/azure/gpt-4o.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-4o"
+status = "deprecated"
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/azure/gpt-4o.toml
+++ b/providers/aixy/models/azure/gpt-4o.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-4o"
+base_model_omit = ["structured_output"]
 status = "deprecated"
 
 [cost]

--- a/providers/aixy/models/azure/gpt-5-mini.toml
+++ b/providers/aixy/models/azure/gpt-5-mini.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-5-mini"
+description = "Compact GPT model for low-latency assistance and high-volume workloads"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.03

--- a/providers/aixy/models/azure/gpt-5-nano.toml
+++ b/providers/aixy/models/azure/gpt-5-nano.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-5-nano"
+description = "Compact GPT model for low-latency assistance and high-volume workloads"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.05
+output = 0.4
+cache_read = 0.01

--- a/providers/aixy/models/azure/gpt-5-pro.toml
+++ b/providers/aixy/models/azure/gpt-5-pro.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-5-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high"]
+
+[cost]
+input = 15
+output = 120

--- a/providers/aixy/models/azure/gpt-5-pro.toml
+++ b/providers/aixy/models/azure/gpt-5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5-pro"
+base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/aixy/models/azure/gpt-5.2.toml
+++ b/providers/aixy/models/azure/gpt-5.2.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-5.2"
+description = "GPT model for general reasoning, writing, coding, and tool-assisted tasks"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.125

--- a/providers/aixy/models/azure/gpt-5.4-mini.toml
+++ b/providers/aixy/models/azure/gpt-5.4-mini.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.4-mini"
+name = "GPT-5.4 Mini"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/aixy/models/azure/gpt-5.4-nano.toml
+++ b/providers/aixy/models/azure/gpt-5.4-nano.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.4-nano"
+name = "GPT-5.4 Nano"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/aixy/models/azure/gpt-5.4-pro.toml
+++ b/providers/aixy/models/azure/gpt-5.4-pro.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.4-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high", "xhigh"]
+
+[cost]
+input = 30
+output = 180
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 60
+output = 270

--- a/providers/aixy/models/azure/gpt-5.4.toml
+++ b/providers/aixy/models/azure/gpt-5.4.toml
@@ -1,0 +1,16 @@
+base_model = "openai/gpt-5.4"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5

--- a/providers/aixy/models/azure/gpt-5.5.toml
+++ b/providers/aixy/models/azure/gpt-5.5.toml
@@ -1,0 +1,16 @@
+base_model = "openai/gpt-5.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1

--- a/providers/aixy/models/azure/gpt-5.6-luna.toml
+++ b/providers/aixy/models/azure/gpt-5.6-luna.toml
@@ -1,0 +1,20 @@
+# Pricing: https://developers.openai.com/api/docs/pricing
+base_model = "openai/gpt-5.6-luna"
+status = "beta"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.4
+output = 1.8
+cache_read = 0.04
+cache_write = 0.5

--- a/providers/aixy/models/azure/gpt-5.6-sol.toml
+++ b/providers/aixy/models/azure/gpt-5.6-sol.toml
@@ -1,0 +1,20 @@
+# Pricing: https://developers.openai.com/api/docs/pricing
+base_model = "openai/gpt-5.6-sol"
+status = "beta"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+cache_write = 12.5

--- a/providers/aixy/models/azure/gpt-5.6-terra.toml
+++ b/providers/aixy/models/azure/gpt-5.6-terra.toml
@@ -1,0 +1,20 @@
+# Pricing: https://developers.openai.com/api/docs/pricing
+base_model = "openai/gpt-5.6-terra"
+status = "beta"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5

--- a/providers/aixy/models/azure/gpt-5.toml
+++ b/providers/aixy/models/azure/gpt-5.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-5"
+description = "GPT model for general reasoning, writing, coding, and tool-assisted tasks"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.13

--- a/providers/aixy/models/azure/gpt-chat-latest.toml
+++ b/providers/aixy/models/azure/gpt-chat-latest.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5.5-instant"
+name = "GPT Chat Latest"
+temperature = false
+status = "beta"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[limit]
+context = 128_000
+input = 111_616
+output = 16_384

--- a/providers/aixy/models/azure/kimi-k2.5.toml
+++ b/providers/aixy/models/azure/kimi-k2.5.toml
@@ -1,0 +1,19 @@
+# Direct endpoint: POST /models/chat/completions?api-version=2024-05-01-preview.
+# Its published request schema documents no toggle, effort, or reasoning budget.
+# https://learn.microsoft.com/en-us/rest/api/microsoftfoundry/model-inference/get-chat-completions/get-chat-completions (accessed 2026-06-25)
+base_model = "moonshotai/kimi-k2.5"
+description = "Kimi multimodal agent model for visual understanding, coding, and planning"
+attachment = false
+temperature = true
+
+interleaved = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.6
+output = 3
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/azure/kimi-k2.5.toml
+++ b/providers/aixy/models/azure/kimi-k2.5.toml
@@ -8,8 +8,7 @@ temperature = true
 
 interleaved = true
 
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = []
 
 [cost]
 input = 0.6

--- a/providers/aixy/models/azure/kimi-k2.6.toml
+++ b/providers/aixy/models/azure/kimi-k2.6.toml
@@ -1,0 +1,18 @@
+# Direct endpoint: POST /models/chat/completions?api-version=2024-05-01-preview.
+# Its published request schema documents no toggle, effort, or reasoning budget.
+# https://learn.microsoft.com/en-us/rest/api/microsoftfoundry/model-inference/get-chat-completions/get-chat-completions (accessed 2026-06-25)
+base_model = "moonshotai/kimi-k2.6"
+description = "Kimi multimodal agent model for visual understanding, coding, and planning"
+attachment = false
+
+interleaved = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.95
+output = 4
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/azure/kimi-k2.6.toml
+++ b/providers/aixy/models/azure/kimi-k2.6.toml
@@ -7,8 +7,7 @@ attachment = false
 
 interleaved = true
 
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = []
 
 [cost]
 input = 0.95

--- a/providers/aixy/models/azure/kimi-k2.7-code.toml
+++ b/providers/aixy/models/azure/kimi-k2.7-code.toml
@@ -1,0 +1,14 @@
+# Pricing source: https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/ (accessed 2026-08-05)
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/azure/llama-3.3-70b-instruct.toml
+++ b/providers/aixy/models/azure/llama-3.3-70b-instruct.toml
@@ -1,0 +1,10 @@
+base_model = "meta/llama-3.3-70b-instruct"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+attachment = false
+
+[cost]
+input = 0.71
+output = 0.71
+
+[limit]
+output = 32_768

--- a/providers/aixy/models/azure/mistral-medium-2505.toml
+++ b/providers/aixy/models/azure/mistral-medium-2505.toml
@@ -1,0 +1,9 @@
+base_model = "mistral/mistral-medium-2505"
+
+[cost]
+input = 0.4
+output = 2
+
+[limit]
+context = 128_000
+output = 128_000

--- a/providers/aixy/models/azure/o1.toml
+++ b/providers/aixy/models/azure/o1.toml
@@ -1,0 +1,15 @@
+base_model = "openai/o1"
+attachment = false
+status = "deprecated"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 15
+output = 60
+cache_read = 7.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/azure/o3-mini.toml
+++ b/providers/aixy/models/azure/o3-mini.toml
@@ -1,0 +1,11 @@
+base_model = "openai/o3-mini"
+status = "deprecated"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.55

--- a/providers/aixy/models/azure/o3-mini.toml
+++ b/providers/aixy/models/azure/o3-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3-mini"
+base_model_omit = ["structured_output"]
 status = "deprecated"
 
 [[reasoning_options]]

--- a/providers/aixy/models/azure/o3.toml
+++ b/providers/aixy/models/azure/o3.toml
@@ -1,0 +1,13 @@
+base_model = "openai/o3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2
+output = 8
+cache_read = 0.5
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/azure/o3.toml
+++ b/providers/aixy/models/azure/o3.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o3"
+base_model_omit = ["structured_output"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/aixy/models/azure/o4-mini.toml
+++ b/providers/aixy/models/azure/o4-mini.toml
@@ -1,4 +1,5 @@
 base_model = "openai/o4-mini"
+base_model_omit = ["structured_output"]
 status = "deprecated"
 
 [[reasoning_options]]

--- a/providers/aixy/models/azure/o4-mini.toml
+++ b/providers/aixy/models/azure/o4-mini.toml
@@ -1,0 +1,11 @@
+base_model = "openai/o4-mini"
+status = "deprecated"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.275

--- a/providers/aixy/models/azure/phi-4-mini.toml
+++ b/providers/aixy/models/azure/phi-4-mini.toml
@@ -1,0 +1,6 @@
+base_model = "microsoft/phi-4-mini"
+description = "Efficient model for low-latency assistance, extraction, and routine automation"
+
+[cost]
+input = 0.075
+output = 0.3

--- a/providers/aixy/models/bedrock/anthropic.claude-fable-5.toml
+++ b/providers/aixy/models/bedrock/anthropic.claude-fable-5.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-fable-5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/aixy/models/bedrock/anthropic.claude-opus-4-1-20250805-v1:0.toml
+++ b/providers/aixy/models/bedrock/anthropic.claude-opus-4-1-20250805-v1:0.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-1-20250805"
+status = "deprecated"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 15
+output = 75
+cache_read = 1.5
+cache_write = 18.75

--- a/providers/aixy/models/bedrock/anthropic.claude-opus-4-6-v1.toml
+++ b/providers/aixy/models/bedrock/anthropic.claude-opus-4-6-v1.toml
@@ -1,0 +1,16 @@
+base_model = "anthropic/claude-opus-4-6"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/anthropic.claude-opus-4-8.toml
+++ b/providers/aixy/models/bedrock/anthropic.claude-opus-4-8.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-8"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/anthropic.claude-opus-5.toml
+++ b/providers/aixy/models/bedrock/anthropic.claude-opus-5.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/anthropic.claude-sonnet-4-6.toml
+++ b/providers/aixy/models/bedrock/anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,16 @@
+base_model = "anthropic/claude-sonnet-4-6"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/aixy/models/bedrock/anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/anthropic.claude-sonnet-5.toml
@@ -1,0 +1,17 @@
+# Aixy forwards this route to amazon-bedrock without translating the model payload.
+# Reasoning controls mirror providers/amazon-bedrock/models/anthropic.claude-sonnet-5.toml.
+base_model = "anthropic/claude-sonnet-5"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/aixy/models/bedrock/anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/anthropic.claude-sonnet-5.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = adaptive|disabled
 # Aixy forwards this route to amazon-bedrock without translating the model payload.
 # Reasoning controls mirror providers/amazon-bedrock/models/anthropic.claude-sonnet-5.toml.
 base_model = "anthropic/claude-sonnet-5"

--- a/providers/aixy/models/bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/aixy/models/bedrock/au.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-haiku-4-5-20251001"
+name = "Claude Haiku 4.5 (AU)"
+structured_output = true
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25

--- a/providers/aixy/models/bedrock/au.anthropic.claude-opus-4-8.toml
+++ b/providers/aixy/models/bedrock/au.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8 (AU)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/au.anthropic.claude-opus-5.toml
+++ b/providers/aixy/models/bedrock/au.anthropic.claude-opus-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (AU)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/aixy/models/bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-sonnet-4-5"
+name = "Claude Sonnet 4.5 (AU)"
+structured_output = true
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/aixy/models/bedrock/au.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/au.anthropic.claude-sonnet-5.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = adaptive|disabled
 # Aixy forwards this route to amazon-bedrock without translating the model payload.
 # Reasoning controls mirror providers/amazon-bedrock/models/au.anthropic.claude-sonnet-5.toml.
 base_model = "anthropic/claude-sonnet-5"

--- a/providers/aixy/models/bedrock/au.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/au.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to amazon-bedrock without translating the model payload.
+# Reasoning controls mirror providers/amazon-bedrock/models/au.anthropic.claude-sonnet-5.toml.
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (AU)"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/aixy/models/bedrock/eu.anthropic.claude-fable-5.toml
+++ b/providers/aixy/models/bedrock/eu.anthropic.claude-fable-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-fable-5"
+name = "Claude Fable 5 (EU)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 11
+output = 55
+cache_read = 1.1
+cache_write = 13.75

--- a/providers/aixy/models/bedrock/eu.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/aixy/models/bedrock/eu.anthropic.claude-opus-4-6-v1.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-opus-4-6"
+name = "Claude Opus 4.6 (EU)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 5.5
+output = 27.5
+cache_read = 0.55
+cache_write = 6.875

--- a/providers/aixy/models/bedrock/eu.anthropic.claude-opus-4-8.toml
+++ b/providers/aixy/models/bedrock/eu.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8 (EU)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5.5
+output = 27.5
+cache_read = 0.55
+cache_write = 6.875

--- a/providers/aixy/models/bedrock/eu.anthropic.claude-opus-5.toml
+++ b/providers/aixy/models/bedrock/eu.anthropic.claude-opus-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (EU)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5.5
+output = 27.5
+cache_read = 0.55
+cache_write = 6.875

--- a/providers/aixy/models/bedrock/eu.anthropic.claude-sonnet-4-6.toml
+++ b/providers/aixy/models/bedrock/eu.anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6 (EU)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3.3
+output = 16.5
+cache_read = 0.33
+cache_write = 4.125

--- a/providers/aixy/models/bedrock/eu.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/eu.anthropic.claude-sonnet-5.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = adaptive|disabled
 # Aixy forwards this route to amazon-bedrock without translating the model payload.
 # Reasoning controls mirror providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-5.toml.
 base_model = "anthropic/claude-sonnet-5"

--- a/providers/aixy/models/bedrock/eu.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/eu.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to amazon-bedrock without translating the model payload.
+# Reasoning controls mirror providers/amazon-bedrock/models/eu.anthropic.claude-sonnet-5.toml.
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (EU)"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2.2
+output = 11
+cache_read = 0.22
+cache_write = 2.75

--- a/providers/aixy/models/bedrock/global.anthropic.claude-fable-5.toml
+++ b/providers/aixy/models/bedrock/global.anthropic.claude-fable-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-fable-5"
+name = "Claude Fable 5 (Global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/aixy/models/bedrock/global.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/aixy/models/bedrock/global.anthropic.claude-opus-4-6-v1.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-opus-4-6"
+name = "Claude Opus 4.6 (Global)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/global.anthropic.claude-opus-4-8.toml
+++ b/providers/aixy/models/bedrock/global.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8 (Global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/global.anthropic.claude-opus-5.toml
+++ b/providers/aixy/models/bedrock/global.anthropic.claude-opus-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (Global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/global.anthropic.claude-sonnet-4-6.toml
+++ b/providers/aixy/models/bedrock/global.anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6 (Global)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/aixy/models/bedrock/global.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/global.anthropic.claude-sonnet-5.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = adaptive|disabled
 # Aixy forwards this route to amazon-bedrock without translating the model payload.
 # Reasoning controls mirror providers/amazon-bedrock/models/global.anthropic.claude-sonnet-5.toml.
 base_model = "anthropic/claude-sonnet-5"

--- a/providers/aixy/models/bedrock/global.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/global.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to amazon-bedrock without translating the model payload.
+# Reasoning controls mirror providers/amazon-bedrock/models/global.anthropic.claude-sonnet-5.toml.
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (Global)"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/aixy/models/bedrock/global.openai.gpt-5.6-luna.toml
+++ b/providers/aixy/models/bedrock/global.openai.gpt-5.6-luna.toml
@@ -1,0 +1,22 @@
+# Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Verified from eu-west-1: returns 200 with reasoning effort set.
+# Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-luna: https://aws.amazon.com/bedrock/pricing/
+base_model = "openai/gpt-5.6-luna"
+name = "GPT-5.6 Luna (Global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.22
+output = 1.32
+cache_read = 0.022
+cache_write = 0.275
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.44
+output = 1.98
+cache_read = 0.044
+cache_write = 0.55

--- a/providers/aixy/models/bedrock/global.openai.gpt-5.6-luna.toml
+++ b/providers/aixy/models/bedrock/global.openai.gpt-5.6-luna.toml
@@ -2,6 +2,7 @@
 # Verified from eu-west-1: returns 200 with reasoning effort set.
 # Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-luna: https://aws.amazon.com/bedrock/pricing/
 base_model = "openai/gpt-5.6-luna"
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-5.6 Luna (Global)"
 
 [[reasoning_options]]

--- a/providers/aixy/models/bedrock/global.openai.gpt-5.6-sol.toml
+++ b/providers/aixy/models/bedrock/global.openai.gpt-5.6-sol.toml
@@ -2,6 +2,7 @@
 # Verified from eu-west-1: returns 200 with reasoning effort set.
 # Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-sol: https://aws.amazon.com/bedrock/pricing/
 base_model = "openai/gpt-5.6-sol"
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-5.6 Sol (Global)"
 
 [[reasoning_options]]

--- a/providers/aixy/models/bedrock/global.openai.gpt-5.6-sol.toml
+++ b/providers/aixy/models/bedrock/global.openai.gpt-5.6-sol.toml
@@ -1,0 +1,22 @@
+# Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Verified from eu-west-1: returns 200 with reasoning effort set.
+# Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-sol: https://aws.amazon.com/bedrock/pricing/
+base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6 Sol (Global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5.5
+output = 33
+cache_read = 0.55
+cache_write = 6.875
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 11
+output = 49.5
+cache_read = 1.1
+cache_write = 13.75

--- a/providers/aixy/models/bedrock/global.openai.gpt-5.6-terra.toml
+++ b/providers/aixy/models/bedrock/global.openai.gpt-5.6-terra.toml
@@ -2,6 +2,7 @@
 # Verified from eu-west-1: effort none|low|medium|high|xhigh|max all return 200.
 # Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-terra: https://aws.amazon.com/bedrock/pricing/
 base_model = "openai/gpt-5.6-terra"
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-5.6 Terra (Global)"
 
 [[reasoning_options]]

--- a/providers/aixy/models/bedrock/global.openai.gpt-5.6-terra.toml
+++ b/providers/aixy/models/bedrock/global.openai.gpt-5.6-terra.toml
@@ -1,0 +1,22 @@
+# Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Verified from eu-west-1: effort none|low|medium|high|xhigh|max all return 200.
+# Pricing mirrors the US in-region on-demand rates on openai.gpt-5.6-terra: https://aws.amazon.com/bedrock/pricing/
+base_model = "openai/gpt-5.6-terra"
+name = "GPT-5.6 Terra (Global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2.2
+output = 13.2
+cache_read = 0.22
+cache_write = 2.75
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4.4
+output = 19.8
+cache_read = 0.44
+cache_write = 5.5

--- a/providers/aixy/models/bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.toml
+++ b/providers/aixy/models/bedrock/jp.anthropic.claude-haiku-4-5-20251001-v1:0.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-haiku-4-5-20251001"
+name = "Claude Haiku 4.5 (JP)"
+structured_output = true
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25

--- a/providers/aixy/models/bedrock/jp.anthropic.claude-opus-4-7.toml
+++ b/providers/aixy/models/bedrock/jp.anthropic.claude-opus-4-7.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-7"
+name = "Claude Opus 4.7 (JP)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/jp.anthropic.claude-opus-4-8.toml
+++ b/providers/aixy/models/bedrock/jp.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8 (JP)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/jp.anthropic.claude-opus-5.toml
+++ b/providers/aixy/models/bedrock/jp.anthropic.claude-opus-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (JP)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
+++ b/providers/aixy/models/bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-sonnet-4-5"
+name = "Claude Sonnet 4.5 (JP)"
+structured_output = true
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/aixy/models/bedrock/jp.anthropic.claude-sonnet-4-6.toml
+++ b/providers/aixy/models/bedrock/jp.anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6 (JP)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/aixy/models/bedrock/jp.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/jp.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to amazon-bedrock without translating the model payload.
+# Reasoning controls mirror providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-5.toml.
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (JP)"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/aixy/models/bedrock/jp.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/jp.anthropic.claude-sonnet-5.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = adaptive|disabled
 # Aixy forwards this route to amazon-bedrock without translating the model payload.
 # Reasoning controls mirror providers/amazon-bedrock/models/jp.anthropic.claude-sonnet-5.toml.
 base_model = "anthropic/claude-sonnet-5"

--- a/providers/aixy/models/bedrock/nvidia.nemotron-nano-12b-v2.toml
+++ b/providers/aixy/models/bedrock/nvidia.nemotron-nano-12b-v2.toml
@@ -1,0 +1,15 @@
+base_model = "nvidia/nemotron-nano-12b-v2-vl"
+name = "NVIDIA Nemotron Nano 12B v2 VL BF16"
+attachment = false
+reasoning = false
+structured_output = true
+
+[cost]
+input = 0.2
+output = 0.6
+
+[limit]
+output = 4_096
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/bedrock/nvidia.nemotron-nano-3-30b.toml
+++ b/providers/aixy/models/bedrock/nvidia.nemotron-nano-3-30b.toml
@@ -1,0 +1,12 @@
+base_model = "nvidia/nemotron-3-nano-30b-a3b"
+name = "NVIDIA Nemotron Nano 3 30B"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.06
+output = 0.24
+
+[limit]
+context = 128_000
+output = 4_096

--- a/providers/aixy/models/bedrock/nvidia.nemotron-nano-9b-v2.toml
+++ b/providers/aixy/models/bedrock/nvidia.nemotron-nano-9b-v2.toml
@@ -1,0 +1,12 @@
+base_model = "nvidia/nemotron-nano-9b-v2"
+name = "NVIDIA Nemotron Nano 9B v2"
+reasoning = false
+structured_output = true
+
+[cost]
+input = 0.06
+output = 0.23
+
+[limit]
+context = 128_000
+output = 4_096

--- a/providers/aixy/models/bedrock/nvidia.nemotron-super-3-120b.toml
+++ b/providers/aixy/models/bedrock/nvidia.nemotron-super-3-120b.toml
@@ -1,0 +1,11 @@
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+name = "NVIDIA Nemotron 3 Super 120B A12B"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 0.65
+
+[limit]
+output = 131_072

--- a/providers/aixy/models/bedrock/openai.gpt-5.4.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.4.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.4"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2.75
+output = 16.5
+cache_read = 0.275
+
+[limit]
+context = 272_000

--- a/providers/aixy/models/bedrock/openai.gpt-5.4.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.4.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4"
-base_model_omit = ["limit.input"]
+base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/aixy/models/bedrock/openai.gpt-5.5.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.5.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5.5"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 5.5
+output = 33
+cache_read = 0.55
+
+[limit]
+context = 272_000

--- a/providers/aixy/models/bedrock/openai.gpt-5.5.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5"
-base_model_omit = ["limit.input"]
+base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/aixy/models/bedrock/openai.gpt-5.6-luna.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.6-luna.toml
@@ -1,0 +1,22 @@
+# Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
+# Bedrock context window: https://developers.openai.com/api/docs/guides/amazon-bedrock
+# In-region on-demand pricing (US East N. Virginia & Ohio; also US West Oregon): https://aws.amazon.com/bedrock/pricing/
+# Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
+base_model = "openai/gpt-5.6-luna"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.22
+output = 1.32
+cache_read = 0.022
+cache_write = 0.275
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.44
+output = 1.98
+cache_read = 0.044
+cache_write = 0.55

--- a/providers/aixy/models/bedrock/openai.gpt-5.6-luna.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.6-luna.toml
@@ -3,6 +3,7 @@
 # In-region on-demand pricing (US East N. Virginia & Ohio; also US West Oregon): https://aws.amazon.com/bedrock/pricing/
 # Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
 base_model = "openai/gpt-5.6-luna"
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/aixy/models/bedrock/openai.gpt-5.6-sol.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.6-sol.toml
@@ -3,6 +3,7 @@
 # In-region on-demand pricing (US East N. Virginia & Ohio): https://aws.amazon.com/bedrock/pricing/
 # Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
 base_model = "openai/gpt-5.6-sol"
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/aixy/models/bedrock/openai.gpt-5.6-sol.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.6-sol.toml
@@ -1,0 +1,22 @@
+# Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
+# Bedrock context window: https://developers.openai.com/api/docs/guides/amazon-bedrock
+# In-region on-demand pricing (US East N. Virginia & Ohio): https://aws.amazon.com/bedrock/pricing/
+# Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
+base_model = "openai/gpt-5.6-sol"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5.5
+output = 33
+cache_read = 0.55
+cache_write = 6.875
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 11
+output = 49.5
+cache_read = 1.1
+cache_write = 13.75

--- a/providers/aixy/models/bedrock/openai.gpt-5.6-terra.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.6-terra.toml
@@ -3,6 +3,7 @@
 # In-region on-demand pricing (US East N. Virginia & Ohio; also US West Oregon): https://aws.amazon.com/bedrock/pricing/
 # Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
 base_model = "openai/gpt-5.6-terra"
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/aixy/models/bedrock/openai.gpt-5.6-terra.toml
+++ b/providers/aixy/models/bedrock/openai.gpt-5.6-terra.toml
@@ -1,0 +1,22 @@
+# Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
+# Bedrock context window: https://developers.openai.com/api/docs/guides/amazon-bedrock
+# In-region on-demand pricing (US East N. Virginia & Ohio; also US West Oregon): https://aws.amazon.com/bedrock/pricing/
+# Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
+base_model = "openai/gpt-5.6-terra"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2.2
+output = 13.2
+cache_read = 0.22
+cache_write = 2.75
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4.4
+output = 19.8
+cache_read = 0.44
+cache_write = 5.5

--- a/providers/aixy/models/bedrock/us.anthropic.claude-fable-5.toml
+++ b/providers/aixy/models/bedrock/us.anthropic.claude-fable-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-fable-5"
+name = "Claude Fable 5 (US)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/aixy/models/bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0.toml
+++ b/providers/aixy/models/bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-opus-4-1-20250805"
+name = "Claude Opus 4.1 (US)"
+status = "deprecated"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 15
+output = 75
+cache_read = 1.5
+cache_write = 18.75

--- a/providers/aixy/models/bedrock/us.anthropic.claude-opus-4-6-v1.toml
+++ b/providers/aixy/models/bedrock/us.anthropic.claude-opus-4-6-v1.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-opus-4-6"
+name = "Claude Opus 4.6 (US)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/us.anthropic.claude-opus-4-8.toml
+++ b/providers/aixy/models/bedrock/us.anthropic.claude-opus-4-8.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8 (US)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/us.anthropic.claude-opus-5.toml
+++ b/providers/aixy/models/bedrock/us.anthropic.claude-opus-5.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (US)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/aixy/models/bedrock/us.anthropic.claude-sonnet-4-6.toml
+++ b/providers/aixy/models/bedrock/us.anthropic.claude-sonnet-4-6.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6 (US)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/aixy/models/bedrock/us.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/us.anthropic.claude-sonnet-5.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = adaptive|disabled
 # Aixy forwards this route to amazon-bedrock without translating the model payload.
 # Reasoning controls mirror providers/amazon-bedrock/models/us.anthropic.claude-sonnet-5.toml.
 base_model = "anthropic/claude-sonnet-5"

--- a/providers/aixy/models/bedrock/us.anthropic.claude-sonnet-5.toml
+++ b/providers/aixy/models/bedrock/us.anthropic.claude-sonnet-5.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to amazon-bedrock without translating the model payload.
+# Reasoning controls mirror providers/amazon-bedrock/models/us.anthropic.claude-sonnet-5.toml.
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (US)"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5

--- a/providers/aixy/models/bedrock/us.deepseek.r1-v1:0.toml
+++ b/providers/aixy/models/bedrock/us.deepseek.r1-v1:0.toml
@@ -1,0 +1,7 @@
+base_model = "deepseek/deepseek-r1"
+name = "DeepSeek-R1 (US)"
+reasoning_options = []
+
+[cost]
+input = 1.35
+output = 5.4

--- a/providers/aixy/models/bedrock/us.meta.llama4-maverick-17b-instruct-v1:0.toml
+++ b/providers/aixy/models/bedrock/us.meta.llama4-maverick-17b-instruct-v1:0.toml
@@ -1,0 +1,6 @@
+base_model = "meta/llama-4-maverick-17b-instruct"
+name = "Llama 4 Maverick 17B Instruct (US)"
+
+[cost]
+input = 0.24
+output = 0.97

--- a/providers/aixy/models/bedrock/us.meta.llama4-scout-17b-instruct-v1:0.toml
+++ b/providers/aixy/models/bedrock/us.meta.llama4-scout-17b-instruct-v1:0.toml
@@ -1,0 +1,6 @@
+base_model = "meta/llama-4-scout-17b-instruct"
+name = "Llama 4 Scout 17B Instruct (US)"
+
+[cost]
+input = 0.17
+output = 0.66

--- a/providers/aixy/models/bedrock/xai.grok-4.3.toml
+++ b/providers/aixy/models/bedrock/xai.grok-4.3.toml
@@ -1,0 +1,16 @@
+base_model = "xai/grok-4.3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/bedrock/xai.grok-4.6.toml
+++ b/providers/aixy/models/bedrock/xai.grok-4.6.toml
@@ -1,0 +1,11 @@
+# Source: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html
+base_model = "xai/grok-4.6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2.2
+output = 6.6
+cache_read = 0.55

--- a/providers/aixy/models/cerebras/gemma-4-31b.toml
+++ b/providers/aixy/models/cerebras/gemma-4-31b.toml
@@ -1,0 +1,14 @@
+base_model = "google/gemma-4-31b-it"
+status = "beta"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 0.99
+output = 1.49
+
+[limit]
+context = 131_072
+output = 40_960

--- a/providers/aixy/models/cerebras/gpt-oss-120b.toml
+++ b/providers/aixy/models/cerebras/gpt-oss-120b.toml
@@ -1,0 +1,12 @@
+base_model = "openai/gpt-oss-120b"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.35
+output = 0.75
+
+[limit]
+output = 40_960

--- a/providers/aixy/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/providers/aixy/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # DeepSeek-V4-Flash-Vision-Exp is priced the same as DeepSeek V4 Flash.
 # https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-22)
 # https://api-docs.deepseek.com/guides/vision (accessed 2026-08-22)

--- a/providers/aixy/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/providers/aixy/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,0 +1,23 @@
+# DeepSeek-V4-Flash-Vision-Exp is priced the same as DeepSeek V4 Flash.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-22)
+# https://api-docs.deepseek.com/guides/vision (accessed 2026-08-22)
+# OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
+# Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
+base_model = "deepseek/deepseek-v4-flash-vision-exp"
+status = "beta"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+reasoning = 0.28
+cache_read = 0.0028

--- a/providers/aixy/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/aixy/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,25 @@
+# Reasoning tokens are billed at the output rate (no separate CoT price).
+# `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
+# OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
+# Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
+# Flash maps requested low→low (unlike Pro, which maps low→high). xhigh→high.
+# https://api-docs.deepseek.com/guides/thinking_mode/ (accessed 2026-08-02)
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+reasoning = 0.28
+cache_read = 0.0028

--- a/providers/aixy/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/aixy/models/deepseek/deepseek-v4-flash.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
 # https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)

--- a/providers/aixy/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/aixy/models/deepseek/deepseek-v4-pro.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
 # https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-12)

--- a/providers/aixy/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/aixy/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,21 @@
+# Reasoning tokens are billed at the output rate (no separate CoT price).
+# `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-12)
+base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.435
+output = 0.87
+reasoning = 0.87
+cache_read = 0.003625

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-flash-0731.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-flash-0731.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Aixy forwards this route to fireworks-ai without translating the model payload.
 # Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash-0731.toml.
 base_model = "deepseek/deepseek-v4-flash-0731"

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-flash-0731.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to fireworks-ai without translating the model payload.
+# Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash-0731.toml.
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-flash.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-flash.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Aixy forwards this route to fireworks-ai without translating the model payload.
 # Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash.toml.
 base_model = "deepseek/deepseek-v4-flash"

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-flash.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-flash.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to fireworks-ai without translating the model payload.
+# Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-flash.toml.
+base_model = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-pro-0813.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-pro-0813.toml
@@ -1,0 +1,20 @@
+# Toggle: thinking.type = enabled|disabled (reasoning_effort = none|false also disables)
+# Effort: reasoning_effort = high|max; low/medium promote to high, xhigh to max
+# Reasoning: https://docs.fireworks.ai/api-reference/post-chatcompletions (accessed 2026-08-14)
+# Pricing: https://fireworks.ai/models/deepseek-ai/deepseek-v4-pro-0813 (accessed 2026-08-14)
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 1.32
+output = 3.96
+cache_read = 0.044

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-pro.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-pro.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Aixy forwards this route to fireworks-ai without translating the model payload.
 # Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro.toml.
 base_model = "deepseek/deepseek-v4-pro"

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-pro.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/deepseek-v4-pro.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to fireworks-ai without translating the model payload.
+# Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/deepseek-v4-pro.toml.
+base_model = "deepseek/deepseek-v4-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.145

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/inkling.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/inkling.toml
@@ -1,0 +1,7 @@
+base_model = "thinkingmachines/inkling"
+reasoning_options = []
+
+[cost]
+input = 1
+output = 4.05
+cache_read = 0.17

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/kimi-k3.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/kimi-k3.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Aixy forwards this route to fireworks-ai without translating the model payload.
 # Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/kimi-k3.toml.
 base_model = "moonshotai/kimi-k3"

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/kimi-k3.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/kimi-k3.toml
@@ -1,0 +1,25 @@
+# Aixy forwards this route to fireworks-ai without translating the model payload.
+# Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/kimi-k3.toml.
+base_model = "moonshotai/kimi-k3"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/muse-glimmer-30b.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/muse-glimmer-30b.toml
@@ -1,0 +1,10 @@
+base_model = "meta/muse-glimmer-30b"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+[cost]
+input = 0.35
+output = 1.5
+cache_read = 0.04

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/nemotron-3-ultra-nvfp4.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/nemotron-3-ultra-nvfp4.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Aixy forwards this route to fireworks-ai without translating the model payload.
 # Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/nemotron-3-ultra-nvfp4.toml.
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/nemotron-3-ultra-nvfp4.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/nemotron-3-ultra-nvfp4.toml
@@ -1,0 +1,14 @@
+# Aixy forwards this route to fireworks-ai without translating the model payload.
+# Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/nemotron-3-ultra-nvfp4.toml.
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.6
+output = 2.4
+cache_read = 0.119
+
+[limit]
+context = 262_144

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b.toml
@@ -1,0 +1,11 @@
+# Aixy forwards this route to fireworks-ai without translating the model payload.
+# Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b.toml.
+base_model = "nvidia/nemotron-3.5-lightning"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.05
+output = 0.2
+cache_read = 0.01

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Aixy forwards this route to fireworks-ai without translating the model payload.
 # Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b.toml.
 base_model = "nvidia/nemotron-3.5-lightning"

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/qwen3p8-max.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/qwen3p8-max.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to fireworks-ai without translating the model payload.
+# Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/qwen3p8-max.toml.
+base_model = "alibaba/qwen3.8-max"
+attachment = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.25
+
+[limit]
+context = 262_144
+
+[modalities]
+input = ["text"]

--- a/providers/aixy/models/fireworks/accounts/fireworks/models/qwen3p8-max.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/models/qwen3p8-max.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Aixy forwards this route to fireworks-ai without translating the model payload.
 # Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/models/qwen3p8-max.toml.
 base_model = "alibaba/qwen3.8-max"

--- a/providers/aixy/models/fireworks/accounts/fireworks/routers/kimi-k3-fast.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/routers/kimi-k3-fast.toml
@@ -1,0 +1,26 @@
+# Aixy forwards this route to fireworks-ai without translating the model payload.
+# Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k3-fast.toml.
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 Fast"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[cost]
+input = 4.5
+output = 22.5
+cache_read = 0.45
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/fireworks/accounts/fireworks/routers/kimi-k3-fast.toml
+++ b/providers/aixy/models/fireworks/accounts/fireworks/routers/kimi-k3-fast.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking.type = enabled|disabled
 # Aixy forwards this route to fireworks-ai without translating the model payload.
 # Reasoning controls mirror providers/fireworks-ai/models/accounts/fireworks/routers/kimi-k3-fast.toml.
 base_model = "moonshotai/kimi-k3"

--- a/providers/aixy/models/groq/allam-2-7b.toml
+++ b/providers/aixy/models/groq/allam-2-7b.toml
@@ -1,0 +1,7 @@
+# ALLaM-2-7B is provided unbilled via the Groq developer tier.
+# Verified via Groq Models API (no pricing object) and https://groq.com/pricing
+base_model = "sdaia/allam-2-7b"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/groq/openai/gpt-oss-120b.toml
+++ b/providers/aixy/models/groq/openai/gpt-oss-120b.toml
@@ -1,0 +1,13 @@
+base_model = "openai/gpt-oss-120b"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.075
+
+[limit]
+output = 65_536

--- a/providers/aixy/models/groq/openai/gpt-oss-20b.toml
+++ b/providers/aixy/models/groq/openai/gpt-oss-20b.toml
@@ -1,0 +1,18 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.groq.com/openai/v1/chat/completions
+# JSON reasoning_effort: "low" | "medium" | "high".
+# Sources: https://console.groq.com/docs/reasoning#options-for-reasoning-effort-gptoss
+base_model = "openai/gpt-oss-20b"
+description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.075
+output = 0.3
+cache_read = 0.0375
+
+[limit]
+output = 65_536

--- a/providers/aixy/models/groq/qwen/qwen3.6-27b.toml
+++ b/providers/aixy/models/groq/qwen/qwen3.6-27b.toml
@@ -1,0 +1,17 @@
+base_model = "alibaba/qwen3.6-27b"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "default"]
+
+[cost]
+input = 0.6
+output = 3
+cache_read = 0.3
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/meta/llama-3.3-70b-instruct.toml
+++ b/providers/aixy/models/meta/llama-3.3-70b-instruct.toml
@@ -1,0 +1,6 @@
+base_model = "meta/llama-3.3-70b-instruct"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/mistral/codestral-latest.toml
+++ b/providers/aixy/models/mistral/codestral-latest.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/codestral-latest"
+
+[cost]
+input = 0.3
+output = 0.9

--- a/providers/aixy/models/mistral/devstral-2512.toml
+++ b/providers/aixy/models/mistral/devstral-2512.toml
@@ -1,0 +1,6 @@
+base_model = "mistral/devstral-2512"
+status = "deprecated"
+
+[cost]
+input = 0.4
+output = 2

--- a/providers/aixy/models/mistral/devstral-medium-2507.toml
+++ b/providers/aixy/models/mistral/devstral-medium-2507.toml
@@ -1,0 +1,7 @@
+base_model = "mistral/devstral-medium-2507"
+description = "Legacy model retained for compatibility with older integrations"
+status = "deprecated"
+
+[cost]
+input = 0.4
+output = 2

--- a/providers/aixy/models/mistral/devstral-medium-latest.toml
+++ b/providers/aixy/models/mistral/devstral-medium-latest.toml
@@ -1,0 +1,7 @@
+base_model = "mistral/devstral-medium-latest"
+description = "Legacy model retained for compatibility with older integrations"
+status = "deprecated"
+
+[cost]
+input = 0.4
+output = 2

--- a/providers/aixy/models/mistral/devstral-small-2507.toml
+++ b/providers/aixy/models/mistral/devstral-small-2507.toml
@@ -1,0 +1,7 @@
+base_model = "mistral/devstral-small-2507"
+description = "Legacy model retained for compatibility with older integrations"
+status = "deprecated"
+
+[cost]
+input = 0.1
+output = 0.3

--- a/providers/aixy/models/mistral/magistral-medium-latest.toml
+++ b/providers/aixy/models/mistral/magistral-medium-latest.toml
@@ -1,0 +1,6 @@
+base_model = "mistral/magistral-medium-latest"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 5

--- a/providers/aixy/models/mistral/mistral-large-2411.toml
+++ b/providers/aixy/models/mistral/mistral-large-2411.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-large-2411"
+
+[cost]
+input = 2
+output = 6

--- a/providers/aixy/models/mistral/mistral-large-2512.toml
+++ b/providers/aixy/models/mistral/mistral-large-2512.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-large-2512"
+
+[cost]
+input = 0.5
+output = 1.5

--- a/providers/aixy/models/mistral/mistral-large-latest.toml
+++ b/providers/aixy/models/mistral/mistral-large-latest.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-large-latest"
+
+[cost]
+input = 0.5
+output = 1.5

--- a/providers/aixy/models/mistral/mistral-medium-2505.toml
+++ b/providers/aixy/models/mistral/mistral-medium-2505.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-medium-2505"
+
+[cost]
+input = 0.4
+output = 2

--- a/providers/aixy/models/mistral/mistral-medium-2604.toml
+++ b/providers/aixy/models/mistral/mistral-medium-2604.toml
@@ -1,0 +1,9 @@
+base_model = "mistral/mistral-medium-2604"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 1.5
+output = 7.5

--- a/providers/aixy/models/mistral/mistral-medium-latest.toml
+++ b/providers/aixy/models/mistral/mistral-medium-latest.toml
@@ -1,0 +1,11 @@
+# mistral-medium-latest is Mistral's alias for Mistral Medium 3.5 (mistral-medium-2604).
+# Medium 3.1 (mistral-medium-2508) was deprecated 2026-05-22, retiring 2026-08-31.
+base_model = "mistral/mistral-medium-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 1.5
+output = 7.5

--- a/providers/aixy/models/mistral/mistral-nemo.toml
+++ b/providers/aixy/models/mistral/mistral-nemo.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-nemo"
+
+[cost]
+input = 0.15
+output = 0.15

--- a/providers/aixy/models/mistral/mistral-small-2506.toml
+++ b/providers/aixy/models/mistral/mistral-small-2506.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-small-2506"
+
+[cost]
+input = 0.1
+output = 0.3

--- a/providers/aixy/models/mistral/mistral-small-2603.toml
+++ b/providers/aixy/models/mistral/mistral-small-2603.toml
@@ -1,0 +1,9 @@
+base_model = "mistral/mistral-small-2603"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/aixy/models/mistral/mistral-small-latest.toml
+++ b/providers/aixy/models/mistral/mistral-small-latest.toml
@@ -1,0 +1,9 @@
+base_model = "mistral/mistral-small-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/aixy/models/mistral/pixtral-12b.toml
+++ b/providers/aixy/models/mistral/pixtral-12b.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/pixtral-12b"
+
+[cost]
+input = 0.15
+output = 0.15

--- a/providers/aixy/models/mistral/pixtral-large-latest.toml
+++ b/providers/aixy/models/mistral/pixtral-large-latest.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/pixtral-large-latest"
+
+[cost]
+input = 2
+output = 6

--- a/providers/aixy/models/mistral/voxtral-small-latest.toml
+++ b/providers/aixy/models/mistral/voxtral-small-latest.toml
@@ -1,0 +1,10 @@
+# Sources :
+#   https://docs.mistral.ai/models/model-cards/voxtral-small-25-07
+#   https://mistral.ai/news/voxtral/
+# Le bloc [cost] ne porte que le texte ($0.10 / $0.30 per 1M tokens) : l'audio en
+# entrée se facture à la MINUTE ($0.004/min), unité que le schéma ne modélise pas.
+base_model = "mistral/voxtral-small-latest"
+
+[cost]
+input = 0.1
+output = 0.3

--- a/providers/aixy/models/nvidia/deepseek-ai/deepseek-v4-flash-0731.toml
+++ b/providers/aixy/models/nvidia/deepseek-ai/deepseek-v4-flash-0731.toml
@@ -1,0 +1,19 @@
+# NIM Chat schema: `reasoning_effort = none|high|max`; `none` disables thinking.
+# https://docs.api.nvidia.com/nim/reference/deepseek-ai-deepseek-v4-flash-infer
+#
+# Pricing: hosted on NVIDIA's API trial tier and currently free — no separate
+# list rate is published for this ID. Source: this model's catalog card,
+# https://build.nvidia.com/deepseek-ai/deepseek-v4-flash-0731 (governed by the
+# NVIDIA API Trial Terms of Service).
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/deepseek-ai/deepseek-v4-flash.toml
+++ b/providers/aixy/models/nvidia/deepseek-ai/deepseek-v4-flash.toml
@@ -1,0 +1,17 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.0028
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/aixy/models/nvidia/deepseek-ai/deepseek-v4-pro.toml
+++ b/providers/aixy/models/nvidia/deepseek-ai/deepseek-v4-pro.toml
@@ -1,0 +1,17 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.435
+output = 0.87
+cache_read = 0.003625
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/aixy/models/nvidia/google/gemma-4-31b-it.toml
+++ b/providers/aixy/models/nvidia/google/gemma-4-31b-it.toml
@@ -1,0 +1,19 @@
+# Aixy forwards this route to nvidia without translating the model payload.
+# Reasoning controls mirror providers/nvidia/models/google/gemma-4-31b-it.toml.
+base_model = "google/gemma-4-31b-it"
+name = "Gemma-4-31B-IT"
+description = "Open Gemma instruction model for efficient chat and self-hosted deployments"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 256_000
+output = 16_384
+
+[modalities]
+input = ["text", "image", "video"]

--- a/providers/aixy/models/nvidia/google/gemma-4-31b-it.toml
+++ b/providers/aixy/models/nvidia/google/gemma-4-31b-it.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # Aixy forwards this route to nvidia without translating the model payload.
 # Reasoning controls mirror providers/nvidia/models/google/gemma-4-31b-it.toml.
 base_model = "google/gemma-4-31b-it"

--- a/providers/aixy/models/nvidia/meta/llama-3.1-8b-instruct.toml
+++ b/providers/aixy/models/nvidia/meta/llama-3.1-8b-instruct.toml
@@ -1,0 +1,10 @@
+base_model = "meta/llama-3.1-8b-instruct"
+name = "Llama 3.1 8B Instruct"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 16_000

--- a/providers/aixy/models/nvidia/meta/llama-3.2-11b-vision-instruct.toml
+++ b/providers/aixy/models/nvidia/meta/llama-3.2-11b-vision-instruct.toml
@@ -1,0 +1,8 @@
+base_model = "meta/llama-3.2-11b-vision-instruct"
+name = "Llama 3.2 11b Vision Instruct"
+description = "Open Llama multimodal model for image understanding and text reasoning"
+structured_output = true
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/meta/llama-3.3-70b-instruct.toml
+++ b/providers/aixy/models/nvidia/meta/llama-3.3-70b-instruct.toml
@@ -1,0 +1,9 @@
+base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama 3.3 70b Instruct"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+attachment = false
+structured_output = true
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/meta/muse-glimmer-30b.toml
+++ b/providers/aixy/models/nvidia/meta/muse-glimmer-30b.toml
@@ -1,0 +1,12 @@
+base_model = "meta/muse-glimmer-30b"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "max"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/minimaxai/minimax-m3.toml
+++ b/providers/aixy/models/nvidia/minimaxai/minimax-m3.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # Aixy forwards this route to nvidia without translating the model payload.
 # Reasoning controls mirror providers/nvidia/models/minimaxai/minimax-m3.toml.
 base_model = "minimax/MiniMax-M3"

--- a/providers/aixy/models/nvidia/minimaxai/minimax-m3.toml
+++ b/providers/aixy/models/nvidia/minimaxai/minimax-m3.toml
@@ -1,0 +1,14 @@
+# Aixy forwards this route to nvidia without translating the model payload.
+# Reasoning controls mirror providers/nvidia/models/minimaxai/minimax-m3.toml.
+base_model = "minimax/MiniMax-M3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 1_000_000
+output = 16_384

--- a/providers/aixy/models/nvidia/mistralai/magistral-small-2506.toml
+++ b/providers/aixy/models/nvidia/mistralai/magistral-small-2506.toml
@@ -1,0 +1,15 @@
+base_model = "mistral/magistral-small-2506"
+name = "Magistral Small 2506"
+description = "Mistral reasoning model for transparent analysis, math, and complex decisions"
+reasoning = false
+tool_call = false
+structured_output = false
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 32_768
+input = 32_768
+output = 32_768

--- a/providers/aixy/models/nvidia/mistralai/mistral-medium-3.5-128b.toml
+++ b/providers/aixy/models/nvidia/mistralai/mistral-medium-3.5-128b.toml
@@ -1,0 +1,15 @@
+# Sources (accessed 2026-07-25):
+# - https://docs.api.nvidia.com/nim/reference/mistralai-mistral-medium-3-5-128b-infer
+# - https://integrate.api.nvidia.com/v1/models id: mistralai/mistral-medium-3.5-128b
+base_model = "mistral/mistral-medium-2604"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 32_768

--- a/providers/aixy/models/nvidia/mistralai/mistral-nemotron.toml
+++ b/providers/aixy/models/nvidia/mistralai/mistral-nemotron.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/mistral-nemotron"
+name = "mistral-nemotron"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/moonshotai/kimi-k2.6.toml
+++ b/providers/aixy/models/nvidia/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,14 @@
+base_model = "moonshotai/kimi-k2.6"
+description = "Kimi multimodal agent model for visual understanding, coding, and planning"
+status = "deprecated"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/moonshotai/kimi-k3.toml
+++ b/providers/aixy/models/nvidia/moonshotai/kimi-k3.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.thinking = true|false
 # NIM wire syntax (verified against integrate.api.nvidia.com/v1, 2026-08-22):
 #   on/off: chat_template_kwargs = { "thinking": true | false }  (default: true)
 #   effort: top-level "reasoning_effort" = "low" | "high" | "max"

--- a/providers/aixy/models/nvidia/moonshotai/kimi-k3.toml
+++ b/providers/aixy/models/nvidia/moonshotai/kimi-k3.toml
@@ -1,0 +1,18 @@
+# NIM wire syntax (verified against integrate.api.nvidia.com/v1, 2026-08-22):
+#   on/off: chat_template_kwargs = { "thinking": true | false }  (default: true)
+#   effort: top-level "reasoning_effort" = "low" | "high" | "max"
+base_model = "moonshotai/kimi-k3"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/llama-3.1-nemotron-70b-instruct.toml
+++ b/providers/aixy/models/nvidia/nvidia/llama-3.1-nemotron-70b-instruct.toml
@@ -1,0 +1,8 @@
+# Sources (accessed 2026-07-25):
+# - https://build.nvidia.com/nvidia/llama-3_1-nemotron-70b-instruct
+# - https://integrate.api.nvidia.com/v1/models id: nvidia/llama-3.1-nemotron-70b-instruct
+base_model = "nvidia/llama-3.1-nemotron-70b-instruct"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/llama-3.1-nemotron-safety-guard-8b-v3.toml
+++ b/providers/aixy/models/nvidia/nvidia/llama-3.1-nemotron-safety-guard-8b-v3.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/llama-3.1-nemotron-safety-guard-8b-v3"
+name = "llama-3.1-nemotron-safety-guard-8b-v3"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1.toml
+++ b/providers/aixy/models/nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1.toml
@@ -1,0 +1,18 @@
+# Sources (accessed 2026-07-25):
+# - https://docs.api.nvidia.com/nim/reference/nvidia-llama-3_1-nemotron-ultra-253b-v1
+# - https://docs.api.nvidia.com/nim/reference/nvidia-llama-3_1-nemotron-ultra-253b-v1-infer
+# - https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1
+# - https://integrate.api.nvidia.com/v1/models id: nvidia/llama-3.1-nemotron-ultra-253b-v1
+# Toggle: system message `detailed thinking on` | `detailed thinking off`.
+# Infer OpenAPI: max_tokens 1..16384.
+base_model = "nvidia/llama-3.1-nemotron-ultra-253b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 16_384

--- a/providers/aixy/models/nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
+++ b/providers/aixy/models/nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.5.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-07-25):
+# - https://docs.api.nvidia.com/nim/reference/nvidia-llama-3_3-nemotron-super-49b-v1_5
+# - https://docs.api.nvidia.com/nim/reference/nvidia-llama-3_3-nemotron-super-49b-v1_5-infer
+# - https://integrate.api.nvidia.com/v1/models id: nvidia/llama-3.3-nemotron-super-49b-v1.5
+# Toggle: empty system prompt = reasoning ON; system content `/no_think` = OFF.
+# Infer OpenAPI: max_tokens 1..65536 (no JSON reasoning field; control is system prompt).
+base_model = "nvidia/llama-3.3-nemotron-super-49b-v1.5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 65_536

--- a/providers/aixy/models/nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.toml
+++ b/providers/aixy/models/nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.toml
@@ -1,0 +1,18 @@
+# Sources (accessed 2026-07-25):
+# - https://docs.api.nvidia.com/nim/reference/nvidia-llama-3_3-nemotron-super-49b-v1
+# - https://docs.api.nvidia.com/nim/reference/nvidia-llama-3_3-nemotron-super-49b-v1-infer
+# - https://huggingface.co/nvidia/Llama-3_3-Nemotron-Super-49B-v1
+# - https://integrate.api.nvidia.com/v1/models id: nvidia/llama-3.3-nemotron-super-49b-v1
+# Toggle: system message `detailed thinking on` | `detailed thinking off`.
+# Infer OpenAPI: max_tokens 1..65536.
+base_model = "nvidia/llama-3.3-nemotron-super-49b-v1"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 65_536

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3-content-safety.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3-content-safety.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/nemotron-3-content-safety"
+name = "nemotron-3-content-safety"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # Aixy forwards this route to nvidia without translating the model payload.
 # Reasoning controls mirror providers/nvidia/models/nvidia/nemotron-3-nano-30b-a3b.toml.
 base_model = "nvidia/nemotron-3-nano-30b-a3b"

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -1,0 +1,15 @@
+# Aixy forwards this route to nvidia without translating the model payload.
+# Reasoning controls mirror providers/nvidia/models/nvidia/nemotron-3-nano-30b-a3b.toml.
+base_model = "nvidia/nemotron-3-nano-30b-a3b"
+name = "nemotron-3-nano-30b-a3b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 131_072
+output = 131_072

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # Aixy forwards this route to nvidia without translating the model payload.
 # Reasoning controls mirror providers/nvidia/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml.
 base_model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml
@@ -1,0 +1,17 @@
+# Aixy forwards this route to nvidia without translating the model payload.
+# Reasoning controls mirror providers/nvidia/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning.toml.
+base_model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+name = "Nemotron 3 Nano Omni"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = -1
+max = 32_768
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # Aixy forwards this route to nvidia without translating the model payload.
 # Reasoning controls mirror providers/nvidia/models/nvidia/nemotron-3-super-120b-a12b.toml.
 base_model = "nvidia/nemotron-3-super-120b-a12b"

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,11 @@
+# Aixy forwards this route to nvidia without translating the model payload.
+# Reasoning controls mirror providers/nvidia/models/nvidia/nemotron-3-super-120b-a12b.toml.
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+name = "Nemotron 3 Super"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.2
+output = 0.8

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,15 @@
+# Aixy forwards this route to nvidia without translating the model payload.
+# Reasoning controls mirror providers/nvidia/models/nvidia/nemotron-3-ultra-550b-a55b.toml.
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.5
+output = 2.5
+cache_read = 0.15
+
+[limit]
+output = 65_536

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # Aixy forwards this route to nvidia without translating the model payload.
 # Reasoning controls mirror providers/nvidia/models/nvidia/nemotron-3-ultra-550b-a55b.toml.
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"

--- a/providers/aixy/models/nvidia/nvidia/nemotron-3.5-lightning-30b-a3b.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-3.5-lightning-30b-a3b.toml
@@ -1,0 +1,13 @@
+# Sources (accessed 2026-08-11):
+# - https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b
+# - https://integrate.api.nvidia.com/v1/models
+# Toggle: chat_template_kwargs.enable_thinking = true|false
+# https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
+base_model = "nvidia/nemotron-3.5-lightning"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/nemotron-content-safety-reasoning-4b.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-content-safety-reasoning-4b.toml
@@ -1,0 +1,7 @@
+base_model = "nvidia/nemotron-content-safety-reasoning-4b"
+name = "nemotron-content-safety-reasoning-4b"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/nemotron-mini-4b-instruct.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-mini-4b-instruct.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/nemotron-mini-4b-instruct"
+name = "nemotron-mini-4b-instruct"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/nemotron-nano-12b-v2-vl.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-nano-12b-v2-vl.toml
@@ -1,0 +1,10 @@
+# Sources (accessed 2026-07-25):
+# - https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-nano-12b-v2-vl-infer
+# - https://integrate.api.nvidia.com/v1/models id: nvidia/nemotron-nano-12b-v2-vl
+# No first-party NIM reasoning ON/OFF control found (unlike Super/Ultra prompt toggles).
+base_model = "nvidia/nemotron-nano-12b-v2-vl"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/nemotron-voicechat.toml
+++ b/providers/aixy/models/nvidia/nvidia/nemotron-voicechat.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/nemotron-voicechat"
+name = "nemotron-voicechat"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/nvidia/nvidia-nemotron-nano-9b-v2.toml
+++ b/providers/aixy/models/nvidia/nvidia/nvidia-nemotron-nano-9b-v2.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # Aixy forwards this route to nvidia without translating the model payload.
 # Reasoning controls mirror providers/nvidia/models/nvidia/nvidia-nemotron-nano-9b-v2.toml.
 base_model = "nvidia/nemotron-nano-9b-v2"

--- a/providers/aixy/models/nvidia/nvidia/nvidia-nemotron-nano-9b-v2.toml
+++ b/providers/aixy/models/nvidia/nvidia/nvidia-nemotron-nano-9b-v2.toml
@@ -1,0 +1,11 @@
+# Aixy forwards this route to nvidia without translating the model payload.
+# Reasoning controls mirror providers/nvidia/models/nvidia/nvidia-nemotron-nano-9b-v2.toml.
+base_model = "nvidia/nemotron-nano-9b-v2"
+name = "nvidia-nemotron-nano-9b-v2"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/openai/gpt-oss-120b.toml
+++ b/providers/aixy/models/nvidia/openai/gpt-oss-120b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT-OSS-120B"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 8_192

--- a/providers/aixy/models/nvidia/openai/gpt-oss-20b.toml
+++ b/providers/aixy/models/nvidia/openai/gpt-oss-20b.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-oss-20b"
+description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/poolside/laguna-xs-2.1.toml
+++ b/providers/aixy/models/nvidia/poolside/laguna-xs-2.1.toml
@@ -1,0 +1,13 @@
+# Sources (accessed 2026-07-25):
+# - https://docs.api.nvidia.com/nim/reference/poolside-laguna-xs-2-1-infer
+# - https://integrate.api.nvidia.com/v1/models id: poolside/laguna-xs-2.1
+# NIM Chat schema exposes no reasoning control field (only temperature/top_p/max_tokens).
+base_model = "poolside/laguna-xs-2.1"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 16_384

--- a/providers/aixy/models/nvidia/qwen/qwen2.5-coder-32b-instruct.toml
+++ b/providers/aixy/models/nvidia/qwen/qwen2.5-coder-32b-instruct.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen2.5-coder-32b-instruct"
+name = "Qwen2.5 Coder 32b Instruct"
+description = "Qwen coding model for software agents, repository edits, and code reasoning"
+structured_output = true
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 128_000
+output = 4_096

--- a/providers/aixy/models/nvidia/qwen/qwen3-coder-480b-a35b-instruct.toml
+++ b/providers/aixy/models/nvidia/qwen/qwen3-coder-480b-a35b-instruct.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3-coder-480b-a35b-instruct"
+name = "Qwen3 Coder 480B A35B Instruct"
+description = "Qwen coding model for software agents, repository edits, and code reasoning"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 66_536

--- a/providers/aixy/models/nvidia/qwen/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/aixy/models/nvidia/qwen/qwen3-next-80b-a3b-instruct.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+name = "Qwen3-Next-80B-A3B-Instruct"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 262_144
+output = 16_384

--- a/providers/aixy/models/nvidia/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/aixy/models/nvidia/qwen/qwen3.5-122b-a10b.toml
@@ -1,0 +1,10 @@
+# Aixy forwards this route to nvidia without translating the model payload.
+# Reasoning controls mirror providers/nvidia/models/qwen/qwen3.5-122b-a10b.toml.
+base_model = "alibaba/qwen3.5-122b-a10b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/aixy/models/nvidia/qwen/qwen3.5-122b-a10b.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # Aixy forwards this route to nvidia without translating the model payload.
 # Reasoning controls mirror providers/nvidia/models/qwen/qwen3.5-122b-a10b.toml.
 base_model = "alibaba/qwen3.5-122b-a10b"

--- a/providers/aixy/models/nvidia/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/aixy/models/nvidia/qwen/qwen3.5-397b-a17b.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # Aixy forwards this route to nvidia without translating the model payload.
 # Reasoning controls mirror providers/nvidia/models/qwen/qwen3.5-397b-a17b.toml.
 base_model = "alibaba/qwen3.5-397b-a17b"

--- a/providers/aixy/models/nvidia/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/aixy/models/nvidia/qwen/qwen3.5-397b-a17b.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to nvidia without translating the model payload.
+# Reasoning controls mirror providers/nvidia/models/qwen/qwen3.5-397b-a17b.toml.
+base_model = "alibaba/qwen3.5-397b-a17b"
+name = "Qwen3.5-397B-A17B"
+description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/nvidia/stepfun-ai/step-3.5-flash.toml
+++ b/providers/aixy/models/nvidia/stepfun-ai/step-3.5-flash.toml
@@ -1,0 +1,13 @@
+base_model = "stepfun/step-3.5-flash"
+description = "StepFun flash model for efficient multimodal reasoning, coding, and tool use"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 16_384

--- a/providers/aixy/models/nvidia/stepfun-ai/step-3.7-flash.toml
+++ b/providers/aixy/models/nvidia/stepfun-ai/step-3.7-flash.toml
@@ -1,0 +1,16 @@
+base_model = "stepfun/step-3.7-flash"
+description = "StepFun flash model for efficient multimodal reasoning, coding, and tool use"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 16_384
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/nvidia/thinkingmachines/inkling.toml
+++ b/providers/aixy/models/nvidia/thinkingmachines/inkling.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-07-25):
+# - https://docs.api.nvidia.com/nim/reference/thinkingmachines-inkling
+# - https://docs.api.nvidia.com/nim/reference/thinkingmachines-inkling-infer
+# - https://thinkingmachines.ai/model-card/inkling/
+# - https://integrate.api.nvidia.com/v1/models id: thinkingmachines/inkling
+# NVIDIA model card Input Types: Text, Image, Audio (WAV 16 kHz).
+# Infer OpenAPI: max_tokens 1..16384; no documented reasoning control field on NIM.
+# Upstream evals use continuous effort (e.g. effort=0.99); not mapped to discrete NIM enum.
+base_model = "thinkingmachines/inkling"
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+output = 16_384

--- a/providers/aixy/models/nvidia/z-ai/glm-5.2.toml
+++ b/providers/aixy/models/nvidia/z-ai/glm-5.2.toml
@@ -1,0 +1,13 @@
+# NIM Chat schema: `chat_template_kwargs.enable_thinking = true|false`.
+# https://docs.api.nvidia.com/nim/reference/z-ai-glm-5.2-infer
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0
+output = 0

--- a/providers/aixy/models/nvidia/z-ai/glm-5.2.toml
+++ b/providers/aixy/models/nvidia/z-ai/glm-5.2.toml
@@ -1,3 +1,4 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
 # NIM Chat schema: `chat_template_kwargs.enable_thinking = true|false`.
 # https://docs.api.nvidia.com/nim/reference/z-ai-glm-5.2-infer
 base_model = "zhipuai/glm-5.2"

--- a/providers/aixy/models/perplexity/sonar-pro.toml
+++ b/providers/aixy/models/perplexity/sonar-pro.toml
@@ -1,0 +1,5 @@
+base_model = "perplexity/sonar-pro"
+
+[cost]
+input = 3
+output = 15

--- a/providers/aixy/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/aixy/models/perplexity/sonar-reasoning-pro.toml
@@ -1,0 +1,16 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.perplexity.ai/v1/sonar
+# JSON reasoning_effort: "minimal" | "low" | "medium" | "high".
+# No toggle or reasoning-token budget is documented for this model.
+# Sources:
+# https://docs.perplexity.ai/api-reference/sonar-post
+# https://docs.perplexity.ai/docs/sonar/models/sonar-reasoning-pro
+base_model = "perplexity/sonar-reasoning-pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 2
+output = 8

--- a/providers/aixy/models/perplexity/sonar.toml
+++ b/providers/aixy/models/perplexity/sonar.toml
@@ -1,0 +1,5 @@
+base_model = "perplexity/sonar"
+
+[cost]
+input = 1
+output = 1

--- a/providers/aixy/models/together/Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/aixy/models/together/Qwen/Qwen3.5-397B-A17B.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Reasoning HTTP format (accessed 2026-06-25):
 # POST https://api.together.ai/v1/chat/completions
 # JSON reasoning.enabled: true | false (thinking is on by default).

--- a/providers/aixy/models/together/Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/aixy/models/together/Qwen/Qwen3.5-397B-A17B.toml
@@ -1,0 +1,26 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# JSON reasoning.enabled: true | false (thinking is on by default).
+# Compatibility: chat_template_kwargs.thinking or .enable_thinking: boolean.
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#enable-and-disable-reasoning
+# Deprecated: no longer listed in the Together.ai serverless catalog (accessed 2026-07-18).
+# Source: https://docs.together.ai/docs/serverless-models
+base_model = "alibaba/qwen3.5-397b-a17b"
+name = "Qwen3.5 397B A17B"
+description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
+attachment = false
+status = "deprecated"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.6
+output = 3.6
+cache_read = 0.35
+
+[limit]
+output = 130_000
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/together/Qwen/Qwen3.5-9B.toml
+++ b/providers/aixy/models/together/Qwen/Qwen3.5-9B.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Reasoning HTTP format (accessed 2026-06-25):
 # POST https://api.together.ai/v1/chat/completions
 # JSON reasoning.enabled: true | false (thinking is on by default).

--- a/providers/aixy/models/together/Qwen/Qwen3.5-9B.toml
+++ b/providers/aixy/models/together/Qwen/Qwen3.5-9B.toml
@@ -1,0 +1,16 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# JSON reasoning.enabled: true | false (thinking is on by default).
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#supported-models
+base_model = "alibaba/qwen3.5-9b"
+description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.17
+output = 0.25
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/together/Qwen/Qwen3.6-Plus.toml
+++ b/providers/aixy/models/together/Qwen/Qwen3.6-Plus.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Reasoning HTTP format (accessed 2026-06-25):
 # POST https://api.together.ai/v1/chat/completions
 # JSON reasoning.enabled: true | false (thinking is on by default).

--- a/providers/aixy/models/together/Qwen/Qwen3.6-Plus.toml
+++ b/providers/aixy/models/together/Qwen/Qwen3.6-Plus.toml
@@ -1,0 +1,20 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# JSON reasoning.enabled: true | false (thinking is on by default).
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#supported-models
+base_model = "alibaba/qwen3.6-plus"
+description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
+attachment = false
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.5
+output = 3
+
+[limit]
+output = 500_000
+
+[modalities]
+input = ["text"]

--- a/providers/aixy/models/together/Qwen/Qwen3.7-Max.toml
+++ b/providers/aixy/models/together/Qwen/Qwen3.7-Max.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.7-max"
+description = "Flagship Qwen model for complex reasoning, coding, and agentic workflows"
+reasoning = false
+
+[cost]
+input = 1.25
+output = 3.75
+cache_read = 0.125
+
+[limit]
+output = 500_000

--- a/providers/aixy/models/together/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/aixy/models/together/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Aixy forwards this route to togetherai without translating the model payload.
 # Reasoning controls mirror providers/togetherai/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml.
 base_model = "deepseek/deepseek-v4-flash-0731"

--- a/providers/aixy/models/together/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/aixy/models/together/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,0 +1,18 @@
+# Aixy forwards this route to togetherai without translating the model payload.
+# Reasoning controls mirror providers/togetherai/models/deepseek-ai/DeepSeek-V4-Flash-0731.toml.
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.03

--- a/providers/aixy/models/together/deepseek-ai/DeepSeek-V4-Pro-0813.toml
+++ b/providers/aixy/models/together/deepseek-ai/DeepSeek-V4-Pro-0813.toml
@@ -1,0 +1,21 @@
+# Aixy forwards this route to togetherai without translating the model payload.
+# Reasoning controls mirror providers/togetherai/models/deepseek-ai/DeepSeek-V4-Pro-0813.toml.
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 1.32
+output = 3.96
+cache_read = 0.13
+
+[limit]
+context = 1_048_576

--- a/providers/aixy/models/together/deepseek-ai/DeepSeek-V4-Pro-0813.toml
+++ b/providers/aixy/models/together/deepseek-ai/DeepSeek-V4-Pro-0813.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Aixy forwards this route to togetherai without translating the model payload.
 # Reasoning controls mirror providers/togetherai/models/deepseek-ai/DeepSeek-V4-Pro-0813.toml.
 base_model = "deepseek/deepseek-v4-pro-0813"

--- a/providers/aixy/models/together/google/gemma-4-31B-it.toml
+++ b/providers/aixy/models/together/google/gemma-4-31B-it.toml
@@ -1,0 +1,15 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# Together's reasoning guide does not document toggle, effort, or budget controls.
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#supported-models
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B Instruct"
+description = "Open Gemma instruction model for efficient chat and self-hosted deployments"
+reasoning_options = []
+
+[cost]
+input = 0.39
+output = 0.97
+
+[limit]
+output = 131_072

--- a/providers/aixy/models/together/moonshotai/Kimi-K2.5.toml
+++ b/providers/aixy/models/together/moonshotai/Kimi-K2.5.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Reasoning HTTP format (accessed 2026-06-25):
 # POST https://api.together.ai/v1/chat/completions
 # Together's current reasoning model table does not list Kimi K2.5; raw HTTP

--- a/providers/aixy/models/together/moonshotai/Kimi-K2.5.toml
+++ b/providers/aixy/models/together/moonshotai/Kimi-K2.5.toml
@@ -1,0 +1,22 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# Together's current reasoning model table does not list Kimi K2.5; raw HTTP
+# reasoning.enabled: true | false acceptance remains unresolved.
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#supported-models
+base_model = "moonshotai/kimi-k2.5"
+description = "Legacy model retained for compatibility with older integrations"
+attachment = false
+temperature = true
+status = "deprecated"
+
+interleaved = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.5
+output = 2.8
+
+[modalities]
+input = ["text", "image"]

--- a/providers/aixy/models/together/moonshotai/Kimi-K2.6.toml
+++ b/providers/aixy/models/together/moonshotai/Kimi-K2.6.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Reasoning HTTP format (accessed 2026-06-25):
 # POST https://api.together.ai/v1/chat/completions
 # JSON reasoning.enabled: true | false (thinking is on by default).

--- a/providers/aixy/models/together/moonshotai/Kimi-K2.6.toml
+++ b/providers/aixy/models/together/moonshotai/Kimi-K2.6.toml
@@ -1,0 +1,17 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# JSON reasoning.enabled: true | false (thinking is on by default).
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#enable-and-disable-reasoning
+base_model = "moonshotai/kimi-k2.6"
+description = "Kimi multimodal agent model for visual understanding, coding, and planning"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 1.2
+output = 4.5
+cache_read = 0.2
+
+[limit]
+output = 131_000

--- a/providers/aixy/models/together/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/aixy/models/together/moonshotai/Kimi-K2.7-Code.toml
@@ -1,0 +1,16 @@
+base_model = "moonshotai/kimi-k2.7-code"
+description = "Kimi coding model for software agents, refactors, and repository reasoning"
+attachment = false
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text"]

--- a/providers/aixy/models/together/moonshotai/Kimi-K3.toml
+++ b/providers/aixy/models/together/moonshotai/Kimi-K3.toml
@@ -1,0 +1,13 @@
+base_model = "moonshotai/kimi-k3"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3

--- a/providers/aixy/models/together/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/aixy/models/together/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Reasoning HTTP format (accessed 2026-06-25):
 # POST https://api.together.ai/v1/chat/completions
 # JSON reasoning.enabled: true | false. Medium effort instead uses

--- a/providers/aixy/models/together/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/aixy/models/together/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,19 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# JSON reasoning.enabled: true | false. Medium effort instead uses
+# chat_template_kwargs.medium_effort: true; otherwise effort defaults to high.
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#reasoning-effort
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+structured_output = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.6
+output = 3.6
+cache_read = 0.2
+
+[limit]
+context = 512_300
+output = 512_300

--- a/providers/aixy/models/together/openai/gpt-oss-120b.toml
+++ b/providers/aixy/models/together/openai/gpt-oss-120b.toml
@@ -1,0 +1,17 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# JSON reasoning_effort: "low" | "medium" | "high".
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#reasoning-effort
+base_model = "openai/gpt-oss-120b"
+description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+output = 131_072

--- a/providers/aixy/models/together/openai/gpt-oss-20b.toml
+++ b/providers/aixy/models/together/openai/gpt-oss-20b.toml
@@ -1,0 +1,17 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# JSON reasoning_effort: "low" | "medium" | "high".
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#reasoning-effort
+base_model = "openai/gpt-oss-20b"
+description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.05
+output = 0.2
+
+[limit]
+output = 131_072

--- a/providers/aixy/models/together/thinkingmachines/Inkling.toml
+++ b/providers/aixy/models/together/thinkingmachines/Inkling.toml
@@ -1,0 +1,15 @@
+base_model = "thinkingmachines/inkling"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 1
+output = 4.05
+cache_read = 0.17
+
+[limit]
+context = 524_288
+output = 131_072

--- a/providers/aixy/models/together/zai-org/GLM-5.1.toml
+++ b/providers/aixy/models/together/zai-org/GLM-5.1.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Reasoning HTTP format (accessed 2026-06-25):
 # POST https://api.together.ai/v1/chat/completions
 # JSON reasoning.enabled: true | false (thinking is on by default).

--- a/providers/aixy/models/together/zai-org/GLM-5.1.toml
+++ b/providers/aixy/models/together/zai-org/GLM-5.1.toml
@@ -1,0 +1,20 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# JSON reasoning.enabled: true | false (thinking is on by default).
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#supported-models
+# Deprecated: no longer listed in the Together.ai serverless catalog (accessed 2026-07-18).
+# Source: https://docs.together.ai/docs/serverless-models
+base_model = "zhipuai/glm-5.1"
+description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
+status = "deprecated"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 202_752

--- a/providers/aixy/models/together/zai-org/GLM-5.2.toml
+++ b/providers/aixy/models/together/zai-org/GLM-5.2.toml
@@ -1,0 +1,22 @@
+# Aixy forwards this route to togetherai without translating the model payload.
+# Reasoning controls mirror providers/togetherai/models/zai-org/GLM-5.2.toml.
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 512_000
+output = 164_000

--- a/providers/aixy/models/together/zai-org/GLM-5.2.toml
+++ b/providers/aixy/models/together/zai-org/GLM-5.2.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Aixy forwards this route to togetherai without translating the model payload.
 # Reasoning controls mirror providers/togetherai/models/zai-org/GLM-5.2.toml.
 base_model = "zhipuai/glm-5.2"

--- a/providers/aixy/models/together/zai-org/GLM-5.toml
+++ b/providers/aixy/models/together/zai-org/GLM-5.toml
@@ -1,3 +1,4 @@
+# Toggle: reasoning.enabled = true|false
 # Reasoning HTTP format (accessed 2026-06-25):
 # POST https://api.together.ai/v1/chat/completions
 # JSON reasoning.enabled: true | false; thinking is on by default.

--- a/providers/aixy/models/together/zai-org/GLM-5.toml
+++ b/providers/aixy/models/together/zai-org/GLM-5.toml
@@ -1,0 +1,22 @@
+# Reasoning HTTP format (accessed 2026-06-25):
+# POST https://api.together.ai/v1/chat/completions
+# JSON reasoning.enabled: true | false; thinking is on by default.
+# Sources: https://docs.together.ai/docs/inference/chat/reasoning#enable-and-disable-reasoning
+# Deprecated: no longer listed in the Together.ai serverless catalog (accessed 2026-07-18).
+# Source: https://docs.together.ai/docs/serverless-models
+base_model = "zhipuai/glm-5"
+structured_output = true
+status = "deprecated"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 1
+output = 3.2
+
+[limit]
+context = 202_752

--- a/providers/aixy/models/vertex/google/gemini-2.5-flash-lite.toml
+++ b/providers/aixy/models/vertex/google/gemini-2.5-flash-lite.toml
@@ -1,6 +1,8 @@
+# Toggle: thinking_config.thinking_budget = 0|positive
 # Aixy forwards this route to google-vertex without translating the model payload.
 # Reasoning controls mirror providers/google-vertex/models/gemini-2.5-flash-lite.toml.
 base_model = "google/gemini-2.5-flash-lite"
+base_model_omit = ["structured_output"]
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/aixy/models/vertex/google/gemini-2.5-flash-lite.toml
+++ b/providers/aixy/models/vertex/google/gemini-2.5-flash-lite.toml
@@ -1,0 +1,17 @@
+# Aixy forwards this route to google-vertex without translating the model payload.
+# Reasoning controls mirror providers/google-vertex/models/gemini-2.5-flash-lite.toml.
+base_model = "google/gemini-2.5-flash-lite"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 512
+max = 24_576
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01
+input_audio = 0.3

--- a/providers/aixy/models/vertex/google/gemini-2.5-flash.toml
+++ b/providers/aixy/models/vertex/google/gemini-2.5-flash.toml
@@ -1,3 +1,4 @@
+# Toggle: thinking_config.thinking_budget = 0|positive
 # Source: https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
 base_model = "google/gemini-2.5-flash"
 description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"

--- a/providers/aixy/models/vertex/google/gemini-2.5-flash.toml
+++ b/providers/aixy/models/vertex/google/gemini-2.5-flash.toml
@@ -1,0 +1,17 @@
+# Source: https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+base_model = "google/gemini-2.5-flash"
+description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 24_576
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03
+input_audio = 1

--- a/providers/aixy/models/vertex/google/gemini-2.5-pro.toml
+++ b/providers/aixy/models/vertex/google/gemini-2.5-pro.toml
@@ -1,0 +1,17 @@
+base_model = "google/gemini-2.5-pro"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 128
+max = 32_768
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 15
+cache_read = 0.25

--- a/providers/aixy/models/vertex/google/gemini-2.5-pro.toml
+++ b/providers/aixy/models/vertex/google/gemini-2.5-pro.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-pro"
+base_model_omit = ["structured_output"]
 
 [[reasoning_options]]
 type = "budget_tokens"

--- a/providers/aixy/models/vertex/google/gemini-3-flash-preview.toml
+++ b/providers/aixy/models/vertex/google/gemini-3-flash-preview.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3-flash-preview"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+input_audio = 1

--- a/providers/aixy/models/vertex/google/gemini-3.1-flash-lite-preview.toml
+++ b/providers/aixy/models/vertex/google/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+status = "deprecated"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+input_audio = 0.5

--- a/providers/aixy/models/vertex/google/gemini-3.1-flash-lite.toml
+++ b/providers/aixy/models/vertex/google/gemini-3.1-flash-lite.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.1-flash-lite"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+input_audio = 0.5

--- a/providers/aixy/models/vertex/google/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/aixy/models/vertex/google/gemini-3.1-pro-preview-customtools.toml
@@ -1,0 +1,16 @@
+base_model = "google/gemini-3.1-pro-preview-customtools"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4

--- a/providers/aixy/models/vertex/google/gemini-3.1-pro-preview.toml
+++ b/providers/aixy/models/vertex/google/gemini-3.1-pro-preview.toml
@@ -1,0 +1,16 @@
+base_model = "google/gemini-3.1-pro-preview"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4

--- a/providers/aixy/models/vertex/google/gemini-3.5-flash-lite.toml
+++ b/providers/aixy/models/vertex/google/gemini-3.5-flash-lite.toml
@@ -1,0 +1,13 @@
+# Sources:
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-5-flash-lite
+base_model = "google/gemini-3.5-flash-lite"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/aixy/models/vertex/google/gemini-3.5-flash.toml
+++ b/providers/aixy/models/vertex/google/gemini-3.5-flash.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-3.5-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+input_audio = 1.5

--- a/providers/aixy/models/vertex/google/gemini-3.6-flash.toml
+++ b/providers/aixy/models/vertex/google/gemini-3.6-flash.toml
@@ -1,0 +1,14 @@
+# Sources:
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-6-flash
+base_model = "google/gemini-3.6-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+input_audio = 0.75

--- a/providers/aixy/models/vertex/google/gemini-3.7-flash.toml
+++ b/providers/aixy/models/vertex/google/gemini-3.7-flash.toml
@@ -1,0 +1,15 @@
+# Sources:
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+# - https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-7-flash
+# - https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thinking
+base_model = "google/gemini-3.7-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+input_audio = 0.75

--- a/providers/aixy/models/vertex/google/gemini-flash-latest.toml
+++ b/providers/aixy/models/vertex/google/gemini-flash-latest.toml
@@ -1,0 +1,12 @@
+# Alias for the current Gemini Flash release (gemini-3.5-flash).
+base_model = "google/gemini-flash-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+input_audio = 1.5

--- a/providers/aixy/models/vertex/google/gemini-flash-lite-latest.toml
+++ b/providers/aixy/models/vertex/google/gemini-flash-lite-latest.toml
@@ -1,5 +1,6 @@
 # Alias for the current Gemini Flash-Lite release (gemini-3.1-flash-lite).
 base_model = "google/gemini-flash-lite-latest"
+base_model_omit = ["structured_output"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/aixy/models/vertex/google/gemini-flash-lite-latest.toml
+++ b/providers/aixy/models/vertex/google/gemini-flash-lite-latest.toml
@@ -1,0 +1,12 @@
+# Alias for the current Gemini Flash-Lite release (gemini-3.1-flash-lite).
+base_model = "google/gemini-flash-lite-latest"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025
+input_audio = 0.5

--- a/providers/aixy/models/xai/grok-4.20-0309-non-reasoning.toml
+++ b/providers/aixy/models/xai/grok-4.20-0309-non-reasoning.toml
@@ -1,0 +1,12 @@
+base_model = "xai/grok-4.20-0309-non-reasoning"
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 5
+cache_read = 0.4

--- a/providers/aixy/models/xai/grok-4.20-0309-reasoning.toml
+++ b/providers/aixy/models/xai/grok-4.20-0309-reasoning.toml
@@ -1,0 +1,13 @@
+base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 5
+cache_read = 0.4

--- a/providers/aixy/models/xai/grok-4.3.toml
+++ b/providers/aixy/models/xai/grok-4.3.toml
@@ -1,0 +1,17 @@
+base_model = "xai/grok-4.3"
+description = "xAI's Grok for chat, coding, agentic tools, and lower hallucination risk"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 5
+cache_read = 0.4

--- a/providers/aixy/models/xai/grok-4.5.toml
+++ b/providers/aixy/models/xai/grok-4.5.toml
@@ -1,0 +1,19 @@
+base_model = "xai/grok-4.5"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.3
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12
+cache_read = 0.6
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/aixy/models/xai/grok-4.6.toml
+++ b/providers/aixy/models/xai/grok-4.6.toml
@@ -1,0 +1,20 @@
+# Sources: https://docs.x.ai/developers/models/grok-4.6, https://docs.x.ai/developers/pricing, and https://docs.x.ai/developers/model-capabilities/text/reasoning
+base_model = "xai/grok-4.6"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12
+cache_read = 1
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/aixy/models/xai/grok-build-0.1.toml
+++ b/providers/aixy/models/xai/grok-build-0.1.toml
@@ -1,0 +1,13 @@
+base_model = "xai/grok-build-0.1"
+reasoning_options = []
+
+[cost]
+input = 1
+output = 2
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2
+output = 4
+cache_read = 0.4


### PR DESCRIPTION
## Summary

- add the remaining 257 provider-qualified Aixy routes generated by the sync module in #5506
- cover Alibaba, Azure, Bedrock, Cerebras, DeepSeek, Fireworks, Groq, Meta, Mistral, NVIDIA, Perplexity, Together, Vertex, and xAI
- factor every route against canonical Models.dev metadata while preserving provider-specific pricing, limits, modalities, lifecycle status, and reasoning controls

This is part 2 of 2. The split exists only to keep each PR below GitHub’s 300-file diff limit used by the repository reviewer. Together, #5506 and this PR expand Aixy from 1 to 506 models.

## Catalog policy

Aixy is a BYOK gateway, so actual availability remains tenant-specific. The catalog lists reviewed first-class integration routes using the public `provider/model` contract. It excludes non-chat surfaces, tenant-defined community endpoints, and source routes without canonical model metadata.

## Validation

- `bun validate`
- 257 model additions; 258 valid Aixy models in this half when combined with the existing route
- complete two-part catalog: 506 resolved Aixy models

## Related

- Part 1 and sync module: #5506
- Original Aixy provider: #5462
- https://docs.aixy-gateway.com/integrations/overview