### PR TITLE
feat(openreason): add OpenReason provider

### DIFF
--- a/providers/openreason/logo.svg
+++ b/providers/openreason/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="OpenReason">
+  <title>OpenReason</title>
+  <!-- Artwork occupies 3..21 in a 24 box, so a 3-unit margin all round. Stroke is 4 units on a
+       mid-stroke path at 5..19 with a 3-unit corner radius. The opening is the 4 units of the top
+       edge between x=16 and x=12. Colour comes from currentColor: one file serves every context. -->
+  <path d="M12 5 L8 5 A3 3 0 0 0 5 8 L5 16 A3 3 0 0 0 8 19 L16 19 A3 3 0 0 0 19 16 L19 8 A3 3 0 0 0 16 5"
+        fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="butt"/>
+</svg>

--- a/providers/openreason/models/deepseek-ai/deepseek-v4-flash-0731.toml
+++ b/providers/openreason/models/deepseek-ai/deepseek-v4-flash-0731.toml
@@ -1,0 +1,19 @@
+# OpenReason routes deepseek-ai/deepseek-v4-flash-0731 through Baseten by
+# default (endpoint pin `@baseten-us`). OpenReason forwards top-level
+# `reasoning_effort` verbatim; the accepted values are
+# `none | minimal | low | medium | high (default) | xhigh | max`, matching
+# Baseten's documented surface. Reasoning output is returned in the
+# `reasoning_content` field.
+# https://openreason.app · https://docs.baseten.co/inference/model-apis/reasoning
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.1371
+output = 0.2743
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/openreason/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/openreason/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,23 @@
+# OpenReason routes moonshotai/kimi-k2.7-code through Baseten by default
+# (endpoint pin `@baseten-us`). The upstream accepts opt-in via
+# `chat_template_args.enable_thinking = true`; OpenReason forwards the value
+# verbatim. No off behavior, effort values, or reasoning-token budget are
+# documented. Reasoning output is returned in the `reasoning_content` field.
+# The Baseten route respects temperature, so we override the canonical
+# `false` to `true` for this host.
+# https://openreason.app · https://docs.baseten.co/inference/model-apis/reasoning
+base_model = "moonshotai/kimi-k2.7-code"
+temperature = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 1.0022
+output = 4.22
+
+[interleaved]
+field = "reasoning_content"
+
+[modalities]
+input = ["text", "image"]

--- a/providers/openreason/models/openai/gpt-oss-120b.toml
+++ b/providers/openreason/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,18 @@
+# OpenReason routes openai/gpt-oss-120b across multiple upstream inference
+# providers (Baseten, Nscale, Nebius, Scaleway). OpenReason forwards top-level
+# `reasoning_effort` verbatim; the published values are the safe intersection
+# accepted at every routed endpoint (`low | medium | high`). Baseten's own
+# endpoint additionally accepts `none | minimal | xhigh | max` — customers
+# pinning `@baseten-us` may send those values, but OpenReason does not
+# advertise them as universally accepted. Reasoning output is returned in
+# the `reasoning_content` field.
+# https://openreason.app
+base_model = "openai/gpt-oss-120b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.1055
+output = 0.422
+
+[interleaved]
+field = "reasoning_content"

--- a/providers/openreason/provider.toml
+++ b/providers/openreason/provider.toml
@@ -1,0 +1,9 @@
+name = "OpenReason"
+# Sovereignty-aware OpenAI-compatible router across US and EU inference.
+# Endpoints are pinned via the `@<endpoint-id>` suffix on the model slug
+# (e.g. moonshotai/kimi-k2.7-code@baseten-us). See docs for the full list.
+# https://openreason.app
+env = ["OPENREASON_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.openreason.app/v1"
+doc = "https://openreason.app/docs"


### PR DESCRIPTION
Adds OpenReason (https://openreason.app) — routes OpenAI-shape traffic to open-weight models with sovereignty-aware regional endpoint pinning.

## Summary

- register OpenReason as an OpenAI-compatible provider at `https://api.openreason.app/v1`
- add the OpenReason logo (currentColor, `viewBox="0 0 24 24"`)
- add 3 initial models, all as `base_model` references

## Catalog scope

This first PR ships our first set of supported models. Follow-up PRs will add the rest of our catalog family-by-family.

Models included:

| Slug | Base | Route | Notes |
|---|---|---|---|
| `moonshotai/kimi-k2.7-code` | `moonshotai/kimi-k2.7-code` | Baseten (`@baseten-us`) | Toggle reasoning; text+image (canonical narrowed from text+image+video); temperature override |
| `deepseek-ai/deepseek-v4-flash-0731` | `deepseek/deepseek-v4-flash-0731` | Baseten (`@baseten-us`) | Full Baseten effort surface `none|minimal|low|medium|high|xhigh|max` |
| `openai/gpt-oss-120b` | `openai/gpt-oss-120b` | Multi-upstream (Baseten, Nscale, Nebius, Scaleway) | Effort `low|medium|high` — safe intersection across all routes |

Every reasoning-capable entry has a top-of-file wire-path comment naming the exact request field OpenReason forwards. Every model whose upstream returns a reasoning side channel declares `[interleaved] field = "reasoning_content"`.

## Pricing

`[cost]` values are OpenReason's own customer prices in USD per 1M tokens. The router returns a per-request customer cost in the `X-OR-Price` response header on every `/v1/chat/completions` call; we verified each of these three prices against a live request. Endpoint pinning uses the `@<endpoint-id>` suffix on the model slug (e.g. `moonshotai/kimi-k2.7-code@baseten-us`).

## Validation

`bun run validate` exits 0 with all 3 OpenReason models accepted by the Zod schema.
