### PR TITLE
feat: add RouterPlex provider

### DIFF
--- a/providers/routerplex/logo.svg
+++ b/providers/routerplex/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M12 2L3 7v10l9 5 9-5V7l-9-5z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+  <path d="M12 12L3 7M12 12l9-5M12 12v10" stroke="currentColor" stroke-width="1" opacity="0.5" stroke-linecap="round"/>
+  <circle cx="12" cy="12" r="1.9" fill="currentColor"/>
+  <circle cx="3" cy="7" r="0.9" fill="currentColor"/>
+  <circle cx="21" cy="7" r="0.9" fill="currentColor"/>
+  <circle cx="12" cy="22" r="0.9" fill="currentColor"/>
+</svg>

--- a/providers/routerplex/models/LongCat-2.0.toml
+++ b/providers/routerplex/models/LongCat-2.0.toml
@@ -1,10 +1,16 @@
-# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-09-01).
 # Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
 # this host bills a discounted cache-hit rate; otherwise cached tokens are billed
 # at the input rate.
+# Toggle: `thinking.type` = enabled|disabled. LongCat exposes binary thinking
+# control, not graded effort — matching providers/longcat/models/LongCat-2.0.toml.
 base_model = "meituan/longcat-2.0"
 
-reasoning_options = [{ type = "effort", values = [ "none", "high" ] }]
+[[reasoning_options]]
+type = "toggle"
+
+[interleaved]
+field = "reasoning_content"
 
 [cost]
 input = 0.3

--- a/providers/routerplex/models/LongCat-2.0.toml
+++ b/providers/routerplex/models/LongCat-2.0.toml
@@ -1,0 +1,11 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "meituan/longcat-2.0"
+
+reasoning_options = [{ type = "effort", values = [ "none", "high" ] }]
+
+[cost]
+input = 0.3
+output = 1.2

--- a/providers/routerplex/models/MiniMax-M2.7-highspeed.toml
+++ b/providers/routerplex/models/MiniMax-M2.7-highspeed.toml
@@ -1,0 +1,14 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "minimax/MiniMax-M2.7-highspeed"
+
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 2.4
+
+[limit]
+context = 196_000

--- a/providers/routerplex/models/MiniMax-M2.7.toml
+++ b/providers/routerplex/models/MiniMax-M2.7.toml
@@ -1,0 +1,14 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "minimax/MiniMax-M2.7"
+
+reasoning_options = []
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 196_000

--- a/providers/routerplex/models/MiniMax-M3-highspeed.toml
+++ b/providers/routerplex/models/MiniMax-M3-highspeed.toml
@@ -1,0 +1,19 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `thinking.type` / `reasoning_effort`.
+base_model = "minimax/MiniMax-M3"
+name = "MiniMax-M3-highspeed"
+description = "Low-latency MiniMax M3 variant for interactive coding and agent loops"
+
+[[reasoning_options]]
+type = "toggle"
+
+
+[cost]
+input = 0.45
+output = 1.8
+
+[limit]
+context = 1_000_000

--- a/providers/routerplex/models/MiniMax-M3.toml
+++ b/providers/routerplex/models/MiniMax-M3.toml
@@ -1,0 +1,17 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `thinking.type` / `reasoning_effort`.
+base_model = "minimax/MiniMax-M3"
+
+[[reasoning_options]]
+type = "toggle"
+
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+context = 1_000_000

--- a/providers/routerplex/models/claude-fable-5.toml
+++ b/providers/routerplex/models/claude-fable-5.toml
@@ -1,0 +1,11 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "anthropic/claude-fable-5"
+
+reasoning_options = [{ type = "effort", values = [ "low", "medium", "high", "xhigh", "max" ] }]
+
+[cost]
+input = 10
+output = 50

--- a/providers/routerplex/models/claude-haiku-4-5.toml
+++ b/providers/routerplex/models/claude-haiku-4-5.toml
@@ -1,0 +1,17 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "anthropic/claude-haiku-4-5"
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+
+[cost]
+input = 1
+output = 5
+
+[limit]
+context = 256_000

--- a/providers/routerplex/models/claude-opus-4-6.toml
+++ b/providers/routerplex/models/claude-opus-4-6.toml
@@ -1,0 +1,18 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "anthropic/claude-opus-4-6"
+
+[[reasoning_options]]
+type = "effort"
+values = [ "low", "medium", "high", "max" ]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+
+[cost]
+input = 5
+output = 25

--- a/providers/routerplex/models/claude-opus-4-7.toml
+++ b/providers/routerplex/models/claude-opus-4-7.toml
@@ -1,0 +1,11 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "anthropic/claude-opus-4-7"
+
+reasoning_options = [{ type = "effort", values = [ "low", "medium", "high", "xhigh", "max" ] }]
+
+[cost]
+input = 5
+output = 25

--- a/providers/routerplex/models/claude-opus-4-8.toml
+++ b/providers/routerplex/models/claude-opus-4-8.toml
@@ -1,0 +1,11 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "anthropic/claude-opus-4-8"
+
+reasoning_options = [{ type = "effort", values = [ "low", "medium", "high", "xhigh", "max" ] }]
+
+[cost]
+input = 5
+output = 25

--- a/providers/routerplex/models/claude-opus-5.toml
+++ b/providers/routerplex/models/claude-opus-5.toml
@@ -1,0 +1,11 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "anthropic/claude-opus-5"
+
+reasoning_options = [{ type = "effort", values = [ "low", "medium", "high", "xhigh", "max" ] }]
+
+[cost]
+input = 5
+output = 25

--- a/providers/routerplex/models/claude-sonnet-4-6.toml
+++ b/providers/routerplex/models/claude-sonnet-4-6.toml
@@ -1,0 +1,18 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "anthropic/claude-sonnet-4-6"
+
+[[reasoning_options]]
+type = "effort"
+values = [ "low", "medium", "high", "max" ]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+
+[cost]
+input = 3
+output = 15

--- a/providers/routerplex/models/claude-sonnet-5.toml
+++ b/providers/routerplex/models/claude-sonnet-5.toml
@@ -1,0 +1,18 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: POST /v1/messages `thinking.type` = enabled|disabled. Effort: `output_config.effort` / `reasoning_effort` = low|medium|high|xhigh|max.
+base_model = "anthropic/claude-sonnet-5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = [ "low", "medium", "high", "xhigh", "max" ]
+
+
+[cost]
+input = 2
+output = 10

--- a/providers/routerplex/models/deepseek-v4-flash.toml
+++ b/providers/routerplex/models/deepseek-v4-flash.toml
@@ -1,0 +1,21 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `thinking.type` = enabled|disabled. Effort: `reasoning_effort` = low|high|max.
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = [ "low", "high", "max" ]
+
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.09
+output = 0.18

--- a/providers/routerplex/models/deepseek-v4-pro.toml
+++ b/providers/routerplex/models/deepseek-v4-pro.toml
@@ -1,0 +1,21 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `thinking.type` = enabled|disabled. Effort: `reasoning_effort` = high|max.
+base_model = "deepseek/deepseek-v4-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = [ "high", "max" ]
+
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.435
+output = 0.87

--- a/providers/routerplex/models/doubao-seed-2.0-code.toml
+++ b/providers/routerplex/models/doubao-seed-2.0-code.toml
@@ -1,0 +1,15 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "bytedance-seed/seed-2.0-code"
+name = "Doubao Seed 2.0 Code"
+
+reasoning_options = [{ type = "effort", values = [ "none", "low", "medium", "high" ] }]
+
+[cost]
+input = 0.67
+output = 3.36
+
+[limit]
+context = 200_000

--- a/providers/routerplex/models/doubao-seed-2.0-pro.toml
+++ b/providers/routerplex/models/doubao-seed-2.0-pro.toml
@@ -1,0 +1,15 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "bytedance-seed/seed-2.0-pro"
+name = "Doubao Seed 2.0 Pro"
+
+reasoning_options = [{ type = "effort", values = [ "none", "low", "medium", "high" ] }]
+
+[cost]
+input = 0.67
+output = 3.36
+
+[limit]
+context = 128_000

--- a/providers/routerplex/models/gemini-3.1-pro.toml
+++ b/providers/routerplex/models/gemini-3.1-pro.toml
@@ -1,0 +1,15 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "google/gemini-3.1-pro-preview"
+name = "Gemini 3.1 Pro"
+
+reasoning_options = [{ type = "effort", values = [ "low", "medium", "high" ] }]
+
+[cost]
+input = 2
+output = 12
+
+[limit]
+context = 1_000_000

--- a/providers/routerplex/models/gemini-3.5-flash.toml
+++ b/providers/routerplex/models/gemini-3.5-flash.toml
@@ -1,0 +1,14 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "google/gemini-3.5-flash"
+
+reasoning_options = [{ type = "effort", values = [ "minimal", "low", "medium", "high" ] }]
+
+[cost]
+input = 1.5
+output = 9
+
+[limit]
+context = 1_000_000

--- a/providers/routerplex/models/glm-5.1.toml
+++ b/providers/routerplex/models/glm-5.1.toml
@@ -1,0 +1,20 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `thinking.type` / `reasoning_effort` on|off.
+base_model = "zhipuai/glm-5.1"
+
+[[reasoning_options]]
+type = "toggle"
+
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+
+[limit]
+context = 256_000

--- a/providers/routerplex/models/glm-5.2.toml
+++ b/providers/routerplex/models/glm-5.2.toml
@@ -1,0 +1,14 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "zhipuai/glm-5.2"
+
+reasoning_options = [{ type = "effort", values = [ "high", "max" ] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4

--- a/providers/routerplex/models/gpt-5.4.toml
+++ b/providers/routerplex/models/gpt-5.4.toml
@@ -1,0 +1,14 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "openai/gpt-5.4"
+
+reasoning_options = [{ type = "effort", values = [ "none", "low", "medium", "high", "xhigh" ] }]
+
+[cost]
+input = 2.5
+output = 15
+
+[limit]
+context = 1_000_000

--- a/providers/routerplex/models/gpt-5.5.toml
+++ b/providers/routerplex/models/gpt-5.5.toml
@@ -1,0 +1,15 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "openai/gpt-5.5"
+base_model_omit = ["limit.input"]
+
+reasoning_options = [{ type = "effort", values = [ "none", "low", "medium", "high", "xhigh" ] }]
+
+[cost]
+input = 5
+output = 30
+
+[limit]
+context = 256_000

--- a/providers/routerplex/models/gpt-5.6-luna.toml
+++ b/providers/routerplex/models/gpt-5.6-luna.toml
@@ -1,0 +1,15 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "openai/gpt-5.6-luna"
+base_model_omit = ["limit.input"]
+
+reasoning_options = [{ type = "effort", values = [ "none", "low", "medium", "high", "xhigh", "max" ] }]
+
+[cost]
+input = 0.2
+output = 1.2
+
+[limit]
+context = 258_000

--- a/providers/routerplex/models/gpt-5.6-sol.toml
+++ b/providers/routerplex/models/gpt-5.6-sol.toml
@@ -1,0 +1,15 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "openai/gpt-5.6-sol"
+base_model_omit = ["limit.input"]
+
+reasoning_options = [{ type = "effort", values = [ "none", "low", "medium", "high", "xhigh", "max" ] }]
+
+[cost]
+input = 5
+output = 30
+
+[limit]
+context = 258_000

--- a/providers/routerplex/models/gpt-5.6-terra.toml
+++ b/providers/routerplex/models/gpt-5.6-terra.toml
@@ -1,0 +1,15 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "openai/gpt-5.6-terra"
+base_model_omit = ["limit.input"]
+
+reasoning_options = [{ type = "effort", values = [ "none", "low", "medium", "high", "xhigh", "max" ] }]
+
+[cost]
+input = 2
+output = 12
+
+[limit]
+context = 258_000

--- a/providers/routerplex/models/grok-4.5.toml
+++ b/providers/routerplex/models/grok-4.5.toml
@@ -1,0 +1,16 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "xai/grok-4.5"
+
+reasoning_options = [{ type = "effort", values = [ "low", "medium", "high" ] }]
+
+[cost]
+input = 2
+output = 6
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12

--- a/providers/routerplex/models/grok-4.6.toml
+++ b/providers/routerplex/models/grok-4.6.toml
@@ -1,0 +1,18 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "xai/grok-4.6"
+
+reasoning_options = [{ type = "effort", values = [ "low", "medium", "high", "xhigh" ] }]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12
+cache_read = 1

--- a/providers/routerplex/models/hy3.toml
+++ b/providers/routerplex/models/hy3.toml
@@ -1,0 +1,11 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "tencent/hy3"
+
+reasoning_options = [{ type = "effort", values = [ "none", "low", "high" ] }]
+
+[cost]
+input = 0.2
+output = 0.8

--- a/providers/routerplex/models/kimi-k2.6.toml
+++ b/providers/routerplex/models/kimi-k2.6.toml
@@ -1,0 +1,20 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `thinking.type` = enabled|disabled / `reasoning_effort`.
+base_model = "moonshotai/kimi-k2.6"
+
+[[reasoning_options]]
+type = "toggle"
+
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4
+
+[limit]
+context = 256_000

--- a/providers/routerplex/models/kimi-k2.7.toml
+++ b/providers/routerplex/models/kimi-k2.7.toml
@@ -1,0 +1,18 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "moonshotai/kimi-k2.7-code"
+name = "Kimi K2.7"
+
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.95
+output = 4
+
+[limit]
+context = 256_000

--- a/providers/routerplex/models/kimi-k3.toml
+++ b/providers/routerplex/models/kimi-k3.toml
@@ -1,0 +1,22 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `thinking.type` = enabled|disabled. Effort: `reasoning_effort` = low|high|max.
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = [ "low", "high", "max" ]
+
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3

--- a/providers/routerplex/models/kimi-k3.toml
+++ b/providers/routerplex/models/kimi-k3.toml
@@ -3,6 +3,8 @@
 # this host bills a discounted cache-hit rate; otherwise cached tokens are billed
 # at the input rate.
 # Toggle: `thinking.type` = enabled|disabled. Effort: `reasoning_effort` = low|high|max.
+# No cache_read: Moonshot publishes a $0.30 cache-hit rate, but this gateway
+# bills cached prompt tokens at the full $3.00 input rate.
 base_model = "moonshotai/kimi-k3"
 
 [[reasoning_options]]
@@ -19,4 +21,3 @@ field = "reasoning_content"
 [cost]
 input = 3
 output = 15
-cache_read = 0.3

--- a/providers/routerplex/models/mimo-v2.5-pro.toml
+++ b/providers/routerplex/models/mimo-v2.5-pro.toml
@@ -1,0 +1,20 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `thinking.type` / `reasoning_effort`.
+base_model = "xiaomi/mimo-v2.5-pro"
+
+[[reasoning_options]]
+type = "toggle"
+
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.44
+output = 0.87
+
+[limit]
+context = 1_000_000

--- a/providers/routerplex/models/mimo-v2.5.toml
+++ b/providers/routerplex/models/mimo-v2.5.toml
@@ -1,0 +1,20 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `thinking.type` / `reasoning_effort`.
+base_model = "xiaomi/mimo-v2.5"
+
+[[reasoning_options]]
+type = "toggle"
+
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.11
+output = 0.28
+
+[limit]
+context = 1_000_000

--- a/providers/routerplex/models/qwen3.6-plus.toml
+++ b/providers/routerplex/models/qwen3.6-plus.toml
@@ -1,0 +1,17 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `enable_thinking` true|false. Budget: `thinking_budget` / `reasoning.max_tokens`.
+base_model = "alibaba/qwen3.6-plus"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+
+[cost]
+input = 0.5
+output = 3

--- a/providers/routerplex/models/qwen3.7-max.toml
+++ b/providers/routerplex/models/qwen3.7-max.toml
@@ -1,0 +1,17 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `enable_thinking` true|false. Budget: `thinking_budget` / `reasoning.max_tokens`.
+base_model = "alibaba/qwen3.7-max"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+
+[cost]
+input = 2.5
+output = 7.5

--- a/providers/routerplex/models/qwen3.7-plus.toml
+++ b/providers/routerplex/models/qwen3.7-plus.toml
@@ -1,0 +1,17 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `enable_thinking` true|false. Budget: `thinking_budget` / `reasoning.max_tokens`.
+base_model = "alibaba/qwen3.7-plus"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+
+
+[cost]
+input = 0.32
+output = 1.28

--- a/providers/routerplex/models/qwen3.8-max.toml
+++ b/providers/routerplex/models/qwen3.8-max.toml
@@ -1,0 +1,26 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+# Toggle: `enable_thinking` true|false (also `reasoning_effort` on /v1/chat/completions). Budget: `thinking_budget` / `reasoning.max_tokens` 0..262144. Effort: `reasoning_effort` = low|medium|xhigh.
+base_model = "alibaba/qwen3.8-max"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = [ "low", "medium", "xhigh" ]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 262_144
+
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2
+output = 6

--- a/providers/routerplex/models/step-3.7-flash.toml
+++ b/providers/routerplex/models/step-3.7-flash.toml
@@ -1,0 +1,14 @@
+# Sources: https://routerplex.com/models and https://routerplex.com/api/models (accessed 2026-08-31).
+# Cost is RouterPlex sell price (USD / 1M tokens). cache_read is listed only when
+# this host bills a discounted cache-hit rate; otherwise cached tokens are billed
+# at the input rate.
+base_model = "stepfun/step-3.7-flash"
+
+reasoning_options = [{ type = "effort", values = [ "low", "medium", "high" ] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.2
+output = 1.15

--- a/providers/routerplex/provider.toml
+++ b/providers/routerplex/provider.toml
@@ -1,0 +1,10 @@
+# OpenAI-compatible POST /v1/chat/completions and /v1/responses: `reasoning_effort`
+# (Responses also accepts `reasoning.effort`). Anthropic POST /v1/messages:
+# `thinking.type` = enabled|disabled and, when enabled, `thinking.budget_tokens`
+# on models that accept a reasoning budget. Exact effort subsets are model-specific.
+# https://routerplex.com/docs (accessed 2026-08-31)
+name = "RouterPlex"
+env = ["ROUTERPLEX_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.routerplex.com/v1"
+doc = "https://routerplex.com/docs"


### PR DESCRIPTION
## Provider

RouterPlex is a multi-model relay (OpenAI-compatible + Anthropic Messages + Responses) at `https://api.routerplex.com/v1`.

- Env: `ROUTERPLEX_API_KEY`
- npm: `@ai-sdk/openai-compatible`
- Docs: https://routerplex.com/docs
- Public catalog: https://routerplex.com/api/models
- Model IDs are unprefixed and match the API (`claude-opus-4-8`, `gpt-5.5`, `kimi-k3`, …)

39 chat models. `gpt-image-2` is served but excluded here — image generation only.

## Host kind and reasoning wire format

This is a **gateway**, not a first-party lab. `reasoning_options` are copied from the underlying lab entry and same-surface peers (first-party `providers/<lab>/`, plus kilo / aihubmix / zenmux / volcengine where the lab host is missing).

Gateway routes:

- `POST /v1/chat/completions` — `reasoning_effort`
- `POST /v1/responses` — `reasoning_effort` / `reasoning.effort`
- `POST /v1/messages` — `thinking.type` and, when enabled, `thinking.budget_tokens` on models that accept a reasoning budget

Exact effort subsets stay model-specific (DeepSeek V4 is `high`/`max`, not a generic L/M/H dump). Every `toggle` carries the wire path in a leading comment.

## Cost

All `cost` values are RouterPlex sell prices (USD / 1M tokens) from the public catalog.

`cache_read` is listed **only** where this host actually bills a discounted cache-hit rate — i.e. where its configured `cache_read` rate is below its `input` rate:

- `grok-4.6` — $0.50, and $1.00 in the 200K long-context tier

Everything else bills cached prompt tokens at the standard input rate, so vendor cache discounts are **not** copied. `kimi-k3` is the case worth calling out: Moonshot publishes a $0.30 cache-hit rate, but RouterPlex does not pass it through and charges the full $3.00 input rate, so listing $0.30 would have understated a cache-heavy bill tenfold.

`grok-4.5` / `grok-4.6` use `[[cost.tiers]]` at 200K because that is how RouterPlex bills long-context prompts.

## Limits

`[limit].context` overrides the lab value on the 19 models where RouterPlex serves a different window (for example GPT-5.5 is 256K on this host, not the lab 1.05M). The other 20 match the lab exactly and are left to inherit.

`[limit].output` is inherited everywhere. RouterPlex does not impose an output cap of its own — nothing in the gateway clamps a request to a per-model output limit — so the lab value is what this host actually serves.

`MiniMax-M3-highspeed` is a host speed SKU of `minimax/MiniMax-M3` (no separate lab file). `kimi-k2.7` maps to `moonshotai/kimi-k2.7-code`. `gemini-3.1-pro` maps to `google/gemini-3.1-pro-preview`.

## Validation

`bun validate` passes (exit 0).

Beyond that, all 39 entries are cross-checked programmatically against `https://routerplex.com/api/models` — `input`, `output`, `cache_read`, tier threshold and tier pricing, plus **resolved** `limit.context` and `limit.output` after the `base_model` merge. No entry disagrees with the live catalog, and the set of listed models exactly equals the set of chat models the API serves.

The upstream catalog API was corrected in the same pass, so the two now agree by construction rather than by hand-copying: capability and output-limit fields there are sourced from this repo's lab metadata keyed by the same `base_model` ids used here.

## Not in this PR

- `gpt-image-2` (image generation only; not a chat model)
- Sync module (catalog is small and hand-authored from the public API)
