### PR TITLE
chore(aihubmix): sync model catalog

### DIFF
--- a/providers/aihubmix/models/deepseek-v4-flash-0731.toml
+++ b/providers/aihubmix/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,11 @@
+# Toggle: enable_thinking = true|false
+base_model = "deepseek/deepseek-v4-flash-0731"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.142
+output = 0.284
+cache_read = 0.0284

--- a/providers/aihubmix/models/deepseek-v4-flash-0731.toml
+++ b/providers/aihubmix/models/deepseek-v4-flash-0731.toml
@@ -1,6 +1,8 @@
 # Toggle: enable_thinking = true|false
+# Effort: reasoning_effort = low|high|max
+# AIHubMix effort levels returned HTTP 200 (validated 2026-08-31T04:17:24Z).
 base_model = "deepseek/deepseek-v4-flash-0731"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/aihubmix/models/deepseek-v4-pro-0813.toml
+++ b/providers/aihubmix/models/deepseek-v4-pro-0813.toml
@@ -1,0 +1,11 @@
+# Toggle: enable_thinking = true|false
+base_model = "deepseek/deepseek-v4-pro-0813"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.6918
+output = 2.0754
+cache_read = 0.023058

--- a/providers/aihubmix/models/deepseek-v4-pro-0813.toml
+++ b/providers/aihubmix/models/deepseek-v4-pro-0813.toml
@@ -1,6 +1,8 @@
 # Toggle: enable_thinking = true|false
+# Effort: reasoning_effort = high|max
+# AIHubMix effort levels returned HTTP 200 (validated 2026-08-31T04:17:24Z).
 base_model = "deepseek/deepseek-v4-pro-0813"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/aihubmix/models/glm-5.3-flash.toml
+++ b/providers/aihubmix/models/glm-5.3-flash.toml
@@ -1,0 +1,17 @@
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.11268
+output = 0.39438
+cache_read = 0.02817
+
+[limit]
+output = 128_000
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/aihubmix/models/glm-5.3-flash.toml
+++ b/providers/aihubmix/models/glm-5.3-flash.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.3-flash"
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/aihubmix/models/glm-5.3.toml
+++ b/providers/aihubmix/models/glm-5.3.toml
@@ -1,0 +1,13 @@
+base_model = "zhipuai/glm-5.3"
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.1268
+output = 3.9438
+cache_read = 0.2817
+
+[limit]
+output = 128_000

--- a/providers/aihubmix/models/glm-5.3.toml
+++ b/providers/aihubmix/models/glm-5.3.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.3"
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/aihubmix/models/grok-4.6.toml
+++ b/providers/aihubmix/models/grok-4.6.toml
@@ -1,0 +1,7 @@
+base_model = "xai/grok-4.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5

--- a/providers/aihubmix/models/qwen3.7-flash.toml
+++ b/providers/aihubmix/models/qwen3.7-flash.toml
@@ -1,0 +1,22 @@
+# Toggle: enable_thinking = true|false
+# Budget: thinking_budget = integer reasoning tokens
+base_model = "alibaba/qwen3.7-flash"
+attachment = false
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0282
+output = 0.1128
+cache_read = 0.00564
+cache_write = 0.03525
+
+[limit]
+context = 991_000
+output = 64_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/aihubmix/models/qwen3.8-2.4t-a95b.toml
+++ b/providers/aihubmix/models/qwen3.8-2.4t-a95b.toml
@@ -1,0 +1,19 @@
+base_model = "alibaba/qwen3.8-2.4t-a95b"
+attachment = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "xhigh"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[limit]
+context = 262_000
+output = 262_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/aihubmix/models/qwen3.8-2.4t-a95b.toml
+++ b/providers/aihubmix/models/qwen3.8-2.4t-a95b.toml
@@ -1,3 +1,5 @@
+# AIHubMix Models API reports text,image input (queried 2026-08-31T04:06:29Z).
+# OpenAI-compatible HTTPS image input returned HTTP 200 (validated 2026-08-31T04:08:19Z).
 base_model = "alibaba/qwen3.8-2.4t-a95b"
 attachment = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "xhigh"] }]


### PR DESCRIPTION
## Summary

Add seven newly available AIHubMix models to the models.dev catalog:

- `deepseek-v4-flash-0731`
- `deepseek-v4-pro-0813`
- `grok-4.6`
- `qwen3.8-2.4t-a95b`
- `qwen3.7-flash`
- `glm-5.3`
- `glm-5.3-flash`

## Changes

- Scope is limited to `providers/aihubmix/models`.
- Inherit exact upstream model metadata through `base_model`.
- Add AIHubMix pricing and verified reasoning controls.
- Add provider-specific limits and modality overrides where AIHubMix differs from the base model.
- Preserve `reasoning_content` interleaving for compatible reasoning models.

## AIHubMix source facts

AIHubMix Models API queried at `2026-08-31T04:18:02Z`; prices are USD per 1M tokens and limits are tokens.

| Model | Input / output / cache-read prices | Context / max output | AIHubMix input modalities |
| --- | --- | --- | --- |
| `deepseek-v4-flash-0731` | `0.142 / 0.284 / 0.0284` | `1,000,000 / 384,000` | text |
| `deepseek-v4-pro-0813` | `0.6918 / 2.0754 / 0.023058` | `1,000,000 / 384,000` | text |
| `grok-4.6` | `2 / 6 / 0.5` | `500,000 / 500,000` | text, image |
| `qwen3.8-2.4t-a95b` | `2 / 6 / 0.5` | `262,000 / 262,000` | text, image |
| `qwen3.7-flash` | `0.0282 / 0.1128 / 0.00564` | `991,000 / 64,000` | text |
| `glm-5.3` | `1.1268 / 3.9438 / 0.2817` | `1,000,000 / 128,000` | text |
| `glm-5.3-flash` | `0.11268 / 0.39438 / 0.02817` | `1,000,000 / 128,000` | text, image, video |

`qwen3.7-flash` additionally reports cache-write pricing of `0.03525` USD/MTok. The Qwen3.8 image override was also verified with an HTTPS image input returning HTTP 200.

## Validation

- `bun validate`
- `bun run build` in `packages/web`
- `git diff --check`
- AIHubMix Models API validator: 7/7 configurations passed
- Live API smoke tests: 23/23 distinct reasoning and structured-output cases returned HTTP 200
- DeepSeek V4 Flash `reasoning_effort`: `low`, `high`, and `max` returned HTTP 200
- DeepSeek V4 Pro `reasoning_effort`: `high` and `max` returned HTTP 200
- Generated local `_api.json` contained all seven model IDs
- OpenCode local registry refresh listed all seven models
- OpenCode TUI manual requests: 7/7 models returned the expected unique response marker, including an in-session switch from Qwen3.8 2.4T A95B to Grok 4.6

No models were renamed, updated, or removed.
