### PR TITLE
feat(greenpt): add GLM-5.3 and GLM-5.3 Flash

### DIFF
--- a/providers/greenpt/models/glm-5.3-flash.toml
+++ b/providers/greenpt/models/glm-5.3-flash.toml
@@ -1,0 +1,17 @@
+# Cost: GreenPT EUR list prices converted at 1.1614 USD/EUR (ECB, 2026-09-08).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# FX: https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/eurofxref-graph-usd.en.html
+# GreenPT accepts reasoning_effort = none|minimal|low|medium|high.
+# Source: https://docs.greenpt.ai/reasoning
+# Cache writes are not charged: https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.3-flash"
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
+attachment = false
+
+[modalities]
+input = ["text"]
+
+[cost]
+input = 0.127754
+cache_read = 0.0255508
+output = 0.511016

--- a/providers/greenpt/models/glm-5.3.toml
+++ b/providers/greenpt/models/glm-5.3.toml
@@ -1,0 +1,13 @@
+# Cost: GreenPT EUR list prices converted at 1.1614 USD/EUR (ECB, 2026-09-08).
+# Sources: https://docs.greenpt.ai/pricing and https://docs.greenpt.ai/model-cards
+# FX: https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/eurofxref-graph-usd.en.html
+# GreenPT accepts reasoning_effort = none|minimal|low|medium|high.
+# Source: https://docs.greenpt.ai/reasoning
+# Cache writes are not charged: https://docs.greenpt.ai/prompt-caching
+base_model = "zhipuai/glm-5.3"
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.27754
+cache_read = 0.319385
+output = 5.11016


### PR DESCRIPTION
GreenPT exposes `glm-5.3` and `glm-5.3-flash`, but its models.dev provider catalog does not list them, so consumers such as OpenCode cannot discover them automatically. This adds both provider entries, following the GreenPT work in #3726 and #3927.

- Inherit shared metadata from `zhipuai/glm-5.3` and `zhipuai/glm-5.3-flash`, including 1M context and 131,072 max output.
- Override Flash input to text-only and disable attachment support to match the GreenPT endpoint's published capabilities.
- Declare GreenPT's documented `reasoning_effort` values: `none`, `minimal`, `low`, `medium`, `high`. Accepted values do not promise that each level changes the model's behavior.
- Convert EUR list prices to USD/MTok using the ECB's 2026-09-08 rate of 1.1614 USD/EUR. Cache writes are not charged and the field is omitted, matching existing GreenPT entries.

| Model | EUR input/cache/output | USD input/cache/output |
|---|---|---|
| glm-5.3 | 1.10 / 0.275 / 4.40 | 1.27754 / 0.319385 / 5.11016 |
| glm-5.3-flash | 0.11 / 0.022 / 0.44 | 0.127754 / 0.0255508 / 0.511016 |

Only these two files are added. The generated GreenPT catalog grows from 37 to 39 entries, with every existing resolved entry identical to the published API snapshot.

Validation: `npm run validate` passes (runs the repository's Bun validator). Explicit resolved-data assertions pass for prices, limits, reasoning controls and modalities. OpenCode 1.18.10 lists both models with equivalent local configuration. `npm test`: 318 pass, 6 fail; the same six failures reproduce with both additions removed, including the missing SDK snapshot module. Production inference was not tested; availability and provider-specific capabilities are sourced from GreenPT's public documentation.

Sources:
- Model IDs and capabilities: https://docs.greenpt.ai/model-cards and https://docs.greenpt.ai/models
- Prices: https://docs.greenpt.ai/pricing
- Reasoning controls: https://docs.greenpt.ai/reasoning
- Caching: https://docs.greenpt.ai/prompt-caching
- Exchange rate: https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/eurofxref-graph-usd.en.html
