### PR TITLE
add OpenAI GPT-6 Astra

### DIFF
--- a/models/openai/gpt-6-astra.toml
+++ b/models/openai/gpt-6-astra.toml
@@ -1,0 +1,21 @@
+name = "GPT-6 Astra"
+description = "OpenAI's most capable model, built for the hardest end-to-end work"
+family = "gpt"
+release_date = "2026-09-04"
+last_updated = "2026-09-04"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+knowledge = "2026-04-30"
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/providers/openai/models/gpt-6-astra.toml
+++ b/providers/openai/models/gpt-6-astra.toml
@@ -1,0 +1,23 @@
+# Model and pricing: https://developers.openai.com/api/docs/models/gpt-6-astra
+base_model = "openai/gpt-6-astra"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10.00
+output = 50.00
+cache_read = 1.00
+cache_write = 12.50
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 20.00
+output = 75.00
+cache_read = 2.00
+cache_write = 25.00
+
+[experimental.modes.fast]
+cost = { input = 20.00, output = 100.00, cache_read = 2.00, cache_write = 25.00 }
+provider = { body = { service_tier = "priority" } }
+
+[experimental.modes.pro]
+provider = { body = { reasoning = { mode = "pro" } } }


### PR DESCRIPTION
Adds GPT-6 Astra to the OpenAI model and provider catalogs.
