### PR TITLE
feat(vivgrid): add glm-5.3-flash

### DIFF
--- a/providers/vivgrid/models/glm-5.3-flash.toml
+++ b/providers/vivgrid/models/glm-5.3-flash.toml
@@ -1,0 +1,12 @@
+# Pricing per https://docs.vivgrid.com/models (accessed 2026-08-27):
+# input $0.15 / cached input $0.04 / output $0.50 per 1M tokens.
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.5
+cache_read = 0.04


### PR DESCRIPTION
## What

Adds `glm-5.3-flash` to the **Vivgrid** provider. Vivgrid now serves Zhipu AI's GLM-5.3-Flash through its unified OpenAI-compatible endpoint.

The lab metadata (`models/zhipuai/glm-5.3-flash.toml`) already exists on `dev`, so this is an override-only provider entry via `base_model` — one new file, nothing else touched.

## Data & sources

| Field | Value | Source |
| --- | --- | --- |
| `cost.input` | $0.15 / 1M | [docs.vivgrid.com/models](https://docs.vivgrid.com/models) |
| `cost.cache_read` | $0.04 / 1M | same |
| `cost.output` | $0.50 / 1M | same |

Vivgrid's list price matches Z.ai's own published rate for this model ($0.15 in / $0.50 out per 1M tokens), with a slightly different cached-input rate.

`reasoning_options`, and the `reasoning_content` interleaved side channel, follow the sibling [`providers/vivgrid/models/glm-5.3.toml`](https://github.com/anomalyco/models.dev/blob/dev/providers/vivgrid/models/glm-5.3.toml) entry — same host, same lab, same model generation, same OpenAI-compatible request surface.

## Checklist

- [x] Non-lab host uses `base_model`
- [x] Provider file is override-only (no duplicated base fields, no provider-only keys under `models/`)
- [x] `reasoning = true` ⇒ `reasoning_options` set, matching this host's peer entry
- [x] Costs are USD per MTok
- [x] `bun validate` passes

## Note for maintainers (out of scope here)

While sourcing this I noticed the existing `models/zhipuai/glm-5.3-flash.toml` has `open_weights = false`, but the weights are public and MIT-licensed:

- https://huggingface.co/zai-org/GLM-5.3-Flash — `license:mit`, not gated, published 2026-08-26

Happy to send that as a separate one-line PR if you'd like — left out of this one to keep the change scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)