### PR TITLE
docs(volcengine): thinking.type auto is not accepted

### DIFF
--- a/providers/volcengine/provider.toml
+++ b/providers/volcengine/provider.toml
@@ -2,7 +2,9 @@ name = "Volcengine Ark"
 env = ["ARK_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
 # Reasoning HTTP format (accessed 2026-08-26):
-# OpenAI Chat: POST /api/v3/chat/completions; `thinking.type` = enabled|disabled|auto,
+# OpenAI Chat: POST /api/v3/chat/completions; `thinking.type` = enabled|disabled
+# (`auto` is documented but rejected with "Unsupported thinking type for the
+# current model" on every model here except doubao-seed-1-6-flash),
 # `reasoning_effort` = minimal|low|medium|high. Plaintext reasoning is in
 # `choices[].message.reasoning_content`, encrypted block is in
 # `choices[].message.encrypted_content` (returned by default).


### PR DESCRIPTION
Follow-up to #5513. I documented `thinking.type = enabled|disabled|auto` in `provider.toml`, but `auto` is not actually accepted.

Tested all 12 models in the provider against `POST /api/v3/chat/completions`:

| value | result |
|---|---|
| `enabled` | works on all 12 |
| `disabled` | works on all 12 |
| `auto` | `Unsupported thinking type for the current model` on 11 of 12 — only `doubao-seed-1-6-flash-250828` accepts it |

`reasoning_effort` = `minimal|low|medium|high` all work as documented.

Comment-only change, `bun validate` clean.