### PR TITLE
feat(groq): add Qwen3.8 27B

### DIFF
--- a/providers/groq/models/qwen/qwen3.8-27b.toml
+++ b/providers/groq/models/qwen/qwen3.8-27b.toml
@@ -1,3 +1,7 @@
+# Sources (accessed 2026-08-29):
+#   - https://console.groq.com/docs/models — context/output limits, modalities, model capabilities
+#   - https://console.groq.com/docs/reasoning — reasoning_effort values (none, default)
+#   - https://groq.com/pricing — input/output/cache_read pricing
 base_model = "alibaba/qwen3.8-27b"
 reasoning_options = [{ type = "effort", values = ["none", "default"] }]
 

--- a/providers/groq/models/qwen/qwen3.8-27b.toml
+++ b/providers/groq/models/qwen/qwen3.8-27b.toml
@@ -1,0 +1,14 @@
+base_model = "alibaba/qwen3.8-27b"
+reasoning_options = [{ type = "effort", values = ["none", "default"] }]
+
+[cost]
+input = 0.80
+output = 4.00
+cache_read = 0.40
+
+[limit]
+context = 131_042
+output = 16_384
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
Adds the Qwen3.8 27B model to the Groq provider catalog.

**Model data** (reported by GET /v1/models):
- base_model: alibaba/qwen3.8-27b
- context window: 131,042
- max output tokens: 16,384
- cost (USD/MTok): input 0.80, output 4.00, cache_read 0.40
- modalities (input): text, image
- reasoning_options: effort [none, default]

Validated with `bun validate` (import gate passes).

**Sources** (first-party, accessed 2026-08-29):
- https://console.groq.com/docs/models — context/output limits, modalities, model capabilities
- https://console.groq.com/docs/reasoning — reasoning_effort options
- https://groq.com/pricing — input/output/cache_read pricing

**Context limit note:** context_limit 131,042 confirmed live against GET https://api.groq.com/openai/v1/models for qwen/qwen3.8-27b on 2026-08-29 (returned context_window = 131042). The value is now closed/confirmed — no correction needed.
