### PR TITLE
fix(anthropic): stop inventing (latest) display-name suffix in sync

### DIFF
--- a/models/anthropic/claude-haiku-4-5.toml
+++ b/models/anthropic/claude-haiku-4-5.toml
@@ -1,4 +1,4 @@
-name = "Claude Haiku 4.5 (latest)"
+name = "Claude Haiku 4.5"
 description = "Fast Claude lane for lightweight agents, office tasks, and responsive chat"
 family = "claude-haiku"
 release_date = "2025-10-15"

--- a/models/anthropic/claude-opus-4-0.toml
+++ b/models/anthropic/claude-opus-4-0.toml
@@ -1,4 +1,4 @@
-name = "Claude Opus 4 (latest)"
+name = "Claude Opus 4"
 description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
 family = "claude-opus"
 release_date = "2025-05-22"

--- a/models/anthropic/claude-opus-4-1.toml
+++ b/models/anthropic/claude-opus-4-1.toml
@@ -1,4 +1,4 @@
-name = "Claude Opus 4.1 (latest)"
+name = "Claude Opus 4.1"
 description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
 family = "claude-opus"
 release_date = "2025-08-05"

--- a/models/anthropic/claude-opus-4-5.toml
+++ b/models/anthropic/claude-opus-4-5.toml
@@ -1,4 +1,4 @@
-name = "Claude Opus 4.5 (latest)"
+name = "Claude Opus 4.5"
 description = "Flagship Claude model for deep reasoning, coding, and long-horizon agents"
 family = "claude-opus"
 release_date = "2025-11-24"

--- a/models/anthropic/claude-sonnet-4-0.toml
+++ b/models/anthropic/claude-sonnet-4-0.toml
@@ -1,4 +1,4 @@
-name = "Claude Sonnet 4 (latest)"
+name = "Claude Sonnet 4"
 description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
 family = "claude-sonnet"
 release_date = "2025-05-22"

--- a/models/anthropic/claude-sonnet-4-5.toml
+++ b/models/anthropic/claude-sonnet-4-5.toml
@@ -1,4 +1,4 @@
-name = "Claude Sonnet 4.5 (latest)"
+name = "Claude Sonnet 4.5"
 description = "Balanced Claude model for coding, analysis, agent workflows, and cost control"
 family = "claude-sonnet"
 release_date = "2025-09-29"

--- a/packages/core/src/sync/providers/anthropic.ts
+++ b/packages/core/src/sync/providers/anthropic.ts
@@ -296,9 +296,7 @@ export function buildAnthropicModel(
   existing: ExistingModel | undefined,
   baseModel?: string,
 ): SyncedModel {
-  const name = model.canonical_id !== undefined && !model.display_name.endsWith("(latest)")
-    ? `${model.display_name} (latest)`
-    : model.display_name;
+  const name = model.display_name.replace(/\s*\(latest\)\s*$/i, "");
   const reasoning = model.capabilities.thinking?.supported ?? existing?.reasoning ?? false;
   const input = [
     "text" as const,

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -994,19 +994,29 @@ test("adds manual budget control for new Anthropic models", () => {
   expect(model.reasoning_options).toEqual([{ type: "budget_tokens" }]);
 });
 
-test("labels Anthropic aliases as latest", () => {
+test("never invents latest tags for Anthropic aliases", () => {
   const model = buildAnthropicModel(anthropicModel({
     id: "claude-sonnet-5",
     canonical_id: "claude-sonnet-5-20260630",
   }), undefined, "anthropic/claude-sonnet-5");
 
-  expect(model.name).toBe("Claude Sonnet 5 (latest)");
+  expect(model.name).toBe("Claude Sonnet 5");
+});
+
+test("strips stale latest suffix from Anthropic display names", () => {
+  const model = buildAnthropicModel(anthropicModel({
+    id: "claude-opus-4-5",
+    canonical_id: "claude-opus-4-5-20251101",
+    display_name: "Claude Opus 4.5 (latest)",
+  }), undefined, "anthropic/claude-opus-4-5");
+
+  expect(model.name).toBe("Claude Opus 4.5");
 });
 
 test("Anthropic sync preserves base model inheritance", () => {
   const resolved = {
     base_model: "anthropic/claude-opus-4-5",
-    name: "Claude Opus 4.5 (latest)",
+    name: "Claude Opus 4.5",
     description: "Flagship Claude model",
     release_date: "2025-11-24",
     last_updated: "2025-11-24",


### PR DESCRIPTION
## Summary
Supersedes #6433 — root fix instead of data patch (close #6433 in favor of this).

`buildAnthropicModel` appended ` (latest)` to every alias (`canonical_id` set). That was correct pre-4.6, but Anthropic froze old aliases and made 4.6+ dateless IDs pinned snapshots, so Opus 4/4.1/4.5 and Sonnet 4/4.5 kept a permanent `(latest)` tag while Opus 5 / Sonnet 5 got none. Same rot would repeat on every future release.

## Changes
- `packages/core/src/sync/providers/anthropic.ts`: use the API `display_name` verbatim, stripping any stale trailing `(latest)` — never invent the suffix. Matches all other providers, where a rolling `-latest` pointer is owned upstream.
- `packages/core/test/sync.test.ts`: replaced `labels Anthropic aliases as latest` with `never invents latest tags` + `strips stale latest suffix`; updated inheritance mock name.
- Swept six stale canonical names: Opus 4/4.1/4.5, Sonnet 4/4.5, Haiku 4.5.

## Verification
- TOML parses cleanly; zero remaining `(latest)` in `models/anthropic/`.
- `bun test` / `bun ./packages/core/script/validate.ts` left to CI (no bun locally).
- Current lineup cross-checked vs https://docs.anthropic.com/en/docs/about-claude/models (Opus 5 / Sonnet 5 / Haiku 4.5 current; Haiku tag removed too since the suffix concept is gone, users pick by version).