### PR TITLE
feat(amazon-bedrock): add Nova cross-region inference profiles

### DIFF
--- a/models/amazon/nova-2-lite.toml
+++ b/models/amazon/nova-2-lite.toml
@@ -1,0 +1,18 @@
+name = "Nova 2 Lite"
+description = "Multimodal reasoning model for visual analysis, planning, and tool use"
+family = "nova"
+release_date = "2024-12-01"
+last_updated = "2024-12-01"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/models/amazon/nova-2-lite.toml
+++ b/models/amazon/nova-2-lite.toml
@@ -1,18 +1,18 @@
 name = "Nova 2 Lite"
 description = "Multimodal reasoning model for visual analysis, planning, and tool use"
 family = "nova"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
+release_date = "2025-12-01"
+last_updated = "2025-12-01"
+attachment = true
 reasoning = true
 temperature = true
 tool_call = true
 open_weights = false
 
 [limit]
-context = 128_000
-output = 4_096
+context = 1_000_000
+output = 64_000
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image", "video", "pdf"]
 output = ["text"]

--- a/models/amazon/nova-lite.toml
+++ b/models/amazon/nova-lite.toml
@@ -1,0 +1,19 @@
+name = "Nova Lite"
+description = "Efficient model for low-latency assistance, extraction, and routine automation"
+family = "nova-lite"
+release_date = "2024-12-03"
+last_updated = "2024-12-03"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 300_000
+output = 8_192
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/models/amazon/nova-micro.toml
+++ b/models/amazon/nova-micro.toml
@@ -1,0 +1,19 @@
+name = "Nova Micro"
+description = "Efficient model for low-latency assistance, extraction, and routine automation"
+family = "nova-micro"
+release_date = "2024-12-03"
+last_updated = "2024-12-03"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/amazon/nova-pro.toml
+++ b/models/amazon/nova-pro.toml
@@ -1,0 +1,19 @@
+name = "Nova Pro"
+description = "Flagship model for demanding analysis, coding, and production agent workflows"
+family = "nova-pro"
+release_date = "2024-12-03"
+last_updated = "2024-12-03"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 300_000
+output = 8_192
+
+[modalities]
+input = ["text", "image", "video"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/apac.amazon.nova-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/apac.amazon.nova-lite-v1:0.toml
@@ -1,0 +1,10 @@
+# APAC cross-Region inference profile, verified via ListInferenceProfiles from ap-southeast-2.
+# Priced at ap-southeast-2 standard; also invocable from ap-northeast-1/ap-southeast-1 where regional rates differ slightly.
+# Prices (Price List): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-lite"
+name = "Nova Lite (APAC)"
+
+[cost]
+input = 0.063
+output = 0.252
+cache_read = 0.01575

--- a/providers/amazon-bedrock/models/apac.amazon.nova-micro-v1:0.toml
+++ b/providers/amazon-bedrock/models/apac.amazon.nova-micro-v1:0.toml
@@ -1,0 +1,10 @@
+# APAC cross-Region inference profile, verified via ListInferenceProfiles from ap-southeast-2.
+# Priced at ap-southeast-2 standard; also invocable from ap-northeast-1/ap-southeast-1 where regional rates differ slightly.
+# Prices (Price List): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-micro"
+name = "Nova Micro (APAC)"
+
+[cost]
+input = 0.037
+output = 0.148
+cache_read = 0.00925

--- a/providers/amazon-bedrock/models/apac.amazon.nova-pro-v1:0.toml
+++ b/providers/amazon-bedrock/models/apac.amazon.nova-pro-v1:0.toml
@@ -1,0 +1,10 @@
+# APAC cross-Region inference profile, verified via ListInferenceProfiles from ap-southeast-2.
+# Priced at ap-southeast-2 standard; also invocable from ap-northeast-1/ap-southeast-1 where regional rates differ slightly.
+# Prices (Price List): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-pro"
+name = "Nova Pro (APAC)"
+
+[cost]
+input = 0.840
+output = 3.360
+cache_read = 0.210

--- a/providers/amazon-bedrock/models/ca.amazon.nova-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/ca.amazon.nova-lite-v1:0.toml
@@ -1,0 +1,9 @@
+# CA cross-Region inference profile, verified via ListInferenceProfiles from ca-central-1.
+# CA geo pricing (Price List ca-central-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-lite"
+name = "Nova Lite (CA)"
+
+[cost]
+input = 0.064
+output = 0.256
+cache_read = 0.016

--- a/providers/amazon-bedrock/models/eu.amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.amazon.nova-2-lite-v1:0.toml
@@ -1,0 +1,11 @@
+# EU cross-Region inference profile, verified via ListInferenceProfiles from eu-west-1.
+# EU geo pricing (Price List eu-west-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# Toggle: reasoningConfig.type = enabled|disabled; Effort: reasoningConfig.maxReasoningEffort = low|medium|high
+base_model = "amazon/nova-2-lite"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+name = "Nova 2 Lite (EU)"
+
+[cost]
+input = 0.374
+output = 3.157
+cache_read = 0.0935

--- a/providers/amazon-bedrock/models/eu.amazon.nova-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.amazon.nova-lite-v1:0.toml
@@ -1,0 +1,9 @@
+# EU cross-Region inference profile, verified via ListInferenceProfiles from eu-west-1.
+# EU geo pricing (Price List eu-west-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-lite"
+name = "Nova Lite (EU)"
+
+[cost]
+input = 0.069
+output = 0.276
+cache_read = 0.01725

--- a/providers/amazon-bedrock/models/eu.amazon.nova-micro-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.amazon.nova-micro-v1:0.toml
@@ -1,0 +1,9 @@
+# EU cross-Region inference profile, verified via ListInferenceProfiles from eu-west-1.
+# EU geo pricing (Price List eu-west-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-micro"
+name = "Nova Micro (EU)"
+
+[cost]
+input = 0.040
+output = 0.160
+cache_read = 0.010

--- a/providers/amazon-bedrock/models/eu.amazon.nova-pro-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.amazon.nova-pro-v1:0.toml
@@ -1,0 +1,9 @@
+# EU cross-Region inference profile, verified via ListInferenceProfiles from eu-west-1.
+# EU geo pricing (Price List eu-west-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-pro"
+name = "Nova Pro (EU)"
+
+[cost]
+input = 0.920
+output = 3.680
+cache_read = 0.230

--- a/providers/amazon-bedrock/models/global.amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.amazon.nova-2-lite-v1:0.toml
@@ -1,0 +1,11 @@
+# Global cross-Region inference profile, verified via ListInferenceProfiles (visible from all regions).
+# Global pricing (Price List us-east-1 global): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# Toggle: reasoningConfig.type = enabled|disabled; Effort: reasoningConfig.maxReasoningEffort = low|medium|high
+base_model = "amazon/nova-2-lite"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+name = "Nova 2 Lite (Global)"
+
+[cost]
+input = 0.300
+output = 2.500
+cache_read = 0.075

--- a/providers/amazon-bedrock/models/jp.amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/jp.amazon.nova-2-lite-v1:0.toml
@@ -1,0 +1,11 @@
+# JP cross-Region inference profile, verified via ListInferenceProfiles from ap-northeast-1.
+# JP geo pricing (Price List ap-northeast-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# Toggle: reasoningConfig.type = enabled|disabled; Effort: reasoningConfig.maxReasoningEffort = low|medium|high
+base_model = "amazon/nova-2-lite"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+name = "Nova 2 Lite (JP)"
+
+[cost]
+input = 0.396
+output = 3.311
+cache_read = 0.099

--- a/providers/amazon-bedrock/models/us.amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.amazon.nova-2-lite-v1:0.toml
@@ -1,0 +1,11 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1 and ca-central-1.
+# US geo pricing (Price List us-east-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# Toggle: reasoningConfig.type = enabled|disabled; Effort: reasoningConfig.maxReasoningEffort = low|medium|high
+base_model = "amazon/nova-2-lite"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
+name = "Nova 2 Lite (US)"
+
+[cost]
+input = 0.33
+output = 2.75
+cache_read = 0.0825

--- a/providers/amazon-bedrock/models/us.amazon.nova-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.amazon.nova-lite-v1:0.toml
@@ -1,0 +1,9 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
+# US geo pricing (Price List us-east-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-lite"
+name = "Nova Lite (US)"
+
+[cost]
+input = 0.06
+output = 0.24
+cache_read = 0.015

--- a/providers/amazon-bedrock/models/us.amazon.nova-micro-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.amazon.nova-micro-v1:0.toml
@@ -1,0 +1,9 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
+# US geo pricing (Price List us-east-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-micro"
+name = "Nova Micro (US)"
+
+[cost]
+input = 0.035
+output = 0.14
+cache_read = 0.00875

--- a/providers/amazon-bedrock/models/us.amazon.nova-pro-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.amazon.nova-pro-v1:0.toml
@@ -1,0 +1,9 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
+# US geo pricing (Price List us-east-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+base_model = "amazon/nova-pro"
+name = "Nova Pro (US)"
+
+[cost]
+input = 0.80
+output = 3.20
+cache_read = 0.20


### PR DESCRIPTION
Bedrock listed zero Nova profiles; AWS actually serves 15. This adds 14 (all except Nova Premier, which has no lab entry yet):

- us/eu/apac × Micro/Lite/Pro (9)
- us/eu/jp/global × 2 Lite (4)
- ca Lite (1)

Also adds the missing lab entries under models/amazon/ (nova-micro/lite/pro/2-lite, transcribed from the bare inline entries) so the new provider files are override-only per policy. Legacy bare inline files untouched.

**Verification**: every profile ID confirmed via live ListInferenceProfiles from its home region(s). Asymmetric on purpose: no jp/apac/ca/global for Nova 1.x except apac-1x + ca-lite, no apac/ca for 2 Lite — that is what AWS returns.

**Pricing**: every figure from the Price List API (regional standard for geo profiles, us-east-1 global for the Global profile). Nova has no cache-write charge (automatic prefix caching), so no cache_write keys. APAC entries priced at ap-southeast-2 standard with a comment noting ap-northeast-1/ap-southeast-1 differ slightly.

**Validation**: bun validate passes; merged output spot-checked (14/14 present, toggle+effort only on 2 Lite, no cache_write leakage).