### PR TITLE
Add ai& GLM-5.3 and Qwen3.8 27B models

### DIFF
--- a/providers/aiand/models/qwen/qwen3.8-27b.toml
+++ b/providers/aiand/models/qwen/qwen3.8-27b.toml
@@ -1,7 +1,12 @@
 # Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
-# 2026-08-29). Catalog reports document+vision+video capabilities, so
-# modalities include pdf alongside text/image/video from the shared base.
-# reasoning_efforts from the live catalog: none|low|medium|xhigh.
+# 2026-08-29). GET /v1/models reports context_window = 262144, input = $0.40,
+# output = $3.00, cached_input = $0.20 per 1M tokens.
+# Modalities: text, image, video, and document (PDF) supported per catalog
+# capabilities (vision|video|document).
+# reasoning_effort verified by live probe on 2026-08-29: accepts none, low,
+# medium, xhigh (200); rejects minimal, high, max with 400 ("Supported
+# values: none, low, medium, xhigh"). effort=none returns no
+# reasoning_content (off).
 base_model = "alibaba/qwen3.8-27b"
 
 [[reasoning_options]]
@@ -11,6 +16,7 @@ values = ["none", "low", "medium", "xhigh"]
 [cost]
 input = 0.4
 output = 3
+cache_read = 0.2
 
 [modalities]
 input = ["text", "image", "video", "pdf"]

--- a/providers/aiand/models/qwen/qwen3.8-27b.toml
+++ b/providers/aiand/models/qwen/qwen3.8-27b.toml
@@ -1,0 +1,16 @@
+# Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
+# 2026-08-29). Catalog reports document+vision+video capabilities, so
+# modalities include pdf alongside text/image/video from the shared base.
+# reasoning_efforts from the live catalog: none|low|medium|xhigh.
+base_model = "alibaba/qwen3.8-27b"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "xhigh"]
+
+[cost]
+input = 0.4
+output = 3
+
+[modalities]
+input = ["text", "image", "video", "pdf"]

--- a/providers/aiand/models/zai-org/glm-5.3.toml
+++ b/providers/aiand/models/zai-org/glm-5.3.toml
@@ -1,7 +1,11 @@
 # Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
-# 2026-08-29). GET /v1/models reports context_window = 1048576 (the shared
-# base model uses 1_000_000), so the exact figure is overridden here.
-# reasoning_efforts from the live catalog: none|low|xhigh|max.
+# 2026-08-29). GET /v1/models reports context_window = 1048576 (shared base
+# model uses 1_000_000), so the exact figure is overridden here.
+# Lab / peer relays (zhipuai, zai, OpenRouter, Kilo) use always-on effort
+# low|high|max. ai&'s deployment differs: live reasoning_effort probe on
+# 2026-08-29 accepts none|low|xhigh|max (200); rejects minimal|medium|high
+# with 400 ("Supported values: none, low, xhigh, max"). effort=none returns
+# no reasoning_content (off); xhigh|max return reasoning_content.
 base_model = "zhipuai/glm-5.3"
 
 [[reasoning_options]]
@@ -11,6 +15,7 @@ values = ["none", "low", "xhigh", "max"]
 [cost]
 input = 1
 output = 4
+cache_read = 0.3
 
 [limit]
 context = 1_048_576

--- a/providers/aiand/models/zai-org/glm-5.3.toml
+++ b/providers/aiand/models/zai-org/glm-5.3.toml
@@ -1,0 +1,16 @@
+# Source: GET https://api.aiand.com/v1/models (USD list prices; accessed
+# 2026-08-29). GET /v1/models reports context_window = 1048576 (the shared
+# base model uses 1_000_000), so the exact figure is overridden here.
+# reasoning_efforts from the live catalog: none|low|xhigh|max.
+base_model = "zhipuai/glm-5.3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "xhigh", "max"]
+
+[cost]
+input = 1
+output = 4
+
+[limit]
+context = 1_048_576


### PR DESCRIPTION
## Summary
Adds two models served by **ai&** (`aiand`) at `https://api.aiand.com/v1`:
- `zai-org/glm-5.3` → `base_model = zhipuai/glm-5.3`
- `qwen/qwen3.8-27b` → `base_model = alibaba/qwen3.8-27b`

## Pricing (USD / 1M tokens, from `GET /v1/models`)
| Model | Input | Cache read | Output | Context |
|-------|------:|----------:|-------:|--------:|
| GLM-5.3 | $1.00 | $0.30 | $4.00 | 1,048,576 |
| Qwen3.8 27B | $0.40 | $0.20 | $3.00 | 262,144 |

## Reasoning options (live chat-completions probe, 2026-08-29)
ai& is a relay, but its backend does **not** match lab/OpenRouter/Kilo for GLM-5.3. Values are what this host accepts:

### `zai-org/glm-5.3`
- Lab / peers: always-on `low|high|max`
- **ai& accepts:** `none|low|xhigh|max` (HTTP 200)
- **ai& rejects:** `minimal|medium|high` (HTTP 400: `Supported values: none, low, xhigh, max`)
- `effort=none` returns no `reasoning_content` (off); `xhigh`/`max` return `reasoning_content`

### `qwen/qwen3.8-27b`
- **ai& accepts:** `none|low|medium|xhigh` (HTTP 200)
- **ai& rejects:** `minimal|high|max` (HTTP 400: `Supported values: none, low, medium, xhigh`)
- `effort=none` returns no `reasoning_content` (off)

## Modalities
- GLM-5.3: inherits text-only from base
- Qwen3.8 27B: `text|image|video|pdf` (catalog `vision|video|document`)

## Source
- `GET https://api.aiand.com/v1/models` (no credentials in this PR)
- Docs: https://docs.aiand.com/
- Live `POST /v1/chat/completions` accept/reject probes for each `reasoning_effort`

## Test plan
- [x] Live probe confirms accepted/rejected efforts for both models
- [x] Files follow existing ai& override-only `base_model` pattern (`glm-5.2`, `kimi-k3`)
- [ ] `bun validate` on CI