### PR TITLE
fix(anthropic): move (latest) tag from 4.5 to 5 for Opus and Sonnet

### DIFF
--- a/models/anthropic/claude-opus-4-5.toml
+++ b/models/anthropic/claude-opus-4-5.toml
@@ -1,4 +1,4 @@
-name = "Claude Opus 4.5 (latest)"
+name = "Claude Opus 4.5"
 description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
 family = "claude-opus"
 release_date = "2025-11-24"

--- a/models/anthropic/claude-opus-5.toml
+++ b/models/anthropic/claude-opus-5.toml
@@ -1,4 +1,4 @@
-name = "Claude Opus 5"
+name = "Claude Opus 5 (latest)"
 description = "Strongest Claude Opus model for coding, agents, and professional work"
 family = "claude-opus"
 release_date = "2026-07-24"

--- a/models/anthropic/claude-sonnet-4-5.toml
+++ b/models/anthropic/claude-sonnet-4-5.toml
@@ -1,4 +1,4 @@
-name = "Claude Sonnet 4.5 (latest)"
+name = "Claude Sonnet 4.5"
 description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
 family = "claude-sonnet"
 release_date = "2025-09-29"

--- a/models/anthropic/claude-sonnet-5.toml
+++ b/models/anthropic/claude-sonnet-5.toml
@@ -1,4 +1,4 @@
-name = "Claude Sonnet 5"
+name = "Claude Sonnet 5 (latest)"
 description = "Everyday Claude agent model for coding, planning, browsing, and general work"
 family = "claude-sonnet"
 release_date = "2026-06-30"


### PR DESCRIPTION
## Summary
- `claude-opus-4-5` / `claude-sonnet-4-5` showed as `(latest)` in opencode `/models` picker while newer `Opus 5` / `Sonnet 5` exist.
- Moves `(latest)` display name to the current models per https://docs.anthropic.com/en/docs/about-claude/models (Opus 5 2026-07-24, Sonnet 5 2026-06-30).
- Haiku 4.5 keeps `(latest)` — no Haiku 5 exists, it is still the current Haiku.

## Changes
- `models/anthropic/claude-opus-4-5.toml`: `Claude Opus 4.5 (latest)` -> `Claude Opus 4.5`
- `models/anthropic/claude-opus-5.toml`: `Claude Opus 5` -> `Claude Opus 5 (latest)`
- `models/anthropic/claude-sonnet-4-5.toml`: `Claude Sonnet 4.5 (latest)` -> `Claude Sonnet 4.5`
- `models/anthropic/claude-sonnet-5.toml`: `Claude Sonnet 5` -> `Claude Sonnet 5 (latest)`

## Verification
- TOML parses cleanly; full `bun ./packages/core/script/validate.ts` left to CI (no bun locally).
- Cross-checked current lineup vs Anthropic docs: Fable 5.1 / Opus 5 / Sonnet 5 / Haiku 4.5.