### PR TITLE
feat(google): add Gemini 3.8 Flash

### DIFF
--- a/models/google/gemini-3.8-flash.toml
+++ b/models/google/gemini-3.8-flash.toml
@@ -1,0 +1,22 @@
+# Sources:
+# - https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
+# - https://ai.google.dev/gemini-api/docs/latest-model
+name = "Gemini 3.8 Flash"
+description = "Google's most intelligent Flash model, engineered for long-horizon software engineering, autonomous agents, and complex enterprise workflows"
+family = "gemini-flash"
+release_date = "2026-09-02"
+last_updated = "2026-09-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio", "pdf"]
+output = ["text"]

--- a/providers/google-vertex/models/gemini-3.8-flash.toml
+++ b/providers/google-vertex/models/gemini-3.8-flash.toml
@@ -1,0 +1,11 @@
+# Sources:
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+# - https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
+base_model = "google/gemini-3.8-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+input_audio = 0.75

--- a/providers/google/models/gemini-3.8-flash.toml
+++ b/providers/google/models/gemini-3.8-flash.toml
@@ -1,0 +1,14 @@
+# Sources:
+# - https://ai.google.dev/gemini-api/docs/pricing
+# - https://ai.google.dev/gemini-api/docs/latest-model
+base_model = "google/gemini-3.8-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+input_audio = 0.75


### PR DESCRIPTION
## Summary
- add Gemini 3.8 Flash base metadata
- add Google AI Studio pricing and reasoning controls
- add Google Vertex pricing and reasoning controls

## Sources
- https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
- https://ai.google.dev/gemini-api/docs/pricing
- https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing