### PR TITLE
feat: update STACKIT models catalogue

### DIFF
--- a/providers/stackit/models/Qwen/Qwen3.6-27B.toml
+++ b/providers/stackit/models/Qwen/Qwen3.6-27B.toml
@@ -1,5 +1,4 @@
 base_model = "alibaba/qwen3.6-27b"
-attachment = false
 reasoning = false
 structured_output = false
 status = "deprecated"

--- a/providers/stackit/models/Qwen/Qwen3.6-27B.toml
+++ b/providers/stackit/models/Qwen/Qwen3.6-27B.toml
@@ -2,6 +2,7 @@ base_model = "alibaba/qwen3.6-27b"
 attachment = false
 reasoning = false
 structured_output = false
+status = deprecated
 
 [cost]
 input = 0.53

--- a/providers/stackit/models/Qwen/Qwen3.6-27B.toml
+++ b/providers/stackit/models/Qwen/Qwen3.6-27B.toml
@@ -13,5 +13,5 @@ context = 262_144
 output = 16_384
 
 [modalities]
-input = ["text"]
+input = ["text", "image"]
 output = ["text"]

--- a/providers/stackit/models/Qwen/Qwen3.6-27B.toml
+++ b/providers/stackit/models/Qwen/Qwen3.6-27B.toml
@@ -2,7 +2,7 @@ base_model = "alibaba/qwen3.6-27b"
 attachment = false
 reasoning = false
 structured_output = false
-status = deprecated
+status = "deprecated"
 
 [cost]
 input = 0.53

--- a/providers/stackit/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/stackit/models/Qwen/Qwen3.8-27B.toml
@@ -1,0 +1,20 @@
+# Sources (accessed 2026-09-09):
+# https://docs.stackit.cloud/de/products/data-and-ai/ai-model-serving/basics/available-shared-models/#qwen38-27b
+# Limits: Context 262K, output 16_384
+# Modalities: text + images in, text out
+base_model = "alibaba/qwen3.8-27b"
+attachment = false
+reasoning = false
+structured_output = false
+
+[cost]
+input = 0.53
+output = 0.76
+
+[limit]
+context = 262_000
+output = 16_384
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/stackit/models/Qwen/Qwen3.8-27B.toml
+++ b/providers/stackit/models/Qwen/Qwen3.8-27B.toml
@@ -3,7 +3,6 @@
 # Limits: Context 262K, output 16_384
 # Modalities: text + images in, text out
 base_model = "alibaba/qwen3.8-27b"
-attachment = false
 reasoning = false
 structured_output = false
 

--- a/providers/stackit/models/google/gemma-3-27b-it.toml
+++ b/providers/stackit/models/google/gemma-3-27b-it.toml
@@ -9,7 +9,7 @@ temperature = true
 tool_call = false
 structured_output = false
 open_weights = true
-status = deprecated
+status = "deprecated"
 
 [cost]
 input = 0.53

--- a/providers/stackit/models/google/gemma-3-27b-it.toml
+++ b/providers/stackit/models/google/gemma-3-27b-it.toml
@@ -16,7 +16,7 @@ input = 0.53
 output = 0.76
 
 [limit]
-context = 37_000
+context = 131_000
 output = 4_096
 
 [modalities]

--- a/providers/stackit/models/google/gemma-3-27b-it.toml
+++ b/providers/stackit/models/google/gemma-3-27b-it.toml
@@ -9,6 +9,7 @@ temperature = true
 tool_call = false
 structured_output = false
 open_weights = true
+status = deprecated
 
 [cost]
 input = 0.53

--- a/providers/stackit/models/google/gemma-4-31b-it.toml
+++ b/providers/stackit/models/google/gemma-4-31b-it.toml
@@ -4,6 +4,7 @@
 # Modalities: text + images in, text out
 base_model = "google/gemma-4-31b-it"
 structured_output = false
+reasoning = true
 reasoning_options = []
 
 [cost]

--- a/providers/stackit/models/google/gemma-4-31b-it.toml
+++ b/providers/stackit/models/google/gemma-4-31b-it.toml
@@ -1,0 +1,19 @@
+# Sources (accessed 2026-09-09):
+# https://docs.stackit.cloud/de/products/data-and-ai/ai-model-serving/basics/available-shared-models/#gemma-4-31b
+# Limits: Context 256K, output 4096
+# Modalities: text + images in, text out
+base_model = "google/gemma-4-31b-it"
+structured_output = false
+reasoning_options = []
+
+[cost]
+input = 0.53
+output = 0.76
+
+[limit]
+context = 256_000
+output = 4_096
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/stackit/models/google/gemma-4-31b-it.toml
+++ b/providers/stackit/models/google/gemma-4-31b-it.toml
@@ -14,7 +14,3 @@ output = 0.76
 [limit]
 context = 256_000
 output = 4_096
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]


### PR DESCRIPTION
### Summary
This PR updates the STACKIT shared-models catalogue against the official docs [Available Shared Models](https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models).


### New models
- `Google/Gemma-4-31b-it`
  -  linked via `base_model = "google/gemma-4-31b-it"` with STACKIT overrides
  - 256K context, 4096 max output
  - text and image input, text-only output
  - Tool calling and Reasoning enabled, structured_output disabled
  - $0.53/$0.76 per 1M
- `Qwen/Qwen3.8-27B`
  -  linked via `base_model = "alibaba/qwen3.8-27b"` with STACKIT overrides
  - 262K context, 16384 max output
  - text and image input, text-only output
  - Tool calling enabled, Reasoning and structured_output disabled
  - $0.53/$0.76 per 1M

### Deprecating models
- `Google/Gemma-3-27b-it`
  - EOL October, 14th 2026
  - replaced by `Google/Gemma-4-31b-it`
  - [official Release Notes](https://docs.stackit.cloud/de/products/data-and-ai/ai-model-serving/release-notes/#stackit-ai-model-serving-release-des-neuen-modells-google-gemma-4-nachfolger-für-google-gemma-3)
- `Qwen/Qwen3.6-27B`
  - EOL December, 08th 2026
  - replaced by `Qwen/Qwen3.8-27B`
  - [official Release Notes](https://docs.stackit.cloud/de/products/data-and-ai/ai-model-serving/release-notes/#stackit-ai-model-serving-release-des-neuen-modells-qwen38-27b-nachfolger-für-qwen36-27b)

### Catalogue updates

- Corrected modalities for Qwen3.6: supports image as input
- Corrected context size for Gemma3: 37_000 → 131_000

### Test plan
- [x] Specs and prices verified against STACKIT docs (per-model facts tables)
- [x] `bun run validate` passed
- [x] `base_model` resolution confirmed (canonical inheritance, overrides applied)