### PR TITLE
feat(vercel): sync AI Gateway models, add GPT-6 Astra

### DIFF
--- a/models/openai/gpt-6-astra-fast.toml
+++ b/models/openai/gpt-6-astra-fast.toml
@@ -1,0 +1,20 @@
+name = "GPT-6 Astra (Fast)"
+description = "Fast variant of GPT-6 Astra for low-latency assistance and high-volume workloads."
+family = "gpt-astra"
+release_date = "2026-09-04"
+last_updated = "2026-09-04"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/models/openai/gpt-6-astra.toml
+++ b/models/openai/gpt-6-astra.toml
@@ -1,0 +1,20 @@
+name = "GPT-6 Astra"
+description = "GPT-6 Astra is OpenAI's most capable model for complex reasoning, coding, computer use, research, and document creation."
+family = "gpt-astra"
+release_date = "2026-09-04"
+last_updated = "2026-09-04"
+attachment = true
+reasoning = true
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 1_050_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image", "pdf"]
+output = ["text"]

--- a/packages/core/src/family.ts
+++ b/packages/core/src/family.ts
@@ -16,6 +16,7 @@ export const ModelFamilyValues = [
   "gpt-sol",
   "gpt-terra",
   "gpt-luna",
+  "gpt-astra",
   "gpt-oss",
   "gpt-image",
 

--- a/providers/vercel/models/inclusionai/ling-3.0-flash-sante-free.toml
+++ b/providers/vercel/models/inclusionai/ling-3.0-flash-sante-free.toml
@@ -1,0 +1,22 @@
+name = "Ling 3.0 Flash Sante (Free)"
+description = "Efficient model for low-latency assistance, extraction, and routine automation"
+family = "ling"
+release_date = "2026-09-04"
+last_updated = "2026-09-04"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = false
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vercel/models/inclusionai/ling-3.0-flash-sante.toml
+++ b/providers/vercel/models/inclusionai/ling-3.0-flash-sante.toml
@@ -1,0 +1,22 @@
+name = "Ling 3.0 Flash Sante"
+description = "Efficient model for low-latency assistance, extraction, and routine automation"
+family = "ling"
+release_date = "2026-09-04"
+last_updated = "2026-09-04"
+attachment = false
+reasoning = true
+tool_call = true
+open_weights = false
+reasoning_options = []
+
+[cost]
+input = 0
+output = 0
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/vercel/models/openai/gpt-6-astra-fast.toml
+++ b/providers/vercel/models/openai/gpt-6-astra-fast.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-6-astra-fast"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 20
+output = 100
+cache_read = 2
+cache_write = 12.5

--- a/providers/vercel/models/openai/gpt-6-astra-fast.toml
+++ b/providers/vercel/models/openai/gpt-6-astra-fast.toml
@@ -1,3 +1,4 @@
+# Pricing: https://ai-gateway.vercel.sh/v1/models (2026-09-04), upper band starts at 272,001 prompt tokens
 base_model = "openai/gpt-6-astra-fast"
 
 [[reasoning_options]]
@@ -9,3 +10,10 @@ input = 20
 output = 100
 cache_read = 2
 cache_write = 12.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_001 }
+input = 40
+output = 150
+cache_read = 4
+cache_write = 25

--- a/providers/vercel/models/openai/gpt-6-astra.toml
+++ b/providers/vercel/models/openai/gpt-6-astra.toml
@@ -1,0 +1,11 @@
+base_model = "openai/gpt-6-astra"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5

--- a/providers/vercel/models/openai/gpt-6-astra.toml
+++ b/providers/vercel/models/openai/gpt-6-astra.toml
@@ -1,3 +1,4 @@
+# Pricing: https://ai-gateway.vercel.sh/v1/models (2026-09-04), upper band starts at 272,001 prompt tokens
 base_model = "openai/gpt-6-astra"
 
 [[reasoning_options]]
@@ -9,3 +10,10 @@ input = 10
 output = 50
 cache_read = 1
 cache_write = 12.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_001 }
+input = 20
+output = 75
+cache_read = 2
+cache_write = 25


### PR DESCRIPTION
## What

Runs the Vercel AI Gateway sync (`bun run vercel:generate`) against the live gateway catalog so opencode's model list picks up newly published models, most notably **GPT-6 Astra** (`openai/gpt-6-astra` and `openai/gpt-6-astra-fast`), released today.

The run also created `inclusionai/ling-3.0-flash-sante` and `inclusionai/ling-3.0-flash-sante-free`, which the gateway now serves.

## Adjustments on top of the raw generator output

- Added complete lab metadata at `models/openai/gpt-6-astra.toml` and `models/openai/gpt-6-astra-fast.toml` (new `gpt-astra` family enum value) and factored the Vercel provider entries into `base_model` form, matching how recent GPT models are structured on this provider.
- Set `reasoning_options` to effort `none/low/medium/high/xhigh/max`, matching the newest-generation peers (`gpt-5.6-luna` on both the first-party OpenAI provider and Vercel).
- Authored the >272k context pricing tiers the generator flattens: the gateway API returns `input_tiers`/`output_tiers` at 272,001 prompt tokens for both astra variants, now written as `[[cost.tiers]]`.

## Sources

- Model metadata, limits, modalities, pricing (including tiers): https://ai-gateway.vercel.sh/v1/models. GPT-6 Astra: 1,050,000 context / 128,000 output, text+image+pdf input; $10/$50 per MTok ($1 cache read, $12.50 cache write) up to 272,001 prompt tokens, then $20/$75 ($2 cache read, $25 cache write). Fast: $20/$100 ($2 cache read), then $40/$150 ($4 cache read) over the tier.

## Validation

- `bun validate` passes
- `bun run vercel:generate --dry-run` is idempotent against this state (0 created/updated/removed)
