### PR TITLE
feat: add nullsink provider

### DIFF
--- a/providers/nullsink/logo.svg
+++ b/providers/nullsink/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 350" fill="currentColor">
+  <path d="M0 0h70v70H0zM140 0h70v70h-70zM280 0h70v70h-70zM70 70h70v70H70zM210 70h70v70h-70zM140 140h70v70h-70zM0 280h350v70H0z"/>
+</svg>

--- a/providers/nullsink/models/claude-fable-5-1.toml
+++ b/providers/nullsink/models/claude-fable-5-1.toml
@@ -1,33 +1,28 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
+# Clients using thinking.block_binding require the thinking-binding-controls-2026-08-01 beta.
+# https://platform.claude.com/docs/en/build-with-claude/preserved-thinking
+# Thinking is always adaptive; thinking.type = disabled is rejected.
+# Effort: output_config.effort = low|medium|high|xhigh|max.
 # Controls: https://platform.claude.com/docs/en/build-with-claude/effort
-# Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
-# Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
 # Adaptive thinking interleaves without a beta header; 1M context is the standard window.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $20/MTok.
+base_model = "anthropic/claude-fable-5-1"
 structured_output = true
 interleaved = true
 reasoning_options = [
-  { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
-  { type = "budget_tokens", min = 1_024 },
+  { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 10
+output = 50
+cache_read = 0.25
+cache_write = 12.5
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-fable-5.toml
+++ b/providers/nullsink/models/claude-fable-5.toml
@@ -1,33 +1,26 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
+# Thinking is always adaptive; thinking.type = disabled is rejected.
+# Effort: output_config.effort = low|medium|high|xhigh|max.
 # Controls: https://platform.claude.com/docs/en/build-with-claude/effort
-# Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
-# Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
 # Adaptive thinking interleaves without a beta header; 1M context is the standard window.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $20/MTok.
+base_model = "anthropic/claude-fable-5"
 structured_output = true
 interleaved = true
 reasoning_options = [
-  { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
-  { type = "budget_tokens", min = 1_024 },
+  { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-haiku-4-5-20251001.toml
+++ b/providers/nullsink/models/claude-haiku-4-5-20251001.toml
@@ -1,33 +1,26 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
-# Controls: https://platform.claude.com/docs/en/build-with-claude/effort
+# Toggle: thinking.type = enabled|disabled.
 # Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
 # Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
-# Adaptive thinking interleaves without a beta header; 1M context is the standard window.
+# No interleaved-thinking beta is forwarded; the standard context window is 200k.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $2/MTok.
+base_model = "anthropic/claude-haiku-4-5-20251001"
 structured_output = true
-interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
   { type = "budget_tokens", min = 1_024 },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-haiku-4-5.toml
+++ b/providers/nullsink/models/claude-haiku-4-5.toml
@@ -1,33 +1,26 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
-# Controls: https://platform.claude.com/docs/en/build-with-claude/effort
+# Toggle: thinking.type = enabled|disabled.
 # Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
 # Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
-# Adaptive thinking interleaves without a beta header; 1M context is the standard window.
+# No interleaved-thinking beta is forwarded; the standard context window is 200k.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $2/MTok.
+base_model = "anthropic/claude-haiku-4-5"
 structured_output = true
-interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
   { type = "budget_tokens", min = 1_024 },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-opus-4-5-20251101.toml
+++ b/providers/nullsink/models/claude-opus-4-5-20251101.toml
@@ -1,33 +1,29 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
+# Toggle: thinking.type = enabled|disabled.
+# Effort: output_config.effort = low|medium|high.
 # Controls: https://platform.claude.com/docs/en/build-with-claude/effort
 # Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
 # Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
-# Adaptive thinking interleaves without a beta header; 1M context is the standard window.
+# No interleaved-thinking beta is forwarded; the standard context window is 200k.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $10/MTok.
+base_model = "anthropic/claude-opus-4-5-20251101"
 structured_output = true
-interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
+  { type = "effort", values = ["low", "medium", "high"] },
   { type = "budget_tokens", min = 1_024 },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-opus-4-5.toml
+++ b/providers/nullsink/models/claude-opus-4-5.toml
@@ -1,33 +1,29 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
+# Toggle: thinking.type = enabled|disabled.
+# Effort: output_config.effort = low|medium|high.
 # Controls: https://platform.claude.com/docs/en/build-with-claude/effort
 # Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
 # Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
-# Adaptive thinking interleaves without a beta header; 1M context is the standard window.
+# No interleaved-thinking beta is forwarded; the standard context window is 200k.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $10/MTok.
+base_model = "anthropic/claude-opus-4-5"
 structured_output = true
-interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
+  { type = "effort", values = ["low", "medium", "high"] },
   { type = "budget_tokens", min = 1_024 },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-opus-4-6.toml
+++ b/providers/nullsink/models/claude-opus-4-6.toml
@@ -10,8 +10,8 @@
 # Adaptive thinking interleaves without a beta header; 1M context is the standard window.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $10/MTok.
+base_model = "anthropic/claude-opus-4-6"
 structured_output = true
 interleaved = true
 reasoning_options = [
@@ -21,13 +21,10 @@ reasoning_options = [
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-opus-4-7.toml
+++ b/providers/nullsink/models/claude-opus-4-7.toml
@@ -1,33 +1,27 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
+# Toggle: thinking.type = adaptive|disabled.
+# Effort: output_config.effort = low|medium|high|xhigh|max.
 # Controls: https://platform.claude.com/docs/en/build-with-claude/effort
-# Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
-# Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
 # Adaptive thinking interleaves without a beta header; 1M context is the standard window.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $10/MTok.
+base_model = "anthropic/claude-opus-4-7"
 structured_output = true
 interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
-  { type = "budget_tokens", min = 1_024 },
+  { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-opus-4-8.toml
+++ b/providers/nullsink/models/claude-opus-4-8.toml
@@ -1,33 +1,27 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
+# Toggle: thinking.type = adaptive|disabled.
+# Effort: output_config.effort = low|medium|high|xhigh|max.
 # Controls: https://platform.claude.com/docs/en/build-with-claude/effort
-# Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
-# Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
 # Adaptive thinking interleaves without a beta header; 1M context is the standard window.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $10/MTok.
+base_model = "anthropic/claude-opus-4-8"
 structured_output = true
 interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
-  { type = "budget_tokens", min = 1_024 },
+  { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-opus-5.toml
+++ b/providers/nullsink/models/claude-opus-5.toml
@@ -1,33 +1,28 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
+# Toggle: thinking.type = adaptive|disabled.
+# Disabling thinking is supported only at low, medium, or high effort; xhigh/max require thinking.
+# Effort: output_config.effort = low|medium|high|xhigh|max.
 # Controls: https://platform.claude.com/docs/en/build-with-claude/effort
-# Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
-# Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
 # Adaptive thinking interleaves without a beta header; 1M context is the standard window.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $10/MTok.
+base_model = "anthropic/claude-opus-5"
 structured_output = true
 interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
-  { type = "budget_tokens", min = 1_024 },
+  { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-sonnet-4-5-20250929.toml
+++ b/providers/nullsink/models/claude-sonnet-4-5-20250929.toml
@@ -1,22 +1,18 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
-# Controls: https://platform.claude.com/docs/en/build-with-claude/effort
+# Toggle: thinking.type = enabled|disabled.
 # Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
 # Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
-# Adaptive thinking interleaves without a beta header; 1M context is the standard window.
+# No interleaved-thinking beta is forwarded; the standard context window is 200k.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
 # cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+base_model = "anthropic/claude-sonnet-4-5-20250929"
 structured_output = true
-interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
   { type = "budget_tokens", min = 1_024 },
 ]
 
@@ -25,9 +21,6 @@ input = 3
 output = 15
 cache_read = 0.3
 cache_write = 3.75
-
-[limit]
-output = 128_000
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-sonnet-4-5.toml
+++ b/providers/nullsink/models/claude-sonnet-4-5.toml
@@ -1,22 +1,18 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
-# Controls: https://platform.claude.com/docs/en/build-with-claude/effort
+# Toggle: thinking.type = enabled|disabled.
 # Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
 # Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
-# Adaptive thinking interleaves without a beta header; 1M context is the standard window.
+# No interleaved-thinking beta is forwarded; the standard context window is 200k.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
 # cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+base_model = "anthropic/claude-sonnet-4-5"
 structured_output = true
-interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
   { type = "budget_tokens", min = 1_024 },
 ]
 
@@ -25,9 +21,6 @@ input = 3
 output = 15
 cache_read = 0.3
 cache_write = 3.75
-
-[limit]
-output = 128_000
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-sonnet-4-6.toml
+++ b/providers/nullsink/models/claude-sonnet-4-6.toml
@@ -1,0 +1,30 @@
+# Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
+# Funding service fees are charged when purchasing credit, separately from inference usage.
+# Native Messages API: https://nullsink.is/api/
+# Toggle: thinking.type = adaptive|disabled; legacy manual thinking uses enabled.
+# Effort: output_config.effort = low|medium|high|max.
+# Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
+# Controls: https://platform.claude.com/docs/en/build-with-claude/effort
+# Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
+# Interleaved thinking is available in adaptive mode without a beta header.
+# Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
+base_model = "anthropic/claude-sonnet-4-6"
+interleaved = true
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "high", "max"] },
+  { type = "budget_tokens", min = 1_024 },
+]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+output = 128_000
+
+[provider]
+npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/claude-sonnet-5.toml
+++ b/providers/nullsink/models/claude-sonnet-5.toml
@@ -1,33 +1,27 @@
 # Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
 # Funding service fees are charged when purchasing credit, separately from inference usage.
 # Native Messages API: https://nullsink.is/api/
-# Toggle: thinking.type = adaptive|disabled. Legacy manual thinking uses enabled.
-# Effort: output_config.effort = low|medium|high|max.
+# Toggle: thinking.type = adaptive|disabled.
+# Effort: output_config.effort = low|medium|high|xhigh|max.
 # Controls: https://platform.claude.com/docs/en/build-with-claude/effort
-# Budget: thinking.budget_tokens with thinking.type = enabled (minimum 1024).
-# Manual budgets: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
 # Thinking modes: https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting
 # Adaptive thinking interleaves without a beta header; 1M context is the standard window.
 # Limits: https://platform.claude.com/docs/en/build-with-claude/context-windows#context-window-sizes-by-model
 # Structured outputs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs (no beta required).
-# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $6/MTok.
-base_model = "anthropic/claude-sonnet-4-6"
+# cache_write is the standard 5-minute rate; optional 1-hour cache writes cost $4/MTok.
+base_model = "anthropic/claude-sonnet-5"
 structured_output = true
 interleaved = true
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["low", "medium", "high", "max"] },
-  { type = "budget_tokens", min = 1_024 },
+  { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] },
 ]
 
 [cost]
-input = 3
-output = 15
-cache_read = 0.3
-cache_write = 3.75
-
-[limit]
-output = 128_000
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
 
 [provider]
 npm = "@ai-sdk/anthropic"

--- a/providers/nullsink/models/deepseek-v4-flash.toml
+++ b/providers/nullsink/models/deepseek-v4-flash.toml
@@ -4,15 +4,18 @@
 # Context and capabilities: https://inference.tinfoil.sh/v1/models
 # Hosted weights and modalities: https://docs.tinfoil.sh/models/chat
 # Controls: https://docs.tinfoil.sh/guides/reasoning#supported-values-per-model
-# Effort: reasoning_effort = low|medium|high; no caller token budget.
-# Reasoning is always on; no off toggle.
-base_model = "openai/gpt-oss-120b"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max; no caller token budget.
+# Off is reasoning_effort=none; no separate toggle.
+base_model = "deepseek/deepseek-v4-flash-0731"
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 0.15
-output = 0.6
-cache_read = 0.15
+input = 0.3
+output = 0.7
+cache_read = 0.06
+
+[limit]
+context = 1_048_576
 
 [provider]
 shape = "completions"

--- a/providers/nullsink/models/gemma4-31b.toml
+++ b/providers/nullsink/models/gemma4-31b.toml
@@ -4,15 +4,15 @@
 # Context and capabilities: https://inference.tinfoil.sh/v1/models
 # Hosted weights and modalities: https://docs.tinfoil.sh/models/chat
 # Controls: https://docs.tinfoil.sh/guides/reasoning#supported-values-per-model
-# Effort: reasoning_effort = low|medium|high; no caller token budget.
-# Reasoning is always on; no off toggle.
-base_model = "openai/gpt-oss-120b"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+# Effort: reasoning_effort = none|minimal|low|medium|high|xhigh|max; no caller token budget.
+# Off is reasoning_effort=none; no separate toggle.
+base_model = "google/gemma-4-31b-it"
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 0.15
-output = 0.6
-cache_read = 0.15
+input = 0.4
+output = 1
+cache_read = 0.4
 
 [provider]
 shape = "completions"

--- a/providers/nullsink/models/glm-5-3-flash.toml
+++ b/providers/nullsink/models/glm-5-3-flash.toml
@@ -4,15 +4,22 @@
 # Context and capabilities: https://inference.tinfoil.sh/v1/models
 # Hosted weights and modalities: https://docs.tinfoil.sh/models/chat
 # Controls: https://docs.tinfoil.sh/guides/reasoning#supported-values-per-model
-# Effort: reasoning_effort = low|medium|high; no caller token budget.
+# Effort: reasoning_effort = low|high|max; no caller token budget.
 # Reasoning is always on; no off toggle.
-base_model = "openai/gpt-oss-120b"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+# Tinfoil documents text/image inputs; the base model supports additional modalities.
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 
 [cost]
-input = 0.15
-output = 0.6
-cache_read = 0.15
+input = 0.4
+output = 1.25
+cache_read = 0.1
+
+[limit]
+context = 1_048_576
+
+[modalities]
+input = ["text", "image"]
 
 [provider]
 shape = "completions"

--- a/providers/nullsink/models/gpt-3.5-turbo.toml
+++ b/providers/nullsink/models/gpt-3.5-turbo.toml
@@ -1,0 +1,16 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Legacy OpenAI models use Chat Completions through the provider default SDK.
+# Upstream shutdown date: 2026-10-23; still advertised in nullsink's model list.
+# https://developers.openai.com/api/docs/deprecations
+base_model = "openai/gpt-3.5-turbo"
+status = "deprecated"
+
+[cost]
+input = 0.5
+output = 1.5
+cache_read = 0
+cache_write = 0
+
+[provider]
+shape = "completions"

--- a/providers/nullsink/models/gpt-4-turbo.toml
+++ b/providers/nullsink/models/gpt-4-turbo.toml
@@ -1,0 +1,16 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Legacy OpenAI models use Chat Completions through the provider default SDK.
+# Upstream shutdown date: 2026-10-23; still advertised in nullsink's model list.
+# https://developers.openai.com/api/docs/deprecations
+base_model = "openai/gpt-4-turbo"
+status = "deprecated"
+
+[cost]
+input = 10
+output = 30
+cache_read = 10
+cache_write = 0
+
+[provider]
+shape = "completions"

--- a/providers/nullsink/models/gpt-4.1-mini.toml
+++ b/providers/nullsink/models/gpt-4.1-mini.toml
@@ -1,0 +1,14 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+base_model = "openai/gpt-4.1-mini"
+
+[cost]
+input = 0.4
+output = 1.6
+cache_read = 0.1
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-4.1-nano.toml
+++ b/providers/nullsink/models/gpt-4.1-nano.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Upstream shutdown date: 2026-10-23; still advertised in nullsink's model list.
+# https://developers.openai.com/api/docs/deprecations
+base_model = "openai/gpt-4.1-nano"
+status = "deprecated"
+
+[cost]
+input = 0.1
+output = 0.4
+cache_read = 0.025
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-4.1.toml
+++ b/providers/nullsink/models/gpt-4.1.toml
@@ -1,0 +1,14 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+base_model = "openai/gpt-4.1"
+
+[cost]
+input = 2
+output = 8
+cache_read = 0.5
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-4.toml
+++ b/providers/nullsink/models/gpt-4.toml
@@ -1,0 +1,16 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Legacy OpenAI models use Chat Completions through the provider default SDK.
+# Upstream shutdown date: 2026-10-23; still advertised in nullsink's model list.
+# https://developers.openai.com/api/docs/deprecations
+base_model = "openai/gpt-4"
+status = "deprecated"
+
+[cost]
+input = 30
+output = 60
+cache_read = 30
+cache_write = 0
+
+[provider]
+shape = "completions"

--- a/providers/nullsink/models/gpt-4o-2024-05-13.toml
+++ b/providers/nullsink/models/gpt-4o-2024-05-13.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Upstream shutdown date: 2026-10-23; still advertised in nullsink's model list.
+# https://developers.openai.com/api/docs/deprecations
+base_model = "openai/gpt-4o-2024-05-13"
+status = "deprecated"
+
+[cost]
+input = 5
+output = 15
+cache_read = 5
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-4o-2024-08-06.toml
+++ b/providers/nullsink/models/gpt-4o-2024-08-06.toml
@@ -1,0 +1,14 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+base_model = "openai/gpt-4o-2024-08-06"
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-4o-2024-11-20.toml
+++ b/providers/nullsink/models/gpt-4o-2024-11-20.toml
@@ -1,0 +1,14 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+base_model = "openai/gpt-4o-2024-11-20"
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-4o-mini.toml
+++ b/providers/nullsink/models/gpt-4o-mini.toml
@@ -1,0 +1,14 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+base_model = "openai/gpt-4o-mini"
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.075
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-4o.toml
+++ b/providers/nullsink/models/gpt-4o.toml
@@ -1,0 +1,14 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+base_model = "openai/gpt-4o"
+
+[cost]
+input = 2.5
+output = 10
+cache_read = 1.25
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5-mini.toml
+++ b/providers/nullsink/models/gpt-5-mini.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5-mini
+base_model = "openai/gpt-5-mini"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5-nano.toml
+++ b/providers/nullsink/models/gpt-5-nano.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5-nano
+base_model = "openai/gpt-5-nano"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.05
+output = 0.4
+cache_read = 0.005
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5-pro.toml
+++ b/providers/nullsink/models/gpt-5-pro.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5-pro
+base_model = "openai/gpt-5-pro"
+reasoning_options = [{ type = "effort", values = ["high"] }]
+
+[cost]
+input = 15
+output = 120
+cache_read = 15
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5.1.toml
+++ b/providers/nullsink/models/gpt-5.1.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5.1
+base_model = "openai/gpt-5.1"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5.2-chat-latest.toml
+++ b/providers/nullsink/models/gpt-5.2-chat-latest.toml
@@ -1,0 +1,20 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5.2-chat-latest
+# Upstream shutdown date: 2026-08-10; still advertised in nullsink's model list.
+# https://developers.openai.com/api/docs/deprecations
+base_model = "openai/gpt-5.2-chat-latest"
+reasoning_options = [{ type = "effort", values = ["medium"] }]
+status = "deprecated"
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5.2-pro.toml
+++ b/providers/nullsink/models/gpt-5.2-pro.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5.2-pro
+base_model = "openai/gpt-5.2-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
+
+[cost]
+input = 21
+output = 168
+cache_read = 21
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5.2.toml
+++ b/providers/nullsink/models/gpt-5.2.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5.2
+base_model = "openai/gpt-5.2"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5.3-chat-latest.toml
+++ b/providers/nullsink/models/gpt-5.3-chat-latest.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Upstream shutdown date: 2026-08-10; still advertised in nullsink's model list.
+# https://developers.openai.com/api/docs/deprecations
+base_model = "openai/gpt-5.3-chat-latest"
+status = "deprecated"
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5.3-codex.toml
+++ b/providers/nullsink/models/gpt-5.3-codex.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5.3-codex
+base_model = "openai/gpt-5.3-codex"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5.4-mini.toml
+++ b/providers/nullsink/models/gpt-5.4-mini.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5.4-mini
+base_model = "openai/gpt-5.4-mini"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5.4-nano.toml
+++ b/providers/nullsink/models/gpt-5.4-nano.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5.4-nano
+base_model = "openai/gpt-5.4-nano"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-5.4-pro.toml
+++ b/providers/nullsink/models/gpt-5.4-pro.toml
@@ -2,23 +2,23 @@
 # API: https://nullsink.is/api/
 # Native OpenAI Responses API; Standard service tier.
 # Reasoning: reasoning.effort, matching the native OpenAI model controls.
-# https://developers.openai.com/api/docs/models/gpt-6-astra
+# https://developers.openai.com/api/docs/models/gpt-5.4-pro
 # Long-context rates apply above 272,000 total input tokens.
-base_model = "openai/gpt-6-astra"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model = "openai/gpt-5.4-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
-input = 10
-output = 50
-cache_read = 1
-cache_write = 12.5
+input = 30
+output = 180
+cache_read = 30
+cache_write = 0
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 20
-output = 75
-cache_read = 2
-cache_write = 25
+input = 60
+output = 270
+cache_read = 60
+cache_write = 0
 
 [provider]
 npm = "@ai-sdk/openai"

--- a/providers/nullsink/models/gpt-5.4.toml
+++ b/providers/nullsink/models/gpt-5.4.toml
@@ -2,23 +2,23 @@
 # API: https://nullsink.is/api/
 # Native OpenAI Responses API; Standard service tier.
 # Reasoning: reasoning.effort, matching the native OpenAI model controls.
-# https://developers.openai.com/api/docs/models/gpt-6-astra
+# https://developers.openai.com/api/docs/models/gpt-5.4
 # Long-context rates apply above 272,000 total input tokens.
-base_model = "openai/gpt-6-astra"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model = "openai/gpt-5.4"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
-input = 10
-output = 50
-cache_read = 1
-cache_write = 12.5
+input = 2.5
+output = 15
+cache_read = 0.25
+cache_write = 0
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 20
-output = 75
-cache_read = 2
-cache_write = 25
+input = 5
+output = 22.5
+cache_read = 0.5
+cache_write = 0
 
 [provider]
 npm = "@ai-sdk/openai"

--- a/providers/nullsink/models/gpt-5.5-pro.toml
+++ b/providers/nullsink/models/gpt-5.5-pro.toml
@@ -2,23 +2,23 @@
 # API: https://nullsink.is/api/
 # Native OpenAI Responses API; Standard service tier.
 # Reasoning: reasoning.effort, matching the native OpenAI model controls.
-# https://developers.openai.com/api/docs/models/gpt-6-astra
+# https://developers.openai.com/api/docs/models/gpt-5.5-pro
 # Long-context rates apply above 272,000 total input tokens.
-base_model = "openai/gpt-6-astra"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model = "openai/gpt-5.5-pro"
+reasoning_options = [{ type = "effort", values = ["medium", "high", "xhigh"] }]
 
 [cost]
-input = 10
-output = 50
-cache_read = 1
-cache_write = 12.5
+input = 30
+output = 180
+cache_read = 30
+cache_write = 0
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 20
-output = 75
-cache_read = 2
-cache_write = 25
+input = 60
+output = 270
+cache_read = 60
+cache_write = 0
 
 [provider]
 npm = "@ai-sdk/openai"

--- a/providers/nullsink/models/gpt-5.5.toml
+++ b/providers/nullsink/models/gpt-5.5.toml
@@ -2,23 +2,23 @@
 # API: https://nullsink.is/api/
 # Native OpenAI Responses API; Standard service tier.
 # Reasoning: reasoning.effort, matching the native OpenAI model controls.
-# https://developers.openai.com/api/docs/models/gpt-6-astra
+# https://developers.openai.com/api/docs/models/gpt-5.5
 # Long-context rates apply above 272,000 total input tokens.
-base_model = "openai/gpt-6-astra"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model = "openai/gpt-5.5"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 
 [cost]
-input = 10
-output = 50
-cache_read = 1
-cache_write = 12.5
+input = 5
+output = 30
+cache_read = 0.5
+cache_write = 0
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 20
-output = 75
-cache_read = 2
-cache_write = 25
+input = 10
+output = 45
+cache_read = 1
+cache_write = 0
 
 [provider]
 npm = "@ai-sdk/openai"

--- a/providers/nullsink/models/gpt-5.6-luna.toml
+++ b/providers/nullsink/models/gpt-5.6-luna.toml
@@ -2,23 +2,23 @@
 # API: https://nullsink.is/api/
 # Native OpenAI Responses API; Standard service tier.
 # Reasoning: reasoning.effort, matching the native OpenAI model controls.
-# https://developers.openai.com/api/docs/models/gpt-6-astra
+# https://developers.openai.com/api/docs/models/gpt-5.6-luna
 # Long-context rates apply above 272,000 total input tokens.
-base_model = "openai/gpt-6-astra"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 10
-output = 50
-cache_read = 1
-cache_write = 12.5
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 20
-output = 75
-cache_read = 2
-cache_write = 25
+input = 0.4
+output = 1.8
+cache_read = 0.04
+cache_write = 0.5
 
 [provider]
 npm = "@ai-sdk/openai"

--- a/providers/nullsink/models/gpt-5.6-sol.toml
+++ b/providers/nullsink/models/gpt-5.6-sol.toml
@@ -2,23 +2,23 @@
 # API: https://nullsink.is/api/
 # Native OpenAI Responses API; Standard service tier.
 # Reasoning: reasoning.effort, matching the native OpenAI model controls.
-# https://developers.openai.com/api/docs/models/gpt-6-astra
+# https://developers.openai.com/api/docs/models/gpt-5.6-sol
 # Long-context rates apply above 272,000 total input tokens.
-base_model = "openai/gpt-6-astra"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 10
-output = 50
-cache_read = 1
-cache_write = 12.5
+input = 4
+output = 20
+cache_read = 0.4
+cache_write = 5
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 20
-output = 75
-cache_read = 2
-cache_write = 25
+input = 8
+output = 30
+cache_read = 0.8
+cache_write = 10
 
 [provider]
 npm = "@ai-sdk/openai"

--- a/providers/nullsink/models/gpt-5.6-terra.toml
+++ b/providers/nullsink/models/gpt-5.6-terra.toml
@@ -2,23 +2,23 @@
 # API: https://nullsink.is/api/
 # Native OpenAI Responses API; Standard service tier.
 # Reasoning: reasoning.effort, matching the native OpenAI model controls.
-# https://developers.openai.com/api/docs/models/gpt-6-astra
+# https://developers.openai.com/api/docs/models/gpt-5.6-terra
 # Long-context rates apply above 272,000 total input tokens.
-base_model = "openai/gpt-6-astra"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 10
-output = 50
-cache_read = 1
-cache_write = 12.5
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 20
-output = 75
-cache_read = 2
-cache_write = 25
+input = 4
+output = 18
+cache_read = 0.4
+cache_write = 5
 
 [provider]
 npm = "@ai-sdk/openai"

--- a/providers/nullsink/models/gpt-5.6.toml
+++ b/providers/nullsink/models/gpt-5.6.toml
@@ -2,23 +2,25 @@
 # API: https://nullsink.is/api/
 # Native OpenAI Responses API; Standard service tier.
 # Reasoning: reasoning.effort, matching the native OpenAI model controls.
-# https://developers.openai.com/api/docs/models/gpt-6-astra
+# https://developers.openai.com/api/docs/models/gpt-5.6
+# The upstream gpt-5.6 alias resolves to GPT-5.6 Sol.
 # Long-context rates apply above 272,000 total input tokens.
-base_model = "openai/gpt-6-astra"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model = "openai/gpt-5.6-sol"
+name = "GPT-5.6"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 
 [cost]
-input = 10
-output = 50
-cache_read = 1
-cache_write = 12.5
+input = 4
+output = 20
+cache_read = 0.4
+cache_write = 5
 
 [[cost.tiers]]
 tier = { type = "context", size = 272_000 }
-input = 20
-output = 75
-cache_read = 2
-cache_write = 25
+input = 8
+output = 30
+cache_read = 0.8
+cache_write = 10
 
 [provider]
 npm = "@ai-sdk/openai"

--- a/providers/nullsink/models/gpt-5.toml
+++ b/providers/nullsink/models/gpt-5.toml
@@ -1,0 +1,17 @@
+# Pricing (USD/MTok): https://nullsink.is/v1/models
+# API: https://nullsink.is/api/
+# Native OpenAI Responses API; Standard service tier.
+# Reasoning: reasoning.effort, matching the native OpenAI model controls.
+# https://developers.openai.com/api/docs/models/gpt-5
+base_model = "openai/gpt-5"
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+cache_write = 0
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-6-astra.toml
+++ b/providers/nullsink/models/gpt-6-astra.toml
@@ -1,0 +1,26 @@
+# Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
+# Funding service fees are charged when purchasing credit, separately from inference usage.
+# Native Responses API: https://nullsink.is/api/
+# Effort: reasoning.effort = low|medium|high|xhigh|max.
+# Controls: https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra
+# Standard service tier only; nullsink rejects priority/flex and disables response storage.
+# The higher rate applies above 272000 total input tokens (inclusive minimum 272001).
+base_model = "openai/gpt-6-astra"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 20
+output = 75
+cache_read = 2
+cache_write = 25
+
+[provider]
+npm = "@ai-sdk/openai"
+shape = "responses"

--- a/providers/nullsink/models/gpt-oss-120b.toml
+++ b/providers/nullsink/models/gpt-oss-120b.toml
@@ -1,0 +1,16 @@
+# Pricing: https://nullsink.is/v1/models (USD per million tokens deducted from prepaid credit).
+# Funding service fees are charged when purchasing credit, separately from inference usage.
+# Served through Tinfoil using nullsink's Chat Completions route: https://nullsink.is/api/
+# Effort: reasoning_effort = low|medium|high; no off toggle or caller token budget.
+# Controls: https://docs.tinfoil.sh/guides/reasoning#supported-values-per-model
+# Context and capabilities: https://inference.tinfoil.sh/v1/models
+base_model = "openai/gpt-oss-120b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.15
+output = 0.6
+cache_read = 0.15
+
+[provider]
+shape = "completions"

--- a/providers/nullsink/models/gpt-oss-safeguard-120b.toml
+++ b/providers/nullsink/models/gpt-oss-safeguard-120b.toml
@@ -6,7 +6,9 @@
 # Controls: https://docs.tinfoil.sh/guides/reasoning#supported-values-per-model
 # Effort: reasoning_effort = low|medium|high; no caller token budget.
 # Reasoning is always on; no off toggle.
-base_model = "openai/gpt-oss-120b"
+# The reasoning guide explicitly documents safeguard effort controls despite the
+# upstream models endpoint classifying this safety model as reasoning=false.
+base_model = "openai/gpt-oss-safeguard-120b"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]

--- a/providers/nullsink/models/kimi-k3.toml
+++ b/providers/nullsink/models/kimi-k3.toml
@@ -4,15 +4,22 @@
 # Context and capabilities: https://inference.tinfoil.sh/v1/models
 # Hosted weights and modalities: https://docs.tinfoil.sh/models/chat
 # Controls: https://docs.tinfoil.sh/guides/reasoning#supported-values-per-model
-# Effort: reasoning_effort = low|medium|high; no caller token budget.
+# Effort: reasoning_effort = low|high|max; no caller token budget.
 # Reasoning is always on; no off toggle.
-base_model = "openai/gpt-oss-120b"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+# Tinfoil documents text/image inputs; the base model supports additional modalities.
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 
 [cost]
-input = 0.15
-output = 0.6
-cache_read = 0.15
+input = 4
+output = 20
+cache_read = 0.8
+
+[limit]
+context = 262_144
+
+[modalities]
+input = ["text", "image"]
 
 [provider]
 shape = "completions"

--- a/providers/nullsink/models/llama3-3-70b.toml
+++ b/providers/nullsink/models/llama3-3-70b.toml
@@ -3,16 +3,15 @@
 # Served through Tinfoil using nullsink's Chat Completions route: https://nullsink.is/api/
 # Context and capabilities: https://inference.tinfoil.sh/v1/models
 # Hosted weights and modalities: https://docs.tinfoil.sh/models/chat
-# Controls: https://docs.tinfoil.sh/guides/reasoning#supported-values-per-model
-# Effort: reasoning_effort = low|medium|high; no caller token budget.
-# Reasoning is always on; no off toggle.
-base_model = "openai/gpt-oss-120b"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+base_model = "meta/llama-3.3-70b-instruct"
 
 [cost]
-input = 0.15
-output = 0.6
-cache_read = 0.15
+input = 1.75
+output = 2.75
+cache_read = 1.75
+
+[limit]
+context = 131_072
 
 [provider]
 shape = "completions"

--- a/providers/nullsink/provider.toml
+++ b/providers/nullsink/provider.toml
@@ -1,0 +1,5 @@
+name = "nullsink"
+env = ["NULLSINK_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://nullsink.is/v1"
+doc = "https://nullsink.is/api/"


### PR DESCRIPTION
Add nullsink, an accountless prepaid API relay, with 53 advertised model IDs: 14 Anthropic, 32 OpenAI, and 7 hosted through Tinfoil. One `NULLSINK_API_KEY` and `https://nullsink.is/v1` cover all models, using per-model SDK adapters for Messages, Responses, or Chat Completions.

Entries inherit shared lab metadata and define provider prices, reasoning controls, hosted limits, and lifecycle status. Pricing matches the [public catalog](https://nullsink.is/v1/models), including cache rates and nine context-price tiers; funding fees are separate. Seven upstream-deprecated IDs remain explicitly marked, including two retired chat aliases still advertised by nullsink. See [API documentation](https://nullsink.is/api/) and the source comments in each entry.

Validation:

- `bun validate` and `git diff --check` pass; all 53 IDs and prices match the public catalog checked 2026-09-08.
- Live native API checks cover streaming, usage reporting, and tool/result round trips on all 46 active IDs. Llama 3.3 required a concrete parameterized lookup prompt and returned the correct result with extra prose.
- Live OpenCode v1.18.29 coding and follow-up sessions pass on Sonnet 4.6, GPT-6 Astra, and GPT-OSS 120B; local catalog routing checks pass.
- Fable 5.1 accepts the released binding beta: signed-thinking replay and the expected prefix-mismatch drop were verified. The deliberately changed-prefix continuation returned an empty refusal.

Coverage is small text/tool requests; maximum contexts, every reasoning setting, and multimodal inputs were not tested.
