### PR TITLE
zai, zhipuai: add missing limit.input for GLM-5.x models

### DIFF
--- a/models/zhipuai/glm-5-turbo.toml
+++ b/models/zhipuai/glm-5-turbo.toml
@@ -12,6 +12,7 @@ open_weights = false
 
 [limit]
 context = 200_000
+input = 68_928
 output = 131_072
 
 [modalities]

--- a/models/zhipuai/glm-5.1.toml
+++ b/models/zhipuai/glm-5.1.toml
@@ -12,6 +12,7 @@ open_weights = true
 
 [limit]
 context = 200_000
+input = 68_928
 output = 131_072
 
 [modalities]

--- a/models/zhipuai/glm-5.2.toml
+++ b/models/zhipuai/glm-5.2.toml
@@ -12,6 +12,7 @@ open_weights = true
 
 [limit]
 context = 1_000_000
+input = 868_928
 output = 131_072
 
 [modalities]

--- a/models/zhipuai/glm-5.3-flash.toml
+++ b/models/zhipuai/glm-5.3-flash.toml
@@ -12,6 +12,7 @@ open_weights = false
 
 [limit]
 context = 1_000_000
+input = 868_928
 output = 131_072
 
 [modalities]

--- a/models/zhipuai/glm-5.3.toml
+++ b/models/zhipuai/glm-5.3.toml
@@ -12,6 +12,7 @@ open_weights = false
 
 [limit]
 context = 1_000_000
+input = 868_928
 output = 131_072
 
 [modalities]

--- a/models/zhipuai/glm-5.toml
+++ b/models/zhipuai/glm-5.toml
@@ -11,6 +11,7 @@ open_weights = true
 
 [limit]
 context = 204_800
+input = 73_728
 output = 131_072
 
 [modalities]

--- a/models/zhipuai/glm-5v-turbo.toml
+++ b/models/zhipuai/glm-5v-turbo.toml
@@ -11,6 +11,7 @@ open_weights = false
 
 [limit]
 context = 200_000
+input = 68_928
 output = 131_072
 
 [modalities]

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -3217,6 +3217,7 @@ test("factors aliased LLM Gateway routes against canonical metadata", () => {
 
   expect(model).toEqual({
     base_model: "zhipuai/glm-5.2",
+    base_model_omit: ["limit.input"],
     cost: {
       input: 1.4,
       output: 4.4,

--- a/providers/ambient/models/ambient/large.toml
+++ b/providers/ambient/models/ambient/large.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+base_model_omit = ["limit.input"]
 name = "Ambient Large"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
 

--- a/providers/ambient/models/z-ai/glm-5.2.toml
+++ b/providers/ambient/models/z-ai/glm-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+base_model_omit = ["limit.input"]
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
 
 [[reasoning_options]]

--- a/providers/ambient/models/zai-org/GLM-5.2-FP8.toml
+++ b/providers/ambient/models/zai-org/GLM-5.2-FP8.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+base_model_omit = ["limit.input"]
 reasoning_options = [
   { type = "effort", values = ["high", "max"] },
 ]

--- a/providers/arcee/models/zai-org/glm-5.2.toml
+++ b/providers/arcee/models/zai-org/glm-5.2.toml
@@ -15,3 +15,4 @@ cache_read = 0.26
 
 [limit]
 context = 262_144
+input = 131_072

--- a/providers/berget/models/zai-org/GLM-5.2.toml
+++ b/providers/berget/models/zai-org/GLM-5.2.toml
@@ -10,6 +10,7 @@ output = 4.84
 
 [limit]
 context = 524_288
+input = 491_520
 output = 32_768
 
 [modalities]

--- a/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-5.2.toml
+++ b/providers/cloudflare-workers-ai/models/@cf/zai-org/glm-5.2.toml
@@ -17,4 +17,5 @@ cache_read = 0.26
 
 [limit]
 context = 262_144
+input = 6_144
 output = 256_000

--- a/providers/digitalocean/models/glm-5.2.toml
+++ b/providers/digitalocean/models/glm-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+base_model_omit = ["limit.input"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/evroc/models/zai-org/GLM-5.2.toml
+++ b/providers/evroc/models/zai-org/GLM-5.2.toml
@@ -10,3 +10,4 @@ output = 5.75
 
 [limit]
 context = 524_288
+input = 393_216

--- a/providers/huggingface/models/zai-org/GLM-5.2.toml
+++ b/providers/huggingface/models/zai-org/GLM-5.2.toml
@@ -7,3 +7,4 @@ output = 4.4
 
 [limit]
 context = 262_144
+input = 131_072

--- a/providers/lilac/models/zai-org/glm-5.2.toml
+++ b/providers/lilac/models/zai-org/glm-5.2.toml
@@ -3,6 +3,7 @@
 # "max" (default) or "high"; effort has no effect when thinking is disabled.
 # https://docs.getlilac.com/inference/chat-completions#reasoning (accessed 2026-06-25)
 base_model = "zhipuai/glm-5.2"
+base_model_omit = ["limit.input"]
 name = "GLM 5.2"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 

--- a/providers/llmgateway-providers/models/canopywave/glm-5.2.toml
+++ b/providers/llmgateway-providers/models/canopywave/glm-5.2.toml
@@ -16,4 +16,5 @@ cache_read = 0.26
 
 [limit]
 context = 200_000
+input = 167_232
 output = 32_768

--- a/providers/llmgateway-providers/models/embercloud/glm-5.2.toml
+++ b/providers/llmgateway-providers/models/embercloud/glm-5.2.toml
@@ -16,4 +16,5 @@ cache_read = 0.234
 
 [limit]
 context = 203_000
+input = 72_000
 output = 131_000

--- a/providers/nebius/models/zai-org/GLM-5.2.toml
+++ b/providers/nebius/models/zai-org/GLM-5.2.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-5.2"
+base_model_omit = ["limit.input"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/openrouter/models/z-ai/glm-5.2:free.toml
+++ b/providers/openrouter/models/z-ai/glm-5.2:free.toml
@@ -15,4 +15,5 @@ output = 0
 
 [limit]
 context = 256_000
+input = 25_600
 output = 230_400

--- a/providers/regolo-ai/models/glm5.2.toml
+++ b/providers/regolo-ai/models/glm5.2.toml
@@ -2,6 +2,7 @@
 # Effort: reasoning_effort = high|max (lab maps low/medium→high, xhigh→max; none skips thinking)
 # Source: https://docs.bigmodel.cn/cn/guide/capabilities/thinking (accessed 2026-06-25)
 base_model = "zhipuai/glm-5.2"
+base_model_omit = ["limit.input"]
 
 reasoning_options = [{ type = "effort", values = ["high", "max"] }]
 

--- a/providers/routing-run/models/glm-5.2-nitro.toml
+++ b/providers/routing-run/models/glm-5.2-nitro.toml
@@ -8,6 +8,7 @@ output = 2.40
 
 [limit]
 context = 200_000
+input = 168_000
 output = 32_000
 
 [interleaved]

--- a/providers/routing-run/models/glm-5.2.toml
+++ b/providers/routing-run/models/glm-5.2.toml
@@ -7,6 +7,7 @@ output = 2.40
 
 [limit]
 context = 200_000
+input = 168_000
 output = 32_000
 
 [interleaved]

--- a/providers/scaleway/models/glm-5.2.toml
+++ b/providers/scaleway/models/glm-5.2.toml
@@ -7,4 +7,5 @@ output = 5.5
 
 [limit]
 context = 256_000
+input = 239_616
 output = 16_384

--- a/providers/synthetic/models/hf:zai-org/GLM-5.2.toml
+++ b/providers/synthetic/models/hf:zai-org/GLM-5.2.toml
@@ -11,4 +11,5 @@ cache_read = 1.4
 
 [limit]
 context = 524_288
+input = 458_752
 output = 65_536

--- a/providers/tinfoil/models/glm-5-2.toml
+++ b/providers/tinfoil/models/glm-5-2.toml
@@ -12,3 +12,4 @@ cache_read = 0.375
 
 [limit]
 context = 393_216
+input = 262_144

--- a/providers/togetherai/models/zai-org/GLM-5.2.toml
+++ b/providers/togetherai/models/zai-org/GLM-5.2.toml
@@ -21,6 +21,7 @@ output = 4.40
 
 [limit]
 context = 512_000
+input = 348_000
 output = 164_000
 
 [modalities]

--- a/providers/umans-ai-coding-plan/models/umans-glm-5.2.toml
+++ b/providers/umans-ai-coding-plan/models/umans-glm-5.2.toml
@@ -15,6 +15,7 @@ cache_write = 0
 
 [limit]
 context = 405_504
+input = 274_432
 
 [modalities]
 input = ["text", "image"]

--- a/providers/umans-ai/models/umans-glm-5.2.toml
+++ b/providers/umans-ai/models/umans-glm-5.2.toml
@@ -14,6 +14,7 @@ cache_read = 0.26
 
 [limit]
 context = 405_504
+input = 274_432
 
 [modalities]
 input = ["text", "image"]

--- a/providers/vultr/models/zai-org/GLM-5.2-FP8.toml
+++ b/providers/vultr/models/zai-org/GLM-5.2-FP8.toml
@@ -10,3 +10,4 @@ output = 3.10
 
 [limit]
 context = 393_216
+input = 262_144

--- a/providers/zai-coding-plan/models/glm-5-turbo.toml
+++ b/providers/zai-coding-plan/models/glm-5-turbo.toml
@@ -24,6 +24,7 @@ cache_write = 0
 
 [limit]
 context = 200000
+input = 68928
 output = 131072
 
 [modalities]

--- a/providers/zai/models/glm-5-turbo.toml
+++ b/providers/zai/models/glm-5-turbo.toml
@@ -24,6 +24,7 @@ cache_write = 0
 
 [limit]
 context = 200000
+input = 68928
 output = 131072
 
 [modalities]

--- a/providers/zai/models/glm-5v-turbo.toml
+++ b/providers/zai/models/glm-5v-turbo.toml
@@ -23,6 +23,7 @@ cache_write = 0
 
 [limit]
 context = 200000
+input = 68928
 output = 131072
 
 [modalities]

--- a/providers/zhipuai-coding-plan/models/glm-5.1.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5.1.toml
@@ -24,6 +24,7 @@ cache_write = 0
 
 [limit]
 context = 200000
+input = 68928
 output = 131072
 
 [modalities]

--- a/providers/zhipuai-coding-plan/models/glm-5v-turbo.toml
+++ b/providers/zhipuai-coding-plan/models/glm-5v-turbo.toml
@@ -23,6 +23,7 @@ cache_write = 0
 
 [limit]
 context = 200000
+input = 68928
 output = 131072
 
 [modalities]

--- a/providers/zhipuai/models/glm-5.1.toml
+++ b/providers/zhipuai/models/glm-5.1.toml
@@ -24,6 +24,7 @@ cache_write = 0
 
 [limit]
 context = 200000
+input = 68928
 output = 131072
 
 [modalities]

--- a/providers/zhipuai/models/glm-5.2.toml
+++ b/providers/zhipuai/models/glm-5.2.toml
@@ -28,6 +28,7 @@ cache_write = 0
 
 [limit]
 context = 1000000
+input = 868928
 output = 131072
 
 [modalities]

--- a/providers/zhipuai/models/glm-5.toml
+++ b/providers/zhipuai/models/glm-5.toml
@@ -23,6 +23,7 @@ cache_write = 0
 
 [limit]
 context = 204800
+input = 73728
 output = 131072
 
 [modalities]

--- a/providers/zhipuai/models/glm-5v-turbo.toml
+++ b/providers/zhipuai/models/glm-5v-turbo.toml
@@ -23,6 +23,7 @@ cache_write = 0
 
 [limit]
 context = 200000
+input = 68928
 output = 131072
 
 [modalities]


### PR DESCRIPTION
## Summary

Adds the missing `limit.input` for the GLM-5.x family, superseding #3739 (closed as stale) and incorporating the review bot's action items from that PR.

Zhipu does not publish a separate max-input figure; the official docs define the context window as the combined total of input and output tokens ([concept-param](https://docs.bigmodel.cn/cn/guide/start/concept-param)), so `limit.input` is derived as `context - output` — the same convention already used for OpenAI entries in `models/` (e.g. `gpt-5.5`: 1_050_000 = 922_000 + 128_000).

Per-model values (official context/output from docs.bigmodel.cn model pages, cross-checked with docs.z.ai where available):

| Model | context | output | input |
|---|---|---|---|
| GLM-5 | 204_800 | 131_072 | 73_728 |
| GLM-5.1 / GLM-5-turbo / GLM-5v-turbo | 200_000 | 131_072 | 68_928 |
| GLM-5.2 / GLM-5.3 / GLM-5.3-Flash | 1_000_000 | 131_072 | 868_928 |

## Changes

- **`models/zhipuai/glm-5*`** (7 files): canonical metadata gets `limit.input`. This is the primary fix — `zai` and coding-plan entries resolve these via `base_model`, which is why editing `providers/*` alone (as #3739 did) never propagated.
- **`providers/{zai,zhipuai,zai-coding-plan,zhipuai-coding-plan}`** (9 files): first-party entries that carry their own `[limit]` block.
- **Third-party `base_model` entries** (24 files): entries whose own `context` is smaller than the inherited `input` get an explicit `input` (= own context − own output) so they don't end up with `input > context` after this change. Degenerate entries (`output >= context`, where the subtraction would go negative) use `base_model_omit = ["limit.input"]` instead — the same pattern the sync tooling itself emits (`baseModelOmit` in `sync/providers/openrouter.ts`).
- **`sync.test.ts`**: the LLM Gateway factoring test now expects `base_model_omit: ["limit.input"]` since the base model gained `limit.input` — expected `baseModelOmit()` behavior, no product change.

`ambient/zai-org/GLM-5.1-FP8` intentionally keeps the inherited input (68_928 ≤ context 202_752).

## Downstream motivation

opencode's `compaction.reserved` is silently ignored for models without `limit.input` because `usable()` only applies the reserved buffer on the `limit.input` branch (anomalyco/opencode#38835). With `limit.input` present in the catalog, `compaction.reserved` takes effect with no opencode-side change.

## Validation

- `bun run validate` exits 0
- `bun test`: all affected tests pass (8 pre-existing failures unrelated to this change, confirmed via clean-baseline stash on WSL)
- Full-catalog invariant scan (via `generateCatalog`): 570 GLM entries across 203 providers, zero `input > context` violations; all first-party `^glm-5` entries have `input`; e.g. `zai/glm-5.2` resolves to `{context: 1000000, input: 868928, output: 131072}`

A follow-up PR could extend `limit.input` to the GLM-4.x family (10 files, same shape).
