### PR TITLE
feat(fireworks): add Qwen3.8 2.4T A95B

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p8-2p4t-a95b.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p8-2p4t-a95b.toml
@@ -1,0 +1,22 @@
+# Model path, serverless pricing, 262K context, text-only input, and function calling:
+# https://fireworks.ai/models/fireworks/qwen3p8-max (accessed 2026-09-04)
+# Fireworks Qwen3 reasoning accepts reasoning_effort none|low|medium|high and
+# integer token limits; reasoning is returned in reasoning_content:
+# https://docs.fireworks.ai/api-reference/post-chatcompletions (accessed 2026-09-04)
+base_model = "alibaba/qwen3.8-2.4t-a95b"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1_024
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.00
+output = 6.00
+cache_read = 0.25

--- a/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p8-2p4t-a95b.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/qwen3p8-2p4t-a95b.toml
@@ -1,17 +1,16 @@
-# Model path, serverless pricing, 262K context, text-only input, and function calling:
+# Fireworks' page retains a qwen3p8-max URL slug, but identifies the served model as
+# Qwen3.8-2.4T-A95B with API path accounts/fireworks/models/qwen3p8-2p4t-a95b;
+# it also documents serverless pricing, 262K context, and text-only input:
 # https://fireworks.ai/models/fireworks/qwen3p8-max (accessed 2026-09-04)
-# Fireworks Qwen3 reasoning accepts reasoning_effort none|low|medium|high and
-# integer token limits; reasoning is returned in reasoning_content:
+# The model requires thinking and accepts reasoning_effort low|medium|xhigh:
+# https://huggingface.co/Qwen/Qwen3.8-2.4T-A95B/raw/main/README.md (accessed 2026-09-04)
+# Fireworks returns reasoning in reasoning_content:
 # https://docs.fireworks.ai/api-reference/post-chatcompletions (accessed 2026-09-04)
 base_model = "alibaba/qwen3.8-2.4t-a95b"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high"]
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 1_024
+values = ["low", "medium", "xhigh"]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Summary

- add Fireworks AI's Qwen3.8 2.4T A95B endpoint using the shared Alibaba base model
- document the model-specific `low` / `medium` / `xhigh` reasoning effort controls
- include serverless pricing, cache-read pricing, and the reasoning response field

The Fireworks model page retains a `qwen3p8-max` URL slug, but its title and published API path identify the served model as Qwen3.8-2.4T-A95B (`accounts/fireworks/models/qwen3p8-2p4t-a95b`).

## Sources

- https://fireworks.ai/models/fireworks/qwen3p8-max
- https://huggingface.co/Qwen/Qwen3.8-2.4T-A95B/raw/main/README.md
- https://docs.fireworks.ai/api-reference/post-chatcompletions

## Test plan

- [x] Run `bun validate`
- [x] Run `git diff --check`
