### PR TITLE
fix(volcengine): correct the effort levels on Seed character

### DIFF
--- a/providers/volcengine/models/doubao-seed-character-260628.toml
+++ b/providers/volcengine/models/doubao-seed-character-260628.toml
@@ -2,8 +2,16 @@
 # CNY→USD rate: 6.737012, 2026-08-26, source: https://open.er-api.com/v6/latest/USD
 # CNY list price source: https://www.volcengine.com/docs/82379/1544106
 # Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high|xhigh|max (no none: this
-# model defaults thinking off, so thinking.type is the real switch here)
+# Effort: reasoning_effort = minimal|low|high, and it must be paired with
+# thinking.type=enabled. This model defaults thinking OFF, so a graded effort sent
+# on its own is rejected: "Invalid combination of reasoning_effort and thinking
+# type: low + disabled". 'none' is likewise unavailable; 'minimal' is the off value.
+# Only three levels are separable. With thinking enabled, n=4 runs per level on a
+# prompt hard enough to consume the budget:
+#   minimal 0 0 0 0                 low  1347/1258/1166/1149
+#   high    1709/2696/1695/1513     max  2304/1881/1985/1480
+# max overlaps high rather than exceeding it, and medium/xhigh sit inside the same
+# band, so they are dropped.
 base_model = "bytedance-seed/seed-character"
 
 [[reasoning_options]]
@@ -11,7 +19,7 @@ type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+values = ["minimal", "low", "high"]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
Driving every volcengine model from the live `api.json` with exactly what it declares turned up that **five of this entry's six effort values are rejected outright**:

```
reasoning_effort=low  -> 400 "Invalid combination of reasoning_effort and
                              thinking type: low + disabled"
```

Same for `medium`, `high`, `xhigh`, `max`. Only `none` and `minimal` are accepted on their own.

The cause: this model **defaults thinking OFF**, so a graded effort has to be paired with `thinking.type=enabled`. The existing comment already noted the default, but the `values` list still implied the levels worked standalone — so a client following the catalog gets a 400.

With thinking enabled they're all accepted, but not all are *separable*. n=4 runs per level on a prompt hard enough to consume the budget:

| level | reasoning tokens |
|---|---|
| `minimal` | 0, 0, 0, 0 |
| `low` | 1347, 1258, 1166, 1149 |
| `high` | 1709, 2696, 1695, 1513 |
| `max` | 2304, 1881, 1985, 1480 |

`max` overlaps `high` rather than exceeding it, and `medium`/`xhigh` fall in the same band. So the effective set is `minimal|low|high`, and the comment now spells out the pairing requirement.

One thing worth flagging for anyone measuring this stuff: **an easy prompt hides it entirely.** On a one-step arithmetic question every level lands at 67–79 reasoning tokens, indistinguishable. I only saw the gradation after switching to a multi-step problem.

Verified with the repo's validator locally (`bun packages/core/script/validate.ts`, exit 0) and confirmed the generated `api.json` lists the three levels.

Third finding from the same api.json audit pass as #5639 and #5644.
