### PR TITLE
fix: Remove structured output restriction for Bedrock GPT-6 Astra

### DIFF
--- a/providers/amazon-bedrock/models/global.openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-6-astra.toml
@@ -6,7 +6,6 @@ base_model = "openai/gpt-6-astra"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-6 Astra (Global)"
-structured_output = false
 
 [cost]
 input = 10.00

--- a/providers/amazon-bedrock/models/us.openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-6-astra.toml
@@ -6,7 +6,6 @@ base_model = "openai/gpt-6-astra"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-6 Astra (US)"
-structured_output = false
 
 [cost]
 input = 11.00


### PR DESCRIPTION
Removed the explicit `structured_output = false` restriction on Bedrock GPT-6 Astra regional profiles. 

The Astra model card isn't out yet in Bedrock docs, but I manually tested and found that Converse API actually does return a correctly formatted response when passing `outputConfig` -> `textFormat` -> `type: json_schema`.

Test code for reference:
  ```python
  import boto3
  
  response = boto3.client("bedrock-runtime", region_name="us-west-2").converse(
      modelId="us.openai.gpt-6-astra",
      messages=[{"role": "user", "content": [{"text": "Michael Chin is 27."}]}],
      outputConfig={
          "textFormat": {
              "type": "json_schema",
              "structure": {
                  "jsonSchema": {
                      "name": "person",
                      "schema": '{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"],"additionalProperties":false}',
                  }
              },
          }
      },
  )
  print(next(b["text"] for b in response["output"]["message"]["content"] if "text" in b))
```
Returns:
```
{"name":"Michael Chin","age":27}
```