### PR TITLE
feat(provider): add four Vancine models

### DIFF
--- a/providers/vancine/models/LongCat-2.0.toml
+++ b/providers/vancine/models/LongCat-2.0.toml
@@ -1,0 +1,19 @@
+# Sources (accessed 2026-08-30):
+# models/meituan/longcat-2.0.toml
+# providers/longcat/models/LongCat-2.0.toml
+# Toggle: thinking.type = "enabled" | "disabled".
+# Interleaved field: reasoning_content.
+# Lab cost: input 0.75 / output 2.95 / cache_read 0.015.
+# Vancine public pricing (/api/pricing) is 0.24 / 0.96 / n/a / 0.0048 (USD/MTok).
+base_model = "meituan/longcat-2.0"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.24
+output = 0.96
+cache_read = 0.0048

--- a/providers/vancine/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/vancine/models/deepseek-v4-flash-vision-exp.toml
@@ -1,0 +1,28 @@
+# Sources (accessed 2026-08-30):
+# https://api-docs.deepseek.com/quick_start/pricing/
+# https://api-docs.deepseek.com/guides/vision
+# models/deepseek/deepseek-v4-flash-vision-exp.toml
+# providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
+# providers/vancine/models/deepseek-v4-flash.toml
+# Toggle: thinking.type = "enabled" | "disabled".
+# Effort: reasoning_effort = "low" | "high" | "max". Priced the same as
+# DeepSeek V4 Flash; reasoning tokens are billed at the output rate.
+# Interleaved field: reasoning_content.
+# Lab cost: input 0.14 / output 0.28 / reasoning 0.28 / cache_read 0.0028.
+# Vancine public pricing (/api/pricing) is 0.22 / 0.66 / n/a / 0.007 (USD/MTok).
+base_model = "deepseek/deepseek-v4-flash-vision-exp"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.22
+output = 0.66
+cache_read = 0.007

--- a/providers/vancine/models/hy4-preview.toml
+++ b/providers/vancine/models/hy4-preview.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-08-30):
+# models/tencent/hy4-preview.toml
+# providers/opencode-go/models/hy4-preview.toml
+# Effort: reasoning_effort = "none" | "high". Off is effort = "none", so
+# no toggle is authored. No interleaved field evidence on this host.
+# Lab cost (Tencent list): input 0.834 / output 2.501 / cache_read 0.042.
+# Vancine public pricing (/api/pricing) is 0.67 / 2.00 / 0.034 (USD/MTok).
+base_model = "tencent/hy4-preview"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "high"]
+
+[cost]
+input = 0.67
+output = 2.00
+cache_read = 0.034

--- a/providers/vancine/models/mimo-v2.5-pro.toml
+++ b/providers/vancine/models/mimo-v2.5-pro.toml
@@ -1,0 +1,20 @@
+# Sources (accessed 2026-08-30):
+# https://platform.xiaomimimo.com/static/docs/api/chat/openai-api.md
+# models/xiaomi/mimo-v2.5-pro.toml
+# providers/xiaomi/models/mimo-v2.5-pro.toml
+# Toggle: thinking.type = "enabled" | "disabled".
+# Interleaved field: reasoning_content.
+# Lab cost: input 0.435 / output 0.87 / cache_read 0.0036.
+# Vancine public pricing (/api/pricing) is 0.348 / 0.696 / n/a / 0.00288 (USD/MTok).
+base_model = "xiaomi/mimo-v2.5-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.348
+output = 0.696
+cache_read = 0.00288


### PR DESCRIPTION
> **AI-assisted contribution notice:** This contribution was AI-assisted. The author `fx247562340` is not among the repository's historical core developers. Model selection, pricing, base-model mapping, and reasoning-option metadata were audited against public Vancine data and existing models.dev lab/provider entries.

## Summary

Add four currently available models to the existing Vancine OpenAI-compatible provider:

- `mimo-v2.5-pro`
- `LongCat-2.0`
- `hy4-preview`
- `deepseek-v4-flash-vision-exp`

This is a provider-catalog-only update. Each entry uses an existing models.dev lab model through `base_model` and contains only Vancine-specific cost and reasoning-surface overrides.

## Models

| Model | Base model | Input | Output | Cache read | Reasoning controls |
|---|---|---:|---:|---:|---|
| `mimo-v2.5-pro` | `xiaomi/mimo-v2.5-pro` | 0.348 | 0.696 | 0.00288 | toggle |
| `LongCat-2.0` | `meituan/longcat-2.0` | 0.24 | 0.96 | 0.0048 | toggle |
| `hy4-preview` | `tencent/hy4-preview` | 0.67 | 2.00 | 0.034 | effort `none/high` |
| `deepseek-v4-flash-vision-exp` | `deepseek/deepseek-v4-flash-vision-exp` | 0.22 | 0.66 | 0.007 | toggle + effort `low/high/max` |

All prices are USD per million tokens and were derived from Vancine's public pricing endpoint:

- https://vancine.com/api/pricing

## Reasoning metadata

- `mimo-v2.5-pro`: `thinking.type = enabled|disabled`; interleaved `reasoning_content`.
- `LongCat-2.0`: `thinking.type = enabled|disabled`; interleaved `reasoning_content`.
- `hy4-preview`: effort `none|high`. Because `none` disables reasoning, no separate toggle is authored. No interleaved field is claimed without Vancine-host evidence.
- `deepseek-v4-flash-vision-exp`: `thinking.type = enabled|disabled`, effort `low|high|max`; interleaved `reasoning_content`.

The entries follow the corresponding lab and established provider metadata already present in models.dev.

## Validation

- `bun validate` — passed
- `git diff --check` — passed
- Exactly four provider model TOML files added
- No existing provider/model files modified
- No `package.json` or `bun.lock` changes
- No paid Vancine API calls were made

## Scope

No sync module, dependencies, provider metadata, logo, lab models, or unrelated catalog entries are changed.
