### PR TITLE
feat: add SandBase provider

### DIFF
--- a/providers/sandbase/logo.svg
+++ b/providers/sandbase/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path fill-rule="evenodd" d="M7 2.5h10a4.5 4.5 0 0 1 4.5 4.5v1A4.5 4.5 0 0 1 17 12.5H7A4.5 4.5 0 0 1 2.5 8V7A4.5 4.5 0 0 1 7 2.5Zm1.5 4A1.5 1.5 0 1 0 8.5 9.5a1.5 1.5 0 0 0 0-3Zm7 0a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z" clip-rule="evenodd"/>
+  <path d="M5 14h9.5a4.5 4.5 0 0 1 0 9H9a6.5 6.5 0 0 1-6.5-6.5A2.5 2.5 0 0 1 5 14Zm.5 3.5a1 1 0 1 0 0 2h3a1 1 0 1 0 0-2h-3Z"/>
+</svg>

--- a/providers/sandbase/models/alibaba/qwen3.7-max.toml
+++ b/providers/sandbase/models/alibaba/qwen3.7-max.toml
@@ -1,0 +1,15 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Off is reasoning_effort=none; graded effort is low|medium|high.
+base_model = "alibaba/qwen3.7-max"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 1.25
+output = 3.75
+cache_read = 0.25

--- a/providers/sandbase/models/alibaba/qwen3.7-plus.toml
+++ b/providers/sandbase/models/alibaba/qwen3.7-plus.toml
@@ -1,0 +1,15 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Off is reasoning_effort=none; graded effort is low|medium|high.
+base_model = "alibaba/qwen3.7-plus"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.08

--- a/providers/sandbase/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/sandbase/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,14 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Effort: reasoning_effort = none|low|medium|high|max
+base_model = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 0.44
+output = 1.32

--- a/providers/sandbase/models/deepseek/deepseek-v4-pro.toml
+++ b/providers/sandbase/models/deepseek/deepseek-v4-pro.toml
@@ -1,0 +1,14 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Effort: reasoning_effort = none|low|medium|high|max
+base_model = "deepseek/deepseek-v4-pro"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "max"]
+
+[cost]
+input = 1.32
+output = 3.96

--- a/providers/sandbase/models/moonshotai/kimi-k3.toml
+++ b/providers/sandbase/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,15 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Effort: reasoning_effort = low|high|max
+base_model = "moonshotai/kimi-k3"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3

--- a/providers/sandbase/models/openai/gpt-5.6-luna.toml
+++ b/providers/sandbase/models/openai/gpt-5.6-luna.toml
@@ -1,0 +1,15 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Effort: reasoning_effort = none|low|medium|high|xhigh|max
+base_model = "openai/gpt-5.6-luna"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.2
+output = 1.2
+cache_read = 0.02
+
+[provider]
+npm = "@ai-sdk/openai"

--- a/providers/sandbase/models/openai/gpt-5.6-sol.toml
+++ b/providers/sandbase/models/openai/gpt-5.6-sol.toml
@@ -1,0 +1,15 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Effort: reasoning_effort = none|low|medium|high|xhigh|max
+base_model = "openai/gpt-5.6-sol"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[provider]
+npm = "@ai-sdk/openai"

--- a/providers/sandbase/models/openai/gpt-5.6-terra.toml
+++ b/providers/sandbase/models/openai/gpt-5.6-terra.toml
@@ -1,0 +1,15 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Effort: reasoning_effort = none|low|medium|high|xhigh|max
+base_model = "openai/gpt-5.6-terra"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[provider]
+npm = "@ai-sdk/openai"

--- a/providers/sandbase/models/z-ai/glm-5.3-flash.toml
+++ b/providers/sandbase/models/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,15 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Effort: reasoning_effort = low|high|max
+base_model = "zhipuai/glm-5.3-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.15
+output = 0.5
+cache_read = 0.03

--- a/providers/sandbase/models/z-ai/glm-5.3.toml
+++ b/providers/sandbase/models/z-ai/glm-5.3.toml
@@ -1,0 +1,15 @@
+# Source: https://www.sandbase.ai/docs/api-reference/models/get
+# Effort: reasoning_effort = low|high|max
+base_model = "zhipuai/glm-5.3"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.28

--- a/providers/sandbase/provider.toml
+++ b/providers/sandbase/provider.toml
@@ -1,0 +1,5 @@
+name = "SandBase"
+npm = "@ai-sdk/openai-compatible"
+env = ["SANDBASE_API_KEY"]
+api = "https://api.sandbase.ai/v1"
+doc = "https://www.sandbase.ai/docs/model-api-reference/llm-models"


### PR DESCRIPTION
## Summary

- add SandBase as an OpenAI-compatible provider
- add 10 coding and agent-oriented models from OpenAI, DeepSeek, Z.ai, Alibaba, and Moonshot AI
- use the Responses API adapter for GPT-5.6 models and Chat Completions for the remaining catalog
- include provider pricing, reasoning controls, and reasoning_content metadata from the live SandBase model API

## Sources

- Provider docs: https://www.sandbase.ai/docs/model-api-reference/llm-models
- Authentication: https://www.sandbase.ai/docs/api-reference/authentication
- Chat Completions: https://www.sandbase.ai/docs/api-reference/llm-gateway
- Responses API: https://www.sandbase.ai/docs/api-reference/responses
- Model metadata and pricing: https://www.sandbase.ai/docs/api-reference/models/get

## Validation

- bun validate
- live Chat Completions tool-call request with z-ai/glm-5.3-flash
- live Responses API request with openai/gpt-5.6-luna
- live reasoning_content checks for DeepSeek V4 Flash, GLM-5.3 Flash, Qwen3.7 Plus, and Kimi K3