### PR TITLE
feat(amazon-bedrock): add us. geo inference profiles for GPT-5.6 Sol, Terra, Luna

### DIFF
--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-luna.toml
@@ -1,0 +1,21 @@
+# US geographic cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Verified from us-east-1: returns 200 via Converse.
+# Geo CRIS pricing and Runtime capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-5.6 Luna (US)"
+structured_output = false
+
+[cost]
+input = 0.22
+output = 1.32
+cache_read = 0.022
+cache_write = 0.275
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 0.44
+output = 1.98
+cache_read = 0.044
+cache_write = 0.55

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-sol.toml
@@ -1,0 +1,21 @@
+# US geographic cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Verified from us-east-1: returns 200 via Converse.
+# Geo CRIS pricing and Runtime capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-5.6 Sol (US)"
+structured_output = false
+
+[cost]
+input = 4.40
+output = 22.00
+cache_read = 0.44
+cache_write = 5.50
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 8.80
+output = 33.00
+cache_read = 0.88
+cache_write = 11.00

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-terra.toml
@@ -1,0 +1,21 @@
+# US geographic cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Verified from us-east-1: returns 200 via Converse.
+# Geo CRIS pricing and Runtime capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-5.6 Terra (US)"
+structured_output = false
+
+[cost]
+input = 2.20
+output = 13.20
+cache_read = 0.22
+cache_write = 2.75
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 4.40
+output = 19.80
+cache_read = 0.44
+cache_write = 5.50


### PR DESCRIPTION
## Summary

Adds the three US geographic cross-Region inference profiles Bedrock serves for GPT-5.6: `us.openai.gpt-5.6-sol`, `us.openai.gpt-5.6-terra` and `us.openai.gpt-5.6-luna`. The catalog currently carries only the `global.` and bare ids, so a caller with US data-residency requirements has no entry to select: `global.` routes to any commercial Region, and the bare id is not available for in-Region inference on `bedrock-runtime` at all.

All three are override-only against the existing lab entries (`openai/gpt-5.6-sol`, `-terra`, `-luna`), so no new `models/` files were needed. They are modelled on the `global.` siblings rather than the bare ids, because both are served by Bedrock core: **no `[provider]` override**, unlike the bare entries which point at `bedrock-mantle`.

Geo CRIS is priced at the In-Region rate, above Global, so these carry the in-region numbers rather than the `global.` sibling's. For Sol short-context that is $4.40 / $22.00 against Global's $4.00 / $20.00, so reusing the `global.` costs would have understated them by 10%.

| model | input | cache write | cache read | output |
| --- | --- | --- | --- | --- |
| `us.openai.gpt-5.6-sol` | $4.40 | $5.50 | $0.44 | $22.00 |
| `us.openai.gpt-5.6-terra` | $2.20 | $2.75 | $0.22 | $13.20 |
| `us.openai.gpt-5.6-luna` | $0.22 | $0.275 | $0.022 | $1.32 |

Above 272K: Sol $8.80 / $33.00, Terra $4.40 / $19.80, Luna $0.44 / $1.98. USD per million tokens, Standard tier. Priority and Flex are not supported for these models.

Rows are the "Geo CRIS" lines on the model cards, each linked in its file's header block: [Sol](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html), [Terra](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html), [Luna](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html).

`structured_output = false` overrides the lab entries, which set it true: structured outputs are listed as not supported on the `bedrock-runtime` endpoint. This matches the `global.` siblings. No `[limit]` or `[modalities]` override, since the 1M context and text/image/pdf input on the lab entries are correct for these profiles.

Terra and Luna also have `in.openai.gpt-5.6-*` India geo profiles. Left out here since I have not called them.

## Verification

- `bun validate`
- All three return 200 from `us-east-1` via Converse on `bedrock-runtime`, which is what justifies omitting the `[provider]` block
- Routing footprint from `get-inference-profile` is `us-east-1`, `us-east-2`, `us-west-2` on all three, confirming the US geography
- Generated catalog entries inherit `limit` (1,050,000 context) and `[modalities]` from the lab entries and carry only `cost`, `reasoning_options`, `name` and `structured_output`, matching the shape of the existing `global.` and bare entries
