### PR TITLE
feat(orcarouter): add GLM-5.3-Flash

### DIFF
--- a/providers/orcarouter/models/z-ai/glm-5.3-flash.toml
+++ b/providers/orcarouter/models/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[cost]
+input = 0.075
+output = 0.25
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/orcarouter/models/z-ai/glm-5.3-flash.toml
+++ b/providers/orcarouter/models/z-ai/glm-5.3-flash.toml
@@ -1,6 +1,9 @@
 base_model = "zhipuai/glm-5.3-flash"
 reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 
+[interleaved]
+field = "reasoning_content"
+
 [cost]
 input = 0.075
 output = 0.25


### PR DESCRIPTION
## What

Add `z-ai/glm-5.3-flash` to the OrcaRouter catalog.

## Details

- `base_model = "zhipuai/glm-5.3-flash"` (metadata already exists in `models/zhipuai/`)
- `reasoning_options`: effort `low | high | max` (same as `glm-5.3`, verified via OrcaRouter `/v1/models` — model always thinks, no toggle)
- Limits from OrcaRouter `/v1/models`: context `1_000_000`, output `128_000`
- Cost per OrcaRouter `/v1/models` pricing: `$0.075` / `$0.25` per 1M tokens

Validated locally with `bun validate` (exit 0, model present in generated catalog).
