### PR TITLE
feat(synthetic): add GLM-5.3-Flash

### DIFF
--- a/providers/synthetic/models/hf:zai-org/GLM-5.3-Flash.toml
+++ b/providers/synthetic/models/hf:zai-org/GLM-5.3-Flash.toml
@@ -1,0 +1,19 @@
+# Pricing, limits, modalities, and reasoning efforts from the live model surface:
+# GET https://api.synthetic.new/openai/v1/models  (hf:zai-org/GLM-5.3-Flash)
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[modalities]
+input = ["text", "image"]
+
+[cost]
+input = 0.15
+output = 0.5
+cache_read = 0.04
+
+[limit]
+context = 524_288
+output = 65_536


### PR DESCRIPTION
Add GLM-5.3-Flash to the Synthetic provider. The model is served by api.synthetic.new/openai/v1 (model id hf:zai-org/GLM-5.3-Flash) but was missing from the catalog.

- context 524288, output 65536 (synthetic serving limits)
- input modalities text+image (canonical lists video+pdf too; synthetic API does not accept those)
- reasoning efforts low/high/max
- interleaved reasoning via reasoning_content
- pricing $0.15/$0.50/$0.04 per MTok (input/output/cache_read)