### PR TITLE
feat(github-copilot): Add sync provider for GitHub Copilot

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -16,6 +16,7 @@ import { deepinfra } from "./providers/deepinfra.js";
 import { digitalocean } from "./providers/digitalocean.js";
 import { edenai } from "./providers/edenai.js";
 import { empiriolabs } from "./providers/empiriolabs.js";
+import { githubCopilot } from "./providers/github-copilot.js";
 import { google } from "./providers/google.js";
 import { hyper } from "./providers/hyper.js";
 import { huggingface } from "./providers/huggingface.js";
@@ -135,6 +136,7 @@ export const providers: {
   digitalocean: SyncProvider<any>;
   edenai: SyncProvider<any>;
   empiriolabs: SyncProvider<any>;
+  "github-copilot": SyncProvider<any>;
   google: SyncProvider<any>;
   hyper: SyncProvider<any>;
   huggingface: SyncProvider<any>;
@@ -167,6 +169,7 @@ export const providers: {
   digitalocean,
   edenai,
   empiriolabs,
+  "github-copilot": githubCopilot,
   google,
   hyper,
   huggingface,
@@ -207,7 +210,7 @@ export const groups = {
     "vercel",
   ],
   cloudflare: ["cloudflare-workers-ai"],
-  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "google", "hyper", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
+  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "github-copilot", "google", "hyper", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;

--- a/packages/core/src/sync/providers/github-copilot.ts
+++ b/packages/core/src/sync/providers/github-copilot.ts
@@ -1,0 +1,163 @@
+import { z } from "zod";
+
+import type { ExistingModel, SyncProvider, SyncedModel } from "../index.js";
+
+const PRICING_ENDPOINT = "https://raw.githubusercontent.com/github/docs/main/data/tables/copilot/models-and-pricing.yml";
+
+const NOT_APPLICABLE = "Not applicable";
+
+const Price = z.string().regex(/^\$\d+(?:\.\d+)?$/u);
+
+export const GitHubCopilotPricingRow = z.object({
+  model: z.string().min(1),
+  provider: z.string().min(1),
+  release_status: z.string().min(1),
+  category: z.string().min(1),
+  threshold: z.string().optional(),
+  tier: z.string().optional(),
+  input: Price,
+  cached_input: Price,
+  output: Price,
+  cache_write: z.union([Price, z.literal(NOT_APPLICABLE)]).optional(),
+  notes: z.string().optional(),
+}).passthrough();
+
+export type GitHubCopilotPricingRow = z.infer<typeof GitHubCopilotPricingRow>;
+
+export interface GitHubCopilotPricingModel {
+  slug: string;
+  releaseStatus: string;
+  rows: GitHubCopilotPricingRow[];
+}
+
+// Map names in pricing YAML to actual filenames in repo
+const FILE_ALIASES: Record<string, string> = {
+  "mai-code-1-flash": "mai-code-1-flash-picker",
+};
+
+const IGNORED_ROWS = new Set([
+  // Goes in [experimental.modes.fast] under claude-opus-4.8
+  "claude-opus-4.8-fast-mode-preview",
+  // No matching model in repo
+  "raptor-mini",
+]);
+
+export function githubCopilotModelSlug(name: string) {
+  return name
+    .replace(/\[\^[^\]]*\]/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9.]+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+}
+
+function price(value: string) {
+  return value === NOT_APPLICABLE ? undefined : Number(value.slice(1));
+}
+
+function rowCost(row: GitHubCopilotPricingRow) {
+  return {
+    input: price(row.input),
+    output: price(row.output),
+    cache_read: price(row.cached_input),
+    cache_write: row.cache_write === undefined ? undefined : price(row.cache_write),
+  };
+}
+
+function longContextThresholdSize(threshold: string | undefined, slug: string) {
+  const match = threshold?.match(/^>\s*(\d+(?:\.\d+)?)\s*([KM])$/u);
+  if (!match) throw new Error(`Unparseable long-context threshold for ${slug}: ${threshold}`);
+  return Number(match[1]) * (match[2] === "K" ? 1_000 : 1_000_000);
+}
+
+export function buildGitHubCopilotCost(model: GitHubCopilotPricingModel) {
+  const defaults: GitHubCopilotPricingRow[] = [];
+  const longContext: GitHubCopilotPricingRow[] = [];
+  for (const row of model.rows) {
+    const tier = row.tier ?? "Default";
+    if (tier === "Default") defaults.push(row);
+    else if (tier === "Long context") longContext.push(row);
+    else throw new Error(`Unknown pricing tier for ${model.slug}: ${row.tier}`);
+  }
+  const base = defaults[0];
+  if (base === undefined || defaults.length > 1) {
+    throw new Error(`Expected exactly one default pricing row for ${model.slug}, found ${defaults.length}`);
+  }
+
+  const tiers = longContext
+    .map((row) => ({
+      tier: { type: "context" as const, size: longContextThresholdSize(row.threshold, model.slug) },
+      ...rowCost(row),
+    }))
+    .sort((a, b) => a.tier.size - b.tier.size);
+
+  return { ...rowCost(base), tiers: tiers.length > 0 ? tiers : undefined };
+}
+
+export function parseGitHubCopilotPricing(raw: unknown) {
+  const rows = z.array(GitHubCopilotPricingRow).parse(raw);
+  const models = new Map<string, GitHubCopilotPricingModel>();
+  for (const row of rows) {
+    const slug = githubCopilotModelSlug(row.model);
+    const model = models.get(slug) ?? { slug, releaseStatus: row.release_status, rows: [] };
+    model.rows.push(row);
+    models.set(slug, model);
+  }
+  return [...models.values()];
+}
+
+export function buildGitHubCopilotModel(
+  model: GitHubCopilotPricingModel,
+  authored: ExistingModel,
+): SyncedModel {
+  // Only update token rates, leaving audio/reasoning rates and all other
+  // fields untouched.
+  const cost = { ...authored.cost, ...buildGitHubCopilotCost(model) };
+  return { ...authored, cost } as SyncedModel;
+}
+
+export const githubCopilot = {
+  id: "github-copilot",
+  name: "GitHub Copilot",
+  modelsDir: "providers/github-copilot/models",
+  skipCreates: true,
+  deleteMissing: false,
+  sourceID(model) {
+    return IGNORED_ROWS.has(model.slug) ? undefined : model.slug;
+  },
+  skippedNotice(ids) {
+    if (ids.length === 0) return [];
+    return [
+      `${ids.length} Copilot pricing table models have no local catalog file: ${ids.map((id) => `\`${id}\``).join(", ")}`,
+    ];
+  },
+  missingNotice(paths) {
+    if (paths.length === 0) return [];
+    return [
+      `${paths.length} local Copilot models are missing from the docs pricing table and were retained: ${paths.map((path) => `\`${path}\``).join(", ")}`,
+    ];
+  },
+  async fetchModels() {
+    const response = await fetch(PRICING_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`Copilot pricing request failed: ${response.status} ${response.statusText}`);
+    }
+    return Bun.YAML.parse(await response.text());
+  },
+  parseModels: parseGitHubCopilotPricing,
+  translateModel(model, context) {
+    if (IGNORED_ROWS.has(model.slug)) return undefined;
+    const candidates = [
+      model.slug,
+      FILE_ALIASES[model.slug],
+      model.releaseStatus === "Public preview" ? `${model.slug}-preview` : undefined,
+    ].filter((candidate) => candidate !== undefined);
+    const id = candidates.find((candidate) => context.authored(candidate) !== undefined);
+    const authored = id === undefined ? undefined : context.authored(id);
+    if (id === undefined || authored === undefined) return undefined;
+    return {
+      id,
+      model: buildGitHubCopilotModel(model, authored),
+      header: "# Pricing: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing\n",
+    };
+  },
+} satisfies SyncProvider<GitHubCopilotPricingModel>;

--- a/packages/core/test/github-copilot.test.ts
+++ b/packages/core/test/github-copilot.test.ts
@@ -1,0 +1,228 @@
+import { expect, test } from "bun:test";
+
+import {
+  buildGitHubCopilotCost,
+  githubCopilotModelSlug,
+  githubCopilot,
+  parseGitHubCopilotPricing,
+  type GitHubCopilotPricingRow,
+} from "../src/sync/providers/github-copilot.js";
+import type { ExistingModel } from "../src/sync/index.js";
+
+function row(overrides: Partial<GitHubCopilotPricingRow>): GitHubCopilotPricingRow {
+  return {
+    model: "GPT-5.6 Terra",
+    provider: "openai",
+    release_status: "GA",
+    category: "Versatile",
+    input: "$2.00",
+    cached_input: "$0.20",
+    output: "$12.00",
+    ...overrides,
+  };
+}
+
+test("slugifies display names into catalog filenames", () => {
+  expect(githubCopilotModelSlug("GPT-5.6 Sol[^gpt-56-sol-promo]")).toBe("gpt-5.6-sol");
+  expect(githubCopilotModelSlug("GPT-5 mini")).toBe("gpt-5-mini");
+  expect(githubCopilotModelSlug("GPT-5.3-Codex")).toBe("gpt-5.3-codex");
+  expect(githubCopilotModelSlug("Claude Opus 4.8 (fast mode) (preview)")).toBe("claude-opus-4.8-fast-mode-preview");
+  expect(githubCopilotModelSlug("MAI-Code-1.1-Flash")).toBe("mai-code-1.1-flash");
+  expect(githubCopilotModelSlug("Kimi K2.7 Code")).toBe("kimi-k2.7-code");
+});
+
+test("groups tier rows under one model", () => {
+  const models = parseGitHubCopilotPricing([
+    row({ threshold: "≤ 272K", tier: "Default" }),
+    row({ threshold: "> 272K", tier: "Long context", input: "$4.00", cached_input: "$0.40", output: "$18.00" }),
+    row({ model: "Claude Sonnet 5", provider: "anthropic", input: "$2.00", output: "$10.00", cache_write: "$2.50" }),
+  ]);
+  expect(models.map((model) => model.slug)).toEqual(["gpt-5.6-terra", "claude-sonnet-5"]);
+  expect(models[0]?.rows).toHaveLength(2);
+});
+
+test("builds flat cost with cache_write and Not applicable handling", () => {
+  const [model] = parseGitHubCopilotPricing([
+    row({ model: "GPT-5.4 mini", input: "$0.75", cached_input: "$0.075", output: "$4.50", cache_write: "Not applicable" }),
+  ]);
+  expect(buildGitHubCopilotCost(model!)).toEqual({
+    input: 0.75,
+    output: 4.5,
+    cache_read: 0.075,
+    cache_write: undefined,
+    tiers: undefined,
+  });
+});
+
+test("builds long-context tiers from threshold rows", () => {
+  const [model] = parseGitHubCopilotPricing([
+    row({ threshold: "≤ 272K", tier: "Default", cache_write: "$2.50" }),
+    row({ threshold: "> 272K", tier: "Long context", input: "$4.00", cached_input: "$0.40", output: "$18.00", cache_write: "$5.00" }),
+  ]);
+  expect(buildGitHubCopilotCost(model!)).toEqual({
+    input: 2,
+    output: 12,
+    cache_read: 0.2,
+    cache_write: 2.5,
+    tiers: [{
+      tier: { type: "context", size: 272_000 },
+      input: 4,
+      output: 18,
+      cache_read: 0.4,
+      cache_write: 5,
+    }],
+  });
+});
+
+test("rejects malformed tables instead of writing garbage", () => {
+  const build = (rows: GitHubCopilotPricingRow[]) => {
+    const models = parseGitHubCopilotPricing(rows);
+    return models.map((model) => buildGitHubCopilotCost(model));
+  };
+  // Unknown tier label.
+  expect(() => build([row({ tier: "Standard" })])).toThrow(/Unknown pricing tier/u);
+  // Two default rows for one model.
+  expect(() => build([row({}), row({})])).toThrow(/exactly one default pricing row/u);
+  // Long-context row without a parseable threshold.
+  expect(() => build([
+    row({ threshold: "≤ 272K", tier: "Default" }),
+    row({ threshold: "272K+", tier: "Long context" }),
+  ])).toThrow(/Unparseable long-context threshold/u);
+  // Price strings are schema-validated before translation.
+  expect(() => build([row({ input: "$1,000.00" })])).toThrow();
+  expect(() => build([row({ input: "Included" })])).toThrow();
+});
+
+function translationContext(files: Record<string, ExistingModel>) {
+  return {
+    existing: (id: string) => files[id],
+    authored: (id: string) => files[id],
+  };
+}
+
+const authoredTerra: ExistingModel = {
+  base_model: "openai/gpt-5.6-terra",
+  cost: { input: 1, output: 1, cache_read: 1 },
+};
+
+test("updates cost on the authored file and preserves audio rates", () => {
+  const [model] = parseGitHubCopilotPricing([row({ cache_write: "$2.50" })]);
+  const translated = githubCopilot.translateModel(model!, translationContext({
+    "gpt-5.6-terra": {
+      ...authoredTerra,
+      cost: { input: 1, output: 1, reasoning: 3, cache_read: 1, input_audio: 1.5, output_audio: 6 },
+    },
+  }));
+  expect(translated?.id).toBe("gpt-5.6-terra");
+  expect(translated?.model.cost).toMatchObject({
+    input: 2,
+    output: 12,
+    reasoning: 3,
+    cache_read: 0.2,
+    cache_write: 2.5,
+    input_audio: 1.5,
+    output_audio: 6,
+  });
+  expect((translated?.model as ExistingModel).base_model).toBe("openai/gpt-5.6-terra");
+});
+
+test("clears authored tiers and cache_write the table no longer lists", () => {
+  const [model] = parseGitHubCopilotPricing([row({ cache_write: "Not applicable" })]);
+  const translated = githubCopilot.translateModel(model!, translationContext({
+    "gpt-5.6-terra": {
+      ...authoredTerra,
+      cost: {
+        input: 1,
+        output: 1,
+        cache_read: 1,
+        cache_write: 9,
+        tiers: [{ tier: { type: "context", size: 272_000 }, input: 9, output: 9 }],
+      },
+    },
+  }));
+  const cost = translated?.model.cost;
+  expect(cost?.input).toBe(2);
+  // Stale authored values must not survive the spread; the runner strips the
+  // explicit undefineds before writing.
+  expect(cost?.cache_write).toBeUndefined();
+  expect(cost?.tiers).toBeUndefined();
+});
+
+test("resolves preview and alias filenames", () => {
+  const preview = parseGitHubCopilotPricing([
+    row({ model: "Gemini 3.1 Pro", provider: "google", release_status: "Public preview" }),
+  ]);
+  expect(githubCopilot.translateModel(preview[0]!, translationContext({
+    "gemini-3.1-pro-preview": authoredTerra,
+  }))?.id).toBe("gemini-3.1-pro-preview");
+
+  const alias = parseGitHubCopilotPricing([row({ model: "MAI-Code-1-Flash", provider: "microsoft" })]);
+  expect(githubCopilot.translateModel(alias[0]!, translationContext({
+    "mai-code-1-flash-picker": authoredTerra,
+  }))?.id).toBe("mai-code-1-flash-picker");
+
+  // An exact slug match wins over both fallbacks.
+  expect(githubCopilot.translateModel(preview[0]!, translationContext({
+    "gemini-3.1-pro": authoredTerra,
+    "gemini-3.1-pro-preview": authoredTerra,
+  }))?.id).toBe("gemini-3.1-pro");
+  expect(githubCopilot.translateModel(alias[0]!, translationContext({
+    "mai-code-1-flash": authoredTerra,
+    "mai-code-1-flash-picker": authoredTerra,
+  }))?.id).toBe("mai-code-1-flash");
+});
+
+test("skips ignored rows silently and unmatched rows with an ID", () => {
+  const [fastMode] = parseGitHubCopilotPricing([
+    row({ model: "Claude Opus 4.8 (fast mode) (preview)", provider: "anthropic" }),
+  ]);
+  expect(githubCopilot.translateModel(fastMode!, translationContext({}))).toBeUndefined();
+  expect(githubCopilot.sourceID(fastMode!)).toBeUndefined();
+
+  const [unmatched] = parseGitHubCopilotPricing([row({ model: "Brand New Model" })]);
+  expect(githubCopilot.translateModel(unmatched!, translationContext({}))).toBeUndefined();
+  expect(githubCopilot.sourceID(unmatched!)).toBe("brand-new-model");
+});
+
+const pricingYaml = `
+- model: 'GPT-5.6 Sol[^gpt-56-sol-promo]'
+  provider: openai
+  release_status: GA
+  category: Powerful
+  threshold: '≤ 272K'
+  tier: Default
+  input: $2.00
+  cached_input: $0.20
+  output: $10.00
+  cache_write: $2.50
+
+- model: 'GPT-5.6 Sol[^gpt-56-sol-promo]'
+  provider: openai
+  release_status: GA
+  category: Powerful
+  threshold: '> 272K'
+  tier: 'Long context'
+  input: $4.00
+  cached_input: $0.40
+  output: $15.00
+  cache_write: $5.00
+`;
+
+test("parses rows straight from the docs YAML format", () => {
+  const models = parseGitHubCopilotPricing(Bun.YAML.parse(pricingYaml));
+  expect(models).toHaveLength(1);
+  expect(models[0]?.slug).toBe("gpt-5.6-sol");
+  expect(buildGitHubCopilotCost(models[0]!)).toEqual({
+    input: 2,
+    output: 10,
+    cache_read: 0.2,
+    cache_write: 2.5,
+    tiers: [{
+      tier: { type: "context", size: 272_000 },
+      input: 4,
+      output: 15,
+      cache_read: 0.4,
+      cache_write: 5,
+    }],
+  });
+});

--- a/providers/github-copilot/models/gemini-3.6-flash.toml
+++ b/providers/github-copilot/models/gemini-3.6-flash.toml
@@ -1,10 +1,19 @@
+# Pricing: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
 base_model = "google/gemini-3.6-flash"
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }, { type = "budget_tokens", min = 256, max = 32_000 }]
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 256
+max = 32_000
 
 [cost]
-input = 1.5
-output = 7.5
-cache_read = 0.15
+input = 0.75
+output = 3.75
+cache_read = 0.075
 
 [limit]
 context = 1_000_000

--- a/providers/github-copilot/models/gpt-5.6-luna.toml
+++ b/providers/github-copilot/models/gpt-5.6-luna.toml
@@ -1,15 +1,19 @@
 # Pricing: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
-# GPT-5.6 Luna reduced rates (matches OpenAI 2026-07-30 cut); long-context threshold >200K
 base_model = "openai/gpt-5.6-luna"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 0.20
-output = 1.20
+input = 0.2
+output = 1.2
 cache_read = 0.02
+cache_write = 0.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 200_000 }
-input = 0.40
-output = 1.80
+input = 0.4
+output = 1.8
 cache_read = 0.04
+cache_write = 0.5

--- a/providers/github-copilot/models/gpt-5.6-sol.toml
+++ b/providers/github-copilot/models/gpt-5.6-sol.toml
@@ -1,19 +1,19 @@
-# Source: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
-# GPT-5.6 Sol promotional pricing (50% off standard rates) through September 3, 2026.
-# Default ≤272K: $2.50 / $0.25 / $3.125 / $15.00 (input / cache_read / cache_write / output)
-# Long context >272K: $5.00 / $0.50 / $6.25 / $22.50
+# Pricing: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
 base_model = "openai/gpt-5.6-sol"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 2.5
-output = 15
-cache_read = 0.25
-cache_write = 3.125
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 5
-output = 22.5
-cache_read = 0.5
-cache_write = 6.25
+input = 4
+output = 15
+cache_read = 0.4
+cache_write = 5

--- a/providers/github-copilot/models/gpt-5.6-terra.toml
+++ b/providers/github-copilot/models/gpt-5.6-terra.toml
@@ -1,15 +1,19 @@
 # Pricing: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
-# GPT-5.6 Terra reduced rates (matches OpenAI 2026-07-30 cut); long-context threshold >272K
 base_model = "openai/gpt-5.6-terra"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
-input = 2.00
-output = 12.00
-cache_read = 0.20
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 4.00
-output = 18.00
-cache_read = 0.40
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5

--- a/sync.md
+++ b/sync.md
@@ -19,6 +19,7 @@ The grouped sync targets are available for local convenience, but CI syncs each 
 - `bun models:sync kilo` syncs only Kilo.
 - `bun models:sync merge-gateway` syncs only Merge Gateway.
 - `bun models:sync openai` syncs only OpenAI catalog availability.
+- `bun models:sync github-copilot` syncs only GitHub Copilot pricing.
 - `bun models:sync tinfoil` syncs only Tinfoil.
 - `bun models:sync aggregators --dry-run` prints changes without writing model files.
 - `bun models:sync aggregators --new-only` creates new model files but skips updates and removals.
@@ -214,6 +215,15 @@ Google is implemented in `packages/core/src/sync/providers/google.ts`.
 - Local Google models missing from the API response are removed.
 - New Google API models are not created automatically (`skipCreates`) and do not open missing-model issues because the endpoint is not lifecycle-authoritative.
 - Missing-model tracking is limited to recognizable public model families; opaque API codenames such as `ajax`, `perseus`, and `thorin` are ignored.
+
+## GitHub Copilot Notes
+
+GitHub Copilot is implemented in `packages/core/src/sync/providers/github-copilot.ts`.
+
+- Source: `https://raw.githubusercontent.com/github/docs/main/data/tables/copilot/models-and-pricing.yml`
+- The YML contains only token rates, so the sync only updates `[cost]`: `input`, `cached_input` (as `cache_read`), `cache_write`, `output`, and long-context rows as `cost.tiers`.
+- Display names are converted to file IDs, with minimal special case logic to match existing model entries.
+- Unmatched rows open missing-model issues, and local entries missing from the source are kept.
 
 ## xAI Notes
 


### PR DESCRIPTION
GitHub Copilot has no pricing API, but the docs pricing page is
rendered from a YAML data file in the public github/docs repo, so this
module syncs [cost] from that file and leaves everything else in the
TOMLs hand-authored. Copilot pricing has needed manual updates a few times
recently (https://github.com/anomalyco/models.dev/issues/3282, https://github.com/anomalyco/models.dev/pull/3965, https://github.com/anomalyco/models.dev/pull/5186), so this should help automate that.