### PR TITLE
fix(fireworks-ai): update GLM 5.3 Flash cache pricing

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
@@ -1,4 +1,4 @@
-# Pricing: https://fireworks.ai/models/fireworks/glm-5p3-flash (accessed 2026-08-29)
+# Pricing: https://fireworks.ai/models/fireworks/glm-5p3-flash (accessed 2026-09-02)
 # Released on Fireworks Serverless API 2026-08-26.
 # Thinking-only model: reasoning cannot be disabled. Use the same two effective
 # tiers as Fireworks GLM 5.3: low/medium collapse to high; max/xhigh select max.
@@ -16,4 +16,4 @@ field = "reasoning_content"
 [cost]
 input = 0.15
 output = 0.50
-cache_read = 0.029
+cache_read = 0.03


### PR DESCRIPTION
Adjust fireworks pricing for GLM 5.3 Flash to $0.03 for cache reads, from what it was originally listed as $0.029.