### PR TITLE
Neon: add claude-fable-5-1, glm-5-3-flash and grok-4-6

### DIFF
--- a/providers/neon/models/claude-fable-5-1.toml
+++ b/providers/neon/models/claude-fable-5-1.toml
@@ -1,11 +1,12 @@
 # Chat Completions `reasoning_effort` is rejected (`Extra inputs are not permitted`).
 # Effort is the Anthropic Messages control: thinking.type adaptive + output_config.effort.
 # No toggle: thinking.type.disabled is rejected, same as claude-fable-5.
+# json_schema on /v1/chat/completions is translated via forced tool use; this
+# model rejects that (INVALID_PARAMETER_VALUE). Measured 2026-09-04.
+# [cost] is the neon.com/models list for this id (10 / 50 / cache_read 0.25 /
+# cache_write 12.5). Sibling claude-fable-5 publishes cache_read = 1; do not
+# copy that onto 5.1.
 base_model = "anthropic/claude-fable-5-1"
-# The gateway translates json_schema on /v1/chat/completions via forced tool use;
-# this model rejects that. Measured 2026-09-04:
-# INVALID_PARAMETER_VALUE: Structured output is not supported for this model
-# because its translation requires forced tool use, which newer Anthropic models reject.
 structured_output = false
 reasoning_options = [
   { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },

--- a/providers/neon/models/claude-fable-5-1.toml
+++ b/providers/neon/models/claude-fable-5-1.toml
@@ -10,8 +10,6 @@ structured_output = false
 reasoning_options = [
   { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
 ]
-# Lab entry carries a knowledge cutoff the website catalog does not publish.
-base_model_omit = ["knowledge"]
 
 [cost]
 input = 10

--- a/providers/neon/models/claude-fable-5-1.toml
+++ b/providers/neon/models/claude-fable-5-1.toml
@@ -1,0 +1,20 @@
+# Chat Completions `reasoning_effort` is rejected (`Extra inputs are not permitted`).
+# Effort is the Anthropic Messages control: thinking.type adaptive + output_config.effort.
+# No toggle: thinking.type.disabled is rejected, same as claude-fable-5.
+base_model = "anthropic/claude-fable-5-1"
+# Databricks translates json_schema on /v1/chat/completions via forced tool use;
+# this model rejects that. Measured 2026-09-04:
+# INVALID_PARAMETER_VALUE: Structured output is not supported for this model
+# because its translation requires forced tool use, which newer Anthropic models reject.
+structured_output = false
+reasoning_options = [
+  { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
+]
+# Lab entry carries a knowledge cutoff the website catalog does not publish.
+base_model_omit = ["knowledge"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 0.25
+cache_write = 12.5

--- a/providers/neon/models/claude-fable-5-1.toml
+++ b/providers/neon/models/claude-fable-5-1.toml
@@ -2,7 +2,7 @@
 # Effort is the Anthropic Messages control: thinking.type adaptive + output_config.effort.
 # No toggle: thinking.type.disabled is rejected, same as claude-fable-5.
 base_model = "anthropic/claude-fable-5-1"
-# Databricks translates json_schema on /v1/chat/completions via forced tool use;
+# The gateway translates json_schema on /v1/chat/completions via forced tool use;
 # this model rejects that. Measured 2026-09-04:
 # INVALID_PARAMETER_VALUE: Structured output is not supported for this model
 # because its translation requires forced tool use, which newer Anthropic models reject.

--- a/providers/neon/models/glm-5-3-flash.toml
+++ b/providers/neon/models/glm-5-3-flash.toml
@@ -1,10 +1,12 @@
 # Effort: chat completions reasoning_effort.
-# `none` is rejected (thinking-only). thinking.type=disabled returns 200 and
-# still emits reasoning_content, so there is no off control.
+# Lab/peers: low|high|max. Neon accepts extra values (minimal, medium, xhigh)
+# with HTTP 200, but a 2026-09-04 effect probe did not show distinct tiers
+# (reasoning_content length is not monotonic). `none` is rejected (thinking-only).
+# thinking.type=disabled returns 200 and still emits reasoning_content.
 base_model = "zhipuai/glm-5.3-flash"
 name = "GLM-5.3 Flash"
 reasoning_options = [
-  { type = "effort", values = ["minimal", "low", "medium", "high", "xhigh", "max"] },
+  { type = "effort", values = ["low", "high", "max"] },
 ]
 
 # List rates. First-party zhipuai currently publishes a 50% promo that Neon does not.

--- a/providers/neon/models/glm-5-3-flash.toml
+++ b/providers/neon/models/glm-5-3-flash.toml
@@ -1,11 +1,12 @@
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = minimal|low|medium|high|xhigh|max
+# `none` is rejected: thinking-only model.
 base_model = "zhipuai/glm-5.3-flash"
 name = "GLM-5.3 Flash"
 open_weights = true
-release_date = "2026-08-28"
-last_updated = "2026-08-28"
 reasoning_options = [
-  { type = "toggle" },                                                              # API: {"thinking": {"type": "enabled"|"disabled"}}
-  { type = "effort", values = ["minimal", "low", "medium", "high", "xhigh", "max"] }, # API: {"reasoning_effort": <v>}; `none` is rejected
+  { type = "toggle" },
+  { type = "effort", values = ["minimal", "low", "medium", "high", "xhigh", "max"] },
 ]
 
 # List rates. First-party zhipuai currently publishes a 50% promo that Neon does not.

--- a/providers/neon/models/glm-5-3-flash.toml
+++ b/providers/neon/models/glm-5-3-flash.toml
@@ -1,11 +1,9 @@
-# Toggle: thinking.type = enabled|disabled
-# Effort: reasoning_effort = minimal|low|medium|high|xhigh|max
-# `none` is rejected: thinking-only model.
+# Effort: chat completions reasoning_effort.
+# `none` is rejected (thinking-only). thinking.type=disabled returns 200 and
+# still emits reasoning_content, so there is no off control.
 base_model = "zhipuai/glm-5.3-flash"
 name = "GLM-5.3 Flash"
-open_weights = true
 reasoning_options = [
-  { type = "toggle" },
   { type = "effort", values = ["minimal", "low", "medium", "high", "xhigh", "max"] },
 ]
 
@@ -14,12 +12,6 @@ reasoning_options = [
 input = 0.15
 output = 0.5
 cache_read = 0.03
-
-# Lab entry also lists video and pdf. A real PNG on /v1/chat/completions returned 200.
-# Video and pdf were not measured.
-[modalities]
-input = ["text", "image"]
-output = ["text"]
 
 # Lab context is 1_000_000. neon.com/models publishes 1_048_576.
 [limit]

--- a/providers/neon/models/glm-5-3-flash.toml
+++ b/providers/neon/models/glm-5-3-flash.toml
@@ -1,0 +1,25 @@
+base_model = "zhipuai/glm-5.3-flash"
+name = "GLM-5.3 Flash"
+open_weights = true
+release_date = "2026-08-28"
+last_updated = "2026-08-28"
+reasoning_options = [
+  { type = "toggle" },                                                              # API: {"thinking": {"type": "enabled"|"disabled"}}
+  { type = "effort", values = ["minimal", "low", "medium", "high", "xhigh", "max"] }, # API: {"reasoning_effort": <v>}; `none` is rejected
+]
+
+# List rates. First-party zhipuai currently publishes a 50% promo that Neon does not.
+[cost]
+input = 0.15
+output = 0.5
+cache_read = 0.03
+
+# Lab entry also lists video and pdf. A real PNG on /v1/chat/completions returned 200.
+# Video and pdf were not measured.
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+# Lab context is 1_000_000. neon.com/models publishes 1_048_576.
+[limit]
+context = 1_048_576

--- a/providers/neon/models/grok-4-6.toml
+++ b/providers/neon/models/grok-4-6.toml
@@ -1,9 +1,13 @@
-# Off is effort=none. Chat completions: reasoning_effort.
-# Responses: reasoning.effort. Native dialect is openai-responses.
-# Neon accepts none, minimal, low, medium, high, xhigh. `max` is rejected.
+# Effort: Chat Completions `reasoning_effort` and Responses `reasoning.effort`.
+# Native dialect is openai-responses: POST /openai/v1/responses returns 200.
+# Chat Completions also returns 200 and accepts `reasoning_effort`.
+# Lab/peers: low|medium|high|xhigh. `max` is rejected.
+# `none` and `minimal` return 200 but do not expose a reasoning channel to
+# compare against, and first-party xAI does not treat this model as disableable.
+# Do not advertise an off switch we cannot verify.
 base_model = "xai/grok-4.6"
 reasoning_options = [
-  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] },
+  { type = "effort", values = ["low", "medium", "high", "xhigh"] },
 ]
 
 # Neon rate is not published yet. Do not copy first-party xAI prices.

--- a/providers/neon/models/grok-4-6.toml
+++ b/providers/neon/models/grok-4-6.toml
@@ -1,11 +1,10 @@
-# Off is effort=none; graded levels on chat completions reasoning_effort.
+# Off is effort=none. Chat completions: reasoning_effort.
+# Responses: reasoning.effort. Native dialect is openai-responses.
 # Neon accepts none, minimal, low, medium, high, xhigh. `max` is rejected.
 base_model = "xai/grok-4.6"
 reasoning_options = [
   { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] },
 ]
-# Lab entry carries a knowledge cutoff the website catalog does not publish.
-base_model_omit = ["knowledge"]
 
 # Neon rate is not published yet. Do not copy first-party xAI prices.
 

--- a/providers/neon/models/grok-4-6.toml
+++ b/providers/neon/models/grok-4-6.toml
@@ -1,9 +1,8 @@
+# Off is effort=none; graded levels on chat completions reasoning_effort.
+# Neon accepts none, minimal, low, medium, high, xhigh. `max` is rejected.
 base_model = "xai/grok-4.6"
-release_date = "2026-08-24"
-last_updated = "2026-08-24"
 reasoning_options = [
-  { type = "toggle" },                                                              # API: {"thinking": {"type": "enabled"|"disabled"}}
-  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, # API: {"reasoning_effort": <v>}; `max` is rejected
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] },
 ]
 # Lab entry carries a knowledge cutoff the website catalog does not publish.
 base_model_omit = ["knowledge"]

--- a/providers/neon/models/grok-4-6.toml
+++ b/providers/neon/models/grok-4-6.toml
@@ -1,0 +1,21 @@
+base_model = "xai/grok-4.6"
+release_date = "2026-08-24"
+last_updated = "2026-08-24"
+reasoning_options = [
+  { type = "toggle" },                                                              # API: {"thinking": {"type": "enabled"|"disabled"}}
+  { type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh"] }, # API: {"reasoning_effort": <v>}; `max` is rejected
+]
+# Lab entry carries a knowledge cutoff the website catalog does not publish.
+base_model_omit = ["knowledge"]
+
+# Neon rate is not published yet. Do not copy first-party xAI prices.
+
+# Lab output is 500_000. The gateway names 524_288:
+# 'max_tokens' (100000000) exceeds model maximum (524288). Measured 2026-09-04.
+[limit]
+output = 524_288
+
+[provider]
+npm = "@ai-sdk/openai"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
+shape = "responses"


### PR DESCRIPTION
## Problem

Neon's AI Gateway serves `claude-fable-5-1`, `glm-5-3-flash` and `grok-4-6`. All three are published at https://neon.com/models and in https://neon.com/models.json, and the Neon provider on models.dev does not list them yet. The lab entries (`models/anthropic/claude-fable-5-1.toml`, `models/zhipuai/glm-5.3-flash.toml`, `models/xai/grok-4.6.toml`) already exist.

## Change

Three override-only provider files under `providers/neon/models/`, each pointing `base_model` at the existing lab entry. Each file carries only the provider-authored fields (`cost`, `reasoning_options`, request shape) and the values where the Neon host measurably differs from the lab. Sources and measurement dates are in leading TOML comments, per the repo's comment policy.

### claude-fable-5-1

- `base_model = "anthropic/claude-fable-5-1"`
- `structured_output = false`. `json_schema` on `/v1/chat/completions` is translated via forced tool use and this model rejects that with `INVALID_PARAMETER_VALUE`.
- Effort `low | medium | high | xhigh | max`, driven by the Anthropic Messages control. No toggle: `thinking.type = disabled` is rejected. Chat Completions `reasoning_effort` is also rejected, so effort is the only control.
- Cost `10 / 50 / cache_read 0.25 / cache_write 12.5`, matching neon.com/models for this id. The sibling Neon `claude-fable-5` file lists `cache_read = 1`; this id publishes `0.25` and the file follows the published rate.

### glm-5-3-flash

- `base_model = "zhipuai/glm-5.3-flash"`, display `name = "GLM-5.3 Flash"`
- Effort `low | high | max`, the lab/peer baseline. `none` is rejected. `thinking.type = disabled` returns 200 but still emits `reasoning_content`, so the file has no toggle: the control does not turn reasoning off.
- Cost `0.15 / 0.5 / cache_read 0.03`. These are list rates; first-party zhipuai currently publishes a 50% promo that Neon does not apply.
- `limit.context = 1_048_576` per neon.com/models. The lab entry has `1_000_000`.

### grok-4-6

- `base_model = "xai/grok-4.6"`
- Effort `low | medium | high | xhigh`, the lab/peer baseline. `max` is rejected.
- No `[cost]`. Neon has not published a rate for this id and the first-party xAI prices are a different host's rates.
- `limit.output = 524_288`. The gateway names the number itself: `'max_tokens' (100000000) exceeds model maximum (524288)`.
- `[provider]` overrides: `npm = "@ai-sdk/openai"`, `api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"`, `shape = "responses"`. `POST /openai/v1/responses` returns 200. Chat Completions also returns 200 and accepts `reasoning_effort`.

## Sources

- https://neon.com/models
- https://neon.com/models.json

## Verification

`bun validate` passes on this branch.

## For your attention

- **grok-4-6 ships without a price.** Neon has not published a rate for it yet. The file gains `[cost]` when neon.com/models does.