### PR TITLE
Neon: correct [cost] on six models

### DIFF
--- a/providers/neon/models/gpt-5-6-luna.toml
+++ b/providers/neon/models/gpt-5-6-luna.toml
@@ -2,15 +2,17 @@ base_model = "openai/gpt-5.6-luna"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 1
-output = 6
-cache_read = 0.1
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 2
-output = 9
-cache_read = 0.2
+input = 0.4
+output = 1.8
+cache_read = 0.04
+cache_write = 0.5
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/neon/models/gpt-5-6-sol.toml
+++ b/providers/neon/models/gpt-5-6-sol.toml
@@ -5,12 +5,14 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 input = 5
 output = 30
 cache_read = 0.5
+cache_write = 6.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
 input = 10
 output = 45
 cache_read = 1
+cache_write = 12.5
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/neon/models/gpt-5-6-terra.toml
+++ b/providers/neon/models/gpt-5-6-terra.toml
@@ -2,15 +2,17 @@ base_model = "openai/gpt-5.6-terra"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 2.5
-output = 15
-cache_read = 0.25
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 5
-output = 22.5
-cache_read = 0.5
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5
 
 [modalities]
 input = ["text", "image", "pdf"]

--- a/providers/neon/models/gpt-oss-120b.toml
+++ b/providers/neon/models/gpt-oss-120b.toml
@@ -2,8 +2,8 @@ base_model = "openai/gpt-oss-120b"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
-input = 0.072
-output = 0.28
+input = 0.15
+output = 0.6
 
 # The Neon gateway caps output below the upstream entry: `max_tokens` one above
 # 25_000 returns 400. Measured at the boundary 2026-08-08. `context` is inherited.

--- a/providers/neon/models/gpt-oss-20b.toml
+++ b/providers/neon/models/gpt-oss-20b.toml
@@ -12,8 +12,8 @@ open_weights = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
-input = 0.05
-output = 0.20
+input = 0.07
+output = 0.3
 
 [limit]
 context = 131_072

--- a/providers/neon/models/inkling.toml
+++ b/providers/neon/models/inkling.toml
@@ -8,6 +8,11 @@ reasoning_options = [
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "max"] }, # API: {"reasoning_effort": <v>}
 ]
 
+[cost]
+input = 1
+output = 4.05
+cache_read = 0.17
+
 # The Neon gateway caps output below the upstream entry: `max_tokens` one above
 # 65_536 returns 400. Measured at the boundary 2026-08-08. `context` is inherited.
 [limit]


### PR DESCRIPTION
Six `neon` models had `[cost]` values that drifted from what the gateway serves. This brings
them back in line with Neon's published catalog at <https://neon.com/models.json>, the source
of truth; after this change their `[cost]` blocks match it exactly.

| Model | Correction |
| --- | --- |
| `gpt-5-6-luna` | input 1→0.2, output 6→1.2, cache_read 0.1→0.02, add cache_write 0.25; tier input 2→0.4, output 9→1.8, cache_read 0.2→0.04, add cache_write 0.5 |
| `gpt-5-6-sol` | add cache_write 6.25; tier add cache_write 12.5 |
| `gpt-5-6-terra` | input 2.5→2, output 15→12, cache_read 0.25→0.2, add cache_write 2.5; tier input 5→4, output 22.5→18, cache_read 0.5→0.4, add cache_write 5 |
| `gpt-oss-120b` | input 0.072→0.15, output 0.28→0.6 |
| `gpt-oss-20b` | input 0.05→0.07, output 0.20→0.3 |
| `inkling` | add missing `[cost]`: input 1, output 4.05, cache_read 0.17 |