### PR TITLE
feat(perplexity-agent): add gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna

### DIFF
--- a/providers/perplexity-agent/models/openai/gpt-5.6-luna.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.6-luna.toml
@@ -1,0 +1,20 @@
+# Perplexity Agent API pricing for openai/gpt-5.6-luna.
+# Source: https://docs.perplexity.ai/docs/agent-api/models#openai
+# Cache read is published as 90% off the active input rate
+# (luna/terra/sol all use the same discount); tier switch is at 272k input tokens.
+base_model = "openai/gpt-5.6-luna"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 1.00
+output = 6.00
+cache_read = 0.10
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 2.00
+output = 9.00
+cache_read = 0.20

--- a/providers/perplexity-agent/models/openai/gpt-5.6-sol.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.6-sol.toml
@@ -1,0 +1,20 @@
+# Perplexity Agent API pricing for openai/gpt-5.6-sol.
+# Source: https://docs.perplexity.ai/docs/agent-api/models#openai
+# Cache read is published as 90% off the active input rate
+# (luna/terra/sol all use the same discount); tier switch is at 272k input tokens.
+base_model = "openai/gpt-5.6-sol"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10.00
+output = 45.00
+cache_read = 1.00

--- a/providers/perplexity-agent/models/openai/gpt-5.6-terra.toml
+++ b/providers/perplexity-agent/models/openai/gpt-5.6-terra.toml
@@ -1,0 +1,20 @@
+# Perplexity Agent API pricing for openai/gpt-5.6-terra.
+# Source: https://docs.perplexity.ai/docs/agent-api/models#openai
+# Cache read is published as 90% off the active input rate
+# (luna/terra/sol all use the same discount); tier switch is at 272k input tokens.
+base_model = "openai/gpt-5.6-terra"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2.50
+output = 15.00
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5.00
+output = 22.50
+cache_read = 0.50


### PR DESCRIPTION
### #3767 this pr was auto closed , but this is needed so opened again.

## Summary

Adds OpenAI's GPT-5.6 family — `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` — to the Perplexity Agent provider, with pricing and reasoning controls verified against the [Perplexity Agent API docs](https://docs.perplexity.ai/docs/agent-api/models#openai). All rates are USD per 1M tokens.

## Pricing

| Model | Input (≤272k / >272k) | Output (≤272k / >272k) | Cache read (≤272k / >272k) |
| --- | --- | --- | --- |
| `openai/gpt-5.6-sol` | $5 / $10 | $30 / $45 | $0.50 / $1.00 |
| `openai/gpt-5.6-terra` | $2.50 / $5 | $15 / $22.50 | $0.25 / $0.50 |
| `openai/gpt-5.6-luna` | $1 / $2 | $6 / $9 | $0.10 / $0.20 |

- `tierThreshold = 272,000` input tokens for all three models.
- Cache read is **90% off the active input rate** (luna/terra/sol all use the same discount).
- Pricing is in **USD per 1M tokens**.

## Reasoning controls

- `reasoning_options = [{type="effort", values=["low","medium","high","xhigh","max"]}]` for all three models.
- Matches the existing Perplexity Agent surface (`gpt-5.4` / `gpt-5.5` peers). `none` is intentionally not exposed on this provider.

## Decisions / notes

- `perplexity-agent` is an OpenAI-compatible relay (`@ai-sdk/openai`, `https://api.perplexity.ai/v1`); entries are `base_model` override-only per the AGENTS.md non-lab-host rule, pointing to the canonical lab metadata (`models/openai/gpt-5.6-sol.toml`, `models/openai/gpt-5.6-terra.toml`, `models/openai/gpt-5.6-luna.toml`).
- `limit` and `modalities` inherit from the lab files.
- Recreates upstream PR #3767 (auto-closed as stale). The `none`-removal review feedback from the original PR has already been applied.


## Docs / sources

- <https://docs.perplexity.ai/docs/agent-api/models#openai>
- <https://platform.openai.com/docs/guides/latest-model>
- <https://openai.com/index/gpt-5-6/>
