### PR TITLE
fix(amazon-bedrock): correct OpenAI catalog

### DIFF
--- a/models/openai/gpt-oss-safeguard-20b.toml
+++ b/models/openai/gpt-oss-safeguard-20b.toml
@@ -1,0 +1,32 @@
+# Model and reasoning controls: https://huggingface.co/openai/gpt-oss-safeguard-20b
+# Text-only, reasoning and structured outputs: https://openai.com/index/gpt-oss-safeguard-technical-report/
+# Tool-call format: https://huggingface.co/openai/gpt-oss-safeguard-20b/blob/main/chat_template.jinja
+# Context: https://huggingface.co/openai/gpt-oss-safeguard-20b/blob/8a11e17b25c973a24099d4016bf2e17dd7ec1574/config.json
+# Output is the configured decoder-context ceiling, not a published hosted-API output maximum.
+# Prompt, reasoning and final output share the 131,072-token budget; usable output is the remaining context.
+# No separate fixed output cap: https://huggingface.co/openai/gpt-oss-safeguard-20b/blob/8a11e17b25c973a24099d4016bf2e17dd7ec1574/generation_config.json
+# Reference generation has a caller-supplied token cap (0 = uncapped): https://github.com/openai/gpt-oss/blob/main/gpt_oss/torch/model.py
+# Release: https://openai.com/index/introducing-gpt-oss-safeguard/
+name = "GPT OSS Safeguard 20B"
+description = "Safety model for policy screening, moderation, and risk-aware routing workflows"
+family = "gpt-oss"
+release_date = "2025-10-29"
+last_updated = "2025-10-29"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/openai/gpt-oss-safeguard-20b"

--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-luna.toml
@@ -1,11 +1,12 @@
 # Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
 # Verified from eu-west-1: returns 200 with reasoning effort set.
 # Global pricing and Runtime capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
+# Cache rates: AWS-published Responses pricing; the card's API coverage can lag live behavior.
+# Converse effort: additionalModelRequestFields.reasoning.effort = none|low|medium|high|xhigh|max.
 base_model = "openai/gpt-5.6-luna"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-5.6 Luna (Global)"
-structured_output = false
 
 [cost]
 input = 0.20

--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-sol.toml
@@ -1,6 +1,8 @@
 # Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
 # Verified from eu-west-1: returns 200 with reasoning effort set.
 # Global pricing and Runtime capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+# Cache rates: AWS-published Responses pricing; the card's API coverage can lag live behavior.
+# Converse effort: additionalModelRequestFields.reasoning.effort = none|low|medium|high|xhigh|max (none verified 2026-09-09).
 base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]

--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-terra.toml
@@ -1,6 +1,8 @@
 # Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
 # Verified from eu-west-1: effort none|low|medium|high|xhigh|max all return 200.
 # Global pricing and Runtime capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html
+# Cache rates: AWS-published Responses pricing; the card's API coverage can lag live behavior.
+# Converse effort: additionalModelRequestFields.reasoning.effort = none|low|medium|high|xhigh|max.
 base_model = "openai/gpt-5.6-terra"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]

--- a/providers/amazon-bedrock/models/global.openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-6-astra.toml
@@ -1,6 +1,8 @@
 # Global cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
-# Bedrock model IDs and routes: https://github.com/openai/codex/pull/42805
-# Global CRIS pricing inferred at 1.0x OpenAI-direct from the GPT-5.6 Sol AWS card precedent.
+# Bedrock model IDs, routes, limits and Global CRIS pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-6-astra.html
+# Cache rates: AWS-published Responses pricing; the card's API coverage can lag live behavior.
+# Converse effort: additionalModelRequestFields.reasoning.effort = low|medium|high|xhigh|max.
+# Live check 2026-09-09 (us-east-1): outputConfig.textFormat enforces JSON schema despite a conflicting user instruction.
 # Effort levels match OpenAI-native Astra (Low..Max, no "none"): https://developers.openai.com/api/docs/models/gpt-6-astra
 base_model = "openai/gpt-6-astra"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]

--- a/providers/amazon-bedrock/models/in.openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/in.openai.gpt-5.6-luna.toml
@@ -1,0 +1,23 @@
+# India cross-Region inference profile served by Bedrock Runtime (Converse).
+# Exact ID, ap-south-1/ap-south-2 availability, Geo CRIS prices and capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
+# Bedrock 1,050,000-token context: https://developers.openai.com/api/docs/guides/amazon-bedrock
+# Effort follows the native model and existing Runtime profiles: https://developers.openai.com/api/docs/models/gpt-5.6-luna
+# Cache rates: AWS-published Responses pricing; the card's API coverage can lag live behavior.
+# Converse effort: additionalModelRequestFields.reasoning.effort = none|low|medium|high|xhigh|max; reasoning_effort is rejected.
+# Live check 2026-09-09 (ap-south-1): nested reasoning.effort=none returns 200.
+base_model = "openai/gpt-5.6-luna"
+name = "GPT-5.6 Luna (India)"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 0.22
+output = 1.32
+cache_read = 0.022
+cache_write = 0.275
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 0.44
+output = 1.98
+cache_read = 0.044
+cache_write = 0.55

--- a/providers/amazon-bedrock/models/in.openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/in.openai.gpt-5.6-terra.toml
@@ -1,0 +1,24 @@
+# India cross-Region inference profile served by Bedrock Runtime (Converse).
+# Exact ID, ap-south-1/ap-south-2 availability, Geo CRIS prices and capabilities: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html
+# Bedrock 1,050,000-token context: https://developers.openai.com/api/docs/guides/amazon-bedrock
+# Effort follows the native model and existing Runtime profiles: https://developers.openai.com/api/docs/models/gpt-5.6-terra
+# Cache rates: AWS-published Responses pricing; the card's API coverage can lag live behavior.
+# Converse effort: additionalModelRequestFields.reasoning.effort = none|low|medium|high|xhigh|max; reasoning_effort is rejected.
+# Live check 2026-09-09 (ap-south-1): nested reasoning.effort=none returns 200.
+base_model = "openai/gpt-5.6-terra"
+name = "GPT-5.6 Terra (India)"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+structured_output = false
+
+[cost]
+input = 2.20
+output = 13.20
+cache_read = 0.22
+cache_write = 2.75
+
+[[cost.tiers]]
+tier = { type = "context", size = 272_000 }
+input = 4.40
+output = 19.80
+cache_read = 0.44
+cache_write = 5.50

--- a/providers/amazon-bedrock/models/openai.gpt-5.4.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.4.toml
@@ -1,3 +1,6 @@
+# Model ID, Mantle /openai/v1/responses route, 272K cap and US pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-54.html
+# Bedrock capabilities: https://developers.openai.com/api/docs/guides/amazon-bedrock
+# Effort: reasoning.effort = none|low|medium|high|xhigh; https://developers.openai.com/api/docs/models/gpt-5.4
 base_model = "openai/gpt-5.4"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
@@ -10,7 +13,6 @@ cache_read = 0.275
 
 [limit]
 context = 272_000
-output = 128_000
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"

--- a/providers/amazon-bedrock/models/openai.gpt-5.5.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.5.toml
@@ -1,3 +1,6 @@
+# Model ID, Mantle /openai/v1/responses route, 272K cap and US pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html
+# Bedrock capabilities: https://developers.openai.com/api/docs/guides/amazon-bedrock
+# Effort: reasoning.effort = none|low|medium|high|xhigh; https://developers.openai.com/api/docs/models/gpt-5.5
 base_model = "openai/gpt-5.5"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh"] }]
 base_model_omit = ["cost.tiers", "cost.context_over_200k", "experimental.modes.fast", "limit.input"]
@@ -10,7 +13,6 @@ cache_read = 0.55
 
 [limit]
 context = 272_000
-output = 128_000
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-luna.toml
@@ -1,6 +1,7 @@
-# Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
+# Mantle Responses model ID, route and pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
+# Effort: reasoning.effort = none|low|medium|high|xhigh|max; https://developers.openai.com/api/docs/models/gpt-5.6-luna
 # Bedrock context window: https://developers.openai.com/api/docs/guides/amazon-bedrock
-# In-region on-demand pricing (US East N. Virginia & Ohio; also US West Oregon): https://aws.amazon.com/bedrock/pricing/
+# In-region Standard pricing for US commercial Regions; GovCloud rates differ.
 # Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
 base_model = "openai/gpt-5.6-luna"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-sol.toml
@@ -1,6 +1,7 @@
-# Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
+# Mantle Responses model ID, route and pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+# Effort: reasoning.effort = none|low|medium|high|xhigh|max; https://developers.openai.com/api/docs/models/gpt-5.6-sol
 # Bedrock context window: https://developers.openai.com/api/docs/guides/amazon-bedrock
-# In-region on-demand pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+# In-region Standard pricing for US commercial Regions.
 # Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
 base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]

--- a/providers/amazon-bedrock/models/openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-5.6-terra.toml
@@ -1,6 +1,7 @@
-# Bedrock model IDs and reasoning support: https://github.com/openai/codex/pull/30285
+# Mantle Responses model ID, route and pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html
+# Effort: reasoning.effort = none|low|medium|high|xhigh|max; https://developers.openai.com/api/docs/models/gpt-5.6-terra
 # Bedrock context window: https://developers.openai.com/api/docs/guides/amazon-bedrock
-# In-region on-demand pricing (US East N. Virginia & Ohio; also US West Oregon): https://aws.amazon.com/bedrock/pricing/
+# In-region Standard pricing for US commercial Regions; GovCloud rates differ.
 # Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
 base_model = "openai/gpt-5.6-terra"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]

--- a/providers/amazon-bedrock/models/openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-6-astra.toml
@@ -1,7 +1,6 @@
-# Bedrock model IDs and routes: https://github.com/openai/codex/pull/42805
+# Bedrock model IDs, routes, limits and pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-6-astra.html
 # Bedrock context window: https://developers.openai.com/api/docs/guides/amazon-bedrock
-# In-region pricing inferred at 1.1x OpenAI-direct from the GPT-5.6 Sol precedent
-# (AWS card prices in-region and Geo CRIS at 1.1x, Global CRIS at 1.0x); no AWS Astra model card published yet.
+# In-region Standard pricing; Mantle is available in us-west-2 (Oregon) only.
 # Effort levels match OpenAI-native Astra (Low..Max, no "none"): https://developers.openai.com/api/docs/models/gpt-6-astra
 # Columns: input / 30m cache write / cache read / output (USD per 1M tokens)
 base_model = "openai/gpt-6-astra"

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
@@ -1,15 +1,11 @@
+# Model ID, Runtime APIs and limits: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html
+# Standard US East (N. Virginia) pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Effort: additionalModelRequestFields.reasoning_effort = low|medium|high (Converse).
+# Request mapping: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
+# Live Converse checks 2026-09-09 (us-east-1): maxTokens=128000 accepted; 131073 rejected with explicit model limit 128000.
+base_model = "openai/gpt-oss-120b"
 name = "gpt-oss-120b"
-description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
-family = "gpt-oss"
-release_date = "2025-08-05"
-last_updated = "2025-08-05"
-attachment = false
-reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [cost]
 input = 0.15
@@ -17,8 +13,4 @@ output = 0.60
 
 [limit]
 context = 128_000
-output = 16_384
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 128_000

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b-1:0.toml
@@ -2,7 +2,7 @@
 # Standard US East (N. Virginia) pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
 # Effort: additionalModelRequestFields.reasoning_effort = low|medium|high (Converse).
 # Request mapping: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
-# Live Converse checks 2026-09-09 (us-east-1): maxTokens=128000 accepted; 131073 rejected with explicit model limit 128000.
+# AWS documents 16K max output. Converse accepts larger maxTokens settings up to the 128K context boundary, but that is not evidence of a larger generation cap.
 base_model = "openai/gpt-oss-120b"
 name = "gpt-oss-120b"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
@@ -13,4 +13,4 @@ output = 0.60
 
 [limit]
 context = 128_000
-output = 128_000
+output = 16_384

--- a/providers/amazon-bedrock/models/openai.gpt-oss-120b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-120b.toml
@@ -1,15 +1,10 @@
+# Model ID, Mantle /v1/responses route and limits: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html
+# Standard US East (N. Virginia) pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Effort: reasoning.effort = low|medium|high (Responses).
+# Native controls: https://huggingface.co/openai/gpt-oss-120b
+base_model = "openai/gpt-oss-120b"
 name = "gpt-oss-120b"
-description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
-family = "gpt-oss"
-release_date = "2025-08-05"
-last_updated = "2025-08-05"
-attachment = false
-reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [cost]
 input = 0.15
@@ -18,10 +13,6 @@ output = 0.60
 [limit]
 context = 128_000
 output = 16_384
-
-[modalities]
-input = ["text"]
-output = ["text"]
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
@@ -1,15 +1,11 @@
+# Model ID, Runtime APIs and limits: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-20b.html
+# Standard US East (N. Virginia) pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Effort: additionalModelRequestFields.reasoning_effort = low|medium|high (Converse).
+# Request mapping: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
+# Live Converse checks 2026-09-09 (us-east-1): maxTokens=128000 accepted; 131073 rejected with explicit model limit 128000.
+base_model = "openai/gpt-oss-20b"
 name = "gpt-oss-20b"
-description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
-family = "gpt-oss"
-release_date = "2025-08-05"
-last_updated = "2025-08-05"
-attachment = false
-reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [cost]
 input = 0.07
@@ -17,8 +13,4 @@ output = 0.30
 
 [limit]
 context = 128_000
-output = 16_384
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 128_000

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b-1:0.toml
@@ -2,7 +2,7 @@
 # Standard US East (N. Virginia) pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
 # Effort: additionalModelRequestFields.reasoning_effort = low|medium|high (Converse).
 # Request mapping: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
-# Live Converse checks 2026-09-09 (us-east-1): maxTokens=128000 accepted; 131073 rejected with explicit model limit 128000.
+# AWS documents 16K max output. Converse accepts larger maxTokens settings up to the 128K context boundary, but that is not evidence of a larger generation cap.
 base_model = "openai/gpt-oss-20b"
 name = "gpt-oss-20b"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
@@ -13,4 +13,4 @@ output = 0.30
 
 [limit]
 context = 128_000
-output = 128_000
+output = 16_384

--- a/providers/amazon-bedrock/models/openai.gpt-oss-20b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-20b.toml
@@ -1,15 +1,10 @@
+# Model ID, Mantle /v1/responses route and limits: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-20b.html
+# Standard US East (N. Virginia) pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Effort: reasoning.effort = low|medium|high (Responses).
+# Native controls: https://huggingface.co/openai/gpt-oss-20b
+base_model = "openai/gpt-oss-20b"
 name = "gpt-oss-20b"
-description = "Open-weight GPT model for self-hosted reasoning and instruction-following workloads"
-family = "gpt-oss"
-release_date = "2025-08-05"
-last_updated = "2025-08-05"
-attachment = false
-reasoning = true
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [cost]
 input = 0.07
@@ -18,10 +13,6 @@ output = 0.30
 [limit]
 context = 128_000
 output = 16_384
-
-[modalities]
-input = ["text"]
-output = ["text"]
 
 [provider]
 npm = "@ai-sdk/amazon-bedrock/mantle"

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-120b.toml
@@ -1,14 +1,11 @@
-name = "GPT OSS Safeguard 120B"
-description = "Safety model for policy screening, moderation, and risk-aware routing workflows"
-family = "gpt-oss"
-release_date = "2025-10-29"
-last_updated = "2025-10-29"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
+# Model ID, Runtime Converse support and limits: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-safeguard-120b.html
+# Standard US East (N. Virginia) pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Native reasoning controls: https://huggingface.co/openai/gpt-oss-safeguard-120b
+# Effort: additionalModelRequestFields.reasoning_effort = low|medium|high, following the GPT-OSS Converse request mapping.
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
+# Live Converse check 2026-09-09 (us-east-1): reasoning_effort=low returns reasoningContent.
+base_model = "openai/gpt-oss-safeguard-120b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.15
@@ -17,7 +14,3 @@ output = 0.60
 [limit]
 context = 128_000
 output = 16_384
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
+++ b/providers/amazon-bedrock/models/openai.gpt-oss-safeguard-20b.toml
@@ -1,14 +1,11 @@
-name = "GPT OSS Safeguard 20B"
-description = "Safety model for policy screening, moderation, and risk-aware routing workflows"
-family = "gpt-oss"
-release_date = "2025-10-29"
-last_updated = "2025-10-29"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
+# Model ID, Runtime Converse support and limits: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-safeguard-20b.html
+# Standard US East (N. Virginia) pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Native reasoning controls: https://huggingface.co/openai/gpt-oss-safeguard-20b
+# Effort: additionalModelRequestFields.reasoning_effort = low|medium|high, following the GPT-OSS Converse request mapping.
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
+# Live Converse check 2026-09-09 (us-east-1): reasoning_effort=low returns reasoningContent.
+base_model = "openai/gpt-oss-safeguard-20b"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
 
 [cost]
 input = 0.07
@@ -17,7 +14,3 @@ output = 0.20
 [limit]
 context = 128_000
 output = 16_384
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/us-gov.openai.gpt-oss-120b-1:0.toml
+++ b/providers/amazon-bedrock/models/us-gov.openai.gpt-oss-120b-1:0.toml
@@ -1,0 +1,15 @@
+# GovCloud cross-Region profile (Converse), exact ID, regions and limits: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html
+# Standard us-gov-west-1 pricing (USD/1K multiplied by 1,000): https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-gov-west-1/index.json
+# Geo inference uses source-region pricing with no routing surcharge: https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+# Effort: additionalModelRequestFields.reasoning_effort = low|medium|high; https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
+base_model = "openai/gpt-oss-120b"
+name = "gpt-oss-120b (GovCloud)"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.18
+output = 0.72
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/amazon-bedrock/models/us-gov.openai.gpt-oss-20b-1:0.toml
+++ b/providers/amazon-bedrock/models/us-gov.openai.gpt-oss-20b-1:0.toml
@@ -1,0 +1,15 @@
+# GovCloud cross-Region profile (Converse), exact ID, regions and limits: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-20b.html
+# Standard us-gov-west-1 pricing (USD/1K multiplied by 1,000): https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-gov-west-1/index.json
+# Geo inference uses source-region pricing with no routing surcharge: https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
+# Effort: additionalModelRequestFields.reasoning_effort = low|medium|high; https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
+base_model = "openai/gpt-oss-20b"
+name = "gpt-oss-20b (GovCloud)"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high"] }]
+
+[cost]
+input = 0.084
+output = 0.36
+
+[limit]
+context = 128_000
+output = 16_384

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-luna.toml
@@ -1,12 +1,14 @@
 # US cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
 # Profile ID verified via ListInferenceProfiles from us-east-1 and ca-central-1.
-# Geo CRIS pricing (= in-region) per the GPT-5.6 AWS card pattern; OpenAI-on-Bedrock is absent from the Price List API.
+# Geo CRIS pricing (= in-region) and Runtime structured outputs: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html
+# Cache rates: AWS-published Responses pricing; live Converse checks 2026-09-09 reported 6,650 cache-write then cache-read tokens.
+# Converse effort: additionalModelRequestFields.reasoning.effort = none|low|medium|high|xhigh|max; reasoning_effort is rejected.
+# Live check 2026-09-09 (us-east-1): outputConfig.textFormat enforces JSON schema despite a conflicting user instruction.
 # Effort levels incl. "none" verified on the Global twin: global.openai.gpt-5.6-luna.toml
 base_model = "openai/gpt-5.6-luna"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
 base_model_omit = ["cost.context_over_200k", "experimental.modes.fast"]
 name = "GPT-5.6 Luna (US)"
-structured_output = false
 
 [cost]
 input = 0.22

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-sol.toml
@@ -1,6 +1,8 @@
 # US cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
 # Profile ID verified via ListInferenceProfiles from us-east-1 and ca-central-1.
-# Geo CRIS pricing (= in-region) per the GPT-5.6 Sol AWS card; OpenAI-on-Bedrock is absent from the Price List API.
+# Geo CRIS pricing (= in-region): https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+# Cache rates: AWS-published Responses pricing; the card's API coverage can lag live behavior.
+# Converse effort: additionalModelRequestFields.reasoning.effort = none|low|medium|high|xhigh|max.
 # Effort levels incl. "none" verified on the Global twin: global.openai.gpt-5.6-sol.toml
 base_model = "openai/gpt-5.6-sol"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-terra.toml
@@ -1,6 +1,8 @@
 # US cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
 # Profile ID verified via ListInferenceProfiles from us-east-1 and ca-central-1.
-# Geo CRIS pricing (= in-region) per the GPT-5.6 AWS card pattern; OpenAI-on-Bedrock is absent from the Price List API.
+# Geo CRIS pricing (= in-region): https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html
+# Cache rates: AWS-published Responses pricing; the card's API coverage can lag live behavior.
+# Converse effort: additionalModelRequestFields.reasoning.effort = none|low|medium|high|xhigh|max.
 # Effort levels incl. "none" verified on the Global twin: global.openai.gpt-5.6-terra.toml
 base_model = "openai/gpt-5.6-terra"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]

--- a/providers/amazon-bedrock/models/us.openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-6-astra.toml
@@ -1,6 +1,8 @@
 # US cross-Region inference profile — served by Bedrock core (Converse), not Mantle, so no [provider] override.
-# Bedrock model IDs and routes: https://github.com/openai/codex/pull/42805
-# Geo CRIS pricing inferred at 1.1x OpenAI-direct (= in-region) from the GPT-5.6 Sol AWS card precedent.
+# Bedrock model IDs, routes, limits and Geo CRIS pricing: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-6-astra.html
+# Cache rates: AWS-published Responses pricing; the card's API coverage can lag live behavior.
+# Converse effort: additionalModelRequestFields.reasoning.effort = low|medium|high|xhigh|max.
+# Live check 2026-09-09 (us-east-1): outputConfig.textFormat enforces JSON schema despite a conflicting user instruction.
 # Effort levels match OpenAI-native Astra (Low..Max, no "none"): https://developers.openai.com/api/docs/models/gpt-6-astra
 base_model = "openai/gpt-6-astra"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]


### PR DESCRIPTION
## Summary

OpenAI-only split of #6637, based on current `dev`.

- Audit all 20 existing OpenAI Bedrock entries without changing their IDs or routes.
- Correct Safeguard reasoning metadata and complete its shared lab entry.
- Correct Runtime output limits and document the distinct Converse reasoning wire shapes.
- Replace inferred Astra citations with the published AWS card; retain upstream structured-output correction.
- Add India GPT-5.6 Luna/Terra and documented GovCloud GPT-OSS profiles.
- Convert open-weight provider entries to override-only `base_model` files.

Targeted Converse checks confirmed Safeguard reasoning, India profile invocation, Luna structured output and caching, Astra structured output, and GPT-OSS Runtime’s 128,000 output boundary.

Sources are in leading TOML comments, including AWS model cards and public pricing.

## Validation

- `bun validate`
- `git diff --check`
- No model deletions or route changes
