### PR TITLE
feat(engy): add engy provider and sync module

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "deepinfra:sync": "bun ./packages/core/script/sync-models.ts deepinfra",
     "cloudflare:sync": "bun ./packages/core/script/sync-models.ts cloudflare-workers-ai",
     "chutes:sync": "bun ./packages/core/script/sync-models.ts chutes",
+    "engy:sync": "bun ./packages/core/script/sync-models.ts engy",
     "databricks:generate": "bun ./packages/core/script/generate-databricks.ts",
     "helicone:generate": "bun ./packages/core/script/generate-helicone.ts",
     "cloudflare-ai-gateway:generate": "bun ./packages/core/script/generate-cloudflare-ai-gateway.ts",

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -18,6 +18,7 @@ import { deepinfra } from "./providers/deepinfra.js";
 import { digitalocean } from "./providers/digitalocean.js";
 import { edenai } from "./providers/edenai.js";
 import { empiriolabs } from "./providers/empiriolabs.js";
+import { engy } from "./providers/engy.js";
 import { githubCopilot } from "./providers/github-copilot.js";
 import { google } from "./providers/google.js";
 import { hyper } from "./providers/hyper.js";
@@ -142,6 +143,7 @@ export const providers: {
   digitalocean: SyncProvider<any>;
   edenai: SyncProvider<any>;
   empiriolabs: SyncProvider<any>;
+  engy: SyncProvider<any>;
   "github-copilot": SyncProvider<any>;
   google: SyncProvider<any>;
   hyper: SyncProvider<any>;
@@ -177,6 +179,7 @@ export const providers: {
   digitalocean,
   edenai,
   empiriolabs,
+  engy,
   "github-copilot": githubCopilot,
   google,
   hyper,
@@ -219,7 +222,7 @@ export const groups = {
     "vercel",
   ],
   cloudflare: ["cloudflare-ai-gateway", "cloudflare-workers-ai"],
-  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "github-copilot", "google", "hyper", "meta", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
+  direct: ["ambient", "anthropic", "baseten", "chutes", "cortecs", "deepinfra", "digitalocean", "engy", "github-copilot", "google", "hyper", "meta", "openai", "ovhcloud", "pioneer", "tinfoil", "venice", "wandb", "xai"],
 } as const;
 
 type ProviderID = keyof typeof providers;

--- a/packages/core/src/sync/providers/engy.ts
+++ b/packages/core/src/sync/providers/engy.ts
@@ -1,0 +1,156 @@
+import { z } from "zod";
+
+import type { ExistingModel, SyncProvider, SyncedModel } from "../index.js";
+import { factorBaseModel, resolveModelMetadataBaseModel } from "./openrouter.js";
+
+const API_ENDPOINT = "https://api.engy.ai/v1/models";
+
+const Pricing = z
+  .object({
+    prompt: z.union([z.string(), z.number()]).optional(),
+    completion: z.union([z.string(), z.number()]).optional(),
+    input_cache_read: z.union([z.string(), z.number()]).optional(),
+  })
+  .passthrough();
+
+export const EngyModel = z
+  .object({
+    id: z.string(),
+    created: z.number().optional(),
+    pricing: Pricing.optional(),
+    context_length: z.number().optional(),
+    max_model_len: z.number().optional(),
+    input_modalities: z.array(z.string()).optional(),
+    output_modalities: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+export const EngyResponse = z.object({ data: z.array(EngyModel) }).passthrough();
+
+export type EngyModel = z.infer<typeof EngyModel>;
+
+type Modality = "text" | "audio" | "image" | "video" | "pdf";
+
+export const engy = {
+  id: "engy",
+  name: "engy",
+  modelsDir: "providers/engy/models",
+  // The public list omits the input/output split, so a created file would ship
+  // limit.output = 0. Unseen ids are reported for a human to author.
+  skipCreates: true,
+  trackMissingModels: true,
+  // The list is unauthenticated and an empty `data` passes the schema; one
+  // truncated 200 must not delete the hand-measured files.
+  deleteMissing: false,
+  sourceID(model) {
+    return model.id;
+  },
+  skippedNotice(ids) {
+    if (ids.length === 0) return [];
+    return [
+      `${ids.length} engy models have no local catalog file and were not created because the public list omits the input/output split; author them after measuring the cap: ${ids.map((id) => `\`${id}\``).join(", ")}`,
+    ];
+  },
+  missingNotice(paths) {
+    if (paths.length === 0) return [];
+    return [
+      `${paths.length} local engy models are missing from the public list and were retained; a human removes retired models: ${paths.map((path) => `\`${path}\``).join(", ")}`,
+    ];
+  },
+  async fetchModels() {
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`engy models request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return EngyResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    return {
+      id: model.id,
+      model: buildEngyModel(model, context.existing(model.id)),
+    };
+  },
+} satisfies SyncProvider<EngyModel>;
+
+export function buildEngyModel(model: EngyModel, existing: ExistingModel | undefined): SyncedModel {
+  // An absent modality list means "not reported", not text-only.
+  const input = model.input_modalities === undefined
+    ? (existing?.modalities?.input ?? ["text"])
+    : normalizeModalities(model.input_modalities);
+  const output = model.output_modalities === undefined
+    ? (existing?.modalities?.output ?? ["text"])
+    : normalizeModalities(model.output_modalities);
+
+  // A non-positive window is a bad row, not a smaller window.
+  const apiContext = model.context_length ?? model.max_model_len ?? 0;
+  const context = apiContext > 0 ? apiContext : existing?.limit?.context ?? 0;
+  const limit = {
+    context,
+    // engy's context is max_input + max_output, so the split stays hand-authored.
+    input: existing?.limit?.input,
+    output: existing?.limit?.output ?? 0,
+  };
+
+  const cost =
+    model.pricing?.prompt !== undefined && model.pricing?.completion !== undefined
+      ? {
+          ...existing?.cost,
+          input: perMillion(model.pricing.prompt),
+          output: perMillion(model.pricing.completion),
+          cache_read:
+            model.pricing.input_cache_read === undefined
+              ? existing?.cost?.cache_read
+              : perMillion(model.pricing.input_cache_read),
+        }
+      : existing?.cost;
+
+  const values = {
+    name: existing?.name ?? model.id,
+    description: existing?.description,
+    family: existing?.family,
+    release_date: existing?.release_date,
+    last_updated: existing?.last_updated,
+    attachment: input.some((value) => value !== "text"),
+    reasoning: existing?.reasoning,
+    temperature: existing?.temperature,
+    tool_call: existing?.tool_call,
+    structured_output: existing?.structured_output,
+    knowledge: existing?.knowledge,
+    open_weights: existing?.open_weights,
+    status: existing?.status,
+    interleaved: existing?.interleaved,
+    cost,
+    limit,
+    modalities: { input, output },
+    provider: existing?.provider,
+    experimental: existing?.experimental,
+  } as Parameters<typeof factorBaseModel>[1];
+
+  // An authored pointer wins: a resolver miss (absent or ambiguous slug) must
+  // not de-factor a committed file.
+  const baseModel = existing?.base_model ?? resolveModelMetadataBaseModel(model.id);
+  return baseModel === undefined
+    ? (values as SyncedModel)
+    : factorBaseModel(baseModel, values, limit, existing?.base_model_omit);
+}
+
+// Wire prices are per-token USD strings. Two of them pick up float error when
+// multiplied to per-1M (0.00000068 * 1e6), so round to micro-dollars.
+function perMillion(value: string | number): number {
+  return Math.round(Number(value) * 1_000_000 * 1e6) / 1e6;
+}
+
+function normalizeModalities(values: string[]): Modality[] {
+  const allowed = new Set<Modality>(["text", "audio", "image", "video", "pdf"]);
+  const result = values
+    .map((value) => value.toLowerCase())
+    .filter((value): value is Modality => allowed.has(value as Modality));
+  const unique = [...new Set(result)];
+  if (unique.length === 0) return ["text"];
+  // Wire order is arbitrary; sort so a rewrite for any other reason keeps catalogue order.
+  const order: Modality[] = ["text", "image", "audio", "video", "pdf"];
+  return unique.sort((a, b) => order.indexOf(a) - order.indexOf(b));
+}

--- a/packages/core/test/engy.test.ts
+++ b/packages/core/test/engy.test.ts
@@ -1,0 +1,344 @@
+import { expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { mergeDeep } from "remeda";
+
+import { syncProvider, type ExistingModel, type SyncedModel, type SyncProvider } from "../src/sync/index.js";
+import { buildEngyModel, engy, type EngyModel } from "../src/sync/providers/engy.js";
+import { modelMetadata } from "../src/sync/providers/openrouter.js";
+
+const REPO = path.join(import.meta.dirname, "..", "..", "..");
+const SHIPPED_DIR = path.join(REPO, "providers", "engy", "models");
+const LAB_DIR = path.join(REPO, "models");
+
+// Two rows of GET https://api.engy.ai/v1/models (2026-08-31), trimmed to the
+// fields the sync reads. Prices are per-token USD strings, two of which are
+// inexact once multiplied to per-1M, and modalities come image-first.
+const PUBLIC_LIST = {
+  object: "list",
+  data: [
+    {
+      id: "glm-5.2",
+      input_modalities: ["text"],
+      output_modalities: ["text"],
+      context_length: 262_144,
+      pricing: { prompt: "0.00000068", completion: "0.0000015", input_cache_read: "0.00000018" },
+    },
+    {
+      id: "glm-5.3-flash",
+      input_modalities: ["image", "text"],
+      output_modalities: ["text"],
+      context_length: 262_144,
+      pricing: { prompt: "0.000000135", completion: "0.00000045", input_cache_read: "0.000000027" },
+    },
+  ],
+};
+const [GLM52_ROW, FLASH_ROW] = engy.parseModels(PUBLIC_LIST) as [EngyModel, EngyModel];
+
+function perToken(usdPerMillion: number | undefined) {
+  return usdPerMillion === undefined ? undefined : (usdPerMillion / 1e6).toFixed(12).replace(/0+$/, "");
+}
+
+// The row engy's list has to serve for the sync to leave a file alone.
+function wireRow(id: string, model: ExistingModel, prompt = perToken(model.cost?.input)): EngyModel {
+  return {
+    id,
+    // engy lists image before text.
+    input_modalities: [...(model.modalities?.input ?? [])].reverse(),
+    output_modalities: model.modalities?.output,
+    context_length: model.limit?.context,
+    pricing: { prompt, completion: perToken(model.cost?.output), input_cache_read: perToken(model.cost?.cache_read) },
+  };
+}
+
+// Every shipped file as the runner sees it: the text, its comment header, the
+// file merged over its lab base, and its wire row. Read from the file so an
+// hourly repricing cannot make the round trips stale.
+type Shipped = { text: string; header: string; resolved: ExistingModel; wire: EngyModel };
+
+const SHIPPED: Record<string, Shipped> = Object.fromEntries(
+  readdirSync(SHIPPED_DIR).map((file) => {
+    const id = file.slice(0, -".toml".length);
+    const text = readFileSync(path.join(SHIPPED_DIR, file), "utf8");
+    const authored = Bun.TOML.parse(text) as ExistingModel;
+    const { benchmarks: _benchmarks, weights: _weights, ...base } = modelMetadata(authored.base_model!);
+    const resolved = mergeDeep(base, authored) as ExistingModel;
+    return [id, { text, header: text.slice(0, text.indexOf("base_model =")), resolved, wire: wireRow(id, resolved) }];
+  }),
+);
+const GLM52 = SHIPPED["glm-5.2"]!;
+const KIMI_K3 = SHIPPED["kimi-k3"]!;
+// The same file with no pointer: what the runner hands over for an inline file.
+const { base_model: _pointer, ...GLM52_INLINE } = GLM52.resolved;
+
+function baseModelOf(model: SyncedModel) {
+  return "base_model" in model ? model.base_model : undefined;
+}
+
+test("parses the public list", () => {
+  const models = engy.parseModels(PUBLIC_LIST);
+  expect(models.map((model) => model.id)).toEqual(["glm-5.2", "glm-5.3-flash"]);
+  expect(models.map((model) => engy.sourceID(model))).toEqual(["glm-5.2", "glm-5.3-flash"]);
+});
+
+test("is update-only: no creates, no deletes, a notice for each", () => {
+  expect(engy).toMatchObject({ skipCreates: true, trackMissingModels: true, deleteMissing: false });
+  // The runner's preserveBaseModel step stays on, so a translated model that
+  // lost its pointer gets it back from the existing file.
+  expect((engy as SyncProvider<EngyModel>).preserveBaseModels).toBeUndefined();
+  expect(engy.skippedNotice([])).toEqual([]);
+  expect(engy.missingNotice([])).toEqual([]);
+});
+
+test("converts per-token price strings to per-1M and rounds away the float error", () => {
+  // Unrounded, these two files would be rewritten on every hourly run.
+  expect(Number("0.00000068") * 1e6).toBe(0.6799999999999999);
+  expect(Number("0.00000045") * 1e6).toBe(0.44999999999999996);
+  expect(buildEngyModel(GLM52_ROW, undefined).cost).toEqual({ input: 0.68, output: 1.5, cache_read: 0.18 });
+  expect(buildEngyModel(FLASH_ROW, undefined).cost).toEqual({ input: 0.135, output: 0.45, cache_read: 0.027 });
+});
+
+test("writes modalities in catalog order, de-duplicated, unknown names dropped", () => {
+  // Factored against zhipuai/glm-5.3-flash, whose output already matches.
+  expect(buildEngyModel(FLASH_ROW, undefined).modalities).toEqual({ input: ["text", "image"] });
+  const model = buildEngyModel(
+    {
+      id: "engy-unlisted-preview",
+      input_modalities: ["PDF", "video", "image", "text", "audio", "text", "telepathy"],
+      output_modalities: [],
+    },
+    undefined,
+  );
+  // An empty list is not "no modalities"; it degrades to text.
+  expect(model.modalities).toEqual({ input: ["text", "image", "audio", "video", "pdf"], output: ["text"] });
+});
+
+test("keeps the authored modalities when the list omits them", () => {
+  // A missing list is "not reported", not text-only: a field rename upstream
+  // must not narrow every file on the hourly run.
+  const row = {
+    ...KIMI_K3.wire,
+    id: "engy-unlisted-preview",
+    input_modalities: undefined,
+    output_modalities: undefined,
+  };
+  const authored: ExistingModel = { modalities: { input: ["text", "image"], output: ["text", "image"] } };
+  expect(buildEngyModel(row, authored).modalities).toEqual(authored.modalities);
+  expect(buildEngyModel(row, undefined).modalities).toEqual({ input: ["text"], output: ["text"] });
+});
+
+test("derives attachment from the input engy serves", () => {
+  // Text-only on engy while alibaba/qwen3.6-35b-a3b takes images: written out.
+  const qwen = buildEngyModel(SHIPPED["qwen3.6-35b-a3b"]!.wire, undefined);
+  expect(qwen).toMatchObject({ attachment: false, modalities: { input: ["text"] } });
+  // Image-capable on engy and on the base: nothing to write.
+  expect(buildEngyModel(FLASH_ROW, undefined)).not.toHaveProperty("attachment");
+  // No base to inherit from: written either way.
+  const bare = buildEngyModel({ id: "engy-unlisted-preview", input_modalities: ["image", "text"] }, undefined);
+  expect(bare.attachment).toBe(true);
+});
+
+test("resolves engy's bare slugs to the lab file each shipped entry points at", () => {
+  for (const [id, { resolved }] of Object.entries(SHIPPED)) {
+    expect(baseModelOf(buildEngyModel({ id }, undefined))).toBe(resolved.base_model);
+  }
+  expect(buildEngyModel({ id: "engy-unlisted-preview" }, undefined)).not.toHaveProperty("base_model");
+});
+
+test("an authored base_model wins on a resolver miss", () => {
+  // The resolver has nothing for this slug, as it has nothing for an ambiguous
+  // one. The committed pointer must win, or the file is rewritten as an inline
+  // copy of the lab entry.
+  const model = buildEngyModel({ ...GLM52.wire, id: "engy-unlisted-preview" }, GLM52.resolved);
+  expect(baseModelOf(model)).toBe("zhipuai/glm-5.2");
+  expect(model).not.toHaveProperty("description");
+  expect(model).not.toHaveProperty("family");
+  expect(model).toMatchObject({ cost: GLM52.resolved.cost, limit: GLM52.resolved.limit });
+});
+
+test("carries every field the list does not report through an inline file", () => {
+  // Nothing factors these away on the inline path, so each must be copied over
+  // or the rewrite drops it.
+  const existing: ExistingModel = {
+    ...GLM52_INLINE,
+    knowledge: "2026-03",
+    status: "beta",
+    provider: { body: { chat_template_kwargs: { enable_thinking: true } } },
+    experimental: { modes: { fast: { cost: { input: 1.36, output: 3 } } } },
+  };
+  const model = buildEngyModel({ ...GLM52.wire, id: "engy-unlisted-preview" }, existing);
+  expect(model).not.toHaveProperty("base_model");
+  for (const key of [
+    "name", "description", "family", "release_date", "last_updated", "reasoning", "temperature", "tool_call",
+    "structured_output", "open_weights", "knowledge", "status", "interleaved", "provider", "experimental",
+  ] as const) {
+    expect(existing[key]).toBeDefined();
+    expect(model[key]).toEqual(existing[key]);
+  }
+  // reasoning_options are the runner's to carry (preserveReasoningOptions).
+  expect(model).not.toHaveProperty("reasoning_options");
+});
+
+test("passes an authored base_model_omit through", () => {
+  const model = buildEngyModel(GLM52.wire, { ...GLM52.resolved, base_model_omit: ["limit.input"] });
+  expect(model).toMatchObject({ base_model: "zhipuai/glm-5.2", base_model_omit: ["limit.input"] });
+});
+
+test("treats an absent or zero context as not reported and never guesses the split", () => {
+  // `??` alone would write context = 0 under the authored input/output split
+  // from one bad row.
+  for (const context_length of [undefined, 0]) {
+    const model = buildEngyModel({ ...GLM52.wire, id: "engy-unlisted-preview", context_length }, GLM52_INLINE);
+    expect(model.limit).toEqual(GLM52.resolved.limit);
+  }
+  // The split lives behind auth on engy.ai/api/v1/models, and the advertised
+  // context is max_input + max_output, so an unseen split stays unset.
+  const bare = buildEngyModel({ ...GLM52.wire, id: "engy-unlisted-preview" }, undefined);
+  expect(bare.limit).toEqual({ context: GLM52.wire.context_length, input: undefined, output: 0 });
+});
+
+test("falls back to the authored cost when the list quotes no prices", () => {
+  const model = buildEngyModel({ ...GLM52.wire, pricing: undefined }, GLM52.resolved);
+  expect(model.cost).toEqual(GLM52.resolved.cost);
+});
+
+test("keeps the authored cache_read when the list quotes none", () => {
+  const model = buildEngyModel(
+    { ...GLM52.wire, pricing: { prompt: "0.0000007", completion: GLM52.wire.pricing?.completion } },
+    GLM52.resolved,
+  );
+  expect(model.cost).toEqual({ ...GLM52.resolved.cost, input: 0.7 });
+});
+
+test("a repricing keeps the authored cost fields the list never quotes", () => {
+  const cost: ExistingModel["cost"] = {
+    ...GLM52.resolved.cost!,
+    cache_write: 0.85,
+    reasoning: 1.5,
+    input_audio: 2,
+    output_audio: 4,
+    tiers: [{ tier: { type: "context", size: 200_000 }, input: 1.36, output: 3, cache_read: 0.36 }],
+  };
+  const model = buildEngyModel(wireRow("glm-5.2", GLM52.resolved, "0.0000007"), { ...GLM52.resolved, cost });
+  expect(model.cost).toEqual({ ...cost, input: 0.7 });
+});
+
+// A throwaway checkout: the engy files plus the lab files they point at, so the
+// runner resolves base_model exactly as it does in the repo.
+async function inRoot(files: Record<string, string>, run: (modelsDir: string) => Promise<void>) {
+  const root = await mkdtemp(path.join(tmpdir(), "models-dev-engy-"));
+  const modelsDir = path.join(root, "providers", "engy", "models");
+  await mkdir(modelsDir, { recursive: true });
+  try {
+    for (const [file, text] of Object.entries(files)) {
+      await writeFile(path.join(modelsDir, file), text);
+      const base = (Bun.TOML.parse(text) as ExistingModel).base_model;
+      if (base === undefined) continue;
+      await mkdir(path.join(root, "models", path.dirname(base)), { recursive: true });
+      await copyFile(path.join(LAB_DIR, `${base}.toml`), path.join(root, "models", `${base}.toml`));
+    }
+    await run(modelsDir);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function engyAt(modelsDir: string, source: () => unknown): SyncProvider<EngyModel> {
+  return { ...engy, modelsDir, async fetchModels() { return source(); } };
+}
+
+// Every shipped model as engy would list it, with any prompt price overridden.
+function list(prompt: Record<string, string> = {}) {
+  return {
+    object: "list",
+    data: Object.entries(SHIPPED).map(([id, { resolved }]) => wireRow(id, resolved, prompt[id])),
+  };
+}
+
+function read(modelsDir: string, file: string) {
+  return readFile(path.join(modelsDir, file), "utf8");
+}
+
+// Doubling a price is exact in binary, so the rewritten line is predictable.
+function doubled(shipped: Shipped) {
+  const input = shipped.resolved.cost!.input;
+  return {
+    prompt: perToken(input * 2)!,
+    rewrite: (text: string) => text.replace(`input = ${input}\n`, `input = ${input * 2}\n`),
+  };
+}
+
+test("the shipped files are a fixed point, and unauthored models are only reported", async () => {
+  await inRoot({ "glm-5.2.toml": GLM52.text, "kimi-k3.toml": KIMI_K3.text }, async (modelsDir) => {
+    const provider = engyAt(modelsDir, () => list());
+    const first = await syncProvider(provider);
+    const second = await syncProvider(provider);
+    for (const result of [first, second]) {
+      expect(result).toMatchObject({ created: 0, updated: 0, deleted: 0, unchanged: 2, files: [] });
+    }
+    expect(await read(modelsDir, "glm-5.2.toml")).toBe(GLM52.text);
+    expect(await read(modelsDir, "kimi-k3.toml")).toBe(KIMI_K3.text);
+
+    // skipCreates: a created file would ship limit.output = 0, so the models
+    // with no local file are named instead.
+    expect(first.notices).toEqual([expect.stringContaining("not created")]);
+    for (const id of Object.keys(SHIPPED).filter((id) => id !== "glm-5.2" && id !== "kimi-k3")) {
+      expect(await Bun.file(path.join(modelsDir, `${id}.toml`)).exists()).toBe(false);
+      expect(first.notices[0]).toContain(`\`${id}\``);
+    }
+    expect(first.notices[0]).not.toContain("`kimi-k3`");
+  });
+});
+
+test("a repricing changes the price line and nothing else", async () => {
+  // Shipped kimi-k3, plus a glm-5.2 that overrides two intrinsic fields of its
+  // base. An exact match proves the header, reasoning_options, the authored
+  // limit split, the overrides and the modality order all survive the rewrite.
+  const glm52 = GLM52.text.replace("\n\n[interleaved]", "\ntemperature = false\ntool_call = false\n\n[interleaved]");
+  await inRoot({ "glm-5.2.toml": glm52, "kimi-k3.toml": KIMI_K3.text }, async (modelsDir) => {
+    let catalog = list();
+    const provider = engyAt(modelsDir, () => catalog);
+    expect(await syncProvider(provider)).toMatchObject({ updated: 0, unchanged: 2 });
+
+    const glm = doubled(GLM52);
+    const kimi = doubled(KIMI_K3);
+    catalog = list({ "glm-5.2": glm.prompt, "kimi-k3": kimi.prompt });
+    expect(await syncProvider(provider)).toMatchObject({ created: 0, updated: 2, deleted: 0 });
+    expect(await read(modelsDir, "glm-5.2.toml")).toBe(glm.rewrite(glm52));
+    expect(await read(modelsDir, "kimi-k3.toml")).toBe(kimi.rewrite(KIMI_K3.text));
+  });
+});
+
+test("a committed file stays factored when its slug no longer resolves", async () => {
+  // The same shape as an ambiguous slug: the resolver has nothing, but the file
+  // already points at zhipuai/glm-5.2.
+  await inRoot({ "engy-unlisted-preview.toml": GLM52.text }, async (modelsDir) => {
+    const row = (prompt?: string) => ({
+      object: "list",
+      data: [{ ...wireRow("glm-5.2", GLM52.resolved, prompt), id: "engy-unlisted-preview" }],
+    });
+    let catalog = row();
+    const provider = engyAt(modelsDir, () => catalog);
+    expect(await syncProvider(provider)).toMatchObject({ updated: 0, unchanged: 1 });
+
+    const glm = doubled(GLM52);
+    catalog = row(glm.prompt);
+    expect(await syncProvider(provider)).toMatchObject({ updated: 1 });
+    expect(await read(modelsDir, "engy-unlisted-preview.toml")).toBe(glm.rewrite(GLM52.text));
+  });
+});
+
+test("an empty list deletes nothing and names the retained files", async () => {
+  // {"data":[]} is a valid response from the unauthenticated endpoint, and
+  // skipCreates could not bring a deleted file back.
+  await inRoot({ "glm-5.2.toml": GLM52.text, "kimi-k3.toml": KIMI_K3.text }, async (modelsDir) => {
+    const result = await syncProvider(engyAt(modelsDir, () => ({ object: "list", data: [] })));
+    expect(result).toMatchObject({ created: 0, updated: 0, deleted: 0, unchanged: 2, files: [] });
+    expect(await read(modelsDir, "glm-5.2.toml")).toBe(GLM52.text);
+    expect(result.notices).toEqual([expect.stringContaining("retained")]);
+    expect(result.notices[0]).toContain("`glm-5.2.toml`");
+    expect(result.notices[0]).toContain("`kimi-k3.toml`");
+  });
+});

--- a/providers/engy/logo.svg
+++ b/providers/engy/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" fill="currentColor"><rect x="205" y="246" width="472" height="132" rx="66"/><rect x="347" y="444" width="472" height="134" rx="67"/><rect x="205" y="647" width="472" height="132" rx="66"/></svg>

--- a/providers/engy/models/deepseek-v4-flash-0731.toml
+++ b/providers/engy/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,27 @@
+# Toggle: chat_template_kwargs.thinking = true|false
+# Effort: reasoning_effort = high|max
+# Prices: https://api.engy.ai/v1/models; limits: authed https://engy.ai/api/v1/models (2026-08-28/30).
+# Reasoning is off unless asked. Live probe 2026-08-30, n=113-126/level at 64k: low, medium and high
+# one rung (p>=0.89), xhigh and max another (p=0.82), high vs max p=0.0064; thinking=false and none
+# suppress reasoning 18/18.
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.045
+output = 0.09
+cache_read = 0.009
+
+[limit]
+context = 1_048_576
+input = 920_576
+output = 128_000

--- a/providers/engy/models/glm-5.2.toml
+++ b/providers/engy/models/glm-5.2.toml
@@ -1,0 +1,27 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
+# Effort: reasoning_effort = high|max
+# Prices: https://api.engy.ai/v1/models; limits: authed https://engy.ai/api/v1/models (2026-08-28/30).
+# Live probe 2026-08-30, n=20/level at 8k: low, medium and high one rung (p>=0.38), xhigh and max
+# another (p=0.19), the rungs apart at p<=2e-07 (MWU), xhigh and max hit the cap 6/20 and 5/20;
+# toggle, none and minimal suppress reasoning 20/20.
+base_model = "zhipuai/glm-5.2"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 0.68
+output = 1.5
+cache_read = 0.18
+
+[limit]
+context = 262_144
+input = 229_376
+output = 32_768

--- a/providers/engy/models/glm-5.3-flash.toml
+++ b/providers/engy/models/glm-5.3-flash.toml
@@ -1,0 +1,27 @@
+# Effort: reasoning_effort = low|high|max
+# Prices: https://api.engy.ai/v1/models; limits: authed https://engy.ai/api/v1/models (2026-08-28/30).
+# Launch discount: page lists 0.15/0.50, billed 0.135/0.45. Served text+image, so input is narrowed.
+# "(Ox Alpha)" is the codename it was served under before the name went public; status unset.
+# Live probe 2026-08-30 at 8k, n=40 for low/medium/high, 20 for xhigh/max: low = medium (p=0.41)
+# < high (p=1.8e-05) < xhigh = max; none/minimal/enable_thinking=false measure as low; 0/320 empty.
+base_model = "zhipuai/glm-5.3-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.135
+output = 0.45
+cache_read = 0.027
+
+[limit]
+context = 262_144
+input = 229_376
+output = 32_768
+
+[modalities]
+input = ["text", "image"]

--- a/providers/engy/models/glm-5.3.toml
+++ b/providers/engy/models/glm-5.3.toml
@@ -1,0 +1,23 @@
+# Effort: reasoning_effort = low|high|max
+# Prices: https://api.engy.ai/v1/models; limits: authed https://engy.ai/api/v1/models (2026-08-28/31).
+# Live probe 2026-08-30 at 8k, n=40 for low/medium/high, 20 for xhigh/max: low = medium (p=0.49)
+# < high (p=3.4e-06) < xhigh = max (MWU). Nothing switches it off: none, minimal and
+# enable_thinking=false measure as low; 0 of 320 empty.
+base_model = "zhipuai/glm-5.3"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.98
+output = 3.08
+cache_read = 0.18
+
+[limit]
+context = 327_680
+input = 294_912
+output = 32_768

--- a/providers/engy/models/kimi-k3.toml
+++ b/providers/engy/models/kimi-k3.toml
@@ -1,0 +1,26 @@
+# Toggle: chat_template_kwargs.thinking = true|false
+# Prices: https://api.engy.ai/v1/models (2026-09-03, raised 30% from 08-28); limits: authed
+# https://engy.ai/api/v1/models (2026-08-30). engy serves this text+image only, so input is narrowed.
+# Live probe 2026-08-30, n=40/level at 16k: reasoning_effort inert, every pair p>=0.61 (MWU);
+# thinking=false suppresses reasoning 40/40. temperature honoured (0 vs 1.5, 12 prompts x 3
+# replicates, 12/12, paired p=0.0005, 2026-08-31); the lab's false is Moonshot's own API.
+base_model = "moonshotai/kimi-k3"
+temperature = true
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 1.95
+output = 9.75
+cache_read = 0.195
+
+[limit]
+input = 983_040
+output = 65_536
+
+[modalities]
+input = ["text", "image"]

--- a/providers/engy/models/qwen3.6-35b-a3b.toml
+++ b/providers/engy/models/qwen3.6-35b-a3b.toml
@@ -1,0 +1,26 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
+# Prices: https://api.engy.ai/v1/models; limits: authed https://engy.ai/api/v1/models (2026-08-28/30).
+# engy serves this deployment text-only, so modalities and attachment are narrowed.
+# Live probe 2026-08-31, n=36/level at 8,192 (the cap): reasoning_effort inert, every pair p>=0.39
+# (MWU); toggle and none suppress reasoning 36/36. No effort control is offered.
+base_model = "alibaba/qwen3.6-35b-a3b"
+attachment = false
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.045
+output = 0.3
+cache_read = 0.015
+
+[limit]
+context = 208_192
+input = 200_000
+output = 8_192
+
+[modalities]
+input = ["text"]

--- a/providers/engy/models/qwen3.8-27b.toml
+++ b/providers/engy/models/qwen3.8-27b.toml
@@ -1,0 +1,30 @@
+# Toggle: chat_template_kwargs.enable_thinking = true|false
+# Effort: reasoning_effort = low|medium|xhigh
+# Prices: https://api.engy.ai/v1/models; limits: authed https://engy.ai/api/v1/models (2026-08-28/30).
+# engy serves this deployment text+image only, so modalities.input is narrowed.
+# Live probe 2026-08-30, n=60/level at 32k: xhigh separates from low and medium (paired p<0.01), high
+# and max behave as xhigh (p>=0.87), medium vs low unsettled (p=0.44); toggle and none suppress 20/20.
+base_model = "alibaba/qwen3.8-27b"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
+
+[cost]
+input = 0.045
+output = 0.32
+cache_read = 0.015
+
+[limit]
+context = 1_000_000
+input = 936_000
+output = 64_000
+
+[modalities]
+input = ["text", "image"]

--- a/providers/engy/provider.toml
+++ b/providers/engy/provider.toml
@@ -1,0 +1,10 @@
+name = "engy"
+env = ["ENGY_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# Raw HTTP reasoning controls (live 2026-08-30), authored per model. POST /v1/chat/completions
+# forwards chat_template_kwargs to the chat template (enable_thinking on glm-5.2 and Qwen, thinking
+# on DeepSeek and Kimi; the GLM-5.3 templates do not switch it off) and takes reasoning_effort
+# none|minimal|low|medium|high|xhigh|max; no budget field. Docs list no models; doc is pricing.
+# Limits: authed GET https://engy.ai/api/v1/models; context = max_input + max_output.
+api = "https://api.engy.ai/v1"
+doc = "https://engy.ai/pricing"

--- a/sync.md
+++ b/sync.md
@@ -335,6 +335,20 @@ Venice is implemented in `packages/core/src/sync/providers/venice.ts`.
 - Every Venice model uses `base_model`; flattened IDs are matched to provider-agnostic metadata before provider-specific overrides are written.
 - Every Venice model declares `reasoning_options`; models without API-provided effort levels use an empty array.
 
+## engy Notes
+
+engy is implemented in `packages/core/src/sync/providers/engy.ts`.
+
+- Run it with `bun models:sync engy` or `bun engy:sync`.
+- Source endpoint: `https://api.engy.ai/v1/models`; no auth required.
+- The endpoint owns `cost.input`, `cost.output` and `cost.cache_read` while quoted, `limit.context` when positive, and `modalities` when sent.
+- `limit.input`/`limit.output`, `reasoning_options`, `interleaved`, the other cost keys, `provider`, `experimental`, `status` and `base_model` are preserved; no public endpoint reports them, and `context_length` is `max_input + max_output`.
+- `skipCreates` and `trackMissingModels` are set: a created file would ship `limit.output = 0`. Unseen IDs open deduped `[missing-model]` issues.
+- `deleteMissing` is `false`: the list is unauthenticated and `{"data":[]}` passes the schema, so a truncated 200 must not delete hand-measured files; they are retained and reported.
+- An authored `base_model` wins over the resolver, so a miss never de-factors a committed file.
+- Per-token USD string prices become per-1M, rounded to six decimals; two would carry float error otherwise.
+- Modalities are sorted into catalogue order; wire order is arbitrary.
+
 ## Standalone Generators
 
 Some provider scripts in `packages/core/script/generate-*.ts` are not wired into `bun models:sync`. When updating those scripts, preserve existing `base_model` and `base_model_omit` fields for generated TOMLs that already use model metadata inheritance. New inheritance-aware output should use `base_model`; do not reintroduce legacy `[extends]` syntax.


### PR DESCRIPTION
## Summary

engy (api.engy.ai) is a multi-model relay: eight open models behind one OpenAI chat-completions endpoint (`@ai-sdk/openai-compatible`), each model file override-only against its lab entry. Provider directory and sync module in one PR, as #3352 and #4506.

## Models

| Model | $/MTok in / out / cached | Context / Input / Output | reasoning_options |
|---|---|---|---|
| qwen3.6-35b-a3b | 0.045 / 0.30 / 0.015 | 208,192 / 200,000 / 8,192 | toggle |
| qwen3.8-27b | 0.045 / 0.32 / 0.015 | 1,001,536 / 936,000 / 65,536 | toggle + low\|medium\|xhigh |
| glm-5.2 | 0.68 / 1.50 / 0.18 | 262,144 / 229,376 / 32,768 | toggle + high\|max |
| glm-5.3 | 0.98 / 3.08 / 0.18 | 327,680 / 294,912 / 32,768 | low\|high\|max |
| glm-5.3-flash | 0.135 / 0.45 / 0.027 | 262,144 / 229,376 / 32,768 | low\|high\|max |
| kimi-k3 | 1.95 / 9.75 / 0.195 | 1,048,576 (inherited) / 983,040 / 65,536 | toggle |
| deepseek-v4-flash-0731 | 0.045 / 0.09 / 0.009 | 1,048,576 / 920,576 / 128,000 | toggle + low\|high\|max |
| deepseek-v4.1-flash | 0.04 / 0.08 / 0.008 | 327,680 / 262,144 / 65,536 | toggle + low\|high\|max |

Image probe: qwen3.8-27b, glm-5.3-flash, kimi-k3, deepseek-v4.1-flash text+image; qwen3.6-35b-a3b text-only, `attachment = false`.
Limits authored: engy's context = max_input + max_output.
`status` unset: "(Ox Alpha)" is glm-5.3-flash's pre-release codename.
kimi-k3 sets `temperature = true`: engy's serve honours it (0 vs 1.5, 12 prompts x 3 replicates, 12/12, paired p=0.0005), where Moonshot's own API, which the lab entry describes, does not.
deepseek-v4.1-flash (added 2026-09-12): not on the 09-03 read, present on the 09-12 read, marked "new" on engy's pricing page; DeepSeek released it on 09-10 (lab entry models/deepseek/deepseek-v4.1-flash.toml). Its context is 327,680 against the lab's 1,000,000, so `limit` is authored; modalities match the lab and are inherited.

## Reasoning

Host: a relay, so the baseline per model is its lab entry plus same-surface peers; effort values follow that baseline, narrowed only where a level measures as another. Toggle `chat_template_kwargs.enable_thinking` (glm-5.2, Qwen) or `.thinking` (DeepSeek, Kimi); effort `reasoning_effort`; no budget field, no `budget_tokens`. Paired prompts, median `reasoning_content` length, Mann-Whitney U, positive control per run; live 2026-08-30/31 on 0.2.10, deepseek-v4.1-flash on 09-12 on 0.2.20.

- qwen3.6-35b-a3b: effort inert, n=36, 8k, all pairs p>=0.39; toggle, `none` suppress 36/36.
- qwen3.8-27b: Alibaba's Qwen3.8 set (qwen3.8-flash) and the peers'. n=60, 32k; xhigh over low, medium paired p<0.01; medium vs low p=0.44, kept as the lab set and engy's mapping, which gives Qwen3.8 its own `medium`; high, max = xhigh p>=0.87; toggle, `none` suppress 20/20.
- glm-5.2: lab set plus toggle. n=20, 8k; low/medium/high one rung p>=0.38, xhigh/max another p=0.19, apart p<=2e-07; toggle, `none`, `minimal` suppress 20/20.
- glm-5.3, glm-5.3-flash: lab set, no toggle. n=40 (xhigh, max 20), 8k; low=medium p=0.49/0.41 < high p=3.4e-06/1.8e-05 < xhigh=max, three rungs, docs say collapse; `none`, `minimal`, the toggle measure as low, 0/320 empty.
- kimi-k3: lab `low|high|max` dropped, inert: n=40, 16k, all pairs p>=0.61; `thinking=false` suppresses 40/40.
- deepseek-v4-flash-0731: the same-surface peer set `low|high|max`, which four peers author with a toggle and twenty more with `none` added. n=113-126, 64k; low=medium=high p>=0.89, xhigh=max p=0.82, high vs max p=0.0064; `thinking=false`, `none` suppress 18/18; off by default.
- deepseek-v4.1-flash: the same set as 0731. n=40/level, 32k, 480/480 completed, 10 hit the cap; low=medium=high (adjacent paired p>=0.04, MWU p>=0.22), xhigh=max (p=0.57), high vs max paired p=1e-04 and low vs max 2e-06 (MWU 0.11 and 0.06: the unpaired test is diluted by prompt-to-prompt spread, medians 431 vs 684 chars). `thinking=false`, `enable_thinking=false` and `none` suppress 40/40 each. `enable_thinking=true` also switches it on here (= `thinking=true`, p=0.90) while it stays inert on 0731; the host's gateway rewrites the generic name onto the switch a template actually reads and v4.1-flash is in that table, so both files name `thinking`, which is what the checkpoint reads and what stays correct off engy. Off by default. Peers author `low|high|max` (fireworks-ai), `none|low|high|xhigh|max` (deepinfra) and `low|high|xhigh` (hyper) from their own serves; engy's published mapping gives the same three as fireworks-ai.

engy publishes the per-template mapping, and every effort set here follows it (engy.ai/docs, read 2026-09-19). Sent to DeepSeek V4, `low` and `medium` both arrive as `low`, `high` as `high`, `xhigh` and `max` as `max`: three levels, which is what both DeepSeek entries carry. Qwen3.8 gets `low`, `medium` and `xhigh`, with `high` and above collapsing onto `xhigh`, which is qwen3.8-27b's set. GLM gets `high` and `max` only, which is glm-5.2's. The host adds that a level is rendered into the prompt as a sentence rather than enforced as a budget (2026-09-15, in the thread), so adjacent levels need not separate on output length; that is why these sets follow the published mapping rather than what a length test resolves.

One quirk for whoever re-measures: `x-engy-miner` is absent on every response slower than about 15 s (114 of 480), which the host has reproduced and not yet fixed; `x_engy.miner` in the body carries the same value.

## Sources

- api.engy.ai/v1/models, 2026-08-28 to 09-03 and 09-12: ids, prices, context, modalities. Two changes across the August reads, both carried by the files: glm-5.3's context 262,144 to 327,680 on 08-31, and kimi-k3's prices up 30% on 09-03 (1.50/7.50/0.15 to 1.95/9.75/0.195), which the sync module caught. The 09-12 read adds deepseek-v4.1-flash and changes nothing else; the module reported it as an unseen id and the file was authored by hand, as designed. The 09-13 read (build 0.2.22) raises qwen3.8-27b's context 1,000,000 to 1,001,536, which the module caught; the new output cap came from the authenticated list.
- engy.ai/api/v1/models (authed), 08-30/31, 09-12 and 09-13: input, output limits; glm-5.3's input 229,376 to 294,912 on 08-31, qwen3.8-27b's output 64,000 to 65,536 on 09-13.
- engy.ai/pricing, 08-30 and 09-12: `doc`, /docs lists no models; glm-5.3-flash's 0.15/0.50 is a launch discount, billed 0.135/0.45. deepseek-v4.1-flash is listed at 0.04/0.08/0.008 with no discount.
- engy.ai/docs, 08-30 and 09-12: `reasoning_effort` enum and mapping, `chat_template_kwargs`.
- api.engy.ai/v1/models re-read 2026-09-19 after the rebase and again 2026-09-20 on build 0.3.0: every price, context and modality unchanged against the files (`bun models:sync engy --dry-run`: 8 unchanged). The toggle was re-checked on 0.3.0, since the probes behind these headers ran on 0.2.10 and 0.2.20: `chat_template_kwargs.thinking = false` suppresses reasoning 4/4 across both DeepSeek models, reasoning is present on the same prompts with it on, and nothing leaks into `content`.
- engy.ai/docs, re-read 2026-09-19: the per-template effort mapping above.
- The host's answers in this thread, 2026-09-15: the effort hint being a prompt line, the toggle-name rewrite, and the dropped headers above.

## Sync

The module writes cost, `limit.context`, `modalities`; headers, `reasoning_options` and the rest are preserved. `skipCreates`: a created file would ship `limit.output = 0`, so a new id opens a `[missing-model]` issue. `deleteMissing: false`: `{"data":[]}` passes the schema; retired ids are reported, not deleted. Authored `base_model` beats the resolver. Prices round to six decimals; reruns are no-ops.

## Test plan

- [x] `bun validate`
- [x] `packages/core/test/engy.test.ts`: 18 pass (the suite reads the shipped files, so the eighth is covered without a fixture change)
- [x] `bun models:sync engy` x2, 2026-09-19, and `--dry-run` again 2026-09-20 on build 0.3.0: 8 unchanged
- [x] Rebased on `dev` f85553799, one conflict in `sync/index.ts`'s registration lists, resolved by keeping both sides alphabetical
- [x] opencode: listed only with `ENGY_API_KEY`; cost = engy's bill (deepseek-v4.1-flash: 67 micro-USD charged against 66.5 from the published prices, 09-12)

engy's maintainer has endorsed the entry on this PR (https://github.com/anomalyco/models.dev/pull/5910#issuecomment-5622230104), confirming the figures that cannot be checked from outside: the authenticated input/output split, the per-deployment modality narrowing, kimi-k3 honouring `temperature`, the glm-5.3-flash launch-discount billing, and the two recent changes the sync caught. He also confirms https://engy.ai/pricing is the `doc` link they want, since their docs list no models. deepseek-v4.1-flash went live after that comment; its figures come from the same endpoints. He answered four further questions on 2026-09-15, and the effort sets on both DeepSeek entries changed as a result; the Reasoning section above carries the outcome.




