### PR TITLE
Azure: Add GPT 6 Astra

### DIFF
--- a/providers/azure/models/gpt-6-astra.toml
+++ b/providers/azure/models/gpt-6-astra.toml
@@ -1,0 +1,17 @@
+# Azure pricing page publishes GPT-6 pricing in the blog rather than the service pricing page; https://azure.microsoft.com/en-us/blog/gpt-6-astra-frontier-intelligence-for-work-now-generally-available-in-microsoft-foundry/
+base_model = "openai/gpt-6-astra"
+status = "beta"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10.00
+output = 50.00
+cache_read = 1.00
+cache_write = 12.50
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 20.00
+output = 75.00
+cache_read = 2.00
+cache_write = 25.00


### PR DESCRIPTION
Add native Azure support for GPT-6 Astra.

Currently prices are mentioned in [the release blog.](https://azure.microsoft.com/en-us/blog/gpt-6-astra-frontier-intelligence-for-work-now-generally-available-in-microsoft-foundry/) while Azure OpenAI pricing is [currently being updated.](https://azure.microsoft.com/en-us/pricing/details/azure-openai/)

`none` and `max` are not the model’s default reasoning effort. They are supported reasoning-effort values exposed by Azure’s Responses API and are also used by the existing Azure GPT-5.6 model TOMLs.

Both values return HTTP 400 when sent through the Chat Completions API, while OpenCode uses the Responses API by default. I’ve therefore included them here, consistent with the existing Azure model TOMLs.