### PR TITLE
feat(zai): serve GLM-5.3-Flash on zai and zai-coding-plan

### DIFF
--- a/providers/zai-coding-plan/models/glm-5.3-flash.toml
+++ b/providers/zai-coding-plan/models/glm-5.3-flash.toml
@@ -1,0 +1,17 @@
+base_model = "zhipuai/glm-5.3-flash"
+# Effort levels mirror the base GLM-5.3-Flash (low, high, max).
+# Included in the GLM Coding Lite plan and billed against plan credits, so no
+# per-token cost (verified against https://api.z.ai/api/coding/paas/v4 2026-08-26).
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0

--- a/providers/zai/models/glm-5.3-flash.toml
+++ b/providers/zai/models/glm-5.3-flash.toml
@@ -1,0 +1,18 @@
+base_model = "zhipuai/glm-5.3-flash"
+# GLM-5.3-Flash reasons by default; effort levels low|high|max, and thinking can
+# be suppressed with {"thinking": {"type": "disabled"}}.
+# https://z.ai/blog/glm-5.3-flash
+# Served by https://api.z.ai/api/paas/v4 (verified against GET /models 2026-08-26).
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.075
+output = 0.25
+cache_read = 0.015
+cache_write = 0


### PR DESCRIPTION
## What

Adds the two missing provider bindings for **GLM-5.3-Flash**:

- `providers/zai/models/glm-5.3-flash.toml`
- `providers/zai-coding-plan/models/glm-5.3-flash.toml`

The lab entry `models/zhipuai/glm-5.3-flash.toml` is already in the catalog, but no provider hosts it, so the model resolves nowhere and never shows up in `api.json`. Both files are override-only (`base_model` + `cost` + `reasoning_options` + `interleaved`), matching the existing `glm-5.3` and `glm-5.3-highspeed` entries.

## Verification

Checked against both live endpoints on 2026-08-26 with a GLM Coding plan key:

| Endpoint | `GET /models` lists `glm-5.3-flash` | chat completion |
|---|---|---|
| `https://api.z.ai/api/paas/v4` | yes | 200 |
| `https://api.z.ai/api/coding/paas/v4` | yes | 200 |

Reasoning behaviour, same run: on by default (~129 reasoning tokens for a trivial prompt), `reasoning_effort: "low"` is honored (~65), and `{"thinking": {"type": "disabled"}}` suppresses it (~11) — so the effort options mirror the base GLM-5.3 family, and `reasoning_content` is the interleaved field.

Pricing on `zai` follows the published rate ($0.075 in / $0.25 out per M, $0.015 cached input). `zai-coding-plan` is billed against plan credits, so cost is 0, consistent with its sibling entries.

`bun validate` passes; both entries resolve to 1,000,000 context / 131,072 output with `["text", "image", "video", "pdf"]` input modalities inherited from the lab file.

## Note

GLM-5.3-Flash is the model that was served during the OpenRouter stealth period as `stealth/ox-alpha`; that alias is now retired and returns `No endpoints found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)