### PR TITLE
fix(bytedance-seed): Seed 1.8 and 1.6 Flash accept image input

### DIFF
--- a/models/bytedance-seed/seed-1-6-flash.toml
+++ b/models/bytedance-seed/seed-1-6-flash.toml
@@ -6,7 +6,7 @@ description = "Low-latency ByteDance Seed model for high-throughput chat, extrac
 family = "seed"
 release_date = "2025-08-28"
 last_updated = "2025-08-28"
-attachment = false
+attachment = true
 reasoning = false
 temperature = true
 tool_call = true
@@ -17,5 +17,5 @@ context = 256_000
 output = 32_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]

--- a/models/bytedance-seed/seed-1-8.toml
+++ b/models/bytedance-seed/seed-1-8.toml
@@ -6,7 +6,7 @@ description = "ByteDance Seed model for multimodal reasoning, long-context analy
 family = "seed"
 release_date = "2025-12-28"
 last_updated = "2025-12-28"
-attachment = false
+attachment = true
 reasoning = true
 temperature = true
 tool_call = true
@@ -17,5 +17,5 @@ context = 256_000
 output = 64_000
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]


### PR DESCRIPTION
## Summary

`models/bytedance-seed/seed-1-8.toml` and `seed-1-6-flash.toml` declare `input = ["text"]`, but both models accept and correctly interpret image input. This flips them to `["text", "image"]` and sets `attachment = true` to match.

`seed-1-6.toml` is **deliberately left text-only** — see below.

## Evidence

Solid-colour PNGs (64x64) sent to `POST /api/v3/chat/completions` on Volcengine Ark, asking only "What color is this image?". Two independent runs using different colour pairs, because a single colour can be guessed:

| model | red/blue run | blue/green run | `prompt_tokens` |
| --- | --- | --- | --- |
| `bytedance-seed/seed-1-8` | Red / Blue | Blue / Green | 65 |
| `bytedance-seed/seed-1-6-flash` | Red / blue | blue / green | 102 |
| `bytedance-seed/seed-1-6` | Unknown / Unknown | Unknown / — | **51** |

ByteDance's own model list also tags both as 多模态理解 (multimodal understanding), and `seed-1-6-flash` additionally as 视觉定位 (visual grounding): https://www.volcengine.com/docs/82379/1330310

### Why Seed 1.6 stays text-only

It is a false positive worth being explicit about: it returns HTTP 200 with `finish_reason: stop` on an image-bearing request, so an error-only check reads as success. But the image never enters the context — `prompt_tokens` stays at 51 versus 65/102 for the two models that do ingest the image, i.e. the attachment contributes nothing, and the model replies that no image was provided. Its `input = ["text"]` is correct and untouched here.

## Scope

Two provider entries resolve against each of these labs — `volcengine` and `ofox/volcengine` — and both relay the same upstream Ark endpoint, so the four affected catalog entries all describe the API actually tested here. `bun validate` passes; the generated diff is exactly those four entries, `attachment false→true` and `input ['text']→['text','image']`, with nothing else moving.

This is a correction to lab-level capability metadata, not a provider addition. Modalities describe what the model can do, not whether a given host has enabled it.
