### PR TITLE
Add DeepSeek-V4-Pro-0813 to SCNet Token Plan

### DIFF
--- a/providers/scnet-token-plan/models/DeepSeek-V4-Pro-0813.toml
+++ b/providers/scnet-token-plan/models/DeepSeek-V4-Pro-0813.toml
@@ -1,0 +1,13 @@
+# Toggle: enable_thinking = true|false
+# Effort: reasoning_effort = high|max
+# https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/api/chat.html (accessed 2026-08-28)
+base_model = "deepseek/deepseek-v4-pro-0813"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0


### PR DESCRIPTION
SCNet has updated the available models for its Token Plan subscription. This time the previously stale documentation page ([https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/plans/token-plan.html#可用模型](https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/plans/token-plan.html#%E5%8F%AF%E7%94%A8%E6%A8%A1%E5%9E%8B)) has also been updated, and it now lists one model that is missing from the scnet-token-plan catalog:

- DeepSeek-V4-Pro-0813

The model is confirmed available via the Token Plan console and the SCNet API (https://api.scnet.cn/api/llm/v1), and it has been added using base_model pointing to the existing lab model deepseek/deepseek-v4-pro-0813, with zero-cost entries to match the provider's prepaid-Credits pricing.

Changes:

- Add providers/scnet-token-plan/models/DeepSeek-V4-Pro-0813.toml