### PR TITLE
fix(fireworks-ai): correct GLM 5.3 / Flash serving limits

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
@@ -5,9 +5,16 @@
 # empirically 2026-09-04 — same prompt yields ~9/17/559 reasoning tokens for
 # low/high/max. max/xhigh select max.
 # https://docs.fireworks.ai/api-reference/post-chatcompletions
+# Serving limits verified 2026-09-07: GET /v1/models reports context_length
+# 1_048_576; an over-limit probe (1_200_012 prompt tokens) was rejected with
+# "model maximum context length: 1048573" — the enforced prompt cap, recorded
+# here (the lab default is 1M context). Output stays at the inherited
+# 131_072: Fireworks validates max_tokens against the context window only
+# (262_144 and 524_288 accepted), and Baseten documents 131_072 for
+# GLM-5.3-Flash.
 base_model = "zhipuai/glm-5.3-flash"
 name = "GLM 5.3 Flash"
-last_updated = "2026-09-04"
+last_updated = "2026-09-07"
 
 [[reasoning_options]]
 type = "effort"
@@ -20,3 +27,6 @@ field = "reasoning_content"
 input = 0.15
 output = 0.50
 cache_read = 0.03
+
+[limit]
+context = 1_048_573

--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3-flash.toml
@@ -9,9 +9,8 @@
 # 1_048_576; an over-limit probe (1_200_012 prompt tokens) was rejected with
 # "model maximum context length: 1048573" — the enforced prompt cap, recorded
 # here (the lab default is 1M context). Output stays at the inherited
-# 131_072: Fireworks validates max_tokens against the context window only
-# (262_144 and 524_288 accepted), and Baseten documents 131_072 for
-# GLM-5.3-Flash.
+# 131_072: Fireworks performs no pre-flight max_tokens validation (up to
+# 2_000_000 accepted), and Baseten documents 131_072 for GLM-5.3-Flash.
 base_model = "zhipuai/glm-5.3-flash"
 name = "GLM 5.3 Flash"
 last_updated = "2026-09-07"

--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3.toml
@@ -6,9 +6,17 @@
 # verified empirically 2026-09-04 — same prompt yields ~10/25/198 reasoning
 # tokens for low/high/max. max/xhigh select max.
 # https://docs.fireworks.ai/api-reference/post-chatcompletions
+# Serving limits verified 2026-09-07: GET /v1/models reports context_length
+# 1_048_576; an over-limit probe (1_200_012 prompt tokens) was rejected with
+# "model maximum context length: 1048573" — the enforced prompt cap, recorded
+# here. max_tokens is validated against the context window, not a separate
+# output cap (262_144 and 524_288 both accepted); output = 262_144 per the
+# Baseten-documented ceiling for the same weights. The Z.ai lab default
+# (1M / 128K, https://docs.z.ai/guides/llm/glm-5.3) understates Fireworks
+# serving.
 base_model = "zhipuai/glm-5.3"
 name = "GLM 5.3"
-last_updated = "2026-09-04"
+last_updated = "2026-09-07"
 
 [[reasoning_options]]
 type = "effort"
@@ -21,3 +29,7 @@ field = "reasoning_content"
 input = 1.40
 output = 4.40
 cache_read = 0.26
+
+[limit]
+context = 1_048_573
+output = 262_144

--- a/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/glm-5p3.toml
@@ -9,9 +9,10 @@
 # Serving limits verified 2026-09-07: GET /v1/models reports context_length
 # 1_048_576; an over-limit probe (1_200_012 prompt tokens) was rejected with
 # "model maximum context length: 1048573" — the enforced prompt cap, recorded
-# here. max_tokens is validated against the context window, not a separate
-# output cap (262_144 and 524_288 both accepted); output = 262_144 per the
-# Baseten-documented ceiling for the same weights. The Z.ai lab default
+# here. Fireworks performs no pre-flight max_tokens validation at all
+# (262_144, 524_288, and 2_000_000 all accepted), so a request-side output
+# ceiling is untestable by probes; output = 262_144 per the Baseten-
+# documented generation ceiling for the same weights. The Z.ai lab default
 # (1M / 128K, https://docs.z.ai/guides/llm/glm-5.3) understates Fireworks
 # serving.
 base_model = "zhipuai/glm-5.3"


### PR DESCRIPTION
## What

Corrects the serving limits on the Fireworks `glm-5p3` and `glm-5p3-flash` entries. Both currently inherit the Z.ai lab defaults (1M context / 128K output per https://docs.z.ai/guides/llm/glm-5.3), which understates what Fireworks actually serves.

## Verification (2026-09-07)

Both models, probed against a Fireworks account:

- `GET /v1/models` reports `context_length = 1_048_576` for both.
- Over-limit probes (1,200,012 prompt tokens) were rejected with `model maximum context length: 1048573` for both — the enforced prompt cap, recorded as `limit.context` (3 tokens below the advertised `context_length`).
- `max_tokens` values up to 2,000,000 were accepted on all three GLM 5.3 deployments (base, Flash, Fast router): Fireworks performs no pre-flight `max_tokens` validation, so the request-side output ceiling is untestable by probes. The recorded output values are cross-host documented generation ceilings, not Fireworks-enforced caps.

## Output values

- `glm-5p3`: `output = 262_144`, per the ceiling Baseten documents for the same weights (their `GLM-5.3` and `GLM-5.3-Fast` entries both record `262_144`).
- `glm-5p3-flash`: output left at the inherited `131_072`, matching Baseten's `GLM-5.3-Flash` documentation.

Related: #6507 adds the `glm-5p3-fast` router with the same verified-limits treatment — note its enforced cap is `1_048_572`; the Fast router deployment reserves one more token than the base deployments.