### PR TITLE
Add OpenZoo provider

### DIFF
--- a/providers/openzoo/logo.svg
+++ b/providers/openzoo/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect x="1.5" y="1.5" width="29" height="29" rx="6" fill="none" stroke="currentColor" stroke-width="3"/>
+  <text x="16" y="21.5" text-anchor="middle" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="13" font-weight="700" fill="currentColor">OZ</text>
+</svg>

--- a/providers/openzoo/models/qwen/qwen3.7-flash.toml
+++ b/providers/openzoo/models/qwen/qwen3.7-flash.toml
@@ -1,9 +1,11 @@
-# Wire path (OpenZoo is an OpenAI-compatible gateway; reasoning controls ride
-# the OpenRouter-style top-level `reasoning` request object, passed through
-# untouched when the caller sets it):
-#   toggle        -> `reasoning: { "enabled": true|false }`
-#   budget_tokens -> `reasoning: { "max_tokens": <int> }`
-# Priced from the live catalog: GET https://api.openzoo.fun/v1/models
+# Wire path (POST http://localhost:8402/v1/chat/completions on the local
+# `npx openzoo` proxy, OpenAI-compatible; reasoning controls ride the
+# OpenRouter-style top-level `reasoning` request object, which the proxy
+# forwards untouched when the caller sets it):
+#   toggle        -> $.reasoning.enabled    = true|false
+#   budget_tokens -> $.reasoning.max_tokens = <int>
+# Priced from the live catalog: GET /v1/models (free; same list on the hosted
+# https://api.openzoo.fun/v1/models and on the local proxy)
 # (prompt_price_per_1m = 0.03, completion_price_per_1m = 0.13)
 base_model = "alibaba/qwen3.7-flash"
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]

--- a/providers/openzoo/models/qwen/qwen3.7-flash.toml
+++ b/providers/openzoo/models/qwen/qwen3.7-flash.toml
@@ -1,3 +1,8 @@
+# Wire path (OpenZoo is an OpenAI-compatible gateway; reasoning controls ride
+# the OpenRouter-style top-level `reasoning` request object, passed through
+# untouched when the caller sets it):
+#   toggle        -> `reasoning: { "enabled": true|false }`
+#   budget_tokens -> `reasoning: { "max_tokens": <int> }`
 # Priced from the live catalog: GET https://api.openzoo.fun/v1/models
 # (prompt_price_per_1m = 0.03, completion_price_per_1m = 0.13)
 base_model = "alibaba/qwen3.7-flash"

--- a/providers/openzoo/models/qwen/qwen3.7-flash.toml
+++ b/providers/openzoo/models/qwen/qwen3.7-flash.toml
@@ -1,0 +1,8 @@
+# Priced from the live catalog: GET https://api.openzoo.fun/v1/models
+# (prompt_price_per_1m = 0.03, completion_price_per_1m = 0.13)
+base_model = "alibaba/qwen3.7-flash"
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", max = 262_144 }]
+
+[cost]
+input = 0.03
+output = 0.13

--- a/providers/openzoo/models/z-ai/glm-5.3-flash.toml
+++ b/providers/openzoo/models/z-ai/glm-5.3-flash.toml
@@ -1,10 +1,12 @@
-# Wire path (OpenZoo is an OpenAI-compatible gateway; reasoning controls ride
-# the OpenRouter-style top-level `reasoning` request object, passed through
-# untouched when the caller sets it):
-#   effort -> `reasoning: { "effort": "low"|"high"|"max" }`
+# Wire path (POST http://localhost:8402/v1/chat/completions on the local
+# `npx openzoo` proxy, OpenAI-compatible; reasoning controls ride the
+# OpenRouter-style top-level `reasoning` request object, which the proxy
+# forwards untouched when the caller sets it):
+#   effort -> $.reasoning.effort = "low"|"high"|"max"
 # Thinking is always on for this model upstream; effort values follow the
 # existing ofox entry for the same base model.
-# Priced from the live catalog: GET https://api.openzoo.fun/v1/models
+# Priced from the live catalog: GET /v1/models (free; same list on the hosted
+# https://api.openzoo.fun/v1/models and on the local proxy)
 # (prompt_price_per_1m = 0.075, completion_price_per_1m = 0.25)
 base_model = "zhipuai/glm-5.3-flash"
 

--- a/providers/openzoo/models/z-ai/glm-5.3-flash.toml
+++ b/providers/openzoo/models/z-ai/glm-5.3-flash.toml
@@ -1,6 +1,11 @@
+# Wire path (OpenZoo is an OpenAI-compatible gateway; reasoning controls ride
+# the OpenRouter-style top-level `reasoning` request object, passed through
+# untouched when the caller sets it):
+#   effort -> `reasoning: { "effort": "low"|"high"|"max" }`
+# Thinking is always on for this model upstream; effort values follow the
+# existing ofox entry for the same base model.
 # Priced from the live catalog: GET https://api.openzoo.fun/v1/models
 # (prompt_price_per_1m = 0.075, completion_price_per_1m = 0.25)
-# Thinking is always on for this model upstream; effort follows the ofox entry.
 base_model = "zhipuai/glm-5.3-flash"
 
 [[reasoning_options]]

--- a/providers/openzoo/models/z-ai/glm-5.3-flash.toml
+++ b/providers/openzoo/models/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,12 @@
+# Priced from the live catalog: GET https://api.openzoo.fun/v1/models
+# (prompt_price_per_1m = 0.075, completion_price_per_1m = 0.25)
+# Thinking is always on for this model upstream; effort follows the ofox entry.
+base_model = "zhipuai/glm-5.3-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.075
+output = 0.25

--- a/providers/openzoo/provider.toml
+++ b/providers/openzoo/provider.toml
@@ -1,5 +1,18 @@
+# Endpoint is the LOCAL proxy, on purpose (same shape as lmstudio's 127.0.0.1:1234):
+# `npx openzoo` (npm `openzoo`, https://github.com/staccDOTsol/openzoo) listens on
+# http://localhost:8402/v1, is OpenAI-compatible, and pays each call over x402 from a
+# local burner wallet. No account. The proxy ignores the API key, so OPENZOO_API_KEY
+# can hold any non-empty value (e.g. sk-openzoo).
+# The hosted https://api.openzoo.fun/v1 answers POST /v1/chat/completions with 402
+# unless the caller pays x402 or presents an OpenZoo subscription key (ozk_live_...),
+# which a plain OpenAI client cannot do, so it is not the default here.
+# GET /v1/models is free on both and lists ids plus pricing.
+# Reasoning wire path (POST /v1/chat/completions): the proxy forwards the
+# OpenRouter-style top-level `reasoning` object untouched:
+#   $.reasoning.enabled (bool), $.reasoning.max_tokens (int), $.reasoning.effort (str).
+# https://github.com/staccDOTsol/openzoo (accessed 2026-09-02)
 name = "OpenZoo"
 env = ["OPENZOO_API_KEY"]
 npm = "@ai-sdk/openai-compatible"
-api = "https://api.openzoo.fun/v1"
+api = "http://localhost:8402/v1"
 doc = "https://openzoo.fun"

--- a/providers/openzoo/provider.toml
+++ b/providers/openzoo/provider.toml
@@ -1,0 +1,5 @@
+name = "OpenZoo"
+env = ["OPENZOO_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.openzoo.fun/v1"
+doc = "https://openzoo.fun"


### PR DESCRIPTION
**Updated: endpoint corrected to the local proxy; see below.** The first revision pointed `api` at `https://api.openzoo.fun/v1` and said any `OPENZOO_API_KEY` value works there. That was wrong: the hosted gateway answers `POST /v1/chat/completions` with `402 Payment Required` unless the caller pays x402 or presents an OpenZoo subscription key (`ozk_live_…`), which `@ai-sdk/openai-compatible` cannot do. `GET /v1/models` is free, which is how the wrong claim slipped through.

Adds [OpenZoo](https://openzoo.fun). `api` is the local proxy: `npx openzoo` (npm `openzoo`, https://github.com/staccDOTsol/openzoo) listens on `http://localhost:8402/v1`, is OpenAI-compatible, and pays each call over x402 from a local burner wallet. No account. The proxy ignores the key, so `OPENZOO_API_KEY` can hold any non-empty value (the LMStudio convention of declaring the env var anyway is followed).

The localhost `api` is deliberate: the proxy is the thing that pays, and the catalog already carries a localhost entry for lmstudio (`http://127.0.0.1:1234/v1`). Same rationale as charmbracelet/catwalk#554. The hosted `https://api.openzoo.fun/v1` is mentioned in the `provider.toml` header only as: answers 402 unless the caller pays x402 or presents an `ozk_live_…` subscription key.

Two models to start, both inheriting via `base_model` (`zhipuai/glm-5.3-flash`, `alibaba/qwen3.7-flash`), with costs snapshotted from the free `GET /v1/models` catalog (`prompt_price_per_1m`/`completion_price_per_1m`; the hosted host and the proxy serve the same list). Each model file opens with the exact wire path for its reasoning controls (`$.reasoning.enabled` / `$.reasoning.max_tokens` on qwen3.7-flash, `$.reasoning.effort` on glm-5.3-flash; the proxy forwards the OpenRouter-style top-level `reasoning` object untouched), per the review bot's action item. Logo is SVG with `currentColor`. `bun validate` passes locally.

Disclosure: I operate OpenZoo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
