### PR TITLE
feat: update IteraCompute models

### DIFF
--- a/providers/iteracompute/models/iteracompute/ornith-1.5-35b-a3b.toml
+++ b/providers/iteracompute/models/iteracompute/ornith-1.5-35b-a3b.toml
@@ -1,0 +1,31 @@
+# Sources (accessed 2026-08-28):
+# https://api.iteracompute.com/v1/models (model ID, availability, limits, and pricing)
+# https://iteracompute.com/docs.html (OpenAI-compatible API documentation)
+# https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B (upstream capabilities)
+#
+# IteraCompute serves the language-only NVFP4 build with a 327,680-token
+# combined window, up to 262,144 input tokens, and up to 65,536 output tokens.
+# Reasoning toggle wire path: reasoning_effort = "none" disables thinking;
+# any accepted non-none effort enables it. Responses stream reasoning through
+# the reasoning_content delta field.
+# Prices are in USD per million tokens.
+base_model = "deepreinforce/ornith-1.5-35b-a3b"
+attachment = false
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.30
+output = 3.00
+
+[limit]
+context = 327_680
+input = 262_144
+output = 65_536
+
+[modalities]
+input = ["text"]

--- a/providers/iteracompute/models/iteracompute/qwen3.8-27b.toml
+++ b/providers/iteracompute/models/iteracompute/qwen3.8-27b.toml
@@ -1,16 +1,24 @@
-# Sources (accessed 2026-08-24):
+# Sources (accessed 2026-09-01):
 # https://api.iteracompute.com/v1/models (model ID, availability, and input/output pricing)
 # https://iteracompute.com/docs.html (OpenAI-compatible API documentation)
-# Cache-read pricing is the rate supplied for the OpenCode/models.dev integration.
+# https://huggingface.co/gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090 (served checkpoint and image input)
 #
 # IteraCompute serves Qwen3.8 27B through its OpenAI-compatible API.
-# Model capabilities, limits, and modalities are inherited from
-# models/alibaba/qwen3.8-27b.toml. Prices are in USD per million tokens.
+# The NVFP4 deployment accepts text and image input and extends the combined
+# serving window to 327,680 tokens with up to 262,144 input and 65,536 output tokens.
+# Prices are in USD per million tokens.
 # Effort: reasoning_effort = none|low|medium|xhigh (xhigh is the default).
 base_model = "alibaba/qwen3.8-27b"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "xhigh"] }]
 
 [cost]
-input = 0.35
-output = 3.00
-cache_read = 0.10
+input = 0.30
+output = 2.50
+
+[limit]
+context = 327_680
+input = 262_144
+output = 65_536
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
## Summary

- update iteracompute/qwen3.8-27b pricing to $0.30/M input tokens and $2.50/M output tokens
- remove the cached-input price from the models.dev entry
- publish IteraCompute's 327,680-token combined serving window, 262,144-token input limit, and 65,536-token output limit
- expose text and image input for the served Qwen3.8 NVFP4 checkpoint; video remains unclaimed because it has not been endpoint-tested
- add iteracompute/ornith-1.5-35b-a3b with its IteraCompute pricing, deployment limits, binary reasoning toggle, and reasoning_content field

## Sources

- https://api.iteracompute.com/v1/models
- https://iteracompute.com/docs.html
- https://huggingface.co/gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090
- https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B

## Validation

- IteraCompute production probe: PNG base64 chat completion returned HTTP 200 and successfully processed the image
- parsed both TOML files successfully
- confirmed the commit changes only the two IteraCompute provider files
- rebased onto the latest dev branch
- full Validate Models / bun validate passed on GitHub Actions