### PR TITLE
Feature/add models

### DIFF
--- a/models/tencent/hy4-preview.toml
+++ b/models/tencent/hy4-preview.toml
@@ -1,0 +1,18 @@
+name = "Hy4 preview"
+description = "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities."
+family = "Hy"
+release_date = "2026-08-28"
+last_updated = "2026-08-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 1_024_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tencent-token-plan/models/hy3.toml
+++ b/providers/tencent-token-plan/models/hy3.toml
@@ -8,7 +8,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
+values = ["none", "high"]
 
 [cost]
 input = 0

--- a/providers/tencent-token-plan/models/hy4-preview.toml
+++ b/providers/tencent-token-plan/models/hy4-preview.toml
@@ -1,6 +1,9 @@
-# Per-token USD pricing is not published yet; zeros match other Token Plan entries.
+# China-site list CNY → USD: list_price / tax_rate * FX (accessed 2026-08-26).
+# Source USD/1k tokens: input 0.000834, output 0.002501, cache hit 0.000042.
+# Catalog is USD / million tokens (×1000).
 # Toggle: thinking.type = enabled|disabled (default disabled)
-# Effort: reasoning_effort = low|medium|high (default low), same as hy3 / hy3-preview
+# Effort: reasoning_effort = none|high
+# https://cloud.tencent.com/document/product/1823/130055
 # https://cloud.tencent.com/document/product/1823/131208
 base_model = "tencent/hy4-preview"
 
@@ -12,7 +15,6 @@ type = "effort"
 values = ["none", "high"]
 
 [cost]
-input = 0
-output = 0
-cache_read = 0
-cache_write = 0
+input = 0.834
+output = 2.501
+cache_read = 0.042

--- a/providers/tencent-token-plan/models/hy4-preview.toml
+++ b/providers/tencent-token-plan/models/hy4-preview.toml
@@ -1,0 +1,18 @@
+# Per-token USD pricing is not published yet; zeros match other Token Plan entries.
+# Toggle: thinking.type = enabled|disabled (default disabled)
+# Effort: reasoning_effort = low|medium|high (default low), same as hy3 / hy3-preview
+# https://cloud.tencent.com/document/product/1823/131208
+base_model = "tencent/hy4-preview"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/tencent-tokenhub/models/hy3.toml
+++ b/providers/tencent-tokenhub/models/hy3.toml
@@ -8,7 +8,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
+values = ["none", "high"]
 
 [cost]
 input = 0

--- a/providers/tencent-tokenhub/models/hy4-preview.toml
+++ b/providers/tencent-tokenhub/models/hy4-preview.toml
@@ -1,0 +1,18 @@
+# Per-token USD pricing is not published yet; zeros match other TokenHub plan entries.
+# Toggle: thinking.type = enabled|disabled (default disabled)
+# Effort: reasoning_effort = low|medium|high (default low), same as hy3 / hy3-preview
+# https://cloud.tencent.com/document/product/1823/131208
+base_model = "tencent/hy4-preview"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/tencent-tokenhub/models/hy4-preview.toml
+++ b/providers/tencent-tokenhub/models/hy4-preview.toml
@@ -1,6 +1,9 @@
-# Per-token USD pricing is not published yet; zeros match other TokenHub plan entries.
+# China-site list CNY → USD: list_price / tax_rate * FX (accessed 2026-08-26).
+# Source USD/1k tokens: input 0.000834, output 0.002501, cache hit 0.000042.
+# Catalog is USD / million tokens (×1000).
 # Toggle: thinking.type = enabled|disabled (default disabled)
-# Effort: reasoning_effort = low|medium|high (default low), same as hy3 / hy3-preview
+# Effort: reasoning_effort = none|high
+# https://cloud.tencent.com/document/product/1823/130055
 # https://cloud.tencent.com/document/product/1823/131208
 base_model = "tencent/hy4-preview"
 
@@ -12,7 +15,6 @@ type = "effort"
 values = ["none", "high"]
 
 [cost]
-input = 0
-output = 0
-cache_read = 0
-cache_write = 0
+input = 0.834
+output = 2.501
+cache_read = 0.042


### PR DESCRIPTION
## Summary
- Add lab metadata for Tencent **Hy4 preview** (`models/tencent/hy4-preview.toml`): 1,024k context, 64k output, closed weights, text-only.
- Serve it on **Tencent TokenHub** and **Tencent Token Plan** via `base_model = "tencent/hy4-preview"` (override-only: `cost` + `reasoning_options`).
- Align Hy3 reasoning effort on those two hosts from `low|medium|high` to `none|high`, matching Hy4 preview on the same APIs.

Per-token USD pricing is not published yet. Costs are `0` to match the existing TokenHub / Token Plan subscription entries.

Reasoning on these hosts:
- Toggle: `thinking.type` = `enabled|disabled` (default disabled)
- Effort: `reasoning_effort` = `none|high`

Docs:
- https://cloud.tencent.com/document/product/1823/131208
- TokenHub: https://cloud.tencent.com/document/product/1823/130050
- Token Plan: https://cloud.tencent.com/document/product/1823/130060

## Test plan
- [x] `bun validate`
- [x] Local `packages/web` (`bun run dev`) — Hy4 preview shows under TokenHub and Token Plan