### PR TITLE
deprecate old gpt chat models

### DIFF
--- a/providers/openai/models/gpt-5.2-chat-latest.toml
+++ b/providers/openai/models/gpt-5.2-chat-latest.toml
@@ -11,6 +11,7 @@ knowledge = "2025-08-31"
 tool_call = true
 structured_output = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 1.75

--- a/providers/openai/models/gpt-5.3-chat-latest.toml
+++ b/providers/openai/models/gpt-5.3-chat-latest.toml
@@ -10,6 +10,7 @@ knowledge = "2025-08-31"
 tool_call = true
 structured_output = true
 open_weights = false
+status = "deprecated"
 
 [cost]
 input = 1.75


### PR DESCRIPTION
these models are deprecated at the openai level and no longer work.

opencode still defaults to `gpt-5.3-chat-latest` when an openai key is present, so the default experience is broken (see https://github.com/anomalyco/opencode/issues/46425).

this change sets them as deprecated in the catalog so that problem goes away and the default opencode picks will work with a more recent model