### PR TITLE
chore(sync): factor vercel claude-fable-5.1 into base_model form

### DIFF
--- a/providers/vercel/models/anthropic/claude-fable-5.1.toml
+++ b/providers/vercel/models/anthropic/claude-fable-5.1.toml
@@ -1,24 +1,12 @@
-name = "Claude Fable 5.1"
+base_model = "anthropic/claude-fable-5-1"
 description = "Claude model for creative writing, analysis, and controlled agent workflows"
-family = "claude-fable"
-release_date = "2026-08-31"
-last_updated = "2026-08-31"
-attachment = true
-reasoning = true
-tool_call = true
-open_weights = false
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
 
 [cost]
 input = 10
 output = 50
 cache_read = 0.25
 cache_write = 12.5
-
-[limit]
-context = 1_000_000
-output = 128_000
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]


### PR DESCRIPTION
Regenerated `providers/vercel/models/anthropic/claude-fable-5.1.toml` with `bun models:sync vercel` now that [#6042](https://github.com/anomalyco/models.dev/pull/6042) resolves dotted Claude IDs across families.

The entry was originally written standalone by the sync (no `base_model`) because `canonicalCandidates()` did not map `claude-fable-5.1` to the canonical `anthropic/claude-fable-5-1` metadata. That left Vercel AI Gateway unlinked from the [/models/anthropic/claude-fable-5-1/](https://models.dev/models/anthropic/claude-fable-5-1/) page, which only associates providers via `base_model` or exact ID match.

Factored form verified identical to what the sync produces under the new code (`--dry-run` reports 0 changes). `bun validate` passes.