### PR TITLE
provider: add clf-ai-gateway (OpenAI-compatible, 9 models)

### DIFF
--- a/providers/clf-ai-gateway/logo.svg
+++ b/providers/clf-ai-gateway/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M9 3H4v18h5v-2H6V5h3V3Z" fill="currentColor"/>
+  <path d="M15 3h5v18h-5v-2h3V5h-3V3Z" fill="currentColor"/>
+  <path d="M9 8.5h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M8 12h13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <path d="M18.2 9.2 21 12l-2.8 2.8" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M9 15.5h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
@@ -1,14 +1,12 @@
 base_model = "deepseek/deepseek-v4-flash"
 
-# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
-# no alias mapping, no separate thinking-toggle field (omitting the field applies the
-# gateway default). The set below is enforced server-side for deepseek-v4-flash: any other value
-# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
-# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
-# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
+# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
+# accepted set per model (400 names it; also in GET /v1/public/models ->
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 563 / medium 242 / high 199 / xhigh 226 (xhigh samples 1210/226/186) → no consistent ordering; low/medium/high/xhigh are accepted but not a reliable control.
+reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
@@ -1,12 +1,15 @@
-base_model = "deepseek/deepseek-v4-flash"
+base_model = "deepseek/deepseek-v4-flash-0731"
 
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 563 / medium 242 / high 199 / xhigh 226 (xhigh samples 1210/226/186) → no consistent ordering; low/medium/high/xhigh are accepted but not a reliable control.
-reasoning_options = []
+# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
+# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
+# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
+# behavior on this host: low 563 / medium 242 / high 199 / xhigh 226 (xhigh samples 1210/226/186) → no consistent ordering; low/medium/high/xhigh are accepted but not a reliable control.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
@@ -3,13 +3,10 @@ base_model = "deepseek/deepseek-v4-flash-0731"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
-# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
-# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
-# behavior on this host: low 563 / medium 242 / high 199 / xhigh 226 (xhigh samples 1210/226/186) → no consistent ordering; low/medium/high/xhigh are accepted but not a reliable control.
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 563 / medium 242 / high 199 / xhigh 226 (xhigh samples 1210/226/186) → no consistent ordering; low/medium/high/xhigh are accepted but not a reliable control.
+reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
@@ -1,11 +1,12 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
 
-# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
-# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
-# accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 563 / medium 242 / high 199 / xhigh 226 (xhigh samples 1210/226/186) → no consistent ordering; low/medium/high/xhigh are accepted but not a reliable control.
+# Wire: only OpenAI-style `reasoning_effort` is forwarded, verbatim. No on/off toggle
+# field is forwarded on this surface, so there is no "toggle" option to expose.
+# Host accept-set for deepseek-v4-flash: low, medium, high, xhigh (anything else -> 400 naming this set; public
+# in GET /v1/public/models -> capabilities.reasoning_efforts). Only the levels with a
+# MEASURED distinct effect are advertised — same prompt, 3 samples per level, median
+# reasoning_tokens, 2026-09-02: low 563 / medium 242 / high 199 / xhigh 226 (xhigh samples 1210/226/186) -> no consistent ordering; the accepted levels are not a reliable control.
+# Accepted levels are inert and no toggle is forwarded -> no real caller control here.
 reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.

--- a/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-flash.toml
@@ -1,0 +1,24 @@
+base_model = "deepseek/deepseek-v4-flash"
+
+# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
+# no alias mapping, no separate thinking-toggle field (omitting the field applies the
+# gateway default). The set below is enforced server-side for deepseek-v4-flash: any other value
+# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
+# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
+# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+# Current promotional pricing (40% off list), USD/MTok — what the API bills today.
+# Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
+[cost]
+input = 0.264
+output = 0.792
+cache_read = 0.008
+
+# This gateway's serving surface, measured (context probed to the boundary;
+# output verified via max_completion_tokens probes).
+[limit]
+context = 1_048_576
+output = 131_072

--- a/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
@@ -1,0 +1,24 @@
+base_model = "deepseek/deepseek-v4-pro"
+
+# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
+# no alias mapping, no separate thinking-toggle field (omitting the field applies the
+# gateway default). The set below is enforced server-side for deepseek-v4-pro: any other value
+# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
+# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
+# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+# Current promotional pricing (40% off list), USD/MTok — what the API bills today.
+# Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
+[cost]
+input = 0.792
+output = 2.376
+cache_read = 0.026
+
+# This gateway's serving surface, measured (context probed to the boundary;
+# output verified via max_completion_tokens probes).
+[limit]
+context = 1_048_576
+output = 131_072

--- a/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
@@ -1,11 +1,11 @@
 base_model = "deepseek/deepseek-v4-pro-0813"
 
-# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
-# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
-# accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 282 / medium 214 / high 746 / xhigh 4124 → three graded behaviors; medium is an accepted alias of low.
+# Wire: only OpenAI-style `reasoning_effort` is forwarded, verbatim. No on/off toggle
+# field is forwarded on this surface, so there is no "toggle" option to expose.
+# Host accept-set for deepseek-v4-pro: low, medium, high, xhigh (anything else -> 400 naming this set; public
+# in GET /v1/public/models -> capabilities.reasoning_efforts). Only the levels with a
+# MEASURED distinct effect are advertised — same prompt, 3 samples per level, median
+# reasoning_tokens, 2026-09-02: low 282 / medium 214 / high 746 / xhigh 4124 -> three graded behaviors; medium is an inert alias of low.
 [[reasoning_options]]
 type = "effort"
 values = ["low", "high", "xhigh"]

--- a/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
@@ -1,14 +1,14 @@
 base_model = "deepseek/deepseek-v4-pro"
 
-# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
-# no alias mapping, no separate thinking-toggle field (omitting the field applies the
-# gateway default). The set below is enforced server-side for deepseek-v4-pro: any other value
-# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
-# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
-# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
+# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
+# accepted set per model (400 names it; also in GET /v1/public/models ->
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 282 / medium 214 / high 746 / xhigh 4124 → three graded behaviors; medium is an accepted alias of low.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+values = ["low", "high", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
@@ -3,13 +3,12 @@ base_model = "deepseek/deepseek-v4-pro-0813"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
-# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
-# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
-# behavior on this host: low 282 / medium 214 / high 746 / xhigh 4124 → three graded behaviors; medium is an accepted alias of low.
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 282 / medium 214 / high 746 / xhigh 4124 → three graded behaviors; medium is an accepted alias of low.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+values = ["low", "high", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
+++ b/providers/clf-ai-gateway/models/deepseek-v4-pro.toml
@@ -1,14 +1,15 @@
-base_model = "deepseek/deepseek-v4-pro"
+base_model = "deepseek/deepseek-v4-pro-0813"
 
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 282 / medium 214 / high 746 / xhigh 4124 → three graded behaviors; medium is an accepted alias of low.
+# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
+# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
+# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
+# behavior on this host: low 282 / medium 214 / high 746 / xhigh 4124 → three graded behaviors; medium is an accepted alias of low.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high", "xhigh"]
+values = ["low", "medium", "high", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-4.7-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-4.7-flash.toml
@@ -1,19 +1,16 @@
 base_model = "zhipuai/glm-4.7-flash"
 
-# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
-# no alias mapping, no separate thinking-toggle field (omitting the field applies the
-# gateway default). The set below is enforced server-side for glm-4.7-flash: any other value
-# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
-# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
-# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high"]
+# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
+# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
+# accepted set per model (400 names it; also in GET /v1/public/models ->
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 1294 / medium 1451 / high 567 with overlapping spreads (high samples 1778/567/192) → no measurable graded control; low/medium/high are accepted but ignored.
+reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
-# No cached tier for this model on this surface (public endpoint: cached_input = null);
-# cached tokens, if any, bill at the input rate.
+# No cached tier for this model on this surface (public endpoint: cached_input = null).
 [cost]
 input = 0.036
 output = 0.24

--- a/providers/clf-ai-gateway/models/glm-4.7-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-4.7-flash.toml
@@ -1,0 +1,25 @@
+base_model = "zhipuai/glm-4.7-flash"
+
+# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
+# no alias mapping, no separate thinking-toggle field (omitting the field applies the
+# gateway default). The set below is enforced server-side for glm-4.7-flash: any other value
+# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
+# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
+# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+# Current promotional pricing (40% off list), USD/MTok — what the API bills today.
+# Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
+# No cached tier for this model on this surface (public endpoint: cached_input = null);
+# cached tokens, if any, bill at the input rate.
+[cost]
+input = 0.036
+output = 0.24
+
+# This gateway's serving surface, measured (context probed to the boundary;
+# output verified via max_completion_tokens probes).
+[limit]
+context = 131_072
+output = 131_072

--- a/providers/clf-ai-gateway/models/glm-4.7-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-4.7-flash.toml
@@ -3,10 +3,13 @@ base_model = "zhipuai/glm-4.7-flash"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 1294 / medium 1451 / high 567 with overlapping spreads (high samples 1778/567/192) → no measurable graded control; low/medium/high are accepted but ignored.
-reasoning_options = []
+# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
+# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
+# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
+# behavior on this host: low 1294 / medium 1451 / high 567 with overlapping spreads (high samples 1778/567/192) → no measurable graded control; low/medium/high are accepted but ignored.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-4.7-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-4.7-flash.toml
@@ -1,11 +1,12 @@
 base_model = "zhipuai/glm-4.7-flash"
 
-# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
-# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
-# accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 1294 / medium 1451 / high 567 with overlapping spreads (high samples 1778/567/192) → no measurable graded control; low/medium/high are accepted but ignored.
+# Wire: only OpenAI-style `reasoning_effort` is forwarded, verbatim. No on/off toggle
+# field is forwarded on this surface, so there is no "toggle" option to expose.
+# Host accept-set for glm-4.7-flash: low, medium, high (anything else -> 400 naming this set; public
+# in GET /v1/public/models -> capabilities.reasoning_efforts). Only the levels with a
+# MEASURED distinct effect are advertised — same prompt, 3 samples per level, median
+# reasoning_tokens, 2026-09-02: low 1294 / medium 1451 / high 567 with overlapping spreads (high samples 1778/567/192) -> no measurable graded control; the accepted levels are inert.
+# Accepted levels are inert and no toggle is forwarded -> no real caller control here.
 reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.

--- a/providers/clf-ai-gateway/models/glm-4.7-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-4.7-flash.toml
@@ -3,13 +3,10 @@ base_model = "zhipuai/glm-4.7-flash"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
-# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
-# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
-# behavior on this host: low 1294 / medium 1451 / high 567 with overlapping spreads (high samples 1778/567/192) → no measurable graded control; low/medium/high are accepted but ignored.
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high"]
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 1294 / medium 1451 / high 567 with overlapping spreads (high samples 1778/567/192) → no measurable graded control; low/medium/high are accepted but ignored.
+reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.2.toml
+++ b/providers/clf-ai-gateway/models/glm-5.2.toml
@@ -1,14 +1,14 @@
 base_model = "zhipuai/glm-5.2"
 
-# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
-# no alias mapping, no separate thinking-toggle field (omitting the field applies the
-# gateway default). The set below is enforced server-side for glm-5.2: any other value
-# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
-# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
-# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
+# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
+# accepted set per model (400 names it; also in GET /v1/public/models ->
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 471 / medium 367 / high 356 / xhigh 666 → only xhigh is distinct; low/medium/high overlap and are accepted aliases of the default.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+values = ["low", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.2.toml
+++ b/providers/clf-ai-gateway/models/glm-5.2.toml
@@ -1,0 +1,24 @@
+base_model = "zhipuai/glm-5.2"
+
+# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
+# no alias mapping, no separate thinking-toggle field (omitting the field applies the
+# gateway default). The set below is enforced server-side for glm-5.2: any other value
+# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
+# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
+# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+# Current promotional pricing (40% off list), USD/MTok — what the API bills today.
+# Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
+[cost]
+input = 0.84
+output = 2.64
+cache_read = 0.156
+
+# This gateway's serving surface, measured (context probed to the boundary;
+# output verified via max_completion_tokens probes).
+[limit]
+context = 262_144
+output = 131_072

--- a/providers/clf-ai-gateway/models/glm-5.2.toml
+++ b/providers/clf-ai-gateway/models/glm-5.2.toml
@@ -1,11 +1,11 @@
 base_model = "zhipuai/glm-5.2"
 
-# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
-# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
-# accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 471 / medium 367 / high 356 / xhigh 666 → only xhigh is distinct; low/medium/high overlap and are accepted aliases of the default.
+# Wire: only OpenAI-style `reasoning_effort` is forwarded, verbatim. No on/off toggle
+# field is forwarded on this surface, so there is no "toggle" option to expose.
+# Host accept-set for glm-5.2: low, medium, high, xhigh (anything else -> 400 naming this set; public
+# in GET /v1/public/models -> capabilities.reasoning_efforts). Only the levels with a
+# MEASURED distinct effect are advertised — same prompt, 3 samples per level, median
+# reasoning_tokens, 2026-09-02: low 471 / medium 367 / high 356 / xhigh 666 -> only xhigh is distinct; low/medium/high overlap (medium/high are inert aliases of low).
 [[reasoning_options]]
 type = "effort"
 values = ["low", "xhigh"]

--- a/providers/clf-ai-gateway/models/glm-5.2.toml
+++ b/providers/clf-ai-gateway/models/glm-5.2.toml
@@ -3,13 +3,12 @@ base_model = "zhipuai/glm-5.2"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
-# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
-# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
-# behavior on this host: low 471 / medium 367 / high 356 / xhigh 666 → only xhigh is distinct; low/medium/high overlap and are accepted aliases of the default.
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 471 / medium 367 / high 356 / xhigh 666 → only xhigh is distinct; low/medium/high overlap and are accepted aliases of the default.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+values = ["low", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.2.toml
+++ b/providers/clf-ai-gateway/models/glm-5.2.toml
@@ -3,12 +3,13 @@ base_model = "zhipuai/glm-5.2"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 471 / medium 367 / high 356 / xhigh 666 → only xhigh is distinct; low/medium/high overlap and are accepted aliases of the default.
+# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
+# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
+# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
+# behavior on this host: low 471 / medium 367 / high 356 / xhigh 666 → only xhigh is distinct; low/medium/high overlap and are accepted aliases of the default.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "xhigh"]
+values = ["low", "medium", "high", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.3-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3-flash.toml
@@ -1,14 +1,14 @@
 base_model = "zhipuai/glm-5.3-flash"
 
-# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
-# no alias mapping, no separate thinking-toggle field (omitting the field applies the
-# gateway default). The set below is enforced server-side for glm-5.3-flash: any other value
-# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
-# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
-# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
+# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
+# accepted set per model (400 names it; also in GET /v1/public/models ->
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 27 / medium 289 / high 31 / xhigh 295 → two behaviors: {low,high} minimal, {medium,xhigh} full. medium and high are accepted aliases.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+values = ["low", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.3-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3-flash.toml
@@ -3,12 +3,13 @@ base_model = "zhipuai/glm-5.3-flash"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 27 / medium 289 / high 31 / xhigh 295 → two behaviors: {low,high} minimal, {medium,xhigh} full. medium and high are accepted aliases.
+# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
+# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
+# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
+# behavior on this host: low 27 / medium 289 / high 31 / xhigh 295 → two behaviors: {low,high} minimal, {medium,xhigh} full. medium and high are accepted aliases.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "xhigh"]
+values = ["low", "medium", "high", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.3-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3-flash.toml
@@ -1,0 +1,29 @@
+base_model = "zhipuai/glm-5.3-flash"
+
+# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
+# no alias mapping, no separate thinking-toggle field (omitting the field applies the
+# gateway default). The set below is enforced server-side for glm-5.3-flash: any other value
+# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
+# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
+# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]
+
+# Current promotional pricing (40% off list), USD/MTok — what the API bills today.
+# Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
+[cost]
+input = 0.09
+output = 0.3
+cache_read = 0.018
+
+# This gateway's serving surface, measured (context probed to the boundary;
+# output verified via max_completion_tokens probes).
+[limit]
+context = 1_048_576
+output = 131_072
+
+# Gateway accepts text + image_url parts only (no video/pdf on this surface).
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/clf-ai-gateway/models/glm-5.3-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3-flash.toml
@@ -3,13 +3,12 @@ base_model = "zhipuai/glm-5.3-flash"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
-# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
-# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
-# behavior on this host: low 27 / medium 289 / high 31 / xhigh 295 → two behaviors: {low,high} minimal, {medium,xhigh} full. medium and high are accepted aliases.
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 27 / medium 289 / high 31 / xhigh 295 → two behaviors: {low,high} minimal, {medium,xhigh} full. medium and high are accepted aliases.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+values = ["low", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.3-flash.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3-flash.toml
@@ -1,11 +1,11 @@
 base_model = "zhipuai/glm-5.3-flash"
 
-# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
-# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
-# accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 27 / medium 289 / high 31 / xhigh 295 → two behaviors: {low,high} minimal, {medium,xhigh} full. medium and high are accepted aliases.
+# Wire: only OpenAI-style `reasoning_effort` is forwarded, verbatim. No on/off toggle
+# field is forwarded on this surface, so there is no "toggle" option to expose.
+# Host accept-set for glm-5.3-flash: low, medium, high, xhigh (anything else -> 400 naming this set; public
+# in GET /v1/public/models -> capabilities.reasoning_efforts). Only the levels with a
+# MEASURED distinct effect are advertised — same prompt, 3 samples per level, median
+# reasoning_tokens, 2026-09-02: low 27 / medium 289 / high 31 / xhigh 295 -> two behaviors: {low,high} minimal, {medium,xhigh} full; medium and high are inert aliases.
 [[reasoning_options]]
 type = "effort"
 values = ["low", "xhigh"]

--- a/providers/clf-ai-gateway/models/glm-5.3.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3.toml
@@ -1,17 +1,14 @@
 base_model = "zhipuai/glm-5.3"
 
-# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
-# no alias mapping, no separate thinking-toggle field (omitting the field applies the
-# gateway default). The set below is enforced server-side for glm-5.3: any other value
-# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
-# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
-# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
-# "none" is deliberately NOT advertised here even though the API accepts it (it is
-# part of the public accept-set): measured 2026-08-28, it does not reliably disable
-# thinking upstream — no hard off switch exists, so we won't promise one to clients.
+# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
+# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
+# accepted set per model (400 names it; also in GET /v1/public/models ->
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 26 / medium 330 / high 32 / max 368 → two behaviors: {low,high} minimal, {medium,max} full. medium and high are accepted aliases; "none" accepted but does not disable thinking.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "max"]
+values = ["low", "max"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.3.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3.toml
@@ -6,12 +6,12 @@ base_model = "zhipuai/glm-5.3"
 # returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
 # "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
 # Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
-# "none" is accepted and validated by the API (part of the public set); measured
-# 2026-08-28: upstream may still emit some reasoning at "none" — there is no hard
-# off switch, so treat "none" as minimize-thinking, not disable.
+# "none" is deliberately NOT advertised here even though the API accepts it (it is
+# part of the public accept-set): measured 2026-08-28, it does not reliably disable
+# thinking upstream — no hard off switch exists, so we won't promise one to clients.
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "max"]
+values = ["low", "medium", "high", "max"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.3.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3.toml
@@ -1,11 +1,11 @@
 base_model = "zhipuai/glm-5.3"
 
-# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
-# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
-# accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 26 / medium 330 / high 32 / max 368 → two behaviors: {low,high} minimal, {medium,max} full. medium and high are accepted aliases; "none" accepted but does not disable thinking.
+# Wire: only OpenAI-style `reasoning_effort` is forwarded, verbatim. No on/off toggle
+# field is forwarded on this surface, so there is no "toggle" option to expose.
+# Host accept-set for glm-5.3: none, low, medium, high, max (anything else -> 400 naming this set; public
+# in GET /v1/public/models -> capabilities.reasoning_efforts). Only the levels with a
+# MEASURED distinct effect are advertised — same prompt, 3 samples per level, median
+# reasoning_tokens, 2026-09-02: low 26 / medium 330 / high 32 / max 368 -> two behaviors: {low,high} minimal, {medium,max} full; medium and high are inert aliases; "none" is accepted but does not disable thinking, so it is not advertised.
 [[reasoning_options]]
 type = "effort"
 values = ["low", "max"]

--- a/providers/clf-ai-gateway/models/glm-5.3.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3.toml
@@ -1,0 +1,27 @@
+base_model = "zhipuai/glm-5.3"
+
+# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
+# no alias mapping, no separate thinking-toggle field (omitting the field applies the
+# gateway default). The set below is enforced server-side for glm-5.3: any other value
+# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
+# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
+# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+# "none" is accepted and validated by the API (part of the public set); measured
+# 2026-08-28: upstream may still emit some reasoning at "none" — there is no hard
+# off switch, so treat "none" as minimize-thinking, not disable.
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+# Current promotional pricing (40% off list), USD/MTok — what the API bills today.
+# Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
+[cost]
+input = 0.84
+output = 2.64
+cache_read = 0.156
+
+# This gateway's serving surface, measured (context probed to the boundary;
+# output verified via max_completion_tokens probes).
+[limit]
+context = 1_048_576
+output = 131_072

--- a/providers/clf-ai-gateway/models/glm-5.3.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3.toml
@@ -3,12 +3,13 @@ base_model = "zhipuai/glm-5.3"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 26 / medium 330 / high 32 / max 368 → two behaviors: {low,high} minimal, {medium,max} full. medium and high are accepted aliases; "none" accepted but does not disable thinking.
+# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
+# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
+# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
+# behavior on this host: low 26 / medium 330 / high 32 / max 368 → two behaviors: {low,high} minimal, {medium,max} full. medium and high are accepted aliases; "none" accepted but does not disable thinking.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "max"]
+values = ["low", "medium", "high", "max"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/glm-5.3.toml
+++ b/providers/clf-ai-gateway/models/glm-5.3.toml
@@ -3,13 +3,12 @@ base_model = "zhipuai/glm-5.3"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
-# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
-# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
-# behavior on this host: low 26 / medium 330 / high 32 / max 368 → two behaviors: {low,high} minimal, {medium,max} full. medium and high are accepted aliases; "none" accepted but does not disable thinking.
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 26 / medium 330 / high 32 / max 368 → two behaviors: {low,high} minimal, {medium,max} full. medium and high are accepted aliases; "none" accepted but does not disable thinking.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "max"]
+values = ["low", "max"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/kimi-k2.6.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.6.toml
@@ -1,11 +1,12 @@
 base_model = "moonshotai/kimi-k2.6"
 
-# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
-# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
-# accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 528 / medium 577 / high 456 → flat; thinking is always on, low/medium/high accepted but ignored (matches the lab: toggle-only).
+# Wire: only OpenAI-style `reasoning_effort` is forwarded, verbatim. No on/off toggle
+# field is forwarded on this surface, so there is no "toggle" option to expose.
+# Host accept-set for kimi-k2.6: low, medium, high (anything else -> 400 naming this set; public
+# in GET /v1/public/models -> capabilities.reasoning_efforts). Only the levels with a
+# MEASURED distinct effect are advertised — same prompt, 3 samples per level, median
+# reasoning_tokens, 2026-09-02: low 528 / medium 577 / high 456 -> flat; thinking is always on and the accepted levels are inert (matches the lab: toggle-only, and no toggle is forwarded here).
+# Accepted levels are inert and no toggle is forwarded -> no real caller control here.
 reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.

--- a/providers/clf-ai-gateway/models/kimi-k2.6.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.6.toml
@@ -3,10 +3,13 @@ base_model = "moonshotai/kimi-k2.6"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 528 / medium 577 / high 456 → flat; thinking is always on, low/medium/high accepted but ignored (matches the lab: toggle-only).
-reasoning_options = []
+# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
+# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
+# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
+# behavior on this host: low 528 / medium 577 / high 456 → flat; thinking is always on, low/medium/high accepted but ignored (matches the lab: toggle-only).
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/kimi-k2.6.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.6.toml
@@ -3,13 +3,10 @@ base_model = "moonshotai/kimi-k2.6"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
-# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
-# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
-# behavior on this host: low 528 / medium 577 / high 456 → flat; thinking is always on, low/medium/high accepted but ignored (matches the lab: toggle-only).
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high"]
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 528 / medium 577 / high 456 → flat; thinking is always on, low/medium/high accepted but ignored (matches the lab: toggle-only).
+reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/kimi-k2.6.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.6.toml
@@ -1,14 +1,12 @@
 base_model = "moonshotai/kimi-k2.6"
 
-# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
-# no alias mapping, no separate thinking-toggle field (omitting the field applies the
-# gateway default). The set below is enforced server-side for kimi-k2.6: any other value
-# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
-# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
-# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high"]
+# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
+# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
+# accepted set per model (400 names it; also in GET /v1/public/models ->
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 528 / medium 577 / high 456 → flat; thinking is always on, low/medium/high accepted but ignored (matches the lab: toggle-only).
+reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/kimi-k2.6.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.6.toml
@@ -1,0 +1,29 @@
+base_model = "moonshotai/kimi-k2.6"
+
+# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
+# no alias mapping, no separate thinking-toggle field (omitting the field applies the
+# gateway default). The set below is enforced server-side for kimi-k2.6: any other value
+# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
+# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
+# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+# Current promotional pricing (40% off list), USD/MTok — what the API bills today.
+# Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
+[cost]
+input = 0.57
+output = 2.4
+cache_read = 0.096
+
+# This gateway's serving surface, measured (context probed to the boundary;
+# output verified via max_completion_tokens probes).
+[limit]
+context = 262_144
+output = 131_072
+
+# Gateway accepts text + image_url parts only (no video/pdf on this surface).
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
@@ -1,11 +1,12 @@
 base_model = "moonshotai/kimi-k2.7-code"
 
-# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
-# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
-# accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 141 / medium 155 / high 283 with overlapping spreads (high 207/283/426 vs medium 210/155/136) → no reliable graded control; accepted but ignored.
+# Wire: only OpenAI-style `reasoning_effort` is forwarded, verbatim. No on/off toggle
+# field is forwarded on this surface, so there is no "toggle" option to expose.
+# Host accept-set for kimi-k2.7-code: low, medium, high (anything else -> 400 naming this set; public
+# in GET /v1/public/models -> capabilities.reasoning_efforts). Only the levels with a
+# MEASURED distinct effect are advertised — same prompt, 3 samples per level, median
+# reasoning_tokens, 2026-09-02: low 141 / medium 155 / high 283 with overlapping spreads (high 207/283/426 vs medium 210/155/136) -> no reliable graded control; accepted levels are inert.
+# Accepted levels are inert and no toggle is forwarded -> no real caller control here.
 reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.

--- a/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
@@ -3,10 +3,13 @@ base_model = "moonshotai/kimi-k2.7-code"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 141 / medium 155 / high 283 with overlapping spreads (high 207/283/426 vs medium 210/155/136) → no reliable graded control; accepted but ignored.
-reasoning_options = []
+# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
+# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
+# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
+# behavior on this host: low 141 / medium 155 / high 283 with overlapping spreads (high 207/283/426 vs medium 210/155/136) → no reliable graded control; accepted but ignored.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
@@ -1,14 +1,12 @@
 base_model = "moonshotai/kimi-k2.7-code"
 
-# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
-# no alias mapping, no separate thinking-toggle field (omitting the field applies the
-# gateway default). The set below is enforced server-side for kimi-k2.7-code: any other value
-# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
-# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
-# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high"]
+# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
+# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
+# accepted set per model (400 names it; also in GET /v1/public/models ->
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 141 / medium 155 / high 283 with overlapping spreads (high 207/283/426 vs medium 210/155/136) → no reliable graded control; accepted but ignored.
+reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
@@ -1,0 +1,29 @@
+base_model = "moonshotai/kimi-k2.7-code"
+
+# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
+# no alias mapping, no separate thinking-toggle field (omitting the field applies the
+# gateway default). The set below is enforced server-side for kimi-k2.7-code: any other value
+# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
+# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
+# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+# Current promotional pricing (40% off list), USD/MTok — what the API bills today.
+# Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
+[cost]
+input = 0.57
+output = 2.4
+cache_read = 0.114
+
+# This gateway's serving surface, measured (context probed to the boundary;
+# output verified via max_completion_tokens probes).
+[limit]
+context = 262_144
+output = 131_072
+
+# Gateway accepts text + image_url parts only (no video/pdf on this surface).
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
+++ b/providers/clf-ai-gateway/models/kimi-k2.7-code.toml
@@ -3,13 +3,10 @@ base_model = "moonshotai/kimi-k2.7-code"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
-# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
-# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
-# behavior on this host: low 141 / medium 155 / high 283 with overlapping spreads (high 207/283/426 vs medium 210/155/136) → no reliable graded control; accepted but ignored.
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high"]
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 141 / medium 155 / high 283 with overlapping spreads (high 207/283/426 vs medium 210/155/136) → no reliable graded control; accepted but ignored.
+reasoning_options = []
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/qwen3.8-27b.toml
+++ b/providers/clf-ai-gateway/models/qwen3.8-27b.toml
@@ -1,0 +1,33 @@
+base_model = "alibaba/qwen3.8-27b"
+
+# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
+# no alias mapping, no separate thinking-toggle field (omitting the field applies the
+# gateway default). The set below is enforced server-side for qwen3.8-27b: any other value
+# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
+# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
+# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
+
+# Current promotional pricing (40% off list), USD/MTok — what the API bills today.
+# Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).
+# cache_read = input is intentional, not a typo: this model has no verified cached
+# tier on this surface, so cached tokens bill at the input rate. The public endpoint
+# shows cached_input == input for both promo and list price (270/270 nano now,
+# 450/450 list) — we do not advertise a cache discount we cannot prove.
+[cost]
+input = 0.27
+output = 1.92
+cache_read = 0.27
+
+# This gateway's serving surface, measured (context probed to the boundary;
+# output verified via max_completion_tokens probes).
+[limit]
+context = 262_144
+output = 131_072
+
+# Gateway accepts text + image_url parts only (no video/pdf on this surface).
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/clf-ai-gateway/models/qwen3.8-27b.toml
+++ b/providers/clf-ai-gateway/models/qwen3.8-27b.toml
@@ -3,13 +3,12 @@ base_model = "alibaba/qwen3.8-27b"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
-# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
-# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
-# behavior on this host: low 138 / medium 166 / xhigh 245 (every xhigh sample above every low sample) → xhigh distinct; medium is an accepted alias of low.
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 138 / medium 166 / xhigh 245 (every xhigh sample above every low sample) → xhigh distinct; medium is an accepted alias of low.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "xhigh"]
+values = ["low", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/qwen3.8-27b.toml
+++ b/providers/clf-ai-gateway/models/qwen3.8-27b.toml
@@ -3,12 +3,13 @@ base_model = "alibaba/qwen3.8-27b"
 # Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
 # (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
 # accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 138 / medium 166 / xhigh 245 (every xhigh sample above every low sample) → xhigh distinct; medium is an accepted alias of low.
+# capabilities.reasoning_efforts). The values below are exactly that host accept-set —
+# what a client can send without a 400. Measured effect per level (same prompt, 3 samples,
+# median reasoning_tokens, 2026-09-02) so nobody has to guess which levels actually change
+# behavior on this host: low 138 / medium 166 / xhigh 245 (every xhigh sample above every low sample) → xhigh distinct; medium is an accepted alias of low.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "xhigh"]
+values = ["low", "medium", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/models/qwen3.8-27b.toml
+++ b/providers/clf-ai-gateway/models/qwen3.8-27b.toml
@@ -1,11 +1,11 @@
 base_model = "alibaba/qwen3.8-27b"
 
-# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
-# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
-# accepted set per model (400 names it; also in GET /v1/public/models ->
-# capabilities.reasoning_efforts). The values advertised below are the subset with a
-# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
-# (2026-09-02): low 138 / medium 166 / xhigh 245 (every xhigh sample above every low sample) → xhigh distinct; medium is an accepted alias of low.
+# Wire: only OpenAI-style `reasoning_effort` is forwarded, verbatim. No on/off toggle
+# field is forwarded on this surface, so there is no "toggle" option to expose.
+# Host accept-set for qwen3.8-27b: low, medium, xhigh (anything else -> 400 naming this set; public
+# in GET /v1/public/models -> capabilities.reasoning_efforts). Only the levels with a
+# MEASURED distinct effect are advertised — same prompt, 3 samples per level, median
+# reasoning_tokens, 2026-09-02: low 138 / medium 166 / xhigh 245 (every xhigh sample above every low sample) -> xhigh distinct; medium is an inert alias of low.
 [[reasoning_options]]
 type = "effort"
 values = ["low", "xhigh"]

--- a/providers/clf-ai-gateway/models/qwen3.8-27b.toml
+++ b/providers/clf-ai-gateway/models/qwen3.8-27b.toml
@@ -1,14 +1,14 @@
 base_model = "alibaba/qwen3.8-27b"
 
-# Reasoning: this surface forwards only OpenAI-style `reasoning_effort`, verbatim —
-# no alias mapping, no separate thinking-toggle field (omitting the field applies the
-# gateway default). The set below is enforced server-side for qwen3.8-27b: any other value
-# returns 400 naming this exact set (e.g. sending "max" to deepseek-v4-flash returns
-# "does not accept reasoning_effort 'max'. Supported: low, medium, high, xhigh").
-# Same set is public in GET /v1/public/models -> capabilities.reasoning_efforts.
+# Reasoning control on this surface: only OpenAI-style `reasoning_effort` is forwarded
+# (verbatim, no alias mapping, no separate thinking toggle). The gateway validates the
+# accepted set per model (400 names it; also in GET /v1/public/models ->
+# capabilities.reasoning_efforts). The values advertised below are the subset with a
+# MEASURED distinct effect — same prompt, 3 samples per level, median reasoning_tokens
+# (2026-09-02): low 138 / medium 166 / xhigh 245 (every xhigh sample above every low sample) → xhigh distinct; medium is an accepted alias of low.
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "xhigh"]
+values = ["low", "xhigh"]
 
 # Current promotional pricing (40% off list), USD/MTok — what the API bills today.
 # Live source: GET /v1/public/models (nano-USD per token; /1000 = USD/MTok).

--- a/providers/clf-ai-gateway/provider.toml
+++ b/providers/clf-ai-gateway/provider.toml
@@ -1,0 +1,10 @@
+name = "CLF AI Gateway"
+env = ["CLF_AI_GATEWAY_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+# OpenAI-compatible gateway reselling Cloudflare Workers AI open-weight models
+# (GLM, Kimi, DeepSeek, Qwen) with prepaid credits. Runs on Workers AI upstream
+# by design and says so publicly: https://clfaigateway.dev/docs
+# Model IDs are the gateway's canonical names (glm-5.3, kimi-k2.7-code, ...);
+# the upstream @cf/... id is returned per model by GET /v1/public/models.
+doc = "https://clfaigateway.dev/docs"
+api = "https://api.clfaigateway.dev/v1"


### PR DESCRIPTION
## Add provider: CLF AI Gateway

OpenAI-compatible gateway at `https://api.clfaigateway.dev/v1`, reselling
Cloudflare Workers AI open-weight models (GLM, Kimi, DeepSeek, Qwen) on prepaid
credits. We are transparent about running on Workers AI upstream — each model's
upstream `@cf/...` id is exposed via `GET /v1/public/models` (no auth required),
which is also the live source for pricing and capabilities.

**What's included**

- `provider.toml` — name, `@ai-sdk/openai-compatible`, env `CLF_AI_GATEWAY_API_KEY`, base URL, docs link.
- `logo.svg` — currentColor, no hard-coded colors.
- `models/` — 9 models. All numbers are **measured against the live endpoint**,
  not copied from upstream marketing pages:
  - `limit.context` verified per model (the 1M models were probed to the
    1,048,576 boundary; we deliberately do NOT repeat the 1,310,720 figure that
    upstream catalog reports — see issue #5824 for that discrepancy).
  - `limit.output` = 131,072, verified by sending `max_completion_tokens` probes.
  - `attachment` only on the 4 models that actually accept images (probed);
    the gateway returns a named 400 for image input on the other five.
  - `cost` = current promotional pricing (40% off list), which is what the API
    actually bills today. We will PR updates when pricing changes; live prices
    are always at https://clfaigateway.dev/models and `GET /v1/public/models`.

**Verification for reviewers**

- `curl https://api.clfaigateway.dev/v1/public/models` — public, no key; ids,
  context windows, capabilities and per-token pricing (nano-USD per token;
  divide by 1000 for USD/MTok) should match these TOML files exactly.
- Docs: https://clfaigateway.dev/docs and https://clfaigateway.dev/docs/coding-agents.