### PR TITLE
fireworks-ai: add missing low reasoning effort tier to glm-5p3 and glm-5p3-flash

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
@@ -1,14 +1,17 @@
 # Pricing: https://fireworks.ai/models/fireworks/glm-5p3-flash (accessed 2026-09-02)
 # Released on Fireworks Serverless API 2026-08-26.
-# Thinking-only model: reasoning cannot be disabled. Use the same two effective
-# tiers as Fireworks GLM 5.3: low/medium collapse to high; max/xhigh select max.
-# https://docs.fireworks.ai/api-reference/post-chatcompletions (accessed 2026-08-29)
+# Thinking-only model: reasoning cannot be disabled. Three distinct effort
+# tiers like Fireworks GLM 5.3 (NOT the two-tier GLM 5.2 collapse): verified
+# empirically 2026-09-04 — same prompt yields ~9/17/559 reasoning tokens for
+# low/high/max. max/xhigh select max.
+# https://docs.fireworks.ai/api-reference/post-chatcompletions
 base_model = "zhipuai/glm-5.3-flash"
 name = "GLM 5.3 Flash"
+last_updated = "2026-09-04"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["low", "high", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3.toml
@@ -1,16 +1,18 @@
 # Pricing: https://docs.fireworks.ai/serverless/pricing (accessed 2026-08-29)
 # Released on Fireworks Serverless API 2026-08-28.
 # Thinking-only model: reasoning cannot be disabled (reasoning_effort="none"
-# and thinking.type="disabled" both return 400). Two effective tiers like
-# GLM 5.2: low/medium collapse to high, max/xhigh select max.
-# https://docs.fireworks.ai/api-reference/post-chatcompletions (accessed 2026-08-29)
+# and thinking.type="disabled" both return 400). Unlike GLM 5.2 (two tiers,
+# low/medium collapse to high), GLM 5.3 has three distinct effort tiers:
+# verified empirically 2026-09-04 — same prompt yields ~10/25/198 reasoning
+# tokens for low/high/max. max/xhigh select max.
+# https://docs.fireworks.ai/api-reference/post-chatcompletions
 base_model = "zhipuai/glm-5.3"
 name = "GLM 5.3"
-last_updated = "2026-08-28"
+last_updated = "2026-09-04"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["low", "high", "max"]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Problem

The Fireworks entries for GLM 5.3 and GLM 5.3 Flash list only `high`/`max` reasoning effort, with a comment claiming the GLM 5.2 two-tier collapse applies (`low`/`medium` → `high`). Downstream consumers (e.g. opencode) therefore only expose high/max for these models.

That claim is incorrect for the 5.3 family. `low` is a real, distinct tier on the Fireworks API for both models. (For GLM 5.2 the collapse is real and that entry is correct as-is.)

## Evidence

Identical prompt against `https://api.fireworks.ai/inference/v1/chat/completions`, varying only `reasoning_effort`, reading `usage.completion_tokens_details.reasoning_tokens`:

**accounts/fireworks/models/glm-5p3**

| effort | reasoning tokens |
|---|---|
| low | 10 |
| high | 25 |
| max | 198 |
| (omitted) | 332 |

**accounts/fireworks/models/glm-5p3-flash**

| effort | reasoning tokens |
|---|---|
| low | 9 |
| high | 17 |
| max | 559 |

No 400s; each tier produces a clearly distinct reasoning budget. This also matches the upstream `zai` provider entries for `glm-5.3`/`glm-5.3-flash`, which already list `low`/`high`/`max`, and z.ai's docs (GLM-5.3 supports low/high/max, no medium rung).

## Change

- `glm-5p3.toml`, `glm-5p3-flash.toml`: `values = ["low", "high", "max"]`, corrected header comments, bumped `last_updated`.

TOML parses clean (validated with Python tomllib; no bun toolchain on this machine for the full validate script — happy to run it if CI doesn't cover it).