### PR TITLE
Feature/add new model

### DIFF
--- a/models/tencent/hy4-preview.toml
+++ b/models/tencent/hy4-preview.toml
@@ -7,7 +7,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
-open_weights = false
+open_weights = true
 
 [limit]
 context = 1_024_000
@@ -16,3 +16,7 @@ output = 64_000
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/tencent/Hy4-preview"

--- a/models/tencent/hy4-preview.toml
+++ b/models/tencent/hy4-preview.toml
@@ -16,7 +16,3 @@ output = 64_000
 [modalities]
 input = ["text"]
 output = ["text"]
-
-[[weights]]
-label = "Hugging Face"
-url = "https://huggingface.co/tencent/Hy4-preview"

--- a/models/tencent/hy4-preview.toml
+++ b/models/tencent/hy4-preview.toml
@@ -1,0 +1,18 @@
+name = "Hy4 preview"
+description = "A next-generation productivity model with significantly enhanced Agent and complex task execution capabilities."
+family = "Hy"
+release_date = "2026-08-28"
+last_updated = "2026-08-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 1_024_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/tencent-token-plan/models/hy4-preview.toml
+++ b/providers/tencent-token-plan/models/hy4-preview.toml
@@ -1,0 +1,20 @@
+# China-site list CNY → USD: list_price / tax_rate * FX (accessed 2026-08-26).
+# Source USD/1k tokens: input 0.000834, output 0.002501, cache hit 0.000042.
+# Catalog is USD / million tokens (×1000).
+# Toggle: thinking.type = enabled|disabled (default disabled)
+# Effort: reasoning_effort = none|high
+# https://cloud.tencent.com/document/product/1823/130055
+# https://cloud.tencent.com/document/product/1823/131208
+base_model = "tencent/hy4-preview"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0.834
+output = 2.501
+cache_read = 0.042

--- a/providers/tencent-tokenhub/models/hy4-preview.toml
+++ b/providers/tencent-tokenhub/models/hy4-preview.toml
@@ -1,0 +1,20 @@
+# China-site list CNY → USD: list_price / tax_rate * FX (accessed 2026-08-26).
+# Source USD/1k tokens: input 0.000834, output 0.002501, cache hit 0.000042.
+# Catalog is USD / million tokens (×1000).
+# Toggle: thinking.type = enabled|disabled (default disabled)
+# Effort: reasoning_effort = none|high
+# https://cloud.tencent.com/document/product/1823/130055
+# https://cloud.tencent.com/document/product/1823/131208
+base_model = "tencent/hy4-preview"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0.834
+output = 2.501
+cache_read = 0.042


### PR DESCRIPTION
## Summary
- Add Tencent Hy4 preview.
- Serve it on TokenHub and Token Plan via `base_model` (cost + reasoning_options only).

## Test plan
- [ ] `bun validate` passes