### PR TITLE
ofox: add z-ai/glm-5.3-flash

### DIFF
--- a/providers/ofox/models/z-ai/glm-5.3-flash.toml
+++ b/providers/ofox/models/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,16 @@
+# Sources:
+# - https://ofox.ai/en/models/z-ai/glm-5.3-flash (Ofox: $0.075/$0.25/M, cache read $0.015/M; 1M context; 131072 max output; effort low/high/max)
+# - https://api.ofox.ai/v2/models/catalog?include=provider_price (provider_price override for z-ai/glm-5.3-flash, verified 2026-08-28)
+# - https://docs.z.ai/guides/overview/pricing (Z.AI list: GLM-5.3-Flash $0.075/$0.25/M, cached input $0.015/M)
+# - https://z.ai/blog/glm-5.3-flash (GLM-5.3-Flash release, effort levels low|high|max)
+# Effort: reasoning_effort = low|high|max
+base_model = "zhipuai/glm-5.3-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.075
+output = 0.25
+cache_read = 0.015


### PR DESCRIPTION
Adds `z-ai/glm-5.3-flash` to the Ofox provider (`base_model = "zhipuai/glm-5.3-flash"`).

Pricing is Ofox's live price, no markup over Z.AI list: $0.075 / $0.25 per 1M tokens, cache read $0.015. Verified against the Ofox catalog `provider_price` override (https://api.ofox.ai/v2/models/catalog?include=provider_price) and https://docs.z.ai/guides/overview/pricing on 2026-08-28. Effort levels low|high|max follow the existing `ofox/z-ai/glm-5.3` entry.

The Ofox sync job runs with skipCreates, so new catalog models need a manual entry; price changes are picked up automatically afterwards.

`bun run validate` passes.