### PR TITLE
feat(aiand): add GLM 5.3 and Qwen 3.8 27B

### DIFF
--- a/providers/aiand/models/qwen/qwen3.8-27b.toml
+++ b/providers/aiand/models/qwen/qwen3.8-27b.toml
@@ -1,0 +1,20 @@
+# Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
+# 2026-08-29). GET /v1/models reports context_window = 262144, input = $0.40,
+# output = $3.00, cached_input = $0.20 per 1M tokens.
+# Modalities: text, image, video, and document (PDF) supported per catalog and
+# live probes.
+# reasoning_effort verified by live probe on 2026-08-29: accepts none, low,
+# medium, xhigh; rejects minimal, high, max with 400.
+base_model = "alibaba/qwen3.8-27b"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "xhigh"]
+
+[cost]
+input = 0.4
+output = 3
+cache_read = 0.2
+
+[modalities]
+input = ["text", "image", "video", "pdf"]

--- a/providers/aiand/models/zai-org/glm-5.3.toml
+++ b/providers/aiand/models/zai-org/glm-5.3.toml
@@ -1,0 +1,18 @@
+# Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
+# 2026-08-29). GET /v1/models reports context_window = 1048576 (shared base
+# model uses 1_000_000), so the exact figure is overridden here.
+# reasoning_effort verified by live probe on 2026-08-29: accepts none, low,
+# xhigh, max; rejects minimal, medium, high with 400.
+base_model = "zhipuai/glm-5.3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "xhigh", "max"]
+
+[cost]
+input = 1
+output = 4
+cache_read = 0.3
+
+[limit]
+context = 1_048_576


### PR DESCRIPTION
## Summary
Adds two new models served by the **ai&** (`aiand`) provider at `https://api.aiand.com/v1`:
- `zai-org/glm-5.3` (GLM 5.3)
- `qwen/qwen3.8-27b` (Qwen 3.8 27B)

## Details

### `providers/aiand/models/zai-org/glm-5.3.toml`
- **Base model**: `zhipuai/glm-5.3`
- **Pricing**: $1.00 input / $4.00 output per 1M tokens (USD), cached input $0.30 / 1M tokens
- **Context window**: 1,048,576 tokens
- **Reasoning options**: `reasoning_effort` probed live on 2026-08-29; accepts `["none", "low", "xhigh", "max"]` (rejects `minimal`, `medium`, `high` with 400)
- **Modalities**: Inherits `["text"]` from base

### `providers/aiand/models/qwen/qwen3.8-27b.toml`
- **Base model**: `alibaba/qwen3.8-27b`
- **Pricing**: $0.40 input / $3.00 output per 1M tokens (USD), cached input $0.20 / 1M tokens
- **Context window**: 262,144 tokens
- **Reasoning options**: `reasoning_effort` probed live on 2026-08-29; accepts `["none", "low", "medium", "xhigh"]` (rejects `minimal`, `high`, `max` with 400)
- **Modalities**: `["text", "image", "video", "pdf"]` (PDF supported via Files API / document conversion per catalog & live probe)

## Verification
- Verified against live `https://api.aiand.com/v1/models` catalog endpoint
- Live chat completions probed with each `reasoning_effort` value and input modality
- Inherits cleanly from existing lab base models (`models/zhipuai/glm-5.3.toml` and `models/alibaba/qwen3.8-27b.toml`)
- Validated against catalog schema
