### PR TITLE
chore(zenmux): mark 1 offline models as deprecated

### DIFF
--- a/providers/zenmux/models/openai/gpt-5.1-chat.toml
+++ b/providers/zenmux/models/openai/gpt-5.1-chat.toml
@@ -8,6 +8,8 @@ tool_call = true
 knowledge = "2025-01-01"
 open_weights = false
 
+status = "deprecated"
+
 [cost]
 input = 1.25
 output = 10.00


### PR DESCRIPTION
## Summary

Add `status = "deprecated"` to 1 ZenMux provider files for models taken offline (visible=2 in DB).

Follows the same pattern as `providers/openai/models/o1.toml`.

## Updated Files

| File | Model Slug |
|------|------------|
| `providers/zenmux/models/openai/gpt-5.1-chat.toml` | `openai/gpt-5.1-chat` |
