### PR TITLE
feat: add Pareto Inference (Pass)

### DIFF
--- a/providers/pareto/logo.svg
+++ b/providers/pareto/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="35 29 180 180">
+  <path d="M48 60 C113 60 174 93 194 194 H48 Z" fill="currentColor" fill-opacity="0.22" />
+  <path d="M52 60 C113 60 174 93 194 190" fill="none" stroke="currentColor" stroke-width="13" stroke-linecap="butt" />
+  <path d="M48 44 V194 H202" fill="none" stroke="currentColor" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/providers/pareto/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/pareto/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,22 @@
+# Paid Pareto Pass: $3/week, up to $20/day of usage; no additional token charges.
+# https://docs.paretoinference.com/pareto-pass
+# Effort: reasoning_effort = high|xhigh; Pareto forwards no reasoning toggle.
+# Effort levels and limits follow OpenRouter (accessed 2026-09-02).
+# https://openrouter.ai/api/v1/models
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "xhigh"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_048_576

--- a/providers/pareto/models/z-ai/glm-5.3-flash.toml
+++ b/providers/pareto/models/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,25 @@
+# Paid Pareto Pass: $3/week, up to $20/day of usage; no additional token charges.
+# https://docs.paretoinference.com/pareto-pass
+# Effort: reasoning_effort = low|high|max; Pareto forwards no reasoning toggle.
+# Limits and input modalities follow OpenRouter (accessed 2026-09-02).
+# https://openrouter.ai/api/v1/models
+base_model = "zhipuai/glm-5.3-flash"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_310_720
+
+[modalities]
+input = ["text", "image", "video"]

--- a/providers/pareto/models/z-ai/glm-5.3.toml
+++ b/providers/pareto/models/z-ai/glm-5.3.toml
@@ -1,0 +1,22 @@
+# Paid Pareto Pass: $3/week, up to $20/day of usage; no additional token charges.
+# https://docs.paretoinference.com/pareto-pass
+# Effort: reasoning_effort = low|high|max; Pareto forwards no reasoning toggle.
+# Limits follow the upstream OpenRouter catalog (accessed 2026-09-02).
+# https://openrouter.ai/api/v1/models
+base_model = "zhipuai/glm-5.3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0
+
+[limit]
+context = 1_310_720

--- a/providers/pareto/provider.toml
+++ b/providers/pareto/provider.toml
@@ -1,0 +1,8 @@
+# Pareto Pass is a paid $3/week subscription with up to $20/day of usage.
+# Zero token costs below mean no additional charge within the Pass allowance,
+# not free access. https://docs.paretoinference.com/pareto-pass
+name = "Pareto Inference (Pass)"
+npm = "@ai-sdk/openai-compatible"
+env = ["PARETO_API_KEY"]
+api = "https://api.paretoinference.com/v1"
+doc = "https://docs.paretoinference.com/pareto-pass"


### PR DESCRIPTION
## Summary

Add **Pareto Inference (Pass)** with three models:

- `z-ai/glm-5.3`
- `z-ai/glm-5.3-flash`
- `deepseek/deepseek-v4-flash`

I work on Pareto Inference. The provider uses the OpenAI-compatible Chat Completions endpoint at `https://api.paretoinference.com/v1`, with `PARETO_API_KEY` for authentication. The model files inherit existing base models. This change adds only one provider file, one logo, and three model files.

## Subscription pricing

This is **paid Pass access, not free access**. Pareto Pass costs **$3/week** and includes up to **$20 of model usage per day**. There are no additional per-token charges within that allowance. The zero cost fields follow the existing `zai-coding-plan` convention. The provider name, documentation link, and source comments identify the paid plan.

This entry does not represent legacy keys or a separate pay-as-you-go product. If a different catalog convention is preferred for subscription providers, I can adjust it.

## Sources

- [Pass price, daily allowance, and key setup](https://docs.paretoinference.com/pareto-pass)
- [Public model IDs](https://api.paretoinference.com/v1/models)
- [API reference](https://docs.paretoinference.com/api-reference)
- [OpenCode setup](https://docs.paretoinference.com/sdk-examples#opencode)
- [OpenRouter catalog](https://openrouter.ai/api/v1/models), checked September 2, 2026, for provider context limits and Flash input modalities. Pareto routes these IDs through OpenRouter.

Pareto accepts `reasoning_effort`. This entry does not advertise OpenRouter's separate `reasoning.enabled` toggle. GLM exposes low/high/max; DeepSeek exposes high/xhigh. Pareto maps max to OpenRouter's xhigh.

## Verification

- `bun validate` passed.
- Web catalog build passed.
- SDK generation, type checking, and all 23 SDK tests passed.
- Two local catalog/logo checks passed with 71 assertions. The generated-provider check failed as expected before this addition.
- Real **OpenCode 1.18.27** loaded the generated catalog through `OPENCODE_MODELS_PATH`, with no manual provider URL or adapter override. Each of the three models completed one permitted local tool call and its response continuation, using its high-effort variant.
- All eight advertised reasoning-effort values returned HTTP 200 on short synthetic requests.
- Test keys had a $0.50 budget, a 15-minute expiry, and one concurrent request. Both keys used during verification were revoked and subsequent requests were rejected.

The OpenCode tests used a 4,096-output-token cap. The effort probes used a 128-output-token cap. Maximum context/output lengths and image/video inputs were not live-tested; those metadata values follow the cited upstream catalog and existing base models.
