### PR TITLE
feat: add CommandCode provider (44 models, capability-probed)

### DIFF
--- a/providers/commandcode/logo.svg
+++ b/providers/commandcode/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M4 3h16a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm1 2v14h14V5H5z"/>
+  <path d="M7.5 8.5 10 11l-2.5 2.5-1.4-1.4L7.2 11 6.1 9.9l1.4-1.4z"/>
+  <path d="M11.5 14.5h5v1.6h-5v-1.6z"/>
+</svg>

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,20 +1,4 @@
-name = "MiniMax-M2.5"
-description = "MiniMax-M2.5 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 200000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "minimax/MiniMax-M2.5"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,4 +1,8 @@
 name = "MiniMax-M2.5"
+description = "MiniMax-M2.5 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,0 +1,13 @@
+name = "MiniMax-M2.5"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 200000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,5 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "minimax/MiniMax-M2.5"
 
-# reasoning_options match first-party ofox surface (same base_model)
-
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,7 +1,5 @@
 base_model = "minimax/MiniMax-M2.5"
 
-# reasoning_options match peer-relay consensus (llmgateway, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M2.5.toml
@@ -1,4 +1,7 @@
 base_model = "minimax/MiniMax-M2.5"
 
+# reasoning_options match peer-relay consensus (llmgateway, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,0 +1,13 @@
+name = "MiniMax-M3"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,4 +1,8 @@
 name = "MiniMax-M3"
+description = "MiniMax-M3 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,17 +1,4 @@
-name = "MiniMax-M3"
-description = "MiniMax-M3 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "minimax/MiniMax-M3"
 
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,4 +1,6 @@
 base_model = "minimax/MiniMax-M3"
 
+# reasoning_options match peer-relay consensus (crossmodel, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,5 +1,13 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "minimax/MiniMax-M3"
 
-# reasoning_options match first-party ofox surface (same base_model)
+[modalities]
+input = ["text"]
+output = ["text"]
 
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,6 +1,5 @@
 base_model = "minimax/MiniMax-M3"
 
-# reasoning_options match peer-relay consensus (crossmodel, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = []

--- a/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
@@ -1,0 +1,13 @@
+name = "Qwen3.6-Max-Preview"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 200000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
@@ -1,4 +1,8 @@
 name = "Qwen3.6-Max-Preview"
+description = "Qwen3.6-Max-Preview served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
@@ -1,20 +1,4 @@
-name = "Qwen3.6-Max-Preview"
-description = "Qwen3.6-Max-Preview served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 200000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "alibaba/qwen3.6-max-preview"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
@@ -1,9 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "alibaba/qwen3.6-max-preview"
 
-# reasoning_options match first-party ofox surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
@@ -1,4 +1,12 @@
 base_model = "alibaba/qwen3.6-max-preview"
 
+# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1
+max = 393216

--- a/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Max-Preview.toml
@@ -1,12 +1,9 @@
 base_model = "alibaba/qwen3.6-max-preview"
 
-# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
 [[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "high", "max"]
+type = "toggle"
 
 [[reasoning_options]]
 type = "budget_tokens"
-min = 1
-max = 393216

--- a/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
@@ -1,0 +1,13 @@
+name = "Qwen3.6-Plus"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 200000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
@@ -1,4 +1,8 @@
 name = "Qwen3.6-Plus"
+description = "Qwen3.6-Plus served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
@@ -1,20 +1,4 @@
-name = "Qwen3.6-Plus"
-description = "Qwen3.6-Plus served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 200000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "alibaba/qwen3.6-plus"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
@@ -1,10 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "alibaba/qwen3.6-plus"
 
-# reasoning_options match first-party alibaba-token-plan surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
-max = 131072
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
@@ -1,4 +1,6 @@
 base_model = "alibaba/qwen3.6-plus"
 
+# reasoning_options match peer-relay consensus (crossmodel, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.6-Plus.toml
@@ -1,6 +1,10 @@
 base_model = "alibaba/qwen3.6-plus"
 
-# reasoning_options match peer-relay consensus (crossmodel, same base_model)
+# reasoning_options match first-party alibaba-token-plan surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 131072

--- a/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
@@ -1,0 +1,13 @@
+name = "Qwen3.7-Flash"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
@@ -1,4 +1,8 @@
 name = "Qwen3.7-Flash"
+description = "Qwen3.7-Flash served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
@@ -1,20 +1,4 @@
-name = "Qwen3.7-Flash"
-description = "Qwen3.7-Flash served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "alibaba/qwen3.7-flash"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
@@ -1,4 +1,7 @@
 base_model = "alibaba/qwen3.7-flash"
 
+# reasoning_options match peer-relay consensus (kilo, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "high"]

--- a/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
@@ -1,7 +1,10 @@
 base_model = "alibaba/qwen3.7-flash"
 
-# reasoning_options match peer-relay consensus (kilo, same base_model)
+# reasoning_options match first-party alibaba-cn surface (same base_model)
 
 [[reasoning_options]]
-type = "effort"
-values = ["none", "high"]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262144

--- a/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Flash.toml
@@ -1,10 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "alibaba/qwen3.7-flash"
 
-# reasoning_options match first-party alibaba-cn surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
-max = 262144
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
@@ -1,20 +1,4 @@
-name = "Qwen3.7-Max"
-description = "Qwen3.7-Max served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "alibaba/qwen3.7-max"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
@@ -1,4 +1,8 @@
 name = "Qwen3.7-Max"
+description = "Qwen3.7-Max served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
@@ -1,0 +1,13 @@
+name = "Qwen3.7-Max"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
@@ -1,6 +1,10 @@
 base_model = "alibaba/qwen3.7-max"
 
-# reasoning_options match peer-relay consensus (alibaba-coding-plan, same base_model)
+# reasoning_options match first-party alibaba-cn surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262144

--- a/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
@@ -1,10 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "alibaba/qwen3.7-max"
 
-# reasoning_options match first-party alibaba-cn surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
-max = 262144
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Max.toml
@@ -1,4 +1,6 @@
 base_model = "alibaba/qwen3.7-max"
 
+# reasoning_options match peer-relay consensus (alibaba-coding-plan, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
@@ -1,4 +1,8 @@
 name = "Qwen3.7-Plus"
+description = "Qwen3.7-Plus served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
@@ -1,20 +1,4 @@
-name = "Qwen3.7-Plus"
-description = "Qwen3.7-Plus served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "alibaba/qwen3.7-plus"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
@@ -1,0 +1,13 @@
+name = "Qwen3.7-Plus"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
@@ -1,4 +1,6 @@
 base_model = "alibaba/qwen3.7-plus"
 
+# reasoning_options match peer-relay consensus (alibaba-coding-plan, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
@@ -1,10 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "alibaba/qwen3.7-plus"
 
-# reasoning_options match first-party alibaba-cn surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
-max = 262144
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.7-Plus.toml
@@ -1,6 +1,10 @@
 base_model = "alibaba/qwen3.7-plus"
 
-# reasoning_options match peer-relay consensus (alibaba-coding-plan, same base_model)
+# reasoning_options match first-party alibaba-cn surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262144

--- a/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
@@ -1,0 +1,13 @@
+name = "Qwen3.8-27B"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 262144
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
@@ -1,4 +1,8 @@
 name = "Qwen3.8-27B"
+description = "Qwen3.8-27B served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
@@ -1,20 +1,4 @@
-name = "Qwen3.8-27B"
-description = "Qwen3.8-27B served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 262144
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "alibaba/qwen3.8-27b"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
@@ -1,4 +1,7 @@
 base_model = "alibaba/qwen3.8-27b"
 
+# reasoning_options match peer-relay consensus (aiand, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "low", "medium", "xhigh"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
@@ -1,9 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "alibaba/qwen3.8-27b"
 
-# reasoning_options match first-party ofox surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
-type = "budget_tokens"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-27B.toml
@@ -1,7 +1,9 @@
 base_model = "alibaba/qwen3.8-27b"
 
-# reasoning_options match peer-relay consensus (aiand, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
 [[reasoning_options]]
-type = "effort"
-values = ["none", "low", "medium", "xhigh"]
+type = "toggle"
+
+[[reasoning_options]]
+type = "budget_tokens"

--- a/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
@@ -1,4 +1,8 @@
 name = "Qwen3.8-Flash"
+description = "Qwen3.8-Flash served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
@@ -1,0 +1,13 @@
+name = "Qwen3.8-Flash"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
@@ -1,20 +1,4 @@
-name = "Qwen3.8-Flash"
-description = "Qwen3.8-Flash served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "alibaba/qwen3.8-flash"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
@@ -1,14 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "alibaba/qwen3.8-flash"
-
-# reasoning_options match first-party alibaba surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "xhigh"]
-
-[[reasoning_options]]
-type = "budget_tokens"
-max = 262144
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
@@ -1,6 +1,6 @@
 base_model = "alibaba/qwen3.8-flash"
 
-# reasoning_options match peer-relay consensus (alibaba, same base_model)
+# reasoning_options match first-party alibaba surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Flash.toml
@@ -1,4 +1,14 @@
 base_model = "alibaba/qwen3.8-flash"
 
+# reasoning_options match peer-relay consensus (alibaba, same base_model)
+
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+max = 262144

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
@@ -1,0 +1,13 @@
+name = "Qwen3.8-Max-0902"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
@@ -1,4 +1,8 @@
 name = "Qwen3.8-Max-0902"
+description = "Qwen3.8-Max-0902 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
@@ -1,20 +1,4 @@
-name = "Qwen3.8-Max-0902"
-description = "Qwen3.8-Max-0902 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "alibaba/qwen3.8-max-0902"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
@@ -1,7 +1,15 @@
 base_model = "alibaba/qwen3.8-max-0902"
 
-# reasoning_options match peer-relay consensus (edenai, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
+
+[[reasoning_options]]
+type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh"]
+values = ["low", "medium", "xhigh"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 262144

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
@@ -1,15 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "alibaba/qwen3.8-max-0902"
-
-# reasoning_options match first-party ofox surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "xhigh"]
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 0
-max = 262144
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max-0902.toml
@@ -1,4 +1,7 @@
 base_model = "alibaba/qwen3.8-max-0902"
 
+# reasoning_options match peer-relay consensus (edenai, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
@@ -1,0 +1,13 @@
+name = "Qwen3.8-Max"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
@@ -1,20 +1,4 @@
-name = "Qwen3.8-Max"
-description = "Qwen3.8-Max served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "alibaba/qwen3.8-max"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
@@ -1,4 +1,8 @@
 name = "Qwen3.8-Max"
+description = "Qwen3.8-Max served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
@@ -1,15 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "alibaba/qwen3.8-max"
-
-# reasoning_options match first-party alibaba surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "xhigh"]
-
-[[reasoning_options]]
-type = "budget_tokens"
-min = 0
-max = 262144
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
@@ -1,4 +1,15 @@
 base_model = "alibaba/qwen3.8-max"
 
+# reasoning_options match peer-relay consensus (alibaba, same base_model)
+
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "xhigh"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 262144

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
@@ -1,6 +1,6 @@
 base_model = "alibaba/qwen3.8-max"
 
-# reasoning_options match peer-relay consensus (alibaba, same base_model)
+# reasoning_options match first-party alibaba surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
@@ -1,20 +1,5 @@
-name = "deepseek-v4-flash-fast"
-description = "deepseek-v4-flash-fast served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "deepseek/deepseek-v4-flash"
+name = "DeepSeek V4 Flash Fast"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
@@ -1,4 +1,8 @@
 name = "deepseek-v4-flash-fast"
+description = "deepseek-v4-flash-fast served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
@@ -1,0 +1,13 @@
+name = "deepseek-v4-flash-fast"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
@@ -1,5 +1,7 @@
 base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek V4 Flash Fast"
 
+# reasoning_options match peer-relay consensus (inferx, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
@@ -1,7 +1,11 @@
 base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek V4 Flash Fast"
 
-# reasoning_options match peer-relay consensus (inferx, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-fast.toml
@@ -1,11 +1,10 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "deepseek/deepseek-v4-flash"
 name = "DeepSeek V4 Flash Fast"
 
-# reasoning_options match first-party ofox surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
-
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,4 +1,8 @@
 name = "deepseek-v4-flash-vision-exp"
+description = "deepseek-v4-flash-vision-exp served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,20 +1,4 @@
-name = "deepseek-v4-flash-vision-exp"
-description = "deepseek-v4-flash-vision-exp served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "deepseek/deepseek-v4-flash-vision-exp"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,0 +1,13 @@
+name = "deepseek-v4-flash-vision-exp"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,10 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "deepseek/deepseek-v4-flash-vision-exp"
-
-# reasoning_options match first-party deepseek surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,6 +1,6 @@
 base_model = "deepseek/deepseek-v4-flash-vision-exp"
 
-# reasoning_options match peer-relay consensus (above, same base_model)
+# reasoning_options match first-party deepseek surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash-vision-exp.toml
@@ -1,4 +1,10 @@
 base_model = "deepseek/deepseek-v4-flash-vision-exp"
 
+# reasoning_options match peer-relay consensus (above, same base_model)
+
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,13 @@
+name = "deepseek-v4-flash"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,8 @@
 name = "deepseek-v4-flash"
+description = "deepseek-v4-flash served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
@@ -1,20 +1,4 @@
-name = "deepseek-v4-flash"
-description = "deepseek-v4-flash served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "deepseek/deepseek-v4-flash"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
@@ -1,10 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "deepseek/deepseek-v4-flash"
-
-# reasoning_options match first-party ofox surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
@@ -1,6 +1,10 @@
 base_model = "deepseek/deepseek-v4-flash"
 
-# reasoning_options match peer-relay consensus (inferx, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
@@ -1,4 +1,6 @@
 base_model = "deepseek/deepseek-v4-flash"
 
+# reasoning_options match peer-relay consensus (inferx, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,13 @@
+name = "deepseek-v4-pro"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,8 @@
 name = "deepseek-v4-pro"
+description = "deepseek-v4-pro served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
@@ -1,20 +1,4 @@
-name = "deepseek-v4-pro"
-description = "deepseek-v4-pro served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "deepseek/deepseek-v4-pro"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
@@ -1,4 +1,10 @@
 base_model = "deepseek/deepseek-v4-pro"
 
+# reasoning_options match peer-relay consensus (alibaba-cn, same base_model)
+
 [[reasoning_options]]
 type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
@@ -1,10 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "deepseek/deepseek-v4-pro"
-
-# reasoning_options match first-party ofox surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-pro.toml
@@ -1,6 +1,6 @@
 base_model = "deepseek/deepseek-v4-pro"
 
-# reasoning_options match peer-relay consensus (alibaba-cn, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/google/gemini-3.8-flash.toml
+++ b/providers/commandcode/models/google/gemini-3.8-flash.toml
@@ -1,0 +1,13 @@
+name = "gemini-3.8-flash"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/google/gemini-3.8-flash.toml
+++ b/providers/commandcode/models/google/gemini-3.8-flash.toml
@@ -1,17 +1,4 @@
-name = "gemini-3.8-flash"
-description = "gemini-3.8-flash served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = false
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "google/gemini-3.8-flash"
 
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/google/gemini-3.8-flash.toml
+++ b/providers/commandcode/models/google/gemini-3.8-flash.toml
@@ -1,4 +1,8 @@
 name = "gemini-3.8-flash"
+description = "gemini-3.8-flash served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = false
 attachment = true
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/google/gemini-3.8-flash.toml
+++ b/providers/commandcode/models/google/gemini-3.8-flash.toml
@@ -1,4 +1,7 @@
 base_model = "google/gemini-3.8-flash"
 
+# reasoning_options match peer-relay consensus (crossmodel, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/google/gemini-3.8-flash.toml
+++ b/providers/commandcode/models/google/gemini-3.8-flash.toml
@@ -1,6 +1,6 @@
 base_model = "google/gemini-3.8-flash"
 
-# reasoning_options match peer-relay consensus (crossmodel, same base_model)
+# reasoning_options match first-party google surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/google/gemini-3.8-flash.toml
+++ b/providers/commandcode/models/google/gemini-3.8-flash.toml
@@ -1,7 +1,9 @@
-base_model = "google/gemini-3.8-flash"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party google surface (same base_model)
+base_model = "google/gemini-3.8-flash"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/gpt-5.6-sol.toml
+++ b/providers/commandcode/models/gpt-5.6-sol.toml
@@ -1,4 +1,8 @@
 name = "gpt-5.6-sol"
+description = "gpt-5.6-sol served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = false
 attachment = true
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/gpt-5.6-sol.toml
+++ b/providers/commandcode/models/gpt-5.6-sol.toml
@@ -1,17 +1,4 @@
-name = "gpt-5.6-sol"
-description = "gpt-5.6-sol served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = false
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "openai/gpt-5.6-sol"
 
-[limit]
-context = 1050000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/gpt-5.6-sol.toml
+++ b/providers/commandcode/models/gpt-5.6-sol.toml
@@ -1,0 +1,13 @@
+name = "gpt-5.6-sol"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 1050000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/gpt-5.6-sol.toml
+++ b/providers/commandcode/models/gpt-5.6-sol.toml
@@ -1,4 +1,7 @@
 base_model = "openai/gpt-5.6-sol"
 
+# reasoning_options match peer-relay consensus (agentrouter, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/gpt-5.6-sol.toml
+++ b/providers/commandcode/models/gpt-5.6-sol.toml
@@ -1,7 +1,9 @@
-base_model = "openai/gpt-5.6-sol"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party openai surface (same base_model)
+base_model = "openai/gpt-5.6-sol"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/gpt-5.6-sol.toml
+++ b/providers/commandcode/models/gpt-5.6-sol.toml
@@ -1,6 +1,6 @@
 base_model = "openai/gpt-5.6-sol"
 
-# reasoning_options match peer-relay consensus (agentrouter, same base_model)
+# reasoning_options match first-party openai surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/meituan/LongCat-2.0:free.toml
+++ b/providers/commandcode/models/meituan/LongCat-2.0:free.toml
@@ -1,20 +1,5 @@
-name = "LongCat-2.0:free"
-description = "LongCat-2.0:free served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1048576
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "meituan/longcat-2.0"
+name = "LongCat 2.0 Free"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/meituan/LongCat-2.0:free.toml
+++ b/providers/commandcode/models/meituan/LongCat-2.0:free.toml
@@ -1,4 +1,8 @@
 name = "LongCat-2.0:free"
+description = "LongCat-2.0:free served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/meituan/LongCat-2.0:free.toml
+++ b/providers/commandcode/models/meituan/LongCat-2.0:free.toml
@@ -1,0 +1,13 @@
+name = "LongCat-2.0:free"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/meituan/LongCat-2.0:free.toml
+++ b/providers/commandcode/models/meituan/LongCat-2.0:free.toml
@@ -1,7 +1,10 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "meituan/longcat-2.0"
 name = "LongCat 2.0 Free"
 
-# reasoning_options match first-party longcat surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/meituan/LongCat-2.0:free.toml
+++ b/providers/commandcode/models/meituan/LongCat-2.0:free.toml
@@ -1,5 +1,7 @@
 base_model = "meituan/longcat-2.0"
 name = "LongCat 2.0 Free"
 
+# reasoning_options match peer-relay consensus (longcat, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/meituan/LongCat-2.0:free.toml
+++ b/providers/commandcode/models/meituan/LongCat-2.0:free.toml
@@ -1,7 +1,7 @@
 base_model = "meituan/longcat-2.0"
 name = "LongCat 2.0 Free"
 
-# reasoning_options match peer-relay consensus (longcat, same base_model)
+# reasoning_options match first-party longcat surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
@@ -1,0 +1,13 @@
+name = "muse-spark-1.2-contributor"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
@@ -1,17 +1,5 @@
-name = "muse-spark-1.2-contributor"
-description = "muse-spark-1.2-contributor served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "meta/muse-spark-1.2"
+name = "Muse Spark 1.2 Contributor"
 
-[limit]
-context = 1048576
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
@@ -1,4 +1,8 @@
 name = "muse-spark-1.2-contributor"
+description = "muse-spark-1.2-contributor served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
@@ -1,8 +1,10 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "meta/muse-spark-1.2"
 name = "Muse Spark 1.2 Contributor"
 
-# reasoning_options match first-party meta surface (same base_model)
-
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
@@ -1,7 +1,7 @@
 base_model = "meta/muse-spark-1.2"
 name = "Muse Spark 1.2 Contributor"
 
-# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+# reasoning_options match first-party meta surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2-contributor.toml
@@ -1,5 +1,8 @@
 base_model = "meta/muse-spark-1.2"
 name = "Muse Spark 1.2 Contributor"
 
+# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh"]

--- a/providers/commandcode/models/meta/muse-spark-1.2.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2.toml
@@ -1,4 +1,8 @@
 name = "muse-spark-1.2"
+description = "muse-spark-1.2 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/meta/muse-spark-1.2.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2.toml
@@ -1,17 +1,4 @@
-name = "muse-spark-1.2"
-description = "muse-spark-1.2 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "meta/muse-spark-1.2"
 
-[limit]
-context = 1048576
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/meta/muse-spark-1.2.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2.toml
@@ -1,0 +1,13 @@
+name = "muse-spark-1.2"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/meta/muse-spark-1.2.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2.toml
@@ -1,4 +1,7 @@
 base_model = "meta/muse-spark-1.2"
 
+# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh"]

--- a/providers/commandcode/models/meta/muse-spark-1.2.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2.toml
@@ -1,7 +1,9 @@
-base_model = "meta/muse-spark-1.2"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party meta surface (same base_model)
+base_model = "meta/muse-spark-1.2"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/meta/muse-spark-1.2.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.2.toml
@@ -1,6 +1,6 @@
 base_model = "meta/muse-spark-1.2"
 
-# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+# reasoning_options match first-party meta surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
@@ -1,4 +1,8 @@
 name = "muse-spark-1.3-contributor"
+description = "muse-spark-1.3-contributor served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
@@ -1,0 +1,13 @@
+name = "muse-spark-1.3-contributor"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
@@ -1,17 +1,5 @@
-name = "muse-spark-1.3-contributor"
-description = "muse-spark-1.3-contributor served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "meta/muse-spark-1.3"
+name = "Muse Spark 1.3 Contributor"
 
-[limit]
-context = 1048576
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
@@ -1,8 +1,8 @@
 base_model = "meta/muse-spark-1.3"
 name = "Muse Spark 1.3 Contributor"
 
-# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+# reasoning_options match first-party meta surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh"]
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
@@ -1,5 +1,8 @@
 base_model = "meta/muse-spark-1.3"
 name = "Muse Spark 1.3 Contributor"
 
+# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh"]

--- a/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3-contributor.toml
@@ -1,8 +1,10 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "meta/muse-spark-1.3"
 name = "Muse Spark 1.3 Contributor"
 
-# reasoning_options match first-party meta surface (same base_model)
-
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/meta/muse-spark-1.3.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3.toml
@@ -1,4 +1,8 @@
 name = "muse-spark-1.3"
+description = "muse-spark-1.3 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/meta/muse-spark-1.3.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3.toml
@@ -1,0 +1,13 @@
+name = "muse-spark-1.3"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/meta/muse-spark-1.3.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3.toml
@@ -1,17 +1,4 @@
-name = "muse-spark-1.3"
-description = "muse-spark-1.3 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "meta/muse-spark-1.3"
 
-[limit]
-context = 1048576
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/meta/muse-spark-1.3.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3.toml
@@ -1,7 +1,9 @@
-base_model = "meta/muse-spark-1.3"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party meta surface (same base_model)
+base_model = "meta/muse-spark-1.3"
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/meta/muse-spark-1.3.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3.toml
@@ -1,7 +1,7 @@
 base_model = "meta/muse-spark-1.3"
 
-# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+# reasoning_options match first-party meta surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"
-values = ["minimal", "low", "medium", "high", "xhigh"]
+values = ["minimal", "low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/meta/muse-spark-1.3.toml
+++ b/providers/commandcode/models/meta/muse-spark-1.3.toml
@@ -1,4 +1,7 @@
 base_model = "meta/muse-spark-1.3"
 
+# reasoning_options match peer-relay consensus (empiriolabs, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["minimal", "low", "medium", "high", "xhigh"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
@@ -1,0 +1,13 @@
+name = "Kimi-K2.5"
+attachment = true
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 256000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
@@ -1,17 +1,4 @@
-name = "Kimi-K2.5"
-description = "Kimi-K2.5 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "moonshotai/kimi-k2.5"
 
-[limit]
-context = 256000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
@@ -1,4 +1,8 @@
 name = "Kimi-K2.5"
+description = "Kimi-K2.5 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
@@ -1,6 +1,6 @@
 base_model = "moonshotai/kimi-k2.5"
 
-# reasoning_options match peer-relay consensus (alibaba-token-plan-cn, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
@@ -1,4 +1,6 @@
 base_model = "moonshotai/kimi-k2.5"
 
+# reasoning_options match peer-relay consensus (alibaba-token-plan-cn, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.5.toml
@@ -1,6 +1,5 @@
+# probed 2026-09-06 on api.commandcode.ai: zero reasoning tokens even with
+# reasoning_effort=high, so reasoning is disabled for this model on this host.
+
 base_model = "moonshotai/kimi-k2.5"
-
-# reasoning_options match first-party ofox surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
+reasoning = false

--- a/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
@@ -1,20 +1,4 @@
-name = "Kimi-K2.6"
-description = "Kimi-K2.6 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 256000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "moonshotai/kimi-k2.6"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
@@ -1,0 +1,13 @@
+name = "Kimi-K2.6"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 256000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
@@ -1,4 +1,8 @@
 name = "Kimi-K2.6"
+description = "Kimi-K2.6 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
@@ -1,6 +1,6 @@
 base_model = "moonshotai/kimi-k2.6"
 
-# reasoning_options match peer-relay consensus (alibaba-token-plan-cn, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
@@ -1,6 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "moonshotai/kimi-k2.6"
 
-# reasoning_options match first-party ofox surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.6.toml
@@ -1,4 +1,6 @@
 base_model = "moonshotai/kimi-k2.6"
 
+# reasoning_options match peer-relay consensus (alibaba-token-plan-cn, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
@@ -1,4 +1,8 @@
 name = "Kimi-K2.7-Code-Highspeed"
+description = "Kimi-K2.7-Code-Highspeed served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
@@ -1,20 +1,4 @@
-name = "Kimi-K2.7-Code-Highspeed"
-description = "Kimi-K2.7-Code-Highspeed served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 262000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "moonshotai/kimi-k2.7-code-highspeed"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
@@ -1,0 +1,13 @@
+name = "Kimi-K2.7-Code-Highspeed"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 262000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
@@ -1,4 +1,7 @@
 base_model = "moonshotai/kimi-k2.7-code-highspeed"
 
+# reasoning_options match peer-relay consensus (llmgateway, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
@@ -1,5 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "moonshotai/kimi-k2.7-code-highspeed"
 
-# reasoning_options match first-party ofox surface (same base_model)
-
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code-Highspeed.toml
@@ -1,7 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code-highspeed"
 
-# reasoning_options match peer-relay consensus (llmgateway, same base_model)
+# reasoning_options match first-party ofox surface (same base_model)
 
-[[reasoning_options]]
-type = "effort"
-values = ["low", "medium", "high", "xhigh", "max"]
+reasoning_options = []

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,4 +1,8 @@
 name = "Kimi-K2.7-Code"
+description = "Kimi-K2.7-Code served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,20 +1,4 @@
-name = "Kimi-K2.7-Code"
-description = "Kimi-K2.7-Code served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 256000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "moonshotai/kimi-k2.7-code"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,0 +1,13 @@
+name = "Kimi-K2.7-Code"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 256000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,6 +1,5 @@
 base_model = "moonshotai/kimi-k2.7-code"
 
-# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+# reasoning_options match first-party moonshotai surface (same base_model)
 
-[[reasoning_options]]
-type = "toggle"
+reasoning_options = []

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,5 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "moonshotai/kimi-k2.7-code"
 
-# reasoning_options match first-party moonshotai surface (same base_model)
-
-reasoning_options = []
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K2.7-Code.toml
@@ -1,4 +1,6 @@
 base_model = "moonshotai/kimi-k2.7-code"
 
+# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K3.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K3.toml
@@ -1,4 +1,8 @@
 name = "Kimi-K3"
+description = "Kimi-K3 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K3.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K3.toml
@@ -1,0 +1,13 @@
+name = "Kimi-K3"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/moonshotai/Kimi-K3.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K3.toml
@@ -1,20 +1,4 @@
-name = "Kimi-K3"
-description = "Kimi-K3 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "moonshotai/kimi-k3"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/moonshotai/Kimi-K3.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K3.toml
@@ -1,4 +1,7 @@
 base_model = "moonshotai/kimi-k3"
 
+# reasoning_options match peer-relay consensus (aiand, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "high", "max"]

--- a/providers/commandcode/models/moonshotai/Kimi-K3.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K3.toml
@@ -1,6 +1,9 @@
 base_model = "moonshotai/kimi-k3"
 
-# reasoning_options match peer-relay consensus (aiand, same base_model)
+# reasoning_options match first-party moonshotai surface (same base_model)
+
+[[reasoning_options]]
+type = "toggle"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/moonshotai/Kimi-K3.toml
+++ b/providers/commandcode/models/moonshotai/Kimi-K3.toml
@@ -1,10 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "moonshotai/kimi-k3"
-
-# reasoning_options match first-party moonshotai surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,0 +1,13 @@
+name = "nemotron-3-ultra-550b-a55b"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,17 +1,4 @@
-name = "nemotron-3-ultra-550b-a55b"
-description = "nemotron-3-ultra-550b-a55b served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,4 +1,8 @@
 name = "nemotron-3-ultra-550b-a55b"
+description = "nemotron-3-ultra-550b-a55b served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,4 +1,6 @@
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 
+# reasoning_options match peer-relay consensus (baseten, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,6 +1,6 @@
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 
-# reasoning_options match peer-relay consensus (baseten, same base_model)
+# reasoning_options match first-party nvidia surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/commandcode/models/nvidia/nemotron-3-ultra-550b-a55b.toml
@@ -1,6 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
 
-# reasoning_options match first-party nvidia surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
@@ -1,0 +1,13 @@
+name = "Step-3.5-Flash"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
@@ -1,20 +1,4 @@
-name = "Step-3.5-Flash"
-description = "Step-3.5-Flash served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "stepfun/step-3.5-flash"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
@@ -1,4 +1,8 @@
 name = "Step-3.5-Flash"
+description = "Step-3.5-Flash served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
@@ -1,4 +1,7 @@
 base_model = "stepfun/step-3.5-flash"
 
+# reasoning_options match peer-relay consensus (edenai, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "high"]

--- a/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.5-Flash.toml
@@ -1,7 +1,9 @@
-base_model = "stepfun/step-3.5-flash"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match peer-relay consensus (edenai, same base_model)
+base_model = "stepfun/step-3.5-flash"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
@@ -1,20 +1,4 @@
-name = "Step-3.7-Flash"
-description = "Step-3.7-Flash served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = false
-temperature = true
-
-[limit]
-context = 256000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "stepfun/step-3.7-flash"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
@@ -1,4 +1,8 @@
 name = "Step-3.7-Flash"
+description = "Step-3.7-Flash served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = false
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
@@ -1,0 +1,13 @@
+name = "Step-3.7-Flash"
+attachment = false
+reasoning = true
+tool_call = false
+temperature = true
+
+[limit]
+context = 256000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
@@ -1,4 +1,7 @@
 base_model = "stepfun/step-3.7-flash"
 
+# reasoning_options match peer-relay consensus (ambient, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
@@ -1,6 +1,6 @@
 base_model = "stepfun/step-3.7-flash"
 
-# reasoning_options match peer-relay consensus (ambient, same base_model)
+# reasoning_options match first-party stepfun surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
+++ b/providers/commandcode/models/stepfun/Step-3.7-Flash.toml
@@ -1,7 +1,14 @@
-base_model = "stepfun/step-3.7-flash"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party stepfun surface (same base_model)
+base_model = "stepfun/step-3.7-flash"
+tool_call = false
+
+[modalities]
+input = ["text"]
+output = ["text"]
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/tencent/hy3-paid.toml
+++ b/providers/commandcode/models/tencent/hy3-paid.toml
@@ -1,4 +1,8 @@
 name = "hy3-paid"
+description = "hy3-paid served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/tencent/hy3-paid.toml
+++ b/providers/commandcode/models/tencent/hy3-paid.toml
@@ -1,0 +1,13 @@
+name = "hy3-paid"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 262144
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/tencent/hy3-paid.toml
+++ b/providers/commandcode/models/tencent/hy3-paid.toml
@@ -1,20 +1,5 @@
-name = "hy3-paid"
-description = "hy3-paid served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 262144
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "tencent/hy3"
+name = "Hunyuan HY3 Paid"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/tencent/hy3-paid.toml
+++ b/providers/commandcode/models/tencent/hy3-paid.toml
@@ -1,8 +1,10 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "tencent/hy3"
 name = "Hunyuan HY3 Paid"
 
-# reasoning_options match peer-relay consensus (crossmodel, same base_model)
-
 [[reasoning_options]]
 type = "effort"
-values = ["none", "low", "high"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/tencent/hy3-paid.toml
+++ b/providers/commandcode/models/tencent/hy3-paid.toml
@@ -1,5 +1,8 @@
 base_model = "tencent/hy3"
 name = "Hunyuan HY3 Paid"
 
+# reasoning_options match peer-relay consensus (crossmodel, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "low", "high"]

--- a/providers/commandcode/models/tencent/hy4-preview.toml
+++ b/providers/commandcode/models/tencent/hy4-preview.toml
@@ -1,0 +1,13 @@
+name = "hy4-preview"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/tencent/hy4-preview.toml
+++ b/providers/commandcode/models/tencent/hy4-preview.toml
@@ -1,20 +1,4 @@
-name = "hy4-preview"
-description = "hy4-preview served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1048576
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "tencent/hy4-preview"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/tencent/hy4-preview.toml
+++ b/providers/commandcode/models/tencent/hy4-preview.toml
@@ -1,4 +1,8 @@
 name = "hy4-preview"
+description = "hy4-preview served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/tencent/hy4-preview.toml
+++ b/providers/commandcode/models/tencent/hy4-preview.toml
@@ -1,4 +1,7 @@
 base_model = "tencent/hy4-preview"
 
+# reasoning_options match peer-relay consensus (crossmodel, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "high"]

--- a/providers/commandcode/models/tencent/hy4-preview.toml
+++ b/providers/commandcode/models/tencent/hy4-preview.toml
@@ -1,7 +1,9 @@
-base_model = "tencent/hy4-preview"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match peer-relay consensus (crossmodel, same base_model)
+base_model = "tencent/hy4-preview"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "high"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/thinkingmachines/inkling-small.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling-small.toml
@@ -1,20 +1,4 @@
-name = "inkling-small"
-description = "inkling-small served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "thinkingmachines/inkling-small"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/thinkingmachines/inkling-small.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling-small.toml
@@ -1,4 +1,8 @@
 name = "inkling-small"
+description = "inkling-small served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/thinkingmachines/inkling-small.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling-small.toml
@@ -1,0 +1,13 @@
+name = "inkling-small"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/thinkingmachines/inkling-small.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling-small.toml
@@ -1,4 +1,7 @@
 base_model = "thinkingmachines/inkling-small"
 
+# reasoning_options match peer-relay consensus (edenai, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "max"]

--- a/providers/commandcode/models/thinkingmachines/inkling-small.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling-small.toml
@@ -1,7 +1,9 @@
-base_model = "thinkingmachines/inkling-small"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match peer-relay consensus (edenai, same base_model)
+base_model = "thinkingmachines/inkling-small"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "minimal", "low", "medium", "high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/thinkingmachines/inkling.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling.toml
@@ -1,0 +1,13 @@
+name = "inkling"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 256000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/thinkingmachines/inkling.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling.toml
@@ -1,20 +1,4 @@
-name = "inkling"
-description = "inkling served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 256000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "thinkingmachines/inkling"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/thinkingmachines/inkling.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling.toml
@@ -1,4 +1,8 @@
 name = "inkling"
+description = "inkling served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/thinkingmachines/inkling.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling.toml
@@ -1,7 +1,10 @@
 base_model = "thinkingmachines/inkling"
 
-# reasoning_options match peer-relay consensus (edenai, same base_model)
+# reasoning_options match first-party thinkingmachines surface (same base_model)
+
+[[reasoning_options]]
+type = "toggle"
 
 [[reasoning_options]]
 type = "effort"
-values = ["none", "minimal", "low", "medium", "high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/thinkingmachines/inkling.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling.toml
@@ -1,4 +1,7 @@
 base_model = "thinkingmachines/inkling"
 
+# reasoning_options match peer-relay consensus (edenai, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["none", "minimal", "low", "medium", "high", "max"]

--- a/providers/commandcode/models/thinkingmachines/inkling.toml
+++ b/providers/commandcode/models/thinkingmachines/inkling.toml
@@ -1,9 +1,8 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "thinkingmachines/inkling"
-
-# reasoning_options match first-party thinkingmachines surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/xai/grok-4.5.toml
+++ b/providers/commandcode/models/xai/grok-4.5.toml
@@ -1,0 +1,13 @@
+name = "grok-4.5"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 500000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/xai/grok-4.5.toml
+++ b/providers/commandcode/models/xai/grok-4.5.toml
@@ -1,20 +1,4 @@
-name = "grok-4.5"
-description = "grok-4.5 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = false
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 500000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "xai/grok-4.5"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/xai/grok-4.5.toml
+++ b/providers/commandcode/models/xai/grok-4.5.toml
@@ -1,4 +1,8 @@
 name = "grok-4.5"
+description = "grok-4.5 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = false
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/xai/grok-4.5.toml
+++ b/providers/commandcode/models/xai/grok-4.5.toml
@@ -1,4 +1,7 @@
 base_model = "xai/grok-4.5"
 
+# reasoning_options match peer-relay consensus (cloudflare-ai-gateway, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high"]

--- a/providers/commandcode/models/xai/grok-4.5.toml
+++ b/providers/commandcode/models/xai/grok-4.5.toml
@@ -1,7 +1,9 @@
-base_model = "xai/grok-4.5"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party xai surface (same base_model)
+base_model = "xai/grok-4.5"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/xai/grok-4.5.toml
+++ b/providers/commandcode/models/xai/grok-4.5.toml
@@ -1,6 +1,6 @@
 base_model = "xai/grok-4.5"
 
-# reasoning_options match peer-relay consensus (cloudflare-ai-gateway, same base_model)
+# reasoning_options match first-party xai surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/xai/grok-4.6.toml
+++ b/providers/commandcode/models/xai/grok-4.6.toml
@@ -1,4 +1,8 @@
 name = "grok-4.6"
+description = "grok-4.6 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = false
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/xai/grok-4.6.toml
+++ b/providers/commandcode/models/xai/grok-4.6.toml
@@ -1,20 +1,4 @@
-name = "grok-4.6"
-description = "grok-4.6 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = false
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 500000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "xai/grok-4.6"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/xai/grok-4.6.toml
+++ b/providers/commandcode/models/xai/grok-4.6.toml
@@ -1,0 +1,13 @@
+name = "grok-4.6"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 500000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/xai/grok-4.6.toml
+++ b/providers/commandcode/models/xai/grok-4.6.toml
@@ -1,7 +1,9 @@
-base_model = "xai/grok-4.6"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party xai surface (same base_model)
+base_model = "xai/grok-4.6"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "medium", "high", "xhigh"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/xai/grok-4.6.toml
+++ b/providers/commandcode/models/xai/grok-4.6.toml
@@ -1,6 +1,6 @@
 base_model = "xai/grok-4.6"
 
-# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+# reasoning_options match first-party xai surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/xai/grok-4.6.toml
+++ b/providers/commandcode/models/xai/grok-4.6.toml
@@ -1,4 +1,7 @@
 base_model = "xai/grok-4.6"
 
+# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high", "xhigh"]

--- a/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,0 +1,13 @@
+name = "mimo-v2.5-pro"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,4 +1,8 @@
 name = "mimo-v2.5-pro"
+description = "mimo-v2.5-pro served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,20 +1,4 @@
-name = "mimo-v2.5-pro"
-description = "mimo-v2.5-pro served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "xiaomi/mimo-v2.5-pro"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,6 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "xiaomi/mimo-v2.5-pro"
 
-# reasoning_options match peer-relay consensus (above, same base_model)
-
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5-pro.toml
@@ -1,4 +1,6 @@
 base_model = "xiaomi/mimo-v2.5-pro"
 
+# reasoning_options match peer-relay consensus (above, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/xiaomi/mimo-v2.5.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5.toml
@@ -1,0 +1,13 @@
+name = "mimo-v2.5"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/xiaomi/mimo-v2.5.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5.toml
@@ -1,4 +1,8 @@
 name = "mimo-v2.5"
+description = "mimo-v2.5 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/xiaomi/mimo-v2.5.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5.toml
@@ -1,20 +1,4 @@
-name = "mimo-v2.5"
-description = "mimo-v2.5 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "xiaomi/mimo-v2.5"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/xiaomi/mimo-v2.5.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5.toml
@@ -1,6 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "xiaomi/mimo-v2.5"
 
-# reasoning_options match peer-relay consensus (aihubmix, same base_model)
-
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/xiaomi/mimo-v2.5.toml
+++ b/providers/commandcode/models/xiaomi/mimo-v2.5.toml
@@ -1,4 +1,6 @@
 base_model = "xiaomi/mimo-v2.5"
 
+# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/z-ai/glm-5.3-flash.toml
+++ b/providers/commandcode/models/z-ai/glm-5.3-flash.toml
@@ -1,20 +1,4 @@
-name = "glm-5.3-flash"
-description = "glm-5.3-flash served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = true
-attachment = true
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1048576
-output = 65536
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+base_model = "zhipuai/glm-5.3-flash"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/z-ai/glm-5.3-flash.toml
+++ b/providers/commandcode/models/z-ai/glm-5.3-flash.toml
@@ -1,4 +1,8 @@
 name = "glm-5.3-flash"
+description = "glm-5.3-flash served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = true
 attachment = true
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text", "image"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/z-ai/glm-5.3-flash.toml
+++ b/providers/commandcode/models/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,13 @@
+name = "glm-5.3-flash"
+attachment = true
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1048576
+output = 65536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/commandcode/models/z-ai/glm-5.3-flash.toml
+++ b/providers/commandcode/models/z-ai/glm-5.3-flash.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5.3-flash"
 
-# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+# reasoning_options match first-party zai surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/z-ai/glm-5.3-flash.toml
+++ b/providers/commandcode/models/z-ai/glm-5.3-flash.toml
@@ -1,7 +1,9 @@
-base_model = "zhipuai/glm-5.3-flash"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party zai surface (same base_model)
+base_model = "zhipuai/glm-5.3-flash"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/z-ai/glm-5.3-flash.toml
+++ b/providers/commandcode/models/z-ai/glm-5.3-flash.toml
@@ -1,4 +1,7 @@
 base_model = "zhipuai/glm-5.3-flash"
 
+# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "high", "max"]

--- a/providers/commandcode/models/zai-org/GLM-5.1.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.1.toml
@@ -1,0 +1,13 @@
+name = "GLM-5.1"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 200000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/zai-org/GLM-5.1.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.1.toml
@@ -1,4 +1,8 @@
 name = "GLM-5.1"
+description = "GLM-5.1 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = false
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.1.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.1.toml
@@ -1,20 +1,4 @@
-name = "GLM-5.1"
-description = "GLM-5.1 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = false
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 200000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "zhipuai/glm-5.1"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.1.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.1.toml
@@ -1,6 +1,9 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "zhipuai/glm-5.1"
 
-# reasoning_options match first-party zai surface (same base_model)
-
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/zai-org/GLM-5.1.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.1.toml
@@ -1,4 +1,6 @@
 base_model = "zhipuai/glm-5.1"
 
+# reasoning_options match peer-relay consensus (alibaba-token-plan, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.1.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.1.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5.1"
 
-# reasoning_options match peer-relay consensus (alibaba-token-plan, same base_model)
+# reasoning_options match first-party zai surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
@@ -1,0 +1,13 @@
+name = "GLM-5.2-Fast"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
@@ -1,20 +1,5 @@
-name = "GLM-5.2-Fast"
-description = "GLM-5.2-Fast served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = false
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "zhipuai/glm-5.2"
+name = "GLM-5.2 Fast"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
@@ -1,4 +1,8 @@
 name = "GLM-5.2-Fast"
+description = "GLM-5.2-Fast served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = false
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
@@ -1,5 +1,8 @@
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Fast"
 
+# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["high", "max"]

--- a/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
@@ -1,7 +1,7 @@
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Fast"
 
-# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+# reasoning_options match first-party zai surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2-Fast.toml
@@ -1,8 +1,10 @@
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
+
 base_model = "zhipuai/glm-5.2"
 name = "GLM-5.2 Fast"
 
-# reasoning_options match first-party zai surface (same base_model)
-
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/zai-org/GLM-5.2.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2.toml
@@ -1,4 +1,8 @@
 name = "GLM-5.2"
+description = "GLM-5.2 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = false
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.2.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2.toml
@@ -1,20 +1,4 @@
-name = "GLM-5.2"
-description = "GLM-5.2 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = false
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "zhipuai/glm-5.2"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.2.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2.toml
@@ -1,0 +1,13 @@
+name = "GLM-5.2"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/zai-org/GLM-5.2.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5.2"
 
-# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+# reasoning_options match first-party zai surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/zai-org/GLM-5.2.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2.toml
@@ -1,4 +1,7 @@
 base_model = "zhipuai/glm-5.2"
 
+# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["high", "max"]

--- a/providers/commandcode/models/zai-org/GLM-5.2.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.2.toml
@@ -1,7 +1,9 @@
-base_model = "zhipuai/glm-5.2"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party zai surface (same base_model)
+base_model = "zhipuai/glm-5.2"
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/zai-org/GLM-5.3.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.3.toml
@@ -1,0 +1,13 @@
+name = "GLM-5.3"
+attachment = false
+reasoning = true
+tool_call = true
+temperature = true
+
+[limit]
+context = 1000000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/zai-org/GLM-5.3.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.3.toml
@@ -1,4 +1,8 @@
 name = "GLM-5.3"
+description = "GLM-5.3 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = false
 attachment = false
 reasoning = true
 tool_call = true
@@ -11,3 +15,6 @@ output = 65536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.3.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.3.toml
@@ -1,20 +1,4 @@
-name = "GLM-5.3"
-description = "GLM-5.3 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = false
-attachment = false
-reasoning = true
-tool_call = true
-temperature = true
-
-[limit]
-context = 1000000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+base_model = "zhipuai/glm-5.3"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.3.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.3.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5.3"
 
-# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+# reasoning_options match first-party zai surface (same base_model)
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/commandcode/models/zai-org/GLM-5.3.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.3.toml
@@ -1,4 +1,7 @@
 base_model = "zhipuai/glm-5.3"
 
+# reasoning_options match peer-relay consensus (aihubmix, same base_model)
+
 [[reasoning_options]]
-type = "toggle"
+type = "effort"
+values = ["low", "high", "max"]

--- a/providers/commandcode/models/zai-org/GLM-5.3.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.3.toml
@@ -1,7 +1,9 @@
-base_model = "zhipuai/glm-5.3"
+# wire (probed 2026-09-06 on api.commandcode.ai): OpenAI-compatible `reasoning_effort`
+# accepts low|medium|high|xhigh|max; "none" is rejected with HTTP 400.
+# No on/off toggle exposed - reasoning stays available at every level.
 
-# reasoning_options match first-party zai surface (same base_model)
+base_model = "zhipuai/glm-5.3"
 
 [[reasoning_options]]
 type = "effort"
-values = ["low", "high", "max"]
+values = ["low", "medium", "high", "xhigh", "max"]

--- a/providers/commandcode/models/zai-org/GLM-5.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.toml
@@ -1,4 +1,8 @@
 name = "GLM-5"
+description = "GLM-5 served via the CommandCode aggregation gateway"
+release_date = "2026-09-05"
+last_updated = "2026-09-05"
+open_weights = false
 attachment = false
 reasoning = false
 tool_call = true

--- a/providers/commandcode/models/zai-org/GLM-5.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.toml
@@ -1,0 +1,13 @@
+name = "GLM-5"
+attachment = false
+reasoning = false
+tool_call = true
+temperature = true
+
+[limit]
+context = 200000
+output = 65536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/commandcode/models/zai-org/GLM-5.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.toml
@@ -1,17 +1,4 @@
-name = "GLM-5"
-description = "GLM-5 served via the CommandCode aggregation gateway"
-release_date = "2026-09-05"
-last_updated = "2026-09-05"
-open_weights = false
-attachment = false
-reasoning = false
-tool_call = true
-temperature = true
+base_model = "zhipuai/glm-5"
 
-[limit]
-context = 200000
-output = 65536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+[[reasoning_options]]
+type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.toml
@@ -1,6 +1,6 @@
 base_model = "zhipuai/glm-5"
 
-# reasoning_options match peer-relay consensus (alibaba-token-plan, same base_model)
+# reasoning_options match first-party zai surface (same base_model)
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.toml
@@ -1,4 +1,6 @@
 base_model = "zhipuai/glm-5"
 
+# reasoning_options match peer-relay consensus (alibaba-token-plan, same base_model)
+
 [[reasoning_options]]
 type = "toggle"

--- a/providers/commandcode/models/zai-org/GLM-5.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.toml
@@ -1,6 +1,5 @@
+# probed 2026-09-06 on api.commandcode.ai: zero reasoning tokens even with
+# reasoning_effort=high, so reasoning is disabled for this model on this host.
+
 base_model = "zhipuai/glm-5"
-
-# reasoning_options match first-party zai surface (same base_model)
-
-[[reasoning_options]]
-type = "toggle"
+reasoning = false

--- a/providers/commandcode/provider.toml
+++ b/providers/commandcode/provider.toml
@@ -1,0 +1,5 @@
+name = "CommandCode"
+npm = "@ai-sdk/openai-compatible"
+env = ["COMMANDCODE_API_KEY"]
+doc = "https://docs.commandcode.ai"
+api = "https://api.commandcode.ai/provider/v1"


### PR DESCRIPTION
## Summary

Adds the **CommandCode** provider — an OpenAI-compatible aggregation gateway (`api.commandcode.ai/provider/v1`) popular with CN users — with 44 model entries, all override-only `base_model` refs against existing lab entries (gateway-specific variants point at their base lab model with a display-name override).

## Method: measured, not vendor claims

Every entry was capability-probed against the live API (scripted, reproducible):

| Probe | Method |
|---|---|
| text | chat completion round-trip |
| vision | digit-recognition test — rendered PNG with a **random digit per model**, model must read the exact digit (rules out lucky guesses) |
| tool_call | function-calling round-trip (`get_weather` probe) |
| reasoning | reasoning tokens in `usage.completion_tokens_details` + `reasoning_content` in message |
| reasoning wire control | `reasoning_effort` enumerated from the gateway's own 400 error |

## Reasoning wire control (probed 2026-09-06, all 44 IDs)

Uniform gateway behavior, verified per model:

- `reasoning_effort` accepts **`low|medium|high|xhigh|max`** on every model; `"none"` is rejected with HTTP 400 (`Invalid option: expected one of "low"|"medium"|"high"|"xhigh"|"max"`)
- No on/off toggle exists on this host (`enable_thinking`, `thinking.type=disabled`, `reasoning.enabled=false` are silently ignored); reasoning stays available at every level
- Each entry documents this in a leading wire comment and authors `effort = [low, medium, high, xhigh, max]`

## Host deltas vs lab metadata (probed)

- `moonshotai/Kimi-K2.5`, `zai-org/GLM-5`: **zero reasoning tokens even with `reasoning_effort=high`** → `reasoning = false` on this host, no `reasoning_options`
- `stepfun/Step-3.7-Flash`: tool-call probe fails → `tool_call = false`; vision probe fails → text-only `[modalities]`
- `MiniMaxAI/MiniMax-M3`: reasoning activates only via `reasoning_effort` (0 tokens by default, 127 at `high`); vision probe fails → text-only
- `meta/muse-spark-1.2/1.3`: reasoning tokens billed but `reasoning_content` not surfaced; `-contributor` variants do surface it
- Qwen 3.7/3.8 series: 3.8 models have vision, 3.7 do not

## Pricing / cost

CommandCode is **subscription-credit based** (https://commandcode.ai/pricing): plans (Go $1/mo, GOAT $10/mo, …) bundle monthly credits; requests debit credits, and some models are free while capacity lasts (Laguna S 2.1, LongCat 2.0). There is **no public per-token USD/MTok price list**, so no `[cost]` is authored — entries are catalog/request metadata only.

## Omitted from the provider's 67-model catalog (22)

Excluded because they were **not verifiable on the tester's plan** — happy to add them if a maintainer with access can probe:

- 13x `HTTP 403` (not enabled on plan): claude-*, most gpt-5.x (except gpt-5.6-sol), several gemini flashes, sakana/fugu-ultra, meta/muse-spark-1.1
- 9x `HTTP 400`: MiniMax-M2.7, claude-fable/opus/sonnet/haiku series
- 1x `HTTP 503`: poolside/laguna-s-2.1-free (free pool, upstream down at test time)
