### PR TITLE
Add Opper sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "requesty:sync": "bun ./packages/core/script/sync-models.ts requesty",
     "merge-gateway:sync": "bun ./packages/core/script/sync-models.ts merge-gateway",
     "nano-gpt:sync": "bun ./packages/core/script/sync-models.ts nano-gpt",
+    "opper:sync": "bun ./packages/core/script/sync-models.ts opper",
     "venice:sync": "bun ./packages/core/script/sync-models.ts venice",
     "tinfoil:sync": "bun ./packages/core/script/sync-models.ts tinfoil",
     "vercel:generate": "bun ./packages/core/script/sync-models.ts vercel",

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -28,6 +28,7 @@ import { nanoGpt } from "./providers/nano-gpt.js";
 import { openai } from "./providers/openai.js";
 import { ofox } from "./providers/ofox.js";
 import { openrouter } from "./providers/openrouter.js";
+import { opper } from "./providers/opper.js";
 import { ovhcloud } from "./providers/ovhcloud.js";
 import { pioneer } from "./providers/pioneer.js";
 import { requesty } from "./providers/requesty.js";
@@ -149,6 +150,7 @@ export const providers: {
   ofox: SyncProvider<any>;
   openai: SyncProvider<any>;
   openrouter: SyncProvider<any>;
+  opper: SyncProvider<any>;
   ovhcloud: SyncProvider<any>;
   pioneer: SyncProvider<any>;
   requesty: SyncProvider<any>;
@@ -182,6 +184,7 @@ export const providers: {
   ofox,
   openai,
   openrouter,
+  opper,
   ovhcloud,
   pioneer,
   requesty,
@@ -205,6 +208,7 @@ export const groups = {
     "merge-gateway",
     "nano-gpt",
     "ofox",
+    "opper",
     "requesty",
     "openrouter",
     "vercel",

--- a/packages/core/src/sync/providers/opper.ts
+++ b/packages/core/src/sync/providers/opper.ts
@@ -1,0 +1,414 @@
+import { z } from "zod";
+
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+import { factorBaseModel, modelMetadata, resolveModelMetadataBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = process.env.OPPER_MODELS_URL ?? "https://api.opper.ai/v3/models?limit=2000";
+
+/**
+ * Opper's `maker` field names the lab that built the model; models.dev files
+ * lab metadata under its own namespace. Only the spellings that differ need an
+ * entry — everything else already matches.
+ */
+const MAKER_NAMESPACE: Record<string, string> = {
+  arcee: "arcee-ai",
+  bytedance: "bytedance-seed",
+  moonshot: "moonshotai",
+  qwen: "alibaba",
+  zai: "zhipuai",
+};
+
+/** models.dev catalogs chat models; Opper's catalog also carries media, embedding and speech routes. */
+const CHAT_TYPE = "llm";
+
+/** The region a route shares with everything else, so it never disambiguates. */
+const UNQUALIFIED_REGION = "GLOBAL";
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+/**
+ * Display names, keyed by route ID and computed once per sync.
+ *
+ * Opper relays the same model from many hosts, so `name` alone is ambiguous for
+ * most of the catalog: fifteen separate routes are called "GLM-5.2". A picker
+ * showing fifteen identical rows is unusable, so a shared name is qualified by
+ * the host it runs on, and by region when one host serves it in several.
+ */
+const labels = new Map<string, string>();
+
+const OpperPricing = z
+  .object({
+    // Every priced Opper route quotes USD per million tokens as an array: one
+    // entry for a flat rate, one per band when `thresholds` is set.
+    billing_unit: z.string().optional(),
+    thresholds: z.array(z.number()).optional(),
+    input: z.array(z.number()).optional(),
+    output: z.array(z.number()).optional(),
+    cached_input: z.array(z.number()).optional(),
+    cache_creation: z.array(z.number()).optional(),
+    // Distinct from `thresholds`: once the input crosses this many tokens the
+    // WHOLE request reprices, rather than only the tokens past the boundary.
+    input_surcharge_threshold_tokens: z.number().optional(),
+    input_surcharge_multiplier: z.number().optional(),
+    output_surcharge_multiplier: z.number().optional(),
+  })
+  .passthrough();
+
+export const OpperModel = z
+  .object({
+    id: z.string().min(1),
+    type: z.string().min(1),
+    name: z.string().min(1),
+    /** The routing key shared by every provider's copy of this model. */
+    model: z.string().min(1),
+    maker: z.string().min(1),
+    /** The route's host: an Opper provider slug such as `tensorx` or `azure-zdr`. */
+    provider: z.string().min(1),
+    provider_display_name: z.string().optional(),
+    region: z.string().optional(),
+    capabilities: z.array(z.string()).default([]),
+    context_window: z.number().int().nonnegative().optional(),
+    max_output_tokens: z.number().int().nonnegative().optional(),
+    params: z
+      .object({
+        temperature: z.unknown().optional(),
+        reasoning: z
+          .object({ supported: z.array(z.string()).optional() })
+          .passthrough()
+          .nullish(),
+      })
+      .passthrough()
+      .optional(),
+    pricing: OpperPricing.optional(),
+  })
+  .passthrough();
+
+export const OpperResponse = z.object({ models: z.array(OpperModel) }).passthrough();
+
+export type OpperModel = z.infer<typeof OpperModel>;
+
+export const opper = {
+  id: "opper",
+  name: "Opper",
+  modelsDir: "providers/opper/models",
+  async fetchModels() {
+    // No auth: /v3/models is the public catalog, so this sync needs no secret.
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`Opper request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    const models = OpperResponse.parse(raw).models.filter((model) => model.type === CHAT_TYPE);
+    const seen = new Set<string>();
+    for (const model of models) {
+      if (seen.has(model.id)) throw new Error(`Duplicate Opper model ID: ${model.id}`);
+      seen.add(model.id);
+    }
+    assignLabels(models);
+    return models;
+  },
+  sourceID(model) {
+    return model.id;
+  },
+  skippedNotice(ids) {
+    if (ids.length === 0) return [];
+    return [
+      `Skipped ${ids.length} Opper route(s) with no matching \`models/\` entry to point \`base_model\` at: ${ids.join(", ")}`,
+    ];
+  },
+  translateModel(model, context) {
+    const existing = context.existing(model.id);
+    // An authored pointer wins: Opper's routing key names a dated snapshot for
+    // some routes (claude-haiku-4-5 routes to claude-haiku-4-5-20251001), and a
+    // sync should not repoint a base_model a human chose.
+    const baseModel = existing?.base_model ?? resolveOpperBaseModel(model);
+    if (baseModel === undefined || !usableLimit(model)) {
+      // Never delete a hand-authored file just because this resolver cannot
+      // reproduce it: preserve what is there and only decline to create new
+      // ones. A route that disappears from /v3/models entirely still gets
+      // removed by the runner, which is the deletion we do want.
+      const authored = context.authored(model.id);
+      return authored === undefined ? undefined : { id: model.id, model: authored as SyncedModel };
+    }
+    return { id: model.id, model: buildOpperModel(model, baseModel, existing) };
+  },
+} satisfies SyncProvider<OpperModel>;
+
+/**
+ * Opper IDs are `<provider>/<provider's own model id>` and carry no lab prefix,
+ * so the lab comes from the `maker` field and the model from the routing key
+ * rather than from the ID.
+ */
+export function resolveOpperBaseModel(model: OpperModel) {
+  const namespace = MAKER_NAMESPACE[model.maker] ?? model.maker;
+  return (
+    resolveModelMetadataBaseModel(`${namespace}/${model.model}`) ??
+    resolveModelMetadataBaseModel(model.model)
+  );
+}
+
+function usableLimit(model: OpperModel) {
+  return (model.context_window ?? 0) > 0;
+}
+
+/**
+ * Qualification ladder, least to most specific. The last rung is the route ID,
+ * which is unique by construction, so a label always exists.
+ */
+const LABEL_RUNGS: Array<(model: OpperModel) => string> = [
+  (model) => model.name,
+  (model) => qualify(model, model.provider_display_name),
+  (model) => qualify(model, host(model), region(model)),
+  (model) => qualify(model, model.provider),
+  (model) => qualify(model, model.id),
+];
+
+/**
+ * Give every route a label that is unique within the provider, adding only as
+ * much qualification as it takes: the bare name where nothing else claims it,
+ * then the host, then host and region, then the raw provider slug — Opper
+ * serves some models from two slugs that share a display name and region, one
+ * of them zero-data-retention.
+ */
+export function assignLabels(models: OpperModel[]) {
+  labels.clear();
+  for (const rung of LABEL_RUNGS) {
+    const counts = countBy(models, rung);
+    for (const model of models) {
+      if (labels.has(model.id)) continue;
+      const label = rung(model);
+      if (counts.get(label) === 1) labels.set(model.id, label);
+    }
+    if (labels.size === models.length) break;
+  }
+  return labels;
+}
+
+function qualify(model: OpperModel, ...parts: Array<string | undefined>) {
+  const qualifiers = parts.filter((part): part is string => part !== undefined && part !== "");
+  return qualifiers.length === 0 ? model.name : `${model.name} (${qualifiers.join(", ")})`;
+}
+
+function host(model: OpperModel) {
+  return model.provider_display_name;
+}
+
+/** A route with no region of its own needs no region in its label. */
+function region(model: OpperModel) {
+  const value = model.region?.toUpperCase();
+  return value === undefined || value === UNQUALIFIED_REGION ? undefined : value;
+}
+
+function countBy<T>(items: T[], key: (item: T) => string) {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const value = key(item);
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export function buildOpperModel(
+  model: OpperModel,
+  baseModel: string,
+  existing: ExistingModel | undefined,
+): SyncedModel {
+  const capabilities = new Set(model.capabilities);
+  // Opper relays the lab's weights, so what the model can do is the lab entry's
+  // claim to make. Opper's catalog records a capability once it has been
+  // verified for a route, which makes its absence silence rather than a denial —
+  // it declares PDF input on none of the OpenAI routes that demonstrably accept
+  // it. So capabilities here only ever widen the base, never narrow it.
+  const base = baseModalities(baseModel);
+  const input = union(base.input, inputModalities(capabilities));
+  const output = union(
+    base.output,
+    capabilities.has("image_generation") ? ["text", "image"] : ["text"],
+  );
+  const context = model.context_window ?? 0;
+  const limit = {
+    context,
+    // An unstated output cap is not a claim that the whole window can be
+    // generated, so an authored figure is preferred before falling back to it.
+    output: model.max_output_tokens
+      ? Math.min(model.max_output_tokens, context)
+      : existing?.limit?.output ?? context,
+  };
+  // `reasoning` and `thinking` are independent flags on an Opper route: some
+  // models emit reasoning tokens without exposing a thinking control and some
+  // do the reverse, so a reasoner is any route showing either, or an effort
+  // ladder under params.
+  const reasoning =
+    capabilities.has("reasoning") ||
+    capabilities.has("thinking") ||
+    (model.params?.reasoning ?? undefined) !== undefined;
+
+  return factorBaseModel(
+    baseModel,
+    {
+      name: labels.get(model.id) ?? model.name,
+      attachment: widen(input.some((modality) => modality !== "text")),
+      reasoning: widen(reasoning),
+      // Price, window and the effort ladder are what Opper serves rather than
+      // what the lab built, so these do override the base.
+      reasoning_options: reasoningOptions(model),
+      tool_call: widen(capabilities.has("tools")),
+      structured_output: widen(capabilities.has("structured_output")),
+      temperature: widen(model.params?.temperature !== undefined),
+      // Neither the interleaved-thinking wire field nor a lifecycle status is
+      // expressed in /v3/models, so an authored value is the only source.
+      interleaved: existing?.interleaved,
+      status: existing?.status,
+      cost: buildCost(model, existing),
+      limit,
+      modalities: { input, output },
+    },
+    limit,
+  );
+}
+
+/** `false` is indistinguishable from "not recorded yet", so only assert the positive. */
+function widen(supported: boolean): true | undefined {
+  return supported ? true : undefined;
+}
+
+function union(base: Modality[], ours: Modality[]): Modality[] {
+  return [...base, ...ours.filter((modality) => !base.includes(modality))];
+}
+
+/** The lab entry's own modalities, so an override can add to them but not subtract. */
+function baseModalities(baseModel: string): { input: Modality[]; output: Modality[] } {
+  try {
+    const metadata = modelMetadata(baseModel) as {
+      modalities?: { input?: Modality[]; output?: Modality[] };
+    };
+    return {
+      input: metadata.modalities?.input ?? [],
+      output: metadata.modalities?.output ?? [],
+    };
+  } catch {
+    return { input: [], output: [] };
+  }
+}
+
+function inputModalities(capabilities: Set<string>): Modality[] {
+  const input: Modality[] = ["text"];
+  if (capabilities.has("vision")) input.push("image");
+  if (capabilities.has("audio")) input.push("audio");
+  if (capabilities.has("video")) input.push("video");
+  if (capabilities.has("pdf")) input.push("pdf");
+  return input;
+}
+
+/**
+ * Opper passes `reasoning_effort` through to the upstream model unchanged, so
+ * the ladder is whatever that model accepts and there is no toggle or budget
+ * control on this surface.
+ *
+ * A route that states no ladder is stating nothing, not stating "no efforts" —
+ * several reasoners with a documented ladder upstream simply have no `params`
+ * entry yet. Leaving the field unset lets the runner keep an authored ladder,
+ * and stamp the empty set only on a genuinely new file.
+ */
+function reasoningOptions(model: OpperModel): SyncedFullModel["reasoning_options"] {
+  const supported = model.params?.reasoning?.supported;
+  if (supported === undefined || supported.length === 0) return undefined;
+  return [{ type: "effort", values: [...supported] as never }];
+}
+
+function buildCost(
+  model: OpperModel,
+  existing: ExistingModel | undefined,
+): SyncedFullModel["cost"] {
+  const pricing = model.pricing;
+  const input = pricing?.input?.[0];
+  const output = pricing?.output?.[0];
+  // A route quoting no price gets no [cost] section rather than a fabricated zero.
+  if (pricing === undefined || input === undefined || output === undefined) return undefined;
+
+  return {
+    input: round(input),
+    output: round(output),
+    cache_read: optionalPrice(pricing.cached_input?.[0]),
+    cache_write: optionalPrice(pricing.cache_creation?.[0]),
+    // Long-context rates are not recorded for every route, so an authored tier
+    // stands rather than being dropped for silence.
+    tiers: costTiers(pricing) ?? (existing?.cost?.tiers as CostTier[] | undefined),
+  };
+}
+
+/** A context tier, whichever of Opper's two long-context mechanisms produced it. */
+type CostTier = NonNullable<NonNullable<SyncedFullModel["cost"]>["tiers"]>[number];
+
+function costTiers(pricing: z.infer<typeof OpperPricing>): CostTier[] | undefined {
+  return bandedTiers(pricing) ?? surchargeTier(pricing);
+}
+
+/** `thresholds: [131072]` with `input: [0.05, 0.12]` means band 0 up to the boundary, band 1 past it. */
+function bandedTiers(pricing: z.infer<typeof OpperPricing>): CostTier[] | undefined {
+  const thresholds = pricing.thresholds;
+  if (thresholds === undefined || thresholds.length === 0) return undefined;
+
+  const tiers = thresholds.flatMap((size, index) => {
+    const band = index + 1;
+    const input = pricing.input?.[band];
+    const output = pricing.output?.[band];
+    if (input === undefined || output === undefined) return [];
+    return [{
+      tier: { type: "context" as const, size },
+      input: round(input),
+      output: round(output),
+      cache_read: optionalPrice(pricing.cached_input?.[band]),
+      cache_write: optionalPrice(pricing.cache_creation?.[band]),
+    }];
+  });
+  return tiers.length > 0 ? tiers : undefined;
+}
+
+/**
+ * The full-request surcharge reprices both sides once the input crosses the
+ * threshold, so it is a context tier too — just expressed as multipliers.
+ * Cache reads and writes are input-side and take the input multiplier, matching
+ * how the gateway bills them.
+ */
+function surchargeTier(pricing: z.infer<typeof OpperPricing>): CostTier[] | undefined {
+  const size = pricing.input_surcharge_threshold_tokens;
+  const inputMultiplier = pricing.input_surcharge_multiplier;
+  const outputMultiplier = pricing.output_surcharge_multiplier;
+  const input = pricing.input?.[0];
+  const output = pricing.output?.[0];
+  if (
+    size === undefined || size <= 0 ||
+    inputMultiplier === undefined || outputMultiplier === undefined ||
+    input === undefined || output === undefined
+  ) {
+    return undefined;
+  }
+
+  return [{
+    tier: { type: "context" as const, size },
+    input: round(input * inputMultiplier),
+    output: round(output * outputMultiplier),
+    cache_read: optionalPrice(scale(pricing.cached_input?.[0], inputMultiplier)),
+    cache_write: optionalPrice(scale(pricing.cache_creation?.[0], inputMultiplier)),
+  }];
+}
+
+function scale(price: number | undefined, multiplier: number) {
+  return price === undefined ? undefined : price * multiplier;
+}
+
+function optionalPrice(price: number | undefined) {
+  return price === undefined || price < 0 ? undefined : round(price);
+}
+
+/**
+ * Prices arrive already denominated per million tokens, but derived rates carry
+ * binary-float noise (a cached rate reads 0.029759999999999998), which the TOML
+ * writer would emit verbatim.
+ */
+function round(price: number): number {
+  return Math.round(price * 1_000_000) / 1_000_000;
+}

--- a/packages/core/test/opper.test.ts
+++ b/packages/core/test/opper.test.ts
@@ -1,0 +1,176 @@
+import { expect, test } from "bun:test";
+
+import {
+  assignLabels,
+  buildOpperModel,
+  resolveOpperBaseModel,
+  type OpperModel,
+} from "../src/sync/providers/opper.js";
+
+function route(overrides: Partial<OpperModel> = {}): OpperModel {
+  return {
+    id: "tensorx/deepseek/deepseek-v4-flash",
+    type: "llm",
+    name: "DeepSeek V4 Flash",
+    model: "deepseek-v4-flash",
+    maker: "deepseek",
+    provider: "tensorx",
+    provider_display_name: "TensorX",
+    region: "EU",
+    capabilities: ["text", "tools"],
+    context_window: 200_000,
+    max_output_tokens: 32_000,
+    ...overrides,
+  } as OpperModel;
+}
+
+function build(model: OpperModel, base = "deepseek/deepseek-v4-flash", existing?: unknown) {
+  assignLabels([model]);
+  return buildOpperModel(model, base, existing as never) as Record<string, unknown>;
+}
+
+test("the lab comes from `maker`, not from the route ID's provider prefix", () => {
+  // `tensorx/deepseek/deepseek-v4-flash` names the host, not the lab, so a
+  // prefix-based resolver would look for a `tensorx` namespace that cannot exist.
+  expect(resolveOpperBaseModel(route())).toBe("deepseek/deepseek-v4-flash");
+});
+
+test.each([
+  { maker: "zai", model: "glm-5.2", expected: "zhipuai/glm-5.2" },
+  { maker: "moonshot", model: "kimi-k3", expected: "moonshotai/kimi-k3" },
+])("maps the $maker namespace onto models.dev's", ({ maker, model, expected }) => {
+  expect(resolveOpperBaseModel(route({ maker, model }))).toBe(expected);
+});
+
+test("a lab with no models.dev entry resolves to nothing rather than inventing one", () => {
+  expect(resolveOpperBaseModel(route({ maker: "nobody", model: "no-such-model" }))).toBeUndefined();
+});
+
+test("prices pass through per million tokens, with float noise rounded away", () => {
+  // A derived cached rate arrives as 0.029759999999999998; the TOML writer
+  // would otherwise emit that verbatim.
+  const built = build(route({
+    pricing: {
+      billing_unit: "per_mtok",
+      input: [0.1488],
+      output: [0.2976],
+      cached_input: [0.029759999999999998],
+    },
+  }));
+  expect(built.cost).toEqual({ input: 0.1488, output: 0.2976, cache_read: 0.02976 });
+});
+
+test("a route quoting no price gets no cost section rather than a fabricated zero", () => {
+  expect(build(route()).cost).toBeUndefined();
+});
+
+test("banded thresholds become context tiers priced at the band past the boundary", () => {
+  const built = build(route({
+    pricing: {
+      billing_unit: "per_mtok",
+      thresholds: [131_072],
+      input: [0.05, 0.12],
+      output: [0.4, 0.96],
+    },
+  }));
+  expect((built.cost as { tiers: unknown }).tiers).toEqual([
+    { tier: { type: "context", size: 131_072 }, input: 0.12, output: 0.96 },
+  ]);
+});
+
+test("a full-request surcharge becomes a tier, multiplying each side by its own factor", () => {
+  // Distinct from banded thresholds: crossing the boundary reprices the WHOLE
+  // request, and cache reads are input-side so they take the input multiplier.
+  const built = build(route({
+    pricing: {
+      billing_unit: "per_mtok",
+      input: [5],
+      output: [30],
+      cached_input: [0.5],
+      input_surcharge_threshold_tokens: 272_000,
+      input_surcharge_multiplier: 2,
+      output_surcharge_multiplier: 1.5,
+    },
+  }));
+  expect((built.cost as { tiers: unknown }).tiers).toEqual([
+    { tier: { type: "context", size: 272_000 }, input: 10, output: 45, cache_read: 1 },
+  ]);
+});
+
+test("an authored long-context tier survives a route that quotes none", () => {
+  // Opper does not record the surcharge on every route that has one, so silence
+  // must not delete a rate a human established.
+  const tiers = [{ tier: { type: "context" as const, size: 272_000 }, input: 60, output: 270 }];
+  const built = build(
+    route({ pricing: { billing_unit: "per_mtok", input: [30], output: [180] } }),
+    "openai/gpt-5.5-pro",
+    { cost: { tiers } },
+  );
+  expect((built.cost as { tiers: unknown }).tiers).toEqual(tiers);
+});
+
+test("the effort ladder is taken from the route, which differs between hosts", () => {
+  const built = build(route({
+    capabilities: ["text", "tools", "reasoning"],
+    params: { reasoning: { supported: ["none", "low", "high"] } },
+  }));
+  expect(built.reasoning_options).toEqual([{ type: "effort", values: ["none", "low", "high"] }]);
+});
+
+test("a route stating no ladder states nothing, so the field is left for the runner", () => {
+  // Grok 4.6 reasons and takes an effort, but carries no params entry. Stamping
+  // [] here would shadow an authored ladder with "no controls".
+  const built = build(route({ capabilities: ["text", "tools", "reasoning"] }));
+  expect("reasoning_options" in built).toBe(false);
+});
+
+test.each([
+  { label: "the reasoning capability", capabilities: ["text", "reasoning"] },
+  { label: "the thinking capability", capabilities: ["text", "thinking"] },
+])("$label marks a reasoner", ({ capabilities }) => {
+  // Against a base that does not reason, so the override is actually written
+  // rather than dropped as inherited.
+  expect(build(route({ capabilities }), "alibaba/qwen-max").reasoning).toBe(true);
+});
+
+test("a capability Opper has not recorded is never asserted as absent", () => {
+  // Opper records a capability once verified for a route, so its absence is
+  // silence. Writing `false` would contradict the lab entry and, for reasoning,
+  // strip the base model's effort controls.
+  const built = build(route({ capabilities: ["text"] }));
+  expect("reasoning" in built).toBe(false);
+  expect("tool_call" in built).toBe(false);
+  expect("structured_output" in built).toBe(false);
+});
+
+test("modalities widen the lab entry and never narrow it", () => {
+  // deepseek-v4-flash declares text input upstream; a route adding PDF widens it.
+  const built = build(route({ capabilities: ["text", "pdf"] }));
+  expect((built.modalities as { input: string[] }).input).toEqual(["text", "pdf"]);
+});
+
+test("an unstated output cap falls back to an authored figure before the whole window", () => {
+  // Opper leaves max_output_tokens at 0 for many routes, which says nothing
+  // about generation length; claiming the full 1M window would be a fiction.
+  const built = build(route({ max_output_tokens: 0 }), "deepseek/deepseek-v4-flash", {
+    limit: { output: 64_000 },
+  });
+  expect((built.limit as { output: number }).output).toBe(64_000);
+});
+
+test("labels qualify only as far as they must to stay unique", () => {
+  const solo = route({ id: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5" });
+  const eu = route({ id: "alibaba:eu/qwen3-vl-flash", name: "Qwen3-VL-Flash", provider: "alibaba:eu", provider_display_name: "Alibaba Cloud", region: "EU" });
+  const global = route({ id: "alibaba:global/qwen3-vl-flash", name: "Qwen3-VL-Flash", provider: "alibaba:global", provider_display_name: "Alibaba Cloud", region: "GLOBAL" });
+  // Same display name AND same region: only the provider slug separates them.
+  const zdr = route({ id: "azure-zdr/gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "azure-zdr", provider_display_name: "Azure", region: "EU" });
+  const azure = route({ id: "azure/gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "azure", provider_display_name: "Azure", region: "EU" });
+
+  const labels = assignLabels([solo, eu, global, zdr, azure]);
+  expect(labels.get("anthropic/claude-sonnet-5")).toBe("Claude Sonnet 5");
+  expect(labels.get("alibaba:eu/qwen3-vl-flash")).toBe("Qwen3-VL-Flash (Alibaba Cloud, EU)");
+  expect(labels.get("alibaba:global/qwen3-vl-flash")).toBe("Qwen3-VL-Flash (Alibaba Cloud)");
+  expect(labels.get("azure-zdr/gpt-5.6-sol")).toBe("GPT-5.6 Sol (azure-zdr)");
+  expect(labels.get("azure/gpt-5.6-sol")).toBe("GPT-5.6 Sol (azure)");
+  expect(new Set(labels.values()).size).toBe(5);
+});

--- a/providers/opper/models/alibaba:eu/qwen3-vl-plus.toml
+++ b/providers/opper/models/alibaba:eu/qwen3-vl-plus.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3-vl-plus"
+name = "Qwen3-VL-Plus (Alibaba Cloud, EU)"
+attachment = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.2
+output = 1.6
+
+[[cost.tiers]]
+tier = { type = "context", size = 131_072 }
+input = 0.6
+output = 4.8

--- a/providers/opper/models/alibaba:global/deepseek-v4-flash.toml
+++ b/providers/opper/models/alibaba:global/deepseek-v4-flash.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash (Alibaba Cloud)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.1488
+output = 0.2976
+cache_read = 0.02976
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/alibaba:global/deepseek-v4-pro.toml
+++ b/providers/opper/models/alibaba:global/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek V4 Pro (Alibaba Cloud)"
+reasoning_options = []
+
+[cost]
+input = 1.7856
+output = 3.5712
+cache_read = 0.1488
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/alibaba:global/glm-5.1.toml
+++ b/providers/opper/models/alibaba:global/glm-5.1.toml
@@ -1,0 +1,17 @@
+base_model = "zhipuai/glm-5.1"
+name = "GLM 5.1 (Alibaba Cloud)"
+reasoning_options = []
+
+[cost]
+input = 0.8928
+output = 3.5712
+cache_read = 0.17856
+
+[[cost.tiers]]
+tier = { type = "context", size = 32_768 }
+input = 1.1904
+output = 4.1664
+cache_read = 0.23808
+
+[limit]
+context = 202_752

--- a/providers/opper/models/alibaba:global/glm-5.2.toml
+++ b/providers/opper/models/alibaba:global/glm-5.2.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Alibaba Cloud)"
+reasoning_options = []
+
+[cost]
+input = 1.1904
+output = 4.1664
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/alibaba:global/kimi-k2.5.toml
+++ b/providers/opper/models/alibaba:global/kimi-k2.5.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k2.5"
+name = "Kimi K2.5 (Alibaba Cloud)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.5952
+output = 3.1248
+cache_read = 0.11904
+
+[limit]
+output = 16_384

--- a/providers/opper/models/alibaba:global/kimi-k2.7-code.toml
+++ b/providers/opper/models/alibaba:global/kimi-k2.7-code.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi K2.7 Code (Alibaba Cloud)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.9672
+output = 4.0176

--- a/providers/opper/models/alibaba:global/qwen3-vl-plus.toml
+++ b/providers/opper/models/alibaba:global/qwen3-vl-plus.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3-vl-plus"
+name = "Qwen3-VL-Plus (Alibaba Cloud)"
+attachment = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.1488
+output = 1.488
+
+[[cost.tiers]]
+tier = { type = "context", size = 131_072 }
+input = 0.4464
+output = 4.464

--- a/providers/opper/models/alibaba:global/qwen3.6-flash.toml
+++ b/providers/opper/models/alibaba:global/qwen3.6-flash.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3.6-flash"
+name = "Qwen3.6-Flash"
+reasoning_options = []
+
+[cost]
+input = 0.17856
+output = 1.07136
+cache_read = 0.017856
+
+[[cost.tiers]]
+tier = { type = "context", size = 262_144 }
+input = 0.71424
+output = 4.28544
+cache_read = 0.071424

--- a/providers/opper/models/alibaba:global/qwen3.7-max.toml
+++ b/providers/opper/models/alibaba:global/qwen3.7-max.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3.7-max"
+name = "Qwen3.7-Max (Alibaba Cloud)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1.7856
+output = 5.3568
+cache_read = 0.35712

--- a/providers/opper/models/alibaba:global/qwen3.7-plus.toml
+++ b/providers/opper/models/alibaba:global/qwen3.7-plus.toml
@@ -1,0 +1,18 @@
+base_model = "alibaba/qwen3.7-plus"
+name = "Qwen3.7-Plus (Alibaba Cloud)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.2976
+output = 1.1904
+cache_read = 0.05952
+
+[[cost.tiers]]
+tier = { type = "context", size = 262_144 }
+input = 0.8928
+output = 3.5712
+cache_read = 0.17856
+
+[limit]
+output = 65_536

--- a/providers/opper/models/alibaba:global/qwen3.8-max.toml
+++ b/providers/opper/models/alibaba:global/qwen3.8-max.toml
@@ -1,0 +1,15 @@
+base_model = "alibaba/qwen3.8-max"
+name = "Qwen3.8-Max"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.25
+
+[limit]
+context = 983_616

--- a/providers/opper/models/anthropic/claude-fable-5.toml
+++ b/providers/opper/models/anthropic/claude-fable-5.toml
@@ -1,5 +1,10 @@
 base_model = "anthropic/claude-fable-5"
+name = "Claude Fable 5 (Anthropic)"
+temperature = true
 structured_output = true
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
@@ -10,6 +15,3 @@ input = 10
 output = 50
 cache_read = 1
 cache_write = 12.5
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/anthropic/claude-haiku-4-5.toml
+++ b/providers/opper/models/anthropic/claude-haiku-4-5.toml
@@ -1,13 +1,13 @@
 base_model = "anthropic/claude-haiku-4-5"
+name = "Claude Haiku 4.5 (Anthropic)"
 structured_output = true
-
 reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 1
 output = 5
 cache_read = 0.1
 cache_write = 1.25
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/anthropic/claude-opus-4-1.toml
+++ b/providers/opper/models/anthropic/claude-opus-4-1.toml
@@ -1,0 +1,12 @@
+base_model = "anthropic/claude-opus-4-1-20250805"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 15
+output = 75
+cache_read = 1.5
+cache_write = 18.75

--- a/providers/opper/models/anthropic/claude-opus-4-5.toml
+++ b/providers/opper/models/anthropic/claude-opus-4-5.toml
@@ -1,5 +1,9 @@
 base_model = "anthropic/claude-opus-4-5"
+name = "Claude Opus 4.5 (Anthropic)"
 structured_output = true
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
@@ -10,6 +14,3 @@ input = 5
 output = 25
 cache_read = 0.5
 cache_write = 6.25
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/anthropic/claude-opus-4-6.toml
+++ b/providers/opper/models/anthropic/claude-opus-4-6.toml
@@ -1,5 +1,9 @@
 base_model = "anthropic/claude-opus-4-6"
+name = "Claude Opus 4.6 (Anthropic)"
 structured_output = true
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
@@ -10,6 +14,3 @@ input = 5
 output = 25
 cache_read = 0.5
 cache_write = 6.25
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/anthropic/claude-opus-4-7.toml
+++ b/providers/opper/models/anthropic/claude-opus-4-7.toml
@@ -1,5 +1,10 @@
 base_model = "anthropic/claude-opus-4-7"
+name = "Claude Opus 4.7 (Anthropic)"
+temperature = true
 structured_output = true
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
@@ -10,6 +15,3 @@ input = 5
 output = 25
 cache_read = 0.5
 cache_write = 6.25
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/anthropic/claude-opus-4-8.toml
+++ b/providers/opper/models/anthropic/claude-opus-4-8.toml
@@ -1,5 +1,10 @@
 base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8 (Anthropic)"
+temperature = true
 structured_output = true
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
@@ -10,6 +15,3 @@ input = 5
 output = 25
 cache_read = 0.5
 cache_write = 6.25
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/anthropic/claude-opus-5.toml
+++ b/providers/opper/models/anthropic/claude-opus-5.toml
@@ -1,5 +1,10 @@
 base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (Anthropic)"
+temperature = true
 structured_output = true
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
@@ -10,6 +15,3 @@ input = 5
 output = 25
 cache_read = 0.5
 cache_write = 6.25
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/anthropic/claude-sonnet-4-5.toml
+++ b/providers/opper/models/anthropic/claude-sonnet-4-5.toml
@@ -1,13 +1,16 @@
 base_model = "anthropic/claude-sonnet-4-5"
+name = "Claude Sonnet 4.5 (Anthropic)"
 structured_output = true
 
-reasoning_options = []
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
 
 [cost]
 input = 3
 output = 15
 cache_read = 0.3
 cache_write = 3.75
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/anthropic/claude-sonnet-4-6.toml
+++ b/providers/opper/models/anthropic/claude-sonnet-4-6.toml
@@ -1,5 +1,9 @@
 base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6 (Anthropic)"
 structured_output = true
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
@@ -10,6 +14,3 @@ input = 3
 output = 15
 cache_read = 0.3
 cache_write = 3.75
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/anthropic/claude-sonnet-5.toml
+++ b/providers/opper/models/anthropic/claude-sonnet-5.toml
@@ -1,9 +1,14 @@
 base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (Anthropic)"
+temperature = true
 structured_output = true
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "max"]
 
 [cost]
 input = 2
@@ -11,5 +16,5 @@ output = 10
 cache_read = 0.2
 cache_write = 2.5
 
-[interleaved]
-field = "reasoning_content"
+[limit]
+output = 64_000

--- a/providers/opper/models/arcee/trinity-large-preview.toml
+++ b/providers/opper/models/arcee/trinity-large-preview.toml
@@ -1,0 +1,10 @@
+base_model = "arcee-ai/trinity-large-preview"
+structured_output = true
+
+[cost]
+input = 0.25
+output = 1
+
+[limit]
+context = 131_072
+output = 8_192

--- a/providers/opper/models/arcee/trinity-large-thinking.toml
+++ b/providers/opper/models/arcee/trinity-large-thinking.toml
@@ -1,0 +1,12 @@
+base_model = "arcee-ai/trinity-large-thinking"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 0.9
+cache_read = 0.06
+
+[limit]
+context = 262_144
+output = 8_192

--- a/providers/opper/models/arcee/trinity-mini.toml
+++ b/providers/opper/models/arcee/trinity-mini.toml
@@ -1,0 +1,10 @@
+base_model = "arcee-ai/trinity-mini"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.045
+output = 0.15
+
+[limit]
+output = 8_192

--- a/providers/opper/models/aws/claude-haiku-4-5-eu.toml
+++ b/providers/opper/models/aws/claude-haiku-4-5-eu.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-haiku-4-5"
+name = "Claude Haiku 4.5 (AWS)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1.1
+output = 5.5
+cache_read = 0.11
+cache_write = 1.375

--- a/providers/opper/models/aws/claude-opus-4-5-eu.toml
+++ b/providers/opper/models/aws/claude-opus-4-5-eu.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-opus-4-5"
+name = "Claude Opus 4.5 (AWS)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/aws/claude-opus-4-6-eu.toml
+++ b/providers/opper/models/aws/claude-opus-4-6-eu.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-opus-4-6"
+name = "Claude Opus 4.6 (AWS)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/aws/claude-opus-4-7.toml
+++ b/providers/opper/models/aws/claude-opus-4-7.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-7"
+name = "Claude Opus 4.7 (AWS)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/aws/claude-opus-4-8.toml
+++ b/providers/opper/models/aws/claude-opus-4-8.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8 (AWS)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/aws/claude-opus-5.toml
+++ b/providers/opper/models/aws/claude-opus-5.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (AWS)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5.5
+output = 27.5
+cache_read = 0.55
+cache_write = 6.875

--- a/providers/opper/models/aws/claude-sonnet-4-5-eu.toml
+++ b/providers/opper/models/aws/claude-sonnet-4-5-eu.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-4-5"
+name = "Claude Sonnet 4.5 (AWS)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 3.3
+output = 16.5
+cache_read = 0.33
+cache_write = 4.125

--- a/providers/opper/models/aws/claude-sonnet-4-6-eu.toml
+++ b/providers/opper/models/aws/claude-sonnet-4-6-eu.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6 (AWS)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 3.3
+output = 16.5
+cache_read = 0.33
+cache_write = 4.125

--- a/providers/opper/models/aws/claude-sonnet-5.toml
+++ b/providers/opper/models/aws/claude-sonnet-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (AWS)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 2.2
+output = 11
+cache_read = 0.22
+cache_write = 2.75
+
+[limit]
+output = 64_000

--- a/providers/opper/models/aws/gpt-5.6-luna.toml
+++ b/providers/opper/models/aws/gpt-5.6-luna.toml
@@ -1,0 +1,23 @@
+base_model = "openai/gpt-5.6-luna"
+base_model_omit = ["limit.input"]
+name = "GPT-5.6 Luna (AWS)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.4
+output = 1.8
+cache_read = 0.04
+cache_write = 0.5
+
+[limit]
+context = 1_000_000

--- a/providers/opper/models/aws/gpt-5.6-sol.toml
+++ b/providers/opper/models/aws/gpt-5.6-sol.toml
@@ -1,0 +1,23 @@
+base_model = "openai/gpt-5.6-sol"
+base_model_omit = ["limit.input"]
+name = "GPT-5.6 Sol (AWS)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+cache_write = 12.5
+
+[limit]
+context = 1_000_000

--- a/providers/opper/models/aws/gpt-5.6-terra.toml
+++ b/providers/opper/models/aws/gpt-5.6-terra.toml
@@ -1,0 +1,23 @@
+base_model = "openai/gpt-5.6-terra"
+base_model_omit = ["limit.input"]
+name = "GPT-5.6 Terra (AWS)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5
+
+[limit]
+context = 1_000_000

--- a/providers/opper/models/aws/gpt-oss-120b-eu.toml
+++ b/providers/opper/models/aws/gpt-oss-120b-eu.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (AWS)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/aws/gpt-oss-20b-eu.toml
+++ b/providers/opper/models/aws/gpt-oss-20b-eu.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (AWS)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.07
+output = 0.3
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/aws/nemotron-nano-12b-v2-vl.toml
+++ b/providers/opper/models/aws/nemotron-nano-12b-v2-vl.toml
@@ -1,0 +1,10 @@
+base_model = "nvidia/nemotron-nano-12b-v2-vl"
+name = "Nemotron Nano 12B VL"
+reasoning_options = []
+
+[cost]
+input = 0.06
+output = 0.24
+
+[limit]
+output = 8_192

--- a/providers/opper/models/aws/nemotron-nano-9b-v2.toml
+++ b/providers/opper/models/aws/nemotron-nano-9b-v2.toml
@@ -1,0 +1,11 @@
+base_model = "nvidia/nemotron-nano-9b-v2"
+name = "Nemotron Nano 9B v2 (AWS)"
+reasoning_options = []
+
+[cost]
+input = 0.04
+output = 0.16
+
+[limit]
+context = 128_000
+output = 8_192

--- a/providers/opper/models/azure-zdr/gpt-5.6-luna-global.toml
+++ b/providers/opper/models/azure-zdr/gpt-5.6-luna-global.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-luna"
+name = "GPT-5.6 Luna (azure-zdr/gpt-5.6-luna-global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.4
+output = 1.8
+cache_read = 0.04
+cache_write = 0.5

--- a/providers/opper/models/azure-zdr/gpt-5.6-luna.toml
+++ b/providers/opper/models/azure-zdr/gpt-5.6-luna.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-luna"
+name = "GPT-5.6 Luna (azure-zdr/gpt-5.6-luna)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.4
+output = 1.8
+cache_read = 0.04
+cache_write = 0.5

--- a/providers/opper/models/azure-zdr/gpt-5.6-sol-global.toml
+++ b/providers/opper/models/azure-zdr/gpt-5.6-sol-global.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6 Sol (azure-zdr/gpt-5.6-sol-global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+cache_write = 12.5

--- a/providers/opper/models/azure-zdr/gpt-5.6-sol.toml
+++ b/providers/opper/models/azure-zdr/gpt-5.6-sol.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6 Sol (azure-zdr/gpt-5.6-sol)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+cache_write = 12.5

--- a/providers/opper/models/azure-zdr/gpt-5.6-terra-global.toml
+++ b/providers/opper/models/azure-zdr/gpt-5.6-terra-global.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-terra"
+name = "GPT-5.6 Terra (azure-zdr/gpt-5.6-terra-global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5

--- a/providers/opper/models/azure-zdr/gpt-5.6-terra.toml
+++ b/providers/opper/models/azure-zdr/gpt-5.6-terra.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-terra"
+name = "GPT-5.6 Terra (azure-zdr/gpt-5.6-terra)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5

--- a/providers/opper/models/azure/claude-fable-5.toml
+++ b/providers/opper/models/azure/claude-fable-5.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-fable-5"
+name = "Claude Fable 5 (Azure)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/opper/models/azure/claude-haiku-4-5.toml
+++ b/providers/opper/models/azure/claude-haiku-4-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-haiku-4-5"
+name = "Claude Haiku 4.5 (Azure)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25

--- a/providers/opper/models/azure/claude-opus-4-5.toml
+++ b/providers/opper/models/azure/claude-opus-4-5.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-opus-4-5"
+name = "Claude Opus 4.5 (Azure)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/azure/claude-opus-4-7.toml
+++ b/providers/opper/models/azure/claude-opus-4-7.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-opus-4-7"
+name = "Claude Opus 4.7 (Azure)"
+temperature = true
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+output = 64_000

--- a/providers/opper/models/azure/claude-opus-4-8.toml
+++ b/providers/opper/models/azure/claude-opus-4-8.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8 (Azure)"
+temperature = true
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/azure/claude-opus-5.toml
+++ b/providers/opper/models/azure/claude-opus-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (Azure)"
+temperature = true
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/azure/claude-sonnet-4-5.toml
+++ b/providers/opper/models/azure/claude-sonnet-4-5.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-sonnet-4-5"
+name = "Claude Sonnet 4.5 (Azure)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/opper/models/azure/claude-sonnet-4-6.toml
+++ b/providers/opper/models/azure/claude-sonnet-4-6.toml
@@ -1,0 +1,13 @@
+base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6 (Azure)"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/opper/models/azure/claude-sonnet-5.toml
+++ b/providers/opper/models/azure/claude-sonnet-5.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (Azure)"
+temperature = true
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+output = 64_000

--- a/providers/opper/models/azure/deepseek-v4-flash-0731.toml
+++ b/providers/opper/models/azure/deepseek-v4-flash-0731.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) (Azure)"
+reasoning_options = []
+
+[cost]
+input = 0.19
+output = 0.51
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/azure/deepseek-v4-pro.toml
+++ b/providers/opper/models/azure/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek V4 Pro (Azure)"
+reasoning_options = []
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.145
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/azure/gpt-4o-eu.toml
+++ b/providers/opper/models/azure/gpt-4o-eu.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-4o-2024-11-20"
+name = "GPT-4o EU"
+
+[cost]
+input = 2.75
+output = 11
+cache_read = 1.375
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/azure/gpt-5-mini.toml
+++ b/providers/opper/models/azure/gpt-5-mini.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5-mini"
+base_model_omit = ["limit.input"]
+name = "GPT-5 Mini (Azure)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/azure/gpt-5-nano.toml
+++ b/providers/opper/models/azure/gpt-5-nano.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5-nano"
+base_model_omit = ["limit.input"]
+name = "GPT-5 Nano (Azure)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.05
+output = 0.4
+cache_read = 0.005
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/azure/gpt-5.1-codex-mini.toml
+++ b/providers/opper/models/azure/gpt-5.1-codex-mini.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-5.1-codex-mini"
+base_model_omit = ["limit.input"]
+name = "GPT-5.1 Codex Mini"
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/azure/gpt-5.1.toml
+++ b/providers/opper/models/azure/gpt-5.1.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5.1"
+base_model_omit = ["limit.input"]
+name = "GPT-5.1 (Azure)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/azure/gpt-5.3-codex.toml
+++ b/providers/opper/models/azure/gpt-5.3-codex.toml
@@ -1,0 +1,12 @@
+base_model = "openai/gpt-5.3-codex"
+base_model_omit = ["limit.input"]
+name = "GPT-5.3 Codex (Azure)"
+reasoning_options = []
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+
+[limit]
+context = 272_000

--- a/providers/opper/models/azure/gpt-5.4-mini.toml
+++ b/providers/opper/models/azure/gpt-5.4-mini.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5.4-mini"
+base_model_omit = ["limit.input"]
+name = "GPT-5.4 Mini (Azure)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/azure/gpt-5.4-nano.toml
+++ b/providers/opper/models/azure/gpt-5.4-nano.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-5.4-nano"
+base_model_omit = ["limit.input"]
+name = "GPT-5.4 Nano (Azure)"
+reasoning_options = []
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/azure/gpt-5.4.toml
+++ b/providers/opper/models/azure/gpt-5.4.toml
@@ -1,0 +1,21 @@
+base_model = "openai/gpt-5.4"
+base_model_omit = ["limit.input"]
+name = "GPT-5.4 (Azure)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5
+
+[limit]
+context = 272_000

--- a/providers/opper/models/azure/gpt-5.5.toml
+++ b/providers/opper/models/azure/gpt-5.5.toml
@@ -1,0 +1,17 @@
+base_model = "openai/gpt-5.5"
+name = "GPT-5.5 (Azure)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1

--- a/providers/opper/models/azure/gpt-5.6-luna-global.toml
+++ b/providers/opper/models/azure/gpt-5.6-luna-global.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-luna"
+name = "GPT-5.6 Luna (azure/gpt-5.6-luna-global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.4
+output = 1.8
+cache_read = 0.04
+cache_write = 0.5

--- a/providers/opper/models/azure/gpt-5.6-luna.toml
+++ b/providers/opper/models/azure/gpt-5.6-luna.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-luna"
+name = "GPT-5.6 Luna (azure/gpt-5.6-luna)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.4
+output = 1.8
+cache_read = 0.04
+cache_write = 0.5

--- a/providers/opper/models/azure/gpt-5.6-sol-global.toml
+++ b/providers/opper/models/azure/gpt-5.6-sol-global.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6 Sol (azure/gpt-5.6-sol-global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+cache_write = 12.5

--- a/providers/opper/models/azure/gpt-5.6-sol.toml
+++ b/providers/opper/models/azure/gpt-5.6-sol.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6 Sol (azure/gpt-5.6-sol)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+cache_write = 6.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+cache_write = 12.5

--- a/providers/opper/models/azure/gpt-5.6-terra-global.toml
+++ b/providers/opper/models/azure/gpt-5.6-terra-global.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-terra"
+name = "GPT-5.6 Terra (azure/gpt-5.6-terra-global)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5

--- a/providers/opper/models/azure/gpt-5.6-terra.toml
+++ b/providers/opper/models/azure/gpt-5.6-terra.toml
@@ -1,0 +1,19 @@
+base_model = "openai/gpt-5.6-terra"
+name = "GPT-5.6 Terra (azure/gpt-5.6-terra)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5

--- a/providers/opper/models/azure/gpt-5.toml
+++ b/providers/opper/models/azure/gpt-5.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5"
+base_model_omit = ["limit.input"]
+name = "GPT-5 (Azure)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/azure/grok-4.3.toml
+++ b/providers/opper/models/azure/grok-4.3.toml
@@ -1,0 +1,11 @@
+base_model = "xai/grok-4.3"
+name = "Grok 4.3 (Azure)"
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[limit]
+output = 1_000_000

--- a/providers/opper/models/azure/kimi-k2.6.toml
+++ b/providers/opper/models/azure/kimi-k2.6.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (Azure)"
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.16

--- a/providers/opper/models/berget/Qwen/Qwen3.8-27B-FP8.toml
+++ b/providers/opper/models/berget/Qwen/Qwen3.8-27B-FP8.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.8-27b"
+name = "Qwen3.8 27B (Berget)"
+reasoning_options = []
+
+[cost]
+input = 0.4658
+output = 3.4935

--- a/providers/opper/models/berget/gemma-4-31b-it.toml
+++ b/providers/opper/models/berget/gemma-4-31b-it.toml
@@ -1,0 +1,14 @@
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B (Berget)"
+reasoning_options = []
+
+[cost]
+input = 0.291125
+output = 0.58225
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image", "audio", "video"]

--- a/providers/opper/models/berget/glm-4.7.toml
+++ b/providers/opper/models/berget/glm-4.7.toml
@@ -1,0 +1,8 @@
+base_model = "zhipuai/glm-4.7"
+name = "GLM 4.7 (berget/glm-4.7)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.81515
+output = 2.91125

--- a/providers/opper/models/berget/gpt-oss-120b.toml
+++ b/providers/opper/models/berget/gpt-oss-120b.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Berget)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.2329
+output = 0.873375
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/berget/kimi-k2.6.toml
+++ b/providers/opper/models/berget/kimi-k2.6.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (Berget)"
+reasoning_options = []
+
+[cost]
+input = 0.873375
+output = 4.07575

--- a/providers/opper/models/berget/kimi-k3.toml
+++ b/providers/opper/models/berget/kimi-k3.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (Berget)"
+temperature = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["max"]
+
+[cost]
+input = 3.4935
+output = 17.4675
+
+[limit]
+context = 327_680
+output = 327_680

--- a/providers/opper/models/berget/llama-3.3-70b-instruct.toml
+++ b/providers/opper/models/berget/llama-3.3-70b-instruct.toml
@@ -1,0 +1,10 @@
+base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama 3.3 70B (Berget)"
+structured_output = true
+
+[cost]
+input = 1.04805
+output = 1.04805
+
+[limit]
+output = 8_192

--- a/providers/opper/models/bytedance:ap/deepseek-v3.2.toml
+++ b/providers/opper/models/bytedance:ap/deepseek-v3.2.toml
@@ -1,0 +1,18 @@
+base_model = "deepseek/deepseek-v3.2"
+name = "DeepSeek V3.2 (BytePlus)"
+reasoning_options = []
+
+[cost]
+input = 0.28
+output = 0.42
+cache_read = 0.056
+
+[[cost.tiers]]
+tier = { type = "context", size = 32_768 }
+input = 0.56
+output = 0.84
+cache_read = 0.056
+
+[limit]
+context = 131_072
+output = 32_768

--- a/providers/opper/models/bytedance:ap/deepseek-v4-flash.toml
+++ b/providers/opper/models/bytedance:ap/deepseek-v4-flash.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash (BytePlus)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/bytedance:ap/deepseek-v4-pro.toml
+++ b/providers/opper/models/bytedance:ap/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek V4 Pro (BytePlus)"
+reasoning_options = []
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.145
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/bytedance:ap/glm-4.7.toml
+++ b/providers/opper/models/bytedance:ap/glm-4.7.toml
@@ -1,0 +1,9 @@
+base_model = "zhipuai/glm-4.7"
+name = "GLM 4.7 (BytePlus)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 2.2
+cache_read = 0.11

--- a/providers/opper/models/bytedance:ap/glm-5.2.toml
+++ b/providers/opper/models/bytedance:ap/glm-5.2.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (BytePlus)"
+reasoning_options = []
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 1_048_576

--- a/providers/opper/models/bytedance:ap/gpt-oss-120b.toml
+++ b/providers/opper/models/bytedance:ap/gpt-oss-120b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (BytePlus)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.5
+
+[limit]
+output = 65_536
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/bytedance:ap/seed-2.0-code.toml
+++ b/providers/opper/models/bytedance:ap/seed-2.0-code.toml
@@ -1,0 +1,14 @@
+base_model = "bytedance-seed/seed-2.0-code"
+name = "Seed 2.0 Code (BytePlus)"
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.1
+
+[[cost.tiers]]
+tier = { type = "context", size = 131_072 }
+input = 1
+output = 6
+cache_read = 0.2

--- a/providers/opper/models/bytedance:ap/seed-2.0-lite.toml
+++ b/providers/opper/models/bytedance:ap/seed-2.0-lite.toml
@@ -1,0 +1,19 @@
+base_model = "bytedance-seed/seed-2.0-lite"
+name = "Seed 2.0 Lite (BytePlus)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.05
+
+[[cost.tiers]]
+tier = { type = "context", size = 131_072 }
+input = 0.5
+output = 4
+cache_read = 0.1
+
+[limit]
+context = 262_144
+output = 131_072

--- a/providers/opper/models/bytedance:ap/seed-2.0-mini.toml
+++ b/providers/opper/models/bytedance:ap/seed-2.0-mini.toml
@@ -1,0 +1,18 @@
+base_model = "bytedance-seed/seed-2.0-mini"
+name = "Seed 2.0 Mini (BytePlus)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.02
+
+[[cost.tiers]]
+tier = { type = "context", size = 131_072 }
+input = 0.2
+output = 0.8
+cache_read = 0.04
+
+[limit]
+context = 262_144
+output = 131_072

--- a/providers/opper/models/bytedance:ap/seed-2.0-pro.toml
+++ b/providers/opper/models/bytedance:ap/seed-2.0-pro.toml
@@ -1,0 +1,18 @@
+base_model = "bytedance-seed/seed-2.0-pro"
+name = "Seed 2.0 Pro (BytePlus)"
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.1
+
+[[cost.tiers]]
+tier = { type = "context", size = 131_072 }
+input = 1
+output = 6
+cache_read = 0.2
+
+[limit]
+context = 262_144
+output = 131_072

--- a/providers/opper/models/bytedance:eu/seed-2.0-lite.toml
+++ b/providers/opper/models/bytedance:eu/seed-2.0-lite.toml
@@ -1,0 +1,19 @@
+base_model = "bytedance-seed/seed-2.0-lite"
+name = "Seed 2.0 Lite (BytePlus, EU)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.05
+
+[[cost.tiers]]
+tier = { type = "context", size = 131_072 }
+input = 0.5
+output = 4
+cache_read = 0.1
+
+[limit]
+context = 262_144
+output = 131_072

--- a/providers/opper/models/bytedance:eu/seed-2.0-mini.toml
+++ b/providers/opper/models/bytedance:eu/seed-2.0-mini.toml
@@ -1,0 +1,18 @@
+base_model = "bytedance-seed/seed-2.0-mini"
+name = "Seed 2.0 Mini (BytePlus, EU)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.02
+
+[[cost.tiers]]
+tier = { type = "context", size = 131_072 }
+input = 0.2
+output = 0.8
+cache_read = 0.04
+
+[limit]
+context = 262_144
+output = 131_072

--- a/providers/opper/models/cerebras/gemma-4-31b.toml
+++ b/providers/opper/models/cerebras/gemma-4-31b.toml
@@ -1,0 +1,10 @@
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B (Cerebras)"
+reasoning_options = []
+
+[cost]
+input = 0.99
+output = 1.49
+
+[limit]
+context = 131_072

--- a/providers/opper/models/cerebras/gpt-oss-120b.toml
+++ b/providers/opper/models/cerebras/gpt-oss-120b.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Cerebras)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.35
+output = 0.75
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/deepinfra/ByteDance/Seed-2.0-code.toml
+++ b/providers/opper/models/deepinfra/ByteDance/Seed-2.0-code.toml
@@ -1,0 +1,12 @@
+base_model = "bytedance-seed/seed-2.0-code"
+name = "Seed 2.0 Code (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.1
+
+[limit]
+context = 256_000
+output = 256_000

--- a/providers/opper/models/deepinfra/ByteDance/Seed-2.0-mini.toml
+++ b/providers/opper/models/deepinfra/ByteDance/Seed-2.0-mini.toml
@@ -1,0 +1,11 @@
+base_model = "bytedance-seed/seed-2.0-mini"
+name = "Seed 2.0 Mini (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.02
+
+[limit]
+output = 256_000

--- a/providers/opper/models/deepinfra/ByteDance/Seed-2.0-pro.toml
+++ b/providers/opper/models/deepinfra/ByteDance/Seed-2.0-pro.toml
@@ -1,0 +1,11 @@
+base_model = "bytedance-seed/seed-2.0-pro"
+name = "Seed 2.0 Pro (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.1
+
+[limit]
+output = 256_000

--- a/providers/opper/models/deepinfra/MiniMaxAI/MiniMax-M2.7.toml
+++ b/providers/opper/models/deepinfra/MiniMaxAI/MiniMax-M2.7.toml
@@ -1,0 +1,12 @@
+base_model = "minimax/MiniMax-M2.7"
+name = "MiniMax M2.7 (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 1
+cache_read = 0.05
+
+[limit]
+context = 196_608

--- a/providers/opper/models/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3-235b-a22b-instruct-2507"
+name = "Qwen3 235B A22B Instruct (2507) (DeepInfra)"
+structured_output = true
+
+[cost]
+input = 0.09
+output = 0.55
+
+[limit]
+output = 262_144

--- a/providers/opper/models/deepinfra/Qwen/Qwen3-30B-A3B.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3-30B-A3B.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3-30b-a3b"
+reasoning_options = []
+
+[cost]
+input = 0.12
+output = 0.5
+
+[limit]
+context = 40_960
+output = 40_960

--- a/providers/opper/models/deepinfra/Qwen/Qwen3-32B.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3-32B.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen3-32b"
+name = "Qwen3 32B (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.08
+output = 0.28
+
+[limit]
+context = 40_960
+output = 40_960

--- a/providers/opper/models/deepinfra/Qwen/Qwen3-Max.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3-Max.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen3-max"
+name = "Qwen3 Max (DeepInfra)"
+structured_output = true
+
+[cost]
+input = 1.2
+output = 6
+cache_read = 0.24
+
+[limit]
+context = 256_000
+output = 256_000

--- a/providers/opper/models/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct.toml
@@ -1,0 +1,13 @@
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+name = "Qwen3 Next 80B A3B Instruct (DeepInfra)"
+reasoning = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.09
+output = 1.1
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/opper/models/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3-VL-235B-A22B-Instruct.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3-vl-235b-a22b-instruct"
+name = "Qwen3 VL 235B A22B Instruct (DeepInfra)"
+
+[cost]
+input = 0.2
+output = 0.88
+cache_read = 0.11
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/opper/models/deepinfra/Qwen/Qwen3.5-122B-A10B.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3.5-122B-A10B.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.5-122b-a10b"
+name = "Qwen3.5 122B A10B (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.29
+output = 2.4
+
+[limit]
+output = 262_144

--- a/providers/opper/models/deepinfra/Qwen/Qwen3.5-27B.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3.5-27B.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.5-27b"
+name = "Qwen3.5 27B (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.26
+output = 2.6
+
+[limit]
+output = 262_144

--- a/providers/opper/models/deepinfra/Qwen/Qwen3.5-35B-A3B.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3.5-35B-A3B.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.5-35b-a3b"
+name = "Qwen3.5 35B A3B (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.14
+output = 1
+cache_read = 0.05
+
+[limit]
+output = 262_144

--- a/providers/opper/models/deepinfra/Qwen/Qwen3.5-397B-A17B.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3.5-397B-A17B.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.5-397b-a17b"
+name = "Qwen 3.5 397B (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.45
+output = 3
+cache_read = 0.22
+
+[limit]
+output = 262_144

--- a/providers/opper/models/deepinfra/Qwen/Qwen3.5-9B.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3.5-9B.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.5-9b"
+name = "Qwen3.5 9B (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.15
+
+[limit]
+output = 262_144

--- a/providers/opper/models/deepinfra/Qwen/Qwen3.6-27B.toml
+++ b/providers/opper/models/deepinfra/Qwen/Qwen3.6-27B.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.6-27b"
+name = "Qwen 3.6 27B (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.32
+output = 3.2
+
+[limit]
+output = 262_144

--- a/providers/opper/models/deepinfra/XiaomiMiMo/MiMo-V2.5-Pro.toml
+++ b/providers/opper/models/deepinfra/XiaomiMiMo/MiMo-V2.5-Pro.toml
@@ -1,0 +1,12 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+name = "MiMo V2.5 Pro (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1
+output = 3
+cache_read = 0.2
+
+[limit]
+output = 1_048_576

--- a/providers/opper/models/deepinfra/XiaomiMiMo/MiMo-V2.5.toml
+++ b/providers/opper/models/deepinfra/XiaomiMiMo/MiMo-V2.5.toml
@@ -1,0 +1,13 @@
+base_model = "xiaomi/mimo-v2.5"
+name = "MiMo V2.5 (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 2
+cache_read = 0.08
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/opper/models/deepinfra/deepseek-ai/DeepSeek-V3-0324.toml
+++ b/providers/opper/models/deepinfra/deepseek-ai/DeepSeek-V3-0324.toml
@@ -1,0 +1,8 @@
+base_model = "deepseek/deepseek-v3-0324"
+name = "DeepSeek V3 (0324) (DeepInfra)"
+structured_output = true
+
+[cost]
+input = 0.24
+output = 0.9
+cache_read = 0.135

--- a/providers/opper/models/deepinfra/deepseek-ai/DeepSeek-V3.1.toml
+++ b/providers/opper/models/deepinfra/deepseek-ai/DeepSeek-V3.1.toml
@@ -1,0 +1,13 @@
+base_model = "deepseek/deepseek-v3.1"
+name = "DeepSeek V3.1 (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 0.95
+cache_read = 0.13
+
+[limit]
+context = 163_840
+output = 163_840

--- a/providers/opper/models/deepinfra/deepseek-ai/DeepSeek-V3.2.toml
+++ b/providers/opper/models/deepinfra/deepseek-ai/DeepSeek-V3.2.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v3.2"
+name = "DeepSeek V3.2 (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.26
+output = 0.38
+cache_read = 0.13
+
+[limit]
+context = 163_840
+output = 163_840

--- a/providers/opper/models/deepinfra/deepseek-ai/DeepSeek-V3.toml
+++ b/providers/opper/models/deepinfra/deepseek-ai/DeepSeek-V3.toml
@@ -1,0 +1,10 @@
+base_model = "deepseek/deepseek-v3"
+name = "DeepSeek V3 (DeepInfra)"
+
+[cost]
+input = 0.32
+output = 0.89
+
+[limit]
+context = 163_840
+output = 163_840

--- a/providers/opper/models/deepinfra/deepseek-v4-flash-0731.toml
+++ b/providers/opper/models/deepinfra/deepseek-v4-flash-0731.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) (DeepInfra)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "xhigh"]
+
+[cost]
+input = 0.09
+output = 0.18
+cache_read = 0.018
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/deepinfra/deepseek-v4-flash.toml
+++ b/providers/opper/models/deepinfra/deepseek-v4-flash.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash (DeepInfra)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "xhigh"]
+
+[cost]
+input = 0.09
+output = 0.18
+cache_read = 0.018
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/deepinfra/deepseek-v4-pro.toml
+++ b/providers/opper/models/deepinfra/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek V4 Pro (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 1.3
+output = 2.6
+cache_read = 0.1
+
+[limit]
+context = 1_048_576
+output = 65_536

--- a/providers/opper/models/deepinfra/gemma-4-26b-a4b-it.toml
+++ b/providers/opper/models/deepinfra/gemma-4-26b-a4b-it.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemma-4-26b-a4b-it"
+name = "Gemma 4 26B A4B IT (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.07
+output = 0.34
+
+[limit]
+output = 262_144
+
+[modalities]
+input = ["text", "image", "audio", "video"]

--- a/providers/opper/models/deepinfra/gemma-4-31b-it.toml
+++ b/providers/opper/models/deepinfra/gemma-4-31b-it.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.13
+output = 0.38
+
+[limit]
+output = 262_144
+
+[modalities]
+input = ["text", "image", "audio", "video"]

--- a/providers/opper/models/deepinfra/glm-5.1.toml
+++ b/providers/opper/models/deepinfra/glm-5.1.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-5.1"
+name = "GLM 5.1 (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 1.05
+output = 3.5
+cache_read = 0.205
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/opper/models/deepinfra/kimi-k2.6.toml
+++ b/providers/opper/models/deepinfra/kimi-k2.6.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.75
+output = 3.5
+cache_read = 0.15

--- a/providers/opper/models/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.toml
+++ b/providers/opper/models/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.toml
@@ -1,0 +1,10 @@
+base_model = "meta/llama-3.2-11b-vision-instruct"
+name = "Llama 3.2 11B Vision Instruct"
+
+[cost]
+input = 0.245
+output = 0.245
+
+[limit]
+context = 131_072
+output = 131_072

--- a/providers/opper/models/deepinfra/moonshotai/Kimi-K2.5.toml
+++ b/providers/opper/models/deepinfra/moonshotai/Kimi-K2.5.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k2.5"
+name = "Kimi K2.5 (DeepInfra)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.45
+output = 2.25
+cache_read = 0.07

--- a/providers/opper/models/deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5.toml
+++ b/providers/opper/models/deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5.toml
@@ -1,0 +1,6 @@
+base_model = "nvidia/llama-3.3-nemotron-super-49b-v1.5"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.4

--- a/providers/opper/models/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.toml
+++ b/providers/opper/models/deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2.toml
@@ -1,0 +1,7 @@
+base_model = "nvidia/nemotron-nano-9b-v2"
+name = "Nemotron Nano 9B v2 (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.04
+output = 0.16

--- a/providers/opper/models/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.toml
+++ b/providers/opper/models/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.toml
@@ -1,0 +1,9 @@
+base_model = "nvidia/nemotron-3-nano-30b-a3b"
+name = "Nemotron 3 Nano 30B A3B (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.05
+output = 0.2
+cache_read = 0.025

--- a/providers/opper/models/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.toml
+++ b/providers/opper/models/deepinfra/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning.toml
@@ -1,0 +1,10 @@
+base_model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+reasoning_options = []
+
+[cost]
+input = 0.2
+output = 0.8
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/opper/models/deepinfra/qwen3.6-35b-a3b.toml
+++ b/providers/opper/models/deepinfra/qwen3.6-35b-a3b.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.6-35b-a3b"
+name = "Qwen 3.6 35B-A3B (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.95
+
+[limit]
+output = 262_144

--- a/providers/opper/models/deepinfra/stepfun-ai/Step-3.5-Flash.toml
+++ b/providers/opper/models/deepinfra/stepfun-ai/Step-3.5-Flash.toml
@@ -1,0 +1,12 @@
+base_model = "stepfun/step-3.5-flash"
+base_model_omit = ["limit.input"]
+reasoning_options = []
+
+[cost]
+input = 0.09
+output = 0.3
+cache_read = 0.02
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/opper/models/deepinfra/zai-org/GLM-4.6.toml
+++ b/providers/opper/models/deepinfra/zai-org/GLM-4.6.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-4.6"
+name = "GLM 4.6 (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 2
+cache_read = 0.1
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/opper/models/deepinfra/zai-org/GLM-4.7-Flash.toml
+++ b/providers/opper/models/deepinfra/zai-org/GLM-4.7-Flash.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-4.7-flash"
+name = "GLM 4.7 Flash (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.06
+output = 0.4
+cache_read = 0.01
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/opper/models/deepinfra/zai-org/GLM-4.7.toml
+++ b/providers/opper/models/deepinfra/zai-org/GLM-4.7.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-4.7"
+name = "GLM 4.7 (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 1.75
+cache_read = 0.08
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/opper/models/deepinfra/zai-org/GLM-5.2.toml
+++ b/providers/opper/models/deepinfra/zai-org/GLM-5.2.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (DeepInfra)"
+reasoning_options = []
+
+[cost]
+input = 0.75
+output = 2.4
+cache_read = 0.14
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/deepinfra/zai-org/GLM-5.toml
+++ b/providers/opper/models/deepinfra/zai-org/GLM-5.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-5"
+name = "GLM 5 (DeepInfra)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 2.08
+cache_read = 0.12
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/opper/models/empiriolabs/gemma-4-26b-a4b.toml
+++ b/providers/opper/models/empiriolabs/gemma-4-26b-a4b.toml
@@ -1,0 +1,14 @@
+base_model = "google/gemma-4-26b-a4b-it"
+name = "Gemma 4 26B A4B IT (EmpirioLabs)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 0.05
+output = 0.29
+cache_read = 0.025
+
+[modalities]
+input = ["text", "image", "video"]

--- a/providers/opper/models/empiriolabs/muse-glimmer-30b.toml
+++ b/providers/opper/models/empiriolabs/muse-glimmer-30b.toml
@@ -1,0 +1,14 @@
+base_model = "meta/muse-glimmer-30b"
+name = "Muse Glimmer 30B (EmpirioLabs)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 0.2
+output = 0.8
+cache_read = 0.05
+
+[limit]
+output = 32_768

--- a/providers/opper/models/empiriolabs/qwen3-5-9b.toml
+++ b/providers/opper/models/empiriolabs/qwen3-5-9b.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3.5-9b"
+name = "Qwen3.5 9B (EmpirioLabs)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 0.09
+output = 0.13
+cache_read = 0.045
+
+[limit]
+output = 32_768

--- a/providers/opper/models/empiriolabs/qwen3-8-27b.toml
+++ b/providers/opper/models/empiriolabs/qwen3-8-27b.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.8-27b"
+name = "Qwen3.8 27B (EmpirioLabs)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "xhigh"]
+
+[cost]
+input = 0.17
+output = 0.5
+cache_read = 0.08

--- a/providers/opper/models/evroc/gpt-oss-120b.toml
+++ b/providers/opper/models/evroc/gpt-oss-120b.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Evroc)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.2329
+output = 0.9316
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/evroc/moonshotai/Kimi-K2.6.toml
+++ b/providers/opper/models/evroc/moonshotai/Kimi-K2.6.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (Evroc)"
+reasoning_options = []
+
+[cost]
+input = 1.572075
+output = 6.2883

--- a/providers/opper/models/evroc/qwen3.8-27b.toml
+++ b/providers/opper/models/evroc/qwen3.8-27b.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.8-27b"
+name = "Qwen3.8 27B (Evroc)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "xhigh"]
+
+[cost]
+input = 0.873375
+output = 3.4935

--- a/providers/opper/models/fireworks/deepseek-v4-flash-0731.toml
+++ b/providers/opper/models/fireworks/deepseek-v4-flash-0731.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) (Fireworks)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.22
+output = 0.66
+cache_read = 0.007
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/fireworks/deepseek-v4-flash.toml
+++ b/providers/opper/models/fireworks/deepseek-v4-flash.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash (Fireworks)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.22
+output = 0.66
+cache_read = 0.007
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/fireworks/deepseek-v4-pro-0813.toml
+++ b/providers/opper/models/fireworks/deepseek-v4-pro-0813.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (Fireworks)"
+reasoning_options = []
+
+[cost]
+input = 1.32
+output = 3.96
+cache_read = 0.044
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/fireworks/deepseek-v4-pro.toml
+++ b/providers/opper/models/fireworks/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek V4 Pro (Fireworks)"
+reasoning_options = []
+
+[cost]
+input = 1.74
+output = 3.48
+cache_read = 0.145
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/fireworks/glm-5p2.toml
+++ b/providers/opper/models/fireworks/glm-5p2.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Fireworks)"
+reasoning_options = []
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.14
+
+[limit]
+context = 1_040_000

--- a/providers/opper/models/fireworks/gpt-oss-120b.toml
+++ b/providers/opper/models/fireworks/gpt-oss-120b.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Fireworks)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.014
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/fireworks/gpt-oss-20b.toml
+++ b/providers/opper/models/fireworks/gpt-oss-20b.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Fireworks)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.07
+output = 0.3
+cache_read = 0.035
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/fireworks/inkling.toml
+++ b/providers/opper/models/fireworks/inkling.toml
@@ -1,0 +1,8 @@
+base_model = "thinkingmachines/inkling"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1
+output = 4.05
+cache_read = 0.17

--- a/providers/opper/models/fireworks/kimi-k2p6.toml
+++ b/providers/opper/models/fireworks/kimi-k2p6.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (Fireworks)"
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.16

--- a/providers/opper/models/fireworks/kimi-k2p7-code-fast.toml
+++ b/providers/opper/models/fireworks/kimi-k2p7-code-fast.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi K2.7 Code Fast"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 1.9
+output = 8
+cache_read = 0.38

--- a/providers/opper/models/fireworks/kimi-k2p7-code.toml
+++ b/providers/opper/models/fireworks/kimi-k2p7-code.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi K2.7 Code (Fireworks)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19

--- a/providers/opper/models/fireworks/kimi-k3.toml
+++ b/providers/opper/models/fireworks/kimi-k3.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (Fireworks)"
+temperature = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["max"]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+
+[limit]
+output = 1_048_576

--- a/providers/opper/models/fireworks/minimax-m2p7.toml
+++ b/providers/opper/models/fireworks/minimax-m2p7.toml
@@ -1,0 +1,12 @@
+base_model = "minimax/MiniMax-M2.7"
+name = "MiniMax M2.7 (Fireworks)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.059
+
+[limit]
+context = 196_608

--- a/providers/opper/models/fireworks/minimax-m3.toml
+++ b/providers/opper/models/fireworks/minimax-m3.toml
@@ -1,0 +1,12 @@
+base_model = "minimax/MiniMax-M3"
+name = "MiniMax M3 (Fireworks)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.059
+
+[limit]
+context = 512_000

--- a/providers/opper/models/fireworks/muse-glimmer-30b.toml
+++ b/providers/opper/models/fireworks/muse-glimmer-30b.toml
@@ -1,0 +1,8 @@
+base_model = "meta/muse-glimmer-30b"
+name = "Muse Glimmer 30B (Fireworks)"
+reasoning_options = []
+
+[cost]
+input = 0.35
+output = 1.5
+cache_read = 0.04

--- a/providers/opper/models/fireworks/qwen3p7-plus.toml
+++ b/providers/opper/models/fireworks/qwen3p7-plus.toml
@@ -1,0 +1,13 @@
+base_model = "alibaba/qwen3.7-plus"
+name = "Qwen3.7-Plus (Fireworks)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.08
+
+[limit]
+context = 262_144
+output = 65_536

--- a/providers/opper/models/fireworks/qwen3p8-2p4t-a95b.toml
+++ b/providers/opper/models/fireworks/qwen3p8-2p4t-a95b.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.8-2.4t-a95b"
+name = "Qwen3.8-2.4T-A95B"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.25
+
+[limit]
+output = 262_144

--- a/providers/opper/models/gcp/claude-haiku-4-5-eu.toml
+++ b/providers/opper/models/gcp/claude-haiku-4-5-eu.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-haiku-4-5"
+name = "Claude Haiku 4.5 (gcp/claude-haiku-4-5-eu)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1.1
+output = 5.5
+cache_read = 0.11
+cache_write = 1.375

--- a/providers/opper/models/gcp/claude-haiku-4-5.toml
+++ b/providers/opper/models/gcp/claude-haiku-4-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-haiku-4-5"
+name = "Claude Haiku 4.5 (gcp/claude-haiku-4-5)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25

--- a/providers/opper/models/gcp/claude-opus-4-5.toml
+++ b/providers/opper/models/gcp/claude-opus-4-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-opus-4-5"
+name = "Claude Opus 4.5 (Google)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/gcp/claude-opus-4-7-eu.toml
+++ b/providers/opper/models/gcp/claude-opus-4-7-eu.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-4-7"
+name = "Claude Opus 4.7 (Google, EU)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5.5
+output = 27.5
+cache_read = 0.55
+cache_write = 6.875
+
+[limit]
+output = 64_000

--- a/providers/opper/models/gcp/claude-opus-4-7.toml
+++ b/providers/opper/models/gcp/claude-opus-4-7.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-opus-4-7"
+name = "Claude Opus 4.7 (Google, US)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+output = 64_000

--- a/providers/opper/models/gcp/claude-sonnet-4-5-eu.toml
+++ b/providers/opper/models/gcp/claude-sonnet-4-5-eu.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-sonnet-4-5"
+name = "Claude Sonnet 4.5 (Google, EU)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 3.3
+output = 16.5
+cache_read = 0.33
+cache_write = 4.125
+
+[[cost.tiers]]
+tier = { type = "context", size = 199_999 }
+input = 6.6
+output = 24.75
+cache_read = 0.66
+cache_write = 8.25

--- a/providers/opper/models/gcp/claude-sonnet-4-5.toml
+++ b/providers/opper/models/gcp/claude-sonnet-4-5.toml
@@ -1,0 +1,17 @@
+base_model = "anthropic/claude-sonnet-4-5"
+name = "Claude Sonnet 4.5 (Google, US)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[[cost.tiers]]
+tier = { type = "context", size = 199_999 }
+input = 6
+output = 22.5
+cache_read = 0.6
+cache_write = 7.5

--- a/providers/opper/models/gemini/deep-research-max-preview-04-2026.toml
+++ b/providers/opper/models/gemini/deep-research-max-preview-04-2026.toml
@@ -1,0 +1,19 @@
+base_model = "google/deep-research-max-preview-04-2026"
+name = "Deep Research Max Preview (Apr-21-2026)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4
+
+[limit]
+context = 131_072

--- a/providers/opper/models/gemini/deep-research-preview-04-2026.toml
+++ b/providers/opper/models/gemini/deep-research-preview-04-2026.toml
@@ -1,0 +1,19 @@
+base_model = "google/deep-research-preview-04-2026"
+name = "Deep Research Preview (Apr-21-2026)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4
+
+[limit]
+context = 131_072

--- a/providers/opper/models/gemini/gemini-2.5-computer-use-preview-10-2025.toml
+++ b/providers/opper/models/gemini/gemini-2.5-computer-use-preview-10-2025.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-2.5-computer-use-preview-10-2025"
+name = "Gemini 2.5 Computer Use Preview 10-2025"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 10
+
+[limit]
+context = 131_072
+output = 65_536

--- a/providers/opper/models/gemini/gemini-2.5-flash-image.toml
+++ b/providers/opper/models/gemini/gemini-2.5-flash-image.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-2.5-flash-image"
+name = "Gemini 2.5 Flash Image (Google, US)"
+tool_call = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.5
+
+[limit]
+context = 1_048_576
+output = 65_536

--- a/providers/opper/models/gemini/gemini-3-flash-preview.toml
+++ b/providers/opper/models/gemini/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+name = "Gemini 3 Flash Preview (gemini)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/opper/models/gemini/gemini-3-pro-image-preview.toml
+++ b/providers/opper/models/gemini/gemini-3-pro-image-preview.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3-pro-image-preview"
+name = "Gemini 3 Pro Image Preview (gemini)"
+tool_call = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 2
+output = 12
+
+[limit]
+context = 1_048_576
+output = 65_536

--- a/providers/opper/models/gemini/gemini-3.1-flash-image-preview.toml
+++ b/providers/opper/models/gemini/gemini-3.1-flash-image-preview.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3.1-flash-image-preview"
+name = "Gemini 3.1 Flash Image Preview (gemini)"
+tool_call = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 3
+
+[limit]
+context = 131_072
+output = 32_768

--- a/providers/opper/models/gemini/gemini-3.1-flash-lite-image.toml
+++ b/providers/opper/models/gemini/gemini-3.1-flash-lite-image.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-3.1-flash-lite-image"
+name = "Gemini 3.1 Flash Lite Image (gemini)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 1.5
+
+[limit]
+context = 131_072
+output = 32_768

--- a/providers/opper/models/gemini/gemini-3.1-flash-lite-preview.toml
+++ b/providers/opper/models/gemini/gemini-3.1-flash-lite-preview.toml
@@ -1,0 +1,7 @@
+base_model = "google/gemini-3.1-flash-lite-preview"
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025

--- a/providers/opper/models/gemini/gemini-3.1-flash-lite.toml
+++ b/providers/opper/models/gemini/gemini-3.1-flash-lite.toml
@@ -1,0 +1,7 @@
+base_model = "google/gemini-3.1-flash-lite"
+name = "Gemini 3.1 Flash Lite (gemini)"
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 1.5

--- a/providers/opper/models/gemini/gemini-3.1-pro-preview-customtools.toml
+++ b/providers/opper/models/gemini/gemini-3.1-pro-preview-customtools.toml
@@ -1,0 +1,6 @@
+base_model = "google/gemini-3.1-pro-preview-customtools"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 12

--- a/providers/opper/models/gemini/gemini-3.1-pro-preview.toml
+++ b/providers/opper/models/gemini/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+name = "Gemini 3.1 Pro Preview (gemini)"
 
 [[reasoning_options]]
 type = "effort"
@@ -10,7 +11,7 @@ output = 12
 cache_read = 0.2
 
 [[cost.tiers]]
-tier = { size = 200_000 }
-input = 4.00
-output = 18.00
-cache_read = 0.40
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4

--- a/providers/opper/models/gemini/gemini-3.5-flash-lite.toml
+++ b/providers/opper/models/gemini/gemini-3.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash-lite"
+name = "Gemini 3.5 Flash Lite (gemini)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/opper/models/gemini/gemini-3.5-flash.toml
+++ b/providers/opper/models/gemini/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+name = "Gemini 3.5 Flash (gemini)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/opper/models/gemini/gemini-3.6-flash.toml
+++ b/providers/opper/models/gemini/gemini-3.6-flash.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.6-flash"
+name = "Gemini 3.6 Flash (gemini)"
+reasoning_options = []
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075

--- a/providers/opper/models/gemini/gemini-flash-latest.toml
+++ b/providers/opper/models/gemini/gemini-flash-latest.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-flash-latest"
+name = "Gemini Flash Latest (gemini)"
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/opper/models/gemini/gemini-flash-lite-latest.toml
+++ b/providers/opper/models/gemini/gemini-flash-lite-latest.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-flash-lite-latest"
+name = "Gemini Flash Lite Latest (gemini)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01

--- a/providers/opper/models/gemini/gemma-4-26b-moe.toml
+++ b/providers/opper/models/gemini/gemma-4-26b-moe.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemma-4-26b-a4b-it"
+name = "Gemma 4 26B A4B IT (Google)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 256_000
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]

--- a/providers/opper/models/gemini/gemma-4-31b.toml
+++ b/providers/opper/models/gemini/gemma-4-31b.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B (Google)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[limit]
+context = 256_000
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]

--- a/providers/opper/models/geodd:no/gpt-oss-120b.toml
+++ b/providers/opper/models/geodd:no/gpt-oss-120b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Geodd, EU)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.039
+output = 0.182
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/geodd:no/gpt-oss-20b.toml
+++ b/providers/opper/models/geodd:no/gpt-oss-20b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Geodd, EU)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.03
+output = 0.14
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/geodd:no/kimi-k2.5.toml
+++ b/providers/opper/models/geodd:no/kimi-k2.5.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.5"
+name = "Kimi K2.5 (Geodd, EU)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 2.6

--- a/providers/opper/models/geodd:us/deepseek-v4-flash.toml
+++ b/providers/opper/models/geodd:us/deepseek-v4-flash.toml
@@ -1,0 +1,14 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash (Geodd)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.14
+output = 0.3
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/geodd:us/deepseek-v4-pro.toml
+++ b/providers/opper/models/geodd:us/deepseek-v4-pro.toml
@@ -1,0 +1,10 @@
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek V4 Pro (Geodd)"
+reasoning_options = []
+
+[cost]
+input = 1.48
+output = 3.4
+
+[limit]
+output = 1_000_000

--- a/providers/opper/models/geodd:us/gemma-4-31b.toml
+++ b/providers/opper/models/geodd:us/gemma-4-31b.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B (Geodd)"
+reasoning_options = []
+
+[cost]
+input = 0.13
+output = 0.37
+
+[limit]
+output = 262_144
+
+[modalities]
+input = ["text", "image", "audio", "video"]

--- a/providers/opper/models/geodd:us/glm-5.toml
+++ b/providers/opper/models/geodd:us/glm-5.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-5"
+name = "GLM 5 (Geodd)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 1.6
+
+[limit]
+context = 200_000
+output = 200_000

--- a/providers/opper/models/geodd:us/gpt-oss-120b.toml
+++ b/providers/opper/models/geodd:us/gpt-oss-120b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Geodd, US)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.039
+output = 0.182
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/geodd:us/gpt-oss-20b.toml
+++ b/providers/opper/models/geodd:us/gpt-oss-20b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Geodd, US)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.03
+output = 0.14
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/geodd:us/kimi-k2.5.toml
+++ b/providers/opper/models/geodd:us/kimi-k2.5.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.5"
+name = "Kimi K2.5 (Geodd, US)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 2.6

--- a/providers/opper/models/geodd:us/kimi-k2.6.toml
+++ b/providers/opper/models/geodd:us/kimi-k2.6.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (Geodd)"
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 3.2

--- a/providers/opper/models/geodd:us/minimax-m2.7.toml
+++ b/providers/opper/models/geodd:us/minimax-m2.7.toml
@@ -1,0 +1,12 @@
+base_model = "minimax/MiniMax-M2.7"
+name = "MiniMax M2.7 (Geodd)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 131_100
+output = 131_100

--- a/providers/opper/models/geodd:us/qwen3-coder-next.toml
+++ b/providers/opper/models/geodd:us/qwen3-coder-next.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3-coder-next"
+name = "Qwen 3 Coder Next (Geodd)"
+
+[cost]
+input = 0.078
+output = 0.98
+
+[limit]
+output = 262_144

--- a/providers/opper/models/groq/gpt-oss-120b.toml
+++ b/providers/opper/models/groq/gpt-oss-120b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Groq)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+context = 128_000
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/groq/gpt-oss-20b.toml
+++ b/providers/opper/models/groq/gpt-oss-20b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Groq)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.075
+output = 0.3
+
+[limit]
+context = 128_000
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/inceptron/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/opper/models/inceptron/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+reasoning_options = []
+
+[cost]
+input = 0.13
+output = 0.28
+cache_read = 0.03
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/inceptron/glm-5.2.toml
+++ b/providers/opper/models/inceptron/glm-5.2.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Inceptron)"
+reasoning_options = []
+
+[cost]
+input = 0.75
+output = 2.9
+cache_read = 0.17
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/inceptron/kimi-k2.6.toml
+++ b/providers/opper/models/inceptron/kimi-k2.6.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (Inceptron)"
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 3.41
+cache_read = 0.2
+
+[limit]
+context = 256_000
+output = 256_000

--- a/providers/opper/models/inceptron/minimax-m2.5.toml
+++ b/providers/opper/models/inceptron/minimax-m2.5.toml
@@ -1,0 +1,13 @@
+base_model = "minimax/MiniMax-M2.5"
+name = "MiniMax M2.5 (Inceptron)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.22
+output = 0.9
+cache_read = 0.05
+
+[limit]
+context = 200_000
+output = 196_608

--- a/providers/opper/models/inceptron/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/opper/models/inceptron/moonshotai/Kimi-K2.7-Code.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi K2.7 Code (Inceptron)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.67
+output = 3.4
+cache_read = 0.15

--- a/providers/opper/models/infercom/deepseek-v3.1.toml
+++ b/providers/opper/models/infercom/deepseek-v3.1.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-v3.1"
+name = "DeepSeek V3.1 (Infercom)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 3.4935
+output = 5.24025
+
+[limit]
+output = 131_072

--- a/providers/opper/models/infercom/deepseek-v3.2.toml
+++ b/providers/opper/models/infercom/deepseek-v3.2.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-v3.2"
+name = "DeepSeek V3.2 (Infercom)"
+reasoning_options = []
+
+[cost]
+input = 3.4935
+output = 5.24025
+
+[limit]
+context = 32_768
+output = 32_768

--- a/providers/opper/models/infercom/gemma-4-31b-it-eu.toml
+++ b/providers/opper/models/infercom/gemma-4-31b-it-eu.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B (Infercom)"
+reasoning_options = []
+
+[cost]
+input = 0.2329
+output = 0.407575
+
+[limit]
+context = 131_072
+output = 131_072

--- a/providers/opper/models/infercom/gpt-oss-120b-eu.toml
+++ b/providers/opper/models/infercom/gpt-oss-120b-eu.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Infercom)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.25619
+output = 0.687055
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/infercom/minimax-m2.7-eu.toml
+++ b/providers/opper/models/infercom/minimax-m2.7-eu.toml
@@ -1,0 +1,11 @@
+base_model = "minimax/MiniMax-M2.7"
+name = "MiniMax M2.7 (Infercom)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.6987
+output = 2.7948
+
+[limit]
+context = 196_608

--- a/providers/opper/models/melious/deepseek-v4-flash-0731.toml
+++ b/providers/opper/models/melious/deepseek-v4-flash-0731.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) (Melious)"
+reasoning_options = []
+
+[cost]
+input = 0.11645
+output = 0.34935
+cache_read = 0.02329
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/melious/deepseek-v4-pro-0813.toml
+++ b/providers/opper/models/melious/deepseek-v4-pro-0813.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (Melious)"
+reasoning_options = []
+
+[cost]
+input = 1.1645
+output = 3.4935
+cache_read = 0.2329
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/melious/glm-5.2.toml
+++ b/providers/opper/models/melious/glm-5.2.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Melious)"
+reasoning_options = []
+
+[cost]
+input = 1.1645
+output = 4.658
+cache_read = 0.291125
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/minimax/m3.toml
+++ b/providers/opper/models/minimax/m3.toml
@@ -3,8 +3,12 @@
 # list (0.30/1.20 base, upper band 0.60/2.40); the delta is flagged to Opper catalog
 # maintainers and this entry will be updated if the billed schedule changes.
 base_model = "minimax/MiniMax-M3"
-
+name = "MiniMax M3 (MiniMax)"
+structured_output = true
 reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.6
@@ -12,13 +16,10 @@ output = 2.4
 cache_read = 0.12
 
 [[cost.tiers]]
-tier = { size = 524_288 }
+tier = { type = "context", size = 524_288 }
 input = 1.2
 output = 4.8
 cache_read = 0.24
 
 [limit]
-context = 1_048_576
-
-[interleaved]
-field = "reasoning_content"
+output = 131_072

--- a/providers/opper/models/mistral/devstral-2512.toml
+++ b/providers/opper/models/mistral/devstral-2512.toml
@@ -1,5 +1,10 @@
 base_model = "mistral/devstral-2512"
+structured_output = true
 
 [cost]
 input = 0.4
 output = 2
+
+[limit]
+context = 256_000
+output = 8_192

--- a/providers/opper/models/mistral/mistral-large-2512.toml
+++ b/providers/opper/models/mistral/mistral-large-2512.toml
@@ -1,5 +1,11 @@
 base_model = "mistral/mistral-large-2512"
+name = "Mistral Large 3 (Mistral)"
+structured_output = true
 
 [cost]
 input = 0.5
 output = 1.5
+
+[limit]
+context = 256_000
+output = 8_192

--- a/providers/opper/models/mistral/mistral-small-2603.toml
+++ b/providers/opper/models/mistral/mistral-small-2603.toml
@@ -1,4 +1,6 @@
 base_model = "mistral/mistral-small-2603"
+name = "Mistral Small 4 (Mistral)"
+structured_output = true
 
 [[reasoning_options]]
 type = "effort"
@@ -7,3 +9,6 @@ values = ["none", "high"]
 [cost]
 input = 0.15
 output = 0.6
+
+[limit]
+output = 8_192

--- a/providers/opper/models/moonshot/kimi-k3.toml
+++ b/providers/opper/models/moonshot/kimi-k3.toml
@@ -1,13 +1,18 @@
 base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (Moonshot AI)"
+temperature = true
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high", "max"]
+values = ["max"]
 
 [cost]
 input = 3
 output = 15
 cache_read = 0.3
 
-[interleaved]
-field = "reasoning_content"
+[limit]
+output = 1_048_576

--- a/providers/opper/models/morph/deepseek-v4-flash-0731.toml
+++ b/providers/opper/models/morph/deepseek-v4-flash-0731.toml
@@ -1,0 +1,14 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) (Morph)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 0.139
+output = 0.278
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/morph/morph-dsv4flash.toml
+++ b/providers/opper/models/morph/morph-dsv4flash.toml
@@ -1,0 +1,14 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash (Morph)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 0.139
+output = 0.278
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/morph/morph-glm52-744b.toml
+++ b/providers/opper/models/morph/morph-glm52-744b.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Morph)"
+reasoning_options = []
+
+[cost]
+input = 1.1
+output = 4.1
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/morph/morph-kimik3-fast.toml
+++ b/providers/opper/models/morph/morph-kimik3-fast.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (morph/morph-kimik3-fast)"
+temperature = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 4.5
+output = 22.5
+cache_read = 0.45
+
+[limit]
+output = 1_048_576

--- a/providers/opper/models/morph/morph-kimik3.toml
+++ b/providers/opper/models/morph/morph-kimik3.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (morph/morph-kimik3)"
+temperature = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2.9
+output = 14
+cache_read = 0.29
+
+[limit]
+output = 1_048_576

--- a/providers/opper/models/morph/morph-minimax27-230b.toml
+++ b/providers/opper/models/morph/morph-minimax27-230b.toml
@@ -1,0 +1,11 @@
+base_model = "minimax/MiniMax-M2.7"
+name = "MiniMax M2.7 (Morph)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.279
+output = 1.2
+
+[limit]
+context = 196_608

--- a/providers/opper/models/morph/morph-minimax3-428b.toml
+++ b/providers/opper/models/morph/morph-minimax3-428b.toml
@@ -1,0 +1,12 @@
+base_model = "minimax/MiniMax-M3"
+name = "MiniMax M3 (Morph)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+context = 256_000
+output = 256_000

--- a/providers/opper/models/morph/morph-qwen35-397b.toml
+++ b/providers/opper/models/morph/morph-qwen35-397b.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.5-397b-a17b"
+name = "Qwen 3.5 397B (Morph)"
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 3.5
+cache_read = 0.3
+
+[limit]
+output = 131_072

--- a/providers/opper/models/morph/morph-qwen36-27b.toml
+++ b/providers/opper/models/morph/morph-qwen36-27b.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.6-27b"
+name = "Qwen 3.6 27B (Morph)"
+reasoning_options = []
+
+[cost]
+input = 0.289
+output = 2.4
+
+[limit]
+context = 131_072
+output = 131_072

--- a/providers/opper/models/nebius/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/opper/models/nebius/MiniMaxAI/MiniMax-M3.toml
@@ -1,0 +1,11 @@
+base_model = "minimax/MiniMax-M3"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 8_000
+output = 8_000

--- a/providers/opper/models/nebius/deepseek-ai/DeepSeek-V4-Flash.toml
+++ b/providers/opper/models/nebius/deepseek-ai/DeepSeek-V4-Flash.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek-V4-Flash"
+reasoning_options = []
+
+[cost]
+input = 0.14
+output = 0.28
+
+[limit]
+context = 8_000
+output = 8_000

--- a/providers/opper/models/nebius/gpt-oss-120b.toml
+++ b/providers/opper/models/nebius/gpt-oss-120b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Nebius)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 0.6
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/nebius/llama-3.3-70b-instruct.toml
+++ b/providers/opper/models/nebius/llama-3.3-70b-instruct.toml
@@ -1,0 +1,11 @@
+base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama 3.3 70B (Nebius)"
+structured_output = true
+
+[cost]
+input = 0.13
+output = 0.4
+
+[limit]
+context = 131_072
+output = 8_192

--- a/providers/opper/models/nebius/minimax-m2.5.toml
+++ b/providers/opper/models/nebius/minimax-m2.5.toml
@@ -1,0 +1,11 @@
+base_model = "minimax/MiniMax-M2.5"
+name = "MiniMax M2.5 (Nebius)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 196_608

--- a/providers/opper/models/nebius/moonshotai/Kimi-K2.6.toml
+++ b/providers/opper/models/nebius/moonshotai/Kimi-K2.6.toml
@@ -1,0 +1,7 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (Nebius)"
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4

--- a/providers/opper/models/nebius/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/opper/models/nebius/moonshotai/Kimi-K2.7-Code.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi-K2.7-Code"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+
+[limit]
+context = 8_000
+output = 8_000

--- a/providers/opper/models/nebius/moonshotai/Kimi-K3.toml
+++ b/providers/opper/models/nebius/moonshotai/Kimi-K3.toml
@@ -1,0 +1,14 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (Nebius)"
+temperature = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 3
+output = 15
+
+[limit]
+output = 1_048_576

--- a/providers/opper/models/nebius/nemotron-3-super-120b-a12b.toml
+++ b/providers/opper/models/nebius/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,11 @@
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+name = "Nemotron 3 Super 120B A12B (Nebius)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 0.9
+
+[limit]
+output = 65_536

--- a/providers/opper/models/nebius/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/opper/models/nebius/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,11 @@
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1
+output = 3
+
+[limit]
+context = 262_144
+output = 65_536

--- a/providers/opper/models/nebius/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/opper/models/nebius/qwen3-235b-a22b-instruct-2507.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3-235b-a22b-instruct-2507"
+name = "Qwen3 235B A22B Instruct (2507) (Nebius)"
+structured_output = true
+
+[cost]
+input = 0.2
+output = 0.6
+
+[limit]
+output = 65_536

--- a/providers/opper/models/nebius/qwen3-32b.toml
+++ b/providers/opper/models/nebius/qwen3-32b.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen3-32b"
+name = "Qwen3 32B (Nebius)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.3
+
+[limit]
+context = 40_960
+output = 8_192

--- a/providers/opper/models/nebius/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/opper/models/nebius/qwen3-next-80b-a3b-thinking.toml
@@ -1,0 +1,12 @@
+base_model = "alibaba/qwen3-next-80b-a3b-thinking"
+name = "Qwen 3 Next 80B A3B Thinking"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 1.2
+
+[limit]
+context = 128_000
+output = 65_536

--- a/providers/opper/models/nebius/qwen3.5-397b-a17b.toml
+++ b/providers/opper/models/nebius/qwen3.5-397b-a17b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.5-397b-a17b"
+name = "Qwen 3.5 397B (Nebius)"
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 3.6

--- a/providers/opper/models/nebius/zai-org/GLM-5.1.toml
+++ b/providers/opper/models/nebius/zai-org/GLM-5.1.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.1"
+name = "GLM 5.1 (Nebius)"
+reasoning_options = []
+
+[cost]
+input = 1.4
+output = 4.4
+
+[limit]
+context = 202_752
+output = 202_752

--- a/providers/opper/models/nebius/zai-org/GLM-5.2.toml
+++ b/providers/opper/models/nebius/zai-org/GLM-5.2.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Nebius)"
+reasoning_options = []
+
+[cost]
+input = 1.4
+output = 4.4
+
+[limit]
+context = 432_000
+output = 432_000

--- a/providers/opper/models/nextbit/deepseek:v4-flash-0731.toml
+++ b/providers/opper/models/nextbit/deepseek:v4-flash-0731.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) (Nextbit)"
+reasoning_options = []
+
+[cost]
+input = 0.16
+output = 0.3
+cache_read = 0.07
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/nextbit/gemma4:26b-a4b.toml
+++ b/providers/opper/models/nextbit/gemma4:26b-a4b.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemma-4-26b-a4b-it"
+name = "Gemma 4 26B A4B IT (Nextbit)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.05
+
+[limit]
+output = 262_144

--- a/providers/opper/models/novita/deepseek-ocr-2.toml
+++ b/providers/opper/models/novita/deepseek-ocr-2.toml
@@ -1,0 +1,9 @@
+base_model = "deepseek/deepseek-ocr-2"
+temperature = true
+
+[cost]
+input = 0.03
+output = 0.03
+
+[limit]
+context = 128_000

--- a/providers/opper/models/novita/deepseek-v3.1.toml
+++ b/providers/opper/models/novita/deepseek-v3.1.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v3.1"
+name = "DeepSeek V3.1 (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.27
+output = 1
+cache_read = 0.135
+
+[limit]
+output = 32_768

--- a/providers/opper/models/novita/deepseek-v3.2.toml
+++ b/providers/opper/models/novita/deepseek-v3.2.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v3.2"
+name = "DeepSeek V3.2 (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.269
+output = 0.4
+cache_read = 0.1345
+
+[limit]
+context = 163_840
+output = 65_536

--- a/providers/opper/models/novita/deepseek-v4-flash-0731.toml
+++ b/providers/opper/models/novita/deepseek-v4-flash-0731.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.44
+output = 1.32
+cache_read = 0.028
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/novita/deepseek-v4-flash.toml
+++ b/providers/opper/models/novita/deepseek-v4-flash.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.028
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/novita/deepseek-v4-pro.toml
+++ b/providers/opper/models/novita/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek V4 Pro (Novita)"
+reasoning_options = []
+
+[cost]
+input = 1.6
+output = 3.2
+cache_read = 0.145
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/novita/deepseek/deepseek-r1.toml
+++ b/providers/opper/models/novita/deepseek/deepseek-r1.toml
@@ -1,0 +1,11 @@
+base_model = "deepseek/deepseek-r1"
+name = "DeepSeek R1 (novita/deepseek/deepseek-r1)"
+reasoning_options = []
+
+[cost]
+input = 4
+output = 4
+
+[limit]
+context = 64_000
+output = 16_000

--- a/providers/opper/models/novita/deepseek/deepseek-v3-0324.toml
+++ b/providers/opper/models/novita/deepseek/deepseek-v3-0324.toml
@@ -1,0 +1,10 @@
+base_model = "deepseek/deepseek-v3-0324"
+name = "DeepSeek V3 (0324) (Novita)"
+structured_output = true
+
+[cost]
+input = 0.27
+output = 1.12
+
+[limit]
+output = 65_536

--- a/providers/opper/models/novita/deepseek/deepseek-v4-pro-0813.toml
+++ b/providers/opper/models/novita/deepseek/deepseek-v4-pro-0813.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (Novita)"
+reasoning_options = []
+
+[cost]
+input = 1.32
+output = 3.96
+cache_read = 0.35
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/novita/glm-4.7-flash.toml
+++ b/providers/opper/models/novita/glm-4.7-flash.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-4.7-flash"
+name = "GLM 4.7 Flash (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.07
+output = 0.4
+cache_read = 0.01
+
+[limit]
+output = 128_000

--- a/providers/opper/models/novita/glm-4.7.toml
+++ b/providers/opper/models/novita/glm-4.7.toml
@@ -1,0 +1,9 @@
+base_model = "zhipuai/glm-4.7"
+name = "GLM 4.7 (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 2.2
+cache_read = 0.11

--- a/providers/opper/models/novita/glm-5.toml
+++ b/providers/opper/models/novita/glm-5.toml
@@ -1,0 +1,8 @@
+base_model = "zhipuai/glm-5"
+name = "GLM 5 (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1
+output = 3.2

--- a/providers/opper/models/novita/google/gemma-4-26b-a4b-it.toml
+++ b/providers/opper/models/novita/google/gemma-4-26b-a4b-it.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemma-4-26b-a4b-it"
+name = "Gemma 4 26B A4B IT (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.13
+output = 0.4
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image", "audio", "video"]

--- a/providers/opper/models/novita/google/gemma-4-31b-it.toml
+++ b/providers/opper/models/novita/google/gemma-4-31b-it.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.14
+output = 0.4
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image", "audio", "video"]

--- a/providers/opper/models/novita/kimi-k2.5.toml
+++ b/providers/opper/models/novita/kimi-k2.5.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k2.5"
+name = "Kimi K2.5 (Novita)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 3
+cache_read = 0.1

--- a/providers/opper/models/novita/kimi-k2.6.toml
+++ b/providers/opper/models/novita/kimi-k2.6.toml
@@ -1,0 +1,8 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.8
+output = 3.4
+cache_read = 0.16

--- a/providers/opper/models/novita/kimi-k3.toml
+++ b/providers/opper/models/novita/kimi-k3.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (Novita)"
+temperature = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["max"]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+
+[limit]
+output = 1_048_576

--- a/providers/opper/models/novita/meta-llama/llama-3.1-8b-instruct.toml
+++ b/providers/opper/models/novita/meta-llama/llama-3.1-8b-instruct.toml
@@ -1,0 +1,11 @@
+base_model = "meta/llama-3.1-8b-instruct"
+name = "Llama 3.1 8B Instruct (Novita)"
+structured_output = true
+
+[cost]
+input = 0.02
+output = 0.05
+
+[limit]
+context = 16_384
+output = 16_384

--- a/providers/opper/models/novita/meta-llama/llama-3.3-70b-instruct.toml
+++ b/providers/opper/models/novita/meta-llama/llama-3.3-70b-instruct.toml
@@ -1,0 +1,11 @@
+base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama 3.3 70B (Novita)"
+structured_output = true
+
+[cost]
+input = 0.135
+output = 0.4
+
+[limit]
+context = 131_072
+output = 120_000

--- a/providers/opper/models/novita/minimax-m2.1.toml
+++ b/providers/opper/models/novita/minimax-m2.1.toml
@@ -1,0 +1,9 @@
+base_model = "minimax/MiniMax-M2.1"
+name = "MiniMax M2.1"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.03

--- a/providers/opper/models/novita/minimax-m2.5.toml
+++ b/providers/opper/models/novita/minimax-m2.5.toml
@@ -1,0 +1,8 @@
+base_model = "minimax/MiniMax-M2.5"
+name = "MiniMax M2.5 (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/opper/models/novita/minimax-m2.toml
+++ b/providers/opper/models/novita/minimax-m2.toml
@@ -1,0 +1,9 @@
+base_model = "minimax/MiniMax-M2"
+name = "MiniMax M2"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.03

--- a/providers/opper/models/novita/minimax/minimax-m2.5-highspeed.toml
+++ b/providers/opper/models/novita/minimax/minimax-m2.5-highspeed.toml
@@ -1,0 +1,11 @@
+base_model = "minimax/MiniMax-M2.5-highspeed"
+name = "MiniMax M2.5-highspeed"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+output = 131_100

--- a/providers/opper/models/novita/minimax/minimax-m2.7-highspeed.toml
+++ b/providers/opper/models/novita/minimax/minimax-m2.7-highspeed.toml
@@ -1,0 +1,8 @@
+base_model = "minimax/MiniMax-M2.7-highspeed"
+name = "MiniMax M2.7-highspeed"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 2.4

--- a/providers/opper/models/novita/minimax/minimax-m2.7.toml
+++ b/providers/opper/models/novita/minimax/minimax-m2.7.toml
@@ -1,0 +1,8 @@
+base_model = "minimax/MiniMax-M2.7"
+name = "MiniMax M2.7 (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/opper/models/novita/minimax/minimax-m3.toml
+++ b/providers/opper/models/novita/minimax/minimax-m3.toml
@@ -1,0 +1,19 @@
+base_model = "minimax/MiniMax-M3"
+name = "MiniMax M3 (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.06
+
+[[cost.tiers]]
+tier = { type = "context", size = 524_288 }
+input = 0.6
+output = 2.4
+cache_read = 0.12
+
+[limit]
+context = 1_000_000
+output = 131_072

--- a/providers/opper/models/novita/mistralai/mistral-nemo.toml
+++ b/providers/opper/models/novita/mistralai/mistral-nemo.toml
@@ -1,0 +1,10 @@
+base_model = "mistral/mistral-nemo"
+structured_output = true
+
+[cost]
+input = 0.04
+output = 0.17
+
+[limit]
+context = 60_288
+output = 16_000

--- a/providers/opper/models/novita/moonshotai/kimi-k2.7-code.toml
+++ b/providers/opper/models/novita/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,9 @@
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi K2.7 Code (Novita)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19

--- a/providers/opper/models/novita/nvidia/nemotron-3-nano-30b-a3b.toml
+++ b/providers/opper/models/novita/nvidia/nemotron-3-nano-30b-a3b.toml
@@ -1,0 +1,11 @@
+base_model = "nvidia/nemotron-3-nano-30b-a3b"
+name = "Nemotron 3 Nano 30B A3B (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.05
+output = 0.2
+
+[limit]
+output = 32_768

--- a/providers/opper/models/novita/openai/gpt-oss-120b.toml
+++ b/providers/opper/models/novita/openai/gpt-oss-120b.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Novita)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.05
+output = 0.25
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/novita/openai/gpt-oss-20b.toml
+++ b/providers/opper/models/novita/openai/gpt-oss-20b.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Novita)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.04
+output = 0.15
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/novita/qwen/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/opper/models/novita/qwen/qwen3-235b-a22b-instruct-2507.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3-235b-a22b-instruct-2507"
+name = "Qwen3 235B A22B Instruct (2507) (Novita)"
+structured_output = true
+
+[cost]
+input = 0.09
+output = 0.58
+
+[limit]
+context = 131_072

--- a/providers/opper/models/novita/qwen/qwen3-coder-30b-a3b-instruct.toml
+++ b/providers/opper/models/novita/qwen/qwen3-coder-30b-a3b-instruct.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
+name = "Qwen3 Coder 30b A3B Instruct"
+structured_output = true
+
+[cost]
+input = 0.07
+output = 0.27
+
+[limit]
+context = 160_000
+output = 32_768

--- a/providers/opper/models/novita/qwen/qwen3-max.toml
+++ b/providers/opper/models/novita/qwen/qwen3-max.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3-max"
+name = "Qwen3 Max (Novita)"
+structured_output = true
+
+[cost]
+input = 2.11
+output = 8.45

--- a/providers/opper/models/novita/qwen/qwen3-next-80b-a3b-instruct.toml
+++ b/providers/opper/models/novita/qwen/qwen3-next-80b-a3b-instruct.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+name = "Qwen3 Next 80B A3B Instruct (Novita)"
+reasoning = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 1.5

--- a/providers/opper/models/novita/qwen/qwen3-vl-235b-a22b-instruct.toml
+++ b/providers/opper/models/novita/qwen/qwen3-vl-235b-a22b-instruct.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-vl-235b-a22b-instruct"
+name = "Qwen3 VL 235B A22B Instruct (Novita)"
+
+[cost]
+input = 0.3
+output = 1.5

--- a/providers/opper/models/novita/qwen/qwen3-vl-235b-a22b-thinking.toml
+++ b/providers/opper/models/novita/qwen/qwen3-vl-235b-a22b-thinking.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-vl-235b-a22b-thinking"
+reasoning_options = []
+
+[cost]
+input = 0.98
+output = 3.95

--- a/providers/opper/models/novita/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/opper/models/novita/qwen/qwen3.5-122b-a10b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.5-122b-a10b"
+name = "Qwen3.5 122B A10B (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 3.2

--- a/providers/opper/models/novita/qwen/qwen3.5-27b.toml
+++ b/providers/opper/models/novita/qwen/qwen3.5-27b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.5-27b"
+name = "Qwen3.5 27B (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.4

--- a/providers/opper/models/novita/qwen/qwen3.5-35b-a3b.toml
+++ b/providers/opper/models/novita/qwen/qwen3.5-35b-a3b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.5-35b-a3b"
+name = "Qwen3.5 35B A3B (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 2

--- a/providers/opper/models/novita/qwen/qwen3.6-27b.toml
+++ b/providers/opper/models/novita/qwen/qwen3.6-27b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.6-27b"
+name = "Qwen 3.6 27B (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 3.6

--- a/providers/opper/models/novita/qwen/qwen3.6-35b-a3b.toml
+++ b/providers/opper/models/novita/qwen/qwen3.6-35b-a3b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.6-35b-a3b"
+name = "Qwen 3.6 35B-A3B (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.248
+output = 1.485

--- a/providers/opper/models/novita/qwen/qwen3.7-max.toml
+++ b/providers/opper/models/novita/qwen/qwen3.7-max.toml
@@ -1,0 +1,8 @@
+base_model = "alibaba/qwen3.7-max"
+name = "Qwen3.7-Max (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 3.75

--- a/providers/opper/models/novita/qwen/qwen3.8-max.toml
+++ b/providers/opper/models/novita/qwen/qwen3.8-max.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.8-max"
+structured_output = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.25

--- a/providers/opper/models/novita/qwen3-coder-480b.toml
+++ b/providers/opper/models/novita/qwen3-coder-480b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3-coder-480b-a35b-instruct"
+name = "Qwen 3 Coder 480B"
+structured_output = true
+
+[cost]
+input = 0.38
+output = 1.55

--- a/providers/opper/models/novita/qwen3-coder-next.toml
+++ b/providers/opper/models/novita/qwen3-coder-next.toml
@@ -1,0 +1,6 @@
+base_model = "alibaba/qwen3-coder-next"
+name = "Qwen 3 Coder Next (Novita)"
+
+[cost]
+input = 0.2
+output = 1.5

--- a/providers/opper/models/novita/qwen3.5-397b-a17b.toml
+++ b/providers/opper/models/novita/qwen3.5-397b-a17b.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3.5-397b-a17b"
+name = "Qwen 3.5 397B (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 3.6

--- a/providers/opper/models/novita/stepfun/step-3.7-flash.toml
+++ b/providers/opper/models/novita/stepfun/step-3.7-flash.toml
@@ -1,0 +1,12 @@
+base_model = "stepfun/step-3.7-flash"
+base_model_omit = ["limit.input"]
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.2
+output = 1.15
+cache_read = 0.04
+
+[limit]
+context = 262_144

--- a/providers/opper/models/novita/tencent/hy3.toml
+++ b/providers/opper/models/novita/tencent/hy3.toml
@@ -1,0 +1,12 @@
+base_model = "tencent/hy3"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.14
+output = 0.58
+cache_read = 0.035
+
+[limit]
+context = 262_144
+output = 262_144

--- a/providers/opper/models/novita/xiaomimimo/mimo-v2.5-pro.toml
+++ b/providers/opper/models/novita/xiaomimimo/mimo-v2.5-pro.toml
@@ -1,0 +1,8 @@
+base_model = "xiaomi/mimo-v2.5-pro"
+name = "MiMo V2.5 Pro (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.522
+output = 1.044

--- a/providers/opper/models/novita/xiaomimimo/mimo-v2.5.toml
+++ b/providers/opper/models/novita/xiaomimimo/mimo-v2.5.toml
@@ -1,0 +1,9 @@
+base_model = "xiaomi/mimo-v2.5"
+name = "MiMo V2.5 (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.168
+output = 0.336
+cache_read = 0.0034

--- a/providers/opper/models/novita/zai-org/glm-4.5-air.toml
+++ b/providers/opper/models/novita/zai-org/glm-4.5-air.toml
@@ -1,0 +1,8 @@
+base_model = "zhipuai/glm-4.5-air"
+name = "GLM 4.5 Air"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.13
+output = 0.85

--- a/providers/opper/models/novita/zai-org/glm-4.5v.toml
+++ b/providers/opper/models/novita/zai-org/glm-4.5v.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-4.5v"
+name = "GLM 4.5V"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 1.8
+
+[limit]
+context = 65_536

--- a/providers/opper/models/novita/zai-org/glm-4.6.toml
+++ b/providers/opper/models/novita/zai-org/glm-4.6.toml
@@ -1,0 +1,8 @@
+base_model = "zhipuai/glm-4.6"
+name = "GLM 4.6 (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.55
+output = 2.2

--- a/providers/opper/models/novita/zai-org/glm-4.6v.toml
+++ b/providers/opper/models/novita/zai-org/glm-4.6v.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-4.6v"
+name = "GLM 4.6V"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 0.9
+
+[limit]
+context = 131_072

--- a/providers/opper/models/novita/zai-org/glm-5-turbo.toml
+++ b/providers/opper/models/novita/zai-org/glm-5-turbo.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5-turbo"
+name = "GLM-5-Turbo (Novita)"
+reasoning_options = []
+
+[cost]
+input = 1.2
+output = 4
+
+[limit]
+context = 202_800

--- a/providers/opper/models/novita/zai-org/glm-5.1.toml
+++ b/providers/opper/models/novita/zai-org/glm-5.1.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.1"
+name = "GLM 5.1 (Novita)"
+reasoning_options = []
+
+[cost]
+input = 1.38
+output = 4.4
+
+[limit]
+context = 204_800

--- a/providers/opper/models/novita/zai-org/glm-5.2.toml
+++ b/providers/opper/models/novita/zai-org/glm-5.2.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Novita)"
+reasoning_options = []
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 1_048_576

--- a/providers/opper/models/novita/zai-org/glm-5.3-flash.toml
+++ b/providers/opper/models/novita/zai-org/glm-5.3-flash.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.3-flash"
+name = "GLM-5.3-Flash (Novita)"
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 0.5
+cache_read = 0.03
+
+[limit]
+context = 1_048_576

--- a/providers/opper/models/novita/zai-org/glm-5v-turbo.toml
+++ b/providers/opper/models/novita/zai-org/glm-5v-turbo.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5v-turbo"
+name = "GLM-5V-Turbo (Novita)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1.2
+output = 4
+
+[limit]
+context = 204_800

--- a/providers/opper/models/openai/gpt-4.1-mini.toml
+++ b/providers/opper/models/openai/gpt-4.1-mini.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-4.1-mini"
+name = "GPT-4.1 Mini"
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.1

--- a/providers/opper/models/openai/gpt-4.1-nano.toml
+++ b/providers/opper/models/openai/gpt-4.1-nano.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-4.1-nano"
+name = "GPT-4.1 Nano"
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.025
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/gpt-4.1.toml
+++ b/providers/opper/models/openai/gpt-4.1.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-4.1"
+
+[cost]
+input = 2
+output = 8
+cache_read = 0.5

--- a/providers/opper/models/openai/gpt-4o-2024-05-13.toml
+++ b/providers/opper/models/openai/gpt-4o-2024-05-13.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-4o-2024-05-13"
+name = "GPT-4o (May 2024)"
+
+[cost]
+input = 5
+output = 15
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/gpt-4o-2024-08-06.toml
+++ b/providers/opper/models/openai/gpt-4o-2024-08-06.toml
@@ -1,0 +1,10 @@
+base_model = "openai/gpt-4o-2024-08-06"
+name = "GPT-4o (Aug 2024)"
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/gpt-4o-mini.toml
+++ b/providers/opper/models/openai/gpt-4o-mini.toml
@@ -1,0 +1,7 @@
+base_model = "openai/gpt-4o-mini"
+name = "GPT-4o Mini"
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.075

--- a/providers/opper/models/openai/gpt-4o.toml
+++ b/providers/opper/models/openai/gpt-4o.toml
@@ -1,0 +1,6 @@
+base_model = "openai/gpt-4o"
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25

--- a/providers/opper/models/openai/gpt-5-mini.toml
+++ b/providers/opper/models/openai/gpt-5-mini.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5-mini"
+base_model_omit = ["limit.input"]
+name = "GPT-5 Mini (OpenAI)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/gpt-5-nano.toml
+++ b/providers/opper/models/openai/gpt-5-nano.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5-nano"
+base_model_omit = ["limit.input"]
+name = "GPT-5 Nano (OpenAI)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 0.05
+output = 0.4
+cache_read = 0.005
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/gpt-5-pro.toml
+++ b/providers/opper/models/openai/gpt-5-pro.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-5-pro"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["high"]
+
+[cost]
+input = 15
+output = 120
+
+[limit]
+context = 272_000
+output = 128_000

--- a/providers/opper/models/openai/gpt-5.1.toml
+++ b/providers/opper/models/openai/gpt-5.1.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5.1"
+base_model_omit = ["limit.input"]
+name = "GPT-5.1 (OpenAI)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/gpt-5.2-pro.toml
+++ b/providers/opper/models/openai/gpt-5.2-pro.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-5.2-pro"
+base_model_omit = ["limit.input"]
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 21
+output = 168
+
+[limit]
+context = 272_000

--- a/providers/opper/models/openai/gpt-5.2.toml
+++ b/providers/opper/models/openai/gpt-5.2.toml
@@ -1,0 +1,17 @@
+base_model = "openai/gpt-5.2"
+base_model_omit = ["limit.input"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/gpt-5.3-chat-latest.toml
+++ b/providers/opper/models/openai/gpt-5.3-chat-latest.toml
@@ -1,6 +1,16 @@
 base_model = "openai/gpt-5.3-chat-latest"
+name = "GPT-5.3 Chat Latest"
+reasoning = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
 
 [cost]
 input = 1.75
 output = 14
 cache_read = 0.175
+
+[limit]
+context = 272_000
+output = 128_000

--- a/providers/opper/models/openai/gpt-5.3-codex.toml
+++ b/providers/opper/models/openai/gpt-5.3-codex.toml
@@ -1,8 +1,15 @@
 base_model = "openai/gpt-5.3-codex"
+base_model_omit = ["limit.input"]
+name = "GPT-5.3 Codex (OpenAI)"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
 
 [cost]
 input = 1.75
 output = 14
 cache_read = 0.175
+
+[limit]
+context = 272_000

--- a/providers/opper/models/openai/gpt-5.4-mini.toml
+++ b/providers/opper/models/openai/gpt-5.4-mini.toml
@@ -1,8 +1,14 @@
 base_model = "openai/gpt-5.4-mini"
+name = "GPT-5.4 Mini (OpenAI)"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
 
 [cost]
 input = 0.75
 output = 4.5
 cache_read = 0.075
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/gpt-5.4-nano.toml
+++ b/providers/opper/models/openai/gpt-5.4-nano.toml
@@ -1,8 +1,14 @@
 base_model = "openai/gpt-5.4-nano"
+name = "GPT-5.4 Nano (OpenAI)"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
 
 [cost]
 input = 0.2
 output = 1.25
 cache_read = 0.02
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/gpt-5.4-pro.toml
+++ b/providers/opper/models/openai/gpt-5.4-pro.toml
@@ -1,12 +1,15 @@
 base_model = "openai/gpt-5.4-pro"
+name = "GPT-5.4 pro"
 
-reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["medium", "high", "xhigh"]
 
 [cost]
 input = 30
 output = 180
 
 [[cost.tiers]]
-tier = { size = 272_000 }
-input = 60.00
-output = 270.00
+tier = { type = "context", size = 272_000 }
+input = 60
+output = 270

--- a/providers/opper/models/openai/gpt-5.4.toml
+++ b/providers/opper/models/openai/gpt-5.4.toml
@@ -1,6 +1,9 @@
 base_model = "openai/gpt-5.4"
+name = "GPT-5.4 (OpenAI)"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
 
 [cost]
 input = 2.5
@@ -8,7 +11,7 @@ output = 15
 cache_read = 0.25
 
 [[cost.tiers]]
-tier = { size = 272_000 }
-input = 5.00
-output = 22.50
-cache_read = 0.50
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 22.5
+cache_read = 0.5

--- a/providers/opper/models/openai/gpt-5.5-pro.toml
+++ b/providers/opper/models/openai/gpt-5.5-pro.toml
@@ -1,12 +1,15 @@
 base_model = "openai/gpt-5.5-pro"
+name = "GPT-5.5 pro"
 
-reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["high"]
 
 [cost]
 input = 30
 output = 180
 
 [[cost.tiers]]
-tier = { size = 272_000 }
-input = 60.00
-output = 270.00
+tier = { type = "context", size = 272_000 }
+input = 60
+output = 270

--- a/providers/opper/models/openai/gpt-5.5.toml
+++ b/providers/opper/models/openai/gpt-5.5.toml
@@ -1,6 +1,9 @@
 base_model = "openai/gpt-5.5"
+name = "GPT-5.5 (OpenAI)"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
 
 [cost]
 input = 5
@@ -8,7 +11,7 @@ output = 30
 cache_read = 0.5
 
 [[cost.tiers]]
-tier = { size = 272_000 }
-input = 10.00
-output = 45.00
-cache_read = 1.00
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1

--- a/providers/opper/models/openai/gpt-5.6-luna.toml
+++ b/providers/opper/models/openai/gpt-5.6-luna.toml
@@ -1,6 +1,9 @@
 base_model = "openai/gpt-5.6-luna"
+name = "GPT-5.6 Luna (OpenAI)"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 0.2
@@ -9,8 +12,8 @@ cache_read = 0.02
 cache_write = 0.25
 
 [[cost.tiers]]
-tier = { size = 272_000 }
-input = 0.40
-output = 1.80
+tier = { type = "context", size = 272_000 }
+input = 0.4
+output = 1.8
 cache_read = 0.04
-cache_write = 0.50
+cache_write = 0.5

--- a/providers/opper/models/openai/gpt-5.6-sol.toml
+++ b/providers/opper/models/openai/gpt-5.6-sol.toml
@@ -1,6 +1,9 @@
 base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6 Sol (OpenAI)"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 5
@@ -9,8 +12,8 @@ cache_read = 0.5
 cache_write = 6.25
 
 [[cost.tiers]]
-tier = { size = 272_000 }
-input = 10.00
-output = 45.00
-cache_read = 1.00
-cache_write = 12.50
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 45
+cache_read = 1
+cache_write = 12.5

--- a/providers/opper/models/openai/gpt-5.6-terra.toml
+++ b/providers/opper/models/openai/gpt-5.6-terra.toml
@@ -1,6 +1,9 @@
 base_model = "openai/gpt-5.6-terra"
+name = "GPT-5.6 Terra (OpenAI)"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 2
@@ -9,8 +12,8 @@ cache_read = 0.2
 cache_write = 2.5
 
 [[cost.tiers]]
-tier = { size = 272_000 }
-input = 4.00
-output = 18.00
-cache_read = 0.40
-cache_write = 5.00
+tier = { type = "context", size = 272_000 }
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5

--- a/providers/opper/models/openai/gpt-5.toml
+++ b/providers/opper/models/openai/gpt-5.toml
@@ -1,0 +1,18 @@
+base_model = "openai/gpt-5"
+base_model_omit = ["limit.input"]
+name = "GPT-5 (OpenAI)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[limit]
+context = 272_000
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/openai/o1-pro.toml
+++ b/providers/opper/models/openai/o1-pro.toml
@@ -1,0 +1,10 @@
+base_model = "openai/o1-pro"
+name = "O1 Pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 150
+output = 600

--- a/providers/opper/models/openai/o1.toml
+++ b/providers/opper/models/openai/o1.toml
@@ -1,0 +1,11 @@
+base_model = "openai/o1"
+name = "O1"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 15
+output = 60
+cache_read = 7.5

--- a/providers/opper/models/openai/o3-mini.toml
+++ b/providers/opper/models/openai/o3-mini.toml
@@ -1,0 +1,15 @@
+base_model = "openai/o3-mini"
+name = "O3 Mini"
+attachment = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.55
+
+[modalities]
+input = ["text", "pdf"]

--- a/providers/opper/models/openai/o3-pro.toml
+++ b/providers/opper/models/openai/o3-pro.toml
@@ -1,0 +1,10 @@
+base_model = "openai/o3-pro"
+name = "O3 Pro"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 20
+output = 80

--- a/providers/opper/models/openai/o3.toml
+++ b/providers/opper/models/openai/o3.toml
@@ -1,0 +1,11 @@
+base_model = "openai/o3"
+name = "O3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 2
+output = 8
+cache_read = 0.5

--- a/providers/opper/models/openai/o4-mini.toml
+++ b/providers/opper/models/openai/o4-mini.toml
@@ -1,0 +1,14 @@
+base_model = "openai/o4-mini"
+name = "O4 Mini"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
+[cost]
+input = 1.1
+output = 4.4
+cache_read = 0.275
+
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/perplexity/sonar-deep-research.toml
+++ b/providers/opper/models/perplexity/sonar-deep-research.toml
@@ -1,0 +1,12 @@
+base_model = "perplexity/sonar-deep-research"
+name = "Perplexity Sonar Deep Research"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 2
+output = 8
+
+[limit]
+output = 8_192

--- a/providers/opper/models/perplexity/sonar-pro.toml
+++ b/providers/opper/models/perplexity/sonar-pro.toml
@@ -1,5 +1,10 @@
 base_model = "perplexity/sonar-pro"
+name = "Perplexity Sonar Pro"
+structured_output = true
 
 [cost]
 input = 3
 output = 15
+
+[limit]
+output = 8_000

--- a/providers/opper/models/perplexity/sonar-reasoning-pro.toml
+++ b/providers/opper/models/perplexity/sonar-reasoning-pro.toml
@@ -1,7 +1,14 @@
 base_model = "perplexity/sonar-reasoning-pro"
+name = "Perplexity Sonar Reasoning Pro"
+structured_output = true
 
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
 
 [cost]
 input = 2
 output = 8
+
+[limit]
+output = 8_192

--- a/providers/opper/models/perplexity/sonar.toml
+++ b/providers/opper/models/perplexity/sonar.toml
@@ -1,5 +1,10 @@
 base_model = "perplexity/sonar"
+name = "Perplexity Sonar"
+structured_output = true
 
 [cost]
 input = 1
 output = 1
+
+[limit]
+output = 8_192

--- a/providers/opper/models/poolside/laguna-s-2.1.toml
+++ b/providers/opper/models/poolside/laguna-s-2.1.toml
@@ -1,0 +1,6 @@
+base_model = "poolside/laguna-s-2.1"
+name = "Poolside Laguna S 2.1"
+reasoning_options = []
+
+[limit]
+context = 262_144

--- a/providers/opper/models/poolside/laguna-xs-2.1.toml
+++ b/providers/opper/models/poolside/laguna-xs-2.1.toml
@@ -1,0 +1,3 @@
+base_model = "poolside/laguna-xs-2.1"
+name = "Poolside Laguna XS 2.1"
+reasoning_options = []

--- a/providers/opper/models/regolo/apertus-70b.toml
+++ b/providers/opper/models/regolo/apertus-70b.toml
@@ -1,0 +1,9 @@
+base_model = "swiss-ai/apertus-70b"
+structured_output = true
+
+[cost]
+input = 0.4658
+output = 2.44545
+
+[limit]
+output = 65_536

--- a/providers/opper/models/regolo/gemma4-31b.toml
+++ b/providers/opper/models/regolo/gemma4-31b.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B (Regolo)"
+reasoning_options = []
+
+[cost]
+input = 0.4658
+output = 2.44545
+
+[limit]
+output = 262_144
+
+[modalities]
+input = ["text", "image", "audio", "video"]

--- a/providers/opper/models/regolo/glm5.2-beta.toml
+++ b/providers/opper/models/regolo/glm5.2-beta.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Regolo)"
+reasoning_options = []
+
+[cost]
+input = 2.329
+output = 6.0554
+
+[limit]
+context = 96_000
+output = 96_000

--- a/providers/opper/models/regolo/gpt-oss-120b.toml
+++ b/providers/opper/models/regolo/gpt-oss-120b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Regolo)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 1.1645
+output = 4.8909
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/regolo/gpt-oss-20b.toml
+++ b/providers/opper/models/regolo/gpt-oss-20b.toml
@@ -1,0 +1,14 @@
+base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Regolo)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.11645
+output = 0.48909
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image"]

--- a/providers/opper/models/regolo/llama-3.3-70b-instruct.toml
+++ b/providers/opper/models/regolo/llama-3.3-70b-instruct.toml
@@ -1,0 +1,10 @@
+base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama 3.3 70B (Regolo)"
+structured_output = true
+
+[cost]
+input = 0.6987
+output = 3.14415
+
+[limit]
+output = 8_192

--- a/providers/opper/models/regolo/mistral-small-4-119b.toml
+++ b/providers/opper/models/regolo/mistral-small-4-119b.toml
@@ -1,0 +1,10 @@
+base_model = "mistral/mistral-small-2603"
+name = "Mistral Small 4 (Regolo)"
+reasoning_options = []
+
+[cost]
+input = 0.58225
+output = 2.44545
+
+[limit]
+output = 8_192

--- a/providers/opper/models/regolo/qwen3-coder-next.toml
+++ b/providers/opper/models/regolo/qwen3-coder-next.toml
@@ -1,0 +1,9 @@
+base_model = "alibaba/qwen3-coder-next"
+name = "Qwen 3 Coder Next (Regolo)"
+
+[cost]
+input = 0.58225
+output = 2.329
+
+[limit]
+output = 262_144

--- a/providers/opper/models/regolo/qwen3.5-122b.toml
+++ b/providers/opper/models/regolo/qwen3.5-122b.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.5-122b-a10b"
+name = "Qwen3.5 122B A10B (Regolo)"
+reasoning_options = []
+
+[cost]
+input = 1.1645
+output = 4.8909
+
+[limit]
+output = 262_144

--- a/providers/opper/models/regolo/qwen3.5-9b.toml
+++ b/providers/opper/models/regolo/qwen3.5-9b.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.5-9b"
+name = "Qwen3.5 9B (Regolo)"
+reasoning_options = []
+
+[cost]
+input = 0.081515
+output = 0.407575
+
+[limit]
+output = 262_144

--- a/providers/opper/models/regolo/qwen3.6-27b.toml
+++ b/providers/opper/models/regolo/qwen3.6-27b.toml
@@ -1,0 +1,10 @@
+base_model = "alibaba/qwen3.6-27b"
+name = "Qwen 3.6 27B (Regolo)"
+reasoning_options = []
+
+[cost]
+input = 0.58225
+output = 2.44545
+
+[limit]
+output = 262_144

--- a/providers/opper/models/sference/Qwen/Qwen3.6-35B-A3B.toml
+++ b/providers/opper/models/sference/Qwen/Qwen3.6-35B-A3B.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3.6-35b-a3b"
+name = "Qwen 3.6 35B-A3B (Sference)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.05
+
+[limit]
+output = 262_144

--- a/providers/opper/models/sference/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/opper/models/sference/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) (Sference)"
+reasoning_options = []
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.07
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/sference/deepseek-v4-flash.toml
+++ b/providers/opper/models/sference/deepseek-v4-flash.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash (Sference)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.07
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/sference/kimi-k3.toml
+++ b/providers/opper/models/sference/kimi-k3.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (Sference)"
+temperature = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2.25
+output = 11.25
+cache_read = 0.225
+
+[limit]
+output = 1_048_576

--- a/providers/opper/models/sference/zai-org/GLM-5.2.toml
+++ b/providers/opper/models/sference/zai-org/GLM-5.2.toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Sference)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 1.2
+output = 4.2
+cache_read = 0.26
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/tensorx/deepseek/deepseek-v3.2.toml
+++ b/providers/opper/models/tensorx/deepseek/deepseek-v3.2.toml
@@ -1,0 +1,16 @@
+base_model = "deepseek/deepseek-v3.2"
+name = "DeepSeek V3.2 (TensorX)"
+attachment = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 0.5
+cache_read = 0.08
+
+[limit]
+context = 163_840
+output = 65_536
+
+[modalities]
+input = ["text", "pdf"]

--- a/providers/opper/models/tensorx/deepseek/deepseek-v4-flash-0731.toml
+++ b/providers/opper/models/tensorx/deepseek/deepseek-v4-flash-0731.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) (TensorX)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.25
+output = 0.3
+cache_read = 0.06
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/tensorx/deepseek/deepseek-v4-flash.toml
+++ b/providers/opper/models/tensorx/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash (TensorX)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[cost]
+input = 0.25
+output = 0.3
+cache_read = 0.06
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/tensorx/deepseek/deepseek-v4-pro.toml
+++ b/providers/opper/models/tensorx/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+base_model = "deepseek/deepseek-v4-pro"
+name = "DeepSeek V4 Pro (TensorX)"
+reasoning_options = []
+
+[cost]
+input = 1.75
+output = 3.5
+cache_read = 0.44
+
+[limit]
+context = 1_048_576
+output = 393_216

--- a/providers/opper/models/tensorx/minimax/minimax-m2.5.toml
+++ b/providers/opper/models/tensorx/minimax/minimax-m2.5.toml
@@ -1,0 +1,17 @@
+base_model = "minimax/MiniMax-M2.5"
+name = "MiniMax M2.5 (TensorX)"
+attachment = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.08
+
+[limit]
+context = 196_608
+output = 196_608
+
+[modalities]
+input = ["text", "pdf"]

--- a/providers/opper/models/tensorx/minimax/minimax-m3.toml
+++ b/providers/opper/models/tensorx/minimax/minimax-m3.toml
@@ -1,0 +1,15 @@
+base_model = "minimax/MiniMax-M3"
+name = "MiniMax M3 (TensorX)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.4
+output = 2
+cache_read = 0.1
+
+[limit]
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video", "pdf"]

--- a/providers/opper/models/tensorx/moonshotai/kimi-k2.5.toml
+++ b/providers/opper/models/tensorx/moonshotai/kimi-k2.5.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k2.5"
+name = "Kimi K2.5 (TensorX)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 2.8
+cache_read = 0.13
+
+[modalities]
+input = ["text", "image", "video", "pdf"]

--- a/providers/opper/models/tensorx/moonshotai/kimi-k2.6.toml
+++ b/providers/opper/models/tensorx/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,11 @@
+base_model = "moonshotai/kimi-k2.6"
+name = "Kimi K2.6 (TensorX)"
+reasoning_options = []
+
+[cost]
+input = 1
+output = 4
+cache_read = 0.25
+
+[modalities]
+input = ["text", "image", "video", "pdf"]

--- a/providers/opper/models/tensorx/moonshotai/kimi-k2.7-code.toml
+++ b/providers/opper/models/tensorx/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,12 @@
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi K2.7 Code (TensorX)"
+temperature = true
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 4.5
+cache_read = 0.31
+
+[modalities]
+input = ["text", "image", "video", "pdf"]

--- a/providers/opper/models/tensorx/moonshotai/kimi-k3.toml
+++ b/providers/opper/models/tensorx/moonshotai/kimi-k3.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (TensorX)"
+temperature = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.75
+
+[limit]
+output = 1_048_576

--- a/providers/opper/models/tensorx/qwen/qwen3-235b-a22b-2507.toml
+++ b/providers/opper/models/tensorx/qwen/qwen3-235b-a22b-2507.toml
@@ -1,0 +1,16 @@
+base_model = "alibaba/qwen3-235b-a22b-instruct-2507"
+name = "Qwen3 235B A22B Instruct (2507) (TensorX)"
+attachment = true
+structured_output = true
+
+[cost]
+input = 0.07
+output = 0.46
+cache_read = 0.02
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "pdf"]

--- a/providers/opper/models/tensorx/qwen/qwen3.5-122b-a10b.toml
+++ b/providers/opper/models/tensorx/qwen/qwen3.5-122b-a10b.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3.5-122b-a10b"
+name = "Qwen3.5 122B A10B (TensorX)"
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 3.5
+cache_read = 0.13
+
+[limit]
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video", "audio", "pdf"]

--- a/providers/opper/models/tensorx/qwen/qwen3.5-9b.toml
+++ b/providers/opper/models/tensorx/qwen/qwen3.5-9b.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3.5-9b"
+name = "Qwen3.5 9B (TensorX)"
+reasoning_options = []
+
+[cost]
+input = 0.15
+output = 0.2
+cache_read = 0.04
+
+[limit]
+output = 262_144
+
+[modalities]
+input = ["text", "image", "video", "pdf"]

--- a/providers/opper/models/tensorx/qwen/qwen3.8-27b.toml
+++ b/providers/opper/models/tensorx/qwen/qwen3.8-27b.toml
@@ -1,0 +1,11 @@
+base_model = "alibaba/qwen3.8-27b"
+name = "Qwen3.8 27B (TensorX)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "xhigh"]
+
+[cost]
+input = 0.4
+output = 2.4
+cache_read = 0.1

--- a/providers/opper/models/tensorx/z-ai/glm-5-turbo.toml
+++ b/providers/opper/models/tensorx/z-ai/glm-5-turbo.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5-turbo"
+name = "GLM-5-Turbo (TensorX)"
+reasoning_options = []
+
+[cost]
+input = 1.2
+output = 4
+cache_read = 0.3
+
+[limit]
+context = 202_752

--- a/providers/opper/models/tensorx/z-ai/glm-5.1.toml
+++ b/providers/opper/models/tensorx/z-ai/glm-5.1.toml
@@ -1,0 +1,11 @@
+base_model = "zhipuai/glm-5.1"
+name = "GLM 5.1 (TensorX)"
+reasoning_options = []
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.35
+
+[limit]
+context = 202_752

--- a/providers/opper/models/tensorx/z-ai/glm-5.2.toml
+++ b/providers/opper/models/tensorx/z-ai/glm-5.2.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (TensorX)"
+reasoning_options = []
+
+[cost]
+input = 1.5
+output = 4.5
+cache_read = 0.38
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/tensorx/z-ai/glm-5.3-flash.toml
+++ b/providers/opper/models/tensorx/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.3-flash"
+name = "GLM-5.3-Flash (TensorX)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.2
+output = 0.5
+cache_read = 0.05
+
+[limit]
+context = 1_048_576

--- a/providers/opper/models/tensorx/z-ai/glm-5.toml
+++ b/providers/opper/models/tensorx/z-ai/glm-5.toml
@@ -1,0 +1,16 @@
+base_model = "zhipuai/glm-5"
+name = "GLM 5 (TensorX)"
+attachment = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1
+output = 3.2
+cache_read = 0.25
+
+[limit]
+context = 202_752
+
+[modalities]
+input = ["text", "pdf"]

--- a/providers/opper/models/tensorx/z-ai/glm-5v-turbo.toml
+++ b/providers/opper/models/tensorx/z-ai/glm-5v-turbo.toml
@@ -1,0 +1,12 @@
+base_model = "zhipuai/glm-5v-turbo"
+name = "GLM-5V-Turbo (TensorX)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1.2
+output = 4
+cache_read = 0.3
+
+[limit]
+context = 202_752

--- a/providers/opper/models/vertexai/claude-fable-5.toml
+++ b/providers/opper/models/vertexai/claude-fable-5.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-fable-5"
+name = "Claude Fable 5 (Google)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/opper/models/vertexai/claude-haiku-4-5-eu.toml
+++ b/providers/opper/models/vertexai/claude-haiku-4-5-eu.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-haiku-4-5"
+name = "Claude Haiku 4.5 (vertexai/claude-haiku-4-5-eu)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1.1
+output = 5.5
+cache_read = 0.11
+cache_write = 1.375

--- a/providers/opper/models/vertexai/claude-haiku-4-5.toml
+++ b/providers/opper/models/vertexai/claude-haiku-4-5.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-haiku-4-5"
+name = "Claude Haiku 4.5 (vertexai/claude-haiku-4-5)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25

--- a/providers/opper/models/vertexai/claude-opus-4-6.toml
+++ b/providers/opper/models/vertexai/claude-opus-4-6.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-opus-4-6"
+name = "Claude Opus 4.6 (Google)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/vertexai/claude-opus-4-8.toml
+++ b/providers/opper/models/vertexai/claude-opus-4-8.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-4-8"
+name = "Claude Opus 4.8 (Google)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/vertexai/claude-opus-5-eu.toml
+++ b/providers/opper/models/vertexai/claude-opus-5-eu.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (Google, EU)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5.5
+output = 27.5
+cache_read = 0.55
+cache_write = 6.875

--- a/providers/opper/models/vertexai/claude-opus-5.toml
+++ b/providers/opper/models/vertexai/claude-opus-5.toml
@@ -1,0 +1,11 @@
+base_model = "anthropic/claude-opus-5"
+name = "Claude Opus 5 (Google, US)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25

--- a/providers/opper/models/vertexai/claude-sonnet-4-6-eu.toml
+++ b/providers/opper/models/vertexai/claude-sonnet-4-6-eu.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6 (Google, EU)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 3.3
+output = 16.5
+cache_read = 0.33
+cache_write = 4.125

--- a/providers/opper/models/vertexai/claude-sonnet-4-6.toml
+++ b/providers/opper/models/vertexai/claude-sonnet-4-6.toml
@@ -1,0 +1,10 @@
+base_model = "anthropic/claude-sonnet-4-6"
+name = "Claude Sonnet 4.6 (Google, US)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75

--- a/providers/opper/models/vertexai/claude-sonnet-5-eu.toml
+++ b/providers/opper/models/vertexai/claude-sonnet-5-eu.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (Google, EU)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 2.2
+output = 11
+cache_read = 0.22
+cache_write = 2.75
+
+[limit]
+output = 64_000

--- a/providers/opper/models/vertexai/claude-sonnet-5.toml
+++ b/providers/opper/models/vertexai/claude-sonnet-5.toml
@@ -1,0 +1,14 @@
+base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet 5 (Google, US)"
+temperature = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+output = 64_000

--- a/providers/opper/models/vertexai/gemini-2.5-flash-eu.toml
+++ b/providers/opper/models/vertexai/gemini-2.5-flash-eu.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-2.5-flash"
+name = "Gemini 2.5 Flash (vertexai/gemini-2.5-flash-eu)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/opper/models/vertexai/gemini-2.5-flash-image.toml
+++ b/providers/opper/models/vertexai/gemini-2.5-flash-image.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-2.5-flash-image"
+name = "Gemini 2.5 Flash Image (Google, EU)"
+tool_call = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.5
+
+[limit]
+context = 1_048_576
+output = 65_536

--- a/providers/opper/models/vertexai/gemini-2.5-flash-lite-eu.toml
+++ b/providers/opper/models/vertexai/gemini-2.5-flash-lite-eu.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-2.5-flash-lite"
+name = "Gemini 2.5 Flash Lite (vertexai/gemini-2.5-flash-lite-eu)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01

--- a/providers/opper/models/vertexai/gemini-2.5-flash-lite.toml
+++ b/providers/opper/models/vertexai/gemini-2.5-flash-lite.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-2.5-flash-lite"
+name = "Gemini 2.5 Flash Lite (vertexai/gemini-2.5-flash-lite)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01

--- a/providers/opper/models/vertexai/gemini-2.5-flash.toml
+++ b/providers/opper/models/vertexai/gemini-2.5-flash.toml
@@ -1,0 +1,11 @@
+base_model = "google/gemini-2.5-flash"
+name = "Gemini 2.5 Flash (vertexai/gemini-2.5-flash)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/opper/models/vertexai/gemini-2.5-pro-eu.toml
+++ b/providers/opper/models/vertexai/gemini-2.5-pro-eu.toml
@@ -1,0 +1,17 @@
+base_model = "google/gemini-2.5-pro"
+name = "Gemini 2.5 Pro (vertexai/gemini-2.5-pro-eu)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.13
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 15
+cache_read = 0.25

--- a/providers/opper/models/vertexai/gemini-2.5-pro.toml
+++ b/providers/opper/models/vertexai/gemini-2.5-pro.toml
@@ -1,0 +1,17 @@
+base_model = "google/gemini-2.5-pro"
+name = "Gemini 2.5 Pro (vertexai/gemini-2.5-pro)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.13
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 15
+cache_read = 0.25

--- a/providers/opper/models/vertexai/gemini-3-flash-preview.toml
+++ b/providers/opper/models/vertexai/gemini-3-flash-preview.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3-flash-preview"
+name = "Gemini 3 Flash Preview (vertexai)"
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05

--- a/providers/opper/models/vertexai/gemini-3-pro-image.toml
+++ b/providers/opper/models/vertexai/gemini-3-pro-image.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3-pro-image-preview"
+name = "Gemini 3 Pro Image Preview (vertexai)"
+tool_call = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 2
+output = 12
+
+[limit]
+context = 1_048_576
+output = 65_536

--- a/providers/opper/models/vertexai/gemini-3.1-flash-image.toml
+++ b/providers/opper/models/vertexai/gemini-3.1-flash-image.toml
@@ -1,0 +1,13 @@
+base_model = "google/gemini-3.1-flash-image-preview"
+name = "Gemini 3.1 Flash Image Preview (vertexai)"
+tool_call = true
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.5
+output = 3
+
+[limit]
+context = 131_072
+output = 32_768

--- a/providers/opper/models/vertexai/gemini-3.1-flash-lite-eu.toml
+++ b/providers/opper/models/vertexai/gemini-3.1-flash-lite-eu.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.1-flash-lite"
+name = "Gemini 3.1 Flash Lite (Google, EU)"
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025

--- a/providers/opper/models/vertexai/gemini-3.1-flash-lite-image.toml
+++ b/providers/opper/models/vertexai/gemini-3.1-flash-lite-image.toml
@@ -1,0 +1,12 @@
+base_model = "google/gemini-3.1-flash-lite-image"
+name = "Gemini 3.1 Flash Lite Image (vertexai)"
+structured_output = true
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 1.5
+
+[limit]
+context = 131_072
+output = 32_768

--- a/providers/opper/models/vertexai/gemini-3.1-flash-lite.toml
+++ b/providers/opper/models/vertexai/gemini-3.1-flash-lite.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.1-flash-lite"
+name = "Gemini 3.1 Flash Lite (vertexai/gemini-3.1-flash-lite)"
+reasoning_options = []
+
+[cost]
+input = 0.25
+output = 1.5
+cache_read = 0.025

--- a/providers/opper/models/vertexai/gemini-3.1-pro-preview.toml
+++ b/providers/opper/models/vertexai/gemini-3.1-pro-preview.toml
@@ -1,0 +1,14 @@
+base_model = "google/gemini-3.1-pro-preview"
+name = "Gemini 3.1 Pro Preview (vertexai)"
+reasoning_options = []
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 18
+cache_read = 0.4

--- a/providers/opper/models/vertexai/gemini-3.5-flash-eu.toml
+++ b/providers/opper/models/vertexai/gemini-3.5-flash-eu.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.5-flash"
+name = "Gemini 3.5 Flash (Google, EU)"
+reasoning_options = []
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15

--- a/providers/opper/models/vertexai/gemini-3.5-flash-lite-eu.toml
+++ b/providers/opper/models/vertexai/gemini-3.5-flash-lite-eu.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.5-flash-lite"
+name = "Gemini 3.5 Flash Lite (Google, EU)"
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/opper/models/vertexai/gemini-3.5-flash-lite.toml
+++ b/providers/opper/models/vertexai/gemini-3.5-flash-lite.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.5-flash-lite"
+name = "Gemini 3.5 Flash Lite (vertexai/gemini-3.5-flash-lite)"
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/opper/models/vertexai/gemini-3.5-flash.toml
+++ b/providers/opper/models/vertexai/gemini-3.5-flash.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.5-flash"
+name = "Gemini 3.5 Flash (vertexai/gemini-3.5-flash)"
+reasoning_options = []
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15

--- a/providers/opper/models/vertexai/gemini-3.6-flash-eu.toml
+++ b/providers/opper/models/vertexai/gemini-3.6-flash-eu.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.6-flash"
+name = "Gemini 3.6 Flash (Google, EU)"
+reasoning_options = []
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075

--- a/providers/opper/models/vertexai/gemini-3.6-flash.toml
+++ b/providers/opper/models/vertexai/gemini-3.6-flash.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-3.6-flash"
+name = "Gemini 3.6 Flash (vertexai/gemini-3.6-flash)"
+reasoning_options = []
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075

--- a/providers/opper/models/vertexai/gemini-3.7-flash-eu.toml
+++ b/providers/opper/models/vertexai/gemini-3.7-flash-eu.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.7-flash"
-name = "Gemini 3.7 Flash (EU)"
+name = "Gemini 3.7 Flash (Google, EU)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/opper/models/vertexai/gemini-3.7-flash.toml
+++ b/providers/opper/models/vertexai/gemini-3.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.7-flash"
+name = "Gemini 3.7 Flash (Google, US)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/opper/models/vertexai/gemini-flash-latest.toml
+++ b/providers/opper/models/vertexai/gemini-flash-latest.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-flash-latest"
+name = "Gemini Flash Latest (vertexai)"
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03

--- a/providers/opper/models/vertexai/gemini-flash-lite-latest.toml
+++ b/providers/opper/models/vertexai/gemini-flash-lite-latest.toml
@@ -1,0 +1,8 @@
+base_model = "google/gemini-flash-lite-latest"
+name = "Gemini Flash Lite Latest (vertexai)"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.01

--- a/providers/opper/models/wafer/deepseek-v4-flash-0731-fast.toml
+++ b/providers/opper/models/wafer/deepseek-v4-flash-0731-fast.toml
@@ -1,0 +1,15 @@
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash (0731) Fast"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 0.28
+output = 0.56
+cache_read = 0.07
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/wafer/glm-5.2.toml
+++ b/providers/opper/models/wafer/glm-5.2.toml
@@ -1,0 +1,15 @@
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Wafer)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 1.26
+output = 3.96
+cache_read = 0.23
+
+[limit]
+context = 1_048_576
+output = 1_048_576

--- a/providers/opper/models/wafer/kimi-k3.toml
+++ b/providers/opper/models/wafer/kimi-k3.toml
@@ -1,0 +1,15 @@
+base_model = "moonshotai/kimi-k3"
+name = "Kimi K3 (Wafer)"
+temperature = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+
+[limit]
+output = 1_048_576

--- a/providers/opper/models/xai/grok-4.3-eu.toml
+++ b/providers/opper/models/xai/grok-4.3-eu.toml
@@ -1,0 +1,11 @@
+base_model = "xai/grok-4.3"
+name = "Grok 4.3 (xAI, EU)"
+reasoning_options = []
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[limit]
+output = 1_000_000

--- a/providers/opper/models/xai/grok-4.3.toml
+++ b/providers/opper/models/xai/grok-4.3.toml
@@ -1,4 +1,8 @@
 base_model = "xai/grok-4.3"
+name = "Grok 4.3 (xAI, US)"
+
+[interleaved]
+field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
@@ -10,10 +14,7 @@ output = 2.5
 cache_read = 0.2
 
 [[cost.tiers]]
-tier = { size = 200_000 }
+tier = { type = "context", size = 200_000 }
 input = 2.5
 output = 5
 cache_read = 0.4
-
-[interleaved]
-field = "reasoning_content"

--- a/providers/opper/models/xai/grok-4.5.toml
+++ b/providers/opper/models/xai/grok-4.5.toml
@@ -1,5 +1,8 @@
 base_model = "xai/grok-4.5"
 
+[interleaved]
+field = "reasoning_content"
+
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high"]
@@ -7,7 +10,7 @@ values = ["low", "medium", "high"]
 [cost]
 input = 2
 output = 6
-cache_read = 0.3
+cache_read = 0.5
 
 [[cost.tiers]]
 tier = { type = "context", size = 200_000 }
@@ -15,5 +18,5 @@ input = 4
 output = 12
 cache_read = 0.6
 
-[interleaved]
-field = "reasoning_content"
+[modalities]
+input = ["text", "image", "pdf"]

--- a/providers/opper/models/xai/grok-4.6.toml
+++ b/providers/opper/models/xai/grok-4.6.toml
@@ -1,5 +1,8 @@
 base_model = "xai/grok-4.6"
 
+[interleaved]
+field = "reasoning_content"
+
 [[reasoning_options]]
 type = "effort"
 values = ["low", "medium", "high", "xhigh"]
@@ -15,5 +18,5 @@ input = 4
 output = 12
 cache_read = 1
 
-[interleaved]
-field = "reasoning_content"
+[modalities]
+input = ["text", "image", "pdf"]

--- a/sync.md
+++ b/sync.md
@@ -306,6 +306,53 @@ Requesty is implemented in `packages/core/src/sync/providers/requesty.ts`.
 - Region variants are written as separate models: `gpt-5.4` and `gpt-5.4@eu` are distinct files that share a `base_model` and differ only in served pricing and limits.
 - Prices are per-token USD and are converted to per-1M-token numbers. `pricing[]` bands become `cost.tiers`, with the first band as the flat `cost`. Price fields are nullable upstream, so a route quoting no prices gets no `[cost]` section rather than a fabricated zero.
 
+## Opper Notes
+
+Opper is implemented in `packages/core/src/sync/providers/opper.ts`.
+
+- Run it with `bun models:sync opper` or `bun opper:sync`.
+- Source endpoint: `https://api.opper.ai/v3/models?limit=2000`. **No auth**: the
+  catalog is public, so this sync needs no secret in CI.
+- Only `type: "llm"` rows are synced. The same endpoint also serves image,
+  video, embedding, rerank, OCR, speech and realtime routes, which the
+  token-cost schema cannot represent.
+- Opper is a relay, so the lab entry stays authoritative for what the weights
+  can do and this sync only ever **widens** capabilities and modalities, never
+  narrows them. Opper records a capability once it has been verified for a
+  route, which makes absence silence rather than denial — it declares PDF input
+  on none of the OpenAI routes that demonstrably accept it, and omits
+  `reasoning` on several models that reason. Writing the negative would
+  contradict the lab entry and, for `reasoning`, strip the base model's effort
+  controls.
+- Opper *is* authoritative for what it serves: price, context window, output
+  cap and the reasoning effort ladder override the base. The ladder is
+  per-route and genuinely differs between hosts — `tensorx/moonshotai/kimi-k3`
+  accepts the full ladder while `moonshot/kimi-k3` accepts only `max` — and
+  requesting an effort outside it is an error rather than a silent downgrade,
+  so a wider ladder than the route accepts would be user-visible breakage.
+- Route IDs are `<host>/<host's own model id>` and carry no lab prefix, so
+  `base_model` resolves from the `maker` field plus the routing key, not from
+  the ID. A route whose lab model has no `models/` entry is skipped and
+  reported as a notice; it is never written inline.
+- An authored `base_model` always wins. Opper's routing key names a dated
+  snapshot for some routes (`anthropic/claude-haiku-4-5` routes to
+  `claude-haiku-4-5-20251001`), and a sync should not repoint a pointer a
+  human chose.
+- Prices are quoted per million tokens already, but derived rates carry
+  binary-float noise (a cached rate reads `0.029759999999999998`) and are
+  rounded. A route quoting no price gets no `[cost]` section.
+- Two distinct long-context mechanisms both become `cost.tiers`: `thresholds`
+  bands the marginal rate, while `input_surcharge_threshold_tokens` reprices
+  the whole request by a per-side multiplier. They are mutually exclusive
+  upstream. An authored tier is preserved where a route quotes neither.
+- Opper relays the same model from many hosts, so `name` alone is ambiguous for
+  most of the catalog — fifteen routes are called "GLM-5.2". Display names are
+  qualified only as far as uniqueness requires: bare name, then host, then host
+  and region, then the raw provider slug (`azure` and `azure-zdr` share a
+  display name and a region).
+- `interleaved` and `status` are not expressed in `/v3/models`, so authored
+  values are the only source and are preserved.
+
 ## Venice Notes
 
 Venice is implemented in `packages/core/src/sync/providers/venice.ts`.


### PR DESCRIPTION
Opper's entry is 40 hand-authored files. Opper relays **603 chat routes**, so the list went stale the moment it was written and cannot track price changes. This adds a sync module, following the shape of `requesty` and `openrouter`.

Source: **`https://api.opper.ai/v3/models?limit=2000`** — public, no auth, so this sync needs **no new secret in CI**.

Result: **428 routes** written as `base_model` + overrides, **175 skipped** (no `models/` entry to point at) and reported as a notice rather than written inline. No file is deleted.

### Only `type: "llm"` is synced

The same endpoint serves image, video, embedding, rerank, OCR, speech and realtime routes. The token-cost schema cannot represent those, so they are filtered out.

### Capabilities only ever widen the lab entry

Opper is a relay, so what the weights can do is the lab entry's claim to make. Opper records a capability once it has been *verified* for a route, which makes absence **silence, not denial** — it declares PDF input on none of the OpenAI routes that demonstrably accept it, and omits `reasoning` on several models that reason. Asserting the negative would contradict the lab entry and, for `reasoning`, strip the base model's effort controls via `preserveReasoningOptions`. So capabilities and modalities are widened, never narrowed.

Price, context window, output cap and the reasoning ladder **do** override, because those describe what Opper serves rather than what the lab built.

### The effort ladder is per-route and genuinely differs by host

`tensorx/moonshotai/kimi-k3` accepts the full ladder; `moonshot/kimi-k3` accepts only `max`. Opper errors on an effort outside a route's ladder rather than silently downgrading, so publishing a wider ladder than the route accepts is user-visible breakage. A route stating no ladder is stating nothing, so the field is left unset for the runner to preserve an authored one.

### Other decisions worth a look

- **`base_model` resolves from `maker` + routing key, not the ID.** IDs are `<host>/<host's own model id>` with no lab prefix, so a prefix-based resolver would look for a `tensorx` namespace that cannot exist.
- **An authored `base_model` always wins.** Opper's routing key names a dated snapshot for some routes (`anthropic/claude-haiku-4-5` routes to `claude-haiku-4-5-20251001`); a sync should not repoint a pointer a human chose.
- **Two long-context mechanisms, both becoming `cost.tiers`.** `thresholds` bands the marginal rate; `input_surcharge_threshold_tokens` reprices the whole request by a per-side multiplier (cache reads are input-side and take the input multiplier). They are mutually exclusive upstream. An authored tier is preserved where a route quotes neither, so silence never deletes a rate a human established.
- **Prices are already per-million** but derived rates carry float noise (a cached rate reads `0.029759999999999998`) and are rounded. A route quoting no price gets no `[cost]` section.
- **Display names are qualified only as far as uniqueness requires.** Opper relays the same model from many hosts, so `name` alone is ambiguous for 71% of the catalog — fifteen routes are called "GLM-5.2". The ladder is bare name → host → host and region → raw provider slug (`azure` and `azure-zdr` share a display name *and* a region), ending at the route ID, which is unique by construction.

### Verification

Following `sync.md` "Adding A Provider":

```
bun models:sync opper --dry-run   →  388 created, 40 updated, 0 removed
bun models:sync opper             →  388 created, 38 updated, 0 removed, 2 unchanged
bun models:sync opper --dry-run   →  0 created, 0 updated, 0 removed, 428 unchanged   ← clean
bun validate                      →  exit 0
bun test                          →  270 pass, 4 fail
```

The 4 failures are **pre-existing on a clean tree** (`generate.test.ts` weights links, `deepinfra` modalities, two `packages/sdk` snapshot tests). This branch adds 17 passing tests and changes none of them: 253 pass / 4 fail before, 270 pass / 4 fail after.

Independently, every generated file was checked against the source response:

| check | result |
|---|---|
| effective `cost.input` / `cost.output` match `/v3/models` | **428 / 428** |
| effective `limit.context` matches `/v3/models` | **428 / 428** |
| display names distinct | **428 / 428** |
| hand-authored keys lost | **0** |

The 38 updated files were diffed semantically (parsed TOML, not lines) to confirm nothing hand-authored is destroyed. What changes: `cost.tiers` normalised to the house `tier = { type = "context", size = … }` form used by the other providers; four effort ladders corrected to what the route actually accepts; one stale `cache_read` (`xai/grok-4.5`, 0.3 → 0.5); names qualified. `interleaved` and `status` are not expressed in `/v3/models`, so authored values are preserved.

`sync.md` gains an **Opper Notes** section documenting all of the above.