### PR TITLE
fix(volcengine): declare reasoning on Seed 1.6 flash and vision

### DIFF
--- a/providers/volcengine/models/doubao-seed-1-6-flash-250828.toml
+++ b/providers/volcengine/models/doubao-seed-1-6-flash-250828.toml
@@ -10,6 +10,7 @@
 # high 599/502/586/837, max 575/863/714/598 -- fully overlapping, and 'none' does not
 # even switch thinking off here, so thinking.type is the only real control.
 base_model = "bytedance-seed/seed-1-6-flash"
+reasoning = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/volcengine/models/doubao-seed-1-6-flash-250828.toml
+++ b/providers/volcengine/models/doubao-seed-1-6-flash-250828.toml
@@ -1,7 +1,21 @@
 # Model ID verified against POST /api/v3/chat/completions (2026-08-26): `doubao-seed-1-6-flash-250828`
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
+# Toggle: thinking.type = enabled|disabled, POST /api/v3/chat/completions
+# (verified 2026-08-27: enabled -> 278 reasoning tokens, disabled -> 0). This model
+# reasons by default -- a bare request with no reasoning params returns 283 reasoning
+# tokens -- so the absence of a reasoning declaration here was wrong.
+# No graded effort: reasoning_effort is accepted but not separable. Over n=4 runs per
+# level, none 762/479/627/646, minimal 715/513/760/717, low 942/561/660/596,
+# high 599/502/586/837, max 575/863/714/598 -- fully overlapping, and 'none' does not
+# even switch thinking off here, so thinking.type is the only real control.
 base_model = "bytedance-seed/seed-1-6-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.02227

--- a/providers/volcengine/models/doubao-seed-1-6-vision-250815.toml
+++ b/providers/volcengine/models/doubao-seed-1-6-vision-250815.toml
@@ -10,6 +10,7 @@
 # max 852/813/1011/699 -- fully overlapping, and 'none' does not switch thinking off,
 # so thinking.type is the only real control.
 base_model = "bytedance-seed/seed-1-6-vision"
+reasoning = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/volcengine/models/doubao-seed-1-6-vision-250815.toml
+++ b/providers/volcengine/models/doubao-seed-1-6-vision-250815.toml
@@ -1,7 +1,21 @@
 # Model ID verified against POST /api/v3/chat/completions (2026-08-26): `doubao-seed-1-6-vision-250815`
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
+# Toggle: thinking.type = enabled|disabled, POST /api/v3/chat/completions
+# (verified 2026-08-27: enabled -> 162 reasoning tokens, disabled -> 0). This model
+# reasons by default -- a bare request with no reasoning params returns 166 reasoning
+# tokens -- so the absence of a reasoning declaration here was wrong.
+# No graded effort: reasoning_effort is accepted but not separable. Over n=4 runs per
+# level, none 895/927/670/736, low 550/901/775/598, high 578/738/787/1031,
+# max 852/813/1011/699 -- fully overlapping, and 'none' does not switch thinking off,
+# so thinking.type is the only real control.
 base_model = "bytedance-seed/seed-1-6-vision"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.11875


### PR DESCRIPTION
`doubao-seed-1-6-flash-250828` and `doubao-seed-1-6-vision-250815` are currently served as `reasoning: false` on models.dev, but both reason by default. A bare request with **no reasoning parameters at all** returns 283 and 166 reasoning tokens respectively, with `reasoning_content` populated.

The cause is a missing `reasoning_options` block on these two entries. The `bytedance-seed` lab entries they inherit from don't declare one either, so nothing supplied it — the other 12 volcengine models each declare their own block, which is why only these two came out wrong.

I found this auditing the live `api.json` against the real API, not from a bug report, so downstream consumers have been reading the wrong flag since #5513. That one's on me.

## What the API actually does

Declared as a **toggle**, because that's the control that works:

| model | `thinking.type=enabled` | `disabled` |
|---|---|---|
| flash | 278 reasoning tokens | 0 |
| vision | 162 reasoning tokens | 0 |

No graded effort on either. `reasoning_effort` is accepted but the levels aren't separable, and `none` doesn't even switch thinking off — measured n=4 per level:

```
flash   none  762 479 627 646     minimal 715 513 760 717
        low   942 561 660 596     high    599 502 586 837
        max   575 863 714 598

vision  none  895 927 670 736     low     550 901 775 598
        high  578 738 787 1031    max     852 813 1011 699
```

Fully overlapping in both cases, so only the toggle is declared. This matches the convention that `values` lists effective levels rather than accepted strings.

Measurements are in each file's leading comment so they don't have to be rerun.
