### PR TITLE
llmtech: enable vision on Qwen3.8-27B-NVFP4

### DIFF
--- a/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
+++ b/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
@@ -5,7 +5,6 @@
 # streaming deltas use `reasoning_content`.
 
 base_model = "alibaba/qwen3.8-27b"
-attachment = true
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
+++ b/providers/llmtech/models/unsloth/Qwen3.8-27B-NVFP4.toml
@@ -5,7 +5,7 @@
 # streaming deltas use `reasoning_content`.
 
 base_model = "alibaba/qwen3.8-27b"
-attachment = false
+attachment = true
 
 [[reasoning_options]]
 type = "toggle"
@@ -20,4 +20,4 @@ output = 2.09
 cache_read = 0.04
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]


### PR DESCRIPTION
The `llmtech` entry currently overrides the base model down to text-only:

```toml
attachment = false

[modalities]
input = ["text"]
```

That was accurate when the provider was submitted — we had not verified image input on our own build at that point. We have since confirmed it works in production, so the override is now wrong in the restrictive direction.

Verified on the live endpoint today against `unsloth/Qwen3.8-27B-NVFP4`:

- an 8x8 PNG (red top half, blue bottom half) sent as `image_url` with a base64 data URI
- HTTP 200, answer `red and blue`
- usage reported `prompt_tokens_details: {"multimodal_tokens": {"image": 64}}`, so image tokens are counted and billed

This PR only flips those two fields:

```diff
- attachment = false
+ attachment = true

  [modalities]
- input = ["text"]
+ input = ["text", "image"]
```

Cost, context and output limits are untouched — `limit` still inherits `context = 262_144` and `output = 32_768` from `alibaba/qwen3.8-27b`.

I deliberately did **not** add `video`, even though the base model declares it and several providers list it: we have not tested video input on our deployment, so claiming it would be a guess.

Disclosure: I run LLM Tech.