### PR TITLE
Add GLM-5.3 to AgentRouter provider

### DIFF
--- a/providers/agentrouter/models/glm-5.3.toml
+++ b/providers/agentrouter/models/glm-5.3.toml
@@ -1,0 +1,4 @@
+# Catalog and endpoint support: https://agentrouter.org/api/pricing
+# AgentRouter publishes relative token ratios, not USD prices, so cost is intentionally omitted.
+base_model = "zhipuai/glm-5.3"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]


### PR DESCRIPTION
Adds `providers/agentrouter/models/glm-5.3.toml`.

- `base_model = "zhipuai/glm-5.3"` — inherits canonical metadata (context 1M / output 131k)
- reasoning effort options `low | high | max` (GLM-5.3 thinking cannot be disabled)
- cost omitted, matching existing AgentRouter model files (relative token ratios, not USD prices)

Validated with `bun run validate` (exit 0).