### PR TITLE
Add abliterated-model-large-v2

### DIFF
--- a/providers/abliteration-ai/models/abliterated-model-large-v2.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large-v2.toml
@@ -1,0 +1,41 @@
+# Sources (accessed 2026-08-31):
+# - Model card, limits (1M context, 999,990 max output), capabilities, GLM-5.3 base:
+#   https://docs.abliteration.ai/models
+# - Reasoning modes and per-endpoint request fields:
+#   https://docs.abliteration.ai/capabilities/thinking
+# - Pricing ($5 per 1M tokens input/output, $0.50 per 1M cached input):
+#   https://abliteration.ai/pricing
+# - Launch announcement (GLM-5.3 base, FP8 hosting, benchmarks):
+#   https://abliteration.ai/blog/introducing-abliterated-model-large-v2
+name = "Abliterated Model Large V2"
+description = "GLM-5.3 model abliterated and finetuned for cyber, ML red teaming, and agent testing"
+release_date = "2026-08-29"
+last_updated = "2026-08-31"
+attachment = false
+reasoning = true
+tool_call = true
+structured_output = true
+temperature = true
+open_weights = false
+
+# Three distinct reasoning depths: low, high, max (default: max).
+# Reasoning cannot be disabled on this model: "none" and {"thinking": false}
+# map to low and hide the trace, so there is no toggle option. Other ladder
+# values are accepted aliases: minimal -> low, medium -> high, xhigh -> max.
+[[reasoning_options]]
+type = "effort" # API: {"reasoning_effort": "<value>"} on /v1/chat/completions
+values = ["low", "high", "max"]
+
+[cost]
+input = 5.00
+output = 5.00
+cache_read = 0.50
+
+[limit]
+context = 1_000_000
+input = 1_000_000
+output = 999_990
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/abliteration-ai/models/abliterated-model-large-v2.toml
+++ b/providers/abliteration-ai/models/abliterated-model-large-v2.toml
@@ -4,6 +4,7 @@
 # - Reasoning modes and per-endpoint request fields:
 #   https://docs.abliteration.ai/capabilities/thinking
 # - Pricing ($5 per 1M tokens input/output, $0.50 per 1M cached input):
+#   https://docs.abliteration.ai/pricing
 #   https://abliteration.ai/pricing
 # - Launch announcement (GLM-5.3 base, FP8 hosting, benchmarks):
 #   https://abliteration.ai/blog/introducing-abliterated-model-large-v2


### PR DESCRIPTION
Adds `abliterated-model-large-v2`, the GLM-5.3-based successor to `abliterated-model-large`. Single new file: `providers/abliteration-ai/models/abliterated-model-large-v2.toml`. No existing entries touched.

## Sources and what each one supports

- **Models page** — https://docs.abliteration.ai/models
  - Model exists and reasons by default; GLM-5.3 base; text-only (image/video rejected with 400); 1M context, 999,990 max output; structured outputs supported
- **Thinking & reasoning effort** — https://docs.abliteration.ai/capabilities/thinking
  - Three distinct reasoning modes — `low`, `high`, `max` (default: `max`) — hence `values = ["low", "high", "max"]`
  - Reasoning **cannot be disabled** on this model: `"none"` and `thinking: false` map to `low` and hide the trace, so there is deliberately no `toggle` option
  - Other ladder values are accepted aliases (`minimal`→`low`, `medium`→`high`, `xhigh`→`max`), documented in the file's comment block
  - Request field: top-level `reasoning_effort` on `/v1/chat/completions`
- **Pricing** — https://docs.abliteration.ai/pricing and https://abliteration.ai/pricing
  - `$5.00 / 1M` input, `$5.00 / 1M` output, `$0.50 / 1M` cached input
- **Launch blog** — https://abliteration.ai/blog/introducing-abliterated-model-large-v2
  - GLM 5.3 base, abliterated post-training, FP8 hosting, 2026-08-29 release

## Validation

- `bun validate` passes
