### PR TITLE
fix(providers): update DeepSeek V4 Pro peak pricing and Ministral 3B price

### DIFF
--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -1,6 +1,10 @@
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
-# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-08-12)
+# https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-09-11)
+# Peak rates below; peak hours are Mon-Fri 01:00-04:00 and
+# 06:00-10:00 UTC, all other hours (off-peak) are billed at half price.
+# From 2026-09-14 Beijing time, deepseek-v4-pro requests are rerouted to
+# V4.1 Flash and billed at the Flash price until V4.1 Pro is released.
 base_model = "deepseek/deepseek-v4-pro-0813"
 name = "DeepSeek V4 Pro"
 # OpenAI: `thinking.type = enabled|disabled`, `reasoning_effort = high|max`.
@@ -18,7 +22,7 @@ values = ["high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 0.435
-output = 0.87
-reasoning = 0.87
-cache_read = 0.003625
+input = 1.32
+output = 3.96
+reasoning = 3.96
+cache_read = 0.044

--- a/providers/deepseek/models/deepseek-v4-pro.toml
+++ b/providers/deepseek/models/deepseek-v4-pro.toml
@@ -1,8 +1,9 @@
 # Reasoning tokens are billed at the output rate (no separate CoT price).
 # `completion_tokens_details.reasoning_tokens` is a subset of completion_tokens.
+# Peak hours are Mon-Fri 01:00-04:00 and 06:00-10:00 UTC; off-peak rates
+# are half of peak and models.dev records the off-peak rate (see deepseek-flash).
+# Peak rates after the 2026-08-28 increase are $1.32 / $3.96 / $0.044 cache hit.
 # https://api-docs.deepseek.com/quick_start/pricing/ (accessed 2026-09-11)
-# Peak rates below; peak hours are Mon-Fri 01:00-04:00 and
-# 06:00-10:00 UTC, all other hours (off-peak) are billed at half price.
 # From 2026-09-14 Beijing time, deepseek-v4-pro requests are rerouted to
 # V4.1 Flash and billed at the Flash price until V4.1 Pro is released.
 base_model = "deepseek/deepseek-v4-pro-0813"
@@ -22,7 +23,7 @@ values = ["high", "max"]
 field = "reasoning_content"
 
 [cost]
-input = 1.32
-output = 3.96
-reasoning = 3.96
-cache_read = 0.044
+input = 0.66
+output = 1.98
+reasoning = 1.98
+cache_read = 0.022

--- a/providers/mistral/models/ministral-3b-latest.toml
+++ b/providers/mistral/models/ministral-3b-latest.toml
@@ -2,7 +2,7 @@ name = "Ministral 3B (latest)"
 description = "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads"
 family = "ministral"
 release_date = "2024-10-01"
-last_updated = "2024-10-04"
+last_updated = "2026-09-11"
 attachment = false
 reasoning = false
 temperature = true
@@ -11,8 +11,8 @@ tool_call = true
 open_weights = true
 
 [cost]
-input = 0.04
-output = 0.04
+input = 0.10
+output = 0.10
 
 [limit]
 context = 128_000


### PR DESCRIPTION
## Summary

Two provider price corrections verified against official sources on 2026-09-11:

- **deepseek/deepseek-v4-pro**: after the 2026-08-28 increase, peak rates are **$1.32 / $3.96** per 1M tokens (cache hit $0.044). Per the DeepSeek convention already used by `deepseek-flash.toml`, the entry records the **off-peak rate: $0.66 / $1.98** (cache hit $0.022, exactly half peak); peak hours are Mon–Fri 01:00–04:00 and 06:00–10:00 UTC, all other hours half price. The file previously held the pre-increase off-peak $0.435 / $0.87.
  - Also noted in comments: from **2026-09-14 Beijing time**, `deepseek-v4-pro` requests are rerouted to V4.1 Flash and billed at the Flash price until V4.1 Pro is released (per the same official page). Happy to mark the entry deprecated / add a status in a follow-up after that date.
- **mistral/ministral-3b-latest**: mistral.ai/pricing/api currently lists **$0.10 / $0.10**; the entry still had the launch-era $0.04 / $0.04 (last_updated 2024-10).

## Sources

- https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-11)
- https://mistral.ai/pricing/api (accessed 2026-09-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)