### PR TITLE
fix(zeldoc): update zdev reasoning effort and release date

### DIFF
--- a/providers/zeldoc/models/zdev.toml
+++ b/providers/zeldoc/models/zdev.toml
@@ -2,11 +2,10 @@
 # https://docs.zeldoc.ai/ (accessed 2026-06-25)
 name = "ZDev"
 description = "Coding model for repository understanding, refactors, and agentic engineering tasks"
-release_date = "2026-04-15"
-last_updated = "2026-04-15"
+release_date = "2026-08-26"
+last_updated = "2026-08-26"
 attachment = true
 reasoning = true
-knowledge = "2025-01"
 temperature = true
 tool_call = true
 structured_output = true
@@ -14,7 +13,7 @@ open_weights = false
 
 [[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["low", "high", "max"]
 
 [interleaved]
 field = "reasoning_content"


### PR DESCRIPTION
## Changes

Model id (`zdev`) and display name ("ZDev") are unchanged.

- Reasoning effort values `["low", "high", "max"]`.
- `release_date` / `last_updated` set to 2026-08-26.
- Dropped `knowledge = "2025-01"`, which had no source.

Attachments, image input, and limits (1M context / 131k output) are unchanged.