### PR TITLE
feat(providers): add PleumRouter

### DIFF
--- a/providers/pleumrouter/logo.svg
+++ b/providers/pleumrouter/logo.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16M4 12h10M4 17h7"/><circle cx="18" cy="15" r="3"/></svg>

--- a/providers/pleumrouter/models/MiniMax-M2.5-highspeed.toml
+++ b/providers/pleumrouter/models/MiniMax-M2.5-highspeed.toml
@@ -1,5 +1,5 @@
 base_model = "minimax/MiniMax-M2.5-highspeed"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 [cost]
 input = 0.6
 output = 2.4

--- a/providers/pleumrouter/models/MiniMax-M2.5-highspeed.toml
+++ b/providers/pleumrouter/models/MiniMax-M2.5-highspeed.toml
@@ -1,0 +1,5 @@
+base_model = "minimax/MiniMax-M2.5-highspeed"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.6
+output = 2.4

--- a/providers/pleumrouter/models/claude-fable-5.toml
+++ b/providers/pleumrouter/models/claude-fable-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-fable-5"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 10
 output = 50

--- a/providers/pleumrouter/models/claude-fable-5.toml
+++ b/providers/pleumrouter/models/claude-fable-5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-fable-5"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 10
+output = 50

--- a/providers/pleumrouter/models/claude-fable-5.toml
+++ b/providers/pleumrouter/models/claude-fable-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-fable-5"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 [cost]
 input = 10
 output = 50

--- a/providers/pleumrouter/models/claude-haiku-4-5.toml
+++ b/providers/pleumrouter/models/claude-haiku-4-5.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-haiku-4-5"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 1
+output = 5

--- a/providers/pleumrouter/models/claude-haiku-4-5.toml
+++ b/providers/pleumrouter/models/claude-haiku-4-5.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-haiku-4-5"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 [cost]
 input = 1
 output = 5

--- a/providers/pleumrouter/models/claude-opus-4-8.toml
+++ b/providers/pleumrouter/models/claude-opus-4-8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 [cost]
 input = 5
 output = 25

--- a/providers/pleumrouter/models/claude-opus-4-8.toml
+++ b/providers/pleumrouter/models/claude-opus-4-8.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-opus-4-8"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 5
 output = 25

--- a/providers/pleumrouter/models/claude-opus-4-8.toml
+++ b/providers/pleumrouter/models/claude-opus-4-8.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-opus-4-8"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 5
+output = 25

--- a/providers/pleumrouter/models/claude-sonnet-4-6.toml
+++ b/providers/pleumrouter/models/claude-sonnet-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 [cost]
 input = 3
 output = 15

--- a/providers/pleumrouter/models/claude-sonnet-4-6.toml
+++ b/providers/pleumrouter/models/claude-sonnet-4-6.toml
@@ -1,5 +1,5 @@
 base_model = "anthropic/claude-sonnet-4-6"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 3
 output = 15

--- a/providers/pleumrouter/models/claude-sonnet-4-6.toml
+++ b/providers/pleumrouter/models/claude-sonnet-4-6.toml
@@ -1,0 +1,5 @@
+base_model = "anthropic/claude-sonnet-4-6"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 3
+output = 15

--- a/providers/pleumrouter/models/codestral-latest.toml
+++ b/providers/pleumrouter/models/codestral-latest.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/codestral-latest"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.3
+output = 0.9

--- a/providers/pleumrouter/models/codestral-latest.toml
+++ b/providers/pleumrouter/models/codestral-latest.toml
@@ -1,5 +1,4 @@
 base_model = "mistral/codestral-latest"
-reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.3
 output = 0.9

--- a/providers/pleumrouter/models/deepseek-v4-flash.toml
+++ b/providers/pleumrouter/models/deepseek-v4-flash.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 0.09
 output = 0.18

--- a/providers/pleumrouter/models/deepseek-v4-flash.toml
+++ b/providers/pleumrouter/models/deepseek-v4-flash.toml
@@ -1,0 +1,5 @@
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.09
+output = 0.18

--- a/providers/pleumrouter/models/deepseek-v4-flash.toml
+++ b/providers/pleumrouter/models/deepseek-v4-flash.toml
@@ -1,5 +1,8 @@
+# Toggle via reasoning_effort: "none"/"minimal" disables reasoning,
+# any other value enables it (PleumRouter wire contract, not a native
+# provider param).
 base_model = "deepseek/deepseek-v4-flash"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.09
 output = 0.18

--- a/providers/pleumrouter/models/deepseek-v4-pro.toml
+++ b/providers/pleumrouter/models/deepseek-v4-pro.toml
@@ -1,5 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 0.66
 output = 1.98

--- a/providers/pleumrouter/models/deepseek-v4-pro.toml
+++ b/providers/pleumrouter/models/deepseek-v4-pro.toml
@@ -1,5 +1,8 @@
+# Toggle via reasoning_effort: "none"/"minimal" disables reasoning,
+# any other value enables it (PleumRouter wire contract, not a native
+# provider param).
 base_model = "deepseek/deepseek-v4-pro"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.66
 output = 1.98

--- a/providers/pleumrouter/models/deepseek-v4-pro.toml
+++ b/providers/pleumrouter/models/deepseek-v4-pro.toml
@@ -1,0 +1,5 @@
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.66
+output = 1.98

--- a/providers/pleumrouter/models/gemini-2.5-pro.toml
+++ b/providers/pleumrouter/models/gemini-2.5-pro.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-2.5-pro"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 1.25
+output = 10

--- a/providers/pleumrouter/models/gemini-2.5-pro.toml
+++ b/providers/pleumrouter/models/gemini-2.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-pro"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 1.25
 output = 10

--- a/providers/pleumrouter/models/gemini-2.5-pro.toml
+++ b/providers/pleumrouter/models/gemini-2.5-pro.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-2.5-pro"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 [cost]
 input = 1.25
 output = 10

--- a/providers/pleumrouter/models/gemini-3-flash-preview.toml
+++ b/providers/pleumrouter/models/gemini-3-flash-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 [cost]
 input = 0.5
 output = 3

--- a/providers/pleumrouter/models/gemini-3-flash-preview.toml
+++ b/providers/pleumrouter/models/gemini-3-flash-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 0.5
 output = 3

--- a/providers/pleumrouter/models/gemini-3-flash-preview.toml
+++ b/providers/pleumrouter/models/gemini-3-flash-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3-flash-preview"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.5
+output = 3

--- a/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 [cost]
 input = 2
 output = 12

--- a/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 2
 output = 12

--- a/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
+++ b/providers/pleumrouter/models/gemini-3.1-pro-preview.toml
@@ -1,0 +1,5 @@
+base_model = "google/gemini-3.1-pro-preview"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 2
+output = 12

--- a/providers/pleumrouter/models/glm-5.1.toml
+++ b/providers/pleumrouter/models/glm-5.1.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.1"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 1.05
 output = 3.5

--- a/providers/pleumrouter/models/glm-5.1.toml
+++ b/providers/pleumrouter/models/glm-5.1.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-5.1"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 1.05
+output = 3.5

--- a/providers/pleumrouter/models/glm-5.1.toml
+++ b/providers/pleumrouter/models/glm-5.1.toml
@@ -1,5 +1,8 @@
+# Toggle via reasoning_effort: "none"/"minimal" disables reasoning,
+# any other value enables it (PleumRouter wire contract, not a native
+# provider param).
 base_model = "zhipuai/glm-5.1"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 1.05
 output = 3.5

--- a/providers/pleumrouter/models/glm-5.3-flash.toml
+++ b/providers/pleumrouter/models/glm-5.3-flash.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.3-flash"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 [cost]
 input = 0.15
 output = 0.5

--- a/providers/pleumrouter/models/glm-5.3-flash.toml
+++ b/providers/pleumrouter/models/glm-5.3-flash.toml
@@ -1,0 +1,5 @@
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.15
+output = 0.5

--- a/providers/pleumrouter/models/glm-5.3-flash.toml
+++ b/providers/pleumrouter/models/glm-5.3-flash.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-5.3-flash"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 0.15
 output = 0.5

--- a/providers/pleumrouter/models/gpt-5-mini.toml
+++ b/providers/pleumrouter/models/gpt-5-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-mini"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 [cost]
 input = 0.25
 output = 2

--- a/providers/pleumrouter/models/gpt-5-mini.toml
+++ b/providers/pleumrouter/models/gpt-5-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-mini"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 0.25
 output = 2

--- a/providers/pleumrouter/models/gpt-5-mini.toml
+++ b/providers/pleumrouter/models/gpt-5-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.25
+output = 2

--- a/providers/pleumrouter/models/gpt-5-nano.toml
+++ b/providers/pleumrouter/models/gpt-5-nano.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.05
+output = 0.4

--- a/providers/pleumrouter/models/gpt-5-nano.toml
+++ b/providers/pleumrouter/models/gpt-5-nano.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-nano"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 [cost]
 input = 0.05
 output = 0.4

--- a/providers/pleumrouter/models/gpt-5-nano.toml
+++ b/providers/pleumrouter/models/gpt-5-nano.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5-nano"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 0.05
 output = 0.4

--- a/providers/pleumrouter/models/gpt-5.4-mini.toml
+++ b/providers/pleumrouter/models/gpt-5.4-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 0.75
 output = 4.5

--- a/providers/pleumrouter/models/gpt-5.4-mini.toml
+++ b/providers/pleumrouter/models/gpt-5.4-mini.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 [cost]
 input = 0.75
 output = 4.5

--- a/providers/pleumrouter/models/gpt-5.4-mini.toml
+++ b/providers/pleumrouter/models/gpt-5.4-mini.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.75
+output = 4.5

--- a/providers/pleumrouter/models/gpt-5.4.toml
+++ b/providers/pleumrouter/models/gpt-5.4.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 2.5
 output = 15

--- a/providers/pleumrouter/models/gpt-5.4.toml
+++ b/providers/pleumrouter/models/gpt-5.4.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.4"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 [cost]
 input = 2.5
 output = 15

--- a/providers/pleumrouter/models/gpt-5.4.toml
+++ b/providers/pleumrouter/models/gpt-5.4.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 2.5
+output = 15

--- a/providers/pleumrouter/models/gpt-5.5.toml
+++ b/providers/pleumrouter/models/gpt-5.5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
 [cost]
 input = 5
 output = 30

--- a/providers/pleumrouter/models/gpt-5.5.toml
+++ b/providers/pleumrouter/models/gpt-5.5.toml
@@ -1,0 +1,5 @@
+base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 5
+output = 30

--- a/providers/pleumrouter/models/gpt-5.5.toml
+++ b/providers/pleumrouter/models/gpt-5.5.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-5.5"
-reasoning_options = [{ type = "effort", values = ["minimal", "none", "low", "medium", "high", "xhigh", "max"] }]
+reasoning_options = []
 [cost]
 input = 5
 output = 30

--- a/providers/pleumrouter/models/mistral-large-latest.toml
+++ b/providers/pleumrouter/models/mistral-large-latest.toml
@@ -1,5 +1,4 @@
 base_model = "mistral/mistral-large-latest"
-reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.5
 output = 1.5

--- a/providers/pleumrouter/models/mistral-large-latest.toml
+++ b/providers/pleumrouter/models/mistral-large-latest.toml
@@ -1,0 +1,5 @@
+base_model = "mistral/mistral-large-latest"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.5
+output = 1.5

--- a/providers/pleumrouter/models/qwen-max.toml
+++ b/providers/pleumrouter/models/qwen-max.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen-max"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 1.6
+output = 6.4

--- a/providers/pleumrouter/models/qwen-max.toml
+++ b/providers/pleumrouter/models/qwen-max.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen-max"
-reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 1.6
 output = 6.4

--- a/providers/pleumrouter/models/qwen3-max.toml
+++ b/providers/pleumrouter/models/qwen3-max.toml
@@ -1,0 +1,5 @@
+base_model = "alibaba/qwen3-max"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 1.2
+output = 6

--- a/providers/pleumrouter/models/qwen3-max.toml
+++ b/providers/pleumrouter/models/qwen3-max.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen3-max"
-reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 1.2
 output = 6

--- a/providers/pleumrouter/models/solar-mini.toml
+++ b/providers/pleumrouter/models/solar-mini.toml
@@ -1,0 +1,5 @@
+base_model = "upstage/solar-mini"
+reasoning_options = [{ type = "toggle" }]
+[cost]
+input = 0.15
+output = 0.15

--- a/providers/pleumrouter/models/solar-pro2.toml
+++ b/providers/pleumrouter/models/solar-pro2.toml
@@ -1,5 +1,5 @@
-base_model = "upstage/solar-mini"
+base_model = "upstage/solar-pro2"
 reasoning_options = [{ type = "toggle" }]
 [cost]
 input = 0.15
-output = 0.15
+output = 0.6

--- a/providers/pleumrouter/models/solar-pro2.toml
+++ b/providers/pleumrouter/models/solar-pro2.toml
@@ -1,5 +1,5 @@
 base_model = "upstage/solar-pro2"
-reasoning_options = [{ type = "toggle" }]
+reasoning_options = []
 [cost]
 input = 0.15
 output = 0.6

--- a/providers/pleumrouter/provider.toml
+++ b/providers/pleumrouter/provider.toml
@@ -1,3 +1,7 @@
+# Costs below are USD/1M tokens (effective rate incl. our markup), from the
+# public catalog at https://apirouter.pleum.ai/v1/models (no auth required, re-verifiable).
+# End-user billing is settled in Korean won (KRW) at checkout; USD here is a
+# reference rate for this catalog, not the currency customers are charged in.
 name = "PleumRouter"
 npm = "@ai-sdk/openai-compatible"
 api = "https://apirouter.pleum.ai/v1"

--- a/providers/pleumrouter/provider.toml
+++ b/providers/pleumrouter/provider.toml
@@ -1,0 +1,5 @@
+name = "PleumRouter"
+npm = "@ai-sdk/openai-compatible"
+api = "https://apirouter.pleum.ai/v1"
+doc = "https://router.pleum.ai/docs"
+env = ["PLEUMROUTER_API_KEY"]


### PR DESCRIPTION
PleumRouter is an OpenAI-compatible LLM gateway operated from South Korea. It routes OpenAI, Anthropic, Google, DeepSeek, Alibaba, Zhipu, Mistral, MiniMax and Upstage models through a single endpoint and bills in Korean won.

- Site: https://router.pleum.ai
- Docs: https://router.pleum.ai/docs
- API base: `https://apirouter.pleum.ai/v1` (OpenAI-compatible)
- npm client: [`pleumrouter`](https://www.npmjs.com/package/pleumrouter)

### About the model entries

All 22 models use `base_model`, so metadata is inherited from the canonical entries here and only the resale price is overridden. Every `base_model` target was checked against the current `dev` tree before submitting — nothing points at a model that does not exist.

Prices are the **effective USD per 1M tokens a caller is actually charged** (list price plus our markup), generated from our live public catalog:

```
https://apirouter.pleum.ai/v1/models
```

That endpoint requires no authentication, so any value in this PR can be re-verified independently.

### On the size of this list

Our catalog is considerably larger than 22 models, but this list is curated to a size comparable to the providers already here rather than dumped wholesale.

### Reasoning options — citations per claim group

- **effort with specific values** (`claude-opus-4-8`, `claude-sonnet-4-6`: `[none, low, medium, high]`; `claude-fable-5`, `gpt-5-mini`, `gpt-5-nano`: `[low, medium, high]`) — cited from our own public docs page describing exactly this: https://router.pleum.ai/docs/features/reasoning ("Opus 4.8/4.7/4.6 and Sonnet 5/4.6 are optional adaptive models: low/medium/high becomes adaptive effort and none becomes disabled"; "gpt-5, gpt-5-mini, and gpt-5-nano are forced-reasoning models: none is removed, while low/medium/high is forwarded"; "claude-fable-5 always uses adaptive thinking and cannot be disabled with none").
- **toggle** (`deepseek-v4-pro`, `deepseek-v4-flash`, `glm-5.1`) — cited from our backend's own reasoning-effort translation table (`pleum/provider_transport/text.py`, the `_EFFORT_OFF_VALUES` set), which treats these providers as accepting only two effective states (off vs. on) regardless of which non-off string is sent.
- **empty (`[]`)** (`claude-haiku-4-5`, `MiniMax-M2.5-highspeed`, `solar-pro2`, `gpt-5.4`/`gpt-5.4-mini`/`gpt-5.5`, `gemini-2.5-pro`/`gemini-3.1-pro-preview`/`gemini-3-flash-preview`, `glm-5.3-flash`) — our live `/v1/models` accepts `reasoning_effort` for several of these, but I do not have a citable source (our docs or code) for which specific values produce distinct results *through this gateway specifically*. I'm reporting no verified caller control rather than adopting the underlying lab's documented behavior, since a relay is not obligated to forward every native control the lab exposes, and I'd rather under-claim than assert something I can't back up.

I know the reviewer bot's latest pass suggests replacing several of those `[]` entries with lab/peer defaults (e.g. GPT-5.4 family effort, Gemini budget_tokens) even without host-specific verification — I'm intentionally not doing that, since it's the same "claim without evidence" pattern its earlier pass (correctly) flagged for the toggle and the uniform 7-value list. Happy to add real per-model values the moment I can cite them from our own docs or code; a maintainer is welcome to weigh in if the project's convention actually prefers inheriting lab defaults by default.