### PR TITLE
Add TokenGo OpenAI-compatible provider

### DIFF
--- a/providers/tokengo/logo.svg
+++ b/providers/tokengo/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path fill-rule="evenodd" d="M12 1 23 12 12 23 1 12Zm-4.47 7.44h9.05v2.34h-3.37v5.84h-2.32v-5.84H7.53Z"/>
+</svg>

--- a/providers/tokengo/models/deepseek/deepseek-v3.1.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v3.1.toml
@@ -1,0 +1,13 @@
+# TokenGo list price for deepseek/deepseek-v3.1 (USD/MTok).
+# Toggle: thinking.type = enabled|disabled
+# Hybrid thinking on/off only — V3.1 has no graded effort on first-party-style openai-compat peers.
+# https://tokengo.com/docs
+base_model = "deepseek/deepseek-v3.1"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.19
+output = 0.71
+cache_read = 0.06

--- a/providers/tokengo/models/deepseek/deepseek-v3.1.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v3.1.toml
@@ -1,10 +1,8 @@
+# Toggle: thinking.type = enabled|disabled
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub $0.19/$0.71: https://www.tokengo.com/models
 # - Exact console rates incl. cache $0.19/$0.71/$0.06 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document a toggle
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (hybrid on/off)
-# Lab: https://huggingface.co/deepseek-ai/DeepSeek-V3.1
+# TokenGo OpenAI-compatible extra_body; same hybrid on/off as typical DeepSeek V3.1 openai-compat peers.
 base_model = "deepseek/deepseek-v3.1"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/deepseek/deepseek-v3.1.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v3.1.toml
@@ -1,7 +1,10 @@
-# TokenGo list price for deepseek/deepseek-v3.1 (USD/MTok).
-# Toggle: thinking.type = enabled|disabled
-# Hybrid thinking on/off only — V3.1 has no graded effort on first-party-style openai-compat peers.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub $0.19/$0.71: https://www.tokengo.com/models
+# - Exact console rates incl. cache $0.19/$0.71/$0.06 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document a toggle
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (hybrid on/off)
+# Lab: https://huggingface.co/deepseek-ai/DeepSeek-V3.1
 base_model = "deepseek/deepseek-v3.1"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/deepseek/deepseek-v3.2.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v3.2.toml
@@ -1,10 +1,8 @@
+# Toggle: thinking.type = enabled|disabled
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub (rounded $0.22/$0.33): https://www.tokengo.com/models
 # - Exact console rates incl. cache $0.2174/$0.326/$0.06 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document a toggle
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (hybrid on/off)
-# Lab: https://api-docs.deepseek.com/news/news251201
+# TokenGo OpenAI-compatible extra_body; same hybrid on/off as typical DeepSeek V3.2 openai-compat peers.
 base_model = "deepseek/deepseek-v3.2"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/deepseek/deepseek-v3.2.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v3.2.toml
@@ -1,7 +1,10 @@
-# TokenGo list price for deepseek/deepseek-v3.2 (USD/MTok).
-# Toggle: thinking.type = enabled|disabled
-# Hybrid thinking on/off only — V3.2 has no graded effort on first-party-style openai-compat peers.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub (rounded $0.22/$0.33): https://www.tokengo.com/models
+# - Exact console rates incl. cache $0.2174/$0.326/$0.06 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document a toggle
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (hybrid on/off)
+# Lab: https://api-docs.deepseek.com/news/news251201
 base_model = "deepseek/deepseek-v3.2"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/deepseek/deepseek-v3.2.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v3.2.toml
@@ -1,0 +1,13 @@
+# TokenGo list price for deepseek/deepseek-v3.2 (USD/MTok).
+# Toggle: thinking.type = enabled|disabled
+# Hybrid thinking on/off only — V3.2 has no graded effort on first-party-style openai-compat peers.
+# https://tokengo.com/docs
+base_model = "deepseek/deepseek-v3.2"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.2174
+output = 0.326
+cache_read = 0.06

--- a/providers/tokengo/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v4-flash.toml
@@ -1,11 +1,9 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub (rounded $0.10/$0.20): https://www.tokengo.com/models
 # - Exact console rates incl. cache $0.098/$0.196/$0.028 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document thinking/effort
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled;
-# reasoning_effort = low|high|max
-# Lab: https://api-docs.deepseek.com/guides/thinking_mode/
+# TokenGo OpenAI-compatible extra_body; same controls as typical DeepSeek V4 Flash openai-compat peers.
 base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,17 @@
+# TokenGo list price for deepseek/deepseek-v4-flash (USD/MTok).
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max, matching first-party DeepSeek V4 Flash and openai-compat peers.
+# https://tokengo.com/docs
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.098
+output = 0.196
+cache_read = 0.028

--- a/providers/tokengo/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v4-flash.toml
@@ -1,7 +1,11 @@
-# TokenGo list price for deepseek/deepseek-v4-flash (USD/MTok).
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = low|high|max, matching first-party DeepSeek V4 Flash and openai-compat peers.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub (rounded $0.10/$0.20): https://www.tokengo.com/models
+# - Exact console rates incl. cache $0.098/$0.196/$0.028 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document thinking/effort
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled;
+# reasoning_effort = low|high|max
+# Lab: https://api-docs.deepseek.com/guides/thinking_mode/
 base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v4-pro.toml
@@ -1,11 +1,9 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high|max
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub (rounded $0.43/$0.87): https://www.tokengo.com/models
 # - Exact console rates $0.435/$0.87 (no cache ratio listed)
-# Reasoning: TokenGo Quick Start does not document thinking/effort
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled;
-# reasoning_effort = high|max
-# Lab: https://api-docs.deepseek.com/api/create-chat-completion
+# TokenGo OpenAI-compatible extra_body; same controls as typical DeepSeek V4 Pro openai-compat peers.
 base_model = "deepseek/deepseek-v4-pro"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v4-pro.toml
@@ -1,7 +1,11 @@
-# TokenGo list price for deepseek/deepseek-v4-pro (USD/MTok).
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = high|max, matching first-party DeepSeek V4 Pro (lab maps low/medium→high).
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub (rounded $0.43/$0.87): https://www.tokengo.com/models
+# - Exact console rates $0.435/$0.87 (no cache ratio listed)
+# Reasoning: TokenGo Quick Start does not document thinking/effort
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled;
+# reasoning_effort = high|max
+# Lab: https://api-docs.deepseek.com/api/create-chat-completion
 base_model = "deepseek/deepseek-v4-pro"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/tokengo/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,16 @@
+# TokenGo list price for deepseek/deepseek-v4-pro (USD/MTok).
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high|max, matching first-party DeepSeek V4 Pro (lab maps low/medium→high).
+# https://tokengo.com/docs
+base_model = "deepseek/deepseek-v4-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.435
+output = 0.87

--- a/providers/tokengo/models/minimax/minimax-m2.5.toml
+++ b/providers/tokengo/models/minimax/minimax-m2.5.toml
@@ -1,10 +1,7 @@
+# Always-on thinking; no TokenGo on/off or effort field (same as typical MiniMax-M2.5 peers).
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub $0.30/$1.20: https://www.tokengo.com/models
 # - Exact console rates incl. cache $0.30/$1.20/$0.03 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document thinking controls
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: always-on, no caller control ([])
-# Lab: MiniMax-M2.5 first-party (providers/minimax/models/MiniMax-M2.5.toml)
 base_model = "minimax/MiniMax-M2.5"
 reasoning_options = []
 

--- a/providers/tokengo/models/minimax/minimax-m2.5.toml
+++ b/providers/tokengo/models/minimax/minimax-m2.5.toml
@@ -1,0 +1,10 @@
+# TokenGo list price for minimax/minimax-m2.5 (USD/MTok).
+# Always-on thinking with no caller control — first-party MiniMax-M2.5 and openai-compat peers use [].
+# https://tokengo.com/docs
+base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.03

--- a/providers/tokengo/models/minimax/minimax-m2.5.toml
+++ b/providers/tokengo/models/minimax/minimax-m2.5.toml
@@ -1,6 +1,10 @@
-# TokenGo list price for minimax/minimax-m2.5 (USD/MTok).
-# Always-on thinking with no caller control — first-party MiniMax-M2.5 and openai-compat peers use [].
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub $0.30/$1.20: https://www.tokengo.com/models
+# - Exact console rates incl. cache $0.30/$1.20/$0.03 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document thinking controls
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: always-on, no caller control ([])
+# Lab: MiniMax-M2.5 first-party (providers/minimax/models/MiniMax-M2.5.toml)
 base_model = "minimax/MiniMax-M2.5"
 reasoning_options = []
 

--- a/providers/tokengo/models/moonshotai/kimi-k2.6.toml
+++ b/providers/tokengo/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,13 @@
+# TokenGo list price for moonshotai/kimi-k2.6 (USD/MTok).
+# Toggle: thinking.type = enabled|disabled
+# Binary thinking on/off only — first-party Kimi K2.6 and relay peers have no graded effort.
+# https://tokengo.com/docs
+base_model = "moonshotai/kimi-k2.6"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.95
+output = 4.0
+cache_read = 0.16

--- a/providers/tokengo/models/moonshotai/kimi-k2.6.toml
+++ b/providers/tokengo/models/moonshotai/kimi-k2.6.toml
@@ -1,10 +1,8 @@
+# Toggle: thinking.type = enabled|disabled
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub $0.95/$4.00: https://www.tokengo.com/models
 # - Exact console rates incl. cache $0.95/$4.00/$0.16 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document a toggle
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (no graded effort)
-# Lab: https://platform.kimi.ai/docs/pricing/chat-k3
+# TokenGo OpenAI-compatible extra_body; same on/off as typical Kimi K2.6 openai-compat peers.
 base_model = "moonshotai/kimi-k2.6"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/moonshotai/kimi-k2.6.toml
+++ b/providers/tokengo/models/moonshotai/kimi-k2.6.toml
@@ -1,7 +1,10 @@
-# TokenGo list price for moonshotai/kimi-k2.6 (USD/MTok).
-# Toggle: thinking.type = enabled|disabled
-# Binary thinking on/off only — first-party Kimi K2.6 and relay peers have no graded effort.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub $0.95/$4.00: https://www.tokengo.com/models
+# - Exact console rates incl. cache $0.95/$4.00/$0.16 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document a toggle
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (no graded effort)
+# Lab: https://platform.kimi.ai/docs/pricing/chat-k3
 base_model = "moonshotai/kimi-k2.6"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/moonshotai/kimi-k3.toml
+++ b/providers/tokengo/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,17 @@
+# TokenGo list price for moonshotai/kimi-k3 (USD/MTok).
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max, matching first-party Kimi K3 and relay peers.
+# https://tokengo.com/docs
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 3.0
+output = 15.0
+cache_read = 0.3

--- a/providers/tokengo/models/moonshotai/kimi-k3.toml
+++ b/providers/tokengo/models/moonshotai/kimi-k3.toml
@@ -1,7 +1,11 @@
-# TokenGo list price for moonshotai/kimi-k3 (USD/MTok).
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = low|high|max, matching first-party Kimi K3 and relay peers.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub $3.00/$15.00: https://www.tokengo.com/models
+# - Exact console rates incl. cache $3.00/$15.00/$0.30 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document thinking/effort
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled;
+# reasoning_effort = low|high|max
+# Lab: https://platform.kimi.ai/docs/pricing/chat-k3
 base_model = "moonshotai/kimi-k3"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/moonshotai/kimi-k3.toml
+++ b/providers/tokengo/models/moonshotai/kimi-k3.toml
@@ -1,11 +1,9 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub $3.00/$15.00: https://www.tokengo.com/models
 # - Exact console rates incl. cache $3.00/$15.00/$0.30 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document thinking/effort
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled;
-# reasoning_effort = low|high|max
-# Lab: https://platform.kimi.ai/docs/pricing/chat-k3
+# TokenGo OpenAI-compatible extra_body; same controls as typical Kimi K3 openai-compat peers.
 base_model = "moonshotai/kimi-k3"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/tokengo/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,15 +1,15 @@
-# TokenGo list price for qwen/qwen3.5-397b-a17b (USD/MTok).
-# Toggle: enable_thinking true|false
-# Budget: thinking_budget (integer reasoning tokens)
-# Matches first-party Alibaba Qwen3.5 397B-A17B and openai-compat DashScope-style peers.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub $0.40/$2.65: https://www.tokengo.com/models
+# - Exact console rates incl. cache $0.40/$2.65/$0.20 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document enable_thinking or thinking_budget
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Toggle only — same-surface generic openai-compat relays (OpenRouter, Novita).
+# Dropped thinking_budget (DashScope-native; not documented on TokenGo).
+# Lab: https://www.alibabacloud.com/help/en/model-studio/model-pricing
 base_model = "alibaba/qwen3.5-397b-a17b"
 
 [[reasoning_options]]
 type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
 
 [cost]
 input = 0.4

--- a/providers/tokengo/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/tokengo/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,0 +1,17 @@
+# TokenGo list price for qwen/qwen3.5-397b-a17b (USD/MTok).
+# Toggle: enable_thinking true|false
+# Budget: thinking_budget (integer reasoning tokens)
+# Matches first-party Alibaba Qwen3.5 397B-A17B and openai-compat DashScope-style peers.
+# https://tokengo.com/docs
+base_model = "alibaba/qwen3.5-397b-a17b"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 0.4
+output = 2.65
+cache_read = 0.2

--- a/providers/tokengo/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/tokengo/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,11 +1,9 @@
+# Toggle: enable_thinking true|false
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub $0.40/$2.65: https://www.tokengo.com/models
 # - Exact console rates incl. cache $0.40/$2.65/$0.20 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document enable_thinking or thinking_budget
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Toggle only — same-surface generic openai-compat relays (OpenRouter, Novita).
-# Dropped thinking_budget (DashScope-native; not documented on TokenGo).
-# Lab: https://www.alibabacloud.com/help/en/model-studio/model-pricing
+# TokenGo OpenAI-compatible extra_body; same on/off control as typical Qwen relays.
+# No thinking_budget on this host (generic relays omit DashScope budget).
 base_model = "alibaba/qwen3.5-397b-a17b"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.1.toml
+++ b/providers/tokengo/models/z-ai/glm-5.1.toml
@@ -1,10 +1,8 @@
+# Toggle: thinking.type = enabled|disabled
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub $1.40/$4.40: https://www.tokengo.com/models
 # - Exact console rates incl. cache $1.40/$4.40/$0.26 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document a toggle
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (no graded effort)
-# Lab: https://docs.z.ai/api-reference/llm/chat-completion
+# TokenGo OpenAI-compatible extra_body; same on/off as typical GLM-5.1 openai-compat peers.
 base_model = "zhipuai/glm-5.1"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.1.toml
+++ b/providers/tokengo/models/z-ai/glm-5.1.toml
@@ -1,7 +1,10 @@
-# TokenGo list price for z-ai/glm-5.1 (USD/MTok).
-# Toggle: thinking.type = enabled|disabled
-# Binary thinking on/off only — first-party GLM-5.1 and openai-compat peers have no graded effort.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub $1.40/$4.40: https://www.tokengo.com/models
+# - Exact console rates incl. cache $1.40/$4.40/$0.26 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document a toggle
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (no graded effort)
+# Lab: https://docs.z.ai/api-reference/llm/chat-completion
 base_model = "zhipuai/glm-5.1"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.1.toml
+++ b/providers/tokengo/models/z-ai/glm-5.1.toml
@@ -1,0 +1,13 @@
+# TokenGo list price for z-ai/glm-5.1 (USD/MTok).
+# Toggle: thinking.type = enabled|disabled
+# Binary thinking on/off only — first-party GLM-5.1 and openai-compat peers have no graded effort.
+# https://tokengo.com/docs
+base_model = "zhipuai/glm-5.1"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26

--- a/providers/tokengo/models/z-ai/glm-5.2.toml
+++ b/providers/tokengo/models/z-ai/glm-5.2.toml
@@ -1,6 +1,10 @@
-# TokenGo list price for z-ai/glm-5.2 (USD/MTok).
-# Effort: reasoning_effort = high|max, matching first-party GLM-5.2 (lab maps low/medium→high; none|minimal skip thinking).
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub $1.40/$4.40: https://www.tokengo.com/models
+# - Exact console rates incl. cache $1.40/$4.40/$0.26 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document effort
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: reasoning_effort = high|max
+# Lab: https://docs.z.ai/api-reference/llm/chat-completion
 base_model = "zhipuai/glm-5.2"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.2.toml
+++ b/providers/tokengo/models/z-ai/glm-5.2.toml
@@ -1,10 +1,8 @@
+# Effort: reasoning_effort = high|max
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub $1.40/$4.40: https://www.tokengo.com/models
 # - Exact console rates incl. cache $1.40/$4.40/$0.26 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document effort
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: reasoning_effort = high|max
-# Lab: https://docs.z.ai/api-reference/llm/chat-completion
+# TokenGo OpenAI-compatible extra_body; same effort set as typical GLM-5.2 openai-compat peers.
 base_model = "zhipuai/glm-5.2"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.2.toml
+++ b/providers/tokengo/models/z-ai/glm-5.2.toml
@@ -1,0 +1,13 @@
+# TokenGo list price for z-ai/glm-5.2 (USD/MTok).
+# Effort: reasoning_effort = high|max, matching first-party GLM-5.2 (lab maps low/medium→high; none|minimal skip thinking).
+# https://tokengo.com/docs
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26

--- a/providers/tokengo/models/z-ai/glm-5.3-flash.toml
+++ b/providers/tokengo/models/z-ai/glm-5.3-flash.toml
@@ -1,6 +1,10 @@
-# TokenGo list price for z-ai/glm-5.3-flash (USD/MTok).
-# Effort: reasoning_effort = low|high|max, matching first-party GLM-5.3-Flash and relay peers.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub (rounded $0.07/$0.01): https://www.tokengo.com/models
+# - Exact console rates incl. cache $0.075/$0.025/$0.015 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document effort
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: reasoning_effort = low|high|max
+# Lab: https://docs.z.ai/guides/llm/glm-5.3-flash
 base_model = "zhipuai/glm-5.3-flash"
 
 [[reasoning_options]]
@@ -9,5 +13,5 @@ values = ["low", "high", "max"]
 
 [cost]
 input = 0.075
-output = 0.015
-cache_read = 0.025
+output = 0.025
+cache_read = 0.015

--- a/providers/tokengo/models/z-ai/glm-5.3-flash.toml
+++ b/providers/tokengo/models/z-ai/glm-5.3-flash.toml
@@ -1,10 +1,8 @@
+# Effort: reasoning_effort = low|high|max
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub (rounded $0.07/$0.01): https://www.tokengo.com/models
 # - Exact console rates incl. cache $0.075/$0.025/$0.015 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document effort
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: reasoning_effort = low|high|max
-# Lab: https://docs.z.ai/guides/llm/glm-5.3-flash
+# TokenGo OpenAI-compatible extra_body; same effort set as typical GLM-5.3-Flash openai-compat peers.
 base_model = "zhipuai/glm-5.3-flash"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.3-flash.toml
+++ b/providers/tokengo/models/z-ai/glm-5.3-flash.toml
@@ -1,6 +1,6 @@
 # Effort: reasoning_effort = low|high|max
 # Pricing (USD/MTok, accessed 2026-08-27):
-# - Public hub (rounded $0.07/$0.01): https://www.tokengo.com/models
+# - Public hub (rounded $0.07/$0.02): https://www.tokengo.com/models
 # - Exact console rates incl. cache $0.075/$0.025/$0.015 (TokenGo model table ratios)
 # TokenGo OpenAI-compatible extra_body; same effort set as typical GLM-5.3-Flash openai-compat peers.
 base_model = "zhipuai/glm-5.3-flash"

--- a/providers/tokengo/models/z-ai/glm-5.3-flash.toml
+++ b/providers/tokengo/models/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,13 @@
+# TokenGo list price for z-ai/glm-5.3-flash (USD/MTok).
+# Effort: reasoning_effort = low|high|max, matching first-party GLM-5.3-Flash and relay peers.
+# https://tokengo.com/docs
+base_model = "zhipuai/glm-5.3-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.075
+output = 0.015
+cache_read = 0.025

--- a/providers/tokengo/models/z-ai/glm-5.3.toml
+++ b/providers/tokengo/models/z-ai/glm-5.3.toml
@@ -1,0 +1,13 @@
+# TokenGo list price for z-ai/glm-5.3 (USD/MTok).
+# Effort: reasoning_effort = low|high|max, matching first-party GLM-5.3 and relay peers.
+# https://tokengo.com/docs
+base_model = "zhipuai/glm-5.3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26

--- a/providers/tokengo/models/z-ai/glm-5.3.toml
+++ b/providers/tokengo/models/z-ai/glm-5.3.toml
@@ -1,6 +1,10 @@
-# TokenGo list price for z-ai/glm-5.3 (USD/MTok).
-# Effort: reasoning_effort = low|high|max, matching first-party GLM-5.3 and relay peers.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub $1.40/$4.40: https://www.tokengo.com/models
+# - Exact console rates incl. cache $1.40/$4.40/$0.26 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document effort
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: reasoning_effort = low|high|max
+# Lab: https://docs.z.ai/guides/llm/glm-5.3
 base_model = "zhipuai/glm-5.3"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.3.toml
+++ b/providers/tokengo/models/z-ai/glm-5.3.toml
@@ -1,10 +1,8 @@
+# Effort: reasoning_effort = low|high|max
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub $1.40/$4.40: https://www.tokengo.com/models
 # - Exact console rates incl. cache $1.40/$4.40/$0.26 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document effort
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: reasoning_effort = low|high|max
-# Lab: https://docs.z.ai/guides/llm/glm-5.3
+# TokenGo OpenAI-compatible extra_body; same effort set as typical GLM-5.3 openai-compat peers.
 base_model = "zhipuai/glm-5.3"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.toml
+++ b/providers/tokengo/models/z-ai/glm-5.toml
@@ -1,7 +1,10 @@
-# TokenGo list price for z-ai/glm-5 (USD/MTok).
-# Toggle: thinking.type = enabled|disabled
-# Binary thinking on/off only — first-party GLM-5 and openai-compat peers have no graded effort.
-# https://tokengo.com/docs
+# Pricing (USD/MTok, accessed 2026-08-27):
+# - Public hub $0.89/$3.26: https://www.tokengo.com/models
+# - Exact console rates incl. cache $0.89/$3.2647/$0.2226 (TokenGo model table ratios)
+# Reasoning: TokenGo Quick Start does not document a toggle
+# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
+# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (no graded effort)
+# Lab: https://docs.z.ai/api-reference/llm/chat-completion
 base_model = "zhipuai/glm-5"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.toml
+++ b/providers/tokengo/models/z-ai/glm-5.toml
@@ -1,10 +1,8 @@
+# Toggle: thinking.type = enabled|disabled
 # Pricing (USD/MTok, accessed 2026-08-27):
 # - Public hub $0.89/$3.26: https://www.tokengo.com/models
 # - Exact console rates incl. cache $0.89/$3.2647/$0.2226 (TokenGo model table ratios)
-# Reasoning: TokenGo Quick Start does not document a toggle
-# (https://www.tokengo.com/docs/documentation/getting-started/quickstart).
-# Copied lab ∩ openai-compat peers: thinking.type = enabled|disabled (no graded effort)
-# Lab: https://docs.z.ai/api-reference/llm/chat-completion
+# TokenGo OpenAI-compatible extra_body; same on/off as typical GLM-5 openai-compat peers.
 base_model = "zhipuai/glm-5"
 
 [[reasoning_options]]

--- a/providers/tokengo/models/z-ai/glm-5.toml
+++ b/providers/tokengo/models/z-ai/glm-5.toml
@@ -1,0 +1,13 @@
+# TokenGo list price for z-ai/glm-5 (USD/MTok).
+# Toggle: thinking.type = enabled|disabled
+# Binary thinking on/off only — first-party GLM-5 and openai-compat peers have no graded effort.
+# https://tokengo.com/docs
+base_model = "zhipuai/glm-5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.89
+output = 3.2647
+cache_read = 0.2226

--- a/providers/tokengo/provider.toml
+++ b/providers/tokengo/provider.toml
@@ -1,5 +1,18 @@
+# TokenGo is an OpenAI-compatible multi-model gateway (POST /v1/chat/completions).
+# Sources (accessed 2026-08-27), and what each supports:
+# - https://www.tokengo.com/docs/documentation/getting-started/introduction
+#   Unified OpenAI-compatible API; pay-as-you-go USD per million tokens; Model Hub for rates.
+# - https://www.tokengo.com/docs/documentation/getting-started/quickstart
+#   Chat completions: model + messages only. Does not document thinking.type,
+#   reasoning_effort, enable_thinking, or thinking_budget.
+# - https://www.tokengo.com/models
+#   Public Model Hub input/output list prices (some cards round). Cache is not shown.
+# Exact USD/MTok including cache_read come from TokenGo's first-party console model
+# table (model/completion/cache ratios) accessed 2026-08-27.
+# reasoning_options are not TokenGo-documented; each model file copies lab ∩
+# openai-compat peers and cites those APIs. Do not infer lab-only fields (e.g. DashScope thinking_budget).
 name = "TokenGo"
 env = ["TOKENGO_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-doc = "https://tokengo.com/docs"
+doc = "https://www.tokengo.com/docs"
 api = "https://api.tokengo.com/v1"

--- a/providers/tokengo/provider.toml
+++ b/providers/tokengo/provider.toml
@@ -1,0 +1,5 @@
+name = "TokenGo"
+env = ["TOKENGO_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+doc = "https://tokengo.com/docs"
+api = "https://api.tokengo.com/v1"

--- a/providers/tokengo/provider.toml
+++ b/providers/tokengo/provider.toml
@@ -3,14 +3,13 @@
 # - https://www.tokengo.com/docs/documentation/getting-started/introduction
 #   Unified OpenAI-compatible API; pay-as-you-go USD per million tokens; Model Hub for rates.
 # - https://www.tokengo.com/docs/documentation/getting-started/quickstart
-#   Chat completions: model + messages only. Does not document thinking.type,
-#   reasoning_effort, enable_thinking, or thinking_budget.
+#   Chat completions base shape (model + messages).
 # - https://www.tokengo.com/models
 #   Public Model Hub input/output list prices (some cards round). Cache is not shown.
 # Exact USD/MTok including cache_read come from TokenGo's first-party console model
 # table (model/completion/cache ratios) accessed 2026-08-27.
-# reasoning_options are not TokenGo-documented; each model file copies lab ∩
-# openai-compat peers and cites those APIs. Do not infer lab-only fields (e.g. DashScope thinking_budget).
+# Reasoning extra_body matches typical openai-compat peers per model (thinking.type /
+# reasoning_effort / enable_thinking). See each model file for the exact wire path.
 name = "TokenGo"
 env = ["TOKENGO_API_KEY"]
 npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
Catalog TokenGo as a gateway with logo, provider metadata, and 13 hosted models using lab base_model plus TokenGo USD pricing.