### PR TITLE
add corvex provider (GLM 5.2 FP8, Kimi K2.7 Code)

### DIFF
--- a/providers/corvex/logo.svg
+++ b/providers/corvex/logo.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 37 22" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Corvex">
+  <path d="M31.4547 4.21955H36.9025L18.4636 21.8203L0 4.21955H5.44779L18.4636 16.6229L31.4547 4.21955Z" fill="currentColor"/>
+  <path d="M18.4999 9.62114L28.5125 0H8.4873L18.4999 9.62114Z" fill="currentColor"/>
+</svg>

--- a/providers/corvex/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/corvex/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,0 +1,24 @@
+# Serving facts (verified live 2026-08-25): 262,144-token context, image input
+# supported, no video. Reasoning HTTP control: `reasoning_effort` accepts
+# none/minimal/low/medium/high/xhigh/max and "none" disables reasoning
+# (`chat_template_kwargs.enable_thinking` is ignored by this model). Free GA
+# launch: cost 0.
+# Sources:
+# https://docs.corvex.cloud/models/moonshotai/Kimi-K2.7-Code
+# https://docs.corvex.cloud/integrations/opencode
+base_model = "moonshotai/kimi-k2.7-code"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0
+output = 0
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/corvex/models/zai-org/GLM-5.2-FP8.toml
+++ b/providers/corvex/models/zai-org/GLM-5.2-FP8.toml
@@ -1,0 +1,28 @@
+# Serving facts (verified live 2026-08-25): FP8 checkpoint, 393,216-token
+# context, text-only (image inputs are rejected with HTTP 400). Reasoning HTTP
+# controls: `chat_template_kwargs.enable_thinking = false` disables reasoning;
+# `reasoning_effort` accepts none/minimal/low/medium/high/xhigh/max and "none"
+# disables reasoning. Free GA launch: cost 0.
+# Sources:
+# https://docs.corvex.cloud/models/zai-org/GLM-5.2-FP8
+# https://docs.corvex.cloud/integrations/opencode
+base_model = "zhipuai/glm-5.2"
+name = "GLM 5.2 FP8"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 393_216
+output = 393_216

--- a/providers/corvex/models/zai-org/GLM-5.2-FP8.toml
+++ b/providers/corvex/models/zai-org/GLM-5.2-FP8.toml
@@ -1,8 +1,10 @@
 # Serving facts (verified live 2026-08-25): FP8 checkpoint, 393,216-token
-# context, text-only (image inputs are rejected with HTTP 400). Reasoning HTTP
-# controls: `chat_template_kwargs.enable_thinking = false` disables reasoning;
-# `reasoning_effort` accepts none/minimal/low/medium/high/xhigh/max and "none"
-# disables reasoning. Free GA launch: cost 0.
+# context, text-only (image inputs are rejected with HTTP 400). Output limit
+# re-verified 2026-09-08: the live /v1/models catalog publishes
+# max_output_tokens = 393216 (no separate output cap below context). Reasoning
+# HTTP control: `reasoning_effort` accepts
+# none/minimal/low/medium/high/xhigh/max and "none" disables reasoning.
+# Free GA launch: cost 0.
 # Sources:
 # https://docs.corvex.cloud/models/zai-org/GLM-5.2-FP8
 # https://docs.corvex.cloud/integrations/opencode
@@ -11,9 +13,6 @@ name = "GLM 5.2 FP8"
 
 [interleaved]
 field = "reasoning_content"
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/corvex/provider.toml
+++ b/providers/corvex/provider.toml
@@ -1,0 +1,9 @@
+# Raw HTTP is POST `/v1/chat/completions` (OpenAI-compatible). Keys are minted
+# in the Token Factory dashboard.
+# https://docs.corvex.cloud/integrations/opencode
+# https://docs.corvex.cloud/getting-started/authentication
+name = "Corvex"
+env = ["CORVEX_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.tokenfactory.corvex.cloud/v1"
+doc = "https://docs.corvex.cloud/integrations/opencode"


### PR DESCRIPTION
Adds Corvex (OpenAI-compatible, api.tokenfactory.corvex.cloud/v1, env CORVEX_API_KEY). Two models via base_model inheritance (zhipuai/glm-5.2, moonshotai/kimi-k2.7-code); free-GA launch, cost 0. Reasoning controls verified against the live API and documented in the TOML comments. bun validate passes.