### PR TITLE
feat(inception): add mercury 2.5 model definition

### DIFF
--- a/providers/inception/models/mercury-2.5.toml
+++ b/providers/inception/models/mercury-2.5.toml
@@ -1,0 +1,29 @@
+name = "Mercury 2.5"
+description = "Mercury 2.5 is the fastest reasoning LLM, and the latest diffusion LLM (dLLM) from Inception"
+# Model exception (accessed 2026-06-25): `reasoning_effort = "instant"` is also
+# accepted for near-realtime responses, but it is not a models.dev effort enum.
+# https://docs.inceptionlabs.ai/capabilities/instant
+family = "mercury"
+release_date = "2026-09-08"
+last_updated = "2026-09-10"
+attachment = false
+reasoning = true
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+temperature = true
+knowledge = "2025-11-01"
+tool_call = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.04
+output = 0.15
+cache_read = 0.004
+
+[limit]
+context = 260_000
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
# Summary

Added Mercury 2.5 model definition to the Inception provider.

# Changes

- `providers/inception/models/mercury-2.5.toml` (new): full model metadata for Mercury 2.5 served via the Inception first-party API (`api.inceptionlabs.ai`).

Model details sourced from: [Inception platform docs](https://platform.inceptionlabs.ai/docs), cross-checked with [OpenRouter](https://openrouter.ai/inception/mercury-2.5)

# Validation

- `bun validate` passes with the new model included (verified locally).

---

PR description generated by `DeepSeek V4 Flash`, edited by me