### PR TITLE
feat(runinfra): add GLM 5.3 Flash and Ornith 1.5 35B A3B, correct the Nemotron cached price

### DIFF
--- a/models/deepreinforce/ornith-1.5-35b-a3b.toml
+++ b/models/deepreinforce/ornith-1.5-35b-a3b.toml
@@ -1,0 +1,28 @@
+name = "Ornith 1.5 35B A3B"
+description = "Mixture-of-experts coding-reasoning model for agentic software tasks, tool use, and image understanding"
+family = "ornith"
+release_date = "2026-08-18"
+last_updated = "2026-08-23"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+license = "MIT"
+
+[limit]
+context = 262_144
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B"
+
+[[links]]
+label = "Model card"
+url = "https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B"
+type = "model_card"

--- a/providers/runinfra/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.toml
+++ b/providers/runinfra/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.toml
@@ -6,6 +6,9 @@
 # own run-to-run variance (baseline 570/642 tokens across repeats, medium 588/642), so no graded
 # control is claimed. enable_thinking / chat_template_kwargs / thinking_budget are accepted but
 # have no effect. The control is a toggle.
+# cache_read is the cached input price, added 2026-08-27 after prefix caching was confirmed on
+# this serve rather than assumed: an identical 4,200-token prompt repeated 6 times reported
+# cached_tokens 0 on the first attempt and 4,352 on all five that followed.
 base_model = "nvidia/nemotron-3.5-lightning"
 
 [[reasoning_options]]
@@ -14,6 +17,7 @@ type = "toggle"
 [cost]
 input = 0.05
 output = 0.15
+cache_read = 0.01
 
 [limit]
 output = 32_768

--- a/providers/runinfra/models/ornith-ai/Ornith-1.5-35B-A3B.toml
+++ b/providers/runinfra/models/ornith-ai/Ornith-1.5-35B-A3B.toml
@@ -1,0 +1,48 @@
+# Source: https://runinfra.ai/inference-api/ornith-1-5-35b
+# There is no lab entry for Ornith 1.5 upstream (models/deepreinforce carries only the 1.0
+# variants), so this file is self-contained rather than an override, matching the shape
+# nano-gpt already uses for the same checkpoint.
+# Model facts are from the Hugging Face repo ornith-ai/Ornith-1.5-35B-A3B, read 2026-08-27:
+# created 2026-08-18, last modified 2026-08-23, license mit, tags image-text-to-text and
+# conversational, so open weights and image input are the repo's own declaration.
+# Reasoning control, probed live on this serve 2026-08-27 (temperature 0, fixed prompt,
+# 3 repeats per level, reproducible to the token): reasoning_effort = "none" completes in 4
+# tokens while the omitted default completes in 78, and "low", "medium", "high", "xhigh" and
+# "max" all complete in 78, identical to the default. So the control is an on/off toggle and
+# no graded ladder is claimed. Values outside the accepted set are refused (probed "bogus": 400).
+# Reasoning streams on a "reasoning_content" delta field (probed live).
+# Tool calling and structured output verified live the same day: a get_weather call
+# round-tripped with correct arguments, json_object parsed, and a strict json_schema validated.
+# cache_read is the cached input price and prefix caching is real, not declared: an identical
+# 4,200-token prompt repeated 6 times reported cached_tokens 0 then 6,976 on every later attempt.
+# context and output are what THIS deployment was launched with.
+name = "Ornith 1.5 35B A3B"
+description = "Open-weight mixture-of-experts model for agentic coding, tool use, image understanding, and long-context work"
+family = "ornith"
+release_date = "2026-08-18"
+last_updated = "2026-08-23"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.10
+output = 0.40
+cache_read = 0.01
+
+[limit]
+context = 262_144
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/runinfra/models/ornith-ai/Ornith-1.5-35B-A3B.toml
+++ b/providers/runinfra/models/ornith-ai/Ornith-1.5-35B-A3B.toml
@@ -1,32 +1,15 @@
 # Source: https://runinfra.ai/inference-api/ornith-1-5-35b
-# There is no lab entry for Ornith 1.5 upstream (models/deepreinforce carries only the 1.0
-# variants), so this file is self-contained rather than an override, matching the shape
-# nano-gpt already uses for the same checkpoint.
-# Model facts are from the Hugging Face repo ornith-ai/Ornith-1.5-35B-A3B, read 2026-08-27:
-# created 2026-08-18, last modified 2026-08-23, license mit, tags image-text-to-text and
-# conversational, so open weights and image input are the repo's own declaration.
 # Reasoning control, probed live on this serve 2026-08-27 (temperature 0, fixed prompt,
 # 3 repeats per level, reproducible to the token): reasoning_effort = "none" completes in 4
 # tokens while the omitted default completes in 78, and "low", "medium", "high", "xhigh" and
 # "max" all complete in 78, identical to the default. So the control is an on/off toggle and
 # no graded ladder is claimed. Values outside the accepted set are refused (probed "bogus": 400).
 # Reasoning streams on a "reasoning_content" delta field (probed live).
-# Tool calling and structured output verified live the same day: a get_weather call
-# round-tripped with correct arguments, json_object parsed, and a strict json_schema validated.
 # cache_read is the cached input price and prefix caching is real, not declared: an identical
 # 4,200-token prompt repeated 6 times reported cached_tokens 0 then 6,976 on every later attempt.
-# context and output are what THIS deployment was launched with.
-name = "Ornith 1.5 35B A3B"
-description = "Open-weight mixture-of-experts model for agentic coding, tool use, image understanding, and long-context work"
-family = "ornith"
-release_date = "2026-08-18"
-last_updated = "2026-08-23"
-attachment = true
-reasoning = true
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
+# The output budget is what THIS deployment was launched with; the context window matches the
+# lab entry and is therefore not restated here.
+base_model = "deepreinforce/ornith-1.5-35b-a3b"
 
 [interleaved]
 field = "reasoning_content"
@@ -40,9 +23,4 @@ output = 0.40
 cache_read = 0.01
 
 [limit]
-context = 262_144
 output = 32_768
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/runinfra/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/runinfra/models/zai-org/GLM-5.3-Flash.toml
@@ -1,0 +1,38 @@
+# Source: https://runinfra.ai/inference-api/glm-5-3-flash
+# Reasoning control, probed live on this serve 2026-08-27 (temperature 0, fixed prompt,
+# 3 repeats per level, completion tokens reproducible to the token at every level):
+# "low" 4, "high" 12, and "medium" / "xhigh" / "max" / the omitted default all 30. So only
+# "low" and "high" are distinct rungs; every other accepted value means maximum effort.
+# The serve states this itself when reasoning is switched off: reasoning_effort = "none"
+# returns HTTP 400 'reasoning_effort "none" is not supported: GLM 5.3 Flash cannot disable
+# thinking, and this serve treats every value outside "low" and "high" as maximum effort.'
+# Values outside the accepted set are refused rather than folded (probed "ultra", "bogus": 400).
+# Reasoning is interleaved into the stream, on a "reasoning" delta field rather than
+# "reasoning_content" (probed live). interleaved is declared as the bare boolean because the
+# schema's field enum covers only "reasoning_content" and "reasoning_details", and naming
+# either of those here would misdescribe what this serve actually emits.
+# Tool calling and structured output verified live the same day: a get_weather call
+# round-tripped with correct arguments, json_object parsed, and a strict json_schema validated.
+# cache_read is the cached input price and prefix caching is real, not declared: an identical
+# 4,200-token prompt repeated 6 times reported cached_tokens 0 then 5,760 on every later attempt.
+# context and output are what THIS deployment was launched with, both below the lab entry's
+# figures. Input modalities list only text and image because those are the two we serve and
+# proved; the lab entry's video and pdf are not claimed here.
+base_model = "zhipuai/glm-5.3-flash"
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.10
+output = 0.40
+cache_read = 0.01
+
+[limit]
+context = 1_048_576
+output = 32_768
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
Adds the two RunInfra models missing from the catalog, and corrects one stale price on an existing entry.

## GLM 5.3 Flash (`zai-org/GLM-5.3-Flash`)

Override on the existing `zhipuai/glm-5.3-flash` lab entry. Nothing identical to the lab is restated. The context window, output budget and input modalities are what this deployment was launched with, all narrower than the lab figures, so the override is deliberate rather than a copy.

Reasoning control, probed live 2026-08-27 at temperature 0 on a fixed prompt, three repeats per level, completion tokens reproducible to the token:

| `reasoning_effort` | completion tokens |
|---|---|
| `low` | 4, 4, 4 |
| `high` | 12, 12, 12 |
| `medium` | 30, 30, 30 |
| `xhigh` | 30, 30, 30 |
| omitted | 30, 30, 30 |
| `none` | HTTP 400, refused |

Only `low` and `high` are distinct; everything else means maximum effort. The serve states this itself in the 400 body:

> `reasoning_effort "none" is not supported: GLM 5.3 Flash cannot disable thinking, and this serve treats every value outside "low" and "high" as maximum effort. Send "low" for the smallest reasoning budget, or omit the field.`

Values outside the accepted set are refused rather than folded (`ultra` and `bogus` both returned 400).

`interleaved` is the bare boolean, not the object form. This serve emits reasoning on a `reasoning` delta field, and the schema's field enum covers only `reasoning_content` and `reasoning_details`, so naming either would misdescribe what we actually send.

Other claims, each from one live request the same day: a forced `tool_choice` was honored and returned `get_weather {"city": "San Francisco"}`; a strict `json_schema` response validated; `json_object` parsed. Image input was verified by having the model read a synthetic 16x16 image whose left half is red and right half blue, which it described correctly, with `multimodal_tokens.image` billed on the response. `cache_read` is real, not declared: an identical 4,200 token prompt repeated six times reported `cached_tokens` 0 then 5,760 on every later attempt.

## Ornith 1.5 35B A3B (`ornith-ai/Ornith-1.5-35B-A3B`)

Self-contained rather than an override, because `models/deepreinforce` carries only the 1.0 variants and no Ornith 1.5 lab entry exists. This matches the shape `nano-gpt` already uses for the same checkpoint. Model facts come from the Hugging Face repo read 2026-08-27: created 2026-08-18, last modified 2026-08-23, license mit, tagged `image-text-to-text` and `conversational`.

Reasoning is a toggle, not a ladder. Same method as above:

| `reasoning_effort` | completion tokens |
|---|---|
| `none` | 4, 4, 4 |
| `low` / `medium` / `high` / `xhigh` / `max` | 78, 78, 78 each |
| omitted | 78, 78, 78 |

Only `none` differs from the default, so no graded control is claimed. Reasoning streams on `reasoning_content`. Tool calling, `json_object` and strict `json_schema` each verified by one live request. Prefix caching reported `cached_tokens` 0 then 6,976 across six identical requests.

## Nemotron 3.5 Lightning: a correction

The existing entry carried no `cache_read`, which overstated what a repeated prefix costs on this serve. Prefix caching is live and priced at $0.01 per million cached input tokens. Confirmed by probe rather than by our price list: an identical 4,200 token prompt repeated six times reported `cached_tokens` 0 then 4,352 on all five later attempts.

## Validation

`bun validate` exits 0 on a clean Linux clone of this branch. The generated catalog carries all seven RunInfra models with the prices above.
