### PR TITLE
fix(kimi-for-coding): update doc URL to models.html

### DIFF
--- a/providers/kimi-for-coding/provider.toml
+++ b/providers/kimi-for-coding/provider.toml
@@ -6,5 +6,5 @@
 name = "Kimi For Coding"
 env = ["KIMI_API_KEY"]
 npm = "@ai-sdk/anthropic"
-doc = "https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html"
+doc = "https://www.kimi.com/code/docs/en/kimi-code/models.html"
 api = "https://api.kimi.com/coding/v1"


### PR DESCRIPTION
The previous `doc` URL for `kimi-for-coding` (`/code/docs/en/third-party-tools/other-coding-agents.html`) now returns 404. Replaced with the current Kimi Code models documentation page (https://www.kimi.com/code/docs/en/kimi-code/models.html).