### PR TITLE
feat(crusoe): add Qwen3-235B-A22B-Instruct-2507 and Nemotron 3 Nano/Super

### DIFF
--- a/providers/crusoe/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
+++ b/providers/crusoe/models/Qwen/Qwen3-235B-A22B-Instruct-2507.toml
@@ -1,0 +1,7 @@
+base_model = "alibaba/qwen3-235b-a22b-instruct-2507"
+
+# Pricing: https://www.crusoe.ai/cloud/pricing (accessed 2026-09-04)
+[cost]
+input = 0.22
+output = 0.80
+cache_read = 0.11

--- a/providers/crusoe/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B.toml
+++ b/providers/crusoe/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B.toml
@@ -1,0 +1,14 @@
+# Not yet live-probed on this endpoint (unlike the entries from #3769 —
+# no API access at submission time). NVIDIA Nemotron 3 models are
+# hybrid-reasoning with an on/off toggle, and the probed sibling on this
+# endpoint (Nemotron-3-Nano-Omni-Reasoning-30B-A3B) behaves as a toggle
+# with inert low/medium/high values, so this is encoded the same way.
+# No interleaved claim is made.
+base_model = "nvidia/nemotron-3-nano-30b-a3b"
+reasoning_options = [{ type = "toggle" }]
+
+# Pricing: https://www.crusoe.ai/cloud/pricing (accessed 2026-09-04)
+[cost]
+input = 0.05
+output = 0.20
+cache_read = 0.03

--- a/providers/crusoe/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.toml
+++ b/providers/crusoe/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B.toml
@@ -1,0 +1,14 @@
+# Not yet live-probed on this endpoint (unlike the entries from #3769 —
+# no API access at submission time). NVIDIA Nemotron 3 models are
+# hybrid-reasoning with an on/off toggle, and the probed sibling on this
+# endpoint (Nemotron-3-Nano-Omni-Reasoning-30B-A3B) behaves as a toggle
+# with inert low/medium/high values, so this is encoded the same way.
+# No interleaved claim is made.
+base_model = "nvidia/nemotron-3-super-120b-a12b"
+reasoning_options = [{ type = "toggle" }]
+
+# Pricing: https://www.crusoe.ai/cloud/pricing (accessed 2026-09-04)
+[cost]
+input = 0.30
+output = 2.40
+cache_read = 0.15


### PR DESCRIPTION
Follow-up to #3769, which shipped the Crusoe provider with 8 models and deferred the rest of the catalog pending verification. This adds three of the deferred models, verified two ways:

- present in the live `/v1/models` catalog listing (ids below are verbatim from it)
- priced on the public pricing page: https://www.crusoe.ai/cloud/pricing (accessed 2026-09-04)

| Model | id on Crusoe | input / output / cache_read (per 1M) |
|---|---|---|
| Qwen3 235B-A22B Instruct 2507 | `Qwen/Qwen3-235B-A22B-Instruct-2507` | $0.22 / $0.80 / $0.11 |
| Nemotron 3 Nano 30B A3B | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B` | $0.05 / $0.20 / $0.03 |
| Nemotron 3 Super 120B A12B | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B` | $0.30 / $2.40 / $0.15 |

Notes, following the conventions worked out in #3769:

- The Nemotron ids really do carry the `NVIDIA-` prefix on this endpoint (the Omni model from #3769 doesn't) — that casing mismatch is why they were dropped from the original PR.
- The two Nemotron entries declare `reasoning_options = [{ type = "toggle" }]` since their base models have `reasoning = true`. Unlike the #3769 entries these are not yet live-probed (no API access at submission time) — the TOML comments say so explicitly; the encoding matches the probed toggle behavior of the Nemotron Omni sibling on this endpoint. Happy to re-probe and adjust if you'd like the same evidence bar as #3769.
- Qwen3-235B-A22B-Instruct-2507 is a plain instruct model (`reasoning = false` upstream), so it's a cost-only entry.

Deliberately NOT included: `deepseek-ai/DeepSeek-V4-Pro` and `deepseek-ai/Deepseek-V4-Flash` (a reasoning-parser issue on Crusoe's V4 deployments is being worked with their inference team — will follow up once fixed), `Nemotron-3-Ultra-550B` (no longer in the live catalog), and the newer `Nemotron-3.5-Lightning` / Yutori entries (pricing/catalog verification still pending).
