### PR TITLE
feat(aihubmix): sync pricing and deprecation from the public catalog

### DIFF
--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { AuthoredModel, AuthoredModelShape, ModelMetadata } from "../schema.js";
 import { openMissingModelIssues } from "./missing-issues.js";
 import { MissingReasoningOptionsError } from "./missing-reasoning-options.js";
+import { aihubmix } from "./providers/aihubmix.js";
 import { ambient } from "./providers/ambient.js";
 import { anthropic } from "./providers/anthropic.js";
 import { baseten } from "./providers/baseten.js";
@@ -130,6 +131,7 @@ export interface SyncResult {
 }
 
 export const providers: {
+  aihubmix: SyncProvider<any>;
   ambient: SyncProvider<any>;
   anthropic: SyncProvider<any>;
   baseten: SyncProvider<any>;
@@ -165,6 +167,7 @@ export const providers: {
   wandb: SyncProvider<any>;
   xai: SyncProvider<any>;
 } = {
+  aihubmix,
   ambient,
   anthropic,
   baseten,
@@ -203,6 +206,7 @@ export const providers: {
 
 export const groups = {
   aggregators: [
+    "aihubmix",
     "crossmodel",
     "edenai",
     "empiriolabs",
@@ -1055,6 +1059,12 @@ export function formatToml(model: z.infer<typeof SyncedAuthoredModel>) {
       if (tier.reasoning !== undefined) lines.push(`reasoning = ${formatNumber(tier.reasoning)}`);
       if (tier.cache_read !== undefined) lines.push(`cache_read = ${formatNumber(tier.cache_read)}`);
       if (tier.cache_write !== undefined) lines.push(`cache_write = ${formatNumber(tier.cache_write)}`);
+      if (tier.input_audio !== undefined) {
+        lines.push(`input_audio = ${formatNumber(tier.input_audio)}`);
+      }
+      if (tier.output_audio !== undefined) {
+        lines.push(`output_audio = ${formatNumber(tier.output_audio)}`);
+      }
     }
   }
 

--- a/packages/core/src/sync/providers/aihubmix.ts
+++ b/packages/core/src/sync/providers/aihubmix.ts
@@ -1,0 +1,135 @@
+import { z } from "zod";
+
+import type { ExistingModel, SyncProvider, SyncedFullModel, SyncedModel } from "../index.js";
+
+const API_ENDPOINT = "https://aihubmix.com/api/v1/models?type=llm";
+
+/** AIHubMix quotes USD per 1M tokens directly, matching the catalog unit. */
+const Pricing = z
+  .object({
+    input: z.number().nullish(),
+    output: z.number().nullish(),
+    cache_read: z.number().nullish(),
+    cache_write: z.number().nullish(),
+  })
+  .passthrough();
+
+export const AihubmixModel = z
+  .object({
+    model_id: z.string().min(1),
+    model_name: z.string().nullish(),
+    pricing: Pricing.nullish(),
+    retire_stage: z.string().nullish(),
+  })
+  .passthrough();
+
+export const AihubmixResponse = z
+  .object({
+    success: z.boolean().nullish(),
+    data: z.array(AihubmixModel).min(1),
+  })
+  .passthrough();
+
+export type AihubmixModel = z.infer<typeof AihubmixModel>;
+
+/**
+ * AIHubMix relays ~400 upstream models while the catalog curates a much smaller
+ * hand-verified subset, so this sync only updates existing TOMLs
+ * (`skipCreates`) and treats the AIHubMix endpoint as authoritative for pricing
+ * and deprecation status only.
+ *
+ * Everything else in the authored TOMLs is preserved as hand-authored, because
+ * the endpoint reports the relay's own conservative defaults rather than the
+ * upstream model's real capabilities: `context_length` is capped per relay
+ * (Claude Opus 4.6 reports 200K against its 1M window), `max_output` is quoted
+ * per default request rather than per model, and `input_modalities` never lists
+ * `pdf` even for models the provider does accept PDFs for. Its free-text
+ * `features` list likewise mixes synonyms (`thinking` vs `reasoning`, `tools`
+ * vs `tool_calling`) and never exposes accepted reasoning effort levels, so
+ * capability flags, `reasoning_options`, `base_model` inheritance, and the
+ * per-model `[provider]` protocol overrides all stay authored.
+ *
+ * Routing aliases such as `alicloud-glm-5.1` and `deep-deepseek-v4-pro` are
+ * served but not listed by the endpoint, so local files missing from the
+ * response are retained (`deleteMissing: false`).
+ */
+export const aihubmix = {
+  id: "aihubmix",
+  name: "AIHubMix",
+  modelsDir: "providers/aihubmix/models",
+  skipCreates: true,
+  trackMissingModels: true,
+  deleteMissing: false,
+  sourceID(model) {
+    // Deprecated relays are not catalog additions worth an issue.
+    return model.retire_stage === "deprecated" ? undefined : model.model_id;
+  },
+  missingNotice(paths) {
+    return paths.map(
+      (file) =>
+        `AIHubMix no longer lists ${file}; confirm it is still a served routing alias or deprecate it.`,
+    );
+  },
+  async fetchModels() {
+    const response = await fetch(process.env.AIHUBMIX_MODELS_URL ?? API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`AIHubMix models request failed: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  },
+  parseModels(raw) {
+    return AihubmixResponse.parse(raw).data;
+  },
+  translateModel(model, context) {
+    const authored = context.authored(model.model_id);
+    if (authored === undefined) return undefined;
+    return {
+      id: model.model_id,
+      model: buildAihubmixModel(model, authored),
+    };
+  },
+} satisfies SyncProvider<AihubmixModel>;
+
+export function buildAihubmixModel(model: AihubmixModel, authored: ExistingModel): SyncedModel {
+  const { id: _id, ...preserved } = authored;
+  return {
+    ...preserved,
+    cost: buildCost(model.pricing, authored.cost),
+    status: model.retire_stage === "deprecated" ? "deprecated" : authored.status,
+  } as SyncedModel;
+}
+
+/**
+ * AIHubMix omits a price field when the model has no such rate, but a partial
+ * authored `[cost]` (tiers, reasoning, audio rates) still carries values the
+ * endpoint does not model, so those are kept.
+ */
+function buildCost(
+  pricing: AihubmixModel["pricing"],
+  authored: ExistingModel["cost"],
+): SyncedFullModel["cost"] {
+  if (pricing == null) return authored;
+  const input = price(pricing.input);
+  const output = price(pricing.output);
+  if (input === undefined || output === undefined) return authored;
+
+  const cacheRead = price(pricing.cache_read);
+  return {
+    ...authored,
+    input,
+    output,
+    // AIHubMix echoes the input price into `cache_read` for models it has no
+    // cached rate for (35 of the 301 priced entries carry a nonzero price this
+    // way; 51 more are free models reporting 0 across the board, where this is
+    // a no-op), so an equal value means "not quoted" rather than "cached reads
+    // cost full price" — taking it literally would overstate e.g. Gemini 3.1
+    // Flash Lite by 10x against the $0.025 every other provider lists.
+    cache_read: cacheRead === input ? authored?.cache_read : (cacheRead ?? authored?.cache_read),
+    cache_write: price(pricing.cache_write) ?? authored?.cache_write,
+  };
+}
+
+function price(value: number | null | undefined) {
+  if (value == null || !Number.isFinite(value) || value < 0) return undefined;
+  return Math.round(value * 1_000_000) / 1_000_000;
+}

--- a/packages/core/test/sync.test.ts
+++ b/packages/core/test/sync.test.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 
 import { formatToml, preserveReasoningOptions, syncProvider, type ExistingModel, type SyncProvider } from "../src/sync/index.js";
 import {
+  aihubmix,
+  buildAihubmixModel,
+  type AihubmixModel,
+} from "../src/sync/providers/aihubmix.js";
+import {
   anthropic,
   buildAnthropicModel,
   parseAnthropicPricing,
@@ -1185,6 +1190,8 @@ test("tracks missing models except for unreliable first-party inventories", () =
   expect(openai.trackMissingModels).toBe(false);
   expect(pioneer.skipCreates).toBe(true);
   expect(pioneer.trackMissingModels).toBe(true);
+  expect(aihubmix.skipCreates).toBe(true);
+  expect(aihubmix.trackMissingModels).toBe(true);
   expect(ofox.skipCreates).toBe(true);
   expect(ofox.trackMissingModels).toBe(true);
   expect(tinfoil.skipCreates).toBe(true);
@@ -5013,4 +5020,76 @@ test("rejects synced model paths that differ only in case", async () => {
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+function aihubmixModel(overrides: Partial<AihubmixModel> = {}): AihubmixModel {
+  return {
+    model_id: "gemini-3.1-flash-lite",
+    model_name: "Gemini 3.1 Flash Lite",
+    pricing: { input: 0.25, output: 1.5, cache_read: 0.025 },
+    ...overrides,
+  };
+}
+
+const aihubmixAuthored: ExistingModel = {
+  id: "gemini-3.1-flash-lite",
+  name: "Gemini 3.1 Flash Lite",
+  attachment: true,
+  reasoning: true,
+  reasoning_options: [{ type: "effort", values: ["minimal", "low", "medium", "high"] }],
+  cost: { input: 0.25, output: 1.5, cache_read: 0.025, cache_write: 1 },
+  limit: { context: 1_048_576, output: 65_536 },
+  modalities: { input: ["text", "image", "audio", "video", "pdf"], output: ["text"] },
+};
+
+test("syncs AIHubMix pricing while preserving hand-authored capabilities", () => {
+  const model = buildAihubmixModel(
+    aihubmixModel({ pricing: { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 } }),
+    aihubmixAuthored,
+  );
+  expect(model.cost).toMatchObject({ input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 });
+  // The endpoint reports relay defaults for these, so authored values win.
+  expect(model.limit).toEqual({ context: 1_048_576, output: 65_536 });
+  expect(model.modalities).toEqual({
+    input: ["text", "image", "audio", "video", "pdf"],
+    output: ["text"],
+  });
+  expect(model.reasoning_options).toEqual([
+    { type: "effort", values: ["minimal", "low", "medium", "high"] },
+  ]);
+});
+
+test("ignores AIHubMix cache_read that merely echoes the input price", () => {
+  const model = buildAihubmixModel(
+    aihubmixModel({ pricing: { input: 0.25, output: 1.5, cache_read: 0.25 } }),
+    aihubmixAuthored,
+  );
+  expect(model.cost?.cache_read).toBe(0.025);
+});
+
+test("keeps authored AIHubMix pricing when the endpoint quotes no rate", () => {
+  const model = buildAihubmixModel(aihubmixModel({ pricing: null }), aihubmixAuthored);
+  expect(model.cost).toEqual(aihubmixAuthored.cost);
+});
+
+test("marks retired AIHubMix relays deprecated and stops tracking them", () => {
+  const retired = aihubmixModel({ retire_stage: "deprecated" });
+  expect(buildAihubmixModel(retired, aihubmixAuthored).status).toBe("deprecated");
+  expect(aihubmix.sourceID?.(retired)).toBeUndefined();
+  expect(aihubmix.sourceID?.(aihubmixModel())).toBe("gemini-3.1-flash-lite");
+});
+
+test("writes per-tier audio pricing", () => {
+  const toml = formatToml({
+    name: "Doubao Seed 2.0 Lite",
+    cost: {
+      input: 0.09041,
+      output: 0.54246,
+      input_audio: 1.269,
+      tiers: [
+        { tier: { type: "context", size: 32_000 }, input: 0.13, output: 0.76, input_audio: 1.902 },
+      ],
+    },
+  } as never);
+  expect(toml).toContain("input_audio = 1.902");
 });

--- a/providers/aihubmix/models/coding-xiaomi-mimo-v2.5-pro.toml
+++ b/providers/aihubmix/models/coding-xiaomi-mimo-v2.5-pro.toml
@@ -1,5 +1,4 @@
 base_model = "xiaomi/mimo-v2.5-pro"
-reasoning_options = [{ type = "toggle" }]
 name = "Coding Xiaomi MiMo-V2.5-Pro"
 family = "mimo-v2.5-pro"
 last_updated = "2026-05-13"
@@ -7,10 +6,13 @@ last_updated = "2026-05-13"
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.2
-output = 0.6
-cache_read = 0.04
+output = 0.4
+cache_read = 0.0016
 
 [[cost.tiers]]
 tier = { type = "context", size = 256_000 }

--- a/providers/aihubmix/models/coding-xiaomi-mimo-v2.5.toml
+++ b/providers/aihubmix/models/coding-xiaomi-mimo-v2.5.toml
@@ -1,5 +1,4 @@
 base_model = "xiaomi/mimo-v2.5"
-reasoning_options = [{ type = "toggle" }]
 name = "Coding Xiaomi MiMo-V2.5"
 family = "mimo-v2.5"
 last_updated = "2026-05-13"
@@ -7,10 +6,13 @@ last_updated = "2026-05-13"
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.08
-output = 0.4
-cache_read = 0.016
+output = 0.16
+cache_read = 0.0016
 
 [[cost.tiers]]
 tier = { type = "context", size = 256_000 }

--- a/providers/aihubmix/models/doubao-seed-2-0-code-preview.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-code-preview.toml
@@ -5,7 +5,6 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true
@@ -14,19 +13,26 @@ open_weights = false
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
-input = 0.48
-output = 2.41
+input = 0.4822
+output = 2.411
 cache_read = 0.09644
 
 [[cost.tiers]]
-tier = { size = 32_000 }
+tier = { type = "context", size = 32_000 }
 input = 0.72
 output = 3.62
 cache_read = 0.144656
 
 [[cost.tiers]]
-tier = { size = 128_000 }
+tier = { type = "context", size = 128_000 }
 input = 1.45
 output = 7.23
 cache_read = 0.28932

--- a/providers/aihubmix/models/doubao-seed-2-0-lite-260428.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-lite-260428.toml
@@ -5,7 +5,6 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true
@@ -14,21 +13,28 @@ open_weights = false
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
-input = 0.08
-output = 0.51
-cache_read = 0.01692
+input = 0.09041
+output = 0.54246
+cache_read = 0.018082
 input_audio = 1.269
 
 [[cost.tiers]]
-tier = { size = 32_000 }
+tier = { type = "context", size = 32_000 }
 input = 0.13
 output = 0.76
 cache_read = 0.02536
 input_audio = 1.902
 
 [[cost.tiers]]
-tier = { size = 128_000 }
+tier = { type = "context", size = 128_000 }
 input = 0.25
 output = 1.52
 cache_read = 0.05072

--- a/providers/aihubmix/models/doubao-seed-2-0-mini-260428.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-mini-260428.toml
@@ -5,7 +5,6 @@ release_date = "2026-04-28"
 last_updated = "2026-04-28"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true
@@ -14,21 +13,28 @@ open_weights = false
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
-input = 0.03
-output = 0.28
+input = 0.0282
+output = 0.282
 cache_read = 0.00564
 input_audio = 0.423
 
 [[cost.tiers]]
-tier = { size = 32_000 }
+tier = { type = "context", size = 32_000 }
 input = 0.06
 output = 0.56
 cache_read = 0.01128
 input_audio = 0.846
 
 [[cost.tiers]]
-tier = { size = 128_000 }
+tier = { type = "context", size = 128_000 }
 input = 0.11
 output = 1.13
 cache_read = 0.02256

--- a/providers/aihubmix/models/doubao-seed-2-0-pro.toml
+++ b/providers/aihubmix/models/doubao-seed-2-0-pro.toml
@@ -5,7 +5,6 @@ release_date = "2026-02-14"
 last_updated = "2026-02-14"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["minimal", "low", "medium", "high"] }]
 temperature = true
 tool_call = true
 structured_output = true
@@ -14,19 +13,26 @@ open_weights = false
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
+
 [cost]
-input = 0.48
-output = 2.41
+input = 0.4822
+output = 2.411
 cache_read = 0.09644
 
 [[cost.tiers]]
-tier = { size = 32_000 }
+tier = { type = "context", size = 32_000 }
 input = 0.72
 output = 3.62
 cache_read = 0.144656
 
 [[cost.tiers]]
-tier = { size = 128_000 }
+tier = { type = "context", size = 128_000 }
 input = 1.45
 output = 7.23
 cache_read = 0.28932

--- a/providers/aihubmix/models/gemini-2.5-flash.toml
+++ b/providers/aihubmix/models/gemini-2.5-flash.toml
@@ -1,3 +1,4 @@
+# Native Gemini uses $.generationConfig.thinkingConfig.thinkingBudget: 0 disables, -1 is dynamic, and manual budgets are 1..24576. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-06-25)
 name = "Gemini 2.5 Flash"
 description = "Fast Gemini model balancing multimodal reasoning, tool use, and cost"
 family = "gemini-flash"
@@ -5,19 +6,29 @@ release_date = "2025-03-20"
 last_updated = "2025-06-05"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 0, max = 24_576 }]
-# Native Gemini uses $.generationConfig.thinkingConfig.thinkingBudget: 0 disables, -1 is dynamic, and manual budgets are 1..24576. https://cloud.google.com/vertex-ai/generative-ai/docs/thinking (accessed 2026-06-25)
 temperature = true
 tool_call = true
 structured_output = true
 knowledge = "2025-01"
 open_weights = false
 
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high"]
+
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 24_576
+
 [cost]
 input = 0.3
-output = 2.50
+output = 2.499
 cache_read = 0.03
-input_audio = 1.00
+input_audio = 1
 
 [limit]
 context = 1_048_576

--- a/providers/aihubmix/models/gemini-3.5-flash.toml
+++ b/providers/aihubmix/models/gemini-3.5-flash.toml
@@ -1,10 +1,13 @@
 base_model = "google/gemini-3.5-flash"
-reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[[reasoning_options]]
+type = "effort"
+values = ["minimal", "low", "medium", "high"]
 
 [cost]
 input = 1.5
 output = 9
-cache_read = 1.5
+cache_read = 0.15
 
 [limit]
 context = 1_000_000

--- a/providers/aihubmix/models/gpt-5.1.toml
+++ b/providers/aihubmix/models/gpt-5.1.toml
@@ -5,17 +5,20 @@ release_date = "2025-11-13"
 last_updated = "2025-11-13"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 temperature = false
-knowledge = "2024-09-30"
 tool_call = true
 structured_output = true
+knowledge = "2024-09-30"
 open_weights = false
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
 
 [cost]
 input = 1.25
-output = 10.00
-cache_read = 0.13
+output = 10
+cache_read = 0.125
 
 [limit]
 context = 400_000

--- a/providers/aihubmix/models/gpt-5.6-luna.toml
+++ b/providers/aihubmix/models/gpt-5.6-luna.toml
@@ -1,12 +1,15 @@
 base_model = "openai/gpt-5.6-luna"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
 [cost]
-input = 1
-output = 6
-cache_read = 0.1
-cache_write = 1.25
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
 
 [limit]
 context = 1_050_000

--- a/providers/aihubmix/models/gpt-5.6-sol.toml
+++ b/providers/aihubmix/models/gpt-5.6-sol.toml
@@ -1,12 +1,15 @@
 base_model = "openai/gpt-5.6-sol"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
 [cost]
-input = 5
-output = 30
-cache_read = 0.5
-cache_write = 6.25
+input = 4
+output = 20
+cache_read = 0.4
+cache_write = 5
 
 [limit]
 context = 1_050_000

--- a/providers/aihubmix/models/gpt-5.6-terra.toml
+++ b/providers/aihubmix/models/gpt-5.6-terra.toml
@@ -1,12 +1,15 @@
 base_model = "openai/gpt-5.6-terra"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 temperature = false
 
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
 [cost]
-input = 2.5
-output = 15
-cache_read = 0.25
-cache_write = 3.125
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
 
 [limit]
 context = 1_050_000

--- a/providers/aihubmix/models/kimi-k2.5.toml
+++ b/providers/aihubmix/models/kimi-k2.5.toml
@@ -5,7 +5,6 @@ release_date = "2026-01"
 last_updated = "2026-01"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 structured_output = true
@@ -15,10 +14,13 @@ open_weights = true
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.6
 output = 3
-cache_read = 0.10
+cache_read = 0.105
 
 [limit]
 context = 262_144

--- a/providers/aihubmix/models/kimi-k2.6.toml
+++ b/providers/aihubmix/models/kimi-k2.6.toml
@@ -5,7 +5,6 @@ release_date = "2026-04-21"
 last_updated = "2026-04-21"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = false
 tool_call = true
 structured_output = true
@@ -15,10 +14,13 @@ open_weights = true
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
 input = 0.95
-output = 4
-cache_read = 0.16
+output = 3.9995
+cache_read = 0.160835
 
 [limit]
 context = 262_144

--- a/providers/aihubmix/models/minimax-m2.7.toml
+++ b/providers/aihubmix/models/minimax-m2.7.toml
@@ -5,19 +5,19 @@ release_date = "2026-03-18"
 last_updated = "2026-03-18"
 attachment = false
 reasoning = true
-reasoning_options = []
 temperature = true
 tool_call = true
 structured_output = true
 open_weights = true
+reasoning_options = []
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.3
-output = 1.2
-cache_read = 0.06
+input = 0.2958
+output = 1.1832
+cache_read = 0.05916
 cache_write = 0.375
 
 [limit]

--- a/providers/aihubmix/models/qwen3.6-flash.toml
+++ b/providers/aihubmix/models/qwen3.6-flash.toml
@@ -5,7 +5,6 @@ release_date = "2026-04-02"
 last_updated = "2026-04-02"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true
@@ -15,14 +14,17 @@ open_weights = false
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
-input = 0.17
-output = 1.01
+input = 0.169
+output = 1.014
 cache_read = 0.0169
 cache_write = 0.21125
 
 [[cost.tiers]]
-tier = { size = 256_000 }
+tier = { type = "context", size = 256_000 }
 input = 0.68
 output = 4.06
 cache_read = 0.0676

--- a/providers/aihubmix/models/qwen3.6-max-preview.toml
+++ b/providers/aihubmix/models/qwen3.6-max-preview.toml
@@ -5,7 +5,6 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = false
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true
@@ -15,14 +14,17 @@ open_weights = false
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
-input = 1.27
-output = 7.61
+input = 1.268
+output = 7.608
 cache_read = 0.1268
 cache_write = 1.585
 
 [[cost.tiers]]
-tier = { size = 128_000 }
+tier = { type = "context", size = 128_000 }
 input = 2.11
 output = 12.67
 cache_read = 0.2112

--- a/providers/aihubmix/models/qwen3.6-plus.toml
+++ b/providers/aihubmix/models/qwen3.6-plus.toml
@@ -5,7 +5,6 @@ release_date = "2026-05-09"
 last_updated = "2026-05-09"
 attachment = true
 reasoning = true
-reasoning_options = [{ type = "toggle" }]
 temperature = true
 tool_call = true
 structured_output = true
@@ -15,14 +14,17 @@ open_weights = false
 [interleaved]
 field = "reasoning_content"
 
+[[reasoning_options]]
+type = "toggle"
+
 [cost]
-input = 0.28
-output = 1.69
+input = 0.282
+output = 1.692
 cache_read = 0.0282
 cache_write = 0.3525
 
 [[cost.tiers]]
-tier = { size = 256_000 }
+tier = { type = "context", size = 256_000 }
 input = 1.13
 output = 6.77
 cache_read = 0.1128

--- a/sync.md
+++ b/sync.md
@@ -248,6 +248,18 @@ xAI is implemented in `packages/core/src/sync/providers/xai.ts`.
 - Existing xAI models are updated from API-authoritative fields while local metadata is preserved for fields the API does not expose, especially output token limits and some feature/capability flags.
 - New xAI API models are not created automatically (`skipCreates`); each missing ID opens a deduped GitHub issue. Alias IDs of models already cataloged under their canonical ID are skipped silently and never reported as missing.
 
+## AIHubMix Notes
+
+- AIHubMix is implemented in `packages/core/src/sync/providers/aihubmix.ts`.
+- Source endpoint: `https://aihubmix.com/api/v1/models?type=llm`.
+- No authentication is required; the catalog is public.
+- The endpoint is authoritative for pricing and deprecation status only. Everything else in the authored TOMLs is preserved.
+- Token limits and modalities are deliberately **not** synced: the endpoint reports the relay's conservative defaults rather than the upstream model's capabilities. It caps `context_length` per relay (Claude Opus 4.6 is listed at 200K against its 1M window), quotes `max_output` per default request, and never lists `pdf` in `input_modalities` even for models that accept PDFs.
+- `cache_read` is ignored when it equals `input`. The endpoint echoes the input price for models with no cached rate configured: 35 of the 301 priced entries carry a nonzero price this way, and 51 more are free models reporting 0 across the board. Taking the echoed value literally would overstate Gemini 3.1 Flash Lite tenfold against the $0.025 every other provider lists.
+- The free-text `features` list mixes synonyms (`thinking` vs `reasoning`, `tools` vs `tool_calling`) and never exposes accepted reasoning effort levels, so capability flags and `reasoning_options` stay hand-authored.
+- AIHubMix relays roughly 400 upstream models against a much smaller hand-verified subset here, so new IDs are not created automatically (`skipCreates`); each missing ID opens a deduped GitHub issue.
+- Routing aliases such as `alicloud-glm-5.1` and `deep-deepseek-v4-pro` are served but not listed by the endpoint, so local files missing from the response are retained (`deleteMissing: false`).
+
 ## Tinfoil Notes
 
 - Tinfoil is implemented in `packages/core/src/sync/providers/tinfoil.ts`.


### PR DESCRIPTION
## Why

AIHubMix has no sync module, so its 77 models are only ever refreshed by hand-written PRs (#5901, #4735, #4495, #3789 …). The last one landed **2026-08-31**, which is why several prices have drifted and new relays never arrive on their own.

The catalog endpoint is public and needs no credentials, so this adds no secrets and no change to `sync-models.yml` — registering the provider is enough for the hourly matrix to pick it up.

```
https://aihubmix.com/api/v1/models?type=llm
```

## Scope: pricing and deprecation only

Same scope as Ofox. Everything else in the authored TOMLs is preserved, because the endpoint reports each **relay's** conservative defaults rather than the upstream model's capabilities:

| Field | Why it is not synced |
|---|---|
| `context_length` | Capped per relay — Claude Opus 4.6 is listed at 200K against its 1M window |
| `max_output` | Quoted per default request, not per model |
| `input_modalities` | Never lists `pdf`, even for models that accept PDFs |
| `features` | Free text mixing synonyms (`thinking`/`reasoning`, `tools`/`tool_calling`); never exposes accepted effort levels |

Measured against the authored files, syncing those four would have been a regression in 12 context values, 14 output limits, and 16 modality lists.

### One pricing guard

`cache_read` is ignored when it equals `input`. The endpoint echoes the input price for priced entries that have no cached rate configured: **35 of 301** carry a nonzero price this way, and 51 more are free models reporting 0 across the board, where the guard is a no-op. Taking that literally would have written `cache_read = 0.25` for Gemini 3.1 Flash Lite, against the `0.025` that 26 other providers in this repo list.

## What the first run changes

17 models. Most are precision refinements (`0.48` → `0.4822`), but it also corrects real drift:

| Model | Before | After | Note |
|---|---|---|---|
| `gpt-5.6-luna` | 1 / 6 | 0.2 / 1.2 | matches `providers/openai` first-party pricing |
| `gpt-5.6-sol` | 5 / 30 | 4 / 20 | current rate |
| `gpt-5.6-terra` | 2.5 / 15 | 2 / 12 | current rate |
| `gemini-3.5-flash` | `cache_read = 1.5` | `0.15` | authored value had the same echoed-input bug |
| `coding-xiaomi-mimo-v2.5` | 0.08 / 0.4 | 0.08 / 0.16 | onto Xiaomi's actual 2:1 ratio |

New relays are not created automatically (`skipCreates`) — AIHubMix serves ~400 upstream models against this hand-verified subset, so each missing ID opens a deduped issue instead. Routing aliases such as `alicloud-glm-5.1` and `deep-deepseek-v4-pro` are served but unlisted, so local files absent from the response are retained (`deleteMissing: false`).

## Prerequisite fix in the shared writer

The first commit is separable. `CostTier` extends `Cost`, so `input_audio`/`output_audio` are valid on a tier, but `formatToml` only emitted them for the top-level `[cost]` table — any sync rewriting a model with tiered audio rates silently dropped them. Without this, the AIHubMix run deletes the tier audio prices from the two Doubao Lite/Mini files.

Relatedly, the Gemini 2.5 Flash thinking-budget comment moves to the file header, since that is the only comment block `formatToml` preserves.

## Verification

- `bun models:sync aihubmix --dry-run` → 17 updated
- `bun models:sync aihubmix` → written
- `bun models:sync aihubmix --dry-run` again → `0 created, 0 updated, 0 removed, 77 unchanged` (idempotent)
- `bun validate` → passes
- `bun test packages/core/test/sync.test.ts` → 198 pass, 5 of them new. The 2 failures (`DeepInfra preserves live modalities for new base models`, `syncs the last LLM Gateway case variant without mixing source records`) reproduce unchanged on a clean `dev` checkout on a case-insensitive filesystem and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
