### PR TITLE
feat(sync): add Neuralwatt provider sync

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -84,6 +84,7 @@ jobs:
           LLMGATEWAY_API_KEY: ${{ secrets.LLMGATEWAY_API_KEY }}
           MERGE_GATEWAY_API_KEY: ${{ secrets.MERGE_GATEWAY_API_KEY }}
           KILO_API_KEY: ${{ secrets.KILO_API_KEY }}
+          NEURALWATT_API_KEY: ${{ secrets.NEURALWATT_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -26,6 +26,7 @@ import { kilo } from "./providers/kilo.js";
 import { llmgateway, llmgatewayProviders } from "./providers/llmgateway.js";
 import { mergeGateway } from "./providers/merge-gateway.js";
 import { nanoGpt } from "./providers/nano-gpt.js";
+import { neuralwatt } from "./providers/neuralwatt.js";
 import { openai } from "./providers/openai.js";
 import { ofox } from "./providers/ofox.js";
 import { openrouter } from "./providers/openrouter.js";
@@ -150,6 +151,7 @@ export const providers: {
   "llmgateway-providers": SyncProvider<any>;
   "merge-gateway": SyncProvider<any>;
   "nano-gpt": SyncProvider<any>;
+  neuralwatt: SyncProvider<any>;
   ofox: SyncProvider<any>;
   openai: SyncProvider<any>;
   openrouter: SyncProvider<any>;
@@ -184,6 +186,7 @@ export const providers: {
   "llmgateway-providers": llmgatewayProviders,
   "merge-gateway": mergeGateway,
   "nano-gpt": nanoGpt,
+  neuralwatt,
   ofox,
   openai,
   openrouter,
@@ -215,7 +218,7 @@ export const groups = {
     "vercel",
   ],
   cloudflare: ["cloudflare-ai-gateway", "cloudflare-workers-ai"],
-  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "github-copilot", "google", "hyper", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
+  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "github-copilot", "google", "hyper", "neuralwatt", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;

--- a/packages/core/src/sync/providers/neuralwatt.ts
+++ b/packages/core/src/sync/providers/neuralwatt.ts
@@ -1,9 +1,14 @@
 import path from "node:path";
 import { z } from "zod";
 
-import { describeModel } from "../../describe.js";
-import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
-import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
+import type {
+  ExistingModel,
+  SyncProvider,
+  SyncedBaseModel,
+  SyncedFullModel,
+  SyncedModel,
+} from "../index.js";
+import { factorBaseModel, modelMetadata, resolveModelMetadataBaseModel } from "./openrouter.js";
 
 const API_ENDPOINT = "https://api.neuralwatt.com/v1/models";
 
@@ -20,6 +25,11 @@ const REPO_SUFFIX = /-(nvfp4|fp8|awq|int4|\d{4})$/;
 // A rewrite drops interior comments, so document the budget control, which
 // the endpoint never describes, in the header the runner re-attaches.
 const BUDGET_HEADER = "# Budget: thinking_token_budget (integer reasoning tokens)\n";
+
+// thinking_token_budget is accepted on every model except these two, which
+// reject it with a 400. Serving tiers share their base model's behaviour.
+// https://portal.neuralwatt.com/docs/api/chat-completions
+const BUDGET_REJECTORS = new Set(["deepseek-v4-flash", "gemma-4-31b"]);
 
 // A canonical ID may carry an MoE active-parameter suffix the served ID drops.
 const MOE_SUFFIX = /^-a\d+b$/;
@@ -49,9 +59,11 @@ const Metadata = z.object({
     vision: z.boolean(),
     reasoning: z.boolean(),
   }).passthrough(),
+  // Optional: `capabilities.reasoning` is the authoritative flag, and a model
+  // with no reasoning at all has no reason to carry an effort ladder.
   reasoning: z.object({
     supported_efforts: z.array(z.string()),
-  }).passthrough(),
+  }).passthrough().optional(),
   limits: z.object({
     max_context_length: z.number().nullish(),
     max_output_tokens: z.number().nullish(),
@@ -77,6 +89,24 @@ export const neuralwatt = {
   modelsDir: "providers/neuralwatt/models",
   // Beta models are listed only for accounts granted access to each one.
   deleteMissing: false,
+  sourceID(model) {
+    return model.id;
+  },
+  skippedNotice(ids) {
+    if (ids.length === 0) return [];
+    return [
+      `${ids.length} Neuralwatt models were not created because no canonical \`models/\` entry resolved for them, or because the API published no usable price.`,
+      `Skipped remote IDs: ${ids.map((id) => `\`${id}\``).join(", ")}`,
+      "Add a `models/<lab>/<model>.toml` entry to include them in the next sync.",
+    ];
+  },
+  missingNotice(paths) {
+    if (paths.length === 0) return [];
+    return [
+      `${paths.length} local Neuralwatt models were absent from the live API and were retained; a run cannot tell a retired model from a beta this account was never granted.`,
+      `Retained local paths: ${paths.map((item) => `\`${item}\``).join(", ")}`,
+    ];
+  },
   async fetchModels() {
     const headers = process.env.NEURALWATT_API_KEY
       ? { Authorization: `Bearer ${process.env.NEURALWATT_API_KEY}` }
@@ -91,7 +121,20 @@ export const neuralwatt = {
     return NeuralwattResponse.parse(raw).data;
   },
   translateModel(model, context) {
-    const translated = buildNeuralwattModel(model, context.existing(model.id), context.authored(model.id));
+    const existing = context.existing(model.id);
+    const authored = context.authored(model.id);
+
+    // The endpoint supplies no description, dates or knowledge cutoff, so a
+    // new ID needs canonical metadata to inherit and a real price. Never
+    // author a standalone definition for a lab model from the API alone.
+    if (
+      existing === undefined
+      && (baseModelFor(model, authored) === undefined || buildCost(model, undefined) === undefined)
+    ) {
+      return undefined;
+    }
+
+    const translated = buildNeuralwattModel(model, existing, authored);
     return {
       id: model.id,
       model: translated,
@@ -106,10 +149,8 @@ export function buildNeuralwattModel(
   model: NeuralwattModel,
   existing: ExistingModel | undefined,
   authored: ExistingModel | undefined,
-  today = new Date().toISOString().slice(0, 10),
 ): SyncedModel {
-  const { capabilities, limits, pricing } = model.metadata;
-  const flex = model.id.endsWith("-flex");
+  const { capabilities, limits } = model.metadata;
 
   const context = limits.max_context_length ?? model.max_model_len ?? existing?.limit?.context ?? 0;
   const limit = {
@@ -119,20 +160,20 @@ export function buildNeuralwattModel(
     output: limits.max_output_tokens ?? existing?.limit?.output ?? context,
   };
 
-  const name = existing?.name ?? model.metadata.display_name;
   const modalities: { input: Modality[]; output: Modality[] } = {
     // Neuralwatt only advertises vision, never video or audio input.
     input: capabilities.vision ? ["text", "image"] : ["text"],
     output: ["text"],
   };
 
-  // Always factor onto canonical metadata; keep an authored pointer we cannot
-  // re-derive, such as a canonical ID carrying a suffix the served ID drops.
-  const baseModel = resolveBaseModel(model) ?? authored?.base_model;
+  const baseModel = baseModelFor(model, authored);
 
-  const values: Omit<SyncedFullModel, "description" | "release_date" | "last_updated"> = {
-    name,
+  const values: Partial<SyncedFullModel> = {
+    name: existing?.name ?? model.metadata.display_name,
+    description: existing?.description,
     family: existing?.family,
+    release_date: existing?.release_date,
+    last_updated: existing?.last_updated,
     attachment: capabilities.vision,
     reasoning: capabilities.reasoning,
     reasoning_options: capabilities.reasoning ? reasoningOptions(model, authored) : undefined,
@@ -150,42 +191,49 @@ export function buildNeuralwattModel(
         : existing?.status,
     // Reasoning traces always come back on a `reasoning` field, provider-wide.
     interleaved: existing?.interleaved ?? (capabilities.reasoning || undefined),
-    cost: pricing.pricing_tbd === true ? existing?.cost : {
-      input: price(pricing.input_per_million, flex) ?? 0,
-      output: price(pricing.output_per_million, flex) ?? 0,
-      cache_read: price(pricing.cached_input_per_million, flex),
-    },
+    cost: buildCost(model, existing),
     limit,
     modalities,
   };
 
-  // A factored model inherits the canonical blurb and dates; a standalone one
-  // needs its own, and every entry reports created = 0, so it gets the run date.
   if (baseModel !== undefined) {
-    const overrides = {
-      ...values,
-      description: existing?.description,
-      release_date: existing?.release_date,
-      last_updated: existing?.last_updated,
-    };
-    return factorBaseModel(baseModel, overrides, limit, authored?.base_model_omit);
+    const factored = factorBaseModel(
+      baseModel,
+      values,
+      limit,
+      authored?.base_model_omit,
+    ) as SyncedBaseModel;
+    return capabilities.reasoning ? factored : omitInheritedReasoningOptions(factored, baseModel);
   }
 
-  return {
-    ...values,
-    release_date: existing?.release_date ?? today,
-    last_updated: existing?.last_updated ?? today,
-    description: existing?.description ?? describeModel({
-      id: model.id,
-      name,
-      reasoning: capabilities.reasoning,
-      tool_call: capabilities.tools,
-      structured_output: capabilities.json_mode,
-      open_weights: true,
-      limit,
-      modalities,
-    }),
-  };
+  // Only a model that already has a local TOML reaches this branch: creates
+  // are skipped without canonical metadata, so nothing here is invented.
+  const required = z.object({
+    name: z.string(),
+    description: z.string(),
+    release_date: z.string(),
+    last_updated: z.string(),
+    cost: z.object({ input: z.number(), output: z.number() }),
+  }).safeParse(values);
+  if (!required.success) {
+    throw new Error(`Neuralwatt model ${model.id} has incomplete local metadata required for sync`);
+  }
+  return values as SyncedFullModel;
+}
+
+// Always factor onto canonical metadata; fall back to an authored pointer we
+// cannot re-derive, such as a canonical ID with a suffix the served ID drops.
+function baseModelFor(model: NeuralwattModel, authored: ExistingModel | undefined) {
+  return resolveBaseModel(model) ?? authored?.base_model;
+}
+
+// The catalog rejects reasoning_options on a non-reasoning model, so a fast
+// variant has to drop the options its canonical entry declares.
+function omitInheritedReasoningOptions(factored: SyncedBaseModel, baseModel: string) {
+  if (modelMetadata(baseModel).reasoning_options === undefined) return factored;
+  const omit = factored.base_model_omit ?? [];
+  if (omit.includes("reasoning_options")) return factored;
+  return { ...factored, base_model_omit: [...omit, "reasoning_options"] };
 }
 
 // Match on the bare slug. The Hugging Face org is no help: repacks are served
@@ -221,15 +269,53 @@ function strip(value: string, suffix: RegExp) {
   return result;
 }
 
-// The API knows the effort ladder; budget controls stay hand-authored.
+// The API knows the effort ladder but never describes thinking_token_budget,
+// so the budget control comes from the provider docs and authored min/max is
+// carried over.
 function reasoningOptions(
   model: NeuralwattModel,
   authored: ExistingModel | undefined,
 ): SyncedFullModel["reasoning_options"] {
-  const values = model.metadata.reasoning.supported_efforts
+  const authoredOptions = authored?.reasoning_options ?? [];
+  const efforts = model.metadata.reasoning?.supported_efforts;
+  const values = (efforts ?? [])
     .filter((effort): effort is Effort => EFFORT_VALUES.includes(effort as Effort));
-  const others = authored?.reasoning_options?.filter((option) => option.type !== "effort") ?? [];
-  return values.length > 0 ? [{ type: "effort", values }, ...others] : others;
+  const options: NonNullable<SyncedFullModel["reasoning_options"]> = authoredOptions
+    .filter((option) => option.type !== "effort");
+
+  if (values.length > 0) {
+    options.unshift({ type: "effort", values });
+  } else if (efforts === undefined) {
+    // No reasoning block at all is silence, not "this model has no effort
+    // levels", so an authored ladder is kept rather than deleted.
+    const authoredEffort = authoredOptions.find((option) => option.type === "effort");
+    if (authoredEffort !== undefined) options.unshift(authoredEffort);
+  }
+
+  if (
+    !BUDGET_REJECTORS.has(strip(model.id, TIER_SUFFIX))
+    && !options.some((option) => option.type === "budget_tokens")
+  ) {
+    options.push({ type: "budget_tokens" });
+  }
+  return options;
+}
+
+// The API is authoritative for pricing, but a partial payload must never be
+// published as free: keep the authored cost until real numbers come back.
+function buildCost(
+  model: NeuralwattModel,
+  existing: ExistingModel | undefined,
+): SyncedFullModel["cost"] | undefined {
+  const { pricing } = model.metadata;
+  const flex = model.id.endsWith("-flex");
+  const input = price(pricing.input_per_million, flex);
+  const output = price(pricing.output_per_million, flex);
+
+  if (pricing.pricing_tbd === true || input === undefined || output === undefined) {
+    return existing?.cost;
+  }
+  return { input, output, cache_read: price(pricing.cached_input_per_million, flex) };
 }
 
 // toPrecision drops the float error in products like 4.5 * 0.65.

--- a/packages/core/src/sync/providers/neuralwatt.ts
+++ b/packages/core/src/sync/providers/neuralwatt.ts
@@ -1,0 +1,229 @@
+import path from "node:path";
+import { z } from "zod";
+
+import { describeModel } from "../../describe.js";
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://api.neuralwatt.com/v1/models";
+
+// Flex is billed at 65% of standard, but /v1/models quotes the standard rate
+// for -flex IDs. https://portal.neuralwatt.com/docs/guides/flex-tier
+const FLEX_MULTIPLIER = 0.65;
+
+// Serving tiers Neuralwatt layers onto a base checkpoint.
+const TIER_SUFFIX = /-(fast|flex|short)$/;
+
+// Quantization and checkpoint-date suffixes on Hugging Face repo names.
+const REPO_SUFFIX = /-(nvfp4|fp8|awq|int4|\d{4})$/;
+
+// A rewrite drops interior comments, so document the budget control, which
+// the endpoint never describes, in the header the runner re-attaches.
+const BUDGET_HEADER = "# Budget: thinking_token_budget (integer reasoning tokens)\n";
+
+// A canonical ID may carry an MoE active-parameter suffix the served ID drops.
+const MOE_SUFFIX = /^-a\d+b$/;
+
+const MODELS_DIR = path.join(import.meta.dirname, "..", "..", "..", "..", "..", "models");
+
+// Catalog effort levels; formatToml orders them weakest to strongest.
+const EFFORT_VALUES = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+type Effort = (typeof EFFORT_VALUES)[number];
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+const Metadata = z.object({
+  display_name: z.string(),
+  description: z.string(),
+  huggingface_id: z.string().nullish(),
+  pricing: z.object({
+    input_per_million: z.number().nullish(),
+    output_per_million: z.number().nullish(),
+    cached_input_per_million: z.number().nullish(),
+    pricing_tbd: z.boolean().optional(),
+  }).passthrough(),
+  capabilities: z.object({
+    tools: z.boolean(),
+    json_mode: z.boolean(),
+    vision: z.boolean(),
+    reasoning: z.boolean(),
+  }).passthrough(),
+  reasoning: z.object({
+    supported_efforts: z.array(z.string()),
+  }).passthrough(),
+  limits: z.object({
+    max_context_length: z.number().nullish(),
+    max_output_tokens: z.number().nullish(),
+  }).passthrough(),
+  deprecated: z.boolean().optional(),
+}).passthrough();
+
+export const NeuralwattModel = z.object({
+  id: z.string(),
+  max_model_len: z.number().optional(),
+  metadata: Metadata,
+}).passthrough();
+
+export const NeuralwattResponse = z.object({
+  data: z.array(NeuralwattModel),
+}).passthrough();
+
+export type NeuralwattModel = z.infer<typeof NeuralwattModel>;
+
+export const neuralwatt = {
+  id: "neuralwatt",
+  name: "Neuralwatt",
+  modelsDir: "providers/neuralwatt/models",
+  // Beta models are listed only for accounts granted access to each one.
+  deleteMissing: false,
+  async fetchModels() {
+    const headers = process.env.NEURALWATT_API_KEY
+      ? { Authorization: `Bearer ${process.env.NEURALWATT_API_KEY}` }
+      : undefined;
+    const response = await fetch(API_ENDPOINT, { headers });
+    if (!response.ok) {
+      throw new Error(`Neuralwatt request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return NeuralwattResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    const translated = buildNeuralwattModel(model, context.existing(model.id), context.authored(model.id));
+    return {
+      id: model.id,
+      model: translated,
+      header: translated.reasoning_options?.some((option) => option.type === "budget_tokens")
+        ? BUDGET_HEADER
+        : undefined,
+    };
+  },
+} satisfies SyncProvider<NeuralwattModel>;
+
+export function buildNeuralwattModel(
+  model: NeuralwattModel,
+  existing: ExistingModel | undefined,
+  authored: ExistingModel | undefined,
+  today = new Date().toISOString().slice(0, 10),
+): SyncedModel {
+  const { capabilities, limits, pricing } = model.metadata;
+  const flex = model.id.endsWith("-flex");
+
+  const context = limits.max_context_length ?? model.max_model_len ?? existing?.limit?.context ?? 0;
+  const limit = {
+    context,
+    input: existing?.limit?.input,
+    // The API reports no output cap for models that can fill the context.
+    output: limits.max_output_tokens ?? existing?.limit?.output ?? context,
+  };
+
+  const name = existing?.name ?? model.metadata.display_name;
+  const modalities: { input: Modality[]; output: Modality[] } = {
+    // Neuralwatt only advertises vision, never video or audio input.
+    input: capabilities.vision ? ["text", "image"] : ["text"],
+    output: ["text"],
+  };
+
+  // Always factor onto canonical metadata; keep an authored pointer we cannot
+  // re-derive, such as a canonical ID carrying a suffix the served ID drops.
+  const baseModel = resolveBaseModel(model) ?? authored?.base_model;
+
+  const values: Omit<SyncedFullModel, "description"> = {
+    name,
+    family: existing?.family,
+    // Every entry reports created = 0, so authored dates are the only source.
+    release_date: existing?.release_date ?? today,
+    last_updated: existing?.last_updated ?? today,
+    attachment: capabilities.vision,
+    reasoning: capabilities.reasoning,
+    reasoning_options: capabilities.reasoning ? reasoningOptions(model, authored) : undefined,
+    temperature: existing?.temperature,
+    tool_call: capabilities.tools,
+    structured_output: capabilities.json_mode,
+    knowledge: existing?.knowledge,
+    // Neuralwatt serves open models only; huggingface_id is often null anyway.
+    open_weights: existing?.open_weights ?? true,
+    status: model.metadata.deprecated === true ? "deprecated" : existing?.status,
+    // Reasoning traces always come back on a `reasoning` field, provider-wide.
+    interleaved: existing?.interleaved ?? (capabilities.reasoning || undefined),
+    cost: pricing.pricing_tbd === true ? existing?.cost : {
+      input: price(pricing.input_per_million, flex) ?? 0,
+      output: price(pricing.output_per_million, flex) ?? 0,
+      cache_read: price(pricing.cached_input_per_million, flex),
+    },
+    limit,
+    modalities,
+  };
+
+  // A factored model inherits the canonical blurb; a standalone one needs its own.
+  if (baseModel !== undefined) {
+    const overrides = { ...values, description: existing?.description };
+    return factorBaseModel(baseModel, overrides, limit, authored?.base_model_omit);
+  }
+
+  return {
+    ...values,
+    description: existing?.description ?? describeModel({
+      id: model.id,
+      name,
+      reasoning: capabilities.reasoning,
+      tool_call: capabilities.tools,
+      structured_output: capabilities.json_mode,
+      open_weights: true,
+      limit,
+      modalities,
+    }),
+  };
+}
+
+// Match on the bare slug. The Hugging Face org is no help: repacks are served
+// under the quantizer's namespace, not the lab's.
+function resolveBaseModel(model: NeuralwattModel): string | undefined {
+  const repo = model.metadata.huggingface_id?.split("/")[1];
+  const slugs = [strip(model.id, TIER_SUFFIX)];
+  if (repo !== undefined) slugs.push(strip(repo.toLowerCase(), REPO_SUFFIX));
+
+  for (const slug of slugs) {
+    const match = resolveModelMetadataBaseModel(slug) ?? resolveMoeBaseModel(slug);
+    if (match !== undefined) return match;
+  }
+  return undefined;
+}
+
+let canonicalIDs: string[] | undefined;
+
+function resolveMoeBaseModel(slug: string): string | undefined {
+  canonicalIDs ??= [...new Bun.Glob("**/*.toml").scanSync({ cwd: MODELS_DIR })]
+    .map((file) => file.slice(0, -5).split(path.sep).join("/"));
+
+  const matches = canonicalIDs.filter((id) => {
+    const name = id.split("/").at(-1) ?? "";
+    return name.startsWith(slug) && MOE_SUFFIX.test(name.slice(slug.length));
+  });
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function strip(value: string, suffix: RegExp) {
+  let result = value;
+  while (suffix.test(result)) result = result.replace(suffix, "");
+  return result;
+}
+
+// The API knows the effort ladder; budget controls stay hand-authored.
+function reasoningOptions(
+  model: NeuralwattModel,
+  authored: ExistingModel | undefined,
+): SyncedFullModel["reasoning_options"] {
+  const values = model.metadata.reasoning.supported_efforts
+    .filter((effort): effort is Effort => EFFORT_VALUES.includes(effort as Effort));
+  const others = authored?.reasoning_options?.filter((option) => option.type !== "effort") ?? [];
+  return values.length > 0 ? [{ type: "effort", values }, ...others] : others;
+}
+
+// toPrecision drops the float error in products like 4.5 * 0.65.
+function price(value: number | null | undefined, flex: boolean) {
+  if (value == null) return undefined;
+  return flex ? Number((value * FLEX_MULTIPLIER).toPrecision(12)) : value;
+}

--- a/packages/core/src/sync/providers/neuralwatt.ts
+++ b/packages/core/src/sync/providers/neuralwatt.ts
@@ -130,12 +130,9 @@ export function buildNeuralwattModel(
   // re-derive, such as a canonical ID carrying a suffix the served ID drops.
   const baseModel = resolveBaseModel(model) ?? authored?.base_model;
 
-  const values: Omit<SyncedFullModel, "description"> = {
+  const values: Omit<SyncedFullModel, "description" | "release_date" | "last_updated"> = {
     name,
     family: existing?.family,
-    // Every entry reports created = 0, so authored dates are the only source.
-    release_date: existing?.release_date ?? today,
-    last_updated: existing?.last_updated ?? today,
     attachment: capabilities.vision,
     reasoning: capabilities.reasoning,
     reasoning_options: capabilities.reasoning ? reasoningOptions(model, authored) : undefined,
@@ -145,7 +142,12 @@ export function buildNeuralwattModel(
     knowledge: existing?.knowledge,
     // Neuralwatt serves open models only; huggingface_id is often null anyway.
     open_weights: existing?.open_weights ?? true,
-    status: model.metadata.deprecated === true ? "deprecated" : existing?.status,
+    // A revived model clears the flag; hand-authored beta/alpha stays.
+    status: model.metadata.deprecated === true
+      ? "deprecated"
+      : existing?.status === "deprecated"
+        ? undefined
+        : existing?.status,
     // Reasoning traces always come back on a `reasoning` field, provider-wide.
     interleaved: existing?.interleaved ?? (capabilities.reasoning || undefined),
     cost: pricing.pricing_tbd === true ? existing?.cost : {
@@ -157,14 +159,22 @@ export function buildNeuralwattModel(
     modalities,
   };
 
-  // A factored model inherits the canonical blurb; a standalone one needs its own.
+  // A factored model inherits the canonical blurb and dates; a standalone one
+  // needs its own, and every entry reports created = 0, so it gets the run date.
   if (baseModel !== undefined) {
-    const overrides = { ...values, description: existing?.description };
+    const overrides = {
+      ...values,
+      description: existing?.description,
+      release_date: existing?.release_date,
+      last_updated: existing?.last_updated,
+    };
     return factorBaseModel(baseModel, overrides, limit, authored?.base_model_omit);
   }
 
   return {
     ...values,
+    release_date: existing?.release_date ?? today,
+    last_updated: existing?.last_updated ?? today,
     description: existing?.description ?? describeModel({
       id: model.id,
       name,

--- a/packages/core/test/neuralwatt.test.ts
+++ b/packages/core/test/neuralwatt.test.ts
@@ -76,8 +76,10 @@ test("factors onto canonical metadata once the serving tier is stripped", () => 
   const model = buildNeuralwattModel(sourceModel("kimi-k3-flex"), undefined, undefined, "2026-08-28");
 
   expect(model).toMatchObject({ base_model: "moonshotai/kimi-k3" });
-  // The canonical blurb is inherited rather than generated.
+  // The canonical blurb and dates are inherited rather than invented.
   expect(model.description).toBeUndefined();
+  expect(model.release_date).toBeUndefined();
+  expect(model.last_updated).toBeUndefined();
 });
 
 test("factors onto a canonical ID whose MoE suffix the served ID drops", () => {
@@ -128,4 +130,12 @@ test("marks deprecated models", () => {
   );
 
   expect(model.status).toBe("deprecated");
+});
+
+test("clears a deprecated status the API no longer reports", () => {
+  const model = buildNeuralwattModel(sourceModel("glm-5.2"), { status: "deprecated" }, undefined, "2026-08-28");
+  const beta = buildNeuralwattModel(sourceModel("glm-5.2"), { status: "beta" }, undefined, "2026-08-28");
+
+  expect(model.status).toBeUndefined();
+  expect(beta.status).toBe("beta");
 });

--- a/packages/core/test/neuralwatt.test.ts
+++ b/packages/core/test/neuralwatt.test.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "bun:test";
+
+import { AuthoredModel } from "../src/schema.js";
+import { buildNeuralwattModel, neuralwatt, type NeuralwattModel } from "../src/sync/providers/neuralwatt.js";
+
+function sourceModel(id: string, metadata: Record<string, unknown> = {}): NeuralwattModel {
+  return {
+    id,
+    max_model_len: 1_048_560,
+    metadata: {
+      display_name: "GLM 5.2",
+      description: "upstream blurb",
+      huggingface_id: null,
+      pricing: { input_per_million: 1.45, output_per_million: 4.5, cached_input_per_million: 0.145 },
+      capabilities: { tools: true, json_mode: false, vision: false, reasoning: true },
+      reasoning: { supported_efforts: ["max", "high", "none"] },
+      limits: { max_context_length: 1_048_560, max_output_tokens: null },
+      deprecated: false,
+      ...metadata,
+    },
+  };
+}
+
+test("applies the flex discount the API omits, without float noise", () => {
+  const model = buildNeuralwattModel(sourceModel("glm-5.2-flex"), undefined, undefined, "2026-08-28");
+
+  expect(model.cost).toEqual({ input: 0.9425, output: 2.925, cache_read: 0.09425 });
+});
+
+test("keeps standard pricing on standard model IDs", () => {
+  const model = buildNeuralwattModel(sourceModel("glm-5.2"), undefined, undefined, "2026-08-28");
+
+  expect(model.cost).toEqual({ input: 1.45, output: 4.5, cache_read: 0.145 });
+});
+
+test("syncs the effort ladder but keeps authored budget controls", () => {
+  const authored = { reasoning_options: [{ type: "budget_tokens" as const }] };
+
+  const model = buildNeuralwattModel(sourceModel("glm-5.2"), undefined, authored, "2026-08-28");
+
+  // formatToml sorts effort values, so the API's order is kept as-is.
+  expect(model.reasoning_options).toEqual([
+    { type: "effort", values: ["max", "high", "none"] },
+    { type: "budget_tokens" },
+  ]);
+});
+
+test("prefers authored catalog metadata over the API blurb and missing dates", () => {
+  const existing = {
+    description: "authored blurb",
+    release_date: "2026-06-17",
+    last_updated: "2026-06-17",
+    limit: { context: 1_048_560, output: 1_048_560 },
+  };
+
+  const model = buildNeuralwattModel(sourceModel("glm-5.2"), existing, undefined, "2026-08-28");
+
+  expect(model.description).toBe("authored blurb");
+  expect(model.release_date).toBe("2026-06-17");
+  // The API reports no output cap for models that can fill the context.
+  expect(model.limit?.output).toBe(1_048_560);
+});
+
+test("creates a complete model for an ID the catalog has never seen", () => {
+  const model = buildNeuralwattModel(sourceModel("glm-6"), undefined, undefined, "2026-08-28");
+
+  expect(AuthoredModel.safeParse({ id: "glm-6", ...model }).success).toBe(true);
+  expect(model.name).toBe("GLM 5.2");
+  expect(model.description).not.toBe("upstream blurb");
+  expect(model.open_weights).toBe(true);
+  expect(model.interleaved).toBe(true);
+  expect(model.release_date).toBe("2026-08-28");
+});
+
+test("factors onto canonical metadata once the serving tier is stripped", () => {
+  const model = buildNeuralwattModel(sourceModel("kimi-k3-flex"), undefined, undefined, "2026-08-28");
+
+  expect(model).toMatchObject({ base_model: "moonshotai/kimi-k3" });
+  // The canonical blurb is inherited rather than generated.
+  expect(model.description).toBeUndefined();
+});
+
+test("factors onto a canonical ID whose MoE suffix the served ID drops", () => {
+  const model = buildNeuralwattModel(sourceModel("qwen3.6-35b-fast"), undefined, undefined, "2026-08-28");
+
+  expect(model).toMatchObject({ base_model: "alibaba/qwen3.6-35b-a3b" });
+});
+
+test("prefers a resolved base over a stale authored pointer", () => {
+  const authored = { base_model: "moonshotai/kimi-k2.6" };
+
+  const model = buildNeuralwattModel(sourceModel("kimi-k3"), undefined, authored, "2026-08-28");
+
+  expect(model).toMatchObject({ base_model: "moonshotai/kimi-k3" });
+});
+
+test("documents the budget control in a header the runner re-attaches", () => {
+  const authored = { reasoning_options: [{ type: "budget_tokens" as const }] };
+  const context = { existing: () => undefined, authored: () => authored };
+
+  const budget = neuralwatt.translateModel(sourceModel("glm-5.2"), context);
+  const none = neuralwatt.translateModel(sourceModel("glm-5.2"), {
+    existing: () => undefined,
+    authored: () => undefined,
+  });
+
+  expect(budget?.header).toBe("# Budget: thinking_token_budget (integer reasoning tokens)\n");
+  expect(none?.header).toBeUndefined();
+});
+
+test("keeps the authored cost when upstream pricing is still tbd", () => {
+  const source = sourceModel("glm-5.2", {
+    pricing: { input_per_million: null, output_per_million: null, pricing_tbd: true },
+  });
+  const existing = { cost: { input: 1.45, output: 4.5 } };
+
+  const model = buildNeuralwattModel(source, existing, undefined, "2026-08-28");
+
+  expect(model.cost).toEqual({ input: 1.45, output: 4.5 });
+});
+
+test("marks deprecated models", () => {
+  const model = buildNeuralwattModel(
+    sourceModel("glm-5.2", { deprecated: true }),
+    undefined,
+    undefined,
+    "2026-08-28",
+  );
+
+  expect(model.status).toBe("deprecated");
+});

--- a/packages/core/test/neuralwatt.test.ts
+++ b/packages/core/test/neuralwatt.test.ts
@@ -21,26 +21,78 @@ function sourceModel(id: string, metadata: Record<string, unknown> = {}): Neural
   };
 }
 
+function context(existing?: Record<string, unknown>, authored = existing) {
+  return { existing: () => existing, authored: () => authored } as Parameters<
+    typeof neuralwatt.translateModel
+  >[1];
+}
+
 test("applies the flex discount the API omits, without float noise", () => {
-  const model = buildNeuralwattModel(sourceModel("glm-5.2-flex"), undefined, undefined, "2026-08-28");
+  const model = buildNeuralwattModel(sourceModel("glm-5.2-flex"), undefined, undefined);
 
   expect(model.cost).toEqual({ input: 0.9425, output: 2.925, cache_read: 0.09425 });
 });
 
 test("keeps standard pricing on standard model IDs", () => {
-  const model = buildNeuralwattModel(sourceModel("glm-5.2"), undefined, undefined, "2026-08-28");
+  const model = buildNeuralwattModel(sourceModel("glm-5.2"), undefined, undefined);
 
   expect(model.cost).toEqual({ input: 1.45, output: 4.5, cache_read: 0.145 });
 });
 
-test("syncs the effort ladder but keeps authored budget controls", () => {
-  const authored = { reasoning_options: [{ type: "budget_tokens" as const }] };
+test("syncs the effort ladder and keeps authored budget bounds", () => {
+  const authored = { reasoning_options: [{ type: "budget_tokens" as const, max: 32_000 }] };
 
-  const model = buildNeuralwattModel(sourceModel("glm-5.2"), undefined, authored, "2026-08-28");
+  const model = buildNeuralwattModel(sourceModel("glm-5.2"), undefined, authored);
 
   // formatToml sorts effort values, so the API's order is kept as-is.
   expect(model.reasoning_options).toEqual([
     { type: "effort", values: ["max", "high", "none"] },
+    { type: "budget_tokens", max: 32_000 },
+  ]);
+});
+
+test("declares the budget control the API never describes", () => {
+  const model = buildNeuralwattModel(sourceModel("glm-5.2"), undefined, undefined);
+
+  expect(model.reasoning_options).toEqual([
+    { type: "effort", values: ["max", "high", "none"] },
+    { type: "budget_tokens" },
+  ]);
+});
+
+test("omits the budget control on the models that reject it", () => {
+  const flash = buildNeuralwattModel(sourceModel("deepseek-v4-flash"), undefined, undefined);
+  const flex = buildNeuralwattModel(sourceModel("deepseek-v4-flash-flex"), undefined, undefined);
+  // Gemma only links to canonical metadata through its repacked repo name.
+  const gemma = buildNeuralwattModel(
+    sourceModel("gemma-4-31b", { huggingface_id: "nvidia/Gemma-4-31B-IT-NVFP4" }),
+    undefined,
+    undefined,
+  );
+
+  for (const model of [flash, flex, gemma]) {
+    expect(model.reasoning_options).toEqual([{ type: "effort", values: ["max", "high", "none"] }]);
+  }
+});
+
+test("gives a budget-only model its single control", () => {
+  const source = sourceModel("kimi-k2.7-code", { reasoning: { supported_efforts: [] } });
+
+  const model = buildNeuralwattModel(source, undefined, undefined);
+
+  expect(model.reasoning_options).toEqual([{ type: "budget_tokens" }]);
+});
+
+test("keeps the authored ladder when the API sends no reasoning block", () => {
+  const source = sourceModel("glm-5.2", { reasoning: undefined });
+  const authored = {
+    reasoning_options: [{ type: "effort" as const, values: ["none" as const, "high" as const] }],
+  };
+
+  const model = buildNeuralwattModel(source, undefined, authored);
+
+  expect(model.reasoning_options).toEqual([
+    { type: "effort", values: ["none", "high"] },
     { type: "budget_tokens" },
   ]);
 });
@@ -53,7 +105,7 @@ test("prefers authored catalog metadata over the API blurb and missing dates", (
     limit: { context: 1_048_560, output: 1_048_560 },
   };
 
-  const model = buildNeuralwattModel(sourceModel("glm-5.2"), existing, undefined, "2026-08-28");
+  const model = buildNeuralwattModel(sourceModel("glm-5.2"), existing, undefined);
 
   expect(model.description).toBe("authored blurb");
   expect(model.release_date).toBe("2026-06-17");
@@ -61,19 +113,28 @@ test("prefers authored catalog metadata over the API blurb and missing dates", (
   expect(model.limit?.output).toBe(1_048_560);
 });
 
-test("creates a complete model for an ID the catalog has never seen", () => {
-  const model = buildNeuralwattModel(sourceModel("glm-6"), undefined, undefined, "2026-08-28");
+test("skips an unknown ID rather than inventing a standalone definition", () => {
+  expect(neuralwatt.translateModel(sourceModel("glm-6"), context())).toBeUndefined();
+  expect(neuralwatt.sourceID(sourceModel("glm-6"))).toBe("glm-6");
+  expect(neuralwatt.skippedNotice(["glm-6"]).join(" ")).toContain("glm-6");
+});
 
-  expect(AuthoredModel.safeParse({ id: "glm-6", ...model }).success).toBe(true);
-  expect(model.name).toBe("GLM 5.2");
-  expect(model.description).not.toBe("upstream blurb");
-  expect(model.open_weights).toBe(true);
-  expect(model.interleaved).toBe(true);
-  expect(model.release_date).toBe("2026-08-28");
+test("keeps writing a pre-existing standalone definition", () => {
+  const existing = {
+    name: "GLM 5.2",
+    description: "authored blurb",
+    release_date: "2026-06-17",
+    last_updated: "2026-06-17",
+  };
+
+  const translated = neuralwatt.translateModel(sourceModel("glm-6"), context(existing));
+
+  expect(AuthoredModel.safeParse({ id: "glm-6", ...translated?.model }).success).toBe(true);
+  expect(translated?.model.release_date).toBe("2026-06-17");
 });
 
 test("factors onto canonical metadata once the serving tier is stripped", () => {
-  const model = buildNeuralwattModel(sourceModel("kimi-k3-flex"), undefined, undefined, "2026-08-28");
+  const model = buildNeuralwattModel(sourceModel("kimi-k3-flex"), undefined, undefined);
 
   expect(model).toMatchObject({ base_model: "moonshotai/kimi-k3" });
   // The canonical blurb and dates are inherited rather than invented.
@@ -83,7 +144,7 @@ test("factors onto canonical metadata once the serving tier is stripped", () => 
 });
 
 test("factors onto a canonical ID whose MoE suffix the served ID drops", () => {
-  const model = buildNeuralwattModel(sourceModel("qwen3.6-35b-fast"), undefined, undefined, "2026-08-28");
+  const model = buildNeuralwattModel(sourceModel("qwen3.6-35b-fast"), undefined, undefined);
 
   expect(model).toMatchObject({ base_model: "alibaba/qwen3.6-35b-a3b" });
 });
@@ -91,20 +152,28 @@ test("factors onto a canonical ID whose MoE suffix the served ID drops", () => {
 test("prefers a resolved base over a stale authored pointer", () => {
   const authored = { base_model: "moonshotai/kimi-k2.6" };
 
-  const model = buildNeuralwattModel(sourceModel("kimi-k3"), undefined, authored, "2026-08-28");
+  const model = buildNeuralwattModel(sourceModel("kimi-k3"), undefined, authored);
 
   expect(model).toMatchObject({ base_model: "moonshotai/kimi-k3" });
 });
 
-test("documents the budget control in a header the runner re-attaches", () => {
-  const authored = { reasoning_options: [{ type: "budget_tokens" as const }] };
-  const context = { existing: () => undefined, authored: () => authored };
-
-  const budget = neuralwatt.translateModel(sourceModel("glm-5.2"), context);
-  const none = neuralwatt.translateModel(sourceModel("glm-5.2"), {
-    existing: () => undefined,
-    authored: () => undefined,
+test("carries no reasoning options onto a non-reasoning variant", () => {
+  const source = sourceModel("kimi-k3-fast", {
+    capabilities: { tools: true, json_mode: true, vision: true, reasoning: false },
+    reasoning: { supported_efforts: ["none"] },
   });
+
+  const model = buildNeuralwattModel(source, undefined, undefined);
+
+  expect(model.reasoning).toBe(false);
+  expect(model.reasoning_options).toBeUndefined();
+  // No reasoning means no reasoning trace to interleave.
+  expect(model.interleaved).toBeUndefined();
+});
+
+test("documents the budget control in a header the runner re-attaches", () => {
+  const budget = neuralwatt.translateModel(sourceModel("glm-5.2"), context());
+  const none = neuralwatt.translateModel(sourceModel("deepseek-v4-flash"), context());
 
   expect(budget?.header).toBe("# Budget: thinking_token_budget (integer reasoning tokens)\n");
   expect(none?.header).toBeUndefined();
@@ -116,25 +185,31 @@ test("keeps the authored cost when upstream pricing is still tbd", () => {
   });
   const existing = { cost: { input: 1.45, output: 4.5 } };
 
-  const model = buildNeuralwattModel(source, existing, undefined, "2026-08-28");
+  const model = buildNeuralwattModel(source, existing, undefined);
 
   expect(model.cost).toEqual({ input: 1.45, output: 4.5 });
 });
 
+test("never publishes a free rate from a partial pricing payload", () => {
+  const source = sourceModel("glm-5.2", {
+    pricing: { input_per_million: 1.45, output_per_million: null },
+  });
+  const existing = { cost: { input: 1.45, output: 4.5 } };
+
+  expect(buildNeuralwattModel(source, existing, undefined).cost).toEqual({ input: 1.45, output: 4.5 });
+  // A new model with no usable price is skipped rather than priced at zero.
+  expect(neuralwatt.translateModel(source, context())).toBeUndefined();
+});
+
 test("marks deprecated models", () => {
-  const model = buildNeuralwattModel(
-    sourceModel("glm-5.2", { deprecated: true }),
-    undefined,
-    undefined,
-    "2026-08-28",
-  );
+  const model = buildNeuralwattModel(sourceModel("glm-5.2", { deprecated: true }), undefined, undefined);
 
   expect(model.status).toBe("deprecated");
 });
 
 test("clears a deprecated status the API no longer reports", () => {
-  const model = buildNeuralwattModel(sourceModel("glm-5.2"), { status: "deprecated" }, undefined, "2026-08-28");
-  const beta = buildNeuralwattModel(sourceModel("glm-5.2"), { status: "beta" }, undefined, "2026-08-28");
+  const model = buildNeuralwattModel(sourceModel("glm-5.2"), { status: "deprecated" }, undefined);
+  const beta = buildNeuralwattModel(sourceModel("glm-5.2"), { status: "beta" }, undefined);
 
   expect(model.status).toBeUndefined();
   expect(beta.status).toBe("beta");

--- a/sync.md
+++ b/sync.md
@@ -312,20 +312,22 @@ Neuralwatt is implemented in `packages/core/src/sync/providers/neuralwatt.ts`.
 - Source endpoint: `https://api.neuralwatt.com/v1/models`.
 - Optional auth: `NEURALWATT_API_KEY`. Without it the response is the public catalog. With it, the response is scoped to that account.
 - `status = "beta"` means not generally available. Beta models appear in the response for an account that requested access to a beta model from the portal models page.
-- `deleteMissing: false`, because we don't want to inadvertently delete a model when (for example) only its visibility changes.
+- `deleteMissing: false`, because we don't want to inadvertently delete a model when (for example) only its visibility changes. A run cannot tell a retired model from a beta this account was never granted, so absent models are retained and listed by `missingNotice`.
 - The `-flex` model IDs are billed at 0.65x standard, but the endpoint quotes the standard rate for them, so the sync applies the multiplier itself. Revisit `FLEX_MULTIPLIER` if the documented discount changes.
-- The API is authoritative for pricing, the context window, vision, tool calling, JSON mode, the reasoning flag, deprecation, and the `reasoning_effort` array. Its metadata blocks are required by the Zod schema, so an upstream change fails the sync.
+- The API is authoritative for pricing, the context window, vision, tool calling, JSON mode, the reasoning flag, deprecation, and the `reasoning_effort` array. `metadata.reasoning` is optional, because a model with no reasoning has no effort ladder to report; every other metadata block is required, so an upstream change there fails the sync.
 - `max_output_tokens` is null for models that can fill their context, so `limit.output` falls back to the authored cap and then to the context window. `limit.input` is always preserved.
-- `pricing_tbd` keeps the existing `[cost]` instead of writing a zero.
+- Prices are never coerced to zero. `pricing_tbd`, a null input price, or a null output price all keep the existing `[cost]`, and a model that has no local `[cost]` to keep is skipped instead of published as free.
 - Neuralwatt currently only advertises vision, not video or audio, so `modalities.input` is `["text", "image"]` or `["text"]`.
 - `created` is always `0`, and the endpoint carries no lifecycle or provenance metadata, so `release_date`, `last_updated`, `knowledge`, `family`, `temperature`, `open_weights`, names, and descriptions are preserved when a model already has them. `status` is preserved too, except that the API deprecation flag sets `status = "deprecated"` and clears it again once the flag goes away.
-- Non-effort reasoning controls are preserved from the authored TOML: the endpoint describes effort levels but never `thinking_token_budget`.
-- New models are created automatically, so a model is usable as soon as Neuralwatt serves it. Every model Neuralwatt serves is open weights, and reasoning traces always return on a `reasoning` field, so `interleaved` is automatically set when the model has a reasoning field.
+- `reasoning_options` combines three sources. The effort ladder comes from `metadata.reasoning.supported_efforts`; a `budget_tokens` control is added from the provider docs, which state `thinking_token_budget` is accepted on every model except `deepseek-v4-flash` and `gemma-4-31b`; authored `min`/`max` bounds on that control are carried over. A missing `metadata.reasoning` block is read as silence, not as "no effort levels", so an authored ladder is kept rather than deleted.
+- A non-reasoning model gets no `reasoning_options` at all. When its `base_model` declares them, the provider file adds `base_model_omit = ["reasoning_options"]`, because the catalog schema rejects options on a model with `reasoning = false`.
 - This provider tries to always use a `base_model` reference. It determines a reference by taking the slug and stripping serving tiers (`-fast`, `-flex`, `-short`, and combinations such as `-short-fast-flex`), and any quantization or checkpoint suffixes.
 - When no exact slug matches, the sync retries against a canonical ID carrying an MoE active-parameter suffix the slug might not have, which is how `qwen3.6-35b` links to `alibaba/qwen3.6-35b-a3b`. Both passes require a unique match, so an ambiguous slug resolves to nothing.
 - Together these resolve all current 20 models. An authored `base_model` is used only when resolution finds no match.
-- A factored model inherits `family`, the description, and the other intrinsic fields; only the served facts stay in the provider file. A model with no canonical match is written inline with a generated description and no `family`.
-- A created model has no `knowledge`, `temperature`, or `budget_tokens` control. Its dates are inherited from `base_model`, or default to the sync date when there is no `base_model`.
+- A factored model inherits `family`, the description, and the other intrinsic fields; only the served facts stay in the provider file.
+- New models are only created when they resolve a `base_model`. The endpoint supplies no description, dates, knowledge cutoff or temperature, so an unknown ID has nothing to author from and is reported through `skippedNotice` instead. Add a `models/<lab>/<model>.toml` entry and the next run picks it up. Models that already have a full inline TOML keep being updated in place.
+- A created model has no `knowledge` or `temperature`, and inherits its dates from `base_model`.
+- Every model Neuralwatt serves is open weights, and reasoning traces always return on a `reasoning` field, so `interleaved` is set for reasoning models.
 - Interior (i.e., not in the header/top of the TOML file) comments are not preserved. Keep per-model wire notes in the leading comment block, which the runner does preserve.
 - The sync emits a `thinking_token_budget` note as a generated header for any model carrying a `budget_tokens` control.
 

--- a/sync.md
+++ b/sync.md
@@ -304,6 +304,31 @@ Chutes is implemented in `packages/core/src/sync/providers/chutes.ts`.
 - `attachment` is derived from non-text `input_modalities`, and all models are `open_weights`.
 - `release_date`/`last_updated` default to the API `created` timestamp but preserve existing hand-authored dates; `knowledge`, `family`, `status`, `interleaved`, and `limit.input` are preserved when present.
 
+## Neuralwatt Notes
+
+Neuralwatt is implemented in `packages/core/src/sync/providers/neuralwatt.ts`.
+
+- Run it with `bun models:sync neuralwatt`; it is also in the `direct` group.
+- Source endpoint: `https://api.neuralwatt.com/v1/models`.
+- Optional auth: `NEURALWATT_API_KEY`. Without it the response is the public catalog. With it, the response is scoped to that account.
+- `status = "beta"` means not generally available. Beta models appear in the response for an account that requested access to a beta model from the portal models page.
+- `deleteMissing: false`, because we don't want to inadvertently delete a model when (for example) only its visibility changes.
+- The `-flex` model IDs are billed at 0.65x standard, but the endpoint quotes the standard rate for them, so the sync applies the multiplier itself. Revisit `FLEX_MULTIPLIER` if the documented discount changes.
+- The API is authoritative for pricing, the context window, vision, tool calling, JSON mode, the reasoning flag, deprecation, and the `reasoning_effort` array. Its metadata blocks are required by the Zod schema, so an upstream change fails the sync.
+- `max_output_tokens` is null for models that can fill their context, so `limit.output` falls back to the authored cap and then to the context window. `limit.input` is always preserved.
+- `pricing_tbd` keeps the existing `[cost]` instead of writing a zero.
+- Neuralwatt currently only advertises vision, not video or audio, so `modalities.input` is `["text", "image"]` or `["text"]`.
+- `created` is always `0`, and the endpoint carries no lifecycle or provenance metadata, so `release_date`, `last_updated`, `knowledge`, `family`, `temperature`, `open_weights`, names, and descriptions are preserved when a model already has them. So is `status`, unless the API reports the model as deprecated.
+- Non-effort reasoning controls are preserved from the authored TOML: the endpoint describes effort levels but never `thinking_token_budget`.
+- New models are created automatically, so a model is usable as soon as Neuralwatt serves it. Every model Neuralwatt serves is open weights, and reasoning traces always return on a `reasoning` field, so `interleaved` is automatically set when the model has a reasoning field.
+- This provider tries to always use a `base_model` reference. It determines a reference by taking the slug and stripping serving tiers (`-fast`, `-flex`, `-short`, and combinations such as `-short-fast-flex`), and any quantization or checkpoint suffixes.
+- When no exact slug matches, the sync retries against a canonical ID carrying an MoE active-parameter suffix the slug might not have, which is how `qwen3.6-35b` links to `alibaba/qwen3.6-35b-a3b`. Both passes require a unique match, so an ambiguous slug resolves to nothing.
+- Together these resolve all current 20 models. An authored `base_model` is never overriden by this auto-linking.
+- A factored model inherits `family`, the description, and the other intrinsic fields; only the served facts stay in the provider file. A model with no canonical match is written inline with a generated description and no `family`.
+- A created model has no `knowledge`, `temperature`, or `budget_tokens` control, and its dates default to the sync date.
+- Interior (i.e., not in the header/top of the TOML file) comments are not preserved. Keep per-model wire notes in the leading comment block, which the runner does preserve.
+- The sync emits a `thinking_token_budget` note as a generated header for any model carrying a `budget_tokens` control.
+
 ## Requesty Notes
 
 Requesty is implemented in `packages/core/src/sync/providers/requesty.ts`.

--- a/sync.md
+++ b/sync.md
@@ -318,14 +318,14 @@ Neuralwatt is implemented in `packages/core/src/sync/providers/neuralwatt.ts`.
 - `max_output_tokens` is null for models that can fill their context, so `limit.output` falls back to the authored cap and then to the context window. `limit.input` is always preserved.
 - `pricing_tbd` keeps the existing `[cost]` instead of writing a zero.
 - Neuralwatt currently only advertises vision, not video or audio, so `modalities.input` is `["text", "image"]` or `["text"]`.
-- `created` is always `0`, and the endpoint carries no lifecycle or provenance metadata, so `release_date`, `last_updated`, `knowledge`, `family`, `temperature`, `open_weights`, names, and descriptions are preserved when a model already has them. So is `status`, unless the API reports the model as deprecated.
+- `created` is always `0`, and the endpoint carries no lifecycle or provenance metadata, so `release_date`, `last_updated`, `knowledge`, `family`, `temperature`, `open_weights`, names, and descriptions are preserved when a model already has them. `status` is preserved too, except that the API deprecation flag sets `status = "deprecated"` and clears it again once the flag goes away.
 - Non-effort reasoning controls are preserved from the authored TOML: the endpoint describes effort levels but never `thinking_token_budget`.
 - New models are created automatically, so a model is usable as soon as Neuralwatt serves it. Every model Neuralwatt serves is open weights, and reasoning traces always return on a `reasoning` field, so `interleaved` is automatically set when the model has a reasoning field.
 - This provider tries to always use a `base_model` reference. It determines a reference by taking the slug and stripping serving tiers (`-fast`, `-flex`, `-short`, and combinations such as `-short-fast-flex`), and any quantization or checkpoint suffixes.
 - When no exact slug matches, the sync retries against a canonical ID carrying an MoE active-parameter suffix the slug might not have, which is how `qwen3.6-35b` links to `alibaba/qwen3.6-35b-a3b`. Both passes require a unique match, so an ambiguous slug resolves to nothing.
-- Together these resolve all current 20 models. An authored `base_model` is never overriden by this auto-linking.
+- Together these resolve all current 20 models. An authored `base_model` is used only when resolution finds no match.
 - A factored model inherits `family`, the description, and the other intrinsic fields; only the served facts stay in the provider file. A model with no canonical match is written inline with a generated description and no `family`.
-- A created model has no `knowledge`, `temperature`, or `budget_tokens` control, and its dates default to the sync date.
+- A created model has no `knowledge`, `temperature`, or `budget_tokens` control. Its dates are inherited from `base_model`, or default to the sync date when there is no `base_model`.
 - Interior (i.e., not in the header/top of the TOML file) comments are not preserved. Keep per-model wire notes in the leading comment block, which the runner does preserve.
 - The sync emits a `thinking_token_budget` note as a generated header for any model carrying a `budget_tokens` control.
 


### PR DESCRIPTION
Adds `packages/core/src/sync/providers/neuralwatt.ts` (+ tests), updates `sync.md` with a Neuralwatt section.

Neuralwatt publishes a rich /v1/models endpoint: per-model pricing, context and output limits, capabilities, a reasoning effort array, a deprecation flag, and a status indicator.

## Provider-specific handling:

- The -flex model IDs are billed at 0.65x standard, but the endpoint quotes the standard rate for them, so the sync applies the multiplier.
- Beta models are listed only for accounts granted access to each one, so deleteMissing is false: a run cannot tell a retired model from one the syncing account was never granted.
- NEURALWATT_API_KEY is optional.
- created is always 0 and the endpoint carries no lifecycle metadata, so dates, knowledge, family, temperature and authored prose are kept.
- Non-effort reasoning controls are preserved, because the endpoint describes effort levels but no thinking_token_budget. It is emitted as a generated file header.
- The provider sync always tries to associate a `base_model`, matching on the slug after stripping serving tiers from the served ID and any quantization or checkpoint suffix from the Hugging Face repo name, with a second pass for canonical IDs carrying an MoE active-parameter suffix.

Registers the provider with the sync runner and the direct group, adds the optional secret to the sync workflow, documents the behaviour in sync.md, and covers the flex multiplier, base model resolution, header generation and the preservation rules with tests.

Note that the first sync run will rewrite 16 of the 20 existing Neuralwatt TOMLs. All 20 end up referencing a base_model, fields equal to the base_model are dropped, and reasoning_options move to table format. The resolved catalog was verified byte-identical before and after, so the change is representational only.