### PR TITLE
fix(alibaba-cn): refresh Bailuan qwen3 prices and split CN qwen3-coder-plus from international symlink

### DIFF
--- a/providers/alibaba-cn/models/qwen-vl-ocr.toml
+++ b/providers/alibaba-cn/models/qwen-vl-ocr.toml
@@ -2,7 +2,7 @@ name = "Qwen-VL OCR"
 description = "OCR model for extracting structured text from documents and screenshots"
 family = "qwen"
 release_date = "2024-10-28"
-last_updated = "2025-04-13"
+last_updated = "2026-09-11"
 attachment = false
 reasoning = false
 temperature = true
@@ -11,8 +11,8 @@ tool_call = false
 open_weights = false
 
 [cost]
-input = 0.717
-output = 0.717
+input = 0.043
+output = 0.072
 
 [limit]
 context = 34_096

--- a/providers/alibaba-cn/models/qwen3-coder-plus.toml
+++ b/providers/alibaba-cn/models/qwen3-coder-plus.toml
@@ -1,1 +1,41 @@
-../../alibaba/models/qwen3-coder-plus.toml
+# China-site (Bailuan) pricing differs from the international console,
+# so this provider entry can no longer share the alibaba symlink ($1/$5).
+# https://help.aliyun.com/zh/model-studio/model-pricing (accessed 2026-09-11)
+name = "Qwen3 Coder Plus"
+description = "Hosted Qwen coder for software agents, repo edits, and long-context code"
+family = "qwen"
+release_date = "2025-07-23"
+last_updated = "2026-09-11"
+attachment = false
+reasoning = false
+temperature = true
+knowledge = "2025-04"
+tool_call = true
+open_weights = true
+
+[cost]
+input = 0.574
+output = 2.296
+
+[[cost.tiers]]
+tier = { type = "context", size = 32_000 }
+input = 0.861
+output = 3.444
+
+[[cost.tiers]]
+tier = { type = "context", size = 128_000 }
+input = 1.435
+output = 5.74
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 2.87
+output = 28.7
+
+[limit]
+context = 1_048_576
+output = 65_536
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/alibaba-cn/models/qwen3-max.toml
+++ b/providers/alibaba-cn/models/qwen3-max.toml
@@ -2,7 +2,7 @@ name = "Qwen3 Max"
 description = "Flagship Qwen model for complex reasoning, coding, and agentic workflows"
 family = "qwen"
 release_date = "2025-09-23"
-last_updated = "2025-09-23"
+last_updated = "2026-09-11"
 attachment = false
 reasoning = false
 temperature = true
@@ -11,8 +11,13 @@ tool_call = true
 open_weights = false
 
 [cost]
-input = 0.861
-output = 3.441
+input = 1.291
+output = 7.749
+
+[[cost.tiers]]
+tier = { type = "context", size = 128_000 }
+input = 2.153
+output = 12.915
 
 [limit]
 context = 262_144

--- a/providers/alibaba-cn/models/qwen3.5-flash.toml
+++ b/providers/alibaba-cn/models/qwen3.5-flash.toml
@@ -2,7 +2,7 @@ name = "Qwen3.5 Flash"
 description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
 family = "qwen"
 release_date = "2026-02-23"
-last_updated = "2026-02-23"
+last_updated = "2026-09-11"
 attachment = true
 reasoning = true
 structured_output = true
@@ -20,8 +20,14 @@ max = 81_920
 
 [cost]
 input = 0.172
-output = 1.72
-reasoning = 1.72
+output = 1.033
+reasoning = 1.033
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 0.689
+output = 4.133
+reasoning = 4.133
 
 [limit]
 context = 1_000_000

--- a/providers/alibaba-cn/models/qwen3.5-plus.toml
+++ b/providers/alibaba-cn/models/qwen3.5-plus.toml
@@ -2,7 +2,7 @@ name = "Qwen3.5 Plus"
 description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
 family = "qwen"
 release_date = "2026-02-16"
-last_updated = "2026-02-16"
+last_updated = "2026-09-11"
 attachment = false
 reasoning = true
 temperature = true
@@ -18,9 +18,15 @@ type = "budget_tokens"
 max = 81_920
 
 [cost]
-input = 0.573
-output = 3.44
-reasoning = 3.44
+input = 0.287
+output = 1.722
+reasoning = 1.722
+
+[[cost.tiers]]
+tier = { type = "context", size = 256_000 }
+input = 1.148
+output = 6.888
+reasoning = 6.888
 
 [limit]
 context = 1_000_000


### PR DESCRIPTION
## Summary

Verified against the official China-site pricing page (https://help.aliyun.com/zh/model-studio/model-pricing) on 2026-09-11):

- **qwen3-max**: now **¥9 / ¥54** for 0–128K (entry held the launch ¥6 / ¥24, ≈$0.861/$3.441); added ¥15 / ¥90 over 128K as a context tier.
- **qwen3.5-plus**: now **¥2 / ¥12** for 0–256K (entry held ¥4 / ¥24); added ¥8 / ¥48 over 256K as a tier.
- **qwen3.5-flash**: now **¥1.2 / ¥7.2** for 0–256K (output entry held ¥12); added ¥4.8 / ¥28.8 over 256K as a tier.
- **qwen-vl-ocr**: the current alias price is **¥0.3 / ¥0.5** (≈$0.043/$0.072); the entry held the deprecated 2025-04-13 snapshot price ¥5 / ¥5.
- **qwen3-coder-plus**: this provider entry was a symlink to `providers/alibaba/models/qwen3-coder-plus.toml` (international console, **$1 / $5**, still correct there — verified on the English billing page). Bailuan's China-site price is now **¥4 / ¥16** (0–32K) with ¥6/24, ¥10/40, ¥20/200 context bands, so the symlink can no longer represent both. Replaced it with a CN-specific entry using the same `cost.tiers` shape as #5597; the international entry is untouched.

CNY→USD conversion follows the 0.1435 convention already used by the other alibaba-cn entries (¥6 → $0.861).

## Sources

- https://help.aliyun.com/zh/model-studio/model-pricing (accessed 2026-09-11)
- https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio (international console, confirms $1/$5 is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)