### PR TITLE
fix(providers/azure): align gpt-5.6-sol pricing with Azure promotional rate

### DIFF
--- a/providers/azure/models/gpt-5.6-sol.toml
+++ b/providers/azure/models/gpt-5.6-sol.toml
@@ -1,17 +1,18 @@
-# Pricing: https://developers.openai.com/api/docs/pricing
+# Pricing: https://azure.microsoft.com/en-us/blog/gpt-5-6-now-available-in-microsoft-foundry/
+# Azure OpenAI metered API pricing for the GPT-5.6 Sol model will be reduced to $4.00 per 1M input tokens and $20.00 per 1M output tokens (20% reduction on input pricing and 33.3% reduction on output pricing). This promotional pricing will run from September 1, 2026, through at least November 30, 2026.
 base_model = "openai/gpt-5.6-sol"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 5.00
-output = 30.00
-cache_read = 0.50
-cache_write = 6.25
+input = 4.00
+output = 20.00
+cache_read = 0.40
+cache_write = 5.00
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 10.00
-output = 45.00
-cache_read = 1.00
-cache_write = 12.50
+input = 8.00
+output = 30.00
+cache_read = 0.80
+cache_write = 10.00


### PR DESCRIPTION
## What

Aligns Azure GPT-5.6 Sol pricing with the Azure promotional rate announced on the Microsoft Foundry blog.

## Source

[Microsoft Azure Blog — GPT-5.6 now available in Microsoft Foundry](https://azure.microsoft.com/en-us/blog/gpt-5-6-now-available-in-microsoft-foundry/)

> Azure OpenAI metered API pricing for the GPT-5.6 Sol model will be reduced to $4.00 per 1M input tokens and $20.00 per 1M output tokens (20% reduction on input pricing and 33.3% reduction on output pricing). This promotional pricing will run from September 1, 2026, through at least November 30, 2026.

## Changes

| | Before | After |
|---|---|---|
| input | $5.00 | $4.00 |
| output | $30.00 | $20.00 |
| cache_read | $0.50 | $0.40 |
| cache_write | $6.25 | $5.00 |
| tier input | $10.00 | $8.00 |
| tier output | $45.00 | $30.00 |
| tier cache_read | $1.00 | $0.80 |
| tier cache_write | $12.50 | $10.00 |

This matches the OpenAI first-party provider pricing updated in #5375 and keeps Azure consistent with the announced Azure rate.

## Validation

- [x] `bun validate` passes
