### PR TITLE
feat(github-copilot): add `gpt-6-astra` provider entry

### DIFF
--- a/providers/github-copilot/models/gpt-6-astra.toml
+++ b/providers/github-copilot/models/gpt-6-astra.toml
@@ -1,0 +1,20 @@
+# Pricing: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
+# GPT-6 Astra rates: ≤272K $10/$1/$12.50/$50; >272K $20/$2/$25/$75 per 1M (input/cached/cache write/output)
+base_model = "openai/gpt-6-astra"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 20
+output = 75
+cache_read = 2
+cache_write = 25


### PR DESCRIPTION
## Summary
- Add only `providers/github-copilot/models/gpt-6-astra.toml` to expose GPT-6 Astra through the GitHub Copilot provider.
- Inherit capabilities, modalities, and token limits from the existing `openai/gpt-6-astra` lab metadata via `base_model`; the provider file is override-only.
- Supply Copilot pricing (default and >272K long-context tier) and the supported reasoning efforts.

## Changes

- **New** `providers/github-copilot/models/gpt-6-astra.toml`
  - `base_model = "openai/gpt-6-astra"`
  - `reasoning_options`: effort `low` / `medium` / `high` / `xhigh` / `max` (matches the first-party `providers/openai/models/gpt-6-astra.toml` entry)
  - `cost` (USD / 1M tokens):

| Tier | input | cache_read | cache_write | output |
| --- | --- | --- | --- | --- |
| Default ≤272K | 10 | 1 | 12.5 | 50 |
| Long context >272K | 20 | 2 | 25 | 75 |

The filename matches the slug the GitHub Copilot sync module derives from the docs pricing table (`gpt-6-astra`), so future `chore(sync)` runs will keep the token rates in sync. The sync module has `skipCreates: true`, which is why this entry needs to be hand-authored first.

## Evidence

| Claim | Source | What it establishes |
| --- | --- | --- |
| Pricing $10 / $1 / $12.50 / $50 default; $20 / $2 / $25 / $75 above 272K | [Models and pricing](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing) | OpenAI table rows for GPT-6 Astra; no promotional footnote |
| Underlying lab model identity, limits, modalities | Existing `models/openai/gpt-6-astra.toml` (#6311) | 1,050,000 context / 922,000 input / 128,000 output; text+image+pdf input |
| Reasoning effort set | First-party `providers/openai/models/gpt-6-astra.toml` (#6321) | effort `low`/`medium`/`high`/`xhigh`/`max` |
| Override pattern on this host | Existing `providers/github-copilot/models/gpt-5.6-sol.toml` | Same `base_model` + `[[cost.tiers]]` at 272K shape |

## Validation
- `bun validate` passes.
- `bun test packages/core/test/github-copilot.test.ts` passes.
- Generated the catalog and verified that `github-copilot/gpt-6-astra` resolves with reasoning, tool calling, pdf input, and the expected context/output limits and cost tiers.
- `git diff --check` passes.
- Did **not** call live `https://api.githubcopilot.com/models` (auth-gated).

## Review notes
- Host classification: multi-model relay (`github-copilot`). Effort levels copied from the first-party OpenAI entry for this model. Copilot's GPT-5.6 entries include `none`, but the GPT-6 Astra lab/first-party entries do not expose it, so it is omitted here.
