### PR TITLE
fix(volcengine): correct the output limit on Seed 2.0 lite and mini

### DIFF
--- a/providers/volcengine/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-lite-260428.toml
@@ -4,7 +4,14 @@
 # Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
 # none/minimal disable thinking, so no separate toggle: sending effort alone
 # already enables it, and thinking.type=disabled + a graded effort is rejected.
+# Output limit: the lab default is 32_000, but this host accepts up to 131_072
+# (verified 2026-08-27: max_tokens=131072 -> 200, 132000 -> 400 invalid), matching
+# what openrouter/kilo/nano-gpt already declare for this model. Overridden below.
 base_model = "bytedance-seed/seed-2.0-lite"
+
+[limit]
+context = 256_000
+output = 131_072
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/volcengine/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-mini-260428.toml
@@ -4,7 +4,14 @@
 # Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max
 # none/minimal disable thinking, so no separate toggle: sending effort alone
 # already enables it, and thinking.type=disabled + a graded effort is rejected.
+# Output limit: the lab default is 32_000, but this host accepts up to 131_072
+# (verified 2026-08-27: max_tokens=131072 -> 200, 132000 -> 400 invalid), matching
+# what openrouter/kilo/nano-gpt already declare for this model. Overridden below.
 base_model = "bytedance-seed/seed-2.0-mini"
+
+[limit]
+context = 256_000
+output = 131_072
 
 [[reasoning_options]]
 type = "effort"


### PR DESCRIPTION
`doubao-seed-2-0-lite-260428` and `doubao-seed-2-0-mini-260428` inherit `output = 32_000` from `models/bytedance-seed`, but this host accepts four times that. Probed the boundary on `/api/v3/chat/completions`:

| model | `max_tokens=131072` | `max_tokens=132000` |
|---|---|---|
| lite | 200 | 400 `max_tokens ... not valid` |
| mini | 200 | 400 |

131_072 is also what `openrouter`, `kilo` and `nano-gpt` already declare for the same base model, so the lab default looks stale rather than host-specific. Added a per-host `[limit]` override, which is the pattern those three use.

**What I deliberately did not change:**

- **`context` stays at the inherited 256_000.** A 180k-token prompt was accepted, which doesn't discriminate between 256_000 and the 262_144 the other hosts claim. No measurement, no change.
- **The Seed 1.6 entries are untouched.** I checked rather than assuming the family shares a ceiling — `doubao-seed-1-6-flash-250828` and `-vision-250815` both *reject* `max_tokens=131072` and genuinely cap at 32_000.
- **The lab file itself is untouched.** `models/bytedance-seed/seed-2.0-lite.toml` is shared by several hosts; correcting it there would change their entries too, which isn't mine to decide in this PR. Happy to follow up separately if you'd rather fix the default.

Verified with the repo's own validator locally (`bun packages/core/script/validate.ts`, exit 0) and confirmed the generated `api.json` reads `output: 131072` for these two while the 1.6 entries stay at `32000`.

Found while auditing the live `api.json` against the real API, same pass that turned up #5639.
