### PR TITLE
feat(friendli): add GLM-5.3-Flash provider support

### DIFF
--- a/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-5.3-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.5
+cache_read = 0.03

--- a/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
@@ -1,8 +1,20 @@
+# Cost, modalities, and reasoning_options verified against live
+# GET https://api.friendli.ai/serverless/v1/models (zai-org/GLM-5.3-Flash):
+# pricing input=0.00000015/output=0.0000005/cache_read=0.00000003 USD-per-token
+# (converted to USD/MTok below); input_modalities=[text,image,video];
+# reasoning_options=[effort low|high|max, budget_tokens min=-1 max=1048576].
+# https://friendli.ai/docs/openapi/model-apis/chat-completions#body-reasoning-budget-one-of-0
+# (accessed 2026-08-29)
 base_model = "zhipuai/glm-5.3-flash"
 
 [[reasoning_options]]
 type = "effort"
 values = ["low", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = -1
+max = 1_048_576
 
 [interleaved]
 field = "reasoning_content"
@@ -15,3 +27,7 @@ output = ["text"]
 input = 0.15
 output = 0.5
 cache_read = 0.03
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
@@ -1,8 +1,5 @@
 base_model = "zhipuai/glm-5.3-flash"
 
-# Friendli serves text-only input for this model:
-# https://api.friendli.ai/serverless/v1/models (accessed 2026-08-27)
-
 [[reasoning_options]]
 type = "effort"
 values = ["low", "high", "max"]
@@ -11,7 +8,7 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]
 
 [cost]

--- a/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
@@ -8,7 +8,7 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [modalities]
-input = ["text", "image"]
+input = ["text", "image", "video"]
 output = ["text"]
 
 [cost]

--- a/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/friendli/models/zai-org/GLM-5.3-Flash.toml
@@ -1,11 +1,18 @@
 base_model = "zhipuai/glm-5.3-flash"
 
+# Friendli serves text-only input for this model:
+# https://api.friendli.ai/serverless/v1/models (accessed 2026-08-27)
+
 [[reasoning_options]]
 type = "effort"
 values = ["low", "high", "max"]
 
 [interleaved]
 field = "reasoning_content"
+
+[modalities]
+input = ["text"]
+output = ["text"]
 
 [cost]
 input = 0.15


### PR DESCRIPTION
## Summary
Adds Friendli as a provider host for zai-org/GLM-5.3-Flash (`base_model = zhipuai/glm-5.3-flash`, override-only).

available at https://api.friendli.ai/serverless/v1/models

## Reasoning
`reasoning_effort` values `low` / `high` / `max` per [chat_template.jinja](https://huggingface.co/zai-org/GLM-5.3-Flash/blob/main/chat_template.jinja):
```
{%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
```
Reasoning is always enabled (no toggle) — unrecognized/omitted values fall back to `max`.

## Cost (USD/MTok)
- input: $0.15
- output: $0.5
- cache_read: $0.03

## Checklist
- [x] Non-lab host uses `base_model`
- [x] Provider file is override-only (cost + reasoning_options + interleaved only)
- [x] `reasoning = true` ⇒ `reasoning_options` set
- [x] Costs in USD/MTok
- [x] `bun validate` passes
