### PR TITLE
feat: add bothub and tokenrouter providers

### DIFF
--- a/providers/bothub/logo.svg
+++ b/providers/bothub/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M12 5.2V7M12 3.8a1.2 1.2 0 1 0 0 2.4 1.2 1.2 0 0 0 0-2.4ZM7.8 8.2A2.2 2.2 0 0 1 10 6h4a2.2 2.2 0 0 1 2.2 2.2v7.6A2.2 2.2 0 0 1 14 18H10a2.2 2.2 0 0 1-2.2-2.2V8.2Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <ellipse cx="9.5" cy="11.5" rx="1" ry="1.3" fill="currentColor"/>
+  <ellipse cx="14.5" cy="11.5" rx="1" ry="1.3" fill="currentColor"/>
+  <rect x="9" y="14" width="6" height="1.4" rx="0.5" fill="currentColor"/>
+  <path d="M5.8 11.2H7M17 11.2h1.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/providers/bothub/logo.svg
+++ b/providers/bothub/logo.svg
@@ -1,7 +1,33 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <path d="M12 5.2V7M12 3.8a1.2 1.2 0 1 0 0 2.4 1.2 1.2 0 0 0 0-2.4ZM7.8 8.2A2.2 2.2 0 0 1 10 6h4a2.2 2.2 0 0 1 2.2 2.2v7.6A2.2 2.2 0 0 1 14 18H10a2.2 2.2 0 0 1-2.2-2.2V8.2Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <ellipse cx="9.5" cy="11.5" rx="1" ry="1.3" fill="currentColor"/>
-  <ellipse cx="14.5" cy="11.5" rx="1" ry="1.3" fill="currentColor"/>
-  <rect x="9" y="14" width="6" height="1.4" rx="0.5" fill="currentColor"/>
-  <path d="M5.8 11.2H7M17 11.2h1.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500">
+  <path d="
+    M 238,170 
+    L 238,126 
+    A 20 20 0 1 1 262,126 
+    L 262,170 
+    L 335,170 
+    A 35 35 0 0 1 370,205 
+    L 370,225 
+    A 12 12 0 0 1 382,237 
+    L 382,263 
+    A 12 12 0 0 1 370,275 
+    L 370,315 
+    A 35 35 0 0 1 335,350 
+    L 165,350 
+    A 35 35 0 0 1 130,315 
+    L 130,275 
+    A 12 12 0 0 1 118,263 
+    L 118,237 
+    A 12 12 0 0 1 130,225 
+    L 130,205 
+    A 35 35 0 0 1 165,170 
+    Z" 
+    fill="none" 
+    stroke="currentColor" 
+    stroke-width="12" 
+    stroke-linecap="round" 
+    stroke-linejoin="round"
+  />
+  <circle cx="202" cy="242" r="21" fill="currentColor" />
+  <circle cx="298" cy="242" r="21" fill="currentColor" />
+  <rect x="205" y="288" width="90" height="26" rx="13" fill="currentColor" />
 </svg>

--- a/providers/bothub/models/gemma-4-31b-it:free.toml
+++ b/providers/bothub/models/gemma-4-31b-it:free.toml
@@ -1,0 +1,11 @@
+name = "Bothub"
+env = ["BOTHUB_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# Raw HTTP reasoning controls (accessed 2026-08-29):
+# Chat POST `/v1/chat/completions` accepts `reasoning_effort =
+# none|low|medium|high|max` for reasoning-capable models; free tier
+# endpoints respond with the upstream reasoning interleaved in the
+# message payload.
+# https://bothub.ru
+api = "https://openai.bothub.ru/v1"
+doc = "https://bothub.ru/models"

--- a/providers/bothub/models/gemma-4-31b-it:free.toml
+++ b/providers/bothub/models/gemma-4-31b-it:free.toml
@@ -1,4 +1,6 @@
-# Bothub wire: reasoning in message.reasoning (also mirrored in message.reasoning_details as reasoning.text)
+# Bothub wire: reasoning arrives in message.reasoning (mirrored in message.reasoning_details as reasoning.text).
+# Toggle: POST /v1/chat/completions request field reasoning_effort = "low" (on) | "none" (off);
+# live-verified 2026-08-29: any non-none value enables thinking, "none" disables it (no graded effect between on-values).
 base_model = "google/gemma-4-31b-it"
 name = "Gemma 4 31B IT (free)"
 

--- a/providers/bothub/models/gemma-4-31b-it:free.toml
+++ b/providers/bothub/models/gemma-4-31b-it:free.toml
@@ -1,9 +1,12 @@
 base_model = "google/gemma-4-31b-it"
 name = "Gemma 4 31B IT (free)"
 
+[interleaved]
+field = "reasoning_details"
+
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "max"]
+values = ["none", "low", "medium", "high"]
 
 [cost]
 input = 0

--- a/providers/bothub/models/gemma-4-31b-it:free.toml
+++ b/providers/bothub/models/gemma-4-31b-it:free.toml
@@ -1,12 +1,11 @@
+# Bothub wire: reasoning in message.reasoning (also mirrored in message.reasoning_details as reasoning.text)
 base_model = "google/gemma-4-31b-it"
 name = "Gemma 4 31B IT (free)"
 
-[interleaved]
-field = "reasoning_details"
+interleaved = true
 
 [[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high"]
+type = "toggle"
 
 [cost]
 input = 0

--- a/providers/bothub/models/gemma-4-31b-it:free.toml
+++ b/providers/bothub/models/gemma-4-31b-it:free.toml
@@ -1,11 +1,10 @@
-name = "Bothub"
-env = ["BOTHUB_API_KEY"]
-npm = "@ai-sdk/openai-compatible"
-# Raw HTTP reasoning controls (accessed 2026-08-29):
-# Chat POST `/v1/chat/completions` accepts `reasoning_effort =
-# none|low|medium|high|max` for reasoning-capable models; free tier
-# endpoints respond with the upstream reasoning interleaved in the
-# message payload.
-# https://bothub.ru
-api = "https://openai.bothub.ru/v1"
-doc = "https://bothub.ru/models"
+base_model = "google/gemma-4-31b-it"
+name = "Gemma 4 31B IT (free)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/bothub/models/nemotron-3-ultra-550b-a55b:free.toml
+++ b/providers/bothub/models/nemotron-3-ultra-550b-a55b:free.toml
@@ -1,0 +1,11 @@
+name = "Bothub"
+env = ["BOTHUB_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# Raw HTTP reasoning controls (accessed 2026-08-29):
+# Chat POST `/v1/chat/completions` accepts `reasoning_effort =
+# none|low|medium|high|max` for reasoning-capable models; free tier
+# endpoints respond with the upstream reasoning interleaved in the
+# message payload.
+# https://bothub.ru
+api = "https://openai.bothub.ru/v1"
+doc = "https://bothub.ru/models"

--- a/providers/bothub/models/nemotron-3-ultra-550b-a55b:free.toml
+++ b/providers/bothub/models/nemotron-3-ultra-550b-a55b:free.toml
@@ -1,11 +1,10 @@
-name = "Bothub"
-env = ["BOTHUB_API_KEY"]
-npm = "@ai-sdk/openai-compatible"
-# Raw HTTP reasoning controls (accessed 2026-08-29):
-# Chat POST `/v1/chat/completions` accepts `reasoning_effort =
-# none|low|medium|high|max` for reasoning-capable models; free tier
-# endpoints respond with the upstream reasoning interleaved in the
-# message payload.
-# https://bothub.ru
-api = "https://openai.bothub.ru/v1"
-doc = "https://bothub.ru/models"
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+name = "Nemotron 3 Ultra (free)"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/bothub/models/nemotron-3-ultra-550b-a55b:free.toml
+++ b/providers/bothub/models/nemotron-3-ultra-550b-a55b:free.toml
@@ -1,12 +1,12 @@
+# Bothub wire: reasoning in message.reasoning (also mirrored in message.reasoning_details as reasoning.text)
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 name = "Nemotron 3 Ultra (free)"
 
-[interleaved]
-field = "reasoning_details"
+interleaved = true
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high"]
+values = ["none", "medium", "high"]
 
 [cost]
 input = 0

--- a/providers/bothub/models/nemotron-3-ultra-550b-a55b:free.toml
+++ b/providers/bothub/models/nemotron-3-ultra-550b-a55b:free.toml
@@ -1,9 +1,12 @@
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 name = "Nemotron 3 Ultra (free)"
 
+[interleaved]
+field = "reasoning_details"
+
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "max"]
+values = ["none", "low", "medium", "high"]
 
 [cost]
 input = 0

--- a/providers/bothub/provider.toml
+++ b/providers/bothub/provider.toml
@@ -1,0 +1,11 @@
+name = "Bothub"
+env = ["BOTHUB_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# Raw HTTP reasoning controls (accessed 2026-08-29):
+# Chat POST `/v1/chat/completions` accepts `reasoning_effort =
+# none|low|medium|high|max` for reasoning-capable models; free tier
+# endpoints respond with the upstream reasoning interleaved in the
+# message payload.
+# https://bothub.ru
+api = "https://openai.bothub.ru/v1"
+doc = "https://bothub.ru/models"

--- a/providers/bothub/provider.toml
+++ b/providers/bothub/provider.toml
@@ -1,11 +1,13 @@
 name = "Bothub"
 env = ["BOTHUB_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-# Raw HTTP reasoning controls (accessed 2026-08-29):
-# Chat POST `/v1/chat/completions` accepts `reasoning_effort =
-# none|low|medium|high|max` for reasoning-capable models; free tier
-# endpoints respond with the upstream reasoning interleaved in the
-# message payload.
+# Raw HTTP reasoning controls (live-verified 2026-08-29):
+# Chat POST `/v1/chat/completions` takes `reasoning_effort`; upstream
+# reasoning returns in the message side channel (`reasoning`, mirrored
+# in `reasoning_details`). Per-model request controls differ:
+# - nemotron-3-ultra-550b-a55b:free: effort none|medium|high
+# - gemma-4-31b-it:free: binary toggle (any non-none value enables
+#   thinking, `none` disables it)
 # https://bothub.ru
 api = "https://openai.bothub.ru/v1"
 doc = "https://bothub.ru/models"

--- a/providers/tokenrouter/logo.svg
+++ b/providers/tokenrouter/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="3" y="7" width="18" height="10" rx="5" stroke="currentColor" stroke-width="1.7"/>
+  <circle cx="16" cy="12" r="3" fill="currentColor"/>
+</svg>

--- a/providers/tokenrouter/models/z-ai/glm-5.3-free.toml
+++ b/providers/tokenrouter/models/z-ai/glm-5.3-free.toml
@@ -6,7 +6,7 @@ field = "reasoning_content"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "max"]
+values = ["low", "high", "max"]
 
 [cost]
 input = 0

--- a/providers/tokenrouter/models/z-ai/glm-5.3-free.toml
+++ b/providers/tokenrouter/models/z-ai/glm-5.3-free.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-5.3"
+name = "GLM-5.3 (free)"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 0
+output = 0

--- a/providers/tokenrouter/provider.toml
+++ b/providers/tokenrouter/provider.toml
@@ -1,0 +1,10 @@
+name = "TokenRouter"
+env = ["TOKENROUTER_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# Raw HTTP reasoning controls (accessed 2026-08-29):
+# Chat POST `/v1/chat/completions` accepts `reasoning_effort =
+# none|low|medium|high|max` for reasoning-capable models; free tier
+# models return upstream reasoning in `reasoning_content`.
+# https://www.tokenrouter.com
+api = "https://api.tokenrouter.com/v1"
+doc = "https://www.tokenrouter.com/docs/tokenrouter-feature-guide/"

--- a/providers/tokenrouter/provider.toml
+++ b/providers/tokenrouter/provider.toml
@@ -1,10 +1,10 @@
 name = "TokenRouter"
 env = ["TOKENROUTER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-# Raw HTTP reasoning controls (accessed 2026-08-29):
+# Raw HTTP reasoning controls (live-verified 2026-08-29):
 # Chat POST `/v1/chat/completions` accepts `reasoning_effort =
-# none|low|medium|high|max` for reasoning-capable models; free tier
-# models return upstream reasoning in `reasoning_content`.
+# low|high|max` (verified set for z-ai/glm-5.3-free); thinking is
+# always on and reasoning returns in `reasoning_content`.
 # https://www.tokenrouter.com
 api = "https://api.tokenrouter.com/v1"
 doc = "https://www.tokenrouter.com/docs/tokenrouter-feature-guide/"


### PR DESCRIPTION
Adds the bothub and tokenrouter providers to the catalog with their free-tier models. All controls below are live-verified against the APIs on 2026-08-29.

## bothub
- `provider.toml` (env `BOTHUB_API_KEY`, openai-compatible, base `https://openai.bothub.ru/v1`)
- `nemotron-3-ultra-550b-a55b:free` (base `nvidia/nemotron-3-ultra-550b-a55b`): effort `none|medium|high`; `none` disables thinking, `medium`/`high` enable it (no distinct graded effect observed between on-values). Reasoning returns in `message.reasoning`, mirrored in `message.reasoning_details` (OpenAI `reasoning.text` items) -> `interleaved = true`.
- `gemma-4-31b-it:free` (base `google/gemma-4-31b-it`): binary toggle via request `reasoning_effort` — `none` disables thinking, any non-none value (`low`/`high`/`max` accepted) enables it with no graded difference, matching the lab/peer toggle-only shape. Same `reasoning` + `reasoning_details` response surface -> `interleaved = true`. Wire path documented in a leading comment.
- `logo.svg`: monochrome rendition of the BotHub robot mark (currentColor, square viewBox).

## tokenrouter
- `provider.toml` (env `TOKENROUTER_API_KEY`, openai-compatible, base `https://api.tokenrouter.com/v1`)
- `z-ai/glm-5.3-free` (base `zhipuai/glm-5.3`): thinking is always on — `reasoning_effort=none` still returns reasoning — so the authored set is the lab/peer `low|high|max`. Reasoning returns in `message.reasoning_content` -> `[interleaved] field = reasoning_content`.
- `logo.svg`: monochrome rendition of the TokenRouter capsule mark (currentColor, square viewBox).