### PR TITLE
fix: expose IteraCompute Ornith image input

### DIFF
--- a/providers/iteracompute/models/iteracompute/ornith-1.5-35b-a3b.toml
+++ b/providers/iteracompute/models/iteracompute/ornith-1.5-35b-a3b.toml
@@ -1,16 +1,16 @@
-# Sources (accessed 2026-08-28):
+# Sources (accessed 2026-09-01):
 # https://api.iteracompute.com/v1/models (model ID, availability, limits, and pricing)
 # https://iteracompute.com/docs.html (OpenAI-compatible API documentation)
 # https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B (upstream capabilities)
 #
-# IteraCompute serves the language-only NVFP4 build with a 327,680-token
-# combined window, up to 262,144 input tokens, and up to 65,536 output tokens.
+# IteraCompute serves the image-capable NVFP4 build with text and image input,
+# a 327,680-token combined window, up to 262,144 input tokens, and up to
+# 65,536 output tokens. The public model card allows up to four image references.
 # Reasoning toggle wire path: reasoning_effort = "none" disables thinking;
 # any accepted non-none effort enables it. Responses stream reasoning through
 # the reasoning_content delta field.
 # Prices are in USD per million tokens.
 base_model = "deepreinforce/ornith-1.5-35b-a3b"
-attachment = false
 
 [interleaved]
 field = "reasoning_content"
@@ -26,6 +26,3 @@ output = 3.00
 context = 327_680
 input = 262_144
 output = 65_536
-
-[modalities]
-input = ["text"]


### PR DESCRIPTION
## Summary

- update IteraCompute Ornith from text-only to text and image input
- remove attachment = false and the text-only modalities override so the provider inherits the lab model's verified image capability
- keep pricing, limits, and reasoning controls unchanged

## Evidence

- https://api.iteracompute.com/v1/models now publishes an image input modality for iteracompute/ornith-1.5-35b-a3b with 1-4 image references
- https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B documents the upstream image capability

## Validation

- parsed the updated TOML with Bun
- git diff --check passed
- confirmed the commit changes only the IteraCompute Ornith provider file
- full Validate Models / bun validate passed on GitHub Actions
- automated review reports no actionable findings