### PR TITLE
Update neuralwatt catalog, GLM-5.3 officially open weights

### DIFF
--- a/models/zhipuai/glm-5.3.toml
+++ b/models/zhipuai/glm-5.3.toml
@@ -8,7 +8,7 @@ reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [limit]
 context = 1_000_000

--- a/providers/neuralwatt/README.md
+++ b/providers/neuralwatt/README.md
@@ -14,6 +14,7 @@ Standard Models
 - gemma-4-31b: Gemma 4 31B, image input, 262K context
 - glm-5.2: GLM 5.2, 1M context
 - glm-5.2-short: GLM 5.2 Short, 200K context, 32K output cap
+- glm-5.3: GLM 5.3, 1M context, gated preview
 - kimi-k2.7-code: Kimi K2.7 Code, image input, 262K context
 - kimi-k3: Kimi K3, image input, 1M context
 - qwen-3.8-27b: Qwen 3.8 27B, image input, 262K context, private preview
@@ -43,7 +44,8 @@ Pricing
 
 Reasoning Controls
 - reasoning_effort accepts the levels in metadata.reasoning.supported_efforts.
-  Every list that offers reasoning also offers none, which is the off switch.
+  Most lists include none, which is the off switch. glm-5.3 is the exception:
+  it reports reasoning.mandatory and offers only low, high and max.
 - accepted_efforts is wider than supported_efforts. The extra values are
   aliases the API folds into a supported level, not distinct levels.
 - thinking_token_budget is accepted on every model except deepseek-v4-flash and

--- a/providers/neuralwatt/models/glm-5.2-fast.toml
+++ b/providers/neuralwatt/models/glm-5.2-fast.toml
@@ -1,20 +1,19 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
+base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2 Fast"
 description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
-family = "glm"
 release_date = "2026-06-17"
 last_updated = "2026-06-17"
-attachment = false
-reasoning = true
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [
-  { type = "effort", values = ["none", "high", "max"] },
-  { type = "budget_tokens" },
-]
-interleaved = true
-temperature = true
-tool_call = true
 structured_output = false
-open_weights = true
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 1.45
@@ -24,7 +23,3 @@ cache_read = 0.145
 [limit]
 context = 1_048_560
 output = 1_048_560
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/neuralwatt/models/glm-5.2-flex.toml
+++ b/providers/neuralwatt/models/glm-5.2-flex.toml
@@ -1,20 +1,19 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
+base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2 Flex"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
 release_date = "2026-06-17"
 last_updated = "2026-06-17"
-attachment = false
-reasoning = true
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [
-  { type = "effort", values = ["none", "high", "max"] },
-  { type = "budget_tokens" },
-]
-interleaved = true
-temperature = true
-tool_call = true
 structured_output = false
-open_weights = true
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 0.9425
@@ -24,7 +23,3 @@ cache_read = 0.09425
 [limit]
 context = 1_048_560
 output = 1_048_560
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/neuralwatt/models/glm-5.2-short-fast-flex.toml
+++ b/providers/neuralwatt/models/glm-5.2-short-fast-flex.toml
@@ -1,20 +1,19 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
+base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2 Short Fast Flex"
 description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
-family = "glm"
 release_date = "2026-06-17"
 last_updated = "2026-06-17"
-attachment = false
-reasoning = true
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [
-  { type = "effort", values = ["none", "high", "max"] },
-  { type = "budget_tokens" },
-]
-interleaved = true
-temperature = true
-tool_call = true
 structured_output = false
-open_weights = true
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 0.9425
@@ -24,7 +23,3 @@ cache_read = 0.09425
 [limit]
 context = 199_984
 output = 32_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/neuralwatt/models/glm-5.2-short-fast.toml
+++ b/providers/neuralwatt/models/glm-5.2-short-fast.toml
@@ -1,20 +1,19 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
+base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2 Short Fast"
 description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
-family = "glm"
 release_date = "2026-06-17"
 last_updated = "2026-06-17"
-attachment = false
-reasoning = true
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [
-  { type = "effort", values = ["none", "high", "max"] },
-  { type = "budget_tokens" },
-]
-interleaved = true
-temperature = true
-tool_call = true
 structured_output = false
-open_weights = true
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 1.45
@@ -24,7 +23,3 @@ cache_read = 0.145
 [limit]
 context = 199_984
 output = 32_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/neuralwatt/models/glm-5.2-short-flex.toml
+++ b/providers/neuralwatt/models/glm-5.2-short-flex.toml
@@ -1,20 +1,19 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
+base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2 Short Flex"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
 release_date = "2026-06-17"
 last_updated = "2026-06-17"
-attachment = false
-reasoning = true
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [
-  { type = "effort", values = ["none", "high", "max"] },
-  { type = "budget_tokens" },
-]
-interleaved = true
-temperature = true
-tool_call = true
 structured_output = false
-open_weights = true
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 0.9425
@@ -24,7 +23,3 @@ cache_read = 0.09425
 [limit]
 context = 199_984
 output = 32_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/neuralwatt/models/glm-5.2-short.toml
+++ b/providers/neuralwatt/models/glm-5.2-short.toml
@@ -1,20 +1,19 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
+base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2 Short"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
 release_date = "2026-06-17"
 last_updated = "2026-06-17"
-attachment = false
-reasoning = true
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [
-  { type = "effort", values = ["none", "high", "max"] },
-  { type = "budget_tokens" },
-]
-interleaved = true
-temperature = true
-tool_call = true
 structured_output = false
-open_weights = true
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 1.45
@@ -24,7 +23,3 @@ cache_read = 0.145
 [limit]
 context = 199_984
 output = 32_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/neuralwatt/models/glm-5.2.toml
+++ b/providers/neuralwatt/models/glm-5.2.toml
@@ -1,20 +1,19 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
+base_model = "zhipuai/glm-5.2"
 name = "GLM 5.2"
 description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
 release_date = "2026-06-17"
 last_updated = "2026-06-17"
-attachment = false
-reasoning = true
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [
-  { type = "effort", values = ["none", "high", "max"] },
-  { type = "budget_tokens" },
-]
-interleaved = true
-temperature = true
-tool_call = true
 structured_output = false
-open_weights = true
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 1.45
@@ -24,7 +23,3 @@ cache_read = 0.145
 [limit]
 context = 1_048_560
 output = 1_048_560
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/neuralwatt/models/glm-5.3.toml
+++ b/providers/neuralwatt/models/glm-5.3.toml
@@ -29,3 +29,4 @@ cache_read = 0.145
 
 [limit]
 context = 1_048_560
+output = 1_048_560

--- a/providers/neuralwatt/models/glm-5.3.toml
+++ b/providers/neuralwatt/models/glm-5.3.toml
@@ -1,0 +1,22 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
+base_model = "zhipuai/glm-5.3"
+name = "GLM 5.3"
+structured_output = false
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+[cost]
+input = 1.45
+output = 4.5
+cache_read = 0.145
+
+[limit]
+context = 1_048_560
+output = 1_048_560

--- a/providers/neuralwatt/models/glm-5.3.toml
+++ b/providers/neuralwatt/models/glm-5.3.toml
@@ -1,7 +1,17 @@
+# Preview rollout: glm-5.3 is a gated preview on Neuralwatt, visible to
+# accounts granted access per the Preview Models guide. Its list price is
+# Neuralwatt's GLM 5.2 parity default and is marked for review at launch,
+# per the model description in GET /v1/models (checked 2026-08-30).
+# Reasoning cannot be disabled (reasoning.mandatory = true), so there is no
+# none level and no toggle. The API supports low, high and max as distinct
+# efforts; minimal, medium and xhigh are accepted as aliases onto them.
 # Budget: thinking_token_budget (integer reasoning tokens)
+# https://portal.neuralwatt.com/docs/api/chat-completions
+# https://portal.neuralwatt.com/docs/guides/preview-models
 base_model = "zhipuai/glm-5.3"
 name = "GLM 5.3"
 structured_output = false
+status = "beta"
 
 interleaved = true
 
@@ -19,4 +29,3 @@ cache_read = 0.145
 
 [limit]
 context = 1_048_560
-output = 1_048_560

--- a/providers/neuralwatt/models/kimi-k2.7-code-fast.toml
+++ b/providers/neuralwatt/models/kimi-k2.7-code-fast.toml
@@ -1,9 +1,12 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
 base_model = "moonshotai/kimi-k2.7-code"
 name = "Kimi K2.7 Code Fast"
 description = "Kimi K2.7 Code with reasoning capped to a short budget for lower latency; reasoning cannot be disabled on this model"
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [{ type = "budget_tokens" }]
+
 interleaved = true
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 0.95
@@ -16,4 +19,3 @@ output = 262_128
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/neuralwatt/models/kimi-k2.7-code-flex.toml
+++ b/providers/neuralwatt/models/kimi-k2.7-code-flex.toml
@@ -1,8 +1,11 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
 base_model = "moonshotai/kimi-k2.7-code"
 name = "Kimi K2.7 Code Flex"
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [{ type = "budget_tokens" }]
+
 interleaved = true
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 0.6175
@@ -15,4 +18,3 @@ output = 262_128
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/neuralwatt/models/kimi-k2.7-code.toml
+++ b/providers/neuralwatt/models/kimi-k2.7-code.toml
@@ -1,7 +1,10 @@
-base_model = "moonshotai/kimi-k2.7-code"
 # Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [{ type = "budget_tokens" }]
+base_model = "moonshotai/kimi-k2.7-code"
+
 interleaved = true
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 0.95
@@ -14,4 +17,3 @@ output = 262_128
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/neuralwatt/models/kimi-k3-fast.toml
+++ b/providers/neuralwatt/models/kimi-k3-fast.toml
@@ -4,8 +4,8 @@ description = "Kimi K3 with thinking disabled for low-latency tool calling, visi
 reasoning = false
 
 [cost]
-input = 3.0
-output = 15.0
+input = 3
+output = 15
 cache_read = 0.3
 
 [limit]
@@ -14,4 +14,3 @@ output = 1_048_560
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/neuralwatt/models/kimi-k3-flex.toml
+++ b/providers/neuralwatt/models/kimi-k3-flex.toml
@@ -1,12 +1,16 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
 base_model = "moonshotai/kimi-k3"
 name = "Kimi K3 Flex"
 description = "Kimi K3 on the flex tier: discounted, best-effort latency, requests may be held under load"
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [
-  { type = "effort", values = ["none", "low", "high", "max"] },
-  { type = "budget_tokens" },
-]
+
 interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 1.95
@@ -19,4 +23,3 @@ output = 1_048_560
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/neuralwatt/models/kimi-k3.toml
+++ b/providers/neuralwatt/models/kimi-k3.toml
@@ -1,15 +1,19 @@
 # Effort: reasoning_effort = none|low|high|max (none disables thinking)
 # Budget: thinking_token_budget (integer reasoning tokens)
 base_model = "moonshotai/kimi-k3"
-reasoning_options = [
-  { type = "effort", values = ["none", "low", "high", "max"] },
-  { type = "budget_tokens" },
-]
+
 interleaved = true
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+
 [cost]
-input = 3.0
-output = 15.0
+input = 3
+output = 15
 cache_read = 0.3
 
 [limit]
@@ -18,4 +22,3 @@ output = 1_048_560
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/neuralwatt/models/qwen3.6-35b-fast.toml
+++ b/providers/neuralwatt/models/qwen3.6-35b-fast.toml
@@ -1,14 +1,10 @@
+base_model = "alibaba/qwen3.6-35b-a3b"
 name = "Qwen3.6 35B Fast"
 description = "Efficient model for low-latency assistance, extraction, and routine automation"
 family = "qwen3.6"
 release_date = "2026-04-01"
 last_updated = "2026-04-01"
-attachment = true
 reasoning = false
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [cost]
 input = 0.29
@@ -21,4 +17,3 @@ output = 131_056
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/neuralwatt/models/qwen3.6-35b.toml
+++ b/providers/neuralwatt/models/qwen3.6-35b.toml
@@ -1,11 +1,15 @@
+# Budget: thinking_token_budget (integer reasoning tokens)
 base_model = "alibaba/qwen3.6-35b-a3b"
 name = "Qwen3.6 35B"
-# Budget: thinking_token_budget (integer reasoning tokens)
-reasoning_options = [
-  { type = "effort", values = ["none", "high"] },
-  { type = "budget_tokens" },
-]
+
 interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
 
 [cost]
 input = 0.29
@@ -18,4 +22,3 @@ output = 131_056
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]


### PR DESCRIPTION
Adds GLM 5.3 to the Neuralwatt catalog, corrects the GLM-5.3 lab entry now
that Zhipu has published the weights, and normalises the existing Neuralwatt
entries.

## Sources

- `GET https://api.neuralwatt.com/v1/models` (checked 2026-08-30, authenticated):
  authoritative for the glm-5.3 price (1.45 input, 4.50 output, 0.145 cached
  input per million, `pricing_tbd: false`), `limits.max_context_length` of
  1048560, `limits.max_output_tokens: null`, `capabilities.json_mode: false`,
  `capabilities.reasoning: true`, `reasoning.mandatory: true`, and
  `reasoning.supported_efforts` of low, high and max. The model description
  also states the gated preview status and that the price is a GLM 5.2 parity
  default pending review at launch.
- https://huggingface.co/zai-org/GLM-5.3: the published GLM-5.3 weights,
  supporting `open_weights = true` on the lab entry. Safetensors are
  downloadable under the GLM-5.3 license.
- https://z.ai/blog/glm-5.3: Zhipu's announcement of the open-weight release,
  supporting the same field.
- https://portal.neuralwatt.com/docs/api/chat-completions: `thinking_token_budget`
  as the reasoning budget field, supporting the `budget_tokens` option.
- https://portal.neuralwatt.com/docs/guides/preview-models: access gating,
  supporting `status = "beta"`.

## Changes

**`models/zhipuai/glm-5.3.toml`: `open_weights` false to true.** The entry was
authored before the weights were public. Zhipu has since published them, so the
recorded value no longer matches the model. No other field changes.

**Added `providers/neuralwatt/models/glm-5.3.toml`**, override-only against
`base_model = "zhipuai/glm-5.3"`. Every field present is a real delta or a
provider-only field:

| Field | Lab entry | Neuralwatt | Why it differs |
| --- | --- | --- | --- |
| `name` | `GLM-5.3` | `GLM 5.3` | Host display name, matching the sibling `glm-5.2` entries |
| `structured_output` | `true` | `false` | API reports `json_mode: false` |
| `limit.context` | 1_000_000 | 1_048_560 | API reports `max_context_length: 1048560` |
| `status` | n/a | `beta` | Gated preview, as with `deepseek-v4-pro` and `qwen-3.8-27b` |
| `cost` | n/a | provider-only | Per the API pricing block |
| `reasoning_options` | n/a | provider-only | Per the API reasoning block |
| `interleaved` | n/a | provider-only | Reasoning traces arrive on a `reasoning` field |

`limit.output` is 1_048_560, matching context. The API reports
`max_output_tokens: null`, and `providers/neuralwatt/README.md` records that
models reporting no cap are limited only by their context window and are
cataloged with output equal to context. All eleven other Neuralwatt entries
with a null cap follow this.

Description, family, dates, `attachment`, `reasoning`, `tool_call`,
`temperature` and `[modalities]` are inherited, not restated.

Sources and rationale are in a leading comment block above the first key, since
sync serialization drops comments elsewhere.

**Effort levels are the three the API supports**, not the six it accepts.
`accepted_efforts` lists minimal, low, medium, high, xhigh and max, but
`effort_aliases` collapses minimal to low, medium to high and xhigh to max, so
only low, high and max are distinct levels. No `none` and no `toggle`: the API
reports `reasoning.mandatory: true`, so reasoning cannot be switched off on this
model. This differs from the `glm-5.2` peer, which does expose `none`.

**Normalised 15 existing Neuralwatt entries.** Rewritten by the sync module:
`reasoning_options` move to table syntax, fields that already match the base
model are dropped, and the default text output modality is left implicit. The
resolved catalog is unchanged. Regenerating it before and after gives byte
identical output for all 20 pre-existing Neuralwatt models, so this commit
carries no data change and can be reviewed as formatting.

`bun validate` passes. Re-running the sync module against the merged result is a
no-op, so the hand-authored `status`, header block and omitted output cap are
stable across future runs.
