### PR TITLE
Mark GLM-5.3-Flash as open weights

### DIFF
--- a/models/zhipuai/glm-5.3-flash.toml
+++ b/models/zhipuai/glm-5.3-flash.toml
@@ -1,3 +1,4 @@
+# Open weights: https://huggingface.co/zai-org/GLM-5.3-Flash (MIT, safetensors)
 name = "GLM-5.3-Flash"
 description = "Native multimodal GLM model for efficient coding and long-horizon agent tasks"
 family = "glm"
@@ -8,7 +9,7 @@ reasoning = true
 temperature = true
 tool_call = true
 structured_output = true
-open_weights = false
+open_weights = true
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
## Problem

`models/zhipuai/glm-5.3-flash.toml` has `open_weights = false`. The weights are public: [zai-org/GLM-5.3-Flash on Hugging Face](https://huggingface.co/zai-org/GLM-5.3-Flash) ships safetensors under the MIT license, with docs for serving the model locally.

Every host that inherits the lab file via `base_model` reports the model as closed unless it overrides the field itself. Four overlays (huggingface, ollama-cloud, venice, wandb) already carry `open_weights = true` to correct for it.

## Change

One field in the lab file, plus a source comment:

```toml
# models/zhipuai/glm-5.3-flash.toml
# Open weights: https://huggingface.co/zai-org/GLM-5.3-Flash (MIT, safetensors)
open_weights = true
```

Host overlays that don't set `open_weights` now resolve to `true`. No overlay files are touched.

## Verification

- `bun validate` passes on this branch.
- Resolved `neon.models["glm-5-3-flash"].open_weights` is `true` (the neon overlay doesn't set the field, so it inherits).

## For your attention

- The four overlays that set `open_weights = true` now restate the base value. Per `AGENTS.md`, overlays shouldn't repeat unchanged base fields, so those lines can be removed in a follow-up. Left out of this PR to keep it to one field.
- `providers/cline-pass/models/cline-pass/glm-5.3-flash.toml` has no `base_model` and sets `open_weights = false` on its own. Unaffected by this change; whether it should also flip is a separate question.