### PR TITLE
feat(provider): add Vancine OpenAI-compatible provider

### DIFF
--- a/providers/vancine/logo.svg
+++ b/providers/vancine/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Outer ring -->
+  <circle cx="12" cy="12" r="9.5"/>
+  <!-- Inscribed infinity (lemniscate) sharing the same vertical axis -->
+  <path d="M7 9.5 C9 6, 11 6, 12 9 C13 12, 15 15, 17 12.5 C18.5 10.5, 16.5 8, 14.5 9.5 C13 10.7, 11.5 12, 10 13.5 C8.5 15, 7 15, 7 13.5"/>
+</svg>

--- a/providers/vancine/models/MiniMax-M3.toml
+++ b/providers/vancine/models/MiniMax-M3.toml
@@ -1,0 +1,22 @@
+# Sources (accessed 2026-06-25):
+# https://platform.minimax.io/docs/api-reference/text-openai-api
+# https://docs.gmicloud.ai/inference-engine/billing/price
+# Lab reasoning controls on the OpenAI-compatible path: $.thinking.type
+# = "enabled" | "adaptive" | "disabled". reasoning_split=true returns the
+# reasoning stream in a separate reasoning_content field.
+# Interleaved field: reasoning_content.
+# Lab cost (token plan): input 0.30 / output 1.20 / cache_read 0.06.
+# Vancine public pricing (/api/pricing) is 0.24 / 0.96 / 0.048 (USD/MTok).
+# No tiered pricing is published on the public Vancine pricing endpoint.
+base_model = "minimax/MiniMax-M3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.24
+output = 0.96
+cache_read = 0.048

--- a/providers/vancine/models/deepseek-v4-flash.toml
+++ b/providers/vancine/models/deepseek-v4-flash.toml
@@ -1,0 +1,27 @@
+# Sources (accessed 2026-08-02):
+# https://api-docs.deepseek.com/guides/thinking_mode/
+# https://api-docs.deepseek.com/quick_start/pricing/
+# Reasoning HTTP format: thinking.type = "enabled" | "disabled";
+# reasoning_effort = "low" | "high" | "max". Flash maps low->low;
+# xhigh maps to high. Reasoning tokens are billed at the output rate.
+# Interleaved field: reasoning_content.
+# Lab cost: input 0.14 / output 0.28 / reasoning 0.28 / cache_read 0.0028.
+# Vancine public pricing (/api/pricing) is 0.22 / 0.66 / n/a / 0.007 (USD/MTok).
+# Vancine ModelList exposes "deepseek-v4-flash", "deepseek-v4-flash-none",
+# "deepseek-v4-flash-max" (relay/channel/deepseek/constants.go).
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.22
+output = 0.66
+cache_read = 0.007

--- a/providers/vancine/models/deepseek-v4-pro.toml
+++ b/providers/vancine/models/deepseek-v4-pro.toml
@@ -1,0 +1,27 @@
+# Sources (accessed 2026-08-12):
+# https://api-docs.deepseek.com/api/create-chat-completion
+# https://api-docs.deepseek.com/guides/thinking_mode/
+# Reasoning HTTP format: thinking.type = "enabled" | "disabled";
+# reasoning_effort = "high" | "max" (Pro does not expose "low"). Reasoning
+# tokens are billed at the output rate.
+# Interleaved field: reasoning_content.
+# Lab cost: input 0.435 / output 0.87 / reasoning 0.87 / cache_read 0.003625.
+# Vancine public pricing (/api/pricing) is 0.66 / 1.98 / n/a / 0.022 (USD/MTok).
+# Vancine ModelList exposes "deepseek-v4-pro", "deepseek-v4-pro-none",
+# "deepseek-v4-pro-max" (relay/channel/deepseek/constants.go).
+base_model = "deepseek/deepseek-v4-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.66
+output = 1.98
+cache_read = 0.022

--- a/providers/vancine/models/glm-5.3-flash.toml
+++ b/providers/vancine/models/glm-5.3-flash.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-08-26):
+# https://docs.bigmodel.cn/cn/guide/capabilities/thinking
+# https://docs.z.ai/guides/overview/pricing
+# Lab cost (no 50% promo): input 0.15 / output 0.50 / cache_read 0.03.
+# Vancine public pricing (/api/pricing) is 0.06 / 0.20 / 0.012 (USD/MTok).
+# Thinking is always enabled, so no toggle.
+base_model = "zhipuai/glm-5.3-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.06
+output = 0.20
+cache_read = 0.012

--- a/providers/vancine/models/glm-5.3.toml
+++ b/providers/vancine/models/glm-5.3.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-08-26):
+# https://docs.bigmodel.cn/cn/guide/capabilities/thinking
+# https://docs.z.ai/guides/overview/pricing
+# Lab cost: input 1.40 / output 4.40 / cache_read 0.26 (USD/MTok).
+# Vancine public pricing (/api/pricing) is 1.12 / 3.52 / 0.208 (USD/MTok).
+# Per the audit-reasoning-options skill, the lab effort list is
+# "low" | "high" | "max"; thinking cannot be disabled, so no toggle.
+base_model = "zhipuai/glm-5.3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 1.12
+output = 3.52
+cache_read = 0.208

--- a/providers/vancine/models/kimi-k3.toml
+++ b/providers/vancine/models/kimi-k3.toml
@@ -1,0 +1,24 @@
+# Sources (accessed 2026-07-17):
+# https://platform.kimi.ai/docs/pricing/chat-k3
+# https://platform.moonshot.ai/docs/api/chat
+# Lab reasoning controls: thinking.type = "enabled" | "disabled" | "adaptive";
+# in adaptive mode the depth is set by output_config.effort = "low"|"high"|"max".
+# Interleaved field: reasoning_content.
+# Lab cost: input 3.00 / output 15.00 / cache_read 0.30 (USD/MTok).
+# Vancine public pricing (/api/pricing) is 2.40 / 12.00 / 0.24 (USD/MTok).
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.40
+output = 12.00
+cache_read = 0.24

--- a/providers/vancine/models/qwen3.8-flash.toml
+++ b/providers/vancine/models/qwen3.8-flash.toml
@@ -1,0 +1,25 @@
+# Sources (accessed 2026-08-27):
+# https://www.qwencloud.com/models/qwen3.8-flash
+# https://docs.qwencloud.com/developer-guides/text-generation/thinking
+# Lab reasoning controls: enable_thinking true|false (toggle);
+# thinking_budget up to 262144. reasoning_effort is NOT exposed for flash
+# (qwencloud docs document it for qwen3.8-max / qwen3.8-max-preview only).
+# Interleaved field: reasoning_content.
+# Lab cost: input 0.15 / output 0.47 / cache_read 0.016 / cache_write 0.20.
+# Vancine public pricing (/api/pricing) is 0.12 / 0.38 / 0.013 / n/a (USD/MTok).
+base_model = "alibaba/qwen3.8-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262_144
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.12
+output = 0.38
+cache_read = 0.013

--- a/providers/vancine/models/qwen3.8-max.toml
+++ b/providers/vancine/models/qwen3.8-max.toml
@@ -1,0 +1,31 @@
+# Sources (accessed 2026-08-04):
+# https://www.qwencloud.com/models/qwen3.8-max
+# https://docs.qwencloud.com/developer-guides/text-generation/thinking
+# https://help.aliyun.com/zh/model-studio/model-pricing
+# Lab reasoning controls: enable_thinking true|false (toggle);
+# reasoning_effort = low|medium|xhigh (default xhigh; high is alias for xhigh);
+# thinking_budget 0..262144 (cannot be combined with reasoning_effort).
+# Interleaved field: reasoning_content.
+# Lab cost: input 2.00 / output 6.00 / cache_read 0.25 / cache_write 2.50.
+# Vancine public pricing (/api/pricing) is 1.60 / 4.80 / 0.20 / n/a (USD/MTok).
+base_model = "alibaba/qwen3.8-max"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 262_144
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.60
+output = 4.80
+cache_read = 0.20

--- a/providers/vancine/provider.toml
+++ b/providers/vancine/provider.toml
@@ -1,0 +1,5 @@
+name = "Vancine"
+npm = "@ai-sdk/openai-compatible"
+env = ["VANCINE_API_KEY"]
+api = "https://vancine.com/v1"
+doc = "https://vancine.com/docs"


### PR DESCRIPTION
## feat(provider): add Vancine OpenAI-compatible provider

> **AI-assisted contribution notice:** This contribution was AI-assisted. The author `fx247562340` is not among the repository's historical core developers (per `git shortlog -sn --all`: Aiden Cline, opencode-agent[bot], Frank, github-actions[bot], Jack, dpuyosa, …). All provider data, base-model selection, reasoning-option evidence, and pricing were derived from the public Vancine `/api/pricing` endpoint and from public upstream lab documentation; no paid Vancine API calls were made.

### Host classification

Vancine is a **multi-model relay / gateway** (China-model aggregation), not a first-party lab. It uses `npm = "@ai-sdk/openai-compatible"` and the OpenAI Chat Completions wire format. Per the upstream `audit-reasoning-options` skill, options for each model were taken from the underlying lab's first-party entry plus same-surface peer consensus.

### Endpoint and authentication

- API: `https://vancine.com/v1`
- Docs: `https://vancine.com/docs`
- Environment variable: `VANCINE_API_KEY`
- npm SDK: `@ai-sdk/openai-compatible`

### Models in this PR (8)

This PR ships **only 8 flagship models**. No media models, no sync module, no additional dependencies.

| Model | `base_model` | input | output | cache_read | reasoning_options |
|---|---|---:|---:|---:|---|
| `glm-5.3` | `zhipuai/glm-5.3` | 1.12 | 3.52 | 0.208 | `effort [low, high, max]` |
| `glm-5.3-flash` | `zhipuai/glm-5.3-flash` | 0.06 | 0.20 | 0.012 | `effort [low, high, max]` |
| `qwen3.8-max` | `alibaba/qwen3.8-max` | 1.60 | 4.80 | 0.20 | `toggle` + `effort [low, medium, xhigh]` + `budget_tokens [0..262144]` |
| `qwen3.8-flash` | `alibaba/qwen3.8-flash` | 0.12 | 0.38 | 0.013 | `toggle` + `budget_tokens [max 262144]` |
| `kimi-k3` | `moonshotai/kimi-k3` | 2.40 | 12.00 | 0.24 | `toggle` + `effort [low, high, max]` |
| `MiniMax-M3` | `minimax/MiniMax-M3` | 0.24 | 0.96 | 0.048 | `toggle` |
| `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` | 0.22 | 0.66 | 0.007 | `toggle` + `effort [low, high, max]` |
| `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` | 0.66 | 1.98 | 0.022 | `toggle` + `effort [high, max]` |

All costs are **USD per million tokens**. All model IDs match the public Vancine API exactly (including the mixed-case `MiniMax-M3`).

### `reasoning_options` evidence summary

- **glm-5.3 / glm-5.3-flash**: zhipuai first-party (`providers/zhipuai/models/glm-5.3.toml` and `glm-5.3-flash.toml`) — both are always-on, effort `low/high/max` with default `max`. Cross-checked against openrouter, kilo, vercel, opencode-go peers — all use the same `effort [low, high, max]`.
- **qwen3.8-max**: alibaba first-party `providers/alibaba/provider.toml` (toggle `enable_thinking`, effort `low/medium/xhigh`, budget `0..262144`); corroborated by `providers/alibaba-token-plan/models/qwen3.8-max.toml`. openrouter uses an extended `minimal/low/medium/high/xhigh` set; we follow the first-party list.
- **qwen3.8-flash**: alibaba first-party docs explicitly state `reasoning_effort` is exposed only for `qwen3.8-max` and `qwen3.8-max-preview` — **not** for flash. Consensus peers (`alibaba-token-plan`, `vercel`) expose only `toggle` + `budget_tokens`; we follow that. We do **not** copy `qwen3.8-max`'s effort list.
- **kimi-k3**: moonshotai first-party `providers/moonshotai/provider.toml` documents `thinking.type = enabled|disabled|adaptive`; in adaptive mode `output_config.effort = low|high|max`. Consensus: openrouter, kilo, kenari all use `toggle + effort [low, high, max]`.
- **MiniMax-M3**: minimax first-party uses `@ai-sdk/anthropic`, which does not apply to the Vancine openai-compatible path. The Vancine source passes the raw `thinking` and `reasoning_split` fields through the generic OpenAI DTO (`relaykit/dto/openai_request.go:100` and `:108`). OpenAI-compatible peer consensus (openrouter, vercel, gmicloud, opencode-go) is `toggle` only.
- **deepseek-v4-flash / deepseek-v4-pro**: deepseek first-party `providers/deepseek/models/deepseek-v4-flash.toml` and `deepseek-v4-pro.toml` document `thinking.type = enabled|disabled` plus `reasoning_effort` (`low|high|max` for flash, `high|max` for pro). Vancine's `relay/channel/deepseek/constants.go` exposes the `-none` and `-max` effort suffixes and the adaptor expands them into the same `thinking.type` / `reasoning_effort` fields, confirming Vancine honors this surface.

### Logo

`providers/vancine/logo.svg` is a monochrome single-color SVG:

- square `viewBox="0 0 24 24"`
- uses `currentColor` (stroke)
- no fixed `width=` / `height=` attributes
- no `<image>`, no `data:` URI, no `base64`, no external `href`
- XML well-formed (parsed with Python ElementTree)
- depicts the Vancine ring + inscribed infinity mark from the public `logo.png`

### Validation

- `bun validate` — exit 0. Vancine provider parses; all 8 model TOML files pass the strict schema; all `reasoning_options` arrays deserialize and merge correctly. No unknown-key errors.
- `git diff --check` — exit 0. No whitespace issues.
- `package.json` and `bun.lock` — unchanged.

### Test results

- `bun test` — exit 1. **253 pass / 4 fail / 624 expect() calls, 12 files.** The 4 failures are **pre-existing on the same upstream HEAD `a5361abe7` without this PR** and have **no relation to the Vancine provider**:

  1. `catalog generation > repository open-weight model metadata includes weights links` — checks that lab entries with `open_weights = true` declare a `[[weights]]` link. Unrelated to providers.
  2. `DeepInfra preserves live modalities for new base models` — DeepInfra sync behavior. Unrelated to providers.
  3. `snapshot exports providers, models, generatedAt, and a default catalog` — `packages/sdk/test/snapshot.test.ts`. The error is `Cannot find module '../src/snapshot.js'`; the file `packages/sdk/src/snapshot.js` is missing from the repository. Pre-existing repo state.
  4. `snapshot entrypoint is self-contained` — `packages/sdk/test/import-boundaries.test.ts`. Same missing `packages/sdk/src/snapshot.js` module. Pre-existing.

  The Vancine provider contributes **zero** test changes. All schema and validation checks for Vancine pass.

### Out of scope

- No models outside the 8 above (no media, no embedding, no other labs).
- No 0731/0813/0423/latest/vision-exp aliases. Vancine API exposes the undated IDs only.
- No sync script, no cron, no extra dependencies, no unrelated refactor.
- No marketing copy or competitor comparison.

### Local safeguards (already executed before opening this PR)

- Vancine production environment was not modified.
- No paid Vancine API call was made; the public `/api/pricing` endpoint was read once.
- No other Models.dev files were modified. The commit is exactly the 10 files listed above.
- `package.json` and `bun.lock` are byte-identical to upstream HEAD.

