### PR TITLE
feat: add Lyceum provider

### DIFF
--- a/models/alibaba/qwen3-30b-a3b-instruct-2507.toml
+++ b/models/alibaba/qwen3-30b-a3b-instruct-2507.toml
@@ -1,0 +1,21 @@
+# https://huggingface.co/Qwen/Qwen3-30B-A3B-Instruct-2507 (accessed 2026-09-02)
+name = "Qwen3 30B-A3B Instruct 2507"
+description = "Qwen3 Mixture-of-Experts instruction model for multilingual chat, coding, and tool use"
+family = "qwen"
+release_date = "2025-07-29"
+last_updated = "2025-07-29"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+license = "apache-2.0"
+
+[limit]
+context = 262_144
+output = 16_384
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/alibaba/qwen3-embedding-8b.toml
+++ b/models/alibaba/qwen3-embedding-8b.toml
@@ -1,0 +1,20 @@
+# https://huggingface.co/Qwen/Qwen3-Embedding-8B (accessed 2026-09-02)
+name = "Qwen3 Embedding 8B"
+description = "Text embedding model for semantic search, retrieval, clustering, and reranking"
+family = "text-embedding"
+release_date = "2025-06-05"
+last_updated = "2025-06-05"
+attachment = false
+reasoning = false
+temperature = false
+tool_call = false
+open_weights = true
+license = "apache-2.0"
+
+[limit]
+context = 32_768
+output = 0
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/google/gemma-3-27b-it.toml
+++ b/models/google/gemma-3-27b-it.toml
@@ -1,0 +1,24 @@
+# Gemma 3 has no native function calling: the served endpoint accepts a tools
+# array but the model answers in prose instead of emitting tool_calls.
+# https://ai.google.dev/gemma/docs/core/model_card_3 (accessed 2026-09-02)
+name = "Gemma 3 27B IT"
+description = "Open multimodal Gemma instruction model for efficient chat, vision, and self-hosted deployments"
+family = "gemma"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+structured_output = true
+knowledge = "2024-08"
+open_weights = true
+license = "gemma"
+
+[limit]
+context = 131_072
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/nousresearch/hermes-4-405b.toml
+++ b/models/nousresearch/hermes-4-405b.toml
@@ -1,0 +1,21 @@
+# https://hermes4.nousresearch.com (accessed 2026-09-02)
+name = "Hermes 4 405B"
+description = "Hybrid reasoning model from Nous Research, built on Llama 3.1 405B for deliberate analysis, math, code, and tool use"
+family = "hermes"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+license = "llama3.1"
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/nousresearch/hermes-4-70b.toml
+++ b/models/nousresearch/hermes-4-70b.toml
@@ -1,0 +1,21 @@
+# https://hermes4.nousresearch.com (accessed 2026-09-02)
+name = "Hermes 4 70B"
+description = "Hybrid reasoning model from Nous Research, built on Llama 3.1 70B for deliberate analysis, math, code, and tool use"
+family = "hermes"
+release_date = "2025-08-26"
+last_updated = "2025-08-26"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+license = "llama3.1"
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/nvidia/cosmos3-super-reasoner.toml
+++ b/models/nvidia/cosmos3-super-reasoner.toml
@@ -1,0 +1,22 @@
+# Reasoning tower of NVIDIA Cosmos 3 Super, a 64B two-tower Mixture-of-Transformers
+# built on the Qwen3-VL 32B architecture.
+# https://developer.nvidia.com/blog/develop-physical-ai-reasoning-world-and-action-models-with-nvidia-cosmos-3/
+# (accessed 2026-09-02)
+name = "Cosmos3 Super Reasoner"
+description = "Physical-AI reasoning model for spatial understanding, multi-agent planning, and vision grounding"
+release_date = "2026-06"
+last_updated = "2026-06"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[limit]
+context = 256_000
+output = 256_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/openbmb/minicpm-v-4_5.toml
+++ b/models/openbmb/minicpm-v-4_5.toml
@@ -1,0 +1,20 @@
+# 8.7B vision-language model with controllable hybrid fast/deep thinking.
+# https://huggingface.co/openbmb/MiniCPM-V-4_5 (accessed 2026-09-02)
+name = "MiniCPM-V 4.5"
+description = "Compact vision-language model for OCR, document parsing, and video understanding"
+release_date = "2025-08"
+last_updated = "2025-09"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = false
+open_weights = true
+license = "apache-2.0"
+
+[limit]
+context = 32_768
+output = 32_768
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/lyceum/logo.svg
+++ b/providers/lyceum/logo.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="currentColor">
+  <!-- Central circle -->
+  <circle cx="50" cy="50" r="6" fill="currentColor"/>
+
+  <!-- Right horizontal ray (longest) - tapered teardrop -->
+  <path d="M 62,48.5 L 94,46 A 4,4 0 0 1 94,54 L 62,51.5 A 1.5,1.5 0 0 1 62,48.5 Z" fill="currentColor"/>
+
+  <!-- Left horizontal ray (longest) -->
+  <path d="M 38,51.5 L 6,54 A 4,4 0 0 1 6,46 L 38,48.5 A 1.5,1.5 0 0 1 38,51.5 Z" fill="currentColor"/>
+
+  <!-- Top vertical ray (medium) -->
+  <path d="M 51.5,38 L 54,10 A 4,4 0 0 0 46,10 L 48.5,38 A 1.5,1.5 0 0 0 51.5,38 Z" fill="currentColor"/>
+
+  <!-- Bottom vertical ray (medium) -->
+  <path d="M 48.5,62 L 46,90 A 4,4 0 0 0 54,90 L 51.5,62 A 1.5,1.5 0 0 0 48.5,62 Z" fill="currentColor"/>
+
+  <!-- Top-right diagonal ray (shortest) - tapered -->
+  <path d="M 57,41 L 72,23 A 3,3 0 0 1 78,29 L 60,44 A 1.5,1.5 0 0 1 57,41 Z" fill="currentColor"/>
+
+  <!-- Top-left diagonal ray (shortest) - tapered -->
+  <path d="M 43,41 L 28,23 A 3,3 0 0 0 22,29 L 40,44 A 1.5,1.5 0 0 0 43,41 Z" fill="currentColor"/>
+
+  <!-- Bottom-right diagonal ray (shortest) - tapered -->
+  <path d="M 57,59 L 72,77 A 3,3 0 0 0 78,71 L 60,56 A 1.5,1.5 0 0 0 57,59 Z" fill="currentColor"/>
+
+  <!-- Bottom-left diagonal ray (shortest) - tapered -->
+  <path d="M 43,59 L 28,77 A 3,3 0 0 1 22,71 L 40,56 A 1.5,1.5 0 0 1 43,59 Z" fill="currentColor"/>
+</svg>

--- a/providers/lyceum/models/deepseek/deepseek-v4-flash-0731.toml
+++ b/providers/lyceum/models/deepseek/deepseek-v4-flash-0731.toml
@@ -1,0 +1,14 @@
+# Effort: reasoning_effort = none|low|high|max; none disables thinking.
+# The unlisted values are accepted but collapse onto these, as on DeepSeek's own API.
+base_model = "deepseek/deepseek-v4-flash-0731"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.25
+output = 0.3
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/lyceum/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,12 @@
+# Effort: reasoning_effort = none|high|max; none disables thinking.
+# low and medium map to high upstream, and minimal skips thinking like none.
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
+interleaved = true
+
+[cost]
+input = 1.75
+output = 3.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/google/gemma-3-27b-it.toml
+++ b/providers/lyceum/models/google/gemma-3-27b-it.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemma-3-27b-it"
+
+[cost]
+input = 0.1
+output = 0.3

--- a/providers/lyceum/models/lyceum/complex.toml
+++ b/providers/lyceum/models/lyceum/complex.toml
@@ -1,0 +1,18 @@
+# Router alias resolved server-side to minimax/minimax-m3; controls and price are its own.
+# No caller control: reasoning_effort, enable_thinking, thinking, thinking.type,
+# reasoning.enabled and chat_template_kwargs.enable_thinking all leave the
+# reasoning on.
+base_model = "minimax/MiniMax-M3"
+name = "Lyceum Complex"
+description = "Routing alias that Lyceum resolves to minimax/minimax-m3"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.4
+output = 2
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/lyceum/reasoning.toml
+++ b/providers/lyceum/models/lyceum/reasoning.toml
@@ -1,0 +1,15 @@
+# Router alias resolved server-side to z-ai/glm-5.2; controls and price are its own.
+# Effort: reasoning_effort = none|high|max; none disables thinking.
+# low and medium map to high upstream, and minimal skips thinking like none.
+base_model = "zhipuai/glm-5.2"
+name = "Lyceum Reasoning"
+description = "Routing alias that Lyceum resolves to z-ai/glm-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
+interleaved = true
+
+[cost]
+input = 1.5
+output = 4.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/lyceum/simple.toml
+++ b/providers/lyceum/models/lyceum/simple.toml
@@ -1,0 +1,13 @@
+# Router alias resolved server-side to qwen/qwen3.5-9b; controls and price are its own.
+# Toggle: reasoning_effort = none disables thinking, any other accepted value enables it.
+base_model = "alibaba/qwen3.5-9b"
+name = "Lyceum Simple"
+description = "Routing alias that Lyceum resolves to qwen/qwen3.5-9b"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.2

--- a/providers/lyceum/models/meta-llama/llama-3.3-70b-instruct.toml
+++ b/providers/lyceum/models/meta-llama/llama-3.3-70b-instruct.toml
@@ -1,0 +1,8 @@
+# The lab row carries attachment = true next to text-only modalities; this host
+# rejects an image_url content part outright, so the override is a real delta.
+base_model = "meta/llama-3.3-70b-instruct"
+attachment = false
+
+[cost]
+input = 0.13
+output = 0.4

--- a/providers/lyceum/models/minimax/minimax-m2.5.toml
+++ b/providers/lyceum/models/minimax/minimax-m2.5.toml
@@ -1,0 +1,16 @@
+# Always reasons. reasoning_effort = none is rejected, and no other wire control
+# turns it off: enable_thinking, thinking, thinking.type, reasoning.enabled and
+# chat_template_kwargs.enable_thinking all leave it on. reasoning.exclude = true
+# only hides the reasoning, which still burns the whole max_tokens budget.
+base_model = "minimax/MiniMax-M2.5"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.3
+output = 1.2
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/minimax/minimax-m3.toml
+++ b/providers/lyceum/models/minimax/minimax-m3.toml
@@ -1,0 +1,15 @@
+# No caller control: reasoning_effort, enable_thinking, thinking, thinking.type,
+# reasoning.enabled and chat_template_kwargs.enable_thinking all leave the
+# reasoning on.
+base_model = "minimax/MiniMax-M3"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.4
+output = 2
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/moonshotai/kimi-k2.6.toml
+++ b/providers/lyceum/models/moonshotai/kimi-k2.6.toml
@@ -1,0 +1,13 @@
+# Toggle: reasoning_effort = none disables thinking, any other accepted value enables it.
+base_model = "moonshotai/kimi-k2.6"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1
+output = 4
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/moonshotai/kimi-k2.7-code.toml
+++ b/providers/lyceum/models/moonshotai/kimi-k2.7-code.toml
@@ -1,0 +1,15 @@
+# No caller control: reasoning_effort, enable_thinking, thinking, thinking.type,
+# reasoning.enabled and chat_template_kwargs.enable_thinking all leave the
+# reasoning on.
+base_model = "moonshotai/kimi-k2.7-code"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.25
+output = 4.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/moonshotai/kimi-k3.toml
+++ b/providers/lyceum/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,12 @@
+# Effort: reasoning_effort = none|low|high|max; none disables thinking.
+# medium is rejected upstream; the rest collapse onto these levels.
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+interleaved = true
+
+[cost]
+input = 3
+output = 15
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/nousresearch/hermes-4-405b.toml
+++ b/providers/lyceum/models/nousresearch/hermes-4-405b.toml
@@ -1,0 +1,11 @@
+# Hybrid reasoner driven by the system prompt, not a request field: it emits
+# <think> blocks inside content, and reasoning_effort changes nothing.
+base_model = "nousresearch/hermes-4-405b"
+reasoning_options = []
+
+[cost]
+input = 1
+output = 3
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/nousresearch/hermes-4-70b.toml
+++ b/providers/lyceum/models/nousresearch/hermes-4-70b.toml
@@ -1,0 +1,11 @@
+# Hybrid reasoner driven by the system prompt, not a request field: it emits
+# <think> blocks inside content, and reasoning_effort changes nothing.
+base_model = "nousresearch/hermes-4-70b"
+reasoning_options = []
+
+[cost]
+input = 0.13
+output = 0.4
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/nvidia/cosmos3-super-reasoner.toml
+++ b/providers/lyceum/models/nvidia/cosmos3-super-reasoner.toml
@@ -1,0 +1,11 @@
+# Reasons into <think> blocks inside content when the system prompt asks for it;
+# reasoning_effort is accepted but changes nothing.
+base_model = "nvidia/cosmos3-super-reasoner"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.3
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/nvidia/llama-3_1-nemotron-ultra-253b-v1.toml
+++ b/providers/lyceum/models/nvidia/llama-3_1-nemotron-ultra-253b-v1.toml
@@ -1,0 +1,9 @@
+# Reasoning is switched by the "detailed thinking on" system prompt, not by a
+# request field: the <think> block arrives inside content and reasoning_effort
+# changes nothing.
+base_model = "nvidia/llama-3.1-nemotron-ultra-253b"
+reasoning_options = []
+
+[cost]
+input = 0.6
+output = 1.8

--- a/providers/lyceum/models/nvidia/nemotron-3-nano-omni.toml
+++ b/providers/lyceum/models/nvidia/nemotron-3-nano-omni.toml
@@ -1,0 +1,9 @@
+# Effort: reasoning_effort = none|low|medium|high|max; none disables thinking.
+# This is the set the relay peers author for the same model.
+base_model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "max"] }]
+interleaved = true
+
+[cost]
+input = 0.06
+output = 0.24

--- a/providers/lyceum/models/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/lyceum/models/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,0 +1,14 @@
+# Effort: reasoning_effort = low|medium|high. This host rejects none, so there is
+# no way to turn the reasoning off.
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.3
+output = 0.9
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/lyceum/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,14 @@
+# Effort: reasoning_effort = none|medium|high; none disables thinking.
+# This is the set the relay peers author for the same model.
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+reasoning_options = [{ type = "effort", values = ["none", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1
+output = 3
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/nvidia/nvidia-nemotron-3-nano-30b-a3b.toml
+++ b/providers/lyceum/models/nvidia/nvidia-nemotron-3-nano-30b-a3b.toml
@@ -1,0 +1,14 @@
+# Toggle: chat_template_kwargs.enable_thinking = false. reasoning_effort is
+# accepted but ignored; the template switch is the only control, and it cuts the
+# completion from 278 to 131 tokens on a fixed prompt rather than just hiding the
+# reasoning.
+base_model = "nvidia/nemotron-3-nano-30b-a3b"
+reasoning_options = [{ type = "toggle" }]
+interleaved = true
+
+[cost]
+input = 0.06
+output = 0.24
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/openai/gpt-oss-120b.toml
+++ b/providers/lyceum/models/openai/gpt-oss-120b.toml
@@ -1,0 +1,8 @@
+# Effort: reasoning_effort = low|medium|high; none and minimal are rejected.
+base_model = "openai/gpt-oss-120b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+interleaved = true
+
+[cost]
+input = 0.15
+output = 0.6

--- a/providers/lyceum/models/openbmb/minicpm-v-4_5.toml
+++ b/providers/lyceum/models/openbmb/minicpm-v-4_5.toml
@@ -1,0 +1,12 @@
+# Serving caps max_tokens at 24576 and rejects a tools array. The hybrid thinking
+# mode is not reachable here: reasoning_effort is rejected and no <think> block or
+# reasoning field ever comes back.
+base_model = "openbmb/minicpm-v-4_5"
+reasoning = false
+
+[cost]
+input = 0.66
+output = 1.11
+
+[limit]
+output = 24_576

--- a/providers/lyceum/models/qwen/qwen2.5-vl-72b-instruct.toml
+++ b/providers/lyceum/models/qwen/qwen2.5-vl-72b-instruct.toml
@@ -1,0 +1,7 @@
+# Vision confirmed end to end: it names the colour of a solid-colour test image.
+base_model = "alibaba/qwen2-5-vl-72b-instruct"
+attachment = true
+
+[cost]
+input = 0.25
+output = 0.75

--- a/providers/lyceum/models/qwen/qwen3-235b-a22b-instruct-2507.toml
+++ b/providers/lyceum/models/qwen/qwen3-235b-a22b-instruct-2507.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-235b-a22b-instruct-2507"
+
+[cost]
+input = 0.2
+output = 0.6

--- a/providers/lyceum/models/qwen/qwen3-30b-a3b-instruct-2507.toml
+++ b/providers/lyceum/models/qwen/qwen3-30b-a3b-instruct-2507.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-30b-a3b-instruct-2507"
+
+[cost]
+input = 0.1
+output = 0.3

--- a/providers/lyceum/models/qwen/qwen3-32b.toml
+++ b/providers/lyceum/models/qwen/qwen3-32b.toml
@@ -1,0 +1,8 @@
+# Reasoning is prompt-driven (Qwen's /think and /no_think convention): the <think>
+# block arrives inside content and reasoning_effort changes nothing.
+base_model = "alibaba/qwen3-32b"
+reasoning_options = []
+
+[cost]
+input = 0.1
+output = 0.3

--- a/providers/lyceum/models/qwen/qwen3-embedding-8b.toml
+++ b/providers/lyceum/models/qwen/qwen3-embedding-8b.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-embedding-8b"
+
+[cost]
+input = 0.01
+output = 0

--- a/providers/lyceum/models/qwen/qwen3-next-80b-a3b-thinking.toml
+++ b/providers/lyceum/models/qwen/qwen3-next-80b-a3b-thinking.toml
@@ -1,0 +1,10 @@
+# No caller control: reasoning_effort, enable_thinking, thinking, thinking.type,
+# reasoning.enabled and chat_template_kwargs.enable_thinking all leave the
+# reasoning on.
+base_model = "alibaba/qwen3-next-80b-a3b-thinking"
+reasoning_options = []
+interleaved = true
+
+[cost]
+input = 0.15
+output = 1.2

--- a/providers/lyceum/models/qwen/qwen3.5-397b-a17b.toml
+++ b/providers/lyceum/models/qwen/qwen3.5-397b-a17b.toml
@@ -1,0 +1,14 @@
+# Toggle: reasoning_effort = none disables thinking, any other accepted value enables it.
+# Rejects an image_url content part, so this host serves it text-only.
+base_model = "alibaba/qwen3.5-397b-a17b"
+attachment = false
+reasoning_options = [{ type = "toggle" }]
+interleaved = true
+
+[cost]
+input = 0.6
+output = 3.6
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/lyceum/models/qwen/qwen3.5-9b.toml
+++ b/providers/lyceum/models/qwen/qwen3.5-9b.toml
@@ -1,0 +1,10 @@
+# Toggle: reasoning_effort = none disables thinking, any other accepted value enables it.
+base_model = "alibaba/qwen3.5-9b"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.2

--- a/providers/lyceum/models/qwen/qwen3.8-2.4t-a95b.toml
+++ b/providers/lyceum/models/qwen/qwen3.8-2.4t-a95b.toml
@@ -1,0 +1,14 @@
+# Effort: reasoning_effort = low|medium|xhigh, matching Alibaba's own qwen3.8
+# entries. This host rejects none, so the reasoning cannot be turned off.
+base_model = "alibaba/qwen3.8-2.4t-a95b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "xhigh"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.5
+output = 6
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/qwen/qwen3.8-27b-instant.toml
+++ b/providers/lyceum/models/qwen/qwen3.8-27b-instant.toml
@@ -1,0 +1,11 @@
+# Name-encoded alias for qwen/qwen3.8-27b: Lyceum sends the request with
+# chat_template_kwargs.enable_thinking = false, so this id never reasons.
+# Same weights and price as qwen/qwen3.8-27b; it exists for clients that cannot set
+# request parameters, such as GitHub Copilot and Cursor.
+base_model = "alibaba/qwen3.8-27b"
+name = "Qwen3.8 27B (Instant)"
+reasoning = false
+
+[cost]
+input = 0.4
+output = 2.4

--- a/providers/lyceum/models/qwen/qwen3.8-27b.toml
+++ b/providers/lyceum/models/qwen/qwen3.8-27b.toml
@@ -1,0 +1,11 @@
+# Effort: reasoning_effort = none|low|medium|xhigh; none disables thinking.
+# high and max are rejected upstream, matching Alibaba's own qwen3.8 entries.
+base_model = "alibaba/qwen3.8-27b"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "xhigh"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.4
+output = 2.4

--- a/providers/lyceum/models/qwen/qwen3.8-flash-next-instant.toml
+++ b/providers/lyceum/models/qwen/qwen3.8-flash-next-instant.toml
@@ -1,0 +1,14 @@
+# Name-encoded alias for qwen/qwen3.8-flash-next: Lyceum sends the request with
+# chat_template_kwargs.enable_thinking = false, so this id never reasons.
+# Same weights and price as qwen/qwen3.8-flash-next; it exists for clients that cannot set
+# request parameters, such as GitHub Copilot and Cursor.
+base_model = "alibaba/qwen3.8-flash-next"
+name = "Qwen3.8 Flash Next (Instant)"
+reasoning = false
+
+[cost]
+input = 0.2
+output = 0.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/qwen/qwen3.8-flash-next.toml
+++ b/providers/lyceum/models/qwen/qwen3.8-flash-next.toml
@@ -1,0 +1,14 @@
+# Effort: reasoning_effort = none|low|medium|xhigh; none disables thinking.
+# high and max are rejected upstream, matching Alibaba's own qwen3.8 entries.
+base_model = "alibaba/qwen3.8-flash-next"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "xhigh"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.2
+output = 0.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/z-ai/glm-5.1.toml
+++ b/providers/lyceum/models/z-ai/glm-5.1.toml
@@ -1,0 +1,15 @@
+# Toggle: reasoning_effort = none disables thinking, any other accepted value enables it.
+# An image_url part is accepted but not actually read (it misnames a solid-colour
+# test image), so the lab's text-only modalities stand.
+base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.4
+output = 4.4
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/z-ai/glm-5.2-instant.toml
+++ b/providers/lyceum/models/z-ai/glm-5.2-instant.toml
@@ -1,0 +1,14 @@
+# Name-encoded alias for z-ai/glm-5.2: Lyceum sends the request with
+# chat_template_kwargs.enable_thinking = false, so this id never reasons.
+# Same weights and price as z-ai/glm-5.2; it exists for clients that cannot set
+# request parameters, such as GitHub Copilot and Cursor.
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 (Instant)"
+reasoning = false
+
+[cost]
+input = 1.5
+output = 4.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/z-ai/glm-5.2.toml
+++ b/providers/lyceum/models/z-ai/glm-5.2.toml
@@ -1,0 +1,12 @@
+# Effort: reasoning_effort = none|high|max; none disables thinking.
+# low and medium map to high upstream, and minimal skips thinking like none.
+base_model = "zhipuai/glm-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "high", "max"] }]
+interleaved = true
+
+[cost]
+input = 1.5
+output = 4.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/z-ai/glm-5.3-flash-instant.toml
+++ b/providers/lyceum/models/z-ai/glm-5.3-flash-instant.toml
@@ -1,0 +1,14 @@
+# Name-encoded alias for z-ai/glm-5.3-flash: Lyceum sends the request with
+# chat_template_kwargs.enable_thinking = false, so this id never reasons.
+# Same weights and price as z-ai/glm-5.3-flash; it exists for clients that cannot set
+# request parameters, such as GitHub Copilot and Cursor.
+base_model = "zhipuai/glm-5.3-flash"
+name = "GLM-5.3 Flash (Instant)"
+reasoning = false
+
+[cost]
+input = 0.2
+output = 0.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/z-ai/glm-5.3-flash.toml
+++ b/providers/lyceum/models/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,14 @@
+# Effort: reasoning_effort = none|low|high|max; none disables thinking.
+# The unlisted values are accepted but collapse onto these, as on Z.ai's own API.
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.2
+output = 0.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/z-ai/glm-5.3-instant.toml
+++ b/providers/lyceum/models/z-ai/glm-5.3-instant.toml
@@ -1,0 +1,14 @@
+# Name-encoded alias for z-ai/glm-5.3: Lyceum sends the request with
+# chat_template_kwargs.enable_thinking = false, so this id never reasons.
+# Same weights and price as z-ai/glm-5.3; it exists for clients that cannot set
+# request parameters, such as GitHub Copilot and Cursor.
+base_model = "zhipuai/glm-5.3"
+name = "GLM-5.3 (Instant)"
+reasoning = false
+
+[cost]
+input = 1.75
+output = 4.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/models/z-ai/glm-5.3.toml
+++ b/providers/lyceum/models/z-ai/glm-5.3.toml
@@ -1,0 +1,12 @@
+# Effort: reasoning_effort = none|low|high|max; none disables thinking.
+# The unlisted values are accepted but collapse onto these, as on Z.ai's own API.
+base_model = "zhipuai/glm-5.3"
+reasoning_options = [{ type = "effort", values = ["none", "low", "high", "max"] }]
+interleaved = true
+
+[cost]
+input = 1.75
+output = 4.5
+
+[limit]
+output = 65_536

--- a/providers/lyceum/provider.toml
+++ b/providers/lyceum/provider.toml
@@ -1,0 +1,12 @@
+# OpenAI-compatible surface: POST https://api.lyceum.technology/openai/v1/chat/completions,
+# GET /openai/v1/models. An Anthropic Messages surface exists at
+# https://api.lyceum.technology/anthropic/v1/messages.
+# Reasoning control is `reasoning_effort`; the accepted values differ per model
+# and are recorded on each model file. `max_tokens` is capped at 65536 for every
+# model, so every entry resolves limit.output to at most that.
+# https://docs.lyceum.technology/docs/inference/serverless (accessed 2026-09-02)
+name = "Lyceum"
+env = ["LYCEUM_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.lyceum.technology/openai/v1"
+doc = "https://docs.lyceum.technology/docs/inference/serverless"


### PR DESCRIPTION
Lyceum (https://lyceum.technology) is an EU-hosted, OpenAI-compatible inference API.
42 model ids at `https://api.lyceum.technology/openai/v1`, auth `LYCEUM_API_KEY`.

Lyceum hosts other labs' models, so every provider entry is `base_model` +
overrides. Six lab entries did not exist yet and are added under `models/`:
`nousresearch/hermes-4-{70b,405b}`, `openbmb/minicpm-v-4_5`,
`google/gemma-3-27b-it`, `nvidia/cosmos3-super-reasoner`,
`alibaba/qwen3-30b-a3b-instruct-2507`, `alibaba/qwen3-embedding-8b`.

Every provider-side value was measured against the live API on 2026-09-02, not
assumed:

- `cost`: `GET /api/v2/external/pricing?resource=serverless_inference`, USD per
  token converted to USD/MTok.
- `reasoning_options`: each `reasoning_effort` value posted to
  `/chat/completions` (3 attempts, to separate real rejections from transients).
  `none` is listed only where it demonstrably suppresses reasoning. `[]` means
  the host accepts no caller control, not that it went untested.
- `interleaved`: which response key carries the reasoning text. `true` where it
  is `reasoning`, which the schema's field enum does not cover.
- `attachment`: an `image_url` content part posted per model; text-only models
  reject it, so the signal discriminates.
- `limit.output`: the proxy rejects `max_tokens` above 65536 for every model, so
  entries resolve to at most that. Three models cap lower and were bisected:
  `openbmb/minicpm-v-4_5` 24576, `qwen/qwen2.5-vl-72b-instruct` and
  `qwen/qwen3-32b` sit under the global cap already.

Two id families are Lyceum-specific aliases, both resolved server-side and
priced identically to their target: `lyceum/{simple,complex,reasoning}` (router
aliases) and the `-instant` suffix (pins `enable_thinking = false` for clients
that cannot set request parameters).

`bun validate` passes.

Happy to supply a test key to a maintainer out of band if CI needs one.
