### PR TITLE
fix(gitlab): add reasoning effort options

### DIFF
--- a/providers/gitlab/models/duo-chat-gpt-5-6-luna.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-6-luna.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.6-luna"
 name = "Agentic Chat (GPT-5.6 Luna)"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 0

--- a/providers/gitlab/models/duo-chat-gpt-5-6-sol.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-6-sol.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.6-sol"
 name = "Agentic Chat (GPT-5.6 Sol)"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 0

--- a/providers/gitlab/models/duo-chat-gpt-5-6-terra.toml
+++ b/providers/gitlab/models/duo-chat-gpt-5-6-terra.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.6-terra"
 name = "Agentic Chat (GPT-5.6 Terra)"
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 0

--- a/providers/gitlab/models/duo-chat-opus-4-8.toml
+++ b/providers/gitlab/models/duo-chat-opus-4-8.toml
@@ -5,7 +5,7 @@ release_date = "2026-05-28"
 last_updated = "2026-05-28"
 attachment = true
 reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 tool_call = true
 knowledge = "2026-01-31"

--- a/providers/gitlab/provider.toml
+++ b/providers/gitlab/provider.toml
@@ -1,7 +1,4 @@
-name = "GitLab Duo"
-env = ["GITLAB_TOKEN"]
-npm = "gitlab-ai-provider"
-# Raw HTTP reasoning controls (sources accessed 2026-06-25):
+# Reasoning controls (sources accessed 2026-09-04):
 # - OpenAI Chat: POST /ai/v1/proxy/openai/v1/chat/completions uses top-level
 #   `reasoning_effort`; Responses: POST /ai/v1/proxy/openai/v1/responses uses
 #   `reasoning = { effort = "..." }`.
@@ -11,11 +8,12 @@ npm = "gitlab-ai-provider"
 #   `thinking = { type = "enabled", budget_tokens = N }` or
 #   `thinking = { type = "disabled" }`; effort is `output_config.effort`.
 #   https://docs.anthropic.com/en/api/messages
-# The npm provider obtains a direct-access token, points the native SDKs at
-# those proxy bases, but builds fixed request bodies without reasoning fields;
-# it does not expose a reasoning passthrough. These raw shapes therefore do not
-# make `reasoning_options` available through this configured npm integration.
+# gitlab-ai-provider 6.14.0 exposes OpenAI `reasoningEffort` and Anthropic
+# `thinking` options through model defaults and per-call provider options.
 # https://gitlab.com/vglafirov/gitlab-ai-provider/-/blob/main/src/gitlab-direct-access.ts
 # https://gitlab.com/vglafirov/gitlab-ai-provider/-/blob/main/src/gitlab-openai-language-model.ts
 # https://gitlab.com/vglafirov/gitlab-ai-provider/-/blob/main/src/gitlab-anthropic-language-model.ts
+name = "GitLab Duo"
+env = ["GITLAB_TOKEN"]
+npm = "gitlab-ai-provider"
 doc = "https://docs.gitlab.com/user/duo_agent_platform/"


### PR DESCRIPTION
gitlab-ai-provider 6.14.0 now forwards reasoning controls for both OpenAI and Anthropic models.

This replaces the empty reasoning menus for GitLab GPT-5.6 Luna, Terra, Sol, and Claude Opus 4.8 with the effort values supported by the provider. It also updates the provider source note to reflect the new support.

Provider change: https://gitlab.com/vglafirov/gitlab-ai-provider/-/merge_requests/36

Validated with `bun validate`.