### PR TITLE
feat(fireworks-ai): add GLM 5.3 Fast router

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p3-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p3-fast.toml
@@ -11,7 +11,10 @@
 # context_length 1_048_576 and a created timestamp of 2026-08-28 (identical
 # to glm-5p3 — router launched with the base model); a max_tokens=262_144
 # probe was accepted, matching the Baseten/Vercel GLM 5.3 Fast output
-# ceilings.
+# ceilings; an over-limit probe (1_200_012 prompt tokens) was rejected
+# with "model maximum context length: 1048572" — the enforced prompt cap
+# sits 4 tokens below the advertised context_length, so that value is
+# recorded here.
 # Thinking-only, effort tiers identical to the sibling glm-5p3 entry:
 # low/high/max (max/xhigh select max).
 base_model = "zhipuai/glm-5.3"
@@ -32,5 +35,5 @@ output = 6.60
 cache_read = 0.39
 
 [limit]
-context = 1_048_576
+context = 1_048_572
 output = 262_144

--- a/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p3-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p3-fast.toml
@@ -9,12 +9,13 @@
 # standard, matching the GLM 5.2 Fast premium over GLM 5.2.
 # Limits and release verified 2026-09-07: GET /v1/models reports
 # context_length 1_048_576 and a created timestamp of 2026-08-28 (identical
-# to glm-5p3 — router launched with the base model); a max_tokens=262_144
-# probe was accepted, matching the Baseten/Vercel GLM 5.3 Fast output
-# ceilings; an over-limit probe (1_200_012 prompt tokens) was rejected
+# to glm-5p3 — router launched with the base model); an over-limit probe
+# (1_200_012 prompt tokens) was rejected
 # with "model maximum context length: 1048572" — the enforced prompt cap
 # sits 4 tokens below the advertised context_length, so that value is
-# recorded here.
+# recorded here. Fireworks performs no pre-flight max_tokens validation
+# (2_000_000 accepted); output = 262_144 per the Baseten/Vercel-documented
+# generation ceiling for the same weights.
 # Thinking-only, effort tiers identical to the sibling glm-5p3 entry:
 # low/high/max (max/xhigh select max).
 base_model = "zhipuai/glm-5.3"

--- a/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p3-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p3-fast.toml
@@ -1,14 +1,22 @@
-# Fast serving-path router for GLM 5.3 — same model, faster serving:
+# Fast serving-path router for GLM 5.3 — same model, faster serving (the
+# chat-completions response echoes the underlying
+# accounts/fireworks/models/glm-5p3):
 # https://docs.fireworks.ai/serverless/serving-paths
 # Router is live on Fireworks accounts but not yet listed on the public
 # pricing page (which currently lists GLM 5.2 Fast only). Pricing confirmed
 # from a Fireworks account rate card (2026-09-07): $2.10 / $0.39 / $6.60
 # per 1M (input / cached input / output) — a 1.5x premium over GLM 5.3
 # standard, matching the GLM 5.2 Fast premium over GLM 5.2.
+# Limits and release verified 2026-09-07: GET /v1/models reports
+# context_length 1_048_576 and a created timestamp of 2026-08-28 (identical
+# to glm-5p3 — router launched with the base model); a max_tokens=262_144
+# probe was accepted, matching the Baseten/Vercel GLM 5.3 Fast output
+# ceilings.
 # Thinking-only, effort tiers identical to the sibling glm-5p3 entry:
 # low/high/max (max/xhigh select max).
 base_model = "zhipuai/glm-5.3"
 name = "GLM 5.3 Fast"
+release_date = "2026-08-28"
 last_updated = "2026-09-07"
 
 [[reasoning_options]]
@@ -22,3 +30,7 @@ field = "reasoning_content"
 input = 2.10
 output = 6.60
 cache_read = 0.39
+
+[limit]
+context = 1_048_576
+output = 262_144

--- a/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p3-fast.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/routers/glm-5p3-fast.toml
@@ -1,0 +1,24 @@
+# Fast serving-path router for GLM 5.3 — same model, faster serving:
+# https://docs.fireworks.ai/serverless/serving-paths
+# Router is live on Fireworks accounts but not yet listed on the public
+# pricing page (which currently lists GLM 5.2 Fast only). Pricing confirmed
+# from a Fireworks account rate card (2026-09-07): $2.10 / $0.39 / $6.60
+# per 1M (input / cached input / output) — a 1.5x premium over GLM 5.3
+# standard, matching the GLM 5.2 Fast premium over GLM 5.2.
+# Thinking-only, effort tiers identical to the sibling glm-5p3 entry:
+# low/high/max (max/xhigh select max).
+base_model = "zhipuai/glm-5.3"
+name = "GLM 5.3 Fast"
+last_updated = "2026-09-07"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.10
+output = 6.60
+cache_read = 0.39


### PR DESCRIPTION
## What

Adds the `accounts/fireworks/routers/glm-5p3-fast` Fast serving-path router for GLM 5.3, following the `glm-5p2-fast` and `kimi-k3-fast` router entries.

## Details

- Same underlying model as GLM 5.3 — Fireworks docs: Fast "is not a different model and the quality of the model remains the same" — so the entry uses `base_model = "zhipuai/glm-5.3"` and overrides only provider-specific fields: pricing, reasoning controls, interleaved reasoning, and serving limits.
- Thinking-only; effort tiers `low` / `high` / `max` — same controls as the sibling Fireworks `glm-5p3` entry.
- Interleaved reasoning via `reasoning_content`, same as the other Fireworks GLM entries.

## Verification (2026-09-07)

- `GET /v1/models` on a Fireworks account: `context_length = 1_048_576`, `supports_tools = true`, `supports_image_input = false`; the `created` timestamp is identical to `glm-5p3` (2026-08-28), so the router launched alongside the base model on Fireworks serverless — that date is used as `release_date`.
- An over-limit probe (1,200,012 prompt tokens) was rejected with `model maximum context length: 1048572`, so `limit.context` records the enforced prompt cap — four tokens below the `context_length` that `/v1/models` advertises, mirroring how `glm-5p2-fast` records 1_048_575.
- `max_tokens` values up to 2,000,000 were accepted (HTTP 200): Fireworks performs no pre-flight `max_tokens` validation, so the request-side output ceiling is untestable by probes. `output = 262_144` records the generation ceiling documented by the Baseten and Vercel entries for the same weights.
- A probe's response echoed `"model": "accounts/fireworks/models/glm-5p3"`, confirming the router serves the same underlying model.

## Pricing

| | USD per 1M tokens |
|---|---|
| Input | $2.10 |
| Cached input | $0.39 |
| Output | $6.60 |

Source: confirmed from a Fireworks account's rates for this router, read 2026-09-07. The router is live but not yet listed on the public Serverless pricing page, which currently lists GLM 5.2 Fast only. The 1.5x premium over GLM 5.3 standard ($1.40 / $0.26 / $4.40) matches the GLM 5.2 Fast premium over GLM 5.2 ($1.40 / $0.14 / $4.40 → $2.10 / $0.21 / $6.60).