### PR TITLE
feat(nvidia): add deepseek-v4-pro-0813 provider entry

### DIFF
--- a/providers/nvidia/models/deepseek-ai/deepseek-v4-pro-0813.toml
+++ b/providers/nvidia/models/deepseek-ai/deepseek-v4-pro-0813.toml
@@ -1,0 +1,17 @@
+# NIM Chat schema: `reasoning_effort = none|high|max`; `none` disables thinking.
+# https://build.nvidia.com/deepseek-ai/deepseek-v4-pro-0813
+#
+# Pricing: hosted on NVIDIA's API trial tier and currently free — no separate
+# list rate is published for this ID. Source: this model's catalog card,
+# https://build.nvidia.com/deepseek-ai/deepseek-v4-pro-0813 (governed by the
+# NVIDIA API Trial Terms of Service).
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0


### PR DESCRIPTION
# PR draft — nvidia: add deepseek-v4-pro-0813 provider entry

Branch: `nvidia-deepseek-v4-pro-0813` (fork 4ebuRushka/models.dev → anomalyco/models.dev:dev)
File: `providers/nvidia/models/deepseek-ai/deepseek-v4-pro-0813.toml`

## Summary
Model `deepseek-ai/deepseek-v4-pro-0813` is live on `integrate.api.nvidia.com/v1/models` but missing from the `nvidia` provider. Added override-only provider file per AGENTS.md (`base_model` + `cost` + `reasoning_options` + `interleaved`).

## Content
```toml
# NIM Chat schema: `reasoning_effort = none|high|max`; `none` disables thinking.
# https://build.nvidia.com/deepseek-ai/deepseek-v4-pro-0813
#
# Pricing: hosted on NVIDIA's API trial tier and currently free — no separate
# list rate is published for this ID. Source: this model's catalog card,
# https://build.nvidia.com/deepseek-ai/deepseek-v4-pro-0813 (governed by the
# NVIDIA API Trial Terms of Service).
base_model = "deepseek/deepseek-v4-pro-0813"

reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]

[interleaved]
field = "reasoning_content"

[cost]
input = 0.0
output = 0.0
```

Base `models/deepseek/deepseek-v4-pro-0813.toml` already exists (release 2026-08-12).

## Validation
- Live endpoint tests via `integrate.api.nvidia.com/v1/chat/completions` through socks5h://127.0.0.1:10808 (11 cases, max_tokens=16):
  - top-level `reasoning_effort`: none/high/max → 200 OK, low → server disconnect (invalid)
  - `chat_template_kwargs.thinking` + `reasoning_effort` low/high/max → 200 OK
  - Chosen `none|high|max` matches NIM Chat schema and sibling entries
- `bun install` + `bun validate` → exit 0; generated JSON contains `nvidia/deepseek-ai/deepseek-v4-pro-0813` with cost 0/0, limit 1M/384K

## Notes
- Cost 0/0 consistent with NVIDIA trial tier — precedent #5288 (flash-0731)
- Precedent #5288: nvidia: add kimi-k3 and deepseek-v4-flash-0731
- Build card: https://build.nvidia.com/deepseek-ai/deepseek-v4-pro-0813 (trial service)
- Catalog: `integrate.api.nvidia.com/v1/models` lists the ID

## Checklist (AGENTS.md)
- [x] base_model points to existing lab file
- [x] override-only (no duplicated lab fields)
- [x] reasoning_options set for reasoning=true
- [x] cost in USD/MTok
- [x] bun validate passes
