### PR TITLE
fix(kimi-for-coding): inherit attachment support for K3 models

### DIFF
--- a/providers/kimi-for-coding/models/k3-256k.toml
+++ b/providers/kimi-for-coding/models/k3-256k.toml
@@ -6,7 +6,6 @@
 base_model = "moonshotai/kimi-k3"
 name = "Kimi K3-256K"
 description = "256K-context version of Kimi K3, reducing token consumption for shorter coding sessions"
-attachment = false
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/kimi-for-coding/models/k3.toml
+++ b/providers/kimi-for-coding/models/k3.toml
@@ -3,7 +3,6 @@
 #   output_config.effort = "low" | "high" | "max"
 # Cost is zeroed per this provider's subscription convention.
 base_model = "moonshotai/kimi-k3"
-attachment = false
 
 [[reasoning_options]]
 type = "toggle"


### PR DESCRIPTION
## What

Drops the stale `attachment = false` override from `k3.toml` and `k3-256k.toml` under `providers/kimi-for-coding/`, letting the flag inherit `true` from the `moonshotai/kimi-k3` lab base (per the repo's override-only rule for `base_model` files).

## Why

Both models accept image input on the Kimi For Coding endpoint, and `k3` also accepts video. This is reflected in Kimi Code's own subscription model catalog (the OAuth-managed provider in the Kimi Code CLI), which lists:

- `k3`: `image_in`, `video_in`
- `k3-256k`: `image_in` (no video)

The TOML files already declare matching `[modalities]` — `k3` inherits `text/image/video` input from the lab base, and `k3-256k` declares `text/image` with a header comment noting "accepts no video input (image only)". The `attachment = false` override contradicted those modalities and makes the models unusable for image attach flows in tools that gate on the flag.

Same class of fix as #5793 (align attachment flag with modalities).

## Validation

`bun validate` passes.
