### PR TITLE
fix(volcengine): declare all seven reasoning_effort levels

### DIFF
--- a/providers/volcengine/models/doubao-seed-1-8-251228.toml
+++ b/providers/volcengine/models/doubao-seed-1-8-251228.toml
@@ -5,16 +5,14 @@
 # here since the catalog has no output-length dimension.
 # Output tiering note applies to the base [cost] block only.
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# none/minimal disable thinking, so no separate toggle: sending effort alone
+# already enables it, and thinking.type=disabled + a graded effort is rejected.
 base_model = "bytedance-seed/seed-1-8"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/volcengine/models/doubao-seed-2-0-code-preview-260215.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-code-preview-260215.toml
@@ -1,16 +1,14 @@
 # Model ID verified against POST /api/v3/chat/completions (2026-08-26): `doubao-seed-2-0-code-preview-260215`
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# none/minimal disable thinking, so no separate toggle: sending effort alone
+# already enables it, and thinking.type=disabled + a graded effort is rejected.
 base_model = "bytedance-seed/seed-2.0-code"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/volcengine/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-lite-260428.toml
@@ -1,16 +1,14 @@
 # Model ID verified against POST /api/v3/chat/completions (2026-08-26): `doubao-seed-2-0-lite-260428`
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# none/minimal disable thinking, so no separate toggle: sending effort alone
+# already enables it, and thinking.type=disabled + a graded effort is rejected.
 base_model = "bytedance-seed/seed-2.0-lite"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/volcengine/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-mini-260428.toml
@@ -1,16 +1,14 @@
 # Model ID verified against POST /api/v3/chat/completions (2026-08-26): `doubao-seed-2-0-mini-260428`
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# none/minimal disable thinking, so no separate toggle: sending effort alone
+# already enables it, and thinking.type=disabled + a graded effort is rejected.
 base_model = "bytedance-seed/seed-2.0-mini"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/volcengine/models/doubao-seed-2-0-pro-260215.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-pro-260215.toml
@@ -1,16 +1,14 @@
 # Model ID verified against POST /api/v3/chat/completions (2026-08-26): `doubao-seed-2-0-pro-260215`
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# none/minimal disable thinking, so no separate toggle: sending effort alone
+# already enables it, and thinking.type=disabled + a graded effort is rejected.
 base_model = "bytedance-seed/seed-2.0-pro"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/volcengine/models/doubao-seed-2-1-pro-260628.toml
+++ b/providers/volcengine/models/doubao-seed-2-1-pro-260628.toml
@@ -1,16 +1,14 @@
 # Model ID verified against POST /api/v3/chat/completions (2026-08-26): `doubao-seed-2-1-pro-260628`
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# none/minimal disable thinking, so no separate toggle: sending effort alone
+# already enables it, and thinking.type=disabled + a graded effort is rejected.
 base_model = "bytedance-seed/seed-2.1-pro"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/volcengine/models/doubao-seed-2-1-turbo-260628.toml
+++ b/providers/volcengine/models/doubao-seed-2-1-turbo-260628.toml
@@ -1,16 +1,14 @@
 # Model ID verified against POST /api/v3/chat/completions (2026-08-26): `doubao-seed-2-1-turbo-260628`
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# none/minimal disable thinking, so no separate toggle: sending effort alone
+# already enables it, and thinking.type=disabled + a graded effort is rejected.
 base_model = "bytedance-seed/seed-2.1-turbo"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/volcengine/models/doubao-seed-character-260628.toml
+++ b/providers/volcengine/models/doubao-seed-character-260628.toml
@@ -2,7 +2,8 @@
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
 # Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high
+# Effort: reasoning_effort = minimal|low|medium|high|xhigh|max (no none: this
+# model defaults thinking off, so thinking.type is the real switch here)
 base_model = "bytedance-seed/seed-character"
 
 [[reasoning_options]]
@@ -10,7 +11,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high"]
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/volcengine/models/doubao-seed-evolving.toml
+++ b/providers/volcengine/models/doubao-seed-evolving.toml
@@ -1,16 +1,14 @@
 # Model ID verified against POST /api/v3/chat/completions (2026-08-26): `doubao-seed-evolving`
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
+# none/minimal disable thinking, so no separate toggle: sending effort alone
+# already enables it, and thinking.type=disabled + a graded effort is rejected.
 base_model = "bytedance-seed/seed-evolving"
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high"]
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/volcengine/provider.toml
+++ b/providers/volcengine/provider.toml
@@ -5,7 +5,9 @@ npm = "@ai-sdk/openai-compatible"
 # OpenAI Chat: POST /api/v3/chat/completions; `thinking.type` = enabled|disabled
 # (`auto` is documented but rejected with "Unsupported thinking type for the
 # current model" on every model here except doubao-seed-1-6-flash),
-# `reasoning_effort` = minimal|low|medium|high. Plaintext reasoning is in
+# `reasoning_effort` = none|minimal|low|medium|high|xhigh|max (none and minimal
+# disable thinking; doubao-seed-1-6-251015 accepts only the middle four).
+# Plaintext reasoning is in
 # `choices[].message.reasoning_content`, encrypted block is in
 # `choices[].message.encrypted_content` (returned by default).
 # Responses: POST /api/v3/responses; `reasoning.effort`; encrypted block requires


### PR DESCRIPTION
## Summary

The Volcengine entries declared four `reasoning_effort` levels. Ark accepts seven — `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` — so `max` was never reachable. It's a real accept-set, not a field that swallows anything: `banana`, `ultra` and `extreme` all come back as `InvalidParameter`.

While fixing that I hit the `toggle` + `none` rule in AGENTS.md, which turns out to be the more interesting half.

## toggle and none are mutually exclusive here — and that matches the API

AGENTS.md says an effort list containing `none` must not be paired with a `toggle`. Measuring the two controls against each other on all nine models:

| probe | result |
| --- | --- |
| effort alone, no `thinking.type` | `reasoning_tokens` > 0 — thinking is already on |
| `thinking.type=enabled` + `reasoning_effort=none` | `reasoning_tokens` = 0 — `none` wins |
| `thinking.type=disabled` + a graded effort | `400 Invalid combination of reasoning_effort and thinking type` |

So they don't compose, they conflict. Eight models move to effort-only with `none` in the list.

**`doubao-seed-character-260628` is the exception and keeps its toggle.** It's the one model that defaults thinking *off* — a bare request returns `reasoning_tokens = 0`, and sending an effort without `thinking.type` is rejected. There `thinking.type` is the real switch, so it gets `toggle` + an effort list that omits `none`.

## On mapping vs acceptance

Worth stating plainly, since it cuts against the obvious reading: on Doubao models `xhigh` and `max` are **not** distinct tiers — Volcengine's [deep-thinking doc](https://www.volcengine.com/docs/82379/1449737) maps them onto `high`, and the token counts agree (`doubao-seed-2-1-pro-260628`, n=4 medians: high 7295, xhigh 7412, max 6920).

They *are* distinct on the hosted third-party models: on `glm-5-2-260617`, `xhigh` maps to `max` and the ranges don't overlap (high 862–930 vs xhigh 1220–1416 over 5 runs).

This PR lists what the API accepts rather than how many distinct behaviours each model exposes. Both conventions exist in the catalog — happy to switch to the effective-tier style if that's preferred.

## Untouched

`doubao-seed-1-6-251015` keeps its four-level list and its toggle: it rejects `none`/`xhigh`/`max` outright with `Invalid reasoning_effort`, so it's already correct. `doubao-seed-1-6-flash-250828` and `doubao-seed-1-6-vision-250815` are `reasoning = false` on their lab entries and carry no `reasoning_options`.

Rebased onto current `dev` so the `thinking.type = auto` correction from #5518 stays intact. `bun validate` clean.