### PR TITLE
feat(bytedance-seed): declare structured_output on 11 Seed models

### DIFF
--- a/models/bytedance-seed/seed-1-6-flash.toml
+++ b/models/bytedance-seed/seed-1-6-flash.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-1-6-vision.toml
+++ b/models/bytedance-seed/seed-1-6-vision.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = false
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-1-6.toml
+++ b/models/bytedance-seed/seed-1-6.toml
@@ -10,6 +10,7 @@ attachment = false
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-1-8.toml
+++ b/models/bytedance-seed/seed-1-8.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-2.0-lite.toml
+++ b/models/bytedance-seed/seed-2.0-lite.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-2.0-mini.toml
+++ b/models/bytedance-seed/seed-2.0-mini.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-2.0-pro.toml
+++ b/models/bytedance-seed/seed-2.0-pro.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-2.1-pro.toml
+++ b/models/bytedance-seed/seed-2.1-pro.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-2.1-turbo.toml
+++ b/models/bytedance-seed/seed-2.1-turbo.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-character.toml
+++ b/models/bytedance-seed/seed-character.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]

--- a/models/bytedance-seed/seed-evolving.toml
+++ b/models/bytedance-seed/seed-evolving.toml
@@ -10,6 +10,7 @@ attachment = true
 reasoning = true
 temperature = true
 tool_call = true
+structured_output = true
 open_weights = false
 
 [limit]


### PR DESCRIPTION
`models/bytedance-seed/seed-2.0-code.toml` already declares
`structured_output = true`, but the other 11 Seed entries omit the field
entirely. Consumers that derive structured-output support from this catalog
therefore treat those models as unsupported — for example
`mastra`'s auto-generated `capabilities/volcengine.json` currently lists only 4
of 15 models under `structuredOutput`, and the 4 it does list are exactly the
ones that inherit the field from other labs.

All 11 were checked against `POST /api/v3/chat/completions` on the Volcengine Ark
host — one call each, with a strict schema:

```json
"response_format": {
  "type": "json_schema",
  "json_schema": {
    "name": "person", "strict": true,
    "schema": {
      "type": "object",
      "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
      "required": ["name", "age"], "additionalProperties": false
    }
  }
}
```

Every one returned HTTP 200 and emitted schema-conforming JSON
(e.g. `{"name": "Alice", "age": 30}`) — I parsed each response and asserted both
required properties were present, rather than treating 200 alone as support:

| Model | Result |
| --- | --- |
| `doubao-seed-1-6-251015` | 200, valid |
| `doubao-seed-1-6-flash-250828` | 200, valid |
| `doubao-seed-1-6-vision-250815` | 200, valid |
| `doubao-seed-1-8-251228` | 200, valid |
| `doubao-seed-2-0-lite-260428` | 200, valid |
| `doubao-seed-2-0-mini-260428` | 200, valid |
| `doubao-seed-2-0-pro-260215` | 200, valid |
| `doubao-seed-2-1-pro-260628` | 200, valid |
| `doubao-seed-2-1-turbo-260628` | 200, valid |
| `doubao-seed-character-260628` | 200, valid |
| `doubao-seed-evolving` | 200, valid |

Declared at the lab level, next to `tool_call`, matching how
`seed-2.0-code.toml` and other labs (e.g. `models/alibaba/qwen3.7-flash.toml`)
place it — so every host carrying these models picks it up.
