### PR TITLE
feat(alibaba): add qwen3.8-flash to alibaba and alibaba-cn

### DIFF
--- a/providers/alibaba-cn/models/qwen3.8-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.8-flash.toml
@@ -4,14 +4,12 @@
 # CNY→USD rate: 6.72, 2026-08-28, source: https://www.nimbuscalc.com/calculators/financial-calculators/currency-converter/USD-CNY-2026-08-26/ (mid-market ~6.7205; 6.72 used)
 # CNY list: input ¥0.8, output ¥2.7, cache hit ¥0.1, explicit cache create ¥1.25 (per 1M tokens).
 # Toggle: enable_thinking true|false (hybrid)
-# Effort: reasoning_effort = low|medium|xhigh
-# Budget: thinking_budget (0..262144) cannot be combined with reasoning_effort
+# Budget: thinking_budget (max 262144) — reasoning_effort is for qwen3.8-max only, not flash
 # Pay-as-you-go on DashScope CN / 千问AI (not Token Plan only).
 base_model = "alibaba/qwen3.8-flash"
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "xhigh"] },
-  { type = "budget_tokens", min = 0, max = 262_144 },
+  { type = "budget_tokens", max = 262_144 },
 ]
 
 [interleaved]

--- a/providers/alibaba-cn/models/qwen3.8-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.8-flash.toml
@@ -1,0 +1,24 @@
+# Sources (accessed 2026-08-28):
+# https://help.aliyun.com/zh/model-studio/qwen3-8-flash (Beijing/China: ¥0.8 in / ¥2.7 out)
+# https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
+# CNY→USD rate: 6.72, 2026-08-28, source: https://www.nimbuscalc.com/calculators/financial-calculators/currency-converter/USD-CNY-2026-08-26/ (mid-market ~6.7205; 6.72 used)
+# CNY list: input ¥0.8, output ¥2.7, cache hit ¥0.1, explicit cache create ¥1.25 (per 1M tokens).
+# Toggle: enable_thinking true|false (hybrid)
+# Effort: reasoning_effort = low|medium|xhigh
+# Budget: thinking_budget (0..262144) cannot be combined with reasoning_effort
+# Pay-as-you-go on DashScope CN / 千问AI (not Token Plan only).
+base_model = "alibaba/qwen3.8-flash"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262_144 },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.11905
+output = 0.40179
+cache_read = 0.01488
+cache_write = 0.18601

--- a/providers/alibaba/models/qwen3.8-flash.toml
+++ b/providers/alibaba/models/qwen3.8-flash.toml
@@ -4,13 +4,11 @@
 # Official international (Singapore) price: $0.15 input / $0.47 output per 1M tokens.
 # Context cache: write (Explicit Cache Creation) $0.20, read (Implicit/Explicit Cache) $0.016.
 # Toggle: enable_thinking true|false (hybrid)
-# Effort: reasoning_effort = low|medium|xhigh
-# Budget: thinking_budget (0..262144) cannot be combined with reasoning_effort
+# Budget: thinking_budget (max 262144) — reasoning_effort is for qwen3.8-max only, not flash
 base_model = "alibaba/qwen3.8-flash"
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "xhigh"] },
-  { type = "budget_tokens", min = 0, max = 262_144 },
+  { type = "budget_tokens", max = 262_144 },
 ]
 
 [interleaved]

--- a/providers/alibaba/models/qwen3.8-flash.toml
+++ b/providers/alibaba/models/qwen3.8-flash.toml
@@ -1,0 +1,23 @@
+# Sources (accessed 2026-08-28):
+# https://www.alibabacloud.com/help/en/model-studio/qwen3-8-flash (Singapore/International: $0.15 in / $0.47 out)
+# https://platform.qianwenai.com/docs/developer-guides/text-generation/thinking
+# Official international (Singapore) price: $0.15 input / $0.47 output per 1M tokens.
+# Context cache: write (Explicit Cache Creation) $0.20, read (Implicit/Explicit Cache) $0.016.
+# Toggle: enable_thinking true|false (hybrid)
+# Effort: reasoning_effort = low|medium|xhigh
+# Budget: thinking_budget (0..262144) cannot be combined with reasoning_effort
+base_model = "alibaba/qwen3.8-flash"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262_144 },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.47
+cache_read = 0.016
+cache_write = 0.20


### PR DESCRIPTION
## Summary
Add the missing `qwen3.8-flash` provider entries for Alibaba's first-party hosts:
- `providers/alibaba/models/qwen3.8-flash.toml` (international / DashScope, Singapore pricing)
- `providers/alibaba-cn/models/qwen3.8-flash.toml` (China / Beijing pricing)

Both use `base_model = "alibaba/qwen3.8-flash"` (lab metadata already exists) and are override-only.

## Pricing sources (authoritative docs)
- International (Singapore): https://www.alibabacloud.com/help/en/model-studio/qwen3-8-flash — input $0.15, output $0.47, cache read $0.016, explicit cache creation $0.20 (per 1M tokens)
- China (Beijing): https://help.aliyun.com/zh/model-studio/qwen3-8-flash — input ¥0.8, output ¥2.7, cache hit ¥0.1, explicit cache creation ¥1.25 (per 1M tokens), converted to USD at 6.72 (2026-08-28)

## Reasoning / controls
Mirrors same-generation `qwen3.8-max` peer: `toggle` (enable_thinking) + `effort` (low/medium/xhigh) + `budget_tokens` (0..262144); `interleaved.field = "reasoning_content"`.

## Validation
- `bun validate` passes (exit 0)