### PR TITLE
feat(vivgrid): add claude-fable-5-1, claude-fable-5, gemini-3.8-flash, deepseek-v4-pro-0813

### DIFF
--- a/providers/vivgrid/models/claude-fable-5-1.toml
+++ b/providers/vivgrid/models/claude-fable-5-1.toml
@@ -1,0 +1,13 @@
+# Pricing, context window and max output:
+# https://docs.vivgrid.com/models/claude-fable-5-1 (accessed 2026-09-07)
+# Cached input is $0.50/MTok. Vivgrid publishes no cache-write rate and states
+# pricing matches the original provider, so Anthropic's $12.50/MTok applies.
+base_model = "anthropic/claude-fable-5-1"
+structured_output = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 0.5
+cache_write = 12.5

--- a/providers/vivgrid/models/claude-fable-5.toml
+++ b/providers/vivgrid/models/claude-fable-5.toml
@@ -1,0 +1,13 @@
+# Pricing, context window and max output:
+# https://docs.vivgrid.com/models/claude-fable-5 (accessed 2026-09-07)
+# Cached input is $1.25/MTok. Vivgrid publishes no cache-write rate and states
+# pricing matches the original provider, so Anthropic's $12.50/MTok applies.
+base_model = "anthropic/claude-fable-5"
+structured_output = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1.25
+cache_write = 12.5

--- a/providers/vivgrid/models/deepseek-v4-pro-0813.toml
+++ b/providers/vivgrid/models/deepseek-v4-pro-0813.toml
@@ -1,0 +1,22 @@
+# Pricing and capabilities:
+# https://docs.vivgrid.com/models/deepseek-v4-pro-0813 (accessed 2026-09-07)
+# Reasoning tokens bill at the output rate (no separate CoT price).
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high|max
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.35
+output = 3.00
+reasoning = 3.00
+cache_read = 0.05

--- a/providers/vivgrid/models/gemini-3.8-flash.toml
+++ b/providers/vivgrid/models/gemini-3.8-flash.toml
@@ -1,0 +1,14 @@
+# Pricing and capabilities:
+# https://docs.vivgrid.com/models/gemini-3.8-flash (accessed 2026-09-07)
+# Vivgrid documents 128K max output for this model, double the 64K the Gemini
+# Flash line normally serves.
+base_model = "google/gemini-3.8-flash"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.75
+output = 3.75
+cache_read = 0.15
+
+[limit]
+output = 128_000


### PR DESCRIPTION
Adds four newly launched Vivgrid models using the `base_model` override pattern. All four lab entries already exist under `models/`, so each provider file carries only host pricing, reasoning controls, and real deltas.

### `claude-fable-5-1`

- **Docs / Dashboard Source:** https://vivgrid.com/docs/models/claude-fable-5-1
- **Context Window:** 1,000,000 tokens
- **Max Output:** 128,000 tokens
- **Reasoning Controls:** Graded reasoning effort (`low`, `medium`, `high`, `xhigh`, `max`) matching Anthropic and peer relay configurations.

### `claude-fable-5`

- **Docs / Dashboard Source:** https://vivgrid.com/docs/models/claude-fable-5
- **Context Window:** 1,000,000 tokens
- **Max Output:** 128,000 tokens
- **Reasoning Controls:** Graded reasoning effort (`low`, `medium`, `high`, `xhigh`, `max`) matching Anthropic and peer relay configurations.

### `gemini-3.8-flash`

- **Docs / Dashboard Source:** https://vivgrid.com/docs/models/gemini-3.8-flash
- **Context Window:** 1,048,576 tokens (inherited; Vivgrid documents this as 1M)
- **Max Output:** 64,000 tokens
- **Reasoning Controls:** Graded reasoning effort (`low`, `medium`, `high`) matching Google and the existing `gemini-3.7-flash` entry on this host.

### `deepseek-v4-pro-0813`

- **Docs / Dashboard Source:** https://vivgrid.com/docs/models/deepseek-v4-pro-0813
- **Context Window:** 1,000,000 tokens
- **Max Output:** 384,000 tokens
- **Reasoning Controls:** Thinking toggle plus graded effort (`high`, `max`) per the DeepSeek V4 policy in `AGENTS.md` and the first-party `providers/deepseek` entry; reasoning is surfaced on the `reasoning_content` side channel.