### PR TITLE
fix(amazon-bedrock): correct Nova catalog

### DIFF
--- a/models/amazon/nova-2-lite.toml
+++ b/models/amazon/nova-2-lite.toml
@@ -1,17 +1,21 @@
+# Sources: https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html
+# Launch: https://aws.amazon.com/about-aws/whats-new/2025/12/nova-2-foundation-models-amazon-bedrock/
 name = "Nova 2 Lite"
 description = "Multimodal reasoning model for visual analysis, planning, and tool use"
 family = "nova"
-release_date = "2025-12-01"
-last_updated = "2025-12-01"
+release_date = "2025-12-02"
+last_updated = "2025-12-02"
 attachment = true
 reasoning = true
 temperature = true
+knowledge = "2025-10"
 tool_call = true
 open_weights = false
 
 [limit]
 context = 1_000_000
-output = 64_000
+output = 65_536
 
 [modalities]
 input = ["text", "image", "video", "pdf"]

--- a/models/amazon/nova-lite.toml
+++ b/models/amazon/nova-lite.toml
@@ -1,3 +1,8 @@
+# Sources: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-lite.html
+# Launch: https://aws.amazon.com/blogs/aws/introducing-amazon-nova-frontier-intelligence-and-industry-leading-price-performance/
+# PDF document input is supported through Bedrock Converse.
+# Output: the Nova V1 guide's 10K is confirmed by US Bedrock Converse boundary checks (2026-09-09).
 name = "Nova Lite"
 description = "Efficient model for low-latency assistance, extraction, and routine automation"
 family = "nova-lite"
@@ -12,8 +17,8 @@ open_weights = false
 
 [limit]
 context = 300_000
-output = 8_192
+output = 10_000
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image", "video", "pdf"]
 output = ["text"]

--- a/models/amazon/nova-micro.toml
+++ b/models/amazon/nova-micro.toml
@@ -1,3 +1,7 @@
+# Sources: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-micro.html
+# Launch: https://aws.amazon.com/blogs/aws/introducing-amazon-nova-frontier-intelligence-and-industry-leading-price-performance/
+# Output: the Nova V1 guide's 10K is confirmed by US Bedrock Converse boundary checks (2026-09-09).
 name = "Nova Micro"
 description = "Efficient model for low-latency assistance, extraction, and routine automation"
 family = "nova-micro"
@@ -12,7 +16,7 @@ open_weights = false
 
 [limit]
 context = 128_000
-output = 8_192
+output = 10_000
 
 [modalities]
 input = ["text"]

--- a/models/amazon/nova-premier.toml
+++ b/models/amazon/nova-premier.toml
@@ -1,0 +1,23 @@
+# Launch: https://aws.amazon.com/blogs/aws/amazon-nova-premier-our-most-capable-model-for-complex-tasks-and-teacher-for-model-distillation/
+# Specs (including 10K output): https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Prompted CoT, not a native thinking mode: https://docs.aws.amazon.com/nova/latest/userguide/prompting-chain-of-thought.html
+# Bedrock's generic Premier card conflicts on launch date, output limit, and reasoning; use the Nova V1 guide and launch announcement.
+name = "Nova Premier"
+description = "Multimodal model for complex analysis, long-context understanding, tool use, and model distillation"
+family = "nova"
+release_date = "2025-04-30"
+last_updated = "2025-04-30"
+attachment = true
+reasoning = false
+temperature = true
+knowledge = "2024-10"
+tool_call = true
+open_weights = false
+
+[limit]
+context = 1_000_000
+output = 10_000
+
+[modalities]
+input = ["text", "image", "video", "pdf"]
+output = ["text"]

--- a/models/amazon/nova-pro.toml
+++ b/models/amazon/nova-pro.toml
@@ -1,3 +1,8 @@
+# Sources: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-pro.html
+# Launch: https://aws.amazon.com/blogs/aws/introducing-amazon-nova-frontier-intelligence-and-industry-leading-price-performance/
+# PDF document input is supported through Bedrock Converse.
+# Output: the Nova V1 guide's 10K is confirmed by US Bedrock Converse boundary checks (2026-09-09).
 name = "Nova Pro"
 description = "Flagship model for demanding analysis, coding, and production agent workflows"
 family = "nova-pro"
@@ -12,8 +17,8 @@ open_weights = false
 
 [limit]
 context = 300_000
-output = 8_192
+output = 10_000
 
 [modalities]
-input = ["text", "image", "video"]
+input = ["text", "image", "video", "pdf"]
 output = ["text"]

--- a/providers/amazon-bedrock/models/amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-2-lite-v1:0.toml
@@ -1,23 +1,21 @@
-name = "Nova 2 Lite"
-description = "Multimodal reasoning model for visual analysis, planning, and tool use"
-family = "nova"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
-reasoning = true
+# Model: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Standard us-east-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+# Reasoning: https://docs.aws.amazon.com/nova/latest/nova2-userguide/extended-thinking.html
+# Toggle: additionalModelRequestFields.reasoningConfig.type = enabled|disabled (Converse).
+# Effort: additionalModelRequestFields.reasoningConfig.maxReasoningEffort = low|medium|high.
+# High effort requires omitting temperature, topP, topK, and maxTokens.
+# Bedrock output cap: US Converse boundary check (2026-09-09) accepts 65,535 and rejects 65,536.
+# Lab specs: https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
+base_model = "amazon/nova-2-lite"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
-temperature = true
-tool_call = true
-open_weights = false
 
 [cost]
 input = 0.33
 output = 2.75
+cache_read = 0.0825
+cache_write = 0.33
 
 [limit]
-context = 128_000
-output = 4_096
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]
+output = 65_535

--- a/providers/amazon-bedrock/models/amazon.nova-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-lite-v1:0.toml
@@ -1,24 +1,11 @@
-name = "Nova Lite"
-description = "Efficient model for low-latency assistance, extraction, and routine automation"
-family = "nova-lite"
-release_date = "2024-12-03"
-last_updated = "2024-12-03"
-attachment = true
-reasoning = false
-temperature = true
-knowledge = "2024-10"
-tool_call = true
-open_weights = false
+# Model: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-lite.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Standard us-east-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+base_model = "amazon/nova-lite"
 
 [cost]
 input = 0.06
 output = 0.24
 cache_read = 0.015
-
-[limit]
-context = 300_000
-output = 8_192
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]
+cache_write = 0.06

--- a/providers/amazon-bedrock/models/amazon.nova-micro-v1:0.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-micro-v1:0.toml
@@ -1,24 +1,11 @@
-name = "Nova Micro"
-description = "Efficient model for low-latency assistance, extraction, and routine automation"
-family = "nova-micro"
-release_date = "2024-12-03"
-last_updated = "2024-12-03"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-10"
-tool_call = true
-open_weights = false
+# Model: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-micro.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Standard us-east-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+base_model = "amazon/nova-micro"
 
 [cost]
 input = 0.035
 output = 0.14
 cache_read = 0.00875
-
-[limit]
-context = 128_000
-output = 8_192
-
-[modalities]
-input = ["text"]
-output = ["text"]
+cache_write = 0.035

--- a/providers/amazon-bedrock/models/amazon.nova-pro-v1:0.toml
+++ b/providers/amazon-bedrock/models/amazon.nova-pro-v1:0.toml
@@ -1,24 +1,11 @@
-name = "Nova Pro"
-description = "Flagship model for demanding analysis, coding, and production agent workflows"
-family = "nova-pro"
-release_date = "2024-12-03"
-last_updated = "2024-12-03"
-attachment = true
-reasoning = false
-temperature = true
-knowledge = "2024-10"
-tool_call = true
-open_weights = false
+# Model: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-pro.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Standard us-east-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+base_model = "amazon/nova-pro"
 
 [cost]
 input = 0.80
 output = 3.20
 cache_read = 0.20
-
-[limit]
-context = 300_000
-output = 8_192
-
-[modalities]
-input = ["text", "image", "video"]
-output = ["text"]
+cache_write = 0.80

--- a/providers/amazon-bedrock/models/apac.amazon.nova-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/apac.amazon.nova-lite-v1:0.toml
@@ -1,6 +1,8 @@
-# APAC cross-Region inference profile, verified via ListInferenceProfiles from ap-southeast-2.
-# Priced at ap-southeast-2 standard; also invocable from ap-northeast-1/ap-southeast-1 where regional rates differ slightly.
-# Prices (Price List): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# APAC cross-Region profile verified by ListInferenceProfiles (ap-southeast-2, 2026-09-08).
+# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/ap-southeast-2/index.json
+# Standard ap-southeast-2 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 base_model = "amazon/nova-lite"
 name = "Nova Lite (APAC)"
 
@@ -8,3 +10,4 @@ name = "Nova Lite (APAC)"
 input = 0.063
 output = 0.252
 cache_read = 0.01575
+cache_write = 0.063

--- a/providers/amazon-bedrock/models/apac.amazon.nova-micro-v1:0.toml
+++ b/providers/amazon-bedrock/models/apac.amazon.nova-micro-v1:0.toml
@@ -1,6 +1,8 @@
-# APAC cross-Region inference profile, verified via ListInferenceProfiles from ap-southeast-2.
-# Priced at ap-southeast-2 standard; also invocable from ap-northeast-1/ap-southeast-1 where regional rates differ slightly.
-# Prices (Price List): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# APAC cross-Region profile verified by ListInferenceProfiles (ap-southeast-2, 2026-09-08).
+# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/ap-southeast-2/index.json
+# Standard ap-southeast-2 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 base_model = "amazon/nova-micro"
 name = "Nova Micro (APAC)"
 
@@ -8,3 +10,4 @@ name = "Nova Micro (APAC)"
 input = 0.037
 output = 0.148
 cache_read = 0.00925
+cache_write = 0.037

--- a/providers/amazon-bedrock/models/apac.amazon.nova-pro-v1:0.toml
+++ b/providers/amazon-bedrock/models/apac.amazon.nova-pro-v1:0.toml
@@ -1,6 +1,8 @@
-# APAC cross-Region inference profile, verified via ListInferenceProfiles from ap-southeast-2.
-# Priced at ap-southeast-2 standard; also invocable from ap-northeast-1/ap-southeast-1 where regional rates differ slightly.
-# Prices (Price List): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# APAC cross-Region profile verified by ListInferenceProfiles (ap-southeast-2, 2026-09-08).
+# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/ap-southeast-2/index.json
+# Standard ap-southeast-2 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 base_model = "amazon/nova-pro"
 name = "Nova Pro (APAC)"
 
@@ -8,3 +10,4 @@ name = "Nova Pro (APAC)"
 input = 0.840
 output = 3.360
 cache_read = 0.210
+cache_write = 0.840

--- a/providers/amazon-bedrock/models/ca.amazon.nova-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/ca.amazon.nova-lite-v1:0.toml
@@ -1,5 +1,8 @@
-# CA cross-Region inference profile, verified via ListInferenceProfiles from ca-central-1.
-# CA geo pricing (Price List ca-central-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# CA cross-Region profile verified by ListInferenceProfiles (ca-central-1, 2026-09-08).
+# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/ca-central-1/index.json
+# Standard ca-central-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 base_model = "amazon/nova-lite"
 name = "Nova Lite (CA)"
 
@@ -7,3 +10,4 @@ name = "Nova Lite (CA)"
 input = 0.064
 output = 0.256
 cache_read = 0.016
+cache_write = 0.064

--- a/providers/amazon-bedrock/models/eu.amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.amazon.nova-2-lite-v1:0.toml
@@ -1,6 +1,13 @@
-# EU cross-Region inference profile, verified via ListInferenceProfiles from eu-west-1.
-# EU geo pricing (Price List eu-west-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
-# Toggle: reasoningConfig.type = enabled|disabled; Effort: reasoningConfig.maxReasoningEffort = low|medium|high
+# EU cross-Region profile verified by ListInferenceProfiles (eu-west-1, 2026-09-08).
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/eu-west-1/index.json
+# Standard eu-west-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+# Reasoning: https://docs.aws.amazon.com/nova/latest/nova2-userguide/extended-thinking.html
+# Toggle: additionalModelRequestFields.reasoningConfig.type = enabled|disabled (Converse).
+# Effort: additionalModelRequestFields.reasoningConfig.maxReasoningEffort = low|medium|high.
+# High effort requires omitting temperature, topP, topK, and maxTokens.
+# Bedrock output cap: US Converse boundary check (2026-09-09) accepts 65,535 and rejects 65,536.
+# Lab specs: https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
 base_model = "amazon/nova-2-lite"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 name = "Nova 2 Lite (EU)"
@@ -9,3 +16,7 @@ name = "Nova 2 Lite (EU)"
 input = 0.374
 output = 3.157
 cache_read = 0.0935
+cache_write = 0.374
+
+[limit]
+output = 65_535

--- a/providers/amazon-bedrock/models/eu.amazon.nova-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.amazon.nova-lite-v1:0.toml
@@ -1,5 +1,8 @@
-# EU cross-Region inference profile, verified via ListInferenceProfiles from eu-west-1.
-# EU geo pricing (Price List eu-west-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# EU cross-Region profile verified by ListInferenceProfiles (eu-west-1, 2026-09-08).
+# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/eu-west-1/index.json
+# Standard eu-west-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 base_model = "amazon/nova-lite"
 name = "Nova Lite (EU)"
 
@@ -7,3 +10,4 @@ name = "Nova Lite (EU)"
 input = 0.069
 output = 0.276
 cache_read = 0.01725
+cache_write = 0.069

--- a/providers/amazon-bedrock/models/eu.amazon.nova-micro-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.amazon.nova-micro-v1:0.toml
@@ -1,5 +1,8 @@
-# EU cross-Region inference profile, verified via ListInferenceProfiles from eu-west-1.
-# EU geo pricing (Price List eu-west-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# EU cross-Region profile verified by ListInferenceProfiles (eu-west-1, 2026-09-08).
+# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/eu-west-1/index.json
+# Standard eu-west-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 base_model = "amazon/nova-micro"
 name = "Nova Micro (EU)"
 
@@ -7,3 +10,4 @@ name = "Nova Micro (EU)"
 input = 0.040
 output = 0.160
 cache_read = 0.010
+cache_write = 0.040

--- a/providers/amazon-bedrock/models/eu.amazon.nova-pro-v1:0.toml
+++ b/providers/amazon-bedrock/models/eu.amazon.nova-pro-v1:0.toml
@@ -1,5 +1,8 @@
-# EU cross-Region inference profile, verified via ListInferenceProfiles from eu-west-1.
-# EU geo pricing (Price List eu-west-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# EU cross-Region profile verified by ListInferenceProfiles (eu-west-1, 2026-09-08).
+# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/eu-west-1/index.json
+# Standard eu-west-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 base_model = "amazon/nova-pro"
 name = "Nova Pro (EU)"
 
@@ -7,3 +10,4 @@ name = "Nova Pro (EU)"
 input = 0.920
 output = 3.680
 cache_read = 0.230
+cache_write = 0.920

--- a/providers/amazon-bedrock/models/global.amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/global.amazon.nova-2-lite-v1:0.toml
@@ -1,6 +1,13 @@
-# Global cross-Region inference profile, verified via ListInferenceProfiles (visible from all regions).
-# Global pricing (Price List us-east-1 global): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
-# Toggle: reasoningConfig.type = enabled|disabled; Effort: reasoningConfig.maxReasoningEffort = low|medium|high
+# Global cross-Region profile verified by ListInferenceProfiles in six source Regions (2026-09-08).
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Global us-east-1 reference rates (cross-region-global SKUs), USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+# Reasoning: https://docs.aws.amazon.com/nova/latest/nova2-userguide/extended-thinking.html
+# Toggle: additionalModelRequestFields.reasoningConfig.type = enabled|disabled (Converse).
+# Effort: additionalModelRequestFields.reasoningConfig.maxReasoningEffort = low|medium|high.
+# High effort requires omitting temperature, topP, topK, and maxTokens.
+# Bedrock output cap: US Converse boundary check (2026-09-09) accepts 65,535 and rejects 65,536.
+# Lab specs: https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
 base_model = "amazon/nova-2-lite"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 name = "Nova 2 Lite (Global)"
@@ -9,3 +16,7 @@ name = "Nova 2 Lite (Global)"
 input = 0.300
 output = 2.500
 cache_read = 0.075
+cache_write = 0.300
+
+[limit]
+output = 65_535

--- a/providers/amazon-bedrock/models/jp.amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/jp.amazon.nova-2-lite-v1:0.toml
@@ -1,6 +1,13 @@
-# JP cross-Region inference profile, verified via ListInferenceProfiles from ap-northeast-1.
-# JP geo pricing (Price List ap-northeast-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
-# Toggle: reasoningConfig.type = enabled|disabled; Effort: reasoningConfig.maxReasoningEffort = low|medium|high
+# JP cross-Region profile verified by ListInferenceProfiles (ap-northeast-1, 2026-09-08).
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/ap-northeast-1/index.json
+# Standard ap-northeast-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+# Reasoning: https://docs.aws.amazon.com/nova/latest/nova2-userguide/extended-thinking.html
+# Toggle: additionalModelRequestFields.reasoningConfig.type = enabled|disabled (Converse).
+# Effort: additionalModelRequestFields.reasoningConfig.maxReasoningEffort = low|medium|high.
+# High effort requires omitting temperature, topP, topK, and maxTokens.
+# Bedrock output cap: US Converse boundary check (2026-09-09) accepts 65,535 and rejects 65,536.
+# Lab specs: https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
 base_model = "amazon/nova-2-lite"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 name = "Nova 2 Lite (JP)"
@@ -9,3 +16,7 @@ name = "Nova 2 Lite (JP)"
 input = 0.396
 output = 3.311
 cache_read = 0.099
+cache_write = 0.396
+
+[limit]
+output = 65_535

--- a/providers/amazon-bedrock/models/us.amazon.nova-2-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.amazon.nova-2-lite-v1:0.toml
@@ -1,6 +1,13 @@
-# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1 and ca-central-1.
-# US geo pricing (Price List us-east-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
-# Toggle: reasoningConfig.type = enabled|disabled; Effort: reasoningConfig.maxReasoningEffort = low|medium|high
+# US cross-Region profile verified by ListInferenceProfiles (us-east-1 and ca-central-1, 2026-09-08).
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Standard us-east-1 reference rates, USD/MTok; Canadian source rates differ. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+# Reasoning: https://docs.aws.amazon.com/nova/latest/nova2-userguide/extended-thinking.html
+# Toggle: additionalModelRequestFields.reasoningConfig.type = enabled|disabled (Converse).
+# Effort: additionalModelRequestFields.reasoningConfig.maxReasoningEffort = low|medium|high.
+# High effort requires omitting temperature, topP, topK, and maxTokens.
+# Bedrock output cap: US Converse boundary check (2026-09-09) accepts 65,535 and rejects 65,536.
+# Lab specs: https://docs.aws.amazon.com/nova/latest/nova2-userguide/what-is-nova-2.html
 base_model = "amazon/nova-2-lite"
 reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "medium", "high"] }]
 name = "Nova 2 Lite (US)"
@@ -9,3 +16,7 @@ name = "Nova 2 Lite (US)"
 input = 0.33
 output = 2.75
 cache_read = 0.0825
+cache_write = 0.33
+
+[limit]
+output = 65_535

--- a/providers/amazon-bedrock/models/us.amazon.nova-lite-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.amazon.nova-lite-v1:0.toml
@@ -1,5 +1,8 @@
-# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
-# US geo pricing (Price List us-east-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# US cross-Region profile verified by ListInferenceProfiles (us-east-1, 2026-09-08).
+# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Standard us-east-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 base_model = "amazon/nova-lite"
 name = "Nova Lite (US)"
 
@@ -7,3 +10,4 @@ name = "Nova Lite (US)"
 input = 0.06
 output = 0.24
 cache_read = 0.015
+cache_write = 0.06

--- a/providers/amazon-bedrock/models/us.amazon.nova-micro-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.amazon.nova-micro-v1:0.toml
@@ -1,5 +1,8 @@
-# US cross-Region inference profile, verified via ListInferenceProfiles from us-east-1.
-# US geo pricing (Price List us-east-1 standard): input/output/cache-read USD per 1M tokens; Nova has no cache-write charge.
+# US cross-Region profile verified by ListInferenceProfiles (us-east-1, 2026-09-08).
+# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
+# Standard us-east-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
+# Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 base_model = "amazon/nova-micro"
 name = "Nova Micro (US)"
 
@@ -7,3 +10,4 @@ name = "Nova Micro (US)"
 input = 0.035
 output = 0.14
 cache_read = 0.00875
+cache_write = 0.035

--- a/providers/amazon-bedrock/models/us.amazon.nova-premier-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.amazon.nova-premier-v1:0.toml
@@ -1,13 +1,16 @@
 # US cross-Region profile verified by ListInferenceProfiles (us-east-1, 2026-09-08).
-# Model: https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html
+# Profile: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-premier.html
 # Pricing: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/us-east-1/index.json
 # Standard us-east-1 reference rates, USD/MTok; rates vary by source Region. Cache writes billed at input rate; no surcharge.
 # Cache billing: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
-base_model = "amazon/nova-pro"
-name = "Nova Pro (US)"
+# Live Converse (2026-09-09): Legacy access gate denies accounts without use in the last 30 days; profile retained for existing users.
+base_model = "amazon/nova-premier"
+name = "Nova Premier (US)"
+status = "deprecated"
+structured_output = false
 
 [cost]
-input = 0.80
-output = 3.20
-cache_read = 0.20
-cache_write = 0.80
+input = 2.50
+output = 12.50
+cache_read = 0.625
+cache_write = 2.50


### PR DESCRIPTION
## Summary

Amazon Nova-only split of #6637, based on current `dev`.

- Correct Nova 2 Lite date, cutoff, modalities, exact lab output, and Bedrock-only 65,535 output cap.
- Correct Nova V1 lab output to 10,000 after live boundary checks.
- Add full cache pricing: writes are billed at input price with no additional surcharge; reads retain discounted rates.
- Add the documented US Nova Premier profile and complete lab metadata, marked `deprecated` because AWS applies a legacy/recent-use access gate.
- Preserve all 18 existing IDs and routes.

Sources are in leading TOML comments, including Nova guides, AWS model cards, public pricing, and [cache billing](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html).

## Validation

- `bun validate`
- `git diff --check`
- No model deletions or route changes
