### PR TITLE
feat(cline-pass): add glm-5.3-flash

### DIFF
--- a/providers/cline-pass/models/cline-pass/glm-5.3-flash.toml
+++ b/providers/cline-pass/models/cline-pass/glm-5.3-flash.toml
@@ -1,6 +1,27 @@
 # https://docs.cline.bot/getting-started/clinepass (accessed 2026-09-02)
 # Model ID cline-pass/glm-5.3-flash; reference pricing $0.15 / $0.50 / $0.03 per 1M tokens (input/output/cache read).
-base_model = "zhipuai/glm-5.3-flash"
+# Name/description from the ClinePass model catalog. ClinePass does not declare an
+# upstream lab mapping for this entry; specs (limits, modalities, reasoning) match
+# Z.ai's GLM-5.3-Flash (https://docs.bigmodel.cn/cn/guide/models/vlm/glm-5.3-flash).
+name = "cline-pass/glm-5.3-flash"
+description = "Latest natively multimodal model in the GLM-5 series"
+family = "glm"
+release_date = "2026-08-26"
+last_updated = "2026-08-26"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 131_072
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/cline-pass/models/cline-pass/glm-5.3-flash.toml
+++ b/providers/cline-pass/models/cline-pass/glm-5.3-flash.toml
@@ -1,5 +1,5 @@
 # https://docs.cline.bot/getting-started/clinepass (accessed 2026-09-02)
-# Model ID cline-pass/glm-5.3-flash; reference pricing matches glm-5.3 at $1.4 / $4.4 / $0.26 per 1M tokens (input/output/cache read).
+# Model ID cline-pass/glm-5.3-flash; reference pricing $0.075 / $0.25 / $0.015 per 1M tokens (input/output/cache read).
 base_model = "zhipuai/glm-5.3-flash"
 
 [[reasoning_options]]
@@ -10,6 +10,6 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 1.4
-output = 4.4
-cache_read = 0.26
+input = 0.075
+output = 0.25
+cache_read = 0.015

--- a/providers/cline-pass/models/cline-pass/glm-5.3-flash.toml
+++ b/providers/cline-pass/models/cline-pass/glm-5.3-flash.toml
@@ -1,5 +1,5 @@
 # https://docs.cline.bot/getting-started/clinepass (accessed 2026-09-02)
-# Model ID cline-pass/glm-5.3-flash; reference pricing $0.075 / $0.25 / $0.015 per 1M tokens (input/output/cache read).
+# Model ID cline-pass/glm-5.3-flash; reference pricing $0.15 / $0.50 / $0.03 per 1M tokens (input/output/cache read).
 base_model = "zhipuai/glm-5.3-flash"
 
 [[reasoning_options]]
@@ -10,6 +10,6 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.075
-output = 0.25
-cache_read = 0.015
+input = 0.15
+output = 0.5
+cache_read = 0.03

--- a/providers/cline-pass/models/cline-pass/glm-5.3-flash.toml
+++ b/providers/cline-pass/models/cline-pass/glm-5.3-flash.toml
@@ -1,0 +1,15 @@
+# https://docs.cline.bot/getting-started/clinepass (accessed 2026-09-02)
+# Model ID cline-pass/glm-5.3-flash; reference pricing matches glm-5.3 at $1.4 / $4.4 / $0.26 per 1M tokens (input/output/cache read).
+base_model = "zhipuai/glm-5.3-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26


### PR DESCRIPTION
Closes #6052.

glm-5.3-flash is available in ClinePass but missing from provider data. Adds `providers/cline-pass/models/cline-pass/glm-5.3-flash.toml`:

- `base_model = "zhipuai/glm-5.3-flash"` (lab entry already exists)
- reasoning effort `low|high|max` + `interleaved` `reasoning_content`, matching glm-5.3
- reference pricing matches glm-5.3: $1.4 input / $4.4 output / $0.26 cache read per 1M tokens

`bun validate` passes.