### PR TITLE
Add DeepSeek V4 Pro, Qwen 3.8 27B, and DeepSeek V4 Flash Flex to neuralwatt

### DIFF
--- a/providers/neuralwatt/models/deepseek-v4-flash-flex.toml
+++ b/providers/neuralwatt/models/deepseek-v4-flash-flex.toml
@@ -3,7 +3,7 @@
 # `-flex` model ID or service_tier="flex" and requires stream=true
 # (non-streaming requests fall through to the standard tier).
 # Cost is the flex rate: 0.65x of standard pricing (35% off) per the flex-tier
-# guide, applied to the current standard rates $0.14/$0.28/$0.028 (accessed
+# guide, applied to the current standard rates $0.14/$0.28/$0.03 (accessed
 # 2026-08-27).
 # Reasoning matches the standard tier: reasoning_effort = none|high|max
 # (default none, reasoning off by default; aliases low/minimal/medium -> high,
@@ -21,7 +21,7 @@ values = ["none", "high", "max"]
 [cost]
 input = 0.091
 output = 0.182
-cache_read = 0.0182
+cache_read = 0.0195
 
 [limit]
 context = 1_048_560

--- a/providers/neuralwatt/models/deepseek-v4-flash-flex.toml
+++ b/providers/neuralwatt/models/deepseek-v4-flash-flex.toml
@@ -3,8 +3,8 @@
 # `-flex` model ID or service_tier="flex" and requires stream=true
 # (non-streaming requests fall through to the standard tier).
 # Cost is the flex rate: 0.65x of standard pricing (35% off) per the flex-tier
-# guide, applied to the current standard rates $0.14/$0.28/$0.03 (accessed
-# 2026-08-27).
+# guide, applied to the standard rates advertised by GET /v1/models
+# ($0.14/$0.28/$0.028, checked 2026-08-27).
 # Reasoning matches the standard tier: reasoning_effort = none|high|max
 # (default none, reasoning off by default; aliases low/minimal/medium -> high,
 # xhigh -> max). thinking_token_budget is rejected with a 400 on V4-Flash
@@ -21,7 +21,7 @@ values = ["none", "high", "max"]
 [cost]
 input = 0.091
 output = 0.182
-cache_read = 0.0195
+cache_read = 0.0182
 
 [limit]
 context = 1_048_560

--- a/providers/neuralwatt/models/deepseek-v4-flash-flex.toml
+++ b/providers/neuralwatt/models/deepseek-v4-flash-flex.toml
@@ -1,0 +1,28 @@
+# Flex-tier variant of deepseek-v4-flash: same model, context window
+# (1,048,560), and output cap (65,536) as the standard tier; requested via the
+# `-flex` model ID or service_tier="flex" and requires stream=true
+# (non-streaming requests fall through to the standard tier).
+# Cost is the flex rate: 0.65x of standard pricing (35% off) per the flex-tier
+# guide, applied to the current standard rates $0.14/$0.28/$0.028 (accessed
+# 2026-08-27).
+# Reasoning matches the standard tier: reasoning_effort = none|high|max
+# (default none, reasoning off by default; aliases low/minimal/medium -> high,
+# xhigh -> max). thinking_token_budget is rejected with a 400 on V4-Flash
+# (and -flex), so it is not declared.
+# https://portal.neuralwatt.com/docs/guides/flex-tier
+# https://portal.neuralwatt.com/docs/api/chat-completions
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash Flex"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.091
+output = 0.182
+cache_read = 0.0182
+
+[limit]
+context = 1_048_560
+output = 65_536

--- a/providers/neuralwatt/models/deepseek-v4-flash.toml
+++ b/providers/neuralwatt/models/deepseek-v4-flash.toml
@@ -6,6 +6,7 @@
 # chat-completions per-model table, verified against the live API on
 # 2026-08-26. Off is effort=none, so no separate toggle. thinking_token_budget
 # is rejected with a 400 on this model, so it is not declared.
+# https://portal.neuralwatt.com/docs/api/models
 # https://portal.neuralwatt.com/pricing
 # https://portal.neuralwatt.com/docs/api/chat-completions
 base_model = "deepseek/deepseek-v4-flash"

--- a/providers/neuralwatt/models/deepseek-v4-flash.toml
+++ b/providers/neuralwatt/models/deepseek-v4-flash.toml
@@ -1,14 +1,22 @@
+# Pricing per the public pricing page (accessed 2026-08-27); previously
+# listed here at $0.104/$0.207/$0.026.
+# Effort: reasoning_effort = none|high|max (default none, reasoning off by
+# default; aliases low/minimal/medium -> high, xhigh -> max) per the
+# chat-completions per-model table, verified against the live API on
+# 2026-08-26. Off is effort=none, so no separate toggle. thinking_token_budget
+# is rejected with a 400 on this model, so it is not declared.
+# https://portal.neuralwatt.com/pricing
+# https://portal.neuralwatt.com/docs/api/chat-completions
 base_model = "deepseek/deepseek-v4-flash"
-name = "DeepSeek V4 Flash"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["none", "high", "max"]
 
 [cost]
-input = 0.104
-output = 0.207
-cache_read = 0.026
+input = 0.14
+output = 0.28
+cache_read = 0.028
 
 [limit]
 context = 1_048_560

--- a/providers/neuralwatt/models/deepseek-v4-flash.toml
+++ b/providers/neuralwatt/models/deepseek-v4-flash.toml
@@ -1,5 +1,6 @@
 # Pricing per the public pricing page (accessed 2026-08-27); previously
-# listed here at $0.104/$0.207/$0.026.
+# listed here at $0.104/$0.207/$0.026. Cached input is the page's explicit
+# per-model rate ($0.03), not the 10%-of-input platform default.
 # Effort: reasoning_effort = none|high|max (default none, reasoning off by
 # default; aliases low/minimal/medium -> high, xhigh -> max) per the
 # chat-completions per-model table, verified against the live API on
@@ -16,7 +17,7 @@ values = ["none", "high", "max"]
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.028
+cache_read = 0.03
 
 [limit]
 context = 1_048_560

--- a/providers/neuralwatt/models/deepseek-v4-flash.toml
+++ b/providers/neuralwatt/models/deepseek-v4-flash.toml
@@ -1,6 +1,6 @@
-# Pricing per the public pricing page (accessed 2026-08-27); previously
-# listed here at $0.104/$0.207/$0.026. Cached input is the page's explicit
-# per-model rate ($0.03), not the 10%-of-input platform default.
+# Pricing from GET /v1/models metadata.pricing, the effective billed rate
+# (checked 2026-08-27); the pricing page shows the same rates with cached
+# input rounded to $0.03. Previously listed here at $0.104/$0.207/$0.026.
 # Effort: reasoning_effort = none|high|max (default none, reasoning off by
 # default; aliases low/minimal/medium -> high, xhigh -> max) per the
 # chat-completions per-model table, verified against the live API on
@@ -17,7 +17,7 @@ values = ["none", "high", "max"]
 [cost]
 input = 0.14
 output = 0.28
-cache_read = 0.03
+cache_read = 0.028
 
 [limit]
 context = 1_048_560

--- a/providers/neuralwatt/models/deepseek-v4-pro.toml
+++ b/providers/neuralwatt/models/deepseek-v4-pro.toml
@@ -1,0 +1,35 @@
+# Preview rollout: deepseek-v4-pro is in private preview on Neuralwatt —
+# visible to paid users after requesting access per model card, per the
+# Preview Models guide. Pricing from the portal model card (USD/MTok); V4-Pro
+# is not yet listed in the public token-pricing table, and no cache-read rate
+# is published for it.
+# Reasoning per the chat-completions per-model table (docs verified against
+# the live API on 2026-08-26): reasoning_effort accepts none|low|high|max as
+# distinct levels with low as the default (reasoning on by default); aliases
+# medium/minimal map to low and xhigh maps to high. thinking_token_budget is
+# accepted on this model (unlike deepseek-v4-flash, which rejects it); no
+# bounds or disable sentinel documented.
+# https://portal.neuralwatt.com/docs/api/chat-completions
+# https://portal.neuralwatt.com/docs/guides/preview-models
+base_model = "deepseek/deepseek-v4-pro"
+status = "beta"
+
+# Effort: reasoning_effort = none|low|high|max (off is effort=none; aliases
+# medium/minimal -> low, xhigh -> high)
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "high", "max"]
+
+# Budget: thinking_token_budget (integer reasoning tokens)
+[[reasoning_options]]
+type = "budget_tokens"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.0
+output = 3.0
+
+[limit]
+context = 1_048_560

--- a/providers/neuralwatt/models/deepseek-v4-pro.toml
+++ b/providers/neuralwatt/models/deepseek-v4-pro.toml
@@ -1,8 +1,8 @@
 # Preview rollout: deepseek-v4-pro is in private preview on Neuralwatt —
 # visible to paid users after requesting access per model card, per the
-# Preview Models guide. Pricing from the portal model card (USD/MTok); V4-Pro
-# is not yet listed in the public token-pricing table, and no cache-read rate
-# is published for it.
+# Preview Models guide. Pricing, output cap, and cache-read from the
+# authenticated GET /v1/models metadata (checked 2026-08-27); V4-Pro is not
+# yet in the public catalog or token-pricing table.
 # Reasoning per the chat-completions per-model table (docs verified against
 # the live API on 2026-08-26): reasoning_effort accepts none|low|high|max as
 # distinct levels with low as the default (reasoning on by default); aliases
@@ -30,6 +30,8 @@ field = "reasoning_content"
 [cost]
 input = 1.0
 output = 3.0
+cache_read = 0.1
 
 [limit]
 context = 1_048_560
+output = 393_216

--- a/providers/neuralwatt/models/qwen-3.8-27b.toml
+++ b/providers/neuralwatt/models/qwen-3.8-27b.toml
@@ -1,0 +1,39 @@
+# Preview rollout: qwen-3.8-27b is in preview on Neuralwatt — early-access
+# program, granted via the portal enroll page; absent from the public
+# /v1/models catalog until access is granted.
+# Effort: reasoning_effort = none|low|medium|xhigh (default xhigh, reasoning
+# on by default); aliases max/xhigh/high -> xhigh and minimal -> low, per the
+# chat-completions per-model table (docs verified against the live API on
+# 2026-08-26). Off is effort=none, so no separate toggle.
+# Budget: thinking_token_budget (integer reasoning tokens) is accepted on this
+# model.
+# Neuralwatt serves text+image input only (lab metadata also lists video).
+# Pricing, context, and output cap from the model page (accessed 2026-08-27):
+# https://portal.neuralwatt.com/models/qwen-3.8-27b
+# https://portal.neuralwatt.com/docs/api/chat-completions
+# https://portal.neuralwatt.com/docs/guides/preview-models
+base_model = "alibaba/qwen3.8-27b"
+status = "beta"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "xhigh"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.45
+output = 3.2
+cache_read = 0.25
+
+[limit]
+context = 262_128
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/neuralwatt/models/qwen-3.8-27b.toml
+++ b/providers/neuralwatt/models/qwen-3.8-27b.toml
@@ -7,8 +7,9 @@
 # 2026-08-26). Off is effort=none, so no separate toggle.
 # Budget: thinking_token_budget (integer reasoning tokens) is accepted on this
 # model.
-# Neuralwatt serves text+image input only (lab metadata also lists video).
-# Pricing, context, and output cap from the model page (accessed 2026-08-27):
+# Neuralwatt serves text+image input only (lab metadata also lists video) and
+# publishes no output cap for this alias, so the lab default is inherited.
+# Pricing, context, and effort ladder from the model page (accessed 2026-08-27):
 # https://portal.neuralwatt.com/models/qwen-3.8-27b
 # https://portal.neuralwatt.com/docs/api/chat-completions
 # https://portal.neuralwatt.com/docs/guides/preview-models
@@ -32,7 +33,6 @@ cache_read = 0.25
 
 [limit]
 context = 262_128
-output = 65_536
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neuralwatt/models/qwen-3.8-27b.toml
+++ b/providers/neuralwatt/models/qwen-3.8-27b.toml
@@ -7,9 +7,9 @@
 # 2026-08-26). Off is effort=none, so no separate toggle.
 # Budget: thinking_token_budget (integer reasoning tokens) is accepted on this
 # model.
-# Neuralwatt serves text+image input only (lab metadata also lists video) and
-# publishes no output cap for this alias, so the lab default is inherited.
-# Pricing, context, and effort ladder from the model page (accessed 2026-08-27):
+# Neuralwatt serves text+image input only (lab metadata also lists video).
+# Pricing, context, output cap, and effort ladder from the model page and the
+# authenticated GET /v1/models metadata (checked 2026-08-27):
 # https://portal.neuralwatt.com/models/qwen-3.8-27b
 # https://portal.neuralwatt.com/docs/api/chat-completions
 # https://portal.neuralwatt.com/docs/guides/preview-models
@@ -33,6 +33,7 @@ cache_read = 0.25
 
 [limit]
 context = 262_128
+output = 65_536
 
 [modalities]
 input = ["text", "image"]

--- a/providers/neuralwatt/provider.toml
+++ b/providers/neuralwatt/provider.toml
@@ -7,10 +7,11 @@ npm = "@ai-sdk/openai-compatible"
 # accepts `reasoning_effort`, with the model-specific normalization documented.
 # Flex tier uses either a `-flex` model ID or `service_tier = "flex"` and
 # requires `stream = true`; non-streaming requests fall through to the standard
-# tier. The official Energy Methodology docs currently state a 0.5 flex pricing
-# multiplier.
+# tier. The flex-tier guide states a 0.65 pricing multiplier (35% off), applied
+# to token billing and energy billing alike (accessed 2026-08-27); earlier
+# flex entries predate the move from 0.5.
 # https://portal.neuralwatt.com/docs/api/chat-completions (accessed 2026-06-25)
-# https://portal.neuralwatt.com/docs/guides/flex-tier
+# https://portal.neuralwatt.com/docs/guides/flex-tier (accessed 2026-08-27)
 # https://portal.neuralwatt.com/docs/energy-methodology (accessed 2026-06-28)
 api = "https://api.neuralwatt.com/v1"
 doc = "https://portal.neuralwatt.com/docs"


### PR DESCRIPTION
# Add DeepSeek V4 Pro, Qwen 3.8 27B, and DeepSeek V4 Flash Flex to neuralwatt

Adds three Neuralwatt model entries and refreshes the existing `deepseek-v4-flash` pricing/reasoning data to current published values. Two of the new models are gated previews — visible only to paid users after requesting access — so they are marked `status = "beta"`.

## Changes

- **New** `providers/neuralwatt/models/deepseek-v4-pro.toml` — private preview
- **New** `providers/neuralwatt/models/qwen-3.8-27b.toml` — preview (early-access program)
- **New** `providers/neuralwatt/models/deepseek-v4-flash-flex.toml` — flex tier of V4 Flash (GA)
- **Update** `providers/neuralwatt/models/deepseek-v4-flash.toml` — current pricing + reasoning efforts; also drops a `name` override identical to the base model

## Data

| Model | ID | Cost (USD/MTok in/out/cache-read) | Limits (ctx/out) | Status | Reasoning |
| --- | --- | --- | --- | --- | --- |
| DeepSeek V4 Pro | `deepseek-v4-pro` | $1.00 / $3.00 / $0.10 | 1,048,560 / 393,216 | private preview → `beta` | `reasoning_effort = none\|low\|high\|max` (default `low`, on by default) + `thinking_token_budget` accepted |
| Qwen3.8 27B | `qwen-3.8-27b` | $0.45 / $3.20 / $0.25 | 262,128 / 65,536 | preview → `beta` | `reasoning_effort = none\|low\|medium\|xhigh` (default `xhigh`, on by default) + `thinking_token_budget` accepted |
| DeepSeek V4 Flash Flex | `deepseek-v4-flash-flex` | $0.091 / $0.182 / $0.0182 (0.65× flex rate) | 1,048,560 / 65,536 | GA | same as V4 Flash: `none\|high\|max` (default `none`) |
| DeepSeek V4 Flash (update) | `deepseek-v4-flash` | ~~$0.104/$0.207/$0.026~~ → $0.14 / $0.28 / $0.028 | unchanged | GA | `high\|max` → `none\|high\|max` (docs now list `none`, default off) |

Notes:

- Both previews follow the repo convention that effort lists containing `none` need no separate `toggle`.
- V4 Pro alias mapping: `medium`/`minimal`→`low`, `xhigh`→`high`. Qwen 3.8: `max`/`xhigh`/`high`→`xhigh`, `minimal`→`low`. V4 Flash: `low`/`minimal`/`medium`→`high`, `xhigh`→`max`.
- `thinking_token_budget` is accepted on `deepseek-v4-pro` and `qwen-3.8-27b` but rejected with a 400 on `deepseek-v4-flash`/`-flex` (V2 runner), so `budget_tokens` is only declared where it works.
- Flex tier: `-flex` model ID or `service_tier = "flex"`, requires `stream = true`; billed at 0.65× standard per the flex-tier guide (accessed 2026-08-27).
- Both previews verified against the authenticated `GET /v1/models` `metadata.pricing`/`metadata.limits`/`metadata.reasoning` (checked 2026-08-27); V4 Pro serves a 393,216 output cap (not the lab's 384,000) and bills cache reads at $0.10 (10% platform default).
- Qwen 3.8 is served text+image only (lab metadata also lists video); modalities overridden accordingly.
- Lab metadata already exists for all three (`models/deepseek/deepseek-v4-pro.toml`, `models/alibaba/qwen3.8-27b.toml`, `models/deepseek/deepseek-v4-flash.toml`), so entries are override-only `base_model` files.

## Sources

- DeepSeek V4 Pro: authenticated [GET /v1/models](https://portal.neuralwatt.com/docs/api/models) (pricing, limits, reasoning; checked 2026-08-27), [chat-completions per-model table](https://portal.neuralwatt.com/docs/api/chat-completions) (efforts, budget; verified 2026-08-26), [preview-models guide](https://portal.neuralwatt.com/docs/guides/preview-models) (gating)
- Qwen 3.8 27B: [model page](https://portal.neuralwatt.com/models/qwen-3.8-27b) (ID, pricing, 262K context, vision, preview/enroll), authenticated [GET /v1/models](https://portal.neuralwatt.com/docs/api/models) (output cap 65,536; checked 2026-08-27), [chat-completions docs](https://portal.neuralwatt.com/docs/api/chat-completions) (efforts, budget)
- V4 Flash / Flex: [GET /v1/models](https://portal.neuralwatt.com/docs/api/models) `metadata.pricing` (effective billed rate; the pricing page displays the same rates with cached input rounded to $0.03), [flex-tier guide](https://portal.neuralwatt.com/docs/guides/flex-tier) (0.65× multiplier, stream requirement), [chat-completions docs](https://portal.neuralwatt.com/docs/api/chat-completions) (efforts incl. `none`; `thinking_token_budget` 400 on flash/-flex)

## Validation

- [x] `bun validate` passes
- [x] Generated JSON verified for all four models: base fields inherited, provider overrides applied as authored
