### PR TITLE
fix(volcengine): drop redundant context override on Seed 2.0 lite/mini

### DIFF
--- a/providers/volcengine/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-lite-260428.toml
@@ -10,7 +10,6 @@
 base_model = "bytedance-seed/seed-2.0-lite"
 
 [limit]
-context = 256_000
 output = 131_072
 
 [[reasoning_options]]

--- a/providers/volcengine/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-mini-260428.toml
@@ -10,7 +10,6 @@
 base_model = "bytedance-seed/seed-2.0-mini"
 
 [limit]
-context = 256_000
 output = 131_072
 
 [[reasoning_options]]


### PR DESCRIPTION
Follow-up to #5644, which merged before this review point was addressed.

The review bot flagged it twice (10:45 and 10:51 UTC on 2026-08-27, the second
after my last commit), and it was right: the lab entries
`models/bytedance-seed/seed-2.0-lite.toml` and `seed-2.0-mini.toml` already
declare `limit.context = 256_000`. Plain objects deep-merge, so restating an
identical inherited value violates the override-only rule for `base_model`
files.

Only `output` is a real delta — the lab says `32_000`, but this host accepts
`131_072` (verified: `max_tokens=131072` → 200, `132000` → 400 invalid). So this
keeps `output` and lets `context` inherit.

For reference, 627 `base_model` files in `providers/` already override
`output` alone under `[limit]` — e.g.
`providers/merge-gateway/models/minimax/minimax-m2.toml` sets only
`output = 8_192` and inherits `context` from a lab entry that declares
`204_800`.

No behavior change to the published catalog: `context` resolves to `256_000`
either way.
