### PR TITLE
feat(vivgrid): add gpt-6-astra

### DIFF
--- a/providers/vivgrid/models/gpt-6-astra.toml
+++ b/providers/vivgrid/models/gpt-6-astra.toml
@@ -1,0 +1,15 @@
+base_model = "openai/gpt-6-astra"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 20
+output = 75
+cache_read = 2
+cache_write = 25


### PR DESCRIPTION
Adds `gpt-6-astra` for Vivgrid using the `base_model` override pattern.

- **Docs / Dashboard Source:** https://vivgrid.com/docs/models
- **Context Window:** 1,050,000 tokens
- **Max Output:** 128,000 tokens
- **Pricing:** $10 / 1M input, $50 / 1M output, $1 / 1M cache read, $12.50 / 1M cache write; $20 / 1M input, $75 / 1M output, $2 / 1M cache read, $25 / 1M cache write over 272K context
- **Reasoning Controls:** Graded reasoning effort (`low`, `medium`, `high`, `xhigh`, `max`) matching OpenAI and peer relay configurations.
