### PR TITLE
feat(amazon-bedrock): add GPT-6 Astra models

### DIFF
--- a/providers/amazon-bedrock/models/global.openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-6-astra.toml
@@ -1,0 +1,22 @@
+# Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Bedrock model IDs and routes: https://github.com/openai/codex/pull/42805
+# Global CRIS pricing inferred at 1.0x OpenAI-direct from the GPT-5.6 Sol AWS card precedent.
+# Effort levels match OpenAI-native Astra (Low..Max, no "none"): https://developers.openai.com/api/docs/models/gpt-6-astra
+base_model = "openai/gpt-6-astra"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-6 Astra (Global)"
+structured_output = false
+
+[cost]
+input = 10.00
+output = 50.00
+cache_read = 1.00
+cache_write = 12.50
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 20.00
+output = 75.00
+cache_read = 2.00
+cache_write = 25.00

--- a/providers/amazon-bedrock/models/openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-6-astra.toml
@@ -1,0 +1,27 @@
+# Bedrock model IDs and routes: https://github.com/openai/codex/pull/42805
+# Bedrock context window: https://developers.openai.com/api/docs/guides/amazon-bedrock
+# In-region pricing inferred at 1.1x OpenAI-direct from the GPT-5.6 Sol precedent
+# (AWS card prices in-region and Geo CRIS at 1.1x, Global CRIS at 1.0x); no AWS Astra model card published yet.
+# Effort levels match OpenAI-native Astra (Low..Max, no "none"): https://developers.openai.com/api/docs/models/gpt-6-astra
+# Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
+base_model = "openai/gpt-6-astra"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+
+[cost]
+input = 11.00
+output = 55.00
+cache_read = 1.10
+cache_write = 13.75
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 22.00
+output = 82.50
+cache_read = 2.20
+cache_write = 27.50
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/us.openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-6-astra.toml
@@ -1,0 +1,22 @@
+# US cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Bedrock model IDs and routes: https://github.com/openai/codex/pull/42805
+# Geo CRIS pricing inferred at 1.1x OpenAI-direct (= in-region) from the GPT-5.6 Sol AWS card precedent.
+# Effort levels match OpenAI-native Astra (Low..Max, no "none"): https://developers.openai.com/api/docs/models/gpt-6-astra
+base_model = "openai/gpt-6-astra"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-6 Astra (US)"
+structured_output = false
+
+[cost]
+input = 11.00
+output = 55.00
+cache_read = 1.10
+cache_write = 13.75
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 22.00
+output = 82.50
+cache_read = 2.20
+cache_write = 27.50


### PR DESCRIPTION
Adds GPT-6 Astra to Amazon Bedrock, which launched there on day one (Sept 3-4) but was missing from the catalog. Three routes, mirroring the GPT-5.6 layout:

- `openai.gpt-6-astra` — Mantle in-region (`[provider]` override, Responses shape)
- `us.openai.gpt-6-astra` — Runtime US cross-region profile (Converse)
- `global.openai.gpt-6-astra` — Runtime Global cross-region profile (Converse)

All three use `base_model = "openai/gpt-6-astra"` (override-only) and inherit limits/modalities/knowledge from the lab file.

**Sources**
- Routes/IDs: OpenAI's own Codex catalog addition (Mantle + Runtime global/US) — https://github.com/openai/codex/pull/42805
- Effort levels Low..Max (no `none`): native Astra API — https://developers.openai.com/api/docs/models/gpt-6-astra — corroborated by the Codex Bedrock reasoning picker, which offers exactly Low/Medium/High/Extra-high/Max on both Mantle and Runtime. This is a deliberate divergence from the 5.6 Bedrock peers (which include `none`); Astra dropped the non-reasoning option natively.
- Context 1.05M: https://developers.openai.com/api/docs/guides/amazon-bedrock

**Pricing (please re-verify against the AWS card when published)**
No AWS Astra model card exists yet, so pricing is inferred from the GPT-5.6 Sol precedent, whose AWS card prices in-region = Geo CRIS at 1.1x OpenAI-direct and Global CRIS at 1.0x: in-region/US 11.00/55.00, Global 10.00/50.00, with the same 272K long-context tier multiples as direct. Each file carries a comment saying so.

**Validation**
- `bun validate` passes; merged output spot-checked (names, costs, effort lists, Mantle override only on bare, `structured_output = false` only on the Converse routes, no experimental leakage).

**Follow-up (not in this PR)**
- The same Codex diff confirms `us.openai.gpt-5.6-{sol,terra,luna}` exist, but models.dev only lists bare + global for 5.6. Worth a separate PR.