### PR TITLE
feat(amazon-bedrock): add Grok 4.6 inference profiles

### DIFF
--- a/providers/amazon-bedrock/models/global.xai.grok-4.6.toml
+++ b/providers/amazon-bedrock/models/global.xai.grok-4.6.toml
@@ -1,0 +1,11 @@
+# Source: AWS Bedrock Grok 4.6 model card — Runtime profiles, pricing, and capabilities.
+base_model = "xai/grok-4.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+name = "Grok 4.6 (Global)"
+last_updated = "2026-08-18"
+structured_output = false
+
+[cost]
+input = 2.00
+output = 6.00
+cache_read = 0.50

--- a/providers/amazon-bedrock/models/us.xai.grok-4.6.toml
+++ b/providers/amazon-bedrock/models/us.xai.grok-4.6.toml
@@ -1,0 +1,11 @@
+# Source: AWS Bedrock Grok 4.6 model card — Runtime profiles, pricing, and capabilities.
+base_model = "xai/grok-4.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+name = "Grok 4.6 (US)"
+last_updated = "2026-08-18"
+structured_output = false
+
+[cost]
+input = 2.20
+output = 6.60
+cache_read = 0.55


### PR DESCRIPTION
## Summary

Add the documented Bedrock Runtime inference profiles alongside the existing Grok 4.6 Mantle entry:

| Model ID | Display name | Input / output / cache read (USD per million tokens) |
| --- | --- | --- |
| `us.xai.grok-4.6` | Grok 4.6 (US) | 2.20 / 6.60 / 0.55 |
| `global.xai.grok-4.6` | Grok 4.6 (Global) | 2.00 / 6.00 / 0.50 |

Both entries inherit the lab model and the provider's default native Bedrock route, following existing regional profile entries. They expose the documented `low`, `medium`, `high`, and `xhigh` reasoning efforts and override structured output support to match Runtime capabilities.

## Source

AWS Bedrock User Guide, **Grok 4.6** model card: Programmatic Access, Pricing, Capabilities and Features, and Usage Considerations and Limitations.

## Validation

- `bun validate` passed.
- Checked the generated entries resolve to `@ai-sdk/amazon-bedrock` with the expected IDs, prices, and capabilities.
