### PR TITLE
feat(providers/azure): add grok-4.6

### DIFF
--- a/providers/azure/models/gpt-5.6-sol.toml
+++ b/providers/azure/models/gpt-5.6-sol.toml
@@ -1,17 +1,18 @@
-# Pricing: https://developers.openai.com/api/docs/pricing
+# Pricing: https://azure.microsoft.com/en-us/blog/gpt-5-6-now-available-in-microsoft-foundry/
+# Azure OpenAI metered API pricing for the GPT-5.6 Sol model will be reduced to $4.00 per 1M input tokens and $20.00 per 1M output tokens (20% reduction on input pricing and 33.3% reduction on output pricing). This promotional pricing will run from September 1, 2026, through at least November 30, 2026.
 base_model = "openai/gpt-5.6-sol"
 status = "beta"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 5.00
-output = 30.00
-cache_read = 0.50
-cache_write = 6.25
+input = 4.00
+output = 20.00
+cache_read = 0.40
+cache_write = 5.00
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 10.00
-output = 45.00
-cache_read = 1.00
-cache_write = 12.50
+input = 8.00
+output = 30.00
+cache_read = 0.80
+cache_write = 10.00

--- a/providers/azure/models/grok-4.6.toml
+++ b/providers/azure/models/grok-4.6.toml
@@ -1,0 +1,22 @@
+# Sources: https://docs.x.ai/developers/model-capabilities/text/reasoning and https://ai.azure.com/catalog/models/grok-4.6
+base_model = "xai/grok-4.6"
+status = "beta"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12
+cache_read = 1
+
+[limit]
+context = 200_000
+output = 128_000


### PR DESCRIPTION
Adds xAI Grok 4.6 to the Azure provider.

Sources:
- https://ai.azure.com/catalog/models/grok-4.6
- https://docs.x.ai/developers/model-capabilities/text/reasoning

Azure specs: 200k context, 128k output, text/image input, preview lifecycle. Reasoning effort levels from xAI docs: low, medium, high, xhigh. Pricing matches xAI first-party Grok 4.6.

bun validate passes.