### PR TITLE
fix(volcengine): Ark host rejects response_format for Seed 2.0 Code

### DIFF
--- a/providers/volcengine/models/doubao-seed-2-0-code-preview-260215.toml
+++ b/providers/volcengine/models/doubao-seed-2-0-code-preview-260215.toml
@@ -5,6 +5,12 @@
 # none/minimal disable thinking, so no separate toggle: sending effort alone
 # already enables it, and thinking.type=disabled + a graded effort is rejected.
 base_model = "bytedance-seed/seed-2.0-code"
+# Structured output: the lab entry declares it and other hosts (e.g. openrouter)
+# do support it, but this host rejects both response_format forms outright:
+#   {"type":"json_object"} / {"type":"json_schema"} -> 400
+#   "`json_object` is not supported by this model"
+# Verified 2026-08-30; omitting response_format returns 200. Host-specific.
+structured_output = false
 
 [[reasoning_options]]
 type = "effort"


### PR DESCRIPTION
`seed-2.0-code` declares `structured_output = true`, but the Ark host rejects both
`response_format` forms for `doubao-seed-2-0-code-preview-260215`:

```
response_format {"type": "json_object"}  -> 400
  The parameter `response_format.type` specified in the request are not valid:
  `json_object` is not supported by this model

response_format {"type": "json_schema"}  -> 400
  ... `json_schema` is not supported by this model
```

The error text names the model explicitly, so this isn't a malformed request.

Two control cases confirm the model is otherwise healthy, and that the failure is
specific to structured output rather than to my request:

| Case | Result |
| --- | --- |
| no `response_format` | 200 — and it emits `{"n":"x"}` when the prompt asks for JSON |
| `response_format: {"type":"text"}` | 200 |
| `response_format: {"type":"json_object"}` | **400** |
| `response_format: {"type":"json_schema"}` | **400** |

So the model can produce JSON if you ask in the prompt; what it doesn't support is
the API-enforced structured-output mode, which is what this field advertises.

For contrast, I re-checked all 15 `volcengine` models the same way: the other 14
accept a strict `json_schema` and return schema-conforming JSON, so
`structured_output = true` is correct for them. This is the single outlier.

Removing the field rather than setting it false, to match how the other Seed lab
entries express "not supported" by omission.

_Found while verifying my own #5702 (which added this field to 11 other Seed
entries) against live behaviour — this one entry predates that PR and wasn't part
of it._
