### PR TITLE
feat(fireworks): add Mistral Large 3 FP8

### DIFF
--- a/providers/fireworks-ai/models/accounts/fireworks/models/mistral-large-3-fp8.toml
+++ b/providers/fireworks-ai/models/accounts/fireworks/models/mistral-large-3-fp8.toml
@@ -1,0 +1,6 @@
+# Fireworks identifies this on-demand FP8 endpoint as Mistral Large 3 675B Instruct 2512,
+# with 256K context, function calling, and image input. It is not offered serverlessly,
+# so there is no per-token price to record:
+# https://fireworks.ai/models/fireworks/mistral-large-3-fp8 (accessed 2026-09-05)
+base_model = "mistral/mistral-large-2512"
+name = "Mistral Large 3 675B Instruct 2512"


### PR DESCRIPTION
## Summary

- add Fireworks AI's `accounts/fireworks/models/mistral-large-3-fp8` endpoint
- map it to the shared Mistral Large 3 lab metadata
- preserve Fireworks's endpoint-specific display name and document that it is on-demand only

## Sources

- https://fireworks.ai/models/fireworks/mistral-large-3-fp8

## Test plan

- [x] Run `bun validate`
- [x] Run `git diff --check`