### PR TITLE
feat(alibaba): add qwen3.8-flash effort levels and first-party entries

### DIFF
--- a/providers/alibaba-cn/models/qwen3.8-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.8-flash.toml
@@ -1,0 +1,26 @@
+# Sources (accessed 2026-08-28):
+# https://www.qianwenai.com/models/qwen3.8-flash
+# https://help.aliyun.com/zh/model-studio/model-pricing (Beijing: ¥0.8 input / ¥2.7
+# output per 1M tokens, flat 0<Token≤1M band, no tiers)
+# CNY→USD rate: 6.737174, 2026-08-28, source: https://open.er-api.com/v6/latest/USD
+# Cache pricing: cache read 10%, explicit cache create 125% of input
+# (https://help.aliyun.com/zh/model-studio/context-cache)
+# Toggle: enable_thinking true|false (hybrid)
+# Effort: reasoning_effort = low|medium|xhigh (not yet in the API reference; see
+# the Qwen3.8-Flash-Next release blog)
+# Budget: thinking_budget (Max Reasoning 262K)
+base_model = "alibaba/qwen3.8-flash"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", max = 262_144 },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.11875
+output = 0.40073
+cache_read = 0.01187
+cache_write = 0.14844

--- a/providers/alibaba-token-plan/models/qwen3.8-flash.toml
+++ b/providers/alibaba-token-plan/models/qwen3.8-flash.toml
@@ -4,13 +4,15 @@
 # https://docs.qwencloud.com/developer-guides/text-generation/thinking
 # https://docs.qwencloud.com/api-reference/chat/openai-chat
 # Toggle: enable_thinking true|false (hybrid)
-# Budget: thinking_budget — model page lists Max Reasoning 262K
-# reasoning_effort is documented for qwen3.8-max / qwen3.8-max-preview only, not flash.
+# Effort: reasoning_effort = low|medium|xhigh (not yet in the API reference; see
+# the Qwen3.8-Flash-Next release blog)
+# Budget: thinking_budget (Max Reasoning 262K)
 # Reasoning streams in reasoning_content.
 # Cost is Credits-subscription (no public USD per-token rate on Token Plan).
 base_model = "alibaba/qwen3.8-flash"
 reasoning_options = [
   { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
   { type = "budget_tokens", max = 262_144 },
 ]
 

--- a/providers/alibaba/models/qwen3.8-flash.toml
+++ b/providers/alibaba/models/qwen3.8-flash.toml
@@ -1,15 +1,11 @@
-# Sources (accessed 2026-08-27):
-# https://help.aliyun.com/zh/model-studio/token-plan-personal-overview
-# https://help.aliyun.com/en/model-studio/token-plan-personal-overview
+# Sources (accessed 2026-08-28):
 # https://www.qwencloud.com/models/qwen3.8-flash
-# https://docs.qwencloud.com/developer-guides/text-generation/thinking
-# https://docs.qwencloud.com/api-reference/chat/openai-chat
+# Pricing: $0.15 input / $0.47 output / cache read $0.016 / cache create $0.2
+# per 1M tokens, flat. (Release blog quotes ~$0.16 input; model page prevails.)
 # Toggle: enable_thinking true|false (hybrid)
 # Effort: reasoning_effort = low|medium|xhigh (not yet in the API reference; see
 # the Qwen3.8-Flash-Next release blog)
 # Budget: thinking_budget (Max Reasoning 262K)
-# Reasoning streams in reasoning_content.
-# Cost is Credits-subscription (no public USD per-token rate on Token Plan).
 base_model = "alibaba/qwen3.8-flash"
 reasoning_options = [
   { type = "toggle" },
@@ -21,7 +17,7 @@ reasoning_options = [
 field = "reasoning_content"
 
 [cost]
-input = 0
-output = 0
-cache_read = 0
-cache_write = 0
+input = 0.15
+output = 0.47
+cache_read = 0.016
+cache_write = 0.2


### PR DESCRIPTION
qwen3.8-flash does support reasoning_effort. The API reference just hasn't been updated for it yet (only max is listed), but the release blog documents the levels, and I verified them live: all three levels work, mutually exclusive with thinking_budget, same behavior as qwen3.8-max.

Also added the missing first-party alibaba / alibaba-cn flash entries while at it. bun validate passes.