### PR TITLE
feat(ollama-cloud): add glm-5.3 model

### DIFF
--- a/providers/ollama-cloud/models/glm-5.3.toml
+++ b/providers/ollama-cloud/models/glm-5.3.toml
@@ -1,0 +1,15 @@
+# Effort: OpenAI POST /v1/chat/completions accepts top-level `reasoning_effort`
+# or `reasoning.effort` with low|high|max (GLM-5.3 always reasons; thinking
+# cannot be disabled, so there is no toggle).
+# Sources: https://docs.ollama.com/capabilities/thinking, https://docs.ollama.com/openai
+# API-verified context: https://ollama.com/api/show (glm_dsa_moe.context_length = 1048576)
+base_model = "zhipuai/glm-5.3"
+open_weights = true
+
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 1_048_576


### PR DESCRIPTION
## Context

Ollama Cloud now serves `glm-5.3` (listed by `GET /api/tags` since 2026-08-28). The lab metadata already exists at [models/zhipuai/glm-5.3.toml](https://github.com/anomalyco/models.dev/blob/dev/models/zhipuai/glm-5.3.toml); this PR adds the missing provider entry so the model surfaces under `ollama-cloud` in the generated catalog.

Confirmed live on the Ollama Cloud API:

```fish
$ curl -s https://ollama.com/api/tags | jq -r '.models[] | .name' | grep glm-5.3
glm-5.3
glm-5.3-flash

$ curl -s https://ollama.com/api/show -d '{"model":"glm-5.3"}' | jq '.capabilities, .details, .model_info["glm_dsa_moe.context_length"]'
[
  "completion",
  "thinking",
  "tools"
]
{
  "parent_model": "glm-5.3",
  "family": "glm_dsa_moe",
  "parameter_size": "753329940480",
  "quantization_level": "FP8"
}
1048576
```

## What changed

- Added `providers/ollama-cloud/models/glm-5.3.toml`, a `base_model`-factored provider entry that inherits provider-agnostic facts from the existing lab metadata and only declares host-specific overrides.

## Critical Changes

- **New model on `ollama-cloud`:** `glm-5.3` now resolves in the generated catalog with `limit.context = 1_048_576` and `reasoning_options` of `effort: ["low", "high", "max"]`.
- **Override-only:** the provider file uses `base_model = "zhipuai/glm-5.3"` and restates only `open_weights`, `reasoning_options`, `[interleaved]`, and `[limit]` (real deltas vs. the lab's 1M context). `name`, `description`, `family`, dates, capabilities, modalities, and `limit.output` are inherited from the lab entry.
- **Reasoning controls:** `effort: ["low", "high", "max"]` with **no toggle** — GLM-5.3 always reasons (thinking cannot be disabled), matching the first-party zhipuai entry ([providers/zhipuai/models/glm-5.3.toml](https://github.com/anomalyco/models.dev/blob/dev/providers/zhipuai/models/glm-5.3.toml)) and the sibling [glm-5.3-flash.toml](https://github.com/anomalyco/models.dev/blob/dev/providers/ollama-cloud/models/glm-5.3-flash.toml) on this provider. Wire path documented in the leading comment per the ollama-cloud convention (see #3985).
- **Context override rationale:** the lab's `1_000_000` is a rounded figure; Ollama Cloud's `/api/show` exposes the real `glm_dsa_moe.context_length = 1_048_576`.
- **`limit.output` inherited (131_072), not set to context:** #1586 established an `output = context` convention for ollama-cloud, but both merged GLM siblings (`glm-5.2`, `glm-5.3-flash`) inherit the lab's `131_072`, and `/api/show` publishes no output limit for this model. I followed the GLM siblings rather than inventing a value with no API evidence — happy to align with #1586 if maintainers prefer.
- **`open_weights = true` override:** matches all three GLM siblings on this provider (Ollama Cloud serves open FP8 weights).

## Expected behavior

- `bun validate` passes (exit 0).
- Resolved provider model:
  - `id`: `glm-5.3`
  - `name`: `GLM-5.3` (inherited from lab)
  - `limit`: `{ context: 1048576, output: 131072 }`
  - `reasoning_options`: `[{ type: "effort", values: ["low", "high", "max"] }]`
  - `interleaved`: `{ field: "reasoning_content" }`
  - All other fields inherited from `models/zhipuai/glm-5.3.toml`.