### PR TITLE
fix(tencent): correct Hy3 input and output limits

### DIFF
--- a/models/tencent/hy3.toml
+++ b/models/tencent/hy3.toml
@@ -1,3 +1,5 @@
+# Tencent documents a 192K maximum input for Hy3.
+# https://cloud.tencent.com/document/product/1823/130051
 name = "Hy3"
 description = "Tencent Hy reasoning model for coding, instruction following, and agent tasks"
 family = "Hy"
@@ -11,6 +13,7 @@ open_weights = true
 
 [limit]
 context = 256_000
+input = 192_000
 output = 64_000
 
 [modalities]

--- a/models/tencent/hy3.toml
+++ b/models/tencent/hy3.toml
@@ -1,4 +1,3 @@
-# Tencent documents a 192K maximum input and 128K maximum output for Hy3.
 # https://cloud.tencent.com/document/product/1823/130051
 name = "Hy3"
 description = "Tencent Hy reasoning model for coding, instruction following, and agent tasks"

--- a/models/tencent/hy3.toml
+++ b/models/tencent/hy3.toml
@@ -1,4 +1,4 @@
-# Tencent documents a 192K maximum input for Hy3.
+# Tencent documents a 192K maximum input and 128K maximum output for Hy3.
 # https://cloud.tencent.com/document/product/1823/130051
 name = "Hy3"
 description = "Tencent Hy reasoning model for coding, instruction following, and agent tasks"
@@ -14,7 +14,7 @@ open_weights = true
 [limit]
 context = 256_000
 input = 192_000
-output = 64_000
+output = 128_000
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
## Summary

- Add `limit.input = 192_000` to the shared `tencent/hy3` base model.
- Correct `limit.output` from `64_000` to `128_000`, retaining the existing `256_000` context window.
- Add a source comment linking Tencent's official model list, which documents 256K context, 192K maximum input, and 128K maximum output for Hy3.

The missing input ceiling lets clients using inherited metadata, including OpenCode Go, budget against the larger context window instead of the input limit. This change updates the shared base model; explicit provider overrides remain intact.

Related: anomalyco/opencode#45168, anomalyco/opencode#46137.

## Source

- [Tencent TokenHub model list](https://cloud.tencent.com/document/product/1823/130051), updated September 1, 2026.

## Validation

- `bun validate` passes.
- Focused schema and base-model inheritance tests: 11 pass.
- Compared generated catalogs before and after: only limits on 20 Hy3 provider entries change; explicit input/output overrides and all other model fields are preserved.
- Broader schema/generation test run: 18 pass, 1 unrelated failure in `repository open-weight model metadata includes weights links`. All 39 models reported by that check are unchanged from the base commit.
