### PR TITLE
feat(models): add GPT-6 Astra benchmarks

### DIFF
--- a/models/openai/gpt-6-astra.toml
+++ b/models/openai/gpt-6-astra.toml
@@ -18,3 +18,148 @@ output = 128_000
 [modalities]
 input = ["text", "image", "pdf"]
 output = ["text"]
+
+[[benchmarks]]
+name = "Agents' Last Exam"
+score = 59.3
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "OSWorld"
+score = 72.6
+metric = "partial score"
+dataset = "V2-Offline (v2026.08.08)"
+version = "2.0"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "ScreenSpot-Pro"
+score = 92.7
+metric = "accuracy"
+variant = "no tools"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "AutomationBench"
+score = 41.4
+metric = "success rate"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "BenchCAD"
+score = 95.9
+metric = "geometric overlap"
+variant = "with tools"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "BrowseComp"
+score = 91.5
+metric = "accuracy"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "Terminal-Bench"
+score = 57.9
+metric = "success rate"
+version = "4.0"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "DeepSWE"
+score = 74.1
+metric = "resolve rate"
+version = "1.1"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "FrontierCode"
+score = 64.5
+metric = "score"
+dataset = "Extended"
+version = "1.1"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "Terminal-Bench Science"
+score = 64.6
+metric = "success rate"
+version = "0.1"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "FrontierMath"
+score = 97.6
+metric = "accuracy"
+dataset = "Tier 4"
+version = "v2"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "GPQA Diamond"
+score = 96.0
+metric = "accuracy"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "Humanity's Last Exam"
+score = 57.2
+metric = "accuracy"
+variant = "with tools"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "ExploitBench"
+score = 100.0
+metric = "success rate"
+variant = "without production safeguards"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "SRE-Bench"
+score = 88.0
+metric = "success rate"
+variant = "single attempt"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "ARC-AGI-3"
+score = 99.9
+metric = "RHAE"
+harness = "Responses API"
+source = "https://openai.com/index/gpt-6-astra/"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "Artificial Analysis Intelligence Index"
+score = 61
+metric = "index score"
+variant = "max"
+version = "4.1.1"
+source = "https://artificialanalysis.ai/articles/benchmarking-gpt-6-astra"
+date = "2026-09-03"
+
+[[benchmarks]]
+name = "Artificial Analysis Coding Agent Index"
+score = 67
+metric = "index score"
+harness = "Codex"
+variant = "max"
+version = "1.4"
+source = "https://artificialanalysis.ai/articles/benchmarking-gpt-6-astra"
+date = "2026-09-03"


### PR DESCRIPTION
## Summary

- add published GPT-6 Astra benchmark results across computer use, professional, coding, academic, cybersecurity, and abstract-reasoning evaluations
- preserve benchmark versions, datasets, harnesses, and evaluation qualifiers where documented
- include independent Artificial Analysis Intelligence and Coding Agent index results

## Sources

- https://openai.com/index/gpt-6-astra/
- https://artificialanalysis.ai/articles/benchmarking-gpt-6-astra

## Validation

- `bun ./packages/core/script/validate.ts`
- `bun test packages/core/test/generate.test.ts --test-name-pattern "repository benchmark metadata is sourced|repository benchmark names are normalized"`