### PR TITLE
Add GLM-5.3, GLM-5.3-Flash, and Qwen3.8-Flash to SCNet Token Plan

### DIFF
--- a/providers/scnet-token-plan/models/GLM-5.3-Flash.toml
+++ b/providers/scnet-token-plan/models/GLM-5.3-Flash.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/scnet-token-plan/models/GLM-5.3.toml
+++ b/providers/scnet-token-plan/models/GLM-5.3.toml
@@ -1,0 +1,10 @@
+base_model = "zhipuai/glm-5.3"
+reasoning_options = []
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/scnet-token-plan/models/Qwen3.8-Flash.toml
+++ b/providers/scnet-token-plan/models/Qwen3.8-Flash.toml
@@ -1,0 +1,13 @@
+# Toggle: enable_thinking = true|false
+# Effort: reasoning_effort only applies to DeepSeek-V4 series (high|max); not documented for Qwen3 series.
+# https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/api/chat.html (accessed 2026-09-01)
+base_model = "alibaba/qwen3.8-flash"
+reasoning_options = [{ type = "toggle" }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0
+output = 0
+cache_read = 0


### PR DESCRIPTION
SCNet has added new models to its Token Plan subscription. The models are now available in the post-subscription console view (model list + deduction multiplier table), and are confirmed working against the SCNet API (https://api.scnet.cn/api/llm/v1). All three are missing from the scnet-token-plan catalog.

Note on the docs page: the "可用模型" (available models) table at https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/plans/token-plan.html#可用模型 has not been updated yet, but the 综合扣减倍率 (deduction multiplier) table on the same page already lists both GLM-5.3-Flash (0.15) and Qwen3.8-Flash (0.14), confirming availability. GLM-5.3 has been on the docs available-models list since earlier but was never added to the catalog.

Models added:
- GLM-5.3 -> zhipuai/glm-5.3
- GLM-5.3-Flash -> zhipuai/glm-5.3-flash
- Qwen3.8-Flash -> alibaba/qwen3.8-flash

All use base_model references to the existing lab models, with zero-cost entries to match the provider's prepaid-Credits pricing. Reasoning options follow the same conventions as the existing SCNet entries (toggle where enable_thinking is documented; reasoning_effort only for DeepSeek-V4 series).

Changes:
- Add providers/scnet-token-plan/models/GLM-5.3.toml
- Add providers/scnet-token-plan/models/GLM-5.3-Flash.toml
- Add providers/scnet-token-plan/models/Qwen3.8-Flash.toml