### PR TITLE
fix(runinfra): correct a 2.4T claim about what the caller actually reads

### DIFF
--- a/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
+++ b/providers/runinfra/models/Inferact/Qwen3.8-2.4T-A95B-NVFP4.toml
@@ -8,11 +8,15 @@
 # It is not published as a separate rung because it is not a distinct behaviour, only the
 # OpenAI ladder's word for the maximum, and this serve's maximum is "xhigh". Callers that
 # send "high" are served rather than refused.
-# Reasoning cannot be turned off: reasoning_effort = "none" is rejected with HTTP 400
-# "Disabling thinking is not supported." That refusal is deliberate and is NOT folded, so a
-# caller asking to switch reasoning off learns the model has no off switch instead of being
-# silently charged the most expensive setting. enable_thinking / chat_template_kwargs /
-# thinking_budget are accepted but have no effect.
+# Reasoning cannot be turned off: reasoning_effort = "none" is rejected with HTTP 400, and the
+# refusal is deliberate rather than folded, so such a request is never silently served and
+# billed at the most expensive setting.
+# ONE CLAIM THAT SAT HERE WAS CORRECTED 2026-08-27 after re-measuring the buyer path. It used
+# to say the caller learns this model has no off switch. That is not what happens. The gateway
+# authors every rejection sentence a buyer reads and answers an unrecognised refusal with a
+# generic one, so a caller sending "none" learns the request was rejected and no more. The
+# reason is recorded because the claim was true when written and quietly stopped being true.
+# enable_thinking / chat_template_kwargs / thinking_budget are accepted but have no effect.
 # cache_read is the cached input price. JSON mode went live on this host 2026-08-17,
 # verified on the public path: 3 of 3 json_object responses parsed and 3 of 3 strict
 # json_schema responses validated, at 0.35x baseline latency, so structured_output now


### PR DESCRIPTION
The entry said a caller sending `reasoning_effort = "none"` learns this model has no off switch. Re-measured on the buyer path 2026-08-27 and 2026-08-28: they do not.

Our gateway authors every rejection sentence a buyer reads and answers an unrecognised upstream refusal with a generic one. The serving stack's own sentence for this case is deliberately not forwarded, so the caller learns the request was rejected and nothing more. The claim was accurate when written and stopped being accurate when the gateway replaced upstream text forwarding, which is the kind of quiet drift worth recording in the comment rather than silently overwriting.

What is still true is unchanged and restated: `"none"` is refused with HTTP 400 rather than folded, so the request is never silently served and billed at the most expensive setting. No published field changes; `reasoning_options` still lists `["low", "medium", "xhigh"]`, which remains a correct subset of the accepted set.

`bun validate` exits 0 on a clean Linux clone of this branch.