### PR TITLE
feat(perplexity-agent): add the new z-ai model catalog glm-5.3 and 5.2

### DIFF
--- a/providers/perplexity-agent/models/z-ai/glm-5.2.toml
+++ b/providers/perplexity-agent/models/z-ai/glm-5.2.toml
@@ -1,0 +1,15 @@
+# Perplexity Agent (OpenAI-compatible relay) pricing per:
+# https://docs.perplexity.ai/docs/agent-api/models#z-ai
+# Reasoning tokens billed at the output rate (no separate CoT price).
+# Effort: reasoning_effort = high|max (Z.AI's effective levels; none/minimal skip,
+# low/medium map to high, xhigh maps to max).
+base_model = "zhipuai/glm-5.2"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.26

--- a/providers/perplexity-agent/models/z-ai/glm-5.3.toml
+++ b/providers/perplexity-agent/models/z-ai/glm-5.3.toml
@@ -1,13 +1,12 @@
 # Perplexity Agent (OpenAI-compatible relay) pricing per:
 # https://docs.perplexity.ai/docs/agent-api/models#z-ai
 # Reasoning tokens billed at the output rate (no separate CoT price).
-# Effort: reasoning_effort = high|max (Z.AI's effective levels; none/minimal skip,
-# low/medium map to high, xhigh maps to max).
+# GLM-5.3 always reasons; low, high, and max are the effective effort levels.
 base_model = "zhipuai/glm-5.3"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["low", "high", "max"]
 
 [cost]
 input = 1.40

--- a/providers/perplexity-agent/models/z-ai/glm-5.3.toml
+++ b/providers/perplexity-agent/models/z-ai/glm-5.3.toml
@@ -1,0 +1,15 @@
+# Perplexity Agent (OpenAI-compatible relay) pricing per:
+# https://docs.perplexity.ai/docs/agent-api/models#z-ai
+# Reasoning tokens billed at the output rate (no separate CoT price).
+# Effort: reasoning_effort = high|max (Z.AI's effective levels; none/minimal skip,
+# low/medium map to high, xhigh maps to max).
+base_model = "zhipuai/glm-5.3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.26


### PR DESCRIPTION
## Summary

Adds Z.AI's GLM-5.2 and GLM-5.3 to `providers/perplexity-agent`, with pricing and reasoning controls verified against the [Perplexity Agent API models docs](https://docs.perplexity.ai/docs/agent-api/models#z-ai). All rates are USD per 1M tokens.

## Pricing

| Model | Input | Output | Cache read | Notes |
| --- | --- | --- | --- | --- |
| `z-ai/glm-5.2` | 1.40 | 4.40 | 0.26 | Flat; effort `high`/`max` |
| `z-ai/glm-5.3` | 1.40 | 4.40 | 0.26 | Flat; effort `high`/`max` |

## Reasoning controls

- Both models expose effort only: `["high","max"]` (Z.AI's effective levels — `none`/`minimal` skip thinking, `low`/`medium` map to `high`, `xhigh` maps to `max`). Matches Z.AI's canonical first-party control set; no separate toggle is exposed on this relay.
- Reasoning tokens are billed at the output rate; no separate `reasoning` cost key.
- No `interleaved` side channel is exposed.