### PR TITLE
Fix name duplicates for Eden AI

### DIFF
--- a/models/google/gemini-3-pro-image-preview.toml
+++ b/models/google/gemini-3-pro-image-preview.toml
@@ -1,4 +1,4 @@
-name = "Nano Banana Pro"
+name = "Nano Banana Pro Preview"
 description = "Nano Banana Pro for higher-fidelity image generation and design-heavy edits"
 family = "gemini-pro"
 release_date = "2025-11-20"

--- a/models/google/gemini-3.1-flash-image-preview.toml
+++ b/models/google/gemini-3.1-flash-image-preview.toml
@@ -1,4 +1,4 @@
-name = "Nano Banana 2"
+name = "Nano Banana 2 Preview"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "gemini-flash"
 release_date = "2026-02-26"

--- a/packages/core/src/sync/providers/edenai.ts
+++ b/packages/core/src/sync/providers/edenai.ts
@@ -59,6 +59,8 @@ const MODALITY_BY_EDENAI: Record<
 };
 
 // Upstreams that are the lab's own API for models under that namespace.
+// The first entry is the unsuffixed display route when several first-party
+// hosts exist (Google AI Studio vs Vertex AI).
 const LAB_UPSTREAMS: Record<string, readonly string[]> = {
   alibaba: ["qwen"],
   amazon: ["amazon"],
@@ -74,6 +76,29 @@ const LAB_UPSTREAMS: Record<string, readonly string[]> = {
   perplexity: ["perplexityai"],
   xai: ["xai"],
   zhipuai: ["zai"],
+};
+
+const ROUTE_LABELS: Record<string, string> = {
+  amazon: "Amazon Bedrock",
+  azure: "Azure",
+  cerebras: "Cerebras",
+  cloudflare: "Cloudflare",
+  compactifai: "CompactifAI",
+  databricks: "Databricks",
+  deepinfra: "Deep Infra",
+  fireworks_ai: "Fireworks AI",
+  flexai: "FlexAI",
+  groq: "Groq",
+  infomaniak: "Infomaniak",
+  ionos: "IONOS",
+  lilac: "Lilac",
+  nebius: "Nebius",
+  ovhcloud: "OVHcloud",
+  qwen: "Alibaba",
+  scaleway: "Scaleway",
+  tensorx: "TensorX",
+  together_ai: "Together AI",
+  vertex: "Vertex AI",
 };
 
 type ReasoningOption = NonNullable<
@@ -238,19 +263,31 @@ function isLatestAlias(model: EdenAIModel) {
   return /(?:^|-)latest$/i.test(slug);
 }
 
+function routeLabel(model: EdenAIModel, baseModel: string) {
+  const lab = baseModel.split("/")[0] ?? "";
+  const primary = LAB_UPSTREAMS[lab]?.[0];
+  if (model.owned_by === primary) return undefined;
+  return ROUTE_LABELS[model.owned_by] ?? titleCaseSlug(model.owned_by);
+}
+
 function displayName(model: EdenAIModel, baseModel: string) {
   const region = REGION_SUFFIX.exec(model.id)?.[0].slice(1);
   const latest = isLatestAlias(model);
-  if (region === undefined && !latest) return undefined;
+  const route = routeLabel(model, baseModel);
+  if (region === undefined && !latest && route === undefined) return undefined;
 
   const canonical = canonicalModelName(baseModel);
   if (canonical === undefined) return undefined;
-  if (latest) {
-    const slug = model.id.replace(REGION_SUFFIX, "").split("/").at(-1) ?? "";
-    const name = `${titleCaseSlug(slug)} (${canonical})`;
-    return region === undefined ? name : `${name} (${region.toUpperCase()})`;
-  }
-  return `${canonical} (${region.toUpperCase()})`;
+
+  const head = latest
+    ? titleCaseSlug(model.id.replace(REGION_SUFFIX, "").split("/").at(-1) ?? "")
+    : canonical;
+  const details = [
+    ...(latest ? [canonical] : []),
+    ...(route !== undefined ? [route] : []),
+    ...(region !== undefined ? [region.toUpperCase()] : []),
+  ];
+  return `${head} (${details.join(", ")})`;
 }
 
 // ========================================

--- a/packages/core/src/sync/providers/edenai.ts
+++ b/packages/core/src/sync/providers/edenai.ts
@@ -217,12 +217,39 @@ function hasOutputLimit(baseModel: string) {
   );
 }
 
-function regionVariantName(model: EdenAIModel, baseModel: string) {
+function titleCaseSlug(slug: string) {
+  return slug
+    .split(/[-_]/)
+    .filter((word) => word.length > 0)
+    .map((word) =>
+      word.toLowerCase() === "gpt"
+        ? "GPT"
+        : word[0]!.toUpperCase() + word.slice(1).toLowerCase(),
+    )
+    .join(" ");
+}
+
+function isLatestAlias(model: EdenAIModel) {
+  if (model.alias_of == null) return false;
+  const id = model.id.replace(REGION_SUFFIX, "");
+  const target = model.alias_of.replace(REGION_SUFFIX, "");
+  if (id.toLowerCase() === target.toLowerCase()) return false;
+  const slug = id.split("/").at(-1) ?? id;
+  return /(?:^|-)latest$/i.test(slug);
+}
+
+function displayName(model: EdenAIModel, baseModel: string) {
   const region = REGION_SUFFIX.exec(model.id)?.[0].slice(1);
-  if (region === undefined) return undefined;
+  const latest = isLatestAlias(model);
+  if (region === undefined && !latest) return undefined;
 
   const canonical = canonicalModelName(baseModel);
   if (canonical === undefined) return undefined;
+  if (latest) {
+    const slug = model.id.replace(REGION_SUFFIX, "").split("/").at(-1) ?? "";
+    const name = `${titleCaseSlug(slug)} (${canonical})`;
+    return region === undefined ? name : `${name} (${region.toUpperCase()})`;
+  }
   return `${canonical} (${region.toUpperCase()})`;
 }
 
@@ -462,7 +489,7 @@ export function buildEdenAIModel(
   return factorBaseModel(
     baseModel,
     {
-      name: regionVariantName(model, baseModel),
+      name: displayName(model, baseModel),
       modalities,
       attachment: input?.some((value) => value !== "text"),
       reasoning_options: reasoningOptions,

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -2617,6 +2617,63 @@ test("names Eden AI regional deployments after the canonical model", () => {
   });
 });
 
+test("names Eden AI latest aliases as Latest plus the current target", () => {
+  expect(
+    buildEdenAIModel(
+      edenAIModel({
+        id: "anthropic/claude-fable-latest",
+        model_name: "claude-fable-5-1",
+        owned_by: "anthropic",
+        alias_of: "anthropic/claude-fable-5-1",
+      }),
+    ),
+  ).toMatchObject({
+    base_model: "anthropic/claude-fable-5-1",
+    name: "Claude Fable Latest (Claude Fable 5.1)",
+  });
+  expect(
+    buildEdenAIModel(
+      edenAIModel({
+        id: "openai/gpt-latest",
+        model_name: "gpt-6-astra",
+        owned_by: "openai",
+        alias_of: "openai/gpt-6-astra",
+      }),
+    ),
+  ).toMatchObject({
+    base_model: "openai/gpt-6-astra",
+    name: "GPT Latest (GPT-6 Astra)",
+  });
+  expect(
+    buildEdenAIModel(
+      edenAIModel({
+        id: "vertex/gemini-flash-latest@us",
+        model_name: "gemini-3.8-flash",
+        owned_by: "vertex",
+        alias_of: "vertex/gemini-3.8-flash",
+      }),
+    ),
+  ).toMatchObject({
+    base_model: "google/gemini-3.8-flash",
+    name: "Gemini Flash Latest (Gemini 3.8 Flash) (US)",
+  });
+});
+
+test("does not treat Eden AI case-only aliases as latest pointers", () => {
+  const built = buildEdenAIModel(
+    edenAIModel({
+      id: "flexai/deepseek-v4-flash-0731",
+      model_name: "DeepSeek-V4-Flash-0731",
+      owned_by: "flexai",
+      alias_of: "flexai/DeepSeek-V4-Flash-0731",
+    }),
+  );
+  expect(built).toMatchObject({
+    base_model: "deepseek/deepseek-v4-flash-0731",
+  });
+  expect(built).not.toHaveProperty("name");
+});
+
 test("builds Eden AI context tiers without reading time-based cache keys", () => {
   const model = edenAIModel({
     id: "openai/gpt-5.6-terra",

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -2613,7 +2613,7 @@ test("names Eden AI regional deployments after the canonical model", () => {
     ),
   ).toMatchObject({
     base_model: "anthropic/claude-opus-5",
-    name: "Claude Opus 5 (EU)",
+    name: "Claude Opus 5 (Amazon Bedrock, EU)",
   });
 });
 
@@ -2655,7 +2655,55 @@ test("names Eden AI latest aliases as Latest plus the current target", () => {
     ),
   ).toMatchObject({
     base_model: "google/gemini-3.8-flash",
-    name: "Gemini Flash Latest (Gemini 3.8 Flash) (US)",
+    name: "Gemini Flash Latest (Gemini 3.8 Flash, Vertex AI, US)",
+  });
+});
+
+test("names Eden AI non-primary hosts distinctly from the lab route", () => {
+  expect(
+    buildEdenAIModel(
+      edenAIModel({
+        id: "google/gemini-3.8-flash",
+        model_name: "gemini-3.8-flash",
+        owned_by: "google",
+      }),
+    ),
+  ).not.toHaveProperty("name");
+  expect(
+    buildEdenAIModel(
+      edenAIModel({
+        id: "vertex/gemini-3.8-flash",
+        model_name: "gemini-3.8-flash",
+        owned_by: "vertex",
+      }),
+    ),
+  ).toMatchObject({
+    base_model: "google/gemini-3.8-flash",
+    name: "Gemini 3.8 Flash (Vertex AI)",
+  });
+  expect(
+    buildEdenAIModel(
+      edenAIModel({
+        id: "vertex/gemini-3.8-flash@us",
+        model_name: "gemini-3.8-flash",
+        owned_by: "vertex",
+      }),
+    ),
+  ).toMatchObject({
+    base_model: "google/gemini-3.8-flash",
+    name: "Gemini 3.8 Flash (Vertex AI, US)",
+  });
+  expect(
+    buildEdenAIModel(
+      edenAIModel({
+        id: "deepinfra/openai/gpt-oss-120b",
+        model_name: "openai/gpt-oss-120b",
+        owned_by: "deepinfra",
+      }),
+    ),
+  ).toMatchObject({
+    base_model: "openai/gpt-oss-120b",
+    name: "GPT OSS 120B (Deep Infra)",
   });
 });
 
@@ -2670,8 +2718,8 @@ test("does not treat Eden AI case-only aliases as latest pointers", () => {
   );
   expect(built).toMatchObject({
     base_model: "deepseek/deepseek-v4-flash-0731",
+    name: "DeepSeek V4 Flash 0731 (FlexAI)",
   });
-  expect(built).not.toHaveProperty("name");
 });
 
 test("builds Eden AI context tiers without reading time-based cache keys", () => {
@@ -2732,9 +2780,15 @@ test("keeps every Eden AI route for models with no first-party relay", () => {
 
   const firstParty = collectFirstPartyBaseModels(models);
   expect(firstParty.size).toBe(0);
+  const names = {
+    deepinfra: "GPT OSS 120B (Deep Infra)",
+    groq: "GPT OSS 120B (Groq)",
+    cerebras: "GPT OSS 120B (Cerebras)",
+  };
   for (const model of models) {
     expect(buildEdenAIModel(model, undefined, firstParty)).toMatchObject({
       base_model: "openai/gpt-oss-120b",
+      name: names[model.owned_by as keyof typeof names],
     });
   }
 });

--- a/providers/edenai/models/amazon/moonshot.kimi-k2-thinking.toml
+++ b/providers/edenai/models/amazon/moonshot.kimi-k2-thinking.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2-thinking"
+name = "Kimi K2 Thinking (Amazon Bedrock)"
 tool_call = false
 structured_output = false
 reasoning_options = []

--- a/providers/edenai/models/amazon/moonshotai.kimi-k2.5.toml
+++ b/providers/edenai/models/amazon/moonshotai.kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+name = "Kimi K2.5 (Amazon Bedrock)"
 structured_output = false
 reasoning_options = []
 

--- a/providers/edenai/models/amazon/zai.glm-4.7-flash.toml
+++ b/providers/edenai/models/amazon/zai.glm-4.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
+name = "GLM-4.7-Flash (Amazon Bedrock)"
 structured_output = false
 reasoning_options = []
 

--- a/providers/edenai/models/amazon/zai.glm-4.7-flash@us.toml
+++ b/providers/edenai/models/amazon/zai.glm-4.7-flash@us.toml
@@ -1,5 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
-name = "GLM-4.7-Flash (US)"
+name = "GLM-4.7-Flash (Amazon Bedrock, US)"
 structured_output = false
 reasoning_options = []
 

--- a/providers/edenai/models/anthropic/claude-fable-latest.toml
+++ b/providers/edenai/models/anthropic/claude-fable-latest.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-fable-5-1"
+name = "Claude Fable Latest (Claude Fable 5.1)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/anthropic/claude-opus-latest.toml
+++ b/providers/edenai/models/anthropic/claude-opus-latest.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-opus-5"
+name = "Claude Opus Latest (Claude Opus 5)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/anthropic/claude-sonnet-latest.toml
+++ b/providers/edenai/models/anthropic/claude-sonnet-latest.toml
@@ -1,4 +1,5 @@
 base_model = "anthropic/claude-sonnet-5"
+name = "Claude Sonnet Latest (Claude Sonnet 5)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/azure/gpt-5.1-codex-max.toml
+++ b/providers/edenai/models/azure/gpt-5.1-codex-max.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.1-codex-max"
 base_model_omit = ["limit.input"]
+name = "GPT-5.1 Codex Max (Azure)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/azure/gpt-5.1-codex-mini.toml
+++ b/providers/edenai/models/azure/gpt-5.1-codex-mini.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.1-codex-mini"
 base_model_omit = ["limit.input"]
+name = "GPT-5.1 Codex mini (Azure)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/azure/gpt-5.1-codex.toml
+++ b/providers/edenai/models/azure/gpt-5.1-codex.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.1-codex"
 base_model_omit = ["limit.input"]
+name = "GPT-5.1 Codex (Azure)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/azure/gpt-5.2-codex.toml
+++ b/providers/edenai/models/azure/gpt-5.2-codex.toml
@@ -1,5 +1,6 @@
 base_model = "openai/gpt-5.2-codex"
 base_model_omit = ["limit.input"]
+name = "GPT-5.2 Codex (Azure)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/cerebras/gpt-oss-120b.toml
+++ b/providers/edenai/models/cerebras/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Cerebras)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it.toml
+++ b/providers/edenai/models/cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it.toml
@@ -1,4 +1,5 @@
 base_model = "aisingapore/gemma-sea-lion-v4-27b-it"
+name = "Gemma-SEA-LION-v4-27B-IT (Cloudflare)"
 structured_output = false
 
 [cost]

--- a/providers/edenai/models/cloudflare/@cf/deepseek-ai/deepseek-v4-flash-0731.toml
+++ b/providers/edenai/models/cloudflare/@cf/deepseek-ai/deepseek-v4-flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (Cloudflare)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/cloudflare/@cf/deepseek-ai/deepseek-v4-pro-0813.toml
+++ b/providers/edenai/models/cloudflare/@cf/deepseek-ai/deepseek-v4-pro-0813.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (Cloudflare)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/cloudflare/@cf/meta/llama-guard-3-8b.toml
+++ b/providers/edenai/models/cloudflare/@cf/meta/llama-guard-3-8b.toml
@@ -1,4 +1,5 @@
 base_model = "meta/llama-guard-3-8b"
+name = "Llama-Guard-3-8B (Cloudflare)"
 structured_output = false
 
 [cost]

--- a/providers/edenai/models/cloudflare/@cf/openai/gpt-oss-120b.toml
+++ b/providers/edenai/models/cloudflare/@cf/openai/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Cloudflare)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/cloudflare/@cf/openai/gpt-oss-20b.toml
+++ b/providers/edenai/models/cloudflare/@cf/openai/gpt-oss-20b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Cloudflare)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct.toml
+++ b/providers/edenai/models/cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct.toml
@@ -1,4 +1,5 @@
 base_model = "alibaba/qwen2.5-coder-32b-instruct"
+name = "Qwen2.5-Coder-32B-Instruct (Cloudflare)"
 tool_call = false
 structured_output = false
 

--- a/providers/edenai/models/cloudflare/@cf/zai-org/glm-4.7-flash.toml
+++ b/providers/edenai/models/cloudflare/@cf/zai-org/glm-4.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
+name = "GLM-4.7-Flash (Cloudflare)"
 structured_output = true
 reasoning_options = []
 

--- a/providers/edenai/models/databricks/databricks-deepseek-v4-flash-0731.toml
+++ b/providers/edenai/models/databricks/databricks-deepseek-v4-flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (Databricks)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/databricks/databricks-deepseek-v4-pro-0813.toml
+++ b/providers/edenai/models/databricks/databricks-deepseek-v4-pro-0813.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (Databricks)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/databricks/databricks-gpt-oss-120b.toml
+++ b/providers/edenai/models/databricks/databricks-gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Databricks)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/databricks/databricks-gpt-oss-120b@eu.toml
+++ b/providers/edenai/models/databricks/databricks-gpt-oss-120b@eu.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-oss-120b"
-name = "GPT OSS 120B (EU)"
+name = "GPT OSS 120B (Databricks, EU)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/databricks/databricks-gpt-oss-20b.toml
+++ b/providers/edenai/models/databricks/databricks-gpt-oss-20b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Databricks)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/databricks/databricks-gpt-oss-20b@eu.toml
+++ b/providers/edenai/models/databricks/databricks-gpt-oss-20b@eu.toml
@@ -1,5 +1,5 @@
 base_model = "openai/gpt-oss-20b"
-name = "GPT OSS 20B (EU)"
+name = "GPT OSS 20B (Databricks, EU)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/deepinfra/ByteDance/Seed-2.0-code.toml
+++ b/providers/edenai/models/deepinfra/ByteDance/Seed-2.0-code.toml
@@ -1,4 +1,5 @@
 base_model = "bytedance-seed/seed-2.0-code"
+name = "Seed 2.0 Code (Deep Infra)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/deepinfra/ByteDance/Seed-2.0-mini.toml
+++ b/providers/edenai/models/deepinfra/ByteDance/Seed-2.0-mini.toml
@@ -1,4 +1,5 @@
 base_model = "bytedance-seed/seed-2.0-mini"
+name = "Seed 2.0 Mini (Deep Infra)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-R1.toml
+++ b/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-R1.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-r1"
+name = "DeepSeek-R1 (Deep Infra)"
 structured_output = false
 reasoning_options = []
 

--- a/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-V3-0324.toml
+++ b/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-V3-0324.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v3-0324"
+name = "DeepSeek V3 0324 (Deep Infra)"
 structured_output = false
 
 [cost]

--- a/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-V3.toml
+++ b/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-V3.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v3"
+name = "DeepSeek-V3 (Deep Infra)"
 structured_output = false
 
 [cost]

--- a/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (Deep Infra)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-V4-Pro-0813.toml
+++ b/providers/edenai/models/deepinfra/deepseek-ai/DeepSeek-V4-Pro-0813.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (Deep Infra)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.toml
+++ b/providers/edenai/models/deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct.toml
@@ -1,4 +1,5 @@
 base_model = "meta/llama-3.2-11b-vision-instruct"
+name = "Llama-3.2-11B-Vision-Instruct (Deep Infra)"
 tool_call = false
 structured_output = true
 

--- a/providers/edenai/models/deepinfra/meta-llama/Llama-3.3-70B-Instruct.toml
+++ b/providers/edenai/models/deepinfra/meta-llama/Llama-3.3-70B-Instruct.toml
@@ -1,4 +1,5 @@
 base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama-3.3-70B-Instruct (Deep Infra)"
 attachment = false
 structured_output = true
 

--- a/providers/edenai/models/deepinfra/meta-llama/Llama-Guard-3-8B.toml
+++ b/providers/edenai/models/deepinfra/meta-llama/Llama-Guard-3-8B.toml
@@ -1,4 +1,5 @@
 base_model = "meta/llama-guard-3-8b"
+name = "Llama-Guard-3-8B (Deep Infra)"
 structured_output = false
 
 [cost]

--- a/providers/edenai/models/deepinfra/meta-models/Muse-Glimmer-30B.toml
+++ b/providers/edenai/models/deepinfra/meta-models/Muse-Glimmer-30B.toml
@@ -1,4 +1,5 @@
 base_model = "meta/muse-glimmer-30b"
+name = "Muse Glimmer 30B (Deep Infra)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/deepinfra/moonshotai/Kimi-K2.5.toml
+++ b/providers/edenai/models/deepinfra/moonshotai/Kimi-K2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+name = "Kimi K2.5 (Deep Infra)"
 reasoning_options = []
 
 [cost]

--- a/providers/edenai/models/deepinfra/nemotron-3-ultra-550b-a55b.toml
+++ b/providers/edenai/models/deepinfra/nemotron-3-ultra-550b-a55b.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+name = "Nemotron 3 Ultra 550B A55B (Deep Infra)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.toml
+++ b/providers/edenai/models/deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/llama-3.1-nemotron-70b-instruct"
+name = "Llama 3.1 Nemotron 70B Instruct (Deep Infra)"
 structured_output = false
 
 [cost]

--- a/providers/edenai/models/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.toml
+++ b/providers/edenai/models/deepinfra/nvidia/Nemotron-3-Nano-30B-A3B.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-nano-30b-a3b"
+name = "Nemotron 3 Nano 30B A3B (Deep Infra)"
 structured_output = true
 reasoning_options = []
 

--- a/providers/edenai/models/deepinfra/openai/gpt-oss-120b.toml
+++ b/providers/edenai/models/deepinfra/openai/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Deep Infra)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/deepinfra/openai/gpt-oss-20b.toml
+++ b/providers/edenai/models/deepinfra/openai/gpt-oss-20b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Deep Infra)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/deepinfra/stepfun-ai/Step-3.5-Flash.toml
+++ b/providers/edenai/models/deepinfra/stepfun-ai/Step-3.5-Flash.toml
@@ -1,5 +1,6 @@
 base_model = "stepfun/step-3.5-flash"
 base_model_omit = ["limit.input"]
+name = "Step 3.5 Flash (Deep Infra)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/deepinfra/stepfun-ai/Step-3.7-Flash.toml
+++ b/providers/edenai/models/deepinfra/stepfun-ai/Step-3.7-Flash.toml
@@ -1,5 +1,6 @@
 base_model = "stepfun/step-3.7-flash"
 base_model_omit = ["limit.input"]
+name = "Step 3.7 Flash (Deep Infra)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/deepinfra/tencent/Hy3.toml
+++ b/providers/edenai/models/deepinfra/tencent/Hy3.toml
@@ -1,5 +1,6 @@
 base_model = "tencent/hy3"
 base_model_omit = ["limit.input"]
+name = "Hy3 (Deep Infra)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/deepinfra/thinkingmachines/Inkling-Small.toml
+++ b/providers/edenai/models/deepinfra/thinkingmachines/Inkling-Small.toml
@@ -1,4 +1,5 @@
 base_model = "thinkingmachines/inkling-small"
+name = "Inkling Small (Deep Infra)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/deepinfra/thinkingmachines/Inkling.toml
+++ b/providers/edenai/models/deepinfra/thinkingmachines/Inkling.toml
@@ -1,4 +1,5 @@
 base_model = "thinkingmachines/inkling"
+name = "Inkling (Deep Infra)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/deepinfra/zai-org/GLM-4.7-Flash.toml
+++ b/providers/edenai/models/deepinfra/zai-org/GLM-4.7-Flash.toml
@@ -1,4 +1,5 @@
 base_model = "zhipuai/glm-4.7-flash"
+name = "GLM-4.7-Flash (Deep Infra)"
 structured_output = true
 reasoning_options = []
 

--- a/providers/edenai/models/fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731.toml
+++ b/providers/edenai/models/fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (Fireworks AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/fireworks_ai/accounts/fireworks/models/deepseek-v4-pro-0813.toml
+++ b/providers/edenai/models/fireworks_ai/accounts/fireworks/models/deepseek-v4-pro-0813.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (Fireworks AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/fireworks_ai/accounts/fireworks/models/inkling.toml
+++ b/providers/edenai/models/fireworks_ai/accounts/fireworks/models/inkling.toml
@@ -1,4 +1,5 @@
 base_model = "thinkingmachines/inkling"
+name = "Inkling (Fireworks AI)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/fireworks_ai/accounts/fireworks/models/muse-glimmer-30b.toml
+++ b/providers/edenai/models/fireworks_ai/accounts/fireworks/models/muse-glimmer-30b.toml
@@ -1,4 +1,5 @@
 base_model = "meta/muse-glimmer-30b"
+name = "Muse Glimmer 30B (Fireworks AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/fireworks_ai/gpt-oss-120b.toml
+++ b/providers/edenai/models/fireworks_ai/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Fireworks AI)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/flexai/Muse-Glimmer-30B.toml
+++ b/providers/edenai/models/flexai/Muse-Glimmer-30B.toml
@@ -1,4 +1,5 @@
 base_model = "meta/muse-glimmer-30b"
+name = "Muse Glimmer 30B (FlexAI)"
 tool_call = false
 structured_output = false
 

--- a/providers/edenai/models/flexai/Nemotron-3-Super-120B-A12B.toml
+++ b/providers/edenai/models/flexai/Nemotron-3-Super-120B-A12B.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-super-120b-a12b"
+name = "Nemotron 3 Super 120B A12B (FlexAI)"
 tool_call = false
 structured_output = false
 

--- a/providers/edenai/models/flexai/Step-3.7-Flash.toml
+++ b/providers/edenai/models/flexai/Step-3.7-Flash.toml
@@ -1,5 +1,6 @@
 base_model = "stepfun/step-3.7-flash"
 base_model_omit = ["limit.input"]
+name = "Step 3.7 Flash (FlexAI)"
 tool_call = false
 structured_output = false
 

--- a/providers/edenai/models/flexai/deepseek-v4-flash-0731.toml
+++ b/providers/edenai/models/flexai/deepseek-v4-flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (FlexAI)"
 tool_call = false
 structured_output = false
 

--- a/providers/edenai/models/flexai/gpt-oss-120b.toml
+++ b/providers/edenai/models/flexai/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (FlexAI)"
 tool_call = false
 structured_output = false
 

--- a/providers/edenai/models/flexai/gpt-oss-20b.toml
+++ b/providers/edenai/models/flexai/gpt-oss-20b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (FlexAI)"
 tool_call = false
 structured_output = false
 

--- a/providers/edenai/models/google/gemini-flash-latest.toml
+++ b/providers/edenai/models/google/gemini-flash-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.8-flash"
+name = "Gemini Flash Latest (Gemini 3.8 Flash)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/google/gemini-pro-latest.toml
+++ b/providers/edenai/models/google/gemini-pro-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+name = "Gemini Pro Latest (Gemini 3.1 Pro Preview)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/groq/openai/gpt-oss-120b.toml
+++ b/providers/edenai/models/groq/openai/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Groq)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/groq/openai/gpt-oss-20b.toml
+++ b/providers/edenai/models/groq/openai/gpt-oss-20b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Groq)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/ionos/meta-llama/Llama-3.3-70B-Instruct.toml
+++ b/providers/edenai/models/ionos/meta-llama/Llama-3.3-70B-Instruct.toml
@@ -1,4 +1,5 @@
 base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama-3.3-70B-Instruct (IONOS)"
 attachment = false
 tool_call = false
 structured_output = false

--- a/providers/edenai/models/ionos/openai/gpt-oss-120b.toml
+++ b/providers/edenai/models/ionos/openai/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (IONOS)"
 tool_call = false
 structured_output = false
 

--- a/providers/edenai/models/nebius/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/edenai/models/nebius/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (Nebius)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/nebius/meta-llama/Llama-3.3-70B-Instruct.toml
+++ b/providers/edenai/models/nebius/meta-llama/Llama-3.3-70B-Instruct.toml
@@ -1,4 +1,5 @@
 base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama-3.3-70B-Instruct (Nebius)"
 attachment = false
 structured_output = true
 

--- a/providers/edenai/models/nebius/nvidia/Nemotron-3-Ultra-550b-a55b.toml
+++ b/providers/edenai/models/nebius/nvidia/Nemotron-3-Ultra-550b-a55b.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-ultra-550b-a55b"
+name = "Nemotron 3 Ultra 550B A55B (Nebius)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/nebius/nvidia/nemotron-3-super-120b-a12b.toml
+++ b/providers/edenai/models/nebius/nvidia/nemotron-3-super-120b-a12b.toml
@@ -1,4 +1,5 @@
 base_model = "nvidia/nemotron-3-super-120b-a12b"
+name = "Nemotron 3 Super 120B A12B (Nebius)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/nebius/openai/gpt-oss-120b.toml
+++ b/providers/edenai/models/nebius/openai/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Nebius)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/openai/gpt-latest.toml
+++ b/providers/edenai/models/openai/gpt-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-6-astra"
+name = "GPT Latest (GPT-6 Astra)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/openai/gpt-mini-latest.toml
+++ b/providers/edenai/models/openai/gpt-mini-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.4-mini"
+name = "GPT Mini Latest (GPT-5.4 mini)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/openai/gpt-pro-latest.toml
+++ b/providers/edenai/models/openai/gpt-pro-latest.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-5.5-pro"
+name = "GPT Pro Latest (GPT-5.5 Pro)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/ovhcloud/gpt-oss-120b.toml
+++ b/providers/edenai/models/ovhcloud/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (OVHcloud)"
 tool_call = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/ovhcloud/gpt-oss-20b.toml
+++ b/providers/edenai/models/ovhcloud/gpt-oss-20b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (OVHcloud)"
 tool_call = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/qwen/deepseek-v4-flash-0731.toml
+++ b/providers/edenai/models/qwen/deepseek-v4-flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (Alibaba)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/qwen/deepseek-v4-pro-0813.toml
+++ b/providers/edenai/models/qwen/deepseek-v4-pro-0813.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (Alibaba)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/scaleway/deepseek-v4-flash-0731.toml
+++ b/providers/edenai/models/scaleway/deepseek-v4-flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (Scaleway)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/scaleway/gpt-oss-120b.toml
+++ b/providers/edenai/models/scaleway/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Scaleway)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/scaleway/llama-3.3-70b-instruct.toml
+++ b/providers/edenai/models/scaleway/llama-3.3-70b-instruct.toml
@@ -1,4 +1,5 @@
 base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama-3.3-70B-Instruct (Scaleway)"
 attachment = false
 structured_output = false
 

--- a/providers/edenai/models/tensorx/deepseek/deepseek-v4-flash-0731.toml
+++ b/providers/edenai/models/tensorx/deepseek/deepseek-v4-flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (TensorX)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/tensorx/deepseek/deepseek-v4-pro-0813.toml
+++ b/providers/edenai/models/tensorx/deepseek/deepseek-v4-pro-0813.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (TensorX)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/tensorx/moonshotai/kimi-k2.5.toml
+++ b/providers/edenai/models/tensorx/moonshotai/kimi-k2.5.toml
@@ -1,4 +1,5 @@
 base_model = "moonshotai/kimi-k2.5"
+name = "Kimi K2.5 (TensorX)"
 structured_output = false
 reasoning_options = []
 

--- a/providers/edenai/models/together_ai/deepseek-ai/DeepSeek-V4-Flash-0731.toml
+++ b/providers/edenai/models/together_ai/deepseek-ai/DeepSeek-V4-Flash-0731.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-flash-0731"
+name = "DeepSeek V4 Flash 0731 (Together AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/together_ai/deepseek-ai/DeepSeek-V4-Pro-0813.toml
+++ b/providers/edenai/models/together_ai/deepseek-ai/DeepSeek-V4-Pro-0813.toml
@@ -1,4 +1,5 @@
 base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro 0813 (Together AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/together_ai/meta-models/Muse-Glimmer-30B.toml
+++ b/providers/edenai/models/together_ai/meta-models/Muse-Glimmer-30B.toml
@@ -1,4 +1,5 @@
 base_model = "meta/muse-glimmer-30b"
+name = "Muse Glimmer 30B (Together AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/together_ai/openai/gpt-oss-120b.toml
+++ b/providers/edenai/models/together_ai/openai/gpt-oss-120b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-120b"
+name = "GPT OSS 120B (Together AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/together_ai/openai/gpt-oss-20b.toml
+++ b/providers/edenai/models/together_ai/openai/gpt-oss-20b.toml
@@ -1,4 +1,5 @@
 base_model = "openai/gpt-oss-20b"
+name = "GPT OSS 20B (Together AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/together_ai/thinkingmachines/Inkling-Small.toml
+++ b/providers/edenai/models/together_ai/thinkingmachines/Inkling-Small.toml
@@ -1,4 +1,5 @@
 base_model = "thinkingmachines/inkling-small"
+name = "Inkling Small (Together AI)"
 structured_output = false
 
 [[reasoning_options]]

--- a/providers/edenai/models/together_ai/thinkingmachines/Inkling.toml
+++ b/providers/edenai/models/together_ai/thinkingmachines/Inkling.toml
@@ -1,4 +1,5 @@
 base_model = "thinkingmachines/inkling"
+name = "Inkling (Together AI)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/vertex/gemini-2.5-flash-image.toml
+++ b/providers/edenai/models/vertex/gemini-2.5-flash-image.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-2.5-flash-image"
+name = "Nano Banana (Vertex AI)"
 structured_output = true
 reasoning_options = []
 

--- a/providers/edenai/models/vertex/gemini-3-flash-preview.toml
+++ b/providers/edenai/models/vertex/gemini-3-flash-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-flash-preview"
+name = "Gemini 3 Flash Preview (Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3-pro-image.toml
+++ b/providers/edenai/models/vertex/gemini-3-pro-image.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3-pro-image"
+name = "Nano Banana Pro (Vertex AI)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/vertex/gemini-3.1-flash-image.toml
+++ b/providers/edenai/models/vertex/gemini-3.1-flash-image.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-image"
+name = "Nano Banana 2 (Vertex AI)"
 structured_output = true
 
 [[reasoning_options]]

--- a/providers/edenai/models/vertex/gemini-3.1-flash-lite-image.toml
+++ b/providers/edenai/models/vertex/gemini-3.1-flash-lite-image.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite-image"
+name = "Nano Banana 2 Lite (Vertex AI)"
 tool_call = false
 structured_output = true
 

--- a/providers/edenai/models/vertex/gemini-3.1-flash-lite.toml
+++ b/providers/edenai/models/vertex/gemini-3.1-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
+name = "Gemini 3.1 Flash Lite (Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.1-flash-lite@eu.toml
+++ b/providers/edenai/models/vertex/gemini-3.1-flash-lite@eu.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
-name = "Gemini 3.1 Flash Lite (EU)"
+name = "Gemini 3.1 Flash Lite (Vertex AI, EU)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.1-flash-lite@us.toml
+++ b/providers/edenai/models/vertex/gemini-3.1-flash-lite@us.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.1-flash-lite"
-name = "Gemini 3.1 Flash Lite (US)"
+name = "Gemini 3.1 Flash Lite (Vertex AI, US)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.1-pro-preview.toml
+++ b/providers/edenai/models/vertex/gemini-3.1-pro-preview.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+name = "Gemini 3.1 Pro Preview (Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.5-flash-lite.toml
+++ b/providers/edenai/models/vertex/gemini-3.5-flash-lite.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash-lite"
+name = "Gemini 3.5 Flash Lite (Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.5-flash-lite@eu.toml
+++ b/providers/edenai/models/vertex/gemini-3.5-flash-lite@eu.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.5-flash-lite"
-name = "Gemini 3.5 Flash Lite (EU)"
+name = "Gemini 3.5 Flash Lite (Vertex AI, EU)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.5-flash-lite@us.toml
+++ b/providers/edenai/models/vertex/gemini-3.5-flash-lite@us.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.5-flash-lite"
-name = "Gemini 3.5 Flash Lite (US)"
+name = "Gemini 3.5 Flash Lite (Vertex AI, US)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.5-flash.toml
+++ b/providers/edenai/models/vertex/gemini-3.5-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.5-flash"
+name = "Gemini 3.5 Flash (Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.5-flash@eu.toml
+++ b/providers/edenai/models/vertex/gemini-3.5-flash@eu.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.5-flash"
-name = "Gemini 3.5 Flash (EU)"
+name = "Gemini 3.5 Flash (Vertex AI, EU)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.5-flash@us.toml
+++ b/providers/edenai/models/vertex/gemini-3.5-flash@us.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.5-flash"
-name = "Gemini 3.5 Flash (US)"
+name = "Gemini 3.5 Flash (Vertex AI, US)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.6-flash.toml
+++ b/providers/edenai/models/vertex/gemini-3.6-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.6-flash"
+name = "Gemini 3.6 Flash (Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.6-flash@eu.toml
+++ b/providers/edenai/models/vertex/gemini-3.6-flash@eu.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.6-flash"
-name = "Gemini 3.6 Flash (EU)"
+name = "Gemini 3.6 Flash (Vertex AI, EU)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.6-flash@us.toml
+++ b/providers/edenai/models/vertex/gemini-3.6-flash@us.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.6-flash"
-name = "Gemini 3.6 Flash (US)"
+name = "Gemini 3.6 Flash (Vertex AI, US)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.7-flash.toml
+++ b/providers/edenai/models/vertex/gemini-3.7-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.7-flash"
+name = "Gemini 3.7 Flash (Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.7-flash@eu.toml
+++ b/providers/edenai/models/vertex/gemini-3.7-flash@eu.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.7-flash"
-name = "Gemini 3.7 Flash (EU)"
+name = "Gemini 3.7 Flash (Vertex AI, EU)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.7-flash@us.toml
+++ b/providers/edenai/models/vertex/gemini-3.7-flash@us.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.7-flash"
-name = "Gemini 3.7 Flash (US)"
+name = "Gemini 3.7 Flash (Vertex AI, US)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.8-flash.toml
+++ b/providers/edenai/models/vertex/gemini-3.8-flash.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.8-flash"
+name = "Gemini 3.8 Flash (Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.8-flash@eu.toml
+++ b/providers/edenai/models/vertex/gemini-3.8-flash@eu.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.8-flash"
-name = "Gemini 3.8 Flash (EU)"
+name = "Gemini 3.8 Flash (Vertex AI, EU)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-3.8-flash@us.toml
+++ b/providers/edenai/models/vertex/gemini-3.8-flash@us.toml
@@ -1,5 +1,5 @@
 base_model = "google/gemini-3.8-flash"
-name = "Gemini 3.8 Flash (US)"
+name = "Gemini 3.8 Flash (Vertex AI, US)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-flash-latest.toml
+++ b/providers/edenai/models/vertex/gemini-flash-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.8-flash"
+name = "Gemini Flash Latest (Gemini 3.8 Flash, Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/vertex/gemini-pro-latest.toml
+++ b/providers/edenai/models/vertex/gemini-pro-latest.toml
@@ -1,4 +1,5 @@
 base_model = "google/gemini-3.1-pro-preview"
+name = "Gemini Pro Latest (Gemini 3.1 Pro Preview, Vertex AI)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/edenai/models/xai/grok-latest.toml
+++ b/providers/edenai/models/xai/grok-latest.toml
@@ -1,4 +1,5 @@
 base_model = "xai/grok-4.6"
+name = "Grok Latest (Grok 4.6)"
 
 [[reasoning_options]]
 type = "effort"

--- a/providers/google/models/gemini-3.1-flash-image-preview.toml
+++ b/providers/google/models/gemini-3.1-flash-image-preview.toml
@@ -1,4 +1,4 @@
-name = "Nano Banana 2"
+name = "Nano Banana 2 Preview"
 description = "Image model for prompt-driven generation, editing, and visual design workflows"
 family = "gemini-flash"
 release_date = "2026-02-26"

--- a/sync.md
+++ b/sync.md
@@ -145,6 +145,7 @@ Actions are pinned by commit SHA. Keep new workflow actions pinned the same way.
 
 - Source endpoint: `https://api.edenai.run/v3/models`; no authentication required.
 - Latest aliases (`alias_of` plus an ID ending in `-latest`) get a distinct display name such as `Claude Fable Latest (Claude Fable 5.1)` so they do not collide with the versioned target in UIs that key on `name`. Case-only `alias_of` duplicates are not treated as latest aliases.
+- Extra labels (current target, host, region) share one parenthetical, e.g. `Gemini Flash Latest (Gemini 3.8 Flash, Vertex AI)` and `GPT OSS 120B (Deep Infra)`. The lab's own API keeps the unsuffixed canonical name; other hosts (Vertex AI, Deep Infra, Groq, Together AI, …) are named.
 - Reasoning effort options are derived from the lab's provider entry or OpenRouter. A toggle-only or budget-only control is not an effort list; do not invent effort levels.
 - When the effort mapper cannot resolve controls, preserve the existing route's authored `reasoning_options` while syncing other authoritative fields. Do not replace authored toggle, effort, or budget controls with `[]`.
 - New reasoning models with neither a resolved mapping nor authored controls remain skipped for manual authoring. No empty placeholder is generated, so the normal auto-merge policy remains unchanged; legitimate always-on `[]` entries are not blanket-blocked.

--- a/sync.md
+++ b/sync.md
@@ -144,6 +144,7 @@ Actions are pinned by commit SHA. Keep new workflow actions pinned the same way.
 ## Eden AI Notes
 
 - Source endpoint: `https://api.edenai.run/v3/models`; no authentication required.
+- Latest aliases (`alias_of` plus an ID ending in `-latest`) get a distinct display name such as `Claude Fable Latest (Claude Fable 5.1)` so they do not collide with the versioned target in UIs that key on `name`. Case-only `alias_of` duplicates are not treated as latest aliases.
 - Reasoning effort options are derived from the lab's provider entry or OpenRouter. A toggle-only or budget-only control is not an effort list; do not invent effort levels.
 - When the effort mapper cannot resolve controls, preserve the existing route's authored `reasoning_options` while syncing other authoritative fields. Do not replace authored toggle, effort, or budget controls with `[]`.
 - New reasoning models with neither a resolved mapping nor authored controls remain skipped for manual authoring. No empty placeholder is generated, so the normal auto-merge policy remains unchanged; legitimate always-on `[]` entries are not blanket-blocked.


### PR DESCRIPTION
Eden AI latest aliases and relay routes inherit the lab `name` via `base_model`, so UIs that key on `name` (for example `opencode` `/models`) show duplicate rows. This PR makes those display names unique and appends Google image preview snapshots with " Preview".

## Sources

- https://api.edenai.run/v3/models
  Supports: `alias_of` plus IDs ending in `-latest` (for example `anthropic/claude-fable-latest` → `anthropic/claude-fable-5-1`, `openai/gpt-latest` → `openai/gpt-6-astra`). Also supports `owned_by` for the upstream host (`google` vs `vertex`, `deepinfra`, `groq`, `together_ai`, …). Case-only `alias_of` pairs such as `flexai/deepseek-v4-flash-0731` vs `flexai/DeepSeek-V4-Flash-0731` are not latest aliases.
- Google model IDs `gemini-3.1-flash-image-preview` / `gemini-3-pro-image-preview` vs the later GA IDs without `-preview`.
  Supports: Preview is a pre-release snapshot, not an image-preview endpoint. Lab names become `Nano Banana 2 Preview` and `Nano Banana Pro Preview` so hosts that inherit via `base_model` stay distinct.

## Eden AI display names

Sync now authors a `name` override when any of these apply:

- Latest alias: `Claude Fable Latest (Claude Fable 5.1)`
- Non-primary host: `GPT OSS 120B (Deep Infra)`, `Gemini 3.8 Flash (Vertex AI)`
- Combined: `Gemini Flash Latest (Gemini 3.8 Flash, Vertex AI)`, `Gemini 3.8 Flash (Vertex AI, US)`

The lab’s own API keeps the unsuffixed canonical name. Extra labels share one parenthetical.

Host classification: Eden AI is a multi-model relay. This change is display `name` only. `cost` and `reasoning_options` are unchanged.

## Validation

- `bun test packages/core/test/sync.test.ts -t "Eden AI"`
- `bun models:sync edenai` (idempotent after the name updates)
- `bun validate`