### PR TITLE
feat(amazon-bedrock): add US Llama/Pixtral/Writer and EU Pixtral profiles

### DIFF
--- a/models/meta/llama-3.1-70b-instruct.toml
+++ b/models/meta/llama-3.1-70b-instruct.toml
@@ -1,0 +1,23 @@
+name = "Llama-3.1-70B-Instruct"
+description = "Open Llama instruction model for multilingual chat, reasoning, and coding"
+family = "llama"
+release_date = "2024-07-23"
+last_updated = "2024-07-23"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2023-12"
+open_weights = true
+
+[limit]
+context = 128_000
+output = 4_096
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct"

--- a/models/mistral/pixtral-large-2502.toml
+++ b/models/mistral/pixtral-large-2502.toml
@@ -1,0 +1,18 @@
+name = "Pixtral Large (25.02)"
+description = "Mistral vision-language model for image understanding and multimodal chat"
+family = "mistral"
+release_date = "2025-04-08"
+last_updated = "2025-04-08"
+attachment = false
+reasoning = false
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 128_000
+output = 8_192
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/models/mistral/pixtral-large-2502.toml
+++ b/models/mistral/pixtral-large-2502.toml
@@ -1,9 +1,9 @@
 name = "Pixtral Large (25.02)"
 description = "Mistral vision-language model for image understanding and multimodal chat"
-family = "mistral"
+family = "pixtral"
 release_date = "2025-04-08"
 last_updated = "2025-04-08"
-attachment = false
+attachment = true
 reasoning = false
 temperature = true
 tool_call = true

--- a/models/writer/palmyra-x4.toml
+++ b/models/writer/palmyra-x4.toml
@@ -1,0 +1,18 @@
+name = "Palmyra X4"
+description = "Reasoning model for deliberate analysis, multi-step problem solving, and tool use"
+family = "palmyra"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 122_880
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/models/writer/palmyra-x5.toml
+++ b/models/writer/palmyra-x5.toml
@@ -1,0 +1,18 @@
+name = "Palmyra X5"
+description = "Reasoning model for deliberate analysis, multi-step problem solving, and tool use"
+family = "palmyra"
+release_date = "2025-04-28"
+last_updated = "2025-04-28"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+open_weights = false
+
+[limit]
+context = 1_040_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/amazon-bedrock/models/eu.mistral.pixtral-large-2502-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.mistral.pixtral-large-2502-v1:0.toml
@@ -1,0 +1,8 @@
+# EU cross-Region inference profile, verified via ListInferenceProfiles from eu-west-1.
+# EU geo pricing (Price List eu-west-1 standard): input/output USD per 1M tokens.
+base_model = "mistral/pixtral-large-2502"
+name = "Pixtral Large (25.02) (EU)"
+
+[cost]
+input = 2.00
+output = 6.00

--- a/providers/amazon-bedrock/models/us.meta.llama3-1-70b-instruct-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.meta.llama3-1-70b-instruct-v1:0.toml
@@ -1,0 +1,8 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
+# US geo pricing (Price List us-east-1 standard): input/output USD per 1M tokens.
+base_model = "meta/llama-3.1-70b-instruct"
+name = "Llama 3.1 70B Instruct (US)"
+
+[cost]
+input = 0.72
+output = 0.72

--- a/providers/amazon-bedrock/models/us.meta.llama3-1-8b-instruct-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.meta.llama3-1-8b-instruct-v1:0.toml
@@ -1,0 +1,8 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
+# US geo pricing (Price List us-east-1 standard): input/output USD per 1M tokens.
+base_model = "meta/llama-3.1-8b-instruct"
+name = "Llama 3.1 8B Instruct (US)"
+
+[cost]
+input = 0.22
+output = 0.22

--- a/providers/amazon-bedrock/models/us.meta.llama3-3-70b-instruct-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.meta.llama3-3-70b-instruct-v1:0.toml
@@ -1,0 +1,9 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
+# US geo pricing (Price List us-east-1 standard): input/output USD per 1M tokens.
+base_model = "meta/llama-3.3-70b-instruct"
+name = "Llama 3.3 70B Instruct (US)"
+attachment = false
+
+[cost]
+input = 0.72
+output = 0.72

--- a/providers/amazon-bedrock/models/us.mistral.pixtral-large-2502-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.mistral.pixtral-large-2502-v1:0.toml
@@ -1,0 +1,8 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
+# US geo pricing (Price List us-east-1 standard): input/output USD per 1M tokens.
+base_model = "mistral/pixtral-large-2502"
+name = "Pixtral Large (25.02) (US)"
+
+[cost]
+input = 2.00
+output = 6.00

--- a/providers/amazon-bedrock/models/us.writer.palmyra-x4-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.writer.palmyra-x4-v1:0.toml
@@ -1,0 +1,9 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
+# US geo pricing (Price List us-east-1 standard): input/output USD per 1M tokens.
+base_model = "writer/palmyra-x4"
+reasoning_options = []
+name = "Palmyra X4 (US)"
+
+[cost]
+input = 2.50
+output = 10.00

--- a/providers/amazon-bedrock/models/us.writer.palmyra-x5-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.writer.palmyra-x5-v1:0.toml
@@ -1,0 +1,9 @@
+# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
+# US geo pricing (Price List us-east-1 standard): input/output USD per 1M tokens.
+base_model = "writer/palmyra-x5"
+reasoning_options = []
+name = "Palmyra X5 (US)"
+
+[cost]
+input = 0.60
+output = 6.00


### PR DESCRIPTION
Adds seven verified-missing Bedrock profiles (all confirmed via live ListInferenceProfiles):

- `us.meta.llama3-{1-70b,1-8b,3-70b}-instruct-v1:0` (us-east-1)
- `us.+eu.mistral.pixtral-large-2502-v1:0` (us-east-1, eu-west-1)
- `us.writer.palmyra-x4/x5-v1:0` (us-east-1)

Also adds the missing lab entries (meta/llama-3.1-70b-instruct, mistral/pixtral-large-2502, writer/palmyra-x4/x5 — the latter two are new lab dirs) so the new provider files are override-only per policy. Legacy bare inline files untouched. The 2502 lab file is separate from pixtral-large-latest (a 2024 snapshot, different model).

**Pricing**: every figure from the Price List API (regional standard for geo profiles). Matches the bare in-region rates in all seven cases (Llama/Pixtral/Writer carry no CRIS premium).

**Validation**: bun validate passes; merged output spot-checked (7/7 present, attachment/reasoning inheritance correct, empty reasoning_options only on Writer mirroring bare).