### PR TITLE
feat(ollama-cloud): add glm-5.3-flash

### DIFF
--- a/providers/ollama-cloud/models/glm-5.3-flash.toml
+++ b/providers/ollama-cloud/models/glm-5.3-flash.toml
@@ -1,0 +1,9 @@
+base_model = "zhipuai/glm-5.3-flash"
+open_weights = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"


### PR DESCRIPTION
GLM-5.3-Flash (320B-A18B, MIT, released 2026-08-26) is served on Ollama Cloud as glm-5.3-flash:cloud. Inherits shared metadata from zhipuai/glm-5.3-flash; overrides open_weights (weights are public on HuggingFace) and adds the effort-based reasoning options and reasoning_content interleave that Ollama's OpenAI-compatible endpoint returns. Verified against https://ollama.com/v1.