### PR TITLE
the-grid-ai: add lab instruments and correct output limits

### DIFF
--- a/providers/the-grid-ai/models/agent-prime.toml
+++ b/providers/the-grid-ai/models/agent-prime.toml
@@ -18,7 +18,7 @@ field = "reasoning_content"
 [limit]
 context = 196_608
 input = 120_000
-output = 30_000
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/the-grid-ai/models/agent-standard.toml
+++ b/providers/the-grid-ai/models/agent-standard.toml
@@ -18,7 +18,7 @@ field = "reasoning_content"
 [limit]
 context = 128_000
 input = 120_000
-output = 16_000
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/the-grid-ai/models/bytedance-pro-latest.toml
+++ b/providers/the-grid-ai/models/bytedance-pro-latest.toml
@@ -5,7 +5,7 @@ release_date = "2026-07-06"
 last_updated = "2026-07-06"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/bytedance-pro-latest.toml
+++ b/providers/the-grid-ai/models/bytedance-pro-latest.toml
@@ -1,0 +1,27 @@
+name = "ByteDance Pro Latest"
+description = "Lab latest market for ByteDance Pro supply. You contract for the latest qualifying route, not a specific model."
+# contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
+release_date = "2026-07-06"
+last_updated = "2026-07-06"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 262_144
+input = 256_000
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+# Pricing on The Grid is variable.
+# Tokens trade on an open market, so cost is not fixed and is intentionally omitted here.

--- a/providers/the-grid-ai/models/claude-opus-latest.toml
+++ b/providers/the-grid-ai/models/claude-opus-latest.toml
@@ -1,0 +1,27 @@
+name = "Claude Opus Latest"
+description = "Lab latest market for Claude Opus frontier supply. You contract for the latest qualifying route, not a specific model."
+# contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
+release_date = "2026-07-06"
+last_updated = "2026-07-30"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 1_000_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+# Pricing on The Grid is variable.
+# Tokens trade on an open market, so cost is not fixed and is intentionally omitted here.

--- a/providers/the-grid-ai/models/claude-opus-latest.toml
+++ b/providers/the-grid-ai/models/claude-opus-latest.toml
@@ -1,3 +1,8 @@
+# Reasoning wire path on POST https://api.thegrid.ai/v1/chat/completions:
+#   toggle -> `reasoning = { enabled = true | false }`
+#   effort -> `reasoning_effort = "low" | "medium" | "high" | "xhigh" | "max"`
+# The instrument reports `reasoning.mandatory = false` at GET /v1/models, which is
+# the same shape the max-tier instruments use for their caller toggle.
 name = "Claude Opus Latest"
 description = "Lab latest market for Claude Opus frontier supply. You contract for the latest qualifying route, not a specific model."
 # contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments

--- a/providers/the-grid-ai/models/code-prime.toml
+++ b/providers/the-grid-ai/models/code-prime.toml
@@ -18,7 +18,7 @@ field = "reasoning_content"
 [limit]
 context = 196_608
 input = 120_000
-output = 30_000
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/the-grid-ai/models/code-standard.toml
+++ b/providers/the-grid-ai/models/code-standard.toml
@@ -18,7 +18,7 @@ field = "reasoning_content"
 [limit]
 context = 128_000
 input = 120_000
-output = 16_000
+output = 65_536
 
 [modalities]
 input = ["text"]

--- a/providers/the-grid-ai/models/deepseek-pro-latest.toml
+++ b/providers/the-grid-ai/models/deepseek-pro-latest.toml
@@ -5,7 +5,7 @@ release_date = "2026-07-06"
 last_updated = "2026-07-06"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/deepseek-pro-latest.toml
+++ b/providers/the-grid-ai/models/deepseek-pro-latest.toml
@@ -1,0 +1,27 @@
+name = "DeepSeek Pro Latest"
+description = "Lab latest market for DeepSeek Pro supply. You contract for the latest qualifying route, not a specific model."
+# contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
+release_date = "2026-07-06"
+last_updated = "2026-07-06"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 1_000_000
+input = 922_000
+output = 384_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+# Pricing on The Grid is variable.
+# Tokens trade on an open market, so cost is not fixed and is intentionally omitted here.

--- a/providers/the-grid-ai/models/gemini-pro-latest.toml
+++ b/providers/the-grid-ai/models/gemini-pro-latest.toml
@@ -1,0 +1,27 @@
+name = "Gemini Pro Latest"
+description = "Lab latest market for Gemini Pro frontier supply. You contract for the latest qualifying route, not a specific model."
+# contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
+release_date = "2026-07-06"
+last_updated = "2026-07-06"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 1_000_000
+input = 922_000
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+# Pricing on The Grid is variable.
+# Tokens trade on an open market, so cost is not fixed and is intentionally omitted here.

--- a/providers/the-grid-ai/models/gemini-pro-latest.toml
+++ b/providers/the-grid-ai/models/gemini-pro-latest.toml
@@ -5,7 +5,7 @@ release_date = "2026-07-06"
 last_updated = "2026-07-06"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/glm-latest.toml
+++ b/providers/the-grid-ai/models/glm-latest.toml
@@ -5,7 +5,7 @@ release_date = "2026-07-06"
 last_updated = "2026-07-06"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/glm-latest.toml
+++ b/providers/the-grid-ai/models/glm-latest.toml
@@ -1,0 +1,27 @@
+name = "GLM Latest"
+description = "Lab latest market for GLM supply. You contract for the latest qualifying route, not a specific model."
+# contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
+release_date = "2026-07-06"
+last_updated = "2026-07-06"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 1_000_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+# Pricing on The Grid is variable.
+# Tokens trade on an open market, so cost is not fixed and is intentionally omitted here.

--- a/providers/the-grid-ai/models/gpt-sol-latest.toml
+++ b/providers/the-grid-ai/models/gpt-sol-latest.toml
@@ -1,0 +1,27 @@
+name = "GPT Sol Latest"
+description = "Lab latest market for GPT frontier supply. You contract for the latest qualifying route, not a specific model."
+# contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
+release_date = "2026-07-06"
+last_updated = "2026-07-06"
+attachment = true
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 1_000_000
+input = 922_000
+output = 128_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+# Pricing on The Grid is variable.
+# Tokens trade on an open market, so cost is not fixed and is intentionally omitted here.

--- a/providers/the-grid-ai/models/gpt-sol-latest.toml
+++ b/providers/the-grid-ai/models/gpt-sol-latest.toml
@@ -5,7 +5,7 @@ release_date = "2026-07-06"
 last_updated = "2026-07-06"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/minimax-latest.toml
+++ b/providers/the-grid-ai/models/minimax-latest.toml
@@ -5,7 +5,7 @@ release_date = "2026-07-06"
 last_updated = "2026-07-06"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 temperature = false
 tool_call = true
 structured_output = true

--- a/providers/the-grid-ai/models/minimax-latest.toml
+++ b/providers/the-grid-ai/models/minimax-latest.toml
@@ -1,0 +1,27 @@
+name = "MiniMax Latest"
+description = "Lab latest market for MiniMax supply. You contract for the latest qualifying route, not a specific model."
+# contract spec: https://thegrid.ai/docs/instrument-specifications/current-instruments
+release_date = "2026-07-06"
+last_updated = "2026-07-06"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+temperature = false
+tool_call = true
+structured_output = true
+open_weights = false
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 1_000_000
+input = 922_000
+output = 512_000
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+# Pricing on The Grid is variable.
+# Tokens trade on an open market, so cost is not fixed and is intentionally omitted here.

--- a/providers/the-grid-ai/models/text-prime.toml
+++ b/providers/the-grid-ai/models/text-prime.toml
@@ -17,7 +17,7 @@ field = "reasoning_content"
 [limit]
 context = 196_608
 input = 120_000
-output = 30_000
+output = 131_072
 
 [modalities]
 input = ["text"]

--- a/providers/the-grid-ai/models/text-standard.toml
+++ b/providers/the-grid-ai/models/text-standard.toml
@@ -17,7 +17,7 @@ field = "reasoning_content"
 [limit]
 context = 128_000
 input = 120_000
-output = 16_000
+output = 65_536
 
 [modalities]
 input = ["text"]


### PR DESCRIPTION
Refreshes the `the-grid-ai` catalog against the live API.

**Disclosure:** I work on The Grid.

Two things, both read from `GET https://api.thegrid.ai/v1/models` (public, no key required):

### 1. Seven lab-scoped instruments were missing

The catalog had the nine task/tier instruments but none of the lab-scoped markets. Adding `claude-opus-latest`, `gpt-sol-latest`, `gemini-pro-latest`, `deepseek-pro-latest`, `glm-latest`, `minimax-latest`, `bytedance-pro-latest`.

Same shape as the existing entries, with per-instrument `reasoning_options` from the API's `reasoning.supported_efforts`, and `attachment` set from `attachments` — image input is available on four of the seven, not all.

### 2. Six output limits were wrong

The prime and standard tiers understated their output ceiling by roughly four times:

| Instrument | was | is |
|---|---|---|
| `agent-prime`, `code-prime`, `text-prime` | 30,000 | **131,072** |
| `agent-standard`, `code-standard`, `text-standard` | 16,000 | **65,536** |

This is the part worth landing regardless of the additions — downstream consumers read these limits, so the low values can truncate output or mis-size context budgets.

### One instrument deliberately held back

`kimi-latest` is **not** in this PR. The API currently reports `max_completion_tokens` equal to its full `context_length` (1,048,576), which leaves no room for input and can't be right. Rather than publish a number I can't stand behind, I've left it out and I'm getting the upstream value fixed. I'll send it separately once it's correct.

Pricing stays omitted for all of these, consistent with the existing entries — Grid instruments are market-priced, so a fixed cost would be wrong within hours.
