### PR TITLE
Add missing Wafer serverless models

### DIFF
--- a/providers/wafer.ai/models/DeepSeek-V4-Flash-0731-Fast.toml
+++ b/providers/wafer.ai/models/DeepSeek-V4-Flash-0731-Fast.toml
@@ -1,0 +1,20 @@
+# Sources (accessed 2026-09-02):
+# - Pricing/capabilities: GET https://pass.wafer.ai/v1/models
+# - Model list: https://docs.wafer.ai/serverless/setup#models
+# Off is reasoning_effort=none; graded levels none|low|high|max (default low)
+base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 Fast"
+description = "The same model served for high TPS."
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.20
+output = 0.25
+cache_read = 0.05
+cache_write = 0
+
+[limit]
+context = 1_048_576

--- a/providers/wafer.ai/models/GLM-5.3-Flash.toml
+++ b/providers/wafer.ai/models/GLM-5.3-Flash.toml
@@ -1,0 +1,21 @@
+# Sources (accessed 2026-09-02):
+# - Pricing/capabilities: GET https://pass.wafer.ai/v1/models
+# - Model list: https://docs.wafer.ai/serverless/setup#models
+# Host control differs from the lab API: Wafer self-hosts GLM-5.3-Flash and
+# applies its own effort control (system-prompt conditioning); its per-model
+# metadata advertises reasoning_effort none|low|high|max (default low, none =
+# off; medium is not a distinct tier).
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.50
+cache_read = 0.03
+cache_write = 0
+
+[limit]
+context = 1_048_576

--- a/providers/wafer.ai/models/GLM-5.3.toml
+++ b/providers/wafer.ai/models/GLM-5.3.toml
@@ -1,0 +1,20 @@
+# Sources (accessed 2026-09-02):
+# - Pricing/capabilities: GET https://pass.wafer.ai/v1/models
+# - Model list: https://docs.wafer.ai/serverless/setup#models
+# Host control differs from the lab API: Wafer self-hosts GLM-5.3 and applies
+# its own effort control (system-prompt conditioning); its per-model metadata
+# advertises reasoning_effort none|low|high|max (default low), with none = off.
+base_model = "zhipuai/glm-5.3"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.26
+cache_write = 0
+
+[limit]
+context = 1_048_576

--- a/providers/wafer.ai/models/Kimi-K3.toml
+++ b/providers/wafer.ai/models/Kimi-K3.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-02):
+# - Pricing/capabilities: GET https://pass.wafer.ai/v1/models
+# - Model list: https://docs.wafer.ai/serverless/setup#models
+# Wafer per-model metadata: "Kimi-K3 reasoning is exposed as off/high/max;
+# low and medium collapse to the same enabled tier" — so reasoning_effort is
+# none|high|max (default none), and low is deliberately not listed.
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30
+cache_write = 0

--- a/providers/wafer.ai/models/Qwen3.5-397B-A17B.toml
+++ b/providers/wafer.ai/models/Qwen3.5-397B-A17B.toml
@@ -1,0 +1,9 @@
+# Sources (accessed 2026-09-02):
+# - Model list: https://docs.wafer.ai/serverless/setup#models (262K context,
+#   serverless-only, non-ZDR)
+# - GET https://pass.wafer.ai/v1/models lists the model but publishes no
+#   pricing or capability metadata for it yet; no public Wafer price as of
+#   2026-09-02, so cost is intentionally omitted.
+# Toggle: enable_thinking = true|false (normalized by the Wafer API)
+base_model = "alibaba/qwen3.5-397b-a17b"
+reasoning_options = [{ type = "toggle" }]


### PR DESCRIPTION
Adds the five models listed at https://docs.wafer.ai/serverless/setup#models that were missing from providers/wafer.ai: GLM-5.3, GLM-5.3-Flash, Kimi-K3, DeepSeek-V4-Flash-0731-Fast, and Qwen3.5-397B-A17B.

Pricing, context, and reasoning-effort tiers taken from the live catalog (https://pass.wafer.ai/v1/models), which the docs cite as authoritative. Qwen3.5-397B-A17B has no published Wafer pricing yet, so its cost block is intentionally omitted with a header comment explaining why.