### PR TITLE
sync(google): add Gemini 3.8 Flash

### DIFF
--- a/models/google/gemini-3.8-flash.toml
+++ b/models/google/gemini-3.8-flash.toml
@@ -1,0 +1,64 @@
+name = "Gemini 3.8 Flash"
+description = "Most intelligent Gemini Flash model for long-horizon software engineering, autonomous agents, and complex enterprise workflows"
+family = "gemini-flash"
+release_date = "2026-09-02"
+last_updated = "2026-09-02"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+knowledge = "2026-03"
+open_weights = false
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text", "image", "video", "audio", "pdf"]
+output = ["text"]
+
+[[benchmarks]]
+name = "Terminal-Bench"
+score = 90.8
+metric = "accuracy"
+version = "2.1"
+source = "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/guides/gemini-3-8-flash"
+date = "2026-09-02"
+
+[[benchmarks]]
+name = "SWE-Bench Pro"
+score = 61.6
+metric = "resolve rate"
+source = "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/guides/gemini-3-8-flash"
+date = "2026-09-02"
+
+[[benchmarks]]
+name = "SWE-Atlas"
+score = 51.9
+metric = "accuracy"
+source = "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/guides/gemini-3-8-flash"
+date = "2026-09-02"
+
+[[benchmarks]]
+name = "GDP.pdf"
+score = 35.0
+metric = "accuracy"
+source = "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/guides/gemini-3-8-flash"
+date = "2026-09-02"
+
+[[benchmarks]]
+name = "CharXiv"
+score = 86.2
+metric = "accuracy"
+variant = "Multimodal"
+source = "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/guides/gemini-3-8-flash"
+date = "2026-09-02"
+
+[[benchmarks]]
+name = "HLE-Verified"
+score = 54.9
+metric = "accuracy"
+source = "https://blog.google/innovation-and-ai/models-and-research/gemini-models/3-8-flash-and-3-8-flash-cyber/"
+date = "2026-09-02"

--- a/providers/google-vertex/models/gemini-3.8-flash.toml
+++ b/providers/google-vertex/models/gemini-3.8-flash.toml
@@ -1,0 +1,14 @@
+# Sources:
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+# - https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-8-flash
+# - https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/guides/gemini-3-8-flash
+# Introductory Standard Global pricing applies through 2026-12-31. The published
+# 2027 rates are $1.50 input, $7.50 output, and $0.15 cache read.
+base_model = "google/gemini-3.8-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+input_audio = 0.75

--- a/providers/google/models/gemini-3.8-flash.toml
+++ b/providers/google/models/gemini-3.8-flash.toml
@@ -1,0 +1,17 @@
+# Sources:
+# - https://blog.google/innovation-and-ai/models-and-research/gemini-models/3-8-flash-and-3-8-flash-cyber/
+# - https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
+# - https://ai.google.dev/gemini-api/docs/pricing#gemini-3.8-flash
+# Introductory Standard pricing applies through 2026-12-31. The published
+# 2027 rates are $1.50 input, $7.50 output, and $0.15 cache read.
+base_model = "google/gemini-3.8-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.075
+input_audio = 0.75


### PR DESCRIPTION
Adds Gemini 3.8 Flash metadata for the Google and Google Vertex providers.

Changes:
- add `models/google/gemini-3.8-flash.toml`
- add `providers/google/models/gemini-3.8-flash.toml`
- add `providers/google-vertex/models/gemini-3.8-flash.toml`

Validation:
- `bun validate`: exit 0
- generated catalog contains `gemini-3.8-flash` on the expected provider surfaces
- working tree was clean before push

The metadata and source links were reviewed to avoid carrying over Gemini 3.7-specific URLs or benchmark data.