### PR TITLE
feat: add Red Hat OpenShift AI (MaaS) provider

### DIFF
--- a/providers/rhoai-maas/logo.svg
+++ b/providers/rhoai-maas/logo.svg
@@ -1,0 +1,5 @@
+<!-- Placeholder mark using currentColor. Replace with the official Red Hat OpenShift AI asset before merge. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round">
+  <path d="M12 2.5 20.5 7v10L12 21.5 3.5 17V7L12 2.5Z" />
+  <circle cx="12" cy="12" r="3.25" fill="currentColor" stroke="none" />
+</svg>

--- a/providers/rhoai-maas/models/ibm/granite-4-h-small.toml
+++ b/providers/rhoai-maas/models/ibm/granite-4-h-small.toml
@@ -1,0 +1,1 @@
+base_model = "ibm/granite-4-h-small"

--- a/providers/rhoai-maas/provider.toml
+++ b/providers/rhoai-maas/provider.toml
@@ -1,0 +1,10 @@
+# Red Hat OpenShift AI Models-as-a-Service (MaaS) exposes an OpenAI-compatible
+# gateway that is deployed per cluster, so there is no single fixed base URL.
+# The `api` value below is a placeholder: the opencode "Red Hat OpenShift AI"
+# provider captures the real per-cluster gateway URL during `opencode auth login`
+# and overrides it at runtime (models are then discovered from `<gateway>/v1/models`).
+name = "Red Hat OpenShift AI"
+env = ["RHOAI_MAAS_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://maas.apps.example.com/v1"
+doc = "https://github.com/opendatahub-io/odh-dashboard/blob/main/packages/maas/docs/opencode-integration.md"


### PR DESCRIPTION
Adds the **Red Hat OpenShift AI** provider (`rhoai-maas`).

Red Hat OpenShift AI's Models-as-a-Service exposes an OpenAI-compatible gateway that is deployed **per cluster**, so there is no single fixed base URL. The companion opencode provider ("Red Hat OpenShift AI") captures the real gateway URL during `opencode auth login` and discovers models live from `<gateway>/v1/models`; the `api` value here is therefore a documented placeholder that the provider overrides at runtime.

- `provider.toml` — `@ai-sdk/openai-compatible`, placeholder `api`, docs link.
- `models/ibm/granite-4-h-small.toml` — one representative open-weight model via `base_model = "ibm/granite-4-h-small"` (MaaS is self-hosted, so no provider-specific pricing is declared).
- `logo.svg` — placeholder mark using `currentColor` (to be replaced with the official asset).

Verified locally with `bun run validate` (passes; the provider and merged model appear in the generated catalog).
