### PR TITLE
feat(CrofAI): Add `deepseek-v4-flash-vision-exp` model

### DIFF
--- a/providers/crof/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/crof/models/deepseek-v4-flash-vision-exp.toml
@@ -1,0 +1,16 @@
+base_model = "deepseek/deepseek-v4-flash-vision-exp"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.08
+output = 0.2
+cache_read = 0.007
+
+[limit]
+output = 131_072
+
+[provider]
+npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
## Summary

Add `deepseek-v4-flash-vision-exp` to CrofAI Provider

## Data Sources

https://crof.ai/pricing
https://crof.ai/docs

## Note

CrofAI is only accept low, medium, high and none reasoning effort.