### PR TITLE
feat(volcengine): add the hosted DeepSeek and GLM models

### DIFF
--- a/providers/volcengine/models/deepseek-v4-flash-ga-260731.toml
+++ b/providers/volcengine/models/deepseek-v4-flash-ga-260731.toml
@@ -1,0 +1,21 @@
+# Model ID verified against POST /api/v3/chat/completions (2026-08-27): `deepseek-v4-flash-ga-260731`
+# CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
+# CNY list price source: https://www.volcengine.com/docs/82379/1544106
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = minimal|low|medium|high
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.4453
+output = 1.3359
+cache_read = 0.01484

--- a/providers/volcengine/models/deepseek-v4-pro-ga-260813.toml
+++ b/providers/volcengine/models/deepseek-v4-pro-ga-260813.toml
@@ -1,0 +1,21 @@
+# Model ID verified against POST /api/v3/chat/completions (2026-08-27): `deepseek-v4-pro-ga-260813`
+# CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
+# CNY list price source: https://www.volcengine.com/docs/82379/1544106
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = minimal|low|medium|high
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.3359
+output = 4.00771
+cache_read = 0.04453

--- a/providers/volcengine/models/glm-5-2-260617.toml
+++ b/providers/volcengine/models/glm-5-2-260617.toml
@@ -1,0 +1,21 @@
+# Model ID verified against POST /api/v3/chat/completions (2026-08-27): `glm-5-2-260617`
+# CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
+# CNY list price source: https://www.volcengine.com/docs/82379/1544106
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = minimal|low|medium|high
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.18747
+output = 4.15615
+cache_read = 0.29687


### PR DESCRIPTION
## Summary

Adds the three non-Doubao models Volcengine Ark serves — DeepSeek V4 Pro, DeepSeek V4 Flash, and GLM-5.2. #5513 covered the Doubao family only.

All three are override-only and resolve against existing lab entries (`deepseek/deepseek-v4-pro-0813`, `deepseek/deepseek-v4-flash-0731`, `zhipuai/glm-5.2`), so no new `models/` files were needed. Note the IDs don't line up by name — Ark uses `deepseek-v4-pro-ga-260813` where the lab entry is `deepseek-v4-pro-0813` — but `base_model` is an explicit pointer, and the filename has to stay the ID the API actually accepts.

Prices are CNY per million tokens converted at **6.737012 CNY/USD (2026-08-26)**, same rate and comment format as #5513:

| model | input | cache read | output |
| --- | --- | --- | --- |
| `deepseek-v4-pro-ga-260813` | ¥9.00 | ¥0.30 | ¥27.00 |
| `deepseek-v4-flash-ga-260731` | ¥3.00 | ¥0.10 | ¥9.00 |
| `glm-5-2-260617` | ¥8.00 | ¥2.00 | ¥28.00 |

These are the current ("正式版") rows on the [pricing page](https://www.volcengine.com/docs/82379/1544106) — both DeepSeek models also list a superseded row there.

No `[modalities]` override: all three reject image input on Ark with `InvalidParameter: Model do not support image input.`, which matches the `input = ["text"]` already on the lab entries.

## Verification

- `bun validate`
- All three called against `POST /api/v3/chat/completions` — completions, `tool_calls`, and both reasoning controls (`thinking.type` enabled/disabled, `reasoning_effort` minimal→high) all work.
- Drove the full generated catalog against the live endpoint afterwards: 15/15 volcengine models respond.
