### PR TITLE
Add DeepSeek V4.1 Flash for deepseek provider

### DIFF
--- a/providers/deepseek/models/deepseek-flash.toml
+++ b/providers/deepseek/models/deepseek-flash.toml
@@ -10,7 +10,6 @@
 # https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-10)
 # https://api-docs.deepseek.com/guides/thinking_mode/ (accessed 2026-09-10)
 base_model = "deepseek/deepseek-v4.1-flash"
-name = "DeepSeek V4.1 Flash"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/deepseek/models/deepseek-flash.toml
+++ b/providers/deepseek/models/deepseek-flash.toml
@@ -1,0 +1,29 @@
+# DeepSeek-V4.1-Flash, served as `deepseek-flash`.
+# The legacy names `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` are
+# still accepted, but those models are retired and requests are served by
+# DeepSeek-V4.1-Flash at the Flash price.
+# Reasoning tokens are billed at the output rate (no separate CoT price).
+# Off-peak rates are half of peak; models.dev records the off-peak rate.
+# OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
+# Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
+# Flash maps requested low -> low (unlike Pro). xhigh -> high.
+# https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-10)
+# https://api-docs.deepseek.com/guides/thinking_mode/ (accessed 2026-09-10)
+base_model = "deepseek/deepseek-v4.1-flash"
+name = "DeepSeek V4.1 Flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.6
+reasoning = 0.6
+cache_read = 0.003

--- a/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
@@ -1,6 +1,8 @@
 # Legacy alias. DeepSeek-V4-Flash-Vision-Exp is retired; requests to
 # `deepseek-v4-flash-vision-exp` are still accepted but served by
 # DeepSeek-V4.1-Flash and billed at the Flash price.
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
 # https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-10)
 base_model = "deepseek/deepseek-v4.1-flash"
 name = "DeepSeek V4 Flash Vision Exp"

--- a/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
@@ -1,10 +1,10 @@
-# DeepSeek-V4-Flash-Vision-Exp is priced the same as DeepSeek V4 Flash.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-22)
-# https://api-docs.deepseek.com/guides/vision (accessed 2026-08-22)
-# OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
-# Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
-base_model = "deepseek/deepseek-v4-flash-vision-exp"
-status = "beta"
+# Legacy alias. DeepSeek-V4-Flash-Vision-Exp is retired; requests to
+# `deepseek-v4-flash-vision-exp` are still accepted but served by
+# DeepSeek-V4.1-Flash and billed at the Flash price.
+# https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-10)
+base_model = "deepseek/deepseek-v4.1-flash"
+name = "DeepSeek V4 Flash Vision Exp"
+status = "deprecated"
 
 [[reasoning_options]]
 type = "toggle"
@@ -17,7 +17,7 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.14
-output = 0.28
-reasoning = 0.28
-cache_read = 0.0028
+input = 0.15
+output = 0.6
+reasoning = 0.6
+cache_read = 0.003

--- a/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
+++ b/providers/deepseek/models/deepseek-v4-flash-vision-exp.toml
@@ -6,8 +6,8 @@
 # https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-10)
 base_model = "deepseek/deepseek-v4.1-flash"
 name = "DeepSeek V4 Flash Vision Exp"
-status = "deprecated"
-
+## mark as deprecated soon
+# status = "deprecated"
 [[reasoning_options]]
 type = "toggle"
 

--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -6,7 +6,8 @@
 # https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-10)
 base_model = "deepseek/deepseek-v4.1-flash"
 name = "DeepSeek V4 Flash"
-status = "deprecated"
+## mark as deprecated soon
+# status = "deprecated"
 
 [[reasoning_options]]
 type = "toggle"

--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -1,6 +1,8 @@
 # Legacy alias. The DeepSeek-V4-Flash model is retired; requests to
 # `deepseek-v4-flash` are still accepted but served by DeepSeek-V4.1-Flash and
 # billed at the Flash price.
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
 # https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-10)
 base_model = "deepseek/deepseek-v4.1-flash"
 name = "DeepSeek V4 Flash"

--- a/providers/deepseek/models/deepseek-v4-flash.toml
+++ b/providers/deepseek/models/deepseek-v4-flash.toml
@@ -1,12 +1,10 @@
-# Reasoning tokens are billed at the output rate (no separate CoT price).
-# `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-07-31)
-# OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = low|high|max`.
-# Anthropic: `thinking.type`, `output_config.effort = low|high|max`; budget ignored.
-# Flash maps requested low→low (unlike Pro, which maps low→high). xhigh→high.
-# https://api-docs.deepseek.com/guides/thinking_mode/ (accessed 2026-08-02)
-base_model = "deepseek/deepseek-v4-flash-0731"
+# Legacy alias. The DeepSeek-V4-Flash model is retired; requests to
+# `deepseek-v4-flash` are still accepted but served by DeepSeek-V4.1-Flash and
+# billed at the Flash price.
+# https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-10)
+base_model = "deepseek/deepseek-v4.1-flash"
 name = "DeepSeek V4 Flash"
+status = "deprecated"
 
 [[reasoning_options]]
 type = "toggle"
@@ -19,7 +17,7 @@ values = ["low", "high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.14
-output = 0.28
-reasoning = 0.28
-cache_read = 0.0028
+input = 0.15
+output = 0.6
+reasoning = 0.6
+cache_read = 0.003


### PR DESCRIPTION
## Summary

DeepSeek's official API now serves `deepseek-flash` (DeepSeek-V4.1-Flash). The legacy names `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` are retired and their requests are served by V4.1-Flash at the Flash price.

The canonical model `models/deepseek/deepseek-v4.1-flash.toml` already exists, but the official `deepseek` provider had no mapping, so models.dev consumers (e.g. opencode) could not select it.

## Changes

- Add `providers/deepseek/models/deepseek-flash.toml` with `base_model = "deepseek/deepseek-v4.1-flash"`
- Mark `deepseek-v4-flash.toml` and `deepseek-v4-flash-vision-exp.toml` as `deprecated` and repoint them to `deepseek/deepseek-v4.1-flash`, updating cost to the Flash rate

## Sources

- https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-10)
- `GET https://api.deepseek.com/models` returns `deepseek-flash` and `deepseek-v4-pro`