### PR TITLE
Add Groq Qwen3.8 27B provider model

### DIFF
--- a/providers/groq/models/qwen/qwen3.8-27b.toml
+++ b/providers/groq/models/qwen/qwen3.8-27b.toml
@@ -1,0 +1,15 @@
+base_model = "alibaba/qwen3.8-27b"
+reasoning_options = [{ type = "effort", values = ["none", "default"] }]
+
+[cost]
+input = 0.60
+output = 3.00
+cache_read = 0.30
+
+[limit]
+context = 131_072
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]


### PR DESCRIPTION
Adds Groq serving details for `qwen/qwen3.8-27b`.

The shared base model `alibaba/qwen3.8-27b` already exists, so this provider file only adds the Groq-specific overrides:

- `base_model` -> reuses the existing shared metadata
- `context = 131_072` -> Groq serves it at ~131K (overrides the base 262K)
- `reasoning_options` -> mirrors Groq's sibling Qwen3.6-27B
- `modalities` -> text + image input

### Pricing disclaimer

`qwen3.8-27b` is very new on Groq, and no Groq-specific published rate is available yet. The cost values below mirror Groq's rate for the sibling Qwen 27B model (`qwen3.6-27b`):

- input: `0.60` / M tokens
- output: `3.00` / M tokens
- cache_read: `0.30` / M tokens

Please update these if Groq publishes a dedicated `qwen3.8-27b` price.
