### PR TITLE
feat: add gitlab duo-chat-gpt-6-astra model

### DIFF
--- a/providers/gitlab/models/duo-chat-gpt-6-astra.toml
+++ b/providers/gitlab/models/duo-chat-gpt-6-astra.toml
@@ -1,0 +1,9 @@
+base_model = "openai/gpt-6-astra"
+name = "Agentic Chat (GPT-6 Astra)"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0
+output = 0
+cache_read = 0
+cache_write = 0


### PR DESCRIPTION
Adds `providers/gitlab/models/duo-chat-gpt-6-astra.toml` for GitLab Duo's OpenAI GPT-6 Astra offering.

- `base_model = "openai/gpt-6-astra"` — inherits context (1,050,000), output (128,000), modalities (text/image/pdf in, text out), and reasoning options from the existing `providers/openai/models/gpt-6-astra.toml` entry.
- Cost is zeroed out (`input`/`output`/`cache_read`/`cache_write` = 0) since GitLab Duo proxy models are billed upstream by GitLab, not directly by the underlying provider.
- `name = "Agentic Chat (GPT-6 Astra)"` follows the existing gitlab `duo-chat-*` naming convention (see `duo-chat-gpt-5-6-sol.toml`, `duo-chat-opus-5.toml`, etc.).

Source (ai-assist models.yml):
```yaml
- name: "GPT-6 Astra"
  provider: "OpenAI"
  gitlab_identifier: "gpt_6_astra"
  max_context_tokens: 1050000
  proxy_provider: openai
  model_class_provider: "openai"
  params:
    model: gpt-6-astra
    max_tokens: 128_000
```

Verified with `bun validate` — the model resolves correctly under `gitlab.models["duo-chat-gpt-6-astra"]` with the inherited metadata from the base model.