### PR TITLE
feat(fireworks-ai): add GLM 5.3 Flash serverless model

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
@@ -1,0 +1,19 @@
+# Pricing: https://fireworks.ai/models/fireworks/glm-5p3-flash (accessed 2026-08-29)
+# Released on Fireworks Serverless API 2026-08-26.
+# Thinking-only model: reasoning cannot be disabled. Use the same two effective
+# tiers as Fireworks GLM 5.3: low/medium collapse to high; max/xhigh select max.
+# https://docs.fireworks.ai/api-reference/post-chatcompletions (accessed 2026-08-29)
+base_model = "zhipuai/glm-5.3-flash"
+name = "GLM 5.3 Flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.50
+cache_read = 0.029


### PR DESCRIPTION
Expose Fireworks' multimodal GLM 5.3 Flash route with its reasoning controls and serverless pricing.