### PR TITLE
Neon: add gpt-6-astra

### DIFF
--- a/models/openai/gpt-6-astra.toml
+++ b/models/openai/gpt-6-astra.toml
@@ -8,6 +8,7 @@ reasoning = true
 temperature = false
 tool_call = true
 structured_output = true
+knowledge = "2026-04-30"
 open_weights = false
 
 [limit]

--- a/providers/neon/models/gpt-6-astra.toml
+++ b/providers/neon/models/gpt-6-astra.toml
@@ -1,0 +1,24 @@
+base_model = "openai/gpt-6-astra"
+knowledge = "2026-04-30"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 20
+output = 75
+cache_read = 2
+cache_write = 25
+
+[modalities]
+output = ["text", "image"]
+
+[provider]
+npm = "@ai-sdk/openai"
+api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
+shape = "responses"

--- a/providers/neon/models/gpt-6-astra.toml
+++ b/providers/neon/models/gpt-6-astra.toml
@@ -1,5 +1,4 @@
 base_model = "openai/gpt-6-astra"
-knowledge = "2026-04-30"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 
 [cost]


### PR DESCRIPTION
## Problem

The Neon AI Gateway serves `gpt-6-astra` on its OpenAI Responses route, but `providers/neon/` had no entry for it. Anyone resolving the Neon catalog from models.dev (the `@ai-sdk` provider registry, OpenCode, anything reading `api.json`) got no `neon.models.gpt-6-astra`, so the model was callable through the gateway and invisible in the catalog.

The lab file `models/openai/gpt-6-astra.toml` already exists on `dev`. This PR adds the Neon host overlay on top of it.

## Change

New file `providers/neon/models/gpt-6-astra.toml`, override-only per the `base_model` rules in `AGENTS.md`:

```toml
base_model = "openai/gpt-6-astra"
reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

[cost]
input = 10
output = 50
cache_read = 1
cache_write = 12.5

[[cost.tiers]]
tier = { type = "context", size = 272_000 }
input = 20
output = 75
cache_read = 2
cache_write = 25

[modalities]
output = ["text", "image"]

[provider]
npm = "@ai-sdk/openai"
api = "${NEON_AI_GATEWAY_BASE_URL}/openai/v1"
shape = "responses"
```

What each override is and where it comes from:

| Field | Value | Source |
| --- | --- | --- |
| `reasoning_options` | effort `low` / `medium` / `high` / `xhigh` / `max` | Same list as `providers/openai/models/gpt-6-astra.toml`; the gateway proxies the OpenAI Responses API, so the caller controls are the lab's |
| `cost` | 10 / 50, cache read 1, cache write 12.5 (USD per MTok) | https://developers.openai.com/api/docs/models/gpt-6-astra |
| `cost.tiers` at 272k context | 20 / 75, cache read 2, cache write 25 | Same page; matches the tier on the first-party OpenAI entry |
| `modalities.output` | `["text", "image"]` | Neon's Responses route returns 200 for the `image_generation` tool on this model. The lab file lists text only, so this is a real host delta |
| `provider` | `@ai-sdk/openai`, `${NEON_AI_GATEWAY_BASE_URL}/openai/v1`, `responses` | Same shape as every other Neon GPT overlay (`gpt-5-6-sol.toml`, `gpt-5-5.toml`, ...) |

Everything else (`name`, `description`, `family`, dates, `attachment`, `reasoning`, `tool_call`, `temperature`, `structured_output`, `limit`, input modalities) is inherited from the lab file and is not restated.

Resolved entry, from `bun validate` output:

```json
"gpt-6-astra": {
  "id": "gpt-6-astra",
  "name": "GPT-6 Astra",
  "family": "gpt-astra",
  "reasoning": true,
  "reasoning_options": [{ "type": "effort", "values": ["low", "medium", "high", "xhigh", "max"] }],
  "tool_call": true,
  "knowledge": "2026-04-30",
  "modalities": { "input": ["text", "image", "pdf"], "output": ["text", "image"] },
  "limit": { "context": 1050000, "input": 922000, "output": 128000 },
  "provider": { "npm": "@ai-sdk/openai", "api": "${NEON_AI_GATEWAY_BASE_URL}/openai/v1", "shape": "responses" },
  "cost": { "input": 10, "output": 50, "cache_read": 1, "cache_write": 12.5, "tiers": [ { "tier": { "type": "context", "size": 272000 }, "input": 20, "output": 75, "cache_read": 2, "cache_write": 25 } ] }
}
```

## Also in here

`models/openai/gpt-6-astra.toml` gains `knowledge = "2026-04-30"`:

| Field | Value | Source |
| --- | --- | --- |
| `knowledge` | `2026-04-30` | Same page as the prices: https://developers.openai.com/api/docs/models/gpt-6-astra, the line that reads "Apr 30, 2026 knowledge cutoff" |

`knowledge` is a lab fact, so it goes on the lab file where every host inherits it (OpenAI, Neon, Kilo, GitHub Copilot, Eden AI and the rest) rather than on this overlay. No other `gpt-6-astra` host set it, so this is additive for all of them. The cost table above maps that URL to rates; this row maps it to the cutoff.

## Verification

- `bun validate` passes on the branch (base `upstream/dev` at `5cafadf`).
- Resolved `neon.models.gpt-6-astra` has `cost`, `reasoning_options`, `limit.context`, `limit.output`, `knowledge = "2026-04-30"` and output modalities `text` + `image`, as shown above.
- Diff against `upstream/dev` is two files: the new overlay and the one-line `knowledge` addition.

Not covered by this PR: a live request through a reader's own gateway. The `image_generation` 200 and the Responses effort values were observed against the Neon gateway; models.dev has no test that exercises hosts.

## For your attention

- `modalities.output` on the Neon overlay includes `image` while the lab file says `text` only. If OpenAI's own catalog should also list image output, that is a separate lab-file change; this PR only records what the Neon host returns.
- `tool_call` is inherited as `true` from the lab file. Nothing in the overlay changes it.
- No `experimental.modes` (`fast`, `pro`) are declared for Neon. The first-party OpenAI entry has them; the Neon gateway's support for `service_tier` and `reasoning.mode = "pro"` was not checked, so they are left out rather than copied.
