### PR TITLE
fix(deepseek): correct V4 Pro/Flash pricing to the published rate card

### DIFF
--- a/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
@@ -1,5 +1,8 @@
+# Prices are DeepSeek's published OFF-PEAK rates, USD per 1M tokens.
+# Peak (01:00-04:00 and 06:00-10:00 UTC, Mon-Fri) is exactly double; models.dev
+# has no time-of-day pricing, and off-peak covers ~79% of hours.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-09-01)
 # DeepSeek-V4-Flash-Vision-Exp is priced the same as DeepSeek V4 Flash.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-22)
 # https://api-docs.deepseek.com/guides/vision (accessed 2026-08-22)
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
 # Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
@@ -17,7 +20,7 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.14
-output = 0.28
-reasoning = 0.28
-cache_read = 0.0028
+input = 0.22
+output = 0.66
+reasoning = 0.66
+cache_read = 0.007

--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -1,6 +1,9 @@
+# Prices are DeepSeek's published OFF-PEAK rates, USD per 1M tokens.
+# Peak (01:00-04:00 and 06:00-10:00 UTC, Mon-Fri) is exactly double; models.dev
+# has no time-of-day pricing, and off-peak covers ~79% of hours.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-09-01)
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
 # Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
 # Flash maps requested low→low (unlike Pro, which maps low→high). xhigh→high.
@@ -19,7 +22,7 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.14
-output = 0.28
-reasoning = 0.28
-cache_read = 0.0028
+input = 0.22
+output = 0.66
+reasoning = 0.66
+cache_read = 0.007

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -1,6 +1,9 @@
+# Prices are DeepSeek's published OFF-PEAK rates, USD per 1M tokens.
+# Peak (01:00-04:00 and 06:00-10:00 UTC, Mon-Fri) is exactly double; models.dev
+# has no time-of-day pricing, and off-peak covers ~79% of hours.
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-09-01)
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-12)
 base_model = "deepseek/deepseek-v4-pro-0813"
 name = "DeepSeek V4 Pro"
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.
@@ -18,7 +21,7 @@ values = ["high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.435
-output = 0.87
-reasoning = 0.87
-cache_read = 0.003625
+input = 0.66
+output = 1.98
+reasoning = 1.98
+cache_read = 0.022


### PR DESCRIPTION
The first-party `deepseek` entries for V4 Pro and V4 Flash are well below DeepSeek's published prices. The gap is worst on **cache reads — 6× low for Pro** — which dominate agentic traffic, so the error compounds rather than cancels.

### Published rates

Per <https://api-docs.deepseek.com/quick_start/pricing/> (accessed 2026-09-01), off-peak, USD per 1M tokens:

| model | cache hit | cache miss | output |
|---|---|---|---|
| `deepseek-v4-pro` | $0.022 | $0.66 | $1.98 |
| `deepseek-v4-flash` | $0.007 | $0.22 | $0.66 |

`deepseek-v4-flash-vision-exp` is priced as Flash, per the existing note in its file.

### Verified against real billing

I repriced 30 days of my own DeepSeek traffic (token counts from local session databases) with these rates and compared against the DeepSeek console's own daily spend:

| day | repriced with these rates | DeepSeek console |
|---|---|---|
| 2026-08-31 | $3.4194 | $3.42 |
| 2026-09-01 | $0.1920 | $0.19 |

To the cent, on two independent days. The current catalog rates come out **~3.7× under**.

### Corroborated inside this repo

Three other hosts of the same models already price as clean, *uniform* multiples of the published card, while the first-party entry's ratios are non-uniform — the signature of a stale entry rather than a different pricing basis:

| entry | input | output | cache_read |
|---|---|---|---|
| `opencode-go` V4 Pro | ×1.000 | ×1.000 | ×1.000 |
| `above` V4 Pro / Flash | ×1.100 | ×1.100 | ×1.100 |
| `aihubmix` V4 Pro | ×1.048 | ×1.048 | ×1.048 |
| **`deepseek` V4 Pro (current)** | **×0.659** | **×0.439** | **×0.165** |

The current Pro numbers trace to a May 2026 edit that divided the then-current values by 4; Flash still carries what look like V3-era rates ($0.14 / $0.28).

### On peak pricing

DeepSeek charges exactly double during peak (01:00–04:00 and 06:00–10:00 UTC, Mon–Fri). models.dev has no time-of-day pricing concept, so I've used **off-peak**, which covers ~79% of hours and matches what `opencode-go` already lists. Each file gets a header comment stating the window and the doubling. Happy to switch to peak, or to a blended figure, if maintainers prefer a different convention — worth settling once, since the same question will recur.

`bun validate` passes; the generated catalog carries the new values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
