### PR TITLE
feat(amazon-bedrock): add GPT-5.6 US profiles and Opus 4.7 AU profile

### DIFF
--- a/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-7.toml
+++ b/providers/amazon-bedrock/models/au.anthropic.claude-opus-4-7.toml
@@ -1,0 +1,12 @@
+# AU cross-Region inference profile, verified via ListInferenceProfiles from ap-southeast-2.
+# AU geo pricing (Price List ap-southeast-2 standard): input/output/cache-read/cache-write USD per 1M tokens.
+# Note: sibling au.* entries are priced at 1.0x; the Price List bills AU-geo calls at the 1.1x standard rate.
+base_model = "anthropic/claude-opus-4-7"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+name = "Claude Opus 4.7 (AU)"
+
+[cost]
+input = 5.50
+output = 27.50
+cache_read = 0.55
+cache_write = 6.875

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-luna.toml
@@ -1,0 +1,22 @@
+# US cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Profile ID verified via ListInferenceProfiles from us-east-1 and ca-central-1.
+# Geo CRIS pricing (= in-region) per the GPT-5.6 AWS card pattern; OpenAI-on-Bedrock is absent from the Price List API.
+# Effort levels incl. "none" verified on the Global twin: global.openai.gpt-5.6-luna.toml
+base_model = "openai/gpt-5.6-luna"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-5.6 Luna (US)"
+structured_output = false
+
+[cost]
+input = 0.22
+output = 1.32
+cache_read = 0.022
+cache_write = 0.275
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 0.44
+output = 1.98
+cache_read = 0.044
+cache_write = 0.55

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-sol.toml
@@ -1,0 +1,22 @@
+# US cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Profile ID verified via ListInferenceProfiles from us-east-1 and ca-central-1.
+# Geo CRIS pricing (= in-region) per the GPT-5.6 Sol AWS card; OpenAI-on-Bedrock is absent from the Price List API.
+# Effort levels incl. "none" verified on the Global twin: global.openai.gpt-5.6-sol.toml
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-5.6 Sol (US)"
+structured_output = false
+
+[cost]
+input = 4.40
+output = 22.00
+cache_read = 0.44
+cache_write = 5.50
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 8.80
+output = 33.00
+cache_read = 0.88
+cache_write = 11.00

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-terra.toml
@@ -1,0 +1,22 @@
+# US cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
+# Profile ID verified via ListInferenceProfiles from us-east-1 and ca-central-1.
+# Geo CRIS pricing (= in-region) per the GPT-5.6 AWS card pattern; OpenAI-on-Bedrock is absent from the Price List API.
+# Effort levels incl. "none" verified on the Global twin: global.openai.gpt-5.6-terra.toml
+base_model = "openai/gpt-5.6-terra"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
+name = "GPT-5.6 Terra (US)"
+structured_output = false
+
+[cost]
+input = 2.20
+output = 13.20
+cache_read = 0.22
+cache_write = 2.75
+
+[[cost.tiers]]
+tier = { size = 272_000 }
+input = 4.40
+output = 19.80
+cache_read = 0.44
+cache_write = 5.50


### PR DESCRIPTION
Adds four verified-missing Bedrock inference profiles (all confirmed via live ListInferenceProfiles):

- `us.openai.gpt-5.6-{sol,terra,luna}` — Runtime US cross-region (Converse), visible from us-east-1 + ca-central-1. Same shape as the Global twins (effort incl. none, structured_output false, 272K tiers).
- `au.anthropic.claude-opus-4-7` — AU cross-region, visible from ap-southeast-2.

**Pricing**
- US 5.6 = in-region rates per the GPT-5.6 AWS card pattern (Geo = in-region). OpenAI-on-Bedrock is absent from the Price List API, so this is inferred like the Astra entries; each file says so.
- AU Opus 4.7 = ap-southeast-2 standard from the Price List API (5.50/27.50/0.55/6.875). Note this is 1.1x while sibling au.* entries say 1.0x — the Price List bills AU-geo calls at standard, so the siblings look stale; happy to follow up with a pricing-correction PR.

**Validation**: bun validate passes; merged output spot-checked.