### PR TITLE
feat(bothub): add GLM-5.3, GLM-5.3-Flash, DeepSeek V4 Flash 0731, V4 Pro 0813 and GPT-5.6 Luna

### DIFF
--- a/providers/bothub/models/deepseek-v4-flash-0731.toml
+++ b/providers/bothub/models/deepseek-v4-flash-0731.toml
@@ -1,18 +1,16 @@
 # Pricing: https://bothub.ru/models (accessed 2026-09-10).
 # RUB converted to USD at the CBR rate 85.4594 RUB/USD (2026-09-10).
-# Controls mirrored from the lab OpenAI surface: toggle via
-# thinking.type = enabled|disabled, effort via reasoning_effort
-# low|high|max (lab maps low to low; xhigh to high).
+# Controls: bothub exposes a single reasoning_effort parameter on
+# POST /v1/chat/completions (see providers/bothub/provider.toml); no
+# thinking.type toggle is documented for this host. Levels verified
+# against the bothub model page; "none" disables reasoning.
 base_model = "deepseek/deepseek-v4-flash-0731"
 
 interleaved = true
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["low", "high", "max"]
+values = ["none", "low", "high", "max"]
 
 [cost]
 input = 0.1

--- a/providers/bothub/models/deepseek-v4-flash-0731.toml
+++ b/providers/bothub/models/deepseek-v4-flash-0731.toml
@@ -1,0 +1,19 @@
+# Pricing: https://bothub.ru/models (accessed 2026-09-10).
+# RUB converted to USD at the CBR rate 85.4594 RUB/USD (2026-09-10).
+# Controls mirrored from the lab OpenAI surface: toggle via
+# thinking.type = enabled|disabled, effort via reasoning_effort
+# low|high|max (lab maps low to low; xhigh to high).
+base_model = "deepseek/deepseek-v4-flash-0731"
+
+interleaved = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.1
+output = 0.28

--- a/providers/bothub/models/deepseek-v4-pro-0813.toml
+++ b/providers/bothub/models/deepseek-v4-pro-0813.toml
@@ -1,18 +1,16 @@
 # Pricing: https://bothub.ru/models (accessed 2026-09-10).
 # RUB converted to USD at the CBR rate 85.4594 RUB/USD (2026-09-10).
-# Controls mirrored from the lab OpenAI surface: toggle via
-# thinking.type = enabled|disabled, effort via reasoning_effort
-# high|max (lab maps low/medium to high; xhigh to high).
+# Controls: bothub exposes a single reasoning_effort parameter on
+# POST /v1/chat/completions (see providers/bothub/provider.toml); no
+# thinking.type toggle is documented for this host. Levels verified
+# against the bothub model page; "none" disables reasoning.
 base_model = "deepseek/deepseek-v4-pro-0813"
 
 interleaved = true
 
 [[reasoning_options]]
-type = "toggle"
-
-[[reasoning_options]]
 type = "effort"
-values = ["high", "max"]
+values = ["none", "high", "max"]
 
 [cost]
 input = 1.61

--- a/providers/bothub/models/deepseek-v4-pro-0813.toml
+++ b/providers/bothub/models/deepseek-v4-pro-0813.toml
@@ -1,0 +1,19 @@
+# Pricing: https://bothub.ru/models (accessed 2026-09-10).
+# RUB converted to USD at the CBR rate 85.4594 RUB/USD (2026-09-10).
+# Controls mirrored from the lab OpenAI surface: toggle via
+# thinking.type = enabled|disabled, effort via reasoning_effort
+# high|max (lab maps low/medium to high; xhigh to high).
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+interleaved = true
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]
+
+[cost]
+input = 1.61
+output = 4.84

--- a/providers/bothub/models/glm-5.3-flash.toml
+++ b/providers/bothub/models/glm-5.3-flash.toml
@@ -1,0 +1,16 @@
+# Pricing: https://bothub.ru/models (accessed 2026-09-10) — includes the
+# site's current -20% promo (list 13.15/47.33 RUB per 1M tokens).
+# RUB converted to USD at the CBR rate 85.4594 RUB/USD (2026-09-10).
+# Controls mirrored from the lab entry: GLM-5.3-Flash always reasons;
+# effort low|high|max with default max, no toggle.
+base_model = "zhipuai/glm-5.3-flash"
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 0.12
+output = 0.44

--- a/providers/bothub/models/glm-5.3.toml
+++ b/providers/bothub/models/glm-5.3.toml
@@ -1,0 +1,16 @@
+# Pricing: https://bothub.ru/models (accessed 2026-09-10) — includes the
+# site's current -20% promo (list 184.04/578.41 RUB per 1M tokens).
+# RUB converted to USD at the CBR rate 85.4594 RUB/USD (2026-09-10).
+# Controls mirrored from the lab entry: GLM-5.3 always reasons; effort
+# low|high|max with default max, no toggle.
+base_model = "zhipuai/glm-5.3"
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 1.72
+output = 5.41

--- a/providers/bothub/models/gpt-5.6-luna.toml
+++ b/providers/bothub/models/gpt-5.6-luna.toml
@@ -1,0 +1,16 @@
+# Pricing: https://bothub.ru/models (accessed 2026-09-10) — includes the
+# site's current -80% promo (list 26.30/157.75 RUB per 1M tokens).
+# RUB converted to USD at the CBR rate 85.4594 RUB/USD (2026-09-10).
+# Controls mirrored from the lab entry: off is effort=none; graded
+# levels — no toggle.
+base_model = "openai/gpt-5.6-luna"
+
+interleaved = true
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 0.06
+output = 0.37


### PR DESCRIPTION
﻿## Summary

Adds 5 pay-as-you-go models to the existing `bothub` provider (added in #5814):

- `glm-5.3` → base_model `zhipuai/glm-5.3`
- `glm-5.3-flash` → base_model `zhipuai/glm-5.3-flash`
- `deepseek-v4-flash-0731` → base_model `deepseek/deepseek-v4-flash-0731`
- `deepseek-v4-pro-0813` → base_model `deepseek/deepseek-v4-pro-0813`
- `gpt-5.6-luna` → base_model `openai/gpt-5.6-luna`

All files are override-only (`base_model` + cost / reasoning_options / interleaved), per AGENTS.md.

## Pricing

Source: https://bothub.ru/models (accessed 2026-09-10). Prices are shown there in RUB per 1M tokens and include the site's current promos (GLM -20%, GPT-5.6 Luna -80%; list prices noted in each file's header comment).

Converted to USD at the CBR (Central Bank of Russia) rate **85.4594 RUB/USD** (2026-09-10), as required ("Cost is always USD", rate noted top-of-file).

| model id | RUB in/out | USD in/out |
|---|---|---|
| glm-5.3 | 147.23 / 462.73 | 1.72 / 5.41 |
| glm-5.3-flash | 10.52 / 37.86 | 0.12 / 0.44 |
| deepseek-v4-flash-0731 | 8.54 / 23.66 | 0.10 / 0.28 |
| deepseek-v4-pro-0813 | 137.95 / 413.85 | 1.61 / 4.84 |
| gpt-5.6-luna | 5.26 / 31.55 | 0.06 / 0.37 |

No cache pricing is published on the bothub pricing page, so only `input`/`output` are set.

## Reasoning controls

Mirrored from the lab entries per the multi-model relay policy (AGENTS.md):

- GLM-5.3 / GLM-5.3-Flash: effort `low|high|max` (always reasons, no toggle) — from `providers/zhipuai/`
- DeepSeek V4 Flash 0731: `toggle` + effort `low|high|max` — from `providers/deepseek/`
- DeepSeek V4 Pro 0813: `toggle` + effort `high|max` — from `providers/deepseek/`
- GPT-5.6 Luna: effort `none|low|medium|high|xhigh|max` — from `providers/openai/`

## Verification

- Model availability confirmed live via `GET https://openai.bothub.ru/v1/models` (all 5 IDs present; `glm-5.3-flash` owned_by `z-ai`, etc.)
- Context/output limits on the bothub model pages match the lab entries (1 048 576 context for all; max output 131 072 for GLM-5.3-Flash, 943 718 for GLM-5.3 and DSv4-Flash-0731, 384 000 for DSv4-Pro-0813, 128 000 for GPT-5.6 Luna) — no `[limit]` overrides needed
- `interleaved = true` matches the existing bothub convention (reasoning returned in `message.reasoning`, documented in `providers/bothub/provider.toml`)
