### PR TITLE
feat(sensenova): add deepseek-v4-pro and kimi-k3

### DIFF
--- a/providers/sensenova/models/deepseek-v4-pro.toml
+++ b/providers/sensenova/models/deepseek-v4-pro.toml
@@ -1,0 +1,30 @@
+# Sources (accessed 2026-09-06):
+# https://platform.sensenova.cn/docs
+# GET /v1/models: context 1048576, max output 65536, fp8, text -> text,
+# supported features tools+json_mode+reasoning; pricing all zero (public beta
+# free on TokenPlan).
+# Version note: the host serves DeepSeek-V4-Pro 0813, so base_model points at
+# the 0813 snapshot. DeepSeek V4 Pro is text-only (no image input).
+# Toggle: thinking.type = enabled|disabled (default enabled)
+# Effort: reasoning_effort = low|high|max; medium and xhigh are accepted but
+# mapped to high. Live calls confirm none disables reasoning and that no
+# better-than-high achievable output differs, so the lab-effective levels
+# (high/max) are authored per AGENTS.md policy for DeepSeek V4.
+base_model = "deepseek/deepseek-v4-pro-0813"
+name = "DeepSeek V4 Pro"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[cost]
+input = 0
+output = 0
+cache_read = 0

--- a/providers/sensenova/models/kimi-k3.toml
+++ b/providers/sensenova/models/kimi-k3.toml
@@ -1,0 +1,30 @@
+# Sources (accessed 2026-09-06):
+# https://platform.sensenova.cn/docs
+# GET /v1/models: context 1048576, max output 65536, fp8, text -> text,
+# supported features tools+json_mode+reasoning; pricing all zero (public beta
+# free on TokenPlan).
+# Reasoning: host docs give reasoning_effort low|high|max (default max); live
+# calls show clear grading (low = 1-14 reasoning tokens, high = 7-36, max =
+# 593-626 on the same prompt). No separate on/off toggle is documented on this
+# host, so the documented effort levels are authored as-is.
+# Image input via base64 image_url is verified live and documented (native
+# multimodal agent model); host docs require base64 (public URLs rejected) and
+# do not document video, so input is limited to text+image.
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [
+  { type = "effort", values = ["low", "high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+output = 65_536
+
+[modalities]
+input = ["text", "image"]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0


### PR DESCRIPTION
Add DeepSeek V4 Pro 0813 and Kimi K3 to the SenseNova provider based on the live GET /v1/models catalog, host docs, and live API probes.

deepseek-v4-pro: base_model deepseek/deepseek-v4-pro-0813 (host serves the 0813 snapshot); reasoning toggle via thinking.type plus effort high/max (docs: reasoning_effort low/high/max, medium/xhigh mapped to high; live probes show low == high reasoning volume); catalog limits context 1048576 / output 65536; zero pricing.

kimi-k3: native multimodal agent model — image input via base64 image_url verified live (video undocumented, so input is text+image); reasoning_effort low/high/max per docs and confirmed graded by live probes; catalog output 65536; zero pricing.

Both expose the reasoning side channel as reasoning_content.