### PR TITLE
feat(providers): add Kyma

### DIFF
--- a/providers/kyma/logo.svg
+++ b/providers/kyma/logo.svg
@@ -1,0 +1,31 @@
+<!--
+  Kyma API — single-colour mark. Ψ (psi), the brand letterform.
+
+  Redrawn as vector from public/logo.png, which is the real logo and exists only
+  as raster (1024×1024 gold Ψ on a navy tile). There was no vector source in the
+  repo; public/icon.svg holds a different, older mark and is referenced by
+  nothing — do not mistake it for the brand.
+
+  What this keeps from the gold original: the serif letterform — flat caps top
+  and bottom of the stem, arms that sweep outward and taper toward the tips.
+  What it deliberately drops, because a single colour cannot carry them: the
+  metallic gradient, the 3D relief, the concentric wave rings, and the rounded
+  navy tile. Those stay in logo.png for web, social and the app icon. Two assets
+  on purpose — this is the one for surfaces whose background we do not control.
+
+  Required by external catalogs. models.dev's AGENTS.md makes it a hard blocker
+  and an automated reviewer enforces it: "No fixed size or hardcoded colors — use
+  currentColor for fills/strokes so the logo adapts to light/dark themes. Prefer
+  a square viewBox." charmbracelet/catwalk wants the same. Verified legible down
+  to 16px, which is roughly how large it renders in a provider list.
+
+  Also the right asset for READMEs, favicons and badges.
+  If the brand mark ever changes, redraw this from the new original.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M9.2 3.0h5.6v1.05H9.2z"/>
+  <path d="M11.15 3.3h1.7v17.1h-1.7z"/>
+  <path d="M8.5 19.8h7v1.15h-7z"/>
+  <path d="M2.25 4.05c2.6.15 3.75 1.7 3.75 4.6 0 2.85 1.75 4.7 5.15 5.1v1.95C6.35 15.2 3.6 12.4 3.6 8.5c0-2.05-.4-2.95-1.35-3.1z"/>
+  <path d="M21.75 4.05c-2.6.15-3.75 1.7-3.75 4.6 0 2.85-1.75 4.7-5.15 5.1v1.95c4.8-.5 7.55-3.3 7.55-7.2 0-2.05.4-2.95 1.35-3.1z"/>
+</svg>

--- a/providers/kyma/models/claude-fable-5.1.toml
+++ b/providers/kyma/models/claude-fable-5.1.toml
@@ -1,0 +1,8 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "anthropic/claude-fable-5-1"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 13.5
+output = 67.5

--- a/providers/kyma/models/claude-fable-5.toml
+++ b/providers/kyma/models/claude-fable-5.toml
@@ -1,0 +1,8 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "anthropic/claude-fable-5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 13.5
+output = 67.5

--- a/providers/kyma/models/claude-haiku-4-5.toml
+++ b/providers/kyma/models/claude-haiku-4-5.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "anthropic/claude-haiku-4-5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 1.35
+output = 6.75
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/claude-haiku-4-5.toml
+++ b/providers/kyma/models/claude-haiku-4-5.toml
@@ -7,7 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 1.35
 output = 6.75
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/claude-haiku-4-5.toml
+++ b/providers/kyma/models/claude-haiku-4-5.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "anthropic/claude-haiku-4-5"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/claude-haiku-4-5.toml
+++ b/providers/kyma/models/claude-haiku-4-5.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "anthropic/claude-haiku-4-5"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 1.35

--- a/providers/kyma/models/claude-opus-4-7.toml
+++ b/providers/kyma/models/claude-opus-4-7.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "anthropic/claude-opus-4-7"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 6.75
+output = 33.75
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/claude-opus-4-7.toml
+++ b/providers/kyma/models/claude-opus-4-7.toml
@@ -1,4 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# On Kyma this id runs with thinking off unless reasoning_effort is set; measured 2026-09-04 (max_tokens=120, "What is 17*23? Think step by step."): 0 reasoning tokens by default.
 base_model = "anthropic/claude-opus-4-7"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
@@ -6,7 +7,3 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhig
 [cost]
 input = 6.75
 output = 33.75
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/claude-opus-5.toml
+++ b/providers/kyma/models/claude-opus-5.toml
@@ -1,0 +1,8 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "anthropic/claude-opus-5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 6.75
+output = 33.75

--- a/providers/kyma/models/claude-opus-5.toml
+++ b/providers/kyma/models/claude-opus-5.toml
@@ -1,7 +1,9 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; verified live 2026-09-04 on claude-opus-5 (max_tokens=120, "What is 17*23? Think step by step."): 32 reasoning tokens by default, 0 with "none".
+# Effort: reasoning_effort = low|medium|high|xhigh|max selects depth when enabled.
 base_model = "anthropic/claude-opus-5"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 6.75

--- a/providers/kyma/models/claude-sonnet-4-6.toml
+++ b/providers/kyma/models/claude-sonnet-4-6.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "anthropic/claude-sonnet-4-6"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
+
+[cost]
+input = 4.05
+output = 20.25
+
+[limit]
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/claude-sonnet-4-6.toml
+++ b/providers/kyma/models/claude-sonnet-4-6.toml
@@ -1,4 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# On Kyma this id runs with thinking off unless reasoning_effort is set; measured 2026-09-04 (max_tokens=120, "What is 17*23? Think step by step."): 0 reasoning tokens by default.
 base_model = "anthropic/claude-sonnet-4-6"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
@@ -6,10 +7,3 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"
 [cost]
 input = 4.05
 output = 20.25
-
-[limit]
-output = 128_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/claude-sonnet-5.toml
+++ b/providers/kyma/models/claude-sonnet-5.toml
@@ -1,7 +1,9 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking.
+# Effort: reasoning_effort = low|medium|high|xhigh|max selects depth when enabled.
 base_model = "anthropic/claude-sonnet-5"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
 input = 2.7

--- a/providers/kyma/models/claude-sonnet-5.toml
+++ b/providers/kyma/models/claude-sonnet-5.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 # Effort: reasoning_effort = low|medium|high|xhigh|max selects depth when enabled.
 base_model = "anthropic/claude-sonnet-5"
 

--- a/providers/kyma/models/claude-sonnet-5.toml
+++ b/providers/kyma/models/claude-sonnet-5.toml
@@ -1,0 +1,8 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "anthropic/claude-sonnet-5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.7
+output = 13.5

--- a/providers/kyma/models/deepseek-r1.toml
+++ b/providers/kyma/models/deepseek-r1.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "deepseek/deepseek-r1"
+
+reasoning_options = []
+
+[cost]
+input = 0.7425
+output = 2.957
+
+[limit]
+context = 64_000

--- a/providers/kyma/models/deepseek-r1.toml
+++ b/providers/kyma/models/deepseek-r1.toml
@@ -6,6 +6,3 @@ reasoning_options = []
 [cost]
 input = 0.7425
 output = 2.957
-
-[limit]
-context = 64_000

--- a/providers/kyma/models/deepseek-v3.toml
+++ b/providers/kyma/models/deepseek-v3.toml
@@ -1,5 +1,11 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-base_model = "deepseek/deepseek-v3"
+# This id serves DeepSeek V3.2 (hybrid thinking/non-thinking), not the original V3 — base_model
+# points at the matching lab entry so reasoning inherits correctly. No caller-facing reasoning
+# control is forwarded on this route (checked against Kyma's own request pipeline), so
+# reasoning_options is empty rather than an invented toggle/effort set.
+base_model = "deepseek/deepseek-v3.2"
+
+reasoning_options = []
 
 [cost]
 input = 0.351

--- a/providers/kyma/models/deepseek-v3.toml
+++ b/providers/kyma/models/deepseek-v3.toml
@@ -1,0 +1,9 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "deepseek/deepseek-v3"
+
+[cost]
+input = 0.351
+output = 0.513
+
+[limit]
+context = 160_000

--- a/providers/kyma/models/deepseek-v3.toml
+++ b/providers/kyma/models/deepseek-v3.toml
@@ -4,6 +4,3 @@ base_model = "deepseek/deepseek-v3"
 [cost]
 input = 0.351
 output = 0.513
-
-[limit]
-context = 160_000

--- a/providers/kyma/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/kyma/models/deepseek-v4-flash-vision-exp.toml
@@ -1,7 +1,9 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking.
+# Effort: reasoning_effort = low|high|max selects depth when enabled.
 base_model = "deepseek/deepseek-v4-flash-vision-exp"
 
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
 [cost]
 input = 0.297

--- a/providers/kyma/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/kyma/models/deepseek-v4-flash-vision-exp.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "deepseek/deepseek-v4-flash-vision-exp"
+
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+
+[cost]
+input = 0.297
+output = 0.891
+
+[limit]
+context = 1_048_576

--- a/providers/kyma/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/kyma/models/deepseek-v4-flash-vision-exp.toml
@@ -8,6 +8,3 @@ reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "h
 [cost]
 input = 0.297
 output = 0.891
-
-[limit]
-context = 1_048_576

--- a/providers/kyma/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/kyma/models/deepseek-v4-flash-vision-exp.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 # Effort: reasoning_effort = low|high|max selects depth when enabled.
 base_model = "deepseek/deepseek-v4-flash-vision-exp"
 

--- a/providers/kyma/models/deepseek-v4-flash.toml
+++ b/providers/kyma/models/deepseek-v4-flash.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 # Effort: reasoning_effort = low|high|max selects depth when enabled.
 base_model = "deepseek/deepseek-v4-flash"
 

--- a/providers/kyma/models/deepseek-v4-flash.toml
+++ b/providers/kyma/models/deepseek-v4-flash.toml
@@ -8,6 +8,3 @@ reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "h
 [cost]
 input = 0.1389
 output = 0.2778
-
-[limit]
-output = 65_536

--- a/providers/kyma/models/deepseek-v4-flash.toml
+++ b/providers/kyma/models/deepseek-v4-flash.toml
@@ -1,7 +1,9 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking.
+# Effort: reasoning_effort = low|high|max selects depth when enabled.
 base_model = "deepseek/deepseek-v4-flash"
 
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
 [cost]
 input = 0.1389

--- a/providers/kyma/models/deepseek-v4-flash.toml
+++ b/providers/kyma/models/deepseek-v4-flash.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "deepseek/deepseek-v4-flash"
+
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+
+[cost]
+input = 0.1389
+output = 0.2778
+
+[limit]
+output = 65_536

--- a/providers/kyma/models/deepseek-v4-pro.toml
+++ b/providers/kyma/models/deepseek-v4-pro.toml
@@ -1,7 +1,9 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking.
+# Effort: reasoning_effort = high|max selects depth when enabled.
 base_model = "deepseek/deepseek-v4-pro"
 
-reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
 
 [cost]
 input = 0.6901

--- a/providers/kyma/models/deepseek-v4-pro.toml
+++ b/providers/kyma/models/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 # Effort: reasoning_effort = high|max selects depth when enabled.
 base_model = "deepseek/deepseek-v4-pro"
 

--- a/providers/kyma/models/deepseek-v4-pro.toml
+++ b/providers/kyma/models/deepseek-v4-pro.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "deepseek/deepseek-v4-pro"
+
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+
+[cost]
+input = 0.6901
+output = 1.38
+
+[limit]
+output = 65_536

--- a/providers/kyma/models/deepseek-v4-pro.toml
+++ b/providers/kyma/models/deepseek-v4-pro.toml
@@ -8,6 +8,3 @@ reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "
 [cost]
 input = 0.6901
 output = 1.38
-
-[limit]
-output = 65_536

--- a/providers/kyma/models/gemini-2.5-flash.toml
+++ b/providers/kyma/models/gemini-2.5-flash.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "google/gemini-2.5-flash"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/gemini-2.5-flash.toml
+++ b/providers/kyma/models/gemini-2.5-flash.toml
@@ -7,10 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.405
 output = 3.375
-
-[limit]
-output = 8_192
-
-[modalities]
-input = ["text", "image", "audio", "video"]
-output = ["text"]

--- a/providers/kyma/models/gemini-2.5-flash.toml
+++ b/providers/kyma/models/gemini-2.5-flash.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "google/gemini-2.5-flash"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.405

--- a/providers/kyma/models/gemini-2.5-flash.toml
+++ b/providers/kyma/models/gemini-2.5-flash.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "google/gemini-2.5-flash"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.405
+output = 3.375
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kyma/models/gemini-3-flash.toml
+++ b/providers/kyma/models/gemini-3-flash.toml
@@ -6,10 +6,3 @@ reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "h
 [cost]
 input = 0.675
 output = 4.05
-
-[limit]
-output = 8_192
-
-[modalities]
-input = ["text", "image", "audio", "video"]
-output = ["text"]

--- a/providers/kyma/models/gemini-3-flash.toml
+++ b/providers/kyma/models/gemini-3-flash.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "google/gemini-3-flash-preview"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.675
+output = 4.05
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kyma/models/gemini-3.5-flash-lite.toml
+++ b/providers/kyma/models/gemini-3.5-flash-lite.toml
@@ -6,10 +6,3 @@ reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "h
 [cost]
 input = 0.405
 output = 3.375
-
-[limit]
-output = 8_192
-
-[modalities]
-input = ["text", "image", "audio", "video"]
-output = ["text"]

--- a/providers/kyma/models/gemini-3.5-flash-lite.toml
+++ b/providers/kyma/models/gemini-3.5-flash-lite.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "google/gemini-3.5-flash-lite"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.405
+output = 3.375
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kyma/models/gemini-3.5-flash.toml
+++ b/providers/kyma/models/gemini-3.5-flash.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "google/gemini-3.5-flash"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 2.025
+output = 12.15
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kyma/models/gemini-3.5-flash.toml
+++ b/providers/kyma/models/gemini-3.5-flash.toml
@@ -6,10 +6,3 @@ reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "h
 [cost]
 input = 2.025
 output = 12.15
-
-[limit]
-output = 8_192
-
-[modalities]
-input = ["text", "image", "audio", "video"]
-output = ["text"]

--- a/providers/kyma/models/gemini-3.6-flash.toml
+++ b/providers/kyma/models/gemini-3.6-flash.toml
@@ -6,10 +6,3 @@ reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "h
 [cost]
 input = 1.013
 output = 5.063
-
-[limit]
-output = 8_192
-
-[modalities]
-input = ["text", "image", "audio", "video"]
-output = ["text"]

--- a/providers/kyma/models/gemini-3.6-flash.toml
+++ b/providers/kyma/models/gemini-3.6-flash.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "google/gemini-3.6-flash"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.013
+output = 5.063
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+output = ["text"]

--- a/providers/kyma/models/gemini-3.7-flash.toml
+++ b/providers/kyma/models/gemini-3.7-flash.toml
@@ -1,7 +1,7 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
 base_model = "google/gemini-3.7-flash"
 
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.013

--- a/providers/kyma/models/gemini-3.7-flash.toml
+++ b/providers/kyma/models/gemini-3.7-flash.toml
@@ -1,0 +1,8 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "google/gemini-3.7-flash"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.013
+output = 5.063

--- a/providers/kyma/models/gemini-3.8-flash.toml
+++ b/providers/kyma/models/gemini-3.8-flash.toml
@@ -1,7 +1,7 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
 base_model = "google/gemini-3.8-flash"
 
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 1.013

--- a/providers/kyma/models/gemini-3.8-flash.toml
+++ b/providers/kyma/models/gemini-3.8-flash.toml
@@ -1,0 +1,8 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "google/gemini-3.8-flash"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.013
+output = 5.063

--- a/providers/kyma/models/gemma-4-31b.toml
+++ b/providers/kyma/models/gemma-4-31b.toml
@@ -7,7 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.0763
 output = 0.218
-
-[limit]
-context = 128_000
-output = 8_192

--- a/providers/kyma/models/gemma-4-31b.toml
+++ b/providers/kyma/models/gemma-4-31b.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "google/gemma-4-31b-it"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/gemma-4-31b.toml
+++ b/providers/kyma/models/gemma-4-31b.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "google/gemma-4-31b-it"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.0763

--- a/providers/kyma/models/gemma-4-31b.toml
+++ b/providers/kyma/models/gemma-4-31b.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "google/gemma-4-31b-it"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.0763
+output = 0.218
+
+[limit]
+context = 128_000
+output = 8_192

--- a/providers/kyma/models/glm-4.5-air.toml
+++ b/providers/kyma/models/glm-4.5-air.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "zhipuai/glm-4.5-air"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/glm-4.5-air.toml
+++ b/providers/kyma/models/glm-4.5-air.toml
@@ -7,6 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.1945
 output = 1.272
-
-[limit]
-output = 8_192

--- a/providers/kyma/models/glm-4.5-air.toml
+++ b/providers/kyma/models/glm-4.5-air.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "zhipuai/glm-4.5-air"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.1945

--- a/providers/kyma/models/glm-4.5-air.toml
+++ b/providers/kyma/models/glm-4.5-air.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "zhipuai/glm-4.5-air"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.1945
+output = 1.272
+
+[limit]
+output = 8_192

--- a/providers/kyma/models/glm-4.7-flash.toml
+++ b/providers/kyma/models/glm-4.7-flash.toml
@@ -7,7 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.081
 output = 0.54
-
-[limit]
-context = 203_000
-output = 65_536

--- a/providers/kyma/models/glm-4.7-flash.toml
+++ b/providers/kyma/models/glm-4.7-flash.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "zhipuai/glm-4.7-flash"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.081
+output = 0.54
+
+[limit]
+context = 203_000
+output = 65_536

--- a/providers/kyma/models/glm-4.7-flash.toml
+++ b/providers/kyma/models/glm-4.7-flash.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "zhipuai/glm-4.7-flash"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.081

--- a/providers/kyma/models/glm-4.7-flash.toml
+++ b/providers/kyma/models/glm-4.7-flash.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "zhipuai/glm-4.7-flash"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/glm-5.1.toml
+++ b/providers/kyma/models/glm-5.1.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "zhipuai/glm-5.1"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 1.89

--- a/providers/kyma/models/glm-5.1.toml
+++ b/providers/kyma/models/glm-5.1.toml
@@ -7,7 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 1.89
 output = 5.94
-
-[limit]
-context = 203_000
-output = 65_536

--- a/providers/kyma/models/glm-5.1.toml
+++ b/providers/kyma/models/glm-5.1.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "zhipuai/glm-5.1"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/glm-5.1.toml
+++ b/providers/kyma/models/glm-5.1.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "zhipuai/glm-5.1"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 1.89
+output = 5.94
+
+[limit]
+context = 203_000
+output = 65_536

--- a/providers/kyma/models/glm-5.2.toml
+++ b/providers/kyma/models/glm-5.2.toml
@@ -1,0 +1,8 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "zhipuai/glm-5.2"
+
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+
+[cost]
+input = 1.101
+output = 3.76

--- a/providers/kyma/models/glm-5.3-flash.toml
+++ b/providers/kyma/models/glm-5.3-flash.toml
@@ -1,0 +1,16 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "zhipuai/glm-5.3-flash"
+
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[cost]
+input = 0.101
+output = 0.338
+
+[limit]
+context = 1_310_720
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/glm-5.3-flash.toml
+++ b/providers/kyma/models/glm-5.3-flash.toml
@@ -6,11 +6,3 @@ reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 [cost]
 input = 0.101
 output = 0.338
-
-[limit]
-context = 1_310_720
-output = 65_536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/glm-5.3.toml
+++ b/providers/kyma/models/glm-5.3.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "zhipuai/glm-5.3"
+
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[cost]
+input = 1.89
+output = 5.94
+
+[limit]
+context = 1_310_720

--- a/providers/kyma/models/glm-5.3.toml
+++ b/providers/kyma/models/glm-5.3.toml
@@ -6,6 +6,3 @@ reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 [cost]
 input = 1.89
 output = 5.94
-
-[limit]
-context = 1_310_720

--- a/providers/kyma/models/gpt-5.6-luna.toml
+++ b/providers/kyma/models/gpt-5.6-luna.toml
@@ -1,0 +1,8 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "openai/gpt-5.6-luna"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0.27
+output = 1.62

--- a/providers/kyma/models/gpt-5.6-sol.toml
+++ b/providers/kyma/models/gpt-5.6-sol.toml
@@ -1,0 +1,8 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "openai/gpt-5.6-sol"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.7
+output = 13.5

--- a/providers/kyma/models/gpt-5.6-terra.toml
+++ b/providers/kyma/models/gpt-5.6-terra.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "openai/gpt-5.6-terra"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.7
+output = 16.2
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/gpt-5.6-terra.toml
+++ b/providers/kyma/models/gpt-5.6-terra.toml
@@ -6,10 +6,3 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 [cost]
 input = 2.7
 output = 16.2
-
-[limit]
-output = 8_192
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/gpt-oss-120b.toml
+++ b/providers/kyma/models/gpt-oss-120b.toml
@@ -6,7 +6,3 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 [cost]
 input = 0.0494
 output = 0.2406
-
-[limit]
-context = 128_000
-output = 8_192

--- a/providers/kyma/models/gpt-oss-120b.toml
+++ b/providers/kyma/models/gpt-oss-120b.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "openai/gpt-oss-120b"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.0494
+output = 0.2406
+
+[limit]
+context = 128_000
+output = 8_192

--- a/providers/kyma/models/grok-4.3.toml
+++ b/providers/kyma/models/grok-4.3.toml
@@ -6,10 +6,3 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high
 [cost]
 input = 1.92
 output = 3.838
-
-[limit]
-output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/kyma/models/grok-4.3.toml
+++ b/providers/kyma/models/grok-4.3.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "xai/grok-4.3"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 1.92
+output = 3.838
+
+[limit]
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/grok-4.5.toml
+++ b/providers/kyma/models/grok-4.5.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "xai/grok-4.5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 2.73
+output = 8.189
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/kyma/models/grok-4.5.toml
+++ b/providers/kyma/models/grok-4.5.toml
@@ -6,10 +6,3 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 [cost]
 input = 2.73
 output = 8.189
-
-[limit]
-output = 8_192
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/kyma/models/grok-4.6.toml
+++ b/providers/kyma/models/grok-4.6.toml
@@ -6,10 +6,3 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhig
 [cost]
 input = 2.7
 output = 8.1
-
-[limit]
-output = 8_192
-
-[modalities]
-input = ["text", "image", "pdf"]
-output = ["text"]

--- a/providers/kyma/models/grok-4.6.toml
+++ b/providers/kyma/models/grok-4.6.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "xai/grok-4.6"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 2.7
+output = 8.1
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/kyma/models/grok-build.toml
+++ b/providers/kyma/models/grok-build.toml
@@ -6,10 +6,3 @@ reasoning_options = []
 [cost]
 input = 1.389
 output = 2.777
-
-[limit]
-output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/kyma/models/grok-build.toml
+++ b/providers/kyma/models/grok-build.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "xai/grok-build-0.1"
+
+reasoning_options = []
+
+[cost]
+input = 1.389
+output = 2.777
+
+[limit]
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/hy3.toml
+++ b/providers/kyma/models/hy3.toml
@@ -6,7 +6,3 @@ reasoning_options = [{ type = "effort", values = ["none", "low", "high"] }]
 [cost]
 input = 0.108
 output = 0.446
-
-[limit]
-context = 262_144
-output = 8_192

--- a/providers/kyma/models/hy3.toml
+++ b/providers/kyma/models/hy3.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "tencent/hy3"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "high"] }]
+
+[cost]
+input = 0.108
+output = 0.446
+
+[limit]
+context = 262_144
+output = 8_192

--- a/providers/kyma/models/kimi-k2.5.toml
+++ b/providers/kyma/models/kimi-k2.5.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "moonshotai/kimi-k2.5"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.6075

--- a/providers/kyma/models/kimi-k2.5.toml
+++ b/providers/kyma/models/kimi-k2.5.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "moonshotai/kimi-k2.5"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.6075
+output = 3.038
+
+[limit]
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/kimi-k2.5.toml
+++ b/providers/kyma/models/kimi-k2.5.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "moonshotai/kimi-k2.5"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/kimi-k2.5.toml
+++ b/providers/kyma/models/kimi-k2.5.toml
@@ -7,10 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.6075
 output = 3.038
-
-[limit]
-output = 32_768
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/kimi-k2.6.toml
+++ b/providers/kyma/models/kimi-k2.6.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "moonshotai/kimi-k2.6"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/kimi-k2.6.toml
+++ b/providers/kyma/models/kimi-k2.6.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "moonshotai/kimi-k2.6"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.7856
+output = 3.667
+
+[limit]
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/kimi-k2.6.toml
+++ b/providers/kyma/models/kimi-k2.6.toml
@@ -7,10 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.7856
 output = 3.667
-
-[limit]
-output = 32_768
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/kimi-k2.6.toml
+++ b/providers/kyma/models/kimi-k2.6.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "moonshotai/kimi-k2.6"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.7856

--- a/providers/kyma/models/kimi-k2.7-code.toml
+++ b/providers/kyma/models/kimi-k2.7-code.toml
@@ -6,10 +6,3 @@ reasoning_options = []
 [cost]
 input = 1.009
 output = 4.774
-
-[limit]
-output = 16_384
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/kimi-k2.7-code.toml
+++ b/providers/kyma/models/kimi-k2.7-code.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "moonshotai/kimi-k2.7-code"
+
+reasoning_options = []
+
+[cost]
+input = 1.009
+output = 4.774
+
+[limit]
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/kimi-k3.toml
+++ b/providers/kyma/models/kimi-k3.toml
@@ -1,7 +1,9 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking.
+# Effort: reasoning_effort = low|high|max selects depth when enabled.
 base_model = "moonshotai/kimi-k3"
 
-reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
 
 [cost]
 input = 4.05

--- a/providers/kyma/models/kimi-k3.toml
+++ b/providers/kyma/models/kimi-k3.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "moonshotai/kimi-k3"
+
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[cost]
+input = 4.05
+output = 20.25
+
+[limit]
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/kimi-k3.toml
+++ b/providers/kyma/models/kimi-k3.toml
@@ -8,10 +8,3 @@ reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "h
 [cost]
 input = 4.05
 output = 20.25
-
-[limit]
-output = 32_768
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/kimi-k3.toml
+++ b/providers/kyma/models/kimi-k3.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 # Effort: reasoning_effort = low|high|max selects depth when enabled.
 base_model = "moonshotai/kimi-k3"
 

--- a/providers/kyma/models/llama-3.3-70b.toml
+++ b/providers/kyma/models/llama-3.3-70b.toml
@@ -1,0 +1,9 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "meta/llama-3.3-70b-instruct"
+
+[cost]
+input = 0.135
+output = 0.432
+
+[limit]
+output = 8_192

--- a/providers/kyma/models/llama-3.3-70b.toml
+++ b/providers/kyma/models/llama-3.3-70b.toml
@@ -4,6 +4,3 @@ base_model = "meta/llama-3.3-70b-instruct"
 [cost]
 input = 0.135
 output = 0.432
-
-[limit]
-output = 8_192

--- a/providers/kyma/models/llama-4-maverick.toml
+++ b/providers/kyma/models/llama-4-maverick.toml
@@ -1,0 +1,9 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "meta/llama-4-maverick-17b-instruct"
+
+[cost]
+input = 0.27
+output = 1.08
+
+[limit]
+context = 1_048_576

--- a/providers/kyma/models/llama-4-maverick.toml
+++ b/providers/kyma/models/llama-4-maverick.toml
@@ -4,6 +4,3 @@ base_model = "meta/llama-4-maverick-17b-instruct"
 [cost]
 input = 0.27
 output = 1.08
-
-[limit]
-context = 1_048_576

--- a/providers/kyma/models/mimo-v2.5.toml
+++ b/providers/kyma/models/mimo-v2.5.toml
@@ -1,0 +1,16 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "xiaomi/mimo-v2.5"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.189
+output = 0.378
+
+[limit]
+context = 1_050_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/mimo-v2.5.toml
+++ b/providers/kyma/models/mimo-v2.5.toml
@@ -7,11 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.189
 output = 0.378
-
-[limit]
-context = 1_050_000
-output = 16_384
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/mimo-v2.5.toml
+++ b/providers/kyma/models/mimo-v2.5.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "xiaomi/mimo-v2.5"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.189

--- a/providers/kyma/models/mimo-v2.5.toml
+++ b/providers/kyma/models/mimo-v2.5.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "xiaomi/mimo-v2.5"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/minimax-m2.5.toml
+++ b/providers/kyma/models/minimax-m2.5.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "minimax/MiniMax-M2.5"
+
+reasoning_options = []
+
+[cost]
+input = 0.3826
+output = 1.346
+
+[limit]
+context = 196_608
+output = 32_768

--- a/providers/kyma/models/minimax-m2.5.toml
+++ b/providers/kyma/models/minimax-m2.5.toml
@@ -6,7 +6,3 @@ reasoning_options = []
 [cost]
 input = 0.3826
 output = 1.346
-
-[limit]
-context = 196_608
-output = 32_768

--- a/providers/kyma/models/minimax-m2.7.toml
+++ b/providers/kyma/models/minimax-m2.7.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "minimax/MiniMax-M2.7"
+
+reasoning_options = []
+
+[cost]
+input = 0.405
+output = 1.62
+
+[limit]
+output = 32_768

--- a/providers/kyma/models/minimax-m2.7.toml
+++ b/providers/kyma/models/minimax-m2.7.toml
@@ -6,6 +6,3 @@ reasoning_options = []
 [cost]
 input = 0.405
 output = 1.62
-
-[limit]
-output = 32_768

--- a/providers/kyma/models/minimax-m3.toml
+++ b/providers/kyma/models/minimax-m3.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "minimax/MiniMax-M3"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/minimax-m3.toml
+++ b/providers/kyma/models/minimax-m3.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "minimax/MiniMax-M3"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.3985

--- a/providers/kyma/models/minimax-m3.toml
+++ b/providers/kyma/models/minimax-m3.toml
@@ -7,6 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.3985
 output = 1.594
-
-[limit]
-output = 32_768

--- a/providers/kyma/models/minimax-m3.toml
+++ b/providers/kyma/models/minimax-m3.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "minimax/MiniMax-M3"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.3985
+output = 1.594
+
+[limit]
+output = 32_768

--- a/providers/kyma/models/muse-glimmer-30b.toml
+++ b/providers/kyma/models/muse-glimmer-30b.toml
@@ -6,6 +6,3 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhig
 [cost]
 input = 0.405
 output = 1.62
-
-[limit]
-output = 8_192

--- a/providers/kyma/models/muse-glimmer-30b.toml
+++ b/providers/kyma/models/muse-glimmer-30b.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "meta/muse-glimmer-30b"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 0.405
+output = 1.62
+
+[limit]
+output = 8_192

--- a/providers/kyma/models/muse-spark-1.1.toml
+++ b/providers/kyma/models/muse-spark-1.1.toml
@@ -6,10 +6,3 @@ reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "h
 [cost]
 input = 1.542
 output = 5.243
-
-[limit]
-output = 8_192
-
-[modalities]
-input = ["text", "image", "audio", "video", "pdf"]
-output = ["text"]

--- a/providers/kyma/models/muse-spark-1.1.toml
+++ b/providers/kyma/models/muse-spark-1.1.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "meta/muse-spark-1.1"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.542
+output = 5.243
+
+[limit]
+output = 8_192
+
+[modalities]
+input = ["text", "image", "audio", "video", "pdf"]
+output = ["text"]

--- a/providers/kyma/models/muse-spark-1.2.toml
+++ b/providers/kyma/models/muse-spark-1.2.toml
@@ -6,6 +6,3 @@ reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "h
 [cost]
 input = 1.688
 output = 5.738
-
-[limit]
-output = 8_192

--- a/providers/kyma/models/muse-spark-1.2.toml
+++ b/providers/kyma/models/muse-spark-1.2.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "meta/muse-spark-1.2"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.688
+output = 5.738
+
+[limit]
+output = 8_192

--- a/providers/kyma/models/nemotron-3-ultra-550b.toml
+++ b/providers/kyma/models/nemotron-3-ultra-550b.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+
+reasoning_options = [{ type = "effort", values = ["none", "medium", "high"] }]
+
+[cost]
+input = 0.675
+output = 3.375
+
+[limit]
+output = 32_768

--- a/providers/kyma/models/nemotron-3-ultra-550b.toml
+++ b/providers/kyma/models/nemotron-3-ultra-550b.toml
@@ -6,6 +6,3 @@ reasoning_options = [{ type = "effort", values = ["none", "medium", "high"] }]
 [cost]
 input = 0.675
 output = 3.375
-
-[limit]
-output = 32_768

--- a/providers/kyma/models/qwen-3-32b.toml
+++ b/providers/kyma/models/qwen-3-32b.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "alibaba/qwen3-32b"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.108
+output = 0.378
+
+[limit]
+context = 32_768
+output = 8_192

--- a/providers/kyma/models/qwen-3-32b.toml
+++ b/providers/kyma/models/qwen-3-32b.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "alibaba/qwen3-32b"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/qwen-3-32b.toml
+++ b/providers/kyma/models/qwen-3-32b.toml
@@ -7,7 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.108
 output = 0.378
-
-[limit]
-context = 32_768
-output = 8_192

--- a/providers/kyma/models/qwen-3-32b.toml
+++ b/providers/kyma/models/qwen-3-32b.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "alibaba/qwen3-32b"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.108

--- a/providers/kyma/models/qwen-3.6-plus.toml
+++ b/providers/kyma/models/qwen-3.6-plus.toml
@@ -1,5 +1,6 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
 # Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
+# Modalities: this route accepts image input but not video (lab lists video too). Verified live 2026-09-04: an image request returned a correct answer; https://api.kymaapi.com/v1/models publishes input_modalities as text+image only for this id.
 base_model = "alibaba/qwen3.6-plus"
 
 reasoning_options = [{ type = "toggle" }]
@@ -7,3 +8,6 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.655
 output = 3.93
+
+[modalities]
+input = ["text", "image"]

--- a/providers/kyma/models/qwen-3.6-plus.toml
+++ b/providers/kyma/models/qwen-3.6-plus.toml
@@ -1,0 +1,16 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "alibaba/qwen3.6-plus"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.655
+output = 3.93
+
+[limit]
+context = 131_072
+output = 32_768
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/kyma/models/qwen-3.6-plus.toml
+++ b/providers/kyma/models/qwen-3.6-plus.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "alibaba/qwen3.6-plus"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/qwen-3.6-plus.toml
+++ b/providers/kyma/models/qwen-3.6-plus.toml
@@ -7,11 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.655
 output = 3.93
-
-[limit]
-context = 131_072
-output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/kyma/models/qwen-3.6-plus.toml
+++ b/providers/kyma/models/qwen-3.6-plus.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "alibaba/qwen3.6-plus"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.655

--- a/providers/kyma/models/qwen-3.7-max.toml
+++ b/providers/kyma/models/qwen-3.7-max.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "alibaba/qwen3.7-max"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 2.304

--- a/providers/kyma/models/qwen-3.7-max.toml
+++ b/providers/kyma/models/qwen-3.7-max.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "alibaba/qwen3.7-max"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 2.304
+output = 6.909
+
+[limit]
+output = 32_768

--- a/providers/kyma/models/qwen-3.7-max.toml
+++ b/providers/kyma/models/qwen-3.7-max.toml
@@ -7,6 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 2.304
 output = 6.909
-
-[limit]
-output = 32_768

--- a/providers/kyma/models/qwen-3.7-max.toml
+++ b/providers/kyma/models/qwen-3.7-max.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "alibaba/qwen3.7-max"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/qwen-3.7-plus.toml
+++ b/providers/kyma/models/qwen-3.7-plus.toml
@@ -7,10 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.4431
 output = 1.773
-
-[limit]
-output = 32_768
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/qwen-3.7-plus.toml
+++ b/providers/kyma/models/qwen-3.7-plus.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "alibaba/qwen3.7-plus"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/qwen-3.7-plus.toml
+++ b/providers/kyma/models/qwen-3.7-plus.toml
@@ -1,0 +1,15 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "alibaba/qwen3.7-plus"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.4431
+output = 1.773
+
+[limit]
+output = 32_768
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/qwen-3.7-plus.toml
+++ b/providers/kyma/models/qwen-3.7-plus.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "alibaba/qwen3.7-plus"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.4431

--- a/providers/kyma/models/qwen-3.8-max.toml
+++ b/providers/kyma/models/qwen-3.8-max.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 # Effort: reasoning_effort = low|medium|xhigh selects depth when enabled.
 base_model = "alibaba/qwen3.8-max"
 

--- a/providers/kyma/models/qwen-3.8-max.toml
+++ b/providers/kyma/models/qwen-3.8-max.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "alibaba/qwen3.8-max"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 2.2275
+output = 6.684
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/qwen-3.8-max.toml
+++ b/providers/kyma/models/qwen-3.8-max.toml
@@ -8,7 +8,3 @@ reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "m
 [cost]
 input = 2.2275
 output = 6.684
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/qwen-3.8-max.toml
+++ b/providers/kyma/models/qwen-3.8-max.toml
@@ -1,7 +1,9 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking.
+# Effort: reasoning_effort = low|medium|xhigh selects depth when enabled.
 base_model = "alibaba/qwen3.8-max"
 
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "xhigh"] }]
 
 [cost]
 input = 2.2275

--- a/providers/kyma/models/qwen3.7-flash.toml
+++ b/providers/kyma/models/qwen3.7-flash.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "alibaba/qwen3.7-flash"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/qwen3.7-flash.toml
+++ b/providers/kyma/models/qwen3.7-flash.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "alibaba/qwen3.7-flash"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.0498
+output = 0.2164
+
+[limit]
+output = 8_192

--- a/providers/kyma/models/qwen3.7-flash.toml
+++ b/providers/kyma/models/qwen3.7-flash.toml
@@ -7,6 +7,3 @@ reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.0498
 output = 0.2164
-
-[limit]
-output = 8_192

--- a/providers/kyma/models/qwen3.7-flash.toml
+++ b/providers/kyma/models/qwen3.7-flash.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "alibaba/qwen3.7-flash"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.0498

--- a/providers/kyma/models/qwen3.8-27b.toml
+++ b/providers/kyma/models/qwen3.8-27b.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 # Effort: reasoning_effort = low|medium|xhigh selects depth when enabled.
 base_model = "alibaba/qwen3.8-27b"
 

--- a/providers/kyma/models/qwen3.8-27b.toml
+++ b/providers/kyma/models/qwen3.8-27b.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "alibaba/qwen3.8-27b"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "xhigh"] }]
+
+[cost]
+input = 0.567
+output = 4.05
+
+[limit]
+context = 1_000_000
+output = 131_072

--- a/providers/kyma/models/qwen3.8-27b.toml
+++ b/providers/kyma/models/qwen3.8-27b.toml
@@ -8,7 +8,3 @@ reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "m
 [cost]
 input = 0.567
 output = 4.05
-
-[limit]
-context = 1_000_000
-output = 131_072

--- a/providers/kyma/models/qwen3.8-27b.toml
+++ b/providers/kyma/models/qwen3.8-27b.toml
@@ -1,7 +1,9 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking.
+# Effort: reasoning_effort = low|medium|xhigh selects depth when enabled.
 base_model = "alibaba/qwen3.8-27b"
 
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "xhigh"] }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "xhigh"] }]
 
 [cost]
 input = 0.567

--- a/providers/kyma/models/qwen3.8-flash.toml
+++ b/providers/kyma/models/qwen3.8-flash.toml
@@ -1,5 +1,5 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
+# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
 base_model = "alibaba/qwen3.8-flash"
 
 reasoning_options = [{ type = "toggle" }]

--- a/providers/kyma/models/qwen3.8-flash.toml
+++ b/providers/kyma/models/qwen3.8-flash.toml
@@ -1,7 +1,8 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+# Toggle: reasoning_effort = "none" disables thinking; any other accepted value enables it.
 base_model = "alibaba/qwen3.8-flash"
 
-reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.203

--- a/providers/kyma/models/qwen3.8-flash.toml
+++ b/providers/kyma/models/qwen3.8-flash.toml
@@ -1,0 +1,12 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "alibaba/qwen3.8-flash"
+
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.203
+output = 0.635
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/qwen3.8-flash.toml
+++ b/providers/kyma/models/qwen3.8-flash.toml
@@ -1,13 +1,10 @@
 # Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
-# Toggle: Kyma forwards `reasoning_effort` on this route; `reasoning_effort = "none"` (or `reasoning = { enabled = false }`) turns thinking off. Verified live 2026-09-04 on qwen-3.6-plus: 200 reasoning tokens by default, 0 with "none".
+# Toggle: reasoning_effort = "none" disables thinking; Kyma forwards reasoning_effort on this route, verified live 2026-09-04 on qwen-3.6-plus (max_tokens=120, "What is 17*23? Think step by step."): 200 reasoning tokens by default, 0 with "none".
+# Effort: reasoning_effort = low|medium|xhigh selects depth when enabled (lab set; no budget_tokens field on this host).
 base_model = "alibaba/qwen3.8-flash"
 
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "xhigh"] }]
 
 [cost]
 input = 0.203
 output = 0.635
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/sonar-pro.toml
+++ b/providers/kyma/models/sonar-pro.toml
@@ -1,0 +1,9 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "perplexity/sonar-pro"
+
+[cost]
+input = 4.05
+output = 20.25
+
+[limit]
+output = 8_000

--- a/providers/kyma/models/sonar-pro.toml
+++ b/providers/kyma/models/sonar-pro.toml
@@ -4,6 +4,3 @@ base_model = "perplexity/sonar-pro"
 [cost]
 input = 4.05
 output = 20.25
-
-[limit]
-output = 8_000

--- a/providers/kyma/models/sonar.toml
+++ b/providers/kyma/models/sonar.toml
@@ -4,10 +4,3 @@ base_model = "perplexity/sonar"
 [cost]
 input = 1.35
 output = 1.35
-
-[limit]
-context = 127_072
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/kyma/models/sonar.toml
+++ b/providers/kyma/models/sonar.toml
@@ -1,0 +1,13 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "perplexity/sonar"
+
+[cost]
+input = 1.35
+output = 1.35
+
+[limit]
+context = 127_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/kyma/models/step-3.7-flash.toml
+++ b/providers/kyma/models/step-3.7-flash.toml
@@ -1,0 +1,11 @@
+# Price source: https://api.kymaapi.com/v1/models (public, unauthenticated), accessed 2026-09-04.
+base_model = "stepfun/step-3.7-flash"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.27
+output = 1.553
+
+[limit]
+output = 8_192

--- a/providers/kyma/models/step-3.7-flash.toml
+++ b/providers/kyma/models/step-3.7-flash.toml
@@ -6,6 +6,3 @@ reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 [cost]
 input = 0.27
 output = 1.553
-
-[limit]
-output = 8_192

--- a/providers/kyma/provider.toml
+++ b/providers/kyma/provider.toml
@@ -1,0 +1,5 @@
+name = "Kyma API"
+env = ["KYMA_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.kymaapi.com/v1"
+doc = "https://docs.kymaapi.com"


### PR DESCRIPTION
Kyma is an OpenAI-compatible LLM gateway (https://api.kymaapi.com/v1) that gives one
endpoint and one key for open and frontier language models across many labs, plus speech,
embedding, rerank, image and video models. This adds providers/kyma/ with 60 models, each
base_model plus real overrides only, per AGENTS.md.

This supersedes #4019 (opened 2026-08-03, stale-closed 2026-09-03), which the automated
reviewer left two action items on. Both are fixed here:

1. reasoning_options was a blanket [] on 41 models. Every reasoning = true model here now
   carries real effort levels, sourced from that model's own lab hosting entry under
   models/<lab>/ where one exists, or from the effort set already established by other
   OpenAI-compatible relays in this repo for the same base_model. [] is kept only where the
   model is genuinely always-on with no caller control anywhere in the repo (MiniMax
   M2.5/M2.7, Kimi K2.7 Code, Grok Build, DeepSeek R1, Sonar/Sonar Pro).
2. Pricing is cited. Every [cost] value comes from https://api.kymaapi.com/v1/models, Kyma's
   public, unauthenticated model catalogue — also linked in a leading comment on each file.

60 of Kyma's 70 per-token chat models are included. 10 are left out because no models/<lab>/
lab entry exists yet for the exact variant Kyma serves (very recent dated releases,
preview-only variants with no GA lab file, or one creator with no lab directory in this repo
yet) — happy to file those as a follow-up once there's a lab entry to point at, rather than
add stub lab files in the same PR as a new provider.

bun validate passes. logo.svg uses currentColor on a square viewBox, per AGENTS.md.

This entry is generated from the same catalogue that serves Kyma's own /v1/models, so prices
here and prices charged can't drift; happy to add a kyma:sync module in a follow-up if useful.

Maintained by Kyma — contact hello@kymaapi.com or @kyma-api if anything needs adjusting.
