### PR TITLE
feat(google-vertex): add xAI Grok models (4.6, 4.3, 4.20, 4.1 Fast)

### DIFF
--- a/models/xai/grok-4.1-fast-reasoning.toml
+++ b/models/xai/grok-4.1-fast-reasoning.toml
@@ -1,0 +1,22 @@
+# Sources:
+# - https://x.ai/news/grok-4-1-fast
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/grok-4-1-fast
+name = "Grok 4.1 Fast (Reasoning)"
+description = "xAI's fast agentic tool-calling model with a 2M context window and built-in reasoning"
+family = "grok"
+release_date = "2025-11-19"
+last_updated = "2025-11-19"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = false
+
+[limit]
+context = 2_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]

--- a/providers/google-vertex/models/xai/grok-4.1-fast-non-reasoning.toml
+++ b/providers/google-vertex/models/xai/grok-4.1-fast-non-reasoning.toml
@@ -1,10 +1,17 @@
-# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.1 Fast (Non-Reasoning)
+# Sources:
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/grok-4-1-fast
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
 base_model = "xai/grok-4.1-fast"
+description = "Fast Grok model for responsive chat, tool-assisted work, and low-latency responses"
+status = "deprecated"
 
 [cost]
 input = 0.2
 output = 0.5
 cache_read = 0.05
+
+[limit]
+context = 128_000
 
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/google-vertex/models/xai/grok-4.1-fast-non-reasoning.toml
+++ b/providers/google-vertex/models/xai/grok-4.1-fast-non-reasoning.toml
@@ -1,0 +1,11 @@
+# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.1 Fast (Non-Reasoning)
+base_model = "xai/grok-4.1-fast"
+
+[cost]
+input = 0.2
+output = 0.5
+cache_read = 0.05
+
+[provider]
+npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/xai/grok-4.1-fast-reasoning.toml
+++ b/providers/google-vertex/models/xai/grok-4.1-fast-reasoning.toml
@@ -1,0 +1,30 @@
+# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.1 Fast (Reasoning)
+name = "Grok 4.1 Fast (Reasoning)"
+description = "Fast Grok model for responsive chat, reasoning, and tool-assisted work"
+family = "grok"
+release_date = "2025-11-19"
+last_updated = "2025-11-19"
+attachment = true
+reasoning = true
+reasoning_options = []
+tool_call = true
+temperature = true
+structured_output = true
+open_weights = false
+
+[cost]
+input = 0.2
+output = 0.5
+cache_read = 0.05
+
+[limit]
+context = 2_000_000
+output = 30_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[provider]
+npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/xai/grok-4.1-fast-reasoning.toml
+++ b/providers/google-vertex/models/xai/grok-4.1-fast-reasoning.toml
@@ -1,16 +1,11 @@
-# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.1 Fast (Reasoning)
-name = "Grok 4.1 Fast (Reasoning)"
+# Sources:
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/grok-4-1-fast
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/capabilities/reasoning
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+base_model = "xai/grok-4.1-fast-reasoning"
 description = "Fast Grok model for responsive chat, reasoning, and tool-assisted work"
-family = "grok"
-release_date = "2025-11-19"
-last_updated = "2025-11-19"
-attachment = true
-reasoning = true
 reasoning_options = []
-tool_call = true
-temperature = true
-structured_output = true
-open_weights = false
+status = "deprecated"
 
 [cost]
 input = 0.2
@@ -18,12 +13,7 @@ output = 0.5
 cache_read = 0.05
 
 [limit]
-context = 2_000_000
-output = 30_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+context = 128_000
 
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/google-vertex/models/xai/grok-4.20-non-reasoning.toml
+++ b/providers/google-vertex/models/xai/grok-4.20-non-reasoning.toml
@@ -1,0 +1,17 @@
+# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.20 (Non-Reasoning)
+base_model = "xai/grok-4.20-0309-non-reasoning"
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 5
+cache_read = 0.4
+
+[provider]
+npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/xai/grok-4.20-non-reasoning.toml
+++ b/providers/google-vertex/models/xai/grok-4.20-non-reasoning.toml
@@ -1,4 +1,6 @@
-# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.20 (Non-Reasoning)
+# Sources:
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/grok-4-20
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
 base_model = "xai/grok-4.20-0309-non-reasoning"
 
 [cost]
@@ -11,6 +13,12 @@ tier = { type = "context", size = 200_000 }
 input = 2.5
 output = 5
 cache_read = 0.4
+
+[limit]
+context = 2_000_000
+
+[modalities]
+input = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/google-vertex/models/xai/grok-4.20-reasoning.toml
+++ b/providers/google-vertex/models/xai/grok-4.20-reasoning.toml
@@ -1,0 +1,18 @@
+# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.20 (Reasoning)
+base_model = "xai/grok-4.20-0309-reasoning"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 5
+cache_read = 0.4
+
+[provider]
+npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/xai/grok-4.20-reasoning.toml
+++ b/providers/google-vertex/models/xai/grok-4.20-reasoning.toml
@@ -1,6 +1,9 @@
-# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.20 (Reasoning)
+# Sources:
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/grok-4-20
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/capabilities/reasoning
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
 base_model = "xai/grok-4.20-0309-reasoning"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+reasoning_options = []
 
 [cost]
 input = 1.25
@@ -12,6 +15,12 @@ tier = { type = "context", size = 200_000 }
 input = 2.5
 output = 5
 cache_read = 0.4
+
+[limit]
+context = 2_000_000
+
+[modalities]
+input = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/google-vertex/models/xai/grok-4.3.toml
+++ b/providers/google-vertex/models/xai/grok-4.3.toml
@@ -1,6 +1,10 @@
-# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.3
+# Sources:
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/grok-4-3
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/capabilities/reasoning
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
 base_model = "xai/grok-4.3"
-reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+reasoning_options = []
+status = "beta"
 
 [cost]
 input = 1.25
@@ -12,6 +16,12 @@ tier = { type = "context", size = 200_000 }
 input = 2.5
 output = 5
 cache_read = 0.4
+
+[limit]
+context = 200_000
+
+[modalities]
+input = ["text", "image"]
 
 [provider]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/google-vertex/models/xai/grok-4.3.toml
+++ b/providers/google-vertex/models/xai/grok-4.3.toml
@@ -1,0 +1,18 @@
+# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.3
+base_model = "xai/grok-4.3"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
+
+[cost]
+input = 1.25
+output = 2.5
+cache_read = 0.2
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 2.5
+output = 5
+cache_read = 0.4
+
+[provider]
+npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/xai/grok-4.6.toml
+++ b/providers/google-vertex/models/xai/grok-4.6.toml
@@ -1,0 +1,18 @@
+# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.6
+base_model = "xai/grok-4.6"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+
+[cost]
+input = 2
+output = 6
+cache_read = 0.5
+
+[[cost.tiers]]
+tier = { type = "context", size = 200_000 }
+input = 4
+output = 12
+cache_read = 1
+
+[provider]
+npm = "@ai-sdk/openai-compatible"
+api = "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}/endpoints/openapi"

--- a/providers/google-vertex/models/xai/grok-4.6.toml
+++ b/providers/google-vertex/models/xai/grok-4.6.toml
@@ -1,6 +1,10 @@
-# Source: Google Cloud Vertex AI Model Garden - xAI Grok 4.6
+# Sources:
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/grok-4-6
+# - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/capabilities/reasoning
+# - https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
 base_model = "xai/grok-4.6"
-reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
+reasoning_options = []
+status = "beta"
 
 [cost]
 input = 2
@@ -12,6 +16,9 @@ tier = { type = "context", size = 200_000 }
 input = 4
 output = 12
 cache_read = 1
+
+[limit]
+context = 524_288
 
 [provider]
 npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
Adds the available xAI Grok partner models to Google Cloud Vertex AI:

- `xai/grok-4.6`
- `xai/grok-4.3`
- `xai/grok-4.20-reasoning`
- `xai/grok-4.20-non-reasoning`
- `xai/grok-4.1-fast-reasoning`
- `xai/grok-4.1-fast-non-reasoning`

The entries use Vertex's documented OpenAI-compatible endpoint, model IDs, context limits, lifecycle statuses, and pricing. Vertex does not expose `reasoning_effort` for Grok reasoning models, so those entries intentionally publish no configurable reasoning options.

Sources:
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/grok/capabilities/reasoning
- https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
