### PR TITLE
feat(modal): add Qwen3.8 Max and GLM 5.3 Flash

### DIFF
--- a/providers/modal/models/Qwen/Qwen3.8-2.4T-A95B.toml
+++ b/providers/modal/models/Qwen/Qwen3.8-2.4T-A95B.toml
@@ -1,0 +1,25 @@
+# Modal Shared Endpoint model ID: Qwen/Qwen3.8-2.4T-A95B.
+# Pricing is USD per 1M tokens: prompt $2.00, cached prompt $0.25,
+# and completion $6.00.
+# Modal documents text-only input, context up to 1,010,000 tokens, and
+# adjustable reasoning effort with low, medium, and xhigh levels.
+# https://modal.com/library/qwen/qwen3-8-max
+# https://modal.com/blog/qwen3-8-2-4t-a95b-now-available-on-modal
+# https://huggingface.co/Qwen/Qwen3.8-2.4T-A95B
+base_model = "alibaba/qwen3.8-2.4t-a95b"
+name = "Qwen3.8-Max"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.0
+output = 6.0
+cache_read = 0.25
+
+[limit]
+context = 1_010_000

--- a/providers/modal/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/modal/models/zai-org/GLM-5.3-Flash.toml
@@ -1,0 +1,24 @@
+# Modal Shared Endpoint model ID: zai-org/GLM-5.3-Flash.
+# Pricing is USD per 1M tokens: prompt $0.45, cached prompt $0.09,
+# and completion $1.50.
+# Modal documents text, image, and video input with a 1M-token context window.
+# Effort: reasoning_effort = low|high|max; defaults to max.
+# https://modal.com/library/zai/glm-5-3-flash
+# https://huggingface.co/zai-org/GLM-5.3-Flash
+base_model = "zhipuai/glm-5.3-flash"
+name = "GLM 5.3 Flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.45
+output = 1.5
+cache_read = 0.09
+
+[modalities]
+input = ["text", "image", "video"]


### PR DESCRIPTION
## Summary

- add Modal's `Qwen/Qwen3.8-2.4T-A95B` Shared Endpoint as Qwen3.8-Max
- add Modal's `zai-org/GLM-5.3-Flash` Shared Endpoint
- record Modal-specific pricing, context/modalities, and each model's reasoning effort controls

## Why

Modal now serves both models through its OpenAI-compatible Shared Endpoints, but neither model was present in the Modal provider catalog. This left them out of the Modal provider page and generated JSON catalog.

Both entries reuse the existing lab metadata through `base_model` and only add Modal-specific overrides.

## Validation

- `bun validate`
- `git diff --check`

The repository-wide `generate.test.ts` suite also ran with 10 passing tests and one pre-existing failure for missing weights links on unrelated open-weight lab models.

## Sources

- [Modal Qwen3.8-Max model page](https://modal.com/library/qwen/qwen3-8-max)
- [Modal Qwen3.8 announcement](https://modal.com/blog/qwen3-8-2-4t-a95b-now-available-on-modal)
- [Qwen3.8-2.4T-A95B model card](https://huggingface.co/Qwen/Qwen3.8-2.4T-A95B)
- [Modal GLM 5.3 Flash model page](https://modal.com/library/zai/glm-5-3-flash)
- [GLM-5.3-Flash model card](https://huggingface.co/zai-org/GLM-5.3-Flash)
