### PR TITLE
feat: add gitlab duo-chat-fable-5-1 model

### DIFF
--- a/providers/gitlab/models/duo-chat-fable-5-1.toml
+++ b/providers/gitlab/models/duo-chat-fable-5-1.toml
@@ -1,0 +1,9 @@
+base_model = "anthropic/claude-fable-5-1"
+name = "Agentic Chat (Claude Fable 5.1)"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
Adds the GitLab Duo agentic-chat entry for the newly released Claude Fable 5.1.

New file: `providers/gitlab/models/duo-chat-fable-5-1.toml`

- `base_model = "anthropic/claude-fable-5-1"` — inherits description, family (`claude-fable`), release/knowledge dates, modalities (`text`/`image`/`pdf` in, `text` out), `temperature = false`, and limits (context 1,000,000 / output 128,000).
- `reasoning_options` — effort levels `low`/`medium`/`high`/`xhigh`/`max`, matching the sibling `duo-chat-fable-5` entry.
- Cost is 0 across the board, as with all GitLab Duo entries (billing is via the GitLab subscription, not per token).

Upstream source of truth is GitLab's `models.yml` (`gitlab_identifier: claude_fable_5_1`, `params.model: claude-fable-5-1`, `max_context_tokens: 1_000_000`, `params.max_tokens: 128_000`).

`bun validate` passes and the model resolves as expected in the generated output.