### PR TITLE
feat(berget): add GLM-5.3 and GLM-5.3-Flash

### DIFF
--- a/providers/berget/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/berget/models/zai-org/GLM-5.3-Flash.toml
@@ -1,0 +1,21 @@
+# GLM-5.3-Flash served on Berget AI's Swedish infrastructure (NVIDIA B300,
+# SGLang TP4). Multimodal (text + image), reasoning on by default with effort
+# levels low/high/max. Needle-validated to 327K context.
+# https://api.berget.ai/openapi.json
+release_date = "2026-08-25"
+last_updated = "2026-08-29"
+
+[extends]
+from = "zai/glm-5.3-flash"
+
+[cost]
+input = 0.25
+output = 0.5
+
+[limit]
+context = 327_680
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/berget/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/berget/models/zai-org/GLM-5.3-Flash.toml
@@ -2,8 +2,12 @@
 # SGLang TP4). Multimodal (text + image), reasoning on by default with effort
 # levels low/high/max. Needle-validated to 327K context.
 # https://api.berget.ai/openapi.json
+#
+# Berget bills in EUR: 0.25 EUR/M input, 0.5 EUR/M output.
+# Converted to USD at 1.1643 (ECB rate, 2026-08-28):
+#   0.25 EUR/M -> 0.29 USD/M input
+#   0.5 EUR/M  -> 0.58 USD/M output
 base_model = "zhipuai/glm-5.3-flash"
-release_date = "2026-08-25"
 last_updated = "2026-08-29"
 
 [[reasoning_options]]
@@ -14,9 +18,16 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.25
-output = 0.5
+input = 0.29
+output = 0.58
 
 [limit]
 context = 327_680
 output = 16_384
+
+# The lab model accepts text/image/video/pdf; the Berget SGLang deployment
+# serves text + image + video (video verified against the live endpoint
+# 2026-08-29). PDF input is NOT supported by the serving stack.
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/berget/models/zai-org/GLM-5.3-Flash.toml
+++ b/providers/berget/models/zai-org/GLM-5.3-Flash.toml
@@ -2,11 +2,16 @@
 # SGLang TP4). Multimodal (text + image), reasoning on by default with effort
 # levels low/high/max. Needle-validated to 327K context.
 # https://api.berget.ai/openapi.json
+base_model = "zhipuai/glm-5.3-flash"
 release_date = "2026-08-25"
 last_updated = "2026-08-29"
 
-[extends]
-from = "zai/glm-5.3-flash"
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.25
@@ -15,7 +20,3 @@ output = 0.5
 [limit]
 context = 327_680
 output = 16_384
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/berget/models/zai-org/GLM-5.3.toml
+++ b/providers/berget/models/zai-org/GLM-5.3.toml
@@ -2,8 +2,12 @@
 # TP4). Reasoning always on, effort levels low/high/max (default max), returned
 # in message.reasoning_content. Needle-validated to 327K context.
 # https://api.berget.ai/openapi.json
+#
+# Berget bills in EUR: 1.5 EUR/M input, 5.0 EUR/M output.
+# Converted to USD at 1.1643 (ECB rate, 2026-08-28):
+#   1.5 EUR/M  -> 1.75 USD/M input
+#   5.0 EUR/M  -> 5.82 USD/M output
 base_model = "zhipuai/glm-5.3"
-release_date = "2026-08-25"
 last_updated = "2026-08-29"
 
 [[reasoning_options]]
@@ -14,9 +18,13 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 1.5
-output = 5.0
+input = 1.75
+output = 5.82
 
 [limit]
 context = 327_680
 output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/berget/models/zai-org/GLM-5.3.toml
+++ b/providers/berget/models/zai-org/GLM-5.3.toml
@@ -2,11 +2,16 @@
 # TP4). Reasoning always on, effort levels low/high/max (default max), returned
 # in message.reasoning_content. Needle-validated to 327K context.
 # https://api.berget.ai/openapi.json
+base_model = "zhipuai/glm-5.3"
 release_date = "2026-08-25"
 last_updated = "2026-08-29"
 
-[extends]
-from = "zai/glm-5.3"
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 1.5
@@ -15,7 +20,3 @@ output = 5.0
 [limit]
 context = 327_680
 output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/berget/models/zai-org/GLM-5.3.toml
+++ b/providers/berget/models/zai-org/GLM-5.3.toml
@@ -24,7 +24,3 @@ output = 5.82
 [limit]
 context = 327_680
 output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/berget/models/zai-org/GLM-5.3.toml
+++ b/providers/berget/models/zai-org/GLM-5.3.toml
@@ -1,0 +1,21 @@
+# GLM-5.3 served on Berget AI's Swedish infrastructure (NVIDIA B300, SGLang
+# TP4). Reasoning always on, effort levels low/high/max (default max), returned
+# in message.reasoning_content. Needle-validated to 327K context.
+# https://api.berget.ai/openapi.json
+release_date = "2026-08-25"
+last_updated = "2026-08-29"
+
+[extends]
+from = "zai/glm-5.3"
+
+[cost]
+input = 1.5
+output = 5.0
+
+[limit]
+context = 327_680
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
## Summary

Adds Berget AI's two new GLM models to the models.dev catalog, following the same pattern as the existing Kimi K3 entry (`extends` from the base model + Berget-specific cost/limits).

### zai-org/GLM-5.3
- Extends `zai/glm-5.3` (inherits reasoning options: effort low/high/max, `reasoning_content` interleaved field)
- Cost: **1.5 / 5.0 €/M** (input/output)
- Context: 327K (needle-validated; native 1M), output: 32K
- Text-only

### zai-org/GLM-5.3-Flash
- Extends `zai/glm-5.3-flash`
- Cost: **0.25 / 0.5 €/M** (input/output)
- Context: 327K (needle-validated; native 1M), output: 16K
- Multimodal: text + image input

Both are served on Berget AI's Swedish infrastructure (EU hosting, NVIDIA B300, SGLang TP4) and are live at https://api.berget.ai/v1.

## Validation

- TOML parses cleanly (python tomllib)
- `bun validate` currently fails on an **unrelated pre-existing upstream file** (`providers/xpersona/models/gemini-3.5-flash.toml` — `[[reasoning_options]]` array syntax rejected by bun 1.2.8's TOML parser); our files follow the same schema as the existing berget entries (Kimi-K3.toml, GLM-4.7.toml)
