### PR TITLE
feat(crof): add DeepSeek V4.1 Flash; clean up model names

### DIFF
--- a/providers/crof/models/deepseek-v4-pro-0813.toml
+++ b/providers/crof/models/deepseek-v4-pro-0813.toml
@@ -1,5 +1,4 @@
 base_model = "deepseek/deepseek-v4-pro-0813"
-name = "DeepSeek V4 Pro (0813)"
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/crof/models/deepseek-v4.1-flash.toml
+++ b/providers/crof/models/deepseek-v4.1-flash.toml
@@ -1,12 +1,12 @@
-base_model = "deepseek/deepseek-v4-flash-0731"
+base_model = "deepseek/deepseek-v4.1-flash"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 
 [interleaved]
 field = "reasoning_content"
 
 [cost]
-input = 0.08
-output = 0.1
+input = 0.1
+output = 0.5
 cache_read = 0.003
 
 [limit]


### PR DESCRIPTION
## Summary

- Add `crof/deepseek-v4.1-flash` as an override-only provider model pointing at the existing lab entry `deepseek/deepseek-v4.1-flash`
- Drop the ad-hoc display-name overrides on `crof/deepseek-v4-flash-0731` ("DeepSeek V4 Flash (New)") and `crof/deepseek-v4-pro-0813` ("DeepSeek V4 Pro (0813)") so they inherit the canonical lab names ("DeepSeek V4 Flash 0731" / "DeepSeek V4 Pro 0813")

## Source

Provider catalog API: https://crof.ai/v2/models (entry `deepseek-v4.1-flash`)

Pricing from the API response (USD / MTok): input $0.10, output $0.50, cache_read $0.003.

## Validation

- [x] `bun validate` passes