### PR TITLE
feat: add Cursor provider

### DIFF
--- a/providers/cursor/logo.svg
+++ b/providers/cursor/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M4 2l16 8-7 2-3 7z"/>
+</svg>

--- a/providers/cursor/models/claude-fable-5-1.toml
+++ b/providers/cursor/models/claude-fable-5-1.toml
@@ -12,6 +12,3 @@ output = 50
 cache_read = 0.25
 cache_write = 12.5
 
-[limit]
-context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/claude-fable-5-1.toml
+++ b/providers/cursor/models/claude-fable-5-1.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-fable-5-1"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 0.25
+cache_write = 12.5
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-fable-5.toml
+++ b/providers/cursor/models/claude-fable-5.toml
@@ -12,6 +12,3 @@ output = 50
 cache_read = 1
 cache_write = 12.5
 
-[limit]
-context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/claude-fable-5.toml
+++ b/providers/cursor/models/claude-fable-5.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-fable-5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 10
+output = 50
+cache_read = 1
+cache_write = 12.5
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-haiku-4-5.toml
+++ b/providers/cursor/models/claude-haiku-4-5.toml
@@ -4,12 +4,8 @@
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
 # Toggle: requested_model.parameters thinking = true|false
 # Reasoning: Cursor wire surface carries thinking/effort variant params only (no reasoning-token budget field); see npm src/protocol/thinking.ts.
-# Note: Cursor lists Haiku 4.5 capabilities as Thinking + Images with no Agent
-# (https://cursor.com/docs model table), so tool_call is disabled on this host
-# even though the lab base supports it.
 base_model = "anthropic/claude-haiku-4-5"
 
-tool_call = false
 reasoning_options = [{ type = "toggle" }]
 
 [cost]

--- a/providers/cursor/models/claude-haiku-4-5.toml
+++ b/providers/cursor/models/claude-haiku-4-5.toml
@@ -1,0 +1,18 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-haiku-4-5"
+
+tool_call = false
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+
+[cost]
+input = 1
+output = 5
+cache_read = 0.1
+cache_write = 1.25
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/cursor/models/claude-haiku-4-5.toml
+++ b/providers/cursor/models/claude-haiku-4-5.toml
@@ -2,6 +2,9 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Note: Cursor lists Haiku 4.5 capabilities as Thinking + Images with no Agent
+# (https://cursor.com/docs model table), so tool_call is disabled on this host
+# even though the lab base supports it.
 base_model = "anthropic/claude-haiku-4-5"
 
 tool_call = false
@@ -14,5 +17,4 @@ cache_read = 0.1
 cache_write = 1.25
 
 [limit]
-context = 200_000
 output = 32_000

--- a/providers/cursor/models/claude-haiku-4-5.toml
+++ b/providers/cursor/models/claude-haiku-4-5.toml
@@ -2,13 +2,15 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Toggle: requested_model.parameters thinking = true|false
+# Reasoning: Cursor wire surface carries thinking/effort variant params only (no reasoning-token budget field); see npm src/protocol/thinking.ts.
 # Note: Cursor lists Haiku 4.5 capabilities as Thinking + Images with no Agent
 # (https://cursor.com/docs model table), so tool_call is disabled on this host
 # even though the lab base supports it.
 base_model = "anthropic/claude-haiku-4-5"
 
 tool_call = false
-reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 1

--- a/providers/cursor/models/claude-opus-4-5.toml
+++ b/providers/cursor/models/claude-opus-4-5.toml
@@ -2,9 +2,10 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Reasoning: Cursor wire surface carries thinking/effort variant params only (no reasoning-token budget field); see npm src/protocol/thinking.ts.
 base_model = "anthropic/claude-opus-4-5"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 5

--- a/providers/cursor/models/claude-opus-4-5.toml
+++ b/providers/cursor/models/claude-opus-4-5.toml
@@ -13,5 +13,4 @@ cache_read = 0.5
 cache_write = 6.25
 
 [limit]
-context = 200_000
 output = 32_000

--- a/providers/cursor/models/claude-opus-4-5.toml
+++ b/providers/cursor/models/claude-opus-4-5.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-opus-4-5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }, { type = "budget_tokens", min = 1_024 }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/cursor/models/claude-opus-4-6.toml
+++ b/providers/cursor/models/claude-opus-4-6.toml
@@ -12,6 +12,3 @@ output = 25
 cache_read = 0.5
 cache_write = 6.25
 
-[limit]
-context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/claude-opus-4-6.toml
+++ b/providers/cursor/models/claude-opus-4-6.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-opus-4-6"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-opus-4-6.toml
+++ b/providers/cursor/models/claude-opus-4-6.toml
@@ -2,9 +2,10 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Reasoning: Cursor wire surface carries thinking/effort variant params only (no reasoning-token budget field); see npm src/protocol/thinking.ts.
 base_model = "anthropic/claude-opus-4-6"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [cost]
 input = 5

--- a/providers/cursor/models/claude-opus-4-7.toml
+++ b/providers/cursor/models/claude-opus-4-7.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-opus-4-7"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-opus-4-7.toml
+++ b/providers/cursor/models/claude-opus-4-7.toml
@@ -12,6 +12,3 @@ output = 25
 cache_read = 0.5
 cache_write = 6.25
 
-[limit]
-context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/claude-opus-4-8.toml
+++ b/providers/cursor/models/claude-opus-4-8.toml
@@ -12,6 +12,3 @@ output = 25
 cache_read = 0.5
 cache_write = 6.25
 
-[limit]
-context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/claude-opus-4-8.toml
+++ b/providers/cursor/models/claude-opus-4-8.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-opus-4-8"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-opus-5.toml
+++ b/providers/cursor/models/claude-opus-5.toml
@@ -12,6 +12,3 @@ output = 25
 cache_read = 0.5
 cache_write = 6.25
 
-[limit]
-context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/claude-opus-5.toml
+++ b/providers/cursor/models/claude-opus-5.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-opus-5"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5
+output = 25
+cache_read = 0.5
+cache_write = 6.25
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-sonnet-4-5.toml
+++ b/providers/cursor/models/claude-sonnet-4-5.toml
@@ -2,9 +2,11 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Toggle: requested_model.parameters thinking = true|false
+# Reasoning: Cursor wire surface carries thinking/effort variant params only (no reasoning-token budget field); see npm src/protocol/thinking.ts.
 base_model = "anthropic/claude-sonnet-4-5"
 
-reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 3
@@ -14,4 +16,3 @@ cache_write = 3.75
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/claude-sonnet-4-5.toml
+++ b/providers/cursor/models/claude-sonnet-4-5.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-sonnet-4-5"
+
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-sonnet-4-6.toml
+++ b/providers/cursor/models/claude-sonnet-4-6.toml
@@ -2,9 +2,10 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Reasoning: Cursor wire surface carries thinking/effort variant params only (no reasoning-token budget field); see npm src/protocol/thinking.ts.
 base_model = "anthropic/claude-sonnet-4-6"
 
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }]
 
 [cost]
 input = 3
@@ -12,5 +13,3 @@ output = 15
 cache_read = 0.3
 cache_write = 3.75
 
-[limit]
-output = 128_000

--- a/providers/cursor/models/claude-sonnet-4-6.toml
+++ b/providers/cursor/models/claude-sonnet-4-6.toml
@@ -13,5 +13,4 @@ cache_read = 0.3
 cache_write = 3.75
 
 [limit]
-context = 1_000_000
 output = 128_000

--- a/providers/cursor/models/claude-sonnet-4-6.toml
+++ b/providers/cursor/models/claude-sonnet-4-6.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-sonnet-4-6"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "max"] }, { type = "budget_tokens", min = 1_024 }]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-sonnet-4.toml
+++ b/providers/cursor/models/claude-sonnet-4.toml
@@ -2,9 +2,11 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Toggle: requested_model.parameters thinking = true|false
+# Reasoning: Cursor wire surface carries thinking/effort variant params only (no reasoning-token budget field); see npm src/protocol/thinking.ts.
 base_model = "anthropic/claude-sonnet-4-0"
 
-reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 3
@@ -21,4 +23,3 @@ cache_write = 7.5
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/claude-sonnet-4.toml
+++ b/providers/cursor/models/claude-sonnet-4.toml
@@ -1,0 +1,24 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-sonnet-4-0"
+
+reasoning_options = [{ type = "budget_tokens", min = 1_024 }]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+cache_write = 3.75
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 6
+output = 22.5
+cache_read = 0.6
+cache_write = 7.5
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-sonnet-5.toml
+++ b/providers/cursor/models/claude-sonnet-5.toml
@@ -1,0 +1,17 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "anthropic/claude-sonnet-5"
+
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2
+output = 10
+cache_read = 0.2
+cache_write = 2.5
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/claude-sonnet-5.toml
+++ b/providers/cursor/models/claude-sonnet-5.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Toggle: requested_model.parameters thinking = true|false
 base_model = "anthropic/claude-sonnet-5"
 
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
@@ -12,6 +13,3 @@ output = 10
 cache_read = 0.2
 cache_write = 2.5
 
-[limit]
-context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/composer-2.5-fast.toml
+++ b/providers/cursor/models/composer-2.5-fast.toml
@@ -1,0 +1,28 @@
+# Faster Composer 2.5 variant, same intelligence at higher rates (sources accessed 2026-09-09):
+# - Pricing ($3.00/$15.00, cache read $0.50): https://cursor.com/docs/models-and-pricing
+# - "Faster variant with the same intelligence", fast is the default: https://cursor.com/blog/composer-2-5
+# - Capabilities (Agent, Thinking, Images; default context 200k): https://cursor.com/docs
+# - OpenCode catalog output (32k base tier): cursor-opencode-provider src/model-config.ts
+name = "Composer 2.5 Fast"
+description = "Faster variant of Cursor's Composer 2.5 with the same intelligence at higher rates"
+release_date = "2026-05-18"
+last_updated = "2026-05-18"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.5
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/cursor/models/composer-2.5.toml
+++ b/providers/cursor/models/composer-2.5.toml
@@ -1,0 +1,28 @@
+# Cursor's proprietary coding model (sources accessed 2026-09-09):
+# - Pricing ($0.50/$2.50, cache read $0.20): https://cursor.com/docs/models-and-pricing
+# - Capabilities (Agent, Thinking, Images; default context 200k): https://cursor.com/docs
+# - Release 2026-05-18; built on Moonshot Kimi K2.5 checkpoint: https://cursor.com/blog/composer-2-5
+# - OpenCode catalog output (32k base tier): cursor-opencode-provider src/model-config.ts
+name = "Composer 2.5"
+description = "Cursor's proprietary coding model for sustained long-running tasks and complex instructions"
+release_date = "2026-05-18"
+last_updated = "2026-05-18"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = false
+tool_call = true
+open_weights = false
+
+[cost]
+input = 0.5
+output = 2.5
+cache_read = 0.2
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/cursor/models/default.toml
+++ b/providers/cursor/models/default.toml
@@ -1,0 +1,25 @@
+# Cursor's Auto router alias (wire id `default`) — sources accessed 2026-09-09:
+# - Cost/Balance/Intelligence modes, bills at routed model's rate: https://cursor.com/changelog/router (2026-07-22)
+# - Pricing ("Auto modes bill at the list price of the routed model"): https://cursor.com/docs/models-and-pricing
+# - Unpriced by design in the npm package (CURSOR_UNPRICED_MODEL_IDS): cursor-opencode-provider src/pricing.ts
+# - Capabilities (thinking/agent/images, 200k context) per AvailableModels fixture: cursor-opencode-provider test/models.test.ts
+# - OpenCode catalog output (32k base tier): cursor-opencode-provider src/model-config.ts
+# release_date marks the Router-powered Auto; Cursor does not publish the original Auto launch date.
+name = "Auto"
+description = "Cursor's Auto router (Cost, Balance, and Intelligence modes); bills at the list price of the model each request is routed to"
+release_date = "2026-07-22"
+last_updated = "2026-07-22"
+attachment = true
+reasoning = true
+reasoning_options = []
+temperature = false
+tool_call = true
+open_weights = false
+
+[limit]
+context = 200_000
+output = 32_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/cursor/models/gemini-2.5-flash.toml
+++ b/providers/cursor/models/gemini-2.5-flash.toml
@@ -2,10 +2,11 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Reasoning: Cursor wire surface carries thinking/effort variant params only (no reasoning-token budget field); see npm src/protocol/thinking.ts.
 # Toggle: requested_model.parameters thinking = true|false
 base_model = "google/gemini-2.5-flash"
 
-reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.3
@@ -14,4 +15,3 @@ cache_read = 0.03
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gemini-2.5-flash.toml
+++ b/providers/cursor/models/gemini-2.5-flash.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "google/gemini-2.5-flash"
+
+reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]
+
+[cost]
+input = 0.3
+output = 2.5
+cache_read = 0.03
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gemini-2.5-flash.toml
+++ b/providers/cursor/models/gemini-2.5-flash.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Toggle: requested_model.parameters thinking = true|false
 base_model = "google/gemini-2.5-flash"
 
 reasoning_options = [{ type = "toggle" }, { type = "budget_tokens", min = 0, max = 24_576 }]

--- a/providers/cursor/models/gemini-3-flash.toml
+++ b/providers/cursor/models/gemini-3-flash.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "google/gemini-3-flash-preview"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.5
+output = 3
+cache_read = 0.05
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gemini-3-flash.toml
+++ b/providers/cursor/models/gemini-3-flash.toml
@@ -13,4 +13,3 @@ cache_read = 0.05
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gemini-3.1-pro.toml
+++ b/providers/cursor/models/gemini-3.1-pro.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "google/gemini-3.1-pro-preview"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gemini-3.1-pro.toml
+++ b/providers/cursor/models/gemini-3.1-pro.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Pricing note: Cursor lists flat $2.00/$12.00 with no long-context band for 3.1 Pro (unlike Google's 200k tier), so no [[cost.tiers]] is authored.
 base_model = "google/gemini-3.1-pro-preview"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]

--- a/providers/cursor/models/gemini-3.1-pro.toml
+++ b/providers/cursor/models/gemini-3.1-pro.toml
@@ -13,4 +13,3 @@ cache_read = 0.2
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gemini-3.5-flash.toml
+++ b/providers/cursor/models/gemini-3.5-flash.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "google/gemini-3.5-flash"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.5
+output = 9
+cache_read = 0.15
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gemini-3.5-flash.toml
+++ b/providers/cursor/models/gemini-3.5-flash.toml
@@ -13,4 +13,3 @@ cache_read = 0.15
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gemini-3.6-flash.toml
+++ b/providers/cursor/models/gemini-3.6-flash.toml
@@ -13,4 +13,3 @@ cache_read = 0.15
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gemini-3.6-flash.toml
+++ b/providers/cursor/models/gemini-3.6-flash.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "google/gemini-3.6-flash"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 1.5
+output = 7.5
+cache_read = 0.15
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gemini-3.7-flash.toml
+++ b/providers/cursor/models/gemini-3.7-flash.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "google/gemini-3.7-flash"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.75
+output = 3.5
+cache_read = 0.075
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gemini-3.7-flash.toml
+++ b/providers/cursor/models/gemini-3.7-flash.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Pricing note: Cursor lists output $3.50 for this model vs Google first-party $3.75; kept as the Cursor-specific list price (https://cursor.com/docs/models-and-pricing).
 base_model = "google/gemini-3.7-flash"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
@@ -13,4 +14,3 @@ cache_read = 0.075
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gemini-3.8-flash.toml
+++ b/providers/cursor/models/gemini-3.8-flash.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "google/gemini-3.8-flash"
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.75
+output = 3.5
+cache_read = 0.075
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gemini-3.8-flash.toml
+++ b/providers/cursor/models/gemini-3.8-flash.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Pricing note: Cursor lists output $3.50 for this model vs Google first-party $3.75; kept as the Cursor-specific list price (https://cursor.com/docs/models-and-pricing).
 base_model = "google/gemini-3.8-flash"
 
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
@@ -13,4 +14,3 @@ cache_read = 0.075
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/glm-5.2.toml
+++ b/providers/cursor/models/glm-5.2.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "zhipuai/glm-5.2"
+
+reasoning_options = [{ type = "effort", values = ["high", "max"] }]
+
+[cost]
+input = 1.4
+output = 4.4
+cache_read = 0.26
+
+[limit]
+context = 200_000
+output = 32_000

--- a/providers/cursor/models/gpt-5-mini.toml
+++ b/providers/cursor/models/gpt-5-mini.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5-mini"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.25
+output = 2
+cache_read = 0.025
+
+[limit]
+context = 272_000
+output = 32_000

--- a/providers/cursor/models/gpt-5.1.toml
+++ b/providers/cursor/models/gpt-5.1.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.1"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 1.25
+output = 10
+cache_read = 0.125
+
+[limit]
+context = 272_000
+output = 32_000

--- a/providers/cursor/models/gpt-5.2.toml
+++ b/providers/cursor/models/gpt-5.2.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.2"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+
+[limit]
+context = 272_000
+output = 32_000

--- a/providers/cursor/models/gpt-5.3-codex.toml
+++ b/providers/cursor/models/gpt-5.3-codex.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.3-codex"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 1.75
+output = 14
+cache_read = 0.175
+
+[limit]
+context = 272_000
+output = 32_000

--- a/providers/cursor/models/gpt-5.4-mini.toml
+++ b/providers/cursor/models/gpt-5.4-mini.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.4-mini"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 0.75
+output = 4.5
+cache_read = 0.075
+
+[limit]
+context = 272_000
+output = 32_000

--- a/providers/cursor/models/gpt-5.4-nano.toml
+++ b/providers/cursor/models/gpt-5.4-nano.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.4-nano"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 0.2
+output = 1.25
+cache_read = 0.02
+
+[limit]
+context = 272_000
+output = 32_000

--- a/providers/cursor/models/gpt-5.4.toml
+++ b/providers/cursor/models/gpt-5.4.toml
@@ -19,4 +19,3 @@ cache_read = 0.5
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gpt-5.4.toml
+++ b/providers/cursor/models/gpt-5.4.toml
@@ -1,0 +1,22 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.4"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 2.5
+output = 15
+cache_read = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 5
+output = 15
+cache_read = 0.5
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gpt-5.4.toml
+++ b/providers/cursor/models/gpt-5.4.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Long-context tier: output stays at the base rate per Cursor's "2x input pricing" note (input-side rates double); unlike first-party OpenAI tiers, which also raise output (e.g. 5.4: 22.5, 5.5: 45).
 base_model = "openai/gpt-5.4"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]

--- a/providers/cursor/models/gpt-5.5.toml
+++ b/providers/cursor/models/gpt-5.5.toml
@@ -1,0 +1,22 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.5"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 5
+output = 30
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 10
+output = 30
+cache_read = 1
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gpt-5.5.toml
+++ b/providers/cursor/models/gpt-5.5.toml
@@ -19,4 +19,3 @@ cache_read = 1
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gpt-5.5.toml
+++ b/providers/cursor/models/gpt-5.5.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Long-context tier: output stays at the base rate per Cursor's "2x input pricing" note (input-side rates double); unlike first-party OpenAI tiers, which also raise output (e.g. 5.4: 22.5, 5.5: 45).
 base_model = "openai/gpt-5.5"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]

--- a/providers/cursor/models/gpt-5.6-luna.toml
+++ b/providers/cursor/models/gpt-5.6-luna.toml
@@ -21,4 +21,3 @@ cache_write = 0.5
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gpt-5.6-luna.toml
+++ b/providers/cursor/models/gpt-5.6-luna.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Long-context tier: output stays at the base rate per Cursor's "2x input pricing" note (input-side rates double); unlike first-party OpenAI tiers, which also raise output (e.g. 5.4: 22.5, 5.5: 45).
 base_model = "openai/gpt-5.6-luna"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor/models/gpt-5.6-luna.toml
+++ b/providers/cursor/models/gpt-5.6-luna.toml
@@ -1,0 +1,24 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.6-luna"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0.2
+output = 1.2
+cache_read = 0.02
+cache_write = 0.25
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.4
+output = 1.2
+cache_read = 0.04
+cache_write = 0.5
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gpt-5.6-sol.toml
+++ b/providers/cursor/models/gpt-5.6-sol.toml
@@ -21,4 +21,3 @@ cache_write = 10
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gpt-5.6-sol.toml
+++ b/providers/cursor/models/gpt-5.6-sol.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Long-context tier: output stays at the base rate per Cursor's "2x input pricing" note (input-side rates double); unlike first-party OpenAI tiers, which also raise output (e.g. 5.4: 22.5, 5.5: 45).
 base_model = "openai/gpt-5.6-sol"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor/models/gpt-5.6-sol.toml
+++ b/providers/cursor/models/gpt-5.6-sol.toml
@@ -1,0 +1,24 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.6-sol"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 4
+output = 20
+cache_read = 0.4
+cache_write = 5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 8
+output = 20
+cache_read = 0.8
+cache_write = 10
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/gpt-5.6-terra.toml
+++ b/providers/cursor/models/gpt-5.6-terra.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Long-context tier: output stays at the base rate per Cursor's "2x input pricing" note (input-side rates double); unlike first-party OpenAI tiers, which also raise output (e.g. 5.4: 22.5, 5.5: 45).
 base_model = "openai/gpt-5.6-terra"
 
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]

--- a/providers/cursor/models/gpt-5.6-terra.toml
+++ b/providers/cursor/models/gpt-5.6-terra.toml
@@ -21,4 +21,3 @@ cache_write = 5
 
 [limit]
 context = 1_000_000
-output = 128_000

--- a/providers/cursor/models/gpt-5.6-terra.toml
+++ b/providers/cursor/models/gpt-5.6-terra.toml
@@ -1,0 +1,24 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "openai/gpt-5.6-terra"
+
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2
+output = 12
+cache_read = 0.2
+cache_write = 2.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4
+output = 12
+cache_read = 0.4
+cache_write = 5
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/grok-4.5-fast.toml
+++ b/providers/cursor/models/grok-4.5-fast.toml
@@ -1,0 +1,22 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "xai/grok-4.5"
+attachment = false
+
+name = "Grok 4.5 Fast"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 4
+output = 18
+cache_read = 1
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cursor/models/grok-4.5.toml
+++ b/providers/cursor/models/grok-4.5.toml
@@ -1,0 +1,21 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "xai/grok-4.5"
+attachment = false
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cursor/models/grok-4.6-fast.toml
+++ b/providers/cursor/models/grok-4.6-fast.toml
@@ -1,0 +1,22 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "xai/grok-4.6"
+attachment = false
+
+name = "Grok 4.6 Fast"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 4
+output = 12
+cache_read = 1
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cursor/models/grok-4.6.toml
+++ b/providers/cursor/models/grok-4.6.toml
@@ -1,0 +1,21 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "xai/grok-4.6"
+attachment = false
+
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[limit]
+context = 256_000
+output = 32_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/cursor/models/kimi-k2.7-code.toml
+++ b/providers/cursor/models/kimi-k2.7-code.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "moonshotai/kimi-k2.7-code"
+
+reasoning_options = []
+
+[cost]
+input = 0.95
+output = 4
+cache_read = 0.19
+
+[limit]
+context = 262_000
+output = 32_000

--- a/providers/cursor/models/kimi-k3.toml
+++ b/providers/cursor/models/kimi-k3.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "moonshotai/kimi-k3"
+
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
+
+[cost]
+input = 3
+output = 15
+cache_read = 0.3
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/models/kimi-k3.toml
+++ b/providers/cursor/models/kimi-k3.toml
@@ -2,6 +2,7 @@
 # - Pricing: https://cursor.com/docs/models-and-pricing
 # - Context/capabilities: https://cursor.com/docs
 # - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+# Toggle: requested_model.parameters thinking = true|false
 base_model = "moonshotai/kimi-k3"
 
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]

--- a/providers/cursor/models/muse-spark-1.3.toml
+++ b/providers/cursor/models/muse-spark-1.3.toml
@@ -1,0 +1,16 @@
+# Sources (accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Context/capabilities: https://cursor.com/docs
+# - npm mapping: cursor-opencode-provider src/pricing-data.ts + src/model-config.ts
+base_model = "meta/muse-spark-1.3"
+
+reasoning_options = [{ type = "effort", values = ["minimal", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 1.25
+output = 4.25
+cache_read = 0.15
+
+[limit]
+context = 1_000_000
+output = 128_000

--- a/providers/cursor/provider.toml
+++ b/providers/cursor/provider.toml
@@ -1,0 +1,12 @@
+# Cursor provider for models.dev (sources accessed 2026-09-09):
+# - Pricing: https://cursor.com/docs/models-and-pricing
+# - Model table (default/max context, Agent/Thinking/Images): https://cursor.com/docs
+# - npm package + model discovery: https://github.com/oakimov/cursor-opencode-provider
+#   (AvailableModels fetch + cursor-models.json cache; src/pricing-data.ts generated
+#   from the Cursor docs via scripts/generate-cursor-pricing.ts; OpenCode catalog
+#   mapping in src/model-config.ts)
+# Auth: CURSOR_API_KEY (API key from https://cursor.com/settings) or browser OAuth via the plugin.
+name = "Cursor"
+npm = "cursor-opencode-provider"
+env = ["CURSOR_API_KEY"]
+doc = "https://cursor.com/docs/models-and-pricing"


### PR DESCRIPTION
Adds the **Cursor** provider (`npm: cursor-opencode-provider`, `env: CURSOR_API_KEY`) with 41 models served through Cursor subscriptions, so Cursor models (including Auto) are selectable in models.dev clients.

## Contents
- `providers/cursor/provider.toml` + `logo.svg` (new provider)
- 38 relay models (`base_model`, override-only): Claude, Gemini, GPT, Grok, Kimi, GLM, Muse Spark
- 2 full-inline Cursor-first-party models: `composer-2.5`, `composer-2.5-fast`
- 1 full-inline alias: `default` (Auto router, intentionally unpriced — bills at routed-model rate)

## Policy notes (per AGENTS.md)
- Host classified as **multi-model relay**: `reasoning_options` copied from lab entries in `providers/<lab>/` (no invented L/M/H, no uncertainty `[]` except Composer/Auto where Thinking-capable with no caller effort control, and `kimi-k2.7-code` matching its lab)
- `base_model` files are override-only (cost, reasoning_options, limit context/output deltas, plus `tool_call=false` on Haiku and text-only modalities + `attachment=false` on Grok per Cursor's capability table)
- Long-context surcharges authored as `[[cost.tiers]]` (200k Sonnet-4, 272k GPTs); costs are USD/MTok
- Bare IDs reuse existing lab metadata (`claude-sonnet-4` → `anthropic/claude-sonnet-4-0`, `gemini-3-flash` → `google/gemini-3-flash-preview`, `gemini-3.1-pro` → `google/gemini-3.1-pro-preview`, `muse-spark-1.3` → `meta/muse-spark-1.3`); no new `models/` files needed

## Sources
- Pricing: https://cursor.com/docs/models-and-pricing
- Context/capabilities: https://cursor.com/docs
- Auto Router (2026-07-22): https://cursor.com/changelog/router
- npm mapping: cursor-opencode-provider `src/pricing-data.ts` + `src/model-config.ts` (AvailableModels discovery)

## Validation
- [x] `bun validate` passes
- [x] New provider has compliant `logo.svg` (currentColor, square viewBox, no fixed size)