### PR TITLE
feat: add Tium provider (OpenAI-compatible)

### DIFF
--- a/providers/tium/logo.svg
+++ b/providers/tium/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <path d="M10 6h12v20a1 1 0 0 1-1 1H11a1 1 0 0 1-1-1V6Z" fill="currentColor"/>
+</svg>

--- a/providers/tium/models/deepseek-v4-flash.toml
+++ b/providers/tium/models/deepseek-v4-flash.toml
@@ -1,0 +1,45 @@
+# Resale of the official DeepSeek API. The Tium gateway forwards the request
+# body verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
+# These are the effective USD rates at the subscription price: $2.8302/MWT (the
+# highest of the three tiers) x the published model multiplier, with the
+# per-model output and cache weights. Source: https://tium.ai/pricing
+# Prepaid credit packs bill at $3.56-$4.50/MWT.
+# Reasoning tokens are counted as output tokens and billed at the output rate.
+#
+# Verified live against api.tium.ai on 2026-09-09:
+#   thinking.type = enabled/disabled both accepted, and disabled genuinely
+#     silences reasoning_content -- a real toggle, not a rubber stamp.
+#   reasoning_content present in the response.
+#   Effort levels are ACCEPTED BUT NOT GRADED. Holding the prompt fixed over 3
+#     runs, reasoning_content medians were none=0, minimal=1734, low=1382,
+#     medium=699, high=1355, xhigh=995, max=1852 chars. Ranges overlapped
+#     throughout and were non-monotonic: minimal exceeded low, which exceeded
+#     medium. `minimal`, `medium` and `xhigh` are accepted on the wire but are
+#     omitted here, having no measurable effect and no place in the lab or peer
+#     baselines. Caveat: many runs hit the 600-token max_tokens ceiling, which
+#     compresses differences at the top end, so this understates any grading
+#     that exists.
+#   `none` produced zero reasoning_content in 3 of 3 runs: a real off switch,
+#     consistent with the verified thinking.type toggle.
+#   Multimodal note: image and PDF parts are accepted with 200, but the base
+#     model is text-only and a 200 on a 16-token reply does not prove the model
+#     reads them. Not asserted here; inherits text-only deliberately.
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "low", "high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.889
+output = 2.668
+reasoning = 2.668
+cache_read = 0.028
+
+[limit]
+context = 128000
+output = 32768

--- a/providers/tium/models/deepseek-v4-flash.toml
+++ b/providers/tium/models/deepseek-v4-flash.toml
@@ -1,5 +1,9 @@
-# Resale of the official DeepSeek API. The Tium gateway forwards the request
-# body verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
+#
+# Resale of the official DeepSeek API. The Tium gateway forwards the
+# request body verbatim apart from `model`, `max_tokens` and
+# `stream_options`.
 # Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
 # These are the effective USD rates at the subscription price: $2.8302/MWT (the
 # highest of the three tiers) x the published model multiplier, with the
@@ -8,27 +12,27 @@
 # Reasoning tokens are counted as output tokens and billed at the output rate.
 #
 # Verified live against api.tium.ai on 2026-09-09:
-#   thinking.type = enabled/disabled both accepted, and disabled genuinely
-#     silences reasoning_content -- a real toggle, not a rubber stamp.
+#   thinking.type enabled/disabled both accepted, and disabled genuinely
+#     silences reasoning_content: a real toggle, not a rubber stamp.
 #   reasoning_content present in the response.
-#   Effort levels are ACCEPTED BUT NOT GRADED. Holding the prompt fixed over 3
-#     runs, reasoning_content medians were none=0, minimal=1734, low=1382,
-#     medium=699, high=1355, xhigh=995, max=1852 chars. Ranges overlapped
-#     throughout and were non-monotonic: minimal exceeded low, which exceeded
-#     medium. `minimal`, `medium` and `xhigh` are accepted on the wire but are
-#     omitted here, having no measurable effect and no place in the lab or peer
-#     baselines. Caveat: many runs hit the 600-token max_tokens ceiling, which
-#     compresses differences at the top end, so this understates any grading
-#     that exists.
-#   `none` produced zero reasoning_content in 3 of 3 runs: a real off switch,
-#     consistent with the verified thinking.type toggle.
+#   Effort levels are accepted but not measurably graded. Over 3 runs on a
+#     fixed prompt, reasoning_content medians were low=1382, medium=699,
+#     high=1355, xhigh=995, max=1852 chars, overlapping and non-monotonic.
+#     `minimal`, `medium` and `xhigh` are accepted on the wire but omitted:
+#     no measurable effect and absent from the lab baseline.
+#     Caveat: many runs hit the 600-token max_tokens ceiling, which
+#     compresses differences at the top end, so this understates any
+#     grading that exists.
+#   `none` also returns zero reasoning_content, but the toggle already
+#     models off, so it is not published as an effort level (AGENTS.md
+#     section 3).
 #   Multimodal note: image and PDF parts are accepted with 200, but the base
-#     model is text-only and a 200 on a 16-token reply does not prove the model
-#     reads them. Not asserted here; inherits text-only deliberately.
+#     model is text-only and a 200 on a 16-token reply does not prove the
+#     model reads them. Not asserted here; inherits text-only deliberately.
 base_model = "deepseek/deepseek-v4-flash"
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["none", "low", "high", "max"] },
+  { type = "effort", values = ["low", "high", "max"] },
 ]
 
 [interleaved]

--- a/providers/tium/models/deepseek-v4-pro.toml
+++ b/providers/tium/models/deepseek-v4-pro.toml
@@ -1,5 +1,9 @@
-# Resale of the official DeepSeek API. The Tium gateway forwards the request
-# body verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = high|max
+#
+# Resale of the official DeepSeek API. The Tium gateway forwards the
+# request body verbatim apart from `model`, `max_tokens` and
+# `stream_options`.
 # Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
 # These are the effective USD rates at the subscription price: $2.8302/MWT (the
 # highest of the three tiers) x the published model multiplier, with the
@@ -8,27 +12,27 @@
 # Reasoning tokens are counted as output tokens and billed at the output rate.
 #
 # Verified live against api.tium.ai on 2026-09-09:
-#   thinking.type = enabled/disabled both accepted, and disabled genuinely
-#     silences reasoning_content -- a real toggle, not a rubber stamp.
+#   thinking.type enabled/disabled both accepted, and disabled genuinely
+#     silences reasoning_content: a real toggle, not a rubber stamp.
 #   reasoning_content present in the response.
-#   Effort levels are ACCEPTED BUT NOT GRADED. Holding the prompt fixed over 3
-#     runs, reasoning_content medians were none=0, minimal=988, low=1148,
-#     medium=1064, high=1074, xhigh=1565, max=1968 chars, with ranges
-#     overlapping throughout. `low` tracked `high` closely, consistent with the
-#     documented low->high mapping on Pro, so `low` is omitted along with
-#     `minimal`, `medium` and `xhigh`: all are accepted on the wire but show no
-#     measurable effect and are absent from the lab and peer baselines. Caveat:
-#     many runs hit the 600-token max_tokens ceiling, which compresses
-#     differences at the top end, so this understates any grading that exists.
-#   `none` produced zero reasoning_content in 3 of 3 runs: a real off switch,
-#     consistent with the verified thinking.type toggle.
+#   Effort levels are accepted but not measurably graded. Over 3 runs on a
+#     fixed prompt, reasoning_content medians were low=1148, medium=1064,
+#     high=1074, xhigh=1565, max=1968 chars, with overlapping ranges. `low`
+#     tracked `high`, consistent with the documented low->high mapping on
+#     Pro, so `low` is omitted along with `minimal`, `medium` and `xhigh`.
+#     Caveat: many runs hit the 600-token max_tokens ceiling, which
+#     compresses differences at the top end, so this understates any
+#     grading that exists.
+#   `none` also returns zero reasoning_content, but the toggle already
+#     models off, so it is not published as an effort level (AGENTS.md
+#     section 3).
 #   Multimodal note: image and PDF parts are accepted with 200, but the base
-#     model is text-only and a 200 on a 16-token reply does not prove the model
-#     reads them. Not asserted here; inherits text-only deliberately.
+#     model is text-only and a 200 on a 16-token reply does not prove the
+#     model reads them. Not asserted here; inherits text-only deliberately.
 base_model = "deepseek/deepseek-v4-pro"
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["none", "high", "max"] },
+  { type = "effort", values = ["high", "max"] },
 ]
 
 [interleaved]

--- a/providers/tium/models/deepseek-v4-pro.toml
+++ b/providers/tium/models/deepseek-v4-pro.toml
@@ -1,0 +1,45 @@
+# Resale of the official DeepSeek API. The Tium gateway forwards the request
+# body verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
+# These are the effective USD rates at the subscription price: $2.8302/MWT (the
+# highest of the three tiers) x the published model multiplier, with the
+# per-model output and cache weights. Source: https://tium.ai/pricing
+# Prepaid credit packs bill at $3.56-$4.50/MWT.
+# Reasoning tokens are counted as output tokens and billed at the output rate.
+#
+# Verified live against api.tium.ai on 2026-09-09:
+#   thinking.type = enabled/disabled both accepted, and disabled genuinely
+#     silences reasoning_content -- a real toggle, not a rubber stamp.
+#   reasoning_content present in the response.
+#   Effort levels are ACCEPTED BUT NOT GRADED. Holding the prompt fixed over 3
+#     runs, reasoning_content medians were none=0, minimal=988, low=1148,
+#     medium=1064, high=1074, xhigh=1565, max=1968 chars, with ranges
+#     overlapping throughout. `low` tracked `high` closely, consistent with the
+#     documented low->high mapping on Pro, so `low` is omitted along with
+#     `minimal`, `medium` and `xhigh`: all are accepted on the wire but show no
+#     measurable effect and are absent from the lab and peer baselines. Caveat:
+#     many runs hit the 600-token max_tokens ceiling, which compresses
+#     differences at the top end, so this understates any grading that exists.
+#   `none` produced zero reasoning_content in 3 of 3 runs: a real off switch,
+#     consistent with the verified thinking.type toggle.
+#   Multimodal note: image and PDF parts are accepted with 200, but the base
+#     model is text-only and a 200 on a 16-token reply does not prove the model
+#     reads them. Not asserted here; inherits text-only deliberately.
+base_model = "deepseek/deepseek-v4-pro"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.668
+output = 8.005
+reasoning = 8.005
+cache_read = 0.089
+
+[limit]
+context = 128000
+output = 32768

--- a/providers/tium/models/glm-5.3-flash.toml
+++ b/providers/tium/models/glm-5.3-flash.toml
@@ -1,0 +1,39 @@
+# Resale of the official Z.ai API. The Tium gateway forwards the request body
+# verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
+# These are the effective USD rates at the subscription price: $2.8302/MWT (the
+# highest of the three tiers) x the published model multiplier, with the
+# per-model output and cache weights. Source: https://tium.ai/pricing
+# Prepaid credit packs bill at $3.56-$4.50/MWT.
+# Reasoning tokens are counted as output tokens and billed at the output rate.
+#
+# Verified live against api.tium.ai on 2026-09-09:
+#   reasoning_effort low|high|max accepted; none|minimal|medium|xhigh rejected
+#     with 400 (negative control fired, so the accepted set is real).
+#   "none" is refused and thinking.type=disabled is refused, so reasoning
+#     cannot be turned off: thinking-only on this host, effort is the only
+#     control.
+#   reasoning_content present in the response.
+#   Effort levels are GRADED, not merely accepted: reasoning_content medians
+#     over 3 runs on a fixed prompt were low=121, high=252, max=1241 chars,
+#     with non-overlapping ranges.
+#   Image input accepted. Video and PDF are REJECTED (400), though the base
+#     model lists them, hence the modalities override.
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[modalities]
+input = ["text", "image"]
+
+[cost]
+input = 0.152
+output = 0.505
+reasoning = 0.505
+cache_read = 0.03
+
+[limit]
+context = 128000
+output = 32768

--- a/providers/tium/models/glm-5.3-flash.toml
+++ b/providers/tium/models/glm-5.3-flash.toml
@@ -1,5 +1,8 @@
-# Resale of the official Z.ai API. The Tium gateway forwards the request body
-# verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Effort: reasoning_effort = low|high|max (no off switch on this host)
+#
+# Resale of the official Z.ai API. The Tium gateway forwards the
+# request body verbatim apart from `model`, `max_tokens` and
+# `stream_options`.
 # Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
 # These are the effective USD rates at the subscription price: $2.8302/MWT (the
 # highest of the three tiers) x the published model multiplier, with the
@@ -8,15 +11,14 @@
 # Reasoning tokens are counted as output tokens and billed at the output rate.
 #
 # Verified live against api.tium.ai on 2026-09-09:
-#   reasoning_effort low|high|max accepted; none|minimal|medium|xhigh rejected
-#     with 400 (negative control fired, so the accepted set is real).
-#   "none" is refused and thinking.type=disabled is refused, so reasoning
-#     cannot be turned off: thinking-only on this host, effort is the only
-#     control.
+#   reasoning_effort low|high|max accepted; none|minimal|medium|xhigh
+#     rejected with 400 (negative control fired, so the set is real).
+#   `none` is refused and thinking.type=disabled is refused, so reasoning
+#     cannot be turned off: thinking-only, effort is the only control.
 #   reasoning_content present in the response.
-#   Effort levels are GRADED, not merely accepted: reasoning_content medians
-#     over 3 runs on a fixed prompt were low=121, high=252, max=1241 chars,
-#     with non-overlapping ranges.
+#   Effort levels are GRADED, not merely accepted: reasoning_content
+#     medians over 3 runs on a fixed prompt were low=121, high=252,
+#     max=1241 chars, with non-overlapping ranges.
 #   Image input accepted. Video and PDF are REJECTED (400), though the base
 #     model lists them, hence the modalities override.
 base_model = "zhipuai/glm-5.3-flash"

--- a/providers/tium/models/glm-5.3.toml
+++ b/providers/tium/models/glm-5.3.toml
@@ -1,0 +1,35 @@
+# Resale of the official Z.ai API. The Tium gateway forwards the request body
+# verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
+# These are the effective USD rates at the subscription price: $2.8302/MWT (the
+# highest of the three tiers) x the published model multiplier, with the
+# per-model output and cache weights. Source: https://tium.ai/pricing
+# Prepaid credit packs bill at $3.56-$4.50/MWT.
+# Reasoning tokens are counted as output tokens and billed at the output rate.
+#
+# Verified live against api.tium.ai on 2026-09-09:
+#   reasoning_effort low|high|max accepted; none|minimal|medium|xhigh rejected
+#     with 400 (negative control fired).
+#   "none" is refused and thinking.type=disabled is refused: thinking-only.
+#   reasoning_content present in the response.
+#   Effort levels are GRADED, not merely accepted: reasoning_content medians
+#     over 3 runs on a fixed prompt were low=94, high=266, max=753 chars,
+#     with non-overlapping ranges.
+#   Text only -- image, PDF and video are all rejected with
+#     "messages.content.type is invalid, allowed values: ['text']". This
+#     matches the base model, so no modalities override is needed.
+base_model = "zhipuai/glm-5.3"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.83
+output = 8.895
+reasoning = 8.895
+cache_read = 0.526
+
+[limit]
+context = 128000
+output = 32768

--- a/providers/tium/models/glm-5.3.toml
+++ b/providers/tium/models/glm-5.3.toml
@@ -1,5 +1,8 @@
-# Resale of the official Z.ai API. The Tium gateway forwards the request body
-# verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Effort: reasoning_effort = low|high|max (no off switch on this host)
+#
+# Resale of the official Z.ai API. The Tium gateway forwards the
+# request body verbatim apart from `model`, `max_tokens` and
+# `stream_options`.
 # Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
 # These are the effective USD rates at the subscription price: $2.8302/MWT (the
 # highest of the three tiers) x the published model multiplier, with the
@@ -8,14 +11,14 @@
 # Reasoning tokens are counted as output tokens and billed at the output rate.
 #
 # Verified live against api.tium.ai on 2026-09-09:
-#   reasoning_effort low|high|max accepted; none|minimal|medium|xhigh rejected
-#     with 400 (negative control fired).
-#   "none" is refused and thinking.type=disabled is refused: thinking-only.
+#   reasoning_effort low|high|max accepted; none|minimal|medium|xhigh
+#     rejected with 400 (negative control fired).
+#   `none` is refused and thinking.type=disabled is refused: thinking-only.
 #   reasoning_content present in the response.
-#   Effort levels are GRADED, not merely accepted: reasoning_content medians
-#     over 3 runs on a fixed prompt were low=94, high=266, max=753 chars,
-#     with non-overlapping ranges.
-#   Text only -- image, PDF and video are all rejected with
+#   Effort levels are GRADED, not merely accepted: reasoning_content
+#     medians over 3 runs on a fixed prompt were low=94, high=266, max=753
+#     chars, with non-overlapping ranges.
+#   Text only: image, PDF and video are all rejected with
 #     "messages.content.type is invalid, allowed values: ['text']". This
 #     matches the base model, so no modalities override is needed.
 base_model = "zhipuai/glm-5.3"

--- a/providers/tium/models/kimi-k3.toml
+++ b/providers/tium/models/kimi-k3.toml
@@ -1,0 +1,46 @@
+# Resale of the official Moonshot API. The Tium gateway forwards the request
+# body verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
+# These are the effective USD rates at the subscription price: $2.8302/MWT (the
+# highest of the three tiers) x the published model multiplier, with the
+# per-model output and cache weights. Source: https://tium.ai/pricing
+# Prepaid credit packs bill at $3.56-$4.50/MWT.
+# Reasoning tokens are counted as output tokens and billed at the output rate.
+#
+# Verified live against api.tium.ai on 2026-09-09:
+#   thinking.type = enabled/disabled both accepted, and disabled genuinely
+#     silences reasoning_content -- a real toggle.
+#   reasoning_content present in the response.
+#   Effort levels are ACCEPTED BUT NOT GRADED. Holding the prompt fixed over 3
+#     runs, reasoning_content medians were none=0, minimal=576, low=470,
+#     medium=851, high=699, xhigh=787, max=662 chars. Ranges overlapped
+#     throughout with no ordering at all. `minimal`, `medium` and `xhigh` are
+#     accepted on the wire but are omitted here, having no measurable effect
+#     and no place in the lab or peer baselines. Caveat: many runs hit the
+#     600-token max_tokens ceiling, which compresses differences at the top
+#     end, so this understates any grading that exists.
+#   `none` produced zero reasoning_content in 3 of 3 runs: a real off switch,
+#     consistent with the verified thinking.type toggle.
+#   Image input accepted. Video is REJECTED ("unsupported video url") though
+#     the base model lists it, hence the modalities override. PDF also refused.
+base_model = "moonshotai/kimi-k3"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["none", "low", "high", "max"] },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[modalities]
+input = ["text", "image"]
+
+[cost]
+input = 6.065
+output = 30.323
+reasoning = 30.323
+cache_read = 0.606
+
+[limit]
+context = 128000
+output = 32768

--- a/providers/tium/models/kimi-k3.toml
+++ b/providers/tium/models/kimi-k3.toml
@@ -1,5 +1,9 @@
-# Resale of the official Moonshot API. The Tium gateway forwards the request
-# body verbatim apart from `model`, `max_tokens` and `stream_options`.
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
+#
+# Resale of the official Moonshot API. The Tium gateway forwards the
+# request body verbatim apart from `model`, `max_tokens` and
+# `stream_options`.
 # Tium bills a monthly allotment of weighted tokens (WT), not USD per token.
 # These are the effective USD rates at the subscription price: $2.8302/MWT (the
 # highest of the three tiers) x the published model multiplier, with the
@@ -8,25 +12,27 @@
 # Reasoning tokens are counted as output tokens and billed at the output rate.
 #
 # Verified live against api.tium.ai on 2026-09-09:
-#   thinking.type = enabled/disabled both accepted, and disabled genuinely
-#     silences reasoning_content -- a real toggle.
+#   thinking.type enabled/disabled both accepted, and disabled genuinely
+#     silences reasoning_content: a real toggle.
 #   reasoning_content present in the response.
-#   Effort levels are ACCEPTED BUT NOT GRADED. Holding the prompt fixed over 3
-#     runs, reasoning_content medians were none=0, minimal=576, low=470,
-#     medium=851, high=699, xhigh=787, max=662 chars. Ranges overlapped
-#     throughout with no ordering at all. `minimal`, `medium` and `xhigh` are
-#     accepted on the wire but are omitted here, having no measurable effect
-#     and no place in the lab or peer baselines. Caveat: many runs hit the
-#     600-token max_tokens ceiling, which compresses differences at the top
-#     end, so this understates any grading that exists.
-#   `none` produced zero reasoning_content in 3 of 3 runs: a real off switch,
-#     consistent with the verified thinking.type toggle.
-#   Image input accepted. Video is REJECTED ("unsupported video url") though
-#     the base model lists it, hence the modalities override. PDF also refused.
+#   Effort levels are accepted but not measurably graded. Over 3 runs on a
+#     fixed prompt, reasoning_content medians were low=470, medium=851,
+#     high=699, xhigh=787, max=662 chars, overlapping with no ordering.
+#     `minimal`, `medium` and `xhigh` are accepted on the wire but omitted:
+#     no measurable effect and absent from the lab baseline.
+#     Caveat: many runs hit the 600-token max_tokens ceiling, which
+#     compresses differences at the top end, so this understates any
+#     grading that exists.
+#   `none` also returns zero reasoning_content, but the toggle already
+#     models off, so it is not published as an effort level (AGENTS.md
+#     section 3).
+#   Image input accepted. Video is REJECTED ("unsupported video url")
+#     though the base model lists it, hence the modalities override. PDF
+#     is also refused.
 base_model = "moonshotai/kimi-k3"
 reasoning_options = [
   { type = "toggle" },
-  { type = "effort", values = ["none", "low", "high", "max"] },
+  { type = "effort", values = ["low", "high", "max"] },
 ]
 
 [interleaved]

--- a/providers/tium/provider.toml
+++ b/providers/tium/provider.toml
@@ -1,0 +1,5 @@
+name = "Tium"
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.tium.ai/v1"
+env = ["TIUM_API_KEY"]
+doc = "https://tium.ai/models"


### PR DESCRIPTION
Adds Tium as an OpenAI-compatible provider. Tium provides open-weight models from a gateway operated in Germany. Entries will be kept current.

**Provider**

- `providers/tium/provider.toml`: `@ai-sdk/openai-compatible`, api `https://api.tium.ai/v1`, env `TIUM_API_KEY`
- `providers/tium/logo.svg`: monochrome, `currentColor`, square viewBox

**Models**

| model | base_model | context | output | input | output $ | cache_read |
|---|---|---:|---:|---:|---:|---:|
| glm-5.3-flash | zhipuai/glm-5.3-flash | 128000 | 32768 | 0.152 | 0.505 | 0.03 |
| deepseek-v4-flash | deepseek/deepseek-v4-flash | 128000 | 32768 | 0.889 | 2.668 | 0.028 |
| deepseek-v4-pro | deepseek/deepseek-v4-pro | 128000 | 32768 | 2.668 | 8.005 | 0.089 |
| glm-5.3 | zhipuai/glm-5.3 | 128000 | 32768 | 2.83 | 8.895 | 0.526 |
| kimi-k3 | moonshotai/kimi-k3 | 128000 | 32768 | 6.065 | 30.323 | 0.606 |

Costs are USD per million tokens. Tium bills a monthly allotment of weighted tokens rather than USD per token. These figures are the effective rate at the subscription price, $2.83/MWT as published at https://tium.ai/pricing, multiplied by each model's published multiplier and weights. Prepaid credit packs bill at $3.56 to $4.50/MWT.

`context` and `output` are this host's policy ceilings. The base models declare 1M context.

**Verification**

All values probed live against api.tium.ai on 2026-09-09.

- glm-5.3 and glm-5.3-flash: `reasoning_effort` accepts `low`, `high`, `max`. `none`, `minimal`, `medium` and `xhigh` return 400. `thinking.type = disabled` returns 400. Both models are thinking-only on this host. The levels are graded, not merely accepted: reasoning_content medians over 3 runs on a fixed prompt were 94/266/753 for glm-5.3 and 121/252/1241 for glm-5.3-flash, with non-overlapping ranges.
- deepseek-v4-flash, deepseek-v4-pro, kimi-k3: `thinking.type` toggles, and `disabled` removes `reasoning_content`. `none` produced zero reasoning_content in 3 of 3 runs. `minimal`, `medium` and `xhigh` are accepted on the wire but produced no distinguishable reasoning volume and are absent from the lab and peer baselines, so they are not published. Per-file comments carry the medians and note that the 600-token cap on the measurement compresses differences at the top end.
- All five return `reasoning_content`, authored as `interleaved`.
- Modalities are narrowed to what the host accepts. glm-5.3-flash rejects video and PDF, kimi-k3 rejects video. DeepSeek accepts image and PDF parts but the base models are text-only and acceptance alone does not prove comprehension, so nothing extra is claimed.
