### PR TITLE
fix(amd): Qwen3.8-Flash-Next accepts image input

### DIFF
--- a/providers/amd/models/Qwen3.8-Flash-Next.toml
+++ b/providers/amd/models/Qwen3.8-Flash-Next.toml
@@ -1,16 +1,17 @@
-# Sources (accessed 2026-08-28):
+# Sources (accessed 2026-09-03):
 # https://developer.amd.com.cn/radeon/tokenfactory
 # Pricing from the Token Factory models API: input $0.15, output $0.47,
 # cache read $0.016 per MTok.
-# AMD hosts a text-only vllm-router deployment (input/output modalities are
-# text only), so the multimodal base entry is overridden below.
+# The AMD deployment accepts image input (GET /v1/models reports text+image
+# modalities) and image understanding was verified live: a rendered-digit
+# test image was read back correctly. The multimodal base entry is therefore
+# overridden to text+image (no video on this host).
 # Reasoning control verified live against POST /v1/chat/completions:
 # reasoning_effort is a validated enum low|medium|xhigh with xhigh the default
 # (values outside the enum return 400; no none, no toggle). No
 # reasoning_content is ever returned (stream + non-stream), so there is no
 # toggle and no interleaved channel on this host.
 base_model = "alibaba/qwen3.8-flash-next"
-attachment = false
 reasoning_options = [
   { type = "effort", values = ["low", "medium", "xhigh"] },
 ]
@@ -21,5 +22,5 @@ output = 0.47
 cache_read = 0.016
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]


### PR DESCRIPTION
Corrects the AMD Token Factory entry for Qwen3.8-Flash-Next: the merged #5731 file declared this host text-only, but live testing on 2026-09-03 shows the AMD deployment accepts image input.

- `GET /v1/models` on the Token Factory API reports `input_modalities: ["text", "image"]` for this model.
- Image understanding verified live: a programmatically rendered test image with a random digit was read back correctly (HTTP 200 + correct answer). Control group: a text-only model on the same host (MiniCPM5-1B) rejects image input with 400, proving the gateway enforces per-model modality rather than swallowing image parts.
- Drop the `attachment = false` and text-only modality override; the multimodal `alibaba/qwen3.8-flash-next` base entry is now narrowed to `text` + `image` input (no video on this host). `attachment` inherits `true` from the base, matching the resolved DeepSeek-V4-Flash-Vision-Exp entry.
- Pricing ($0.15 / $0.47 / $0.016 per MTok) and reasoning controls (`low|medium|xhigh`, xhigh default, no `none`, no toggle, no `reasoning_content`) unchanged from #5731, re-verified live on 2026-09-03.

`bun validate` passes against current `dev` (resolved entry: `attachment = true`, `modalities.input = ["text", "image"]`).