### PR TITLE
fix(amazon-bedrock): correct open model catalog

### DIFF
--- a/models/google/gemma-3-12b-it.toml
+++ b/models/google/gemma-3-12b-it.toml
@@ -8,7 +8,7 @@ last_updated = "2025-03-12"
 attachment = true
 reasoning = false
 temperature = true
-tool_call = false
+tool_call = true
 knowledge = "2024-08"
 open_weights = true
 

--- a/models/google/gemma-3-12b-it.toml
+++ b/models/google/gemma-3-12b-it.toml
@@ -1,0 +1,25 @@
+# https://ai.google.dev/gemma/docs/core/model_card_3
+# https://blog.google/technology/developers/gemma-3/
+name = "Gemma 3 12B IT"
+description = "Open multimodal Gemma instruction model for multilingual text generation and image understanding"
+family = "gemma"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+knowledge = "2024-08"
+open_weights = true
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/google/gemma-3-12b-it"

--- a/models/google/gemma-3-27b-it.toml
+++ b/models/google/gemma-3-27b-it.toml
@@ -8,7 +8,7 @@ last_updated = "2025-03-12"
 attachment = true
 reasoning = false
 temperature = true
-tool_call = false
+tool_call = true
 knowledge = "2024-08"
 open_weights = true
 

--- a/models/google/gemma-3-27b-it.toml
+++ b/models/google/gemma-3-27b-it.toml
@@ -1,0 +1,25 @@
+# https://ai.google.dev/gemma/docs/core/model_card_3
+# https://blog.google/technology/developers/gemma-3/
+name = "Gemma 3 27B IT"
+description = "Largest open Gemma 3 instruction model for multilingual text generation and visual understanding"
+family = "gemma"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+knowledge = "2024-08"
+open_weights = true
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/google/gemma-3-27b-it"

--- a/models/google/gemma-3-4b-it.toml
+++ b/models/google/gemma-3-4b-it.toml
@@ -8,7 +8,7 @@ last_updated = "2025-03-12"
 attachment = true
 reasoning = false
 temperature = true
-tool_call = false
+tool_call = true
 knowledge = "2024-08"
 open_weights = true
 

--- a/models/google/gemma-3-4b-it.toml
+++ b/models/google/gemma-3-4b-it.toml
@@ -1,0 +1,25 @@
+# https://ai.google.dev/gemma/docs/core/model_card_3
+# https://blog.google/technology/developers/gemma-3/
+name = "Gemma 3 4B IT"
+description = "Open multimodal Gemma instruction model for efficient text generation and image understanding"
+family = "gemma"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = false
+knowledge = "2024-08"
+open_weights = true
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/google/gemma-3-4b-it"

--- a/providers/amazon-bedrock/models/deepseek.r1-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.r1-v1:0.toml
@@ -1,24 +1,14 @@
-name = "DeepSeek-R1"
-description = "DeepSeek reasoning model for multi-step analysis, math, coding, and tools"
-family = "deepseek-thinking"
-release_date = "2025-01-20"
-last_updated = "2025-05-29"
-attachment = false
-reasoning = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-deepseek-deepseek-r1.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-deepseek.html
+# Runtime accepts 32,768 output tokens; 8,192 is the quality recommendation.
+# R1 has always-on reasoning and no reasoning toggle, effort, or budget parameter.
+# US Standard pricing; use the us.deepseek.r1-v1:0 profile for on-demand Converse.
+# Live US profile (us-east-1, 2026-09-09): toolConfig rejected with HTTP 400,
+# "This model doesn't support tool use." with AUTO or omitted toolChoice.
+base_model = "deepseek/deepseek-r1"
 reasoning_options = []
-temperature = true
-knowledge = "2024-07"
-tool_call = true
-open_weights = false
+tool_call = false
 
 [cost]
 input = 1.35
 output = 5.4
-
-[limit]
-context = 128_000
-output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
@@ -1,16 +1,11 @@
-name = "DeepSeek-V3.1"
-description = "DeepSeek chat model for instruction following, coding, and analysis"
-family = "deepseek"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-deepseek-deepseek-v3-1.html
+# Runtime ID; Mantle uses deepseek.v3.1. Prices are US Standard.
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default mode, matching V3.2.
+# Live 2026-09-09: high returns reasoningContent; maxTokens=81920 accepted (card's 8K is not the cap).
+base_model = "deepseek/deepseek-v3.1"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-knowledge = "2024-07"
-tool_call = true
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.58
@@ -19,7 +14,3 @@ output = 1.68
 [limit]
 context = 163_840
 output = 81_920
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
@@ -5,6 +5,7 @@
 base_model = "deepseek/deepseek-v3.1"
 last_updated = "2025-09-18"
 reasoning_options = [{ type = "toggle" }]
+interleaved = true
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/deepseek.v3.2.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3.2.toml
@@ -6,6 +6,7 @@
 base_model = "deepseek/deepseek-v3.2"
 last_updated = "2026-02-06"
 reasoning_options = [{ type = "toggle" }]
+interleaved = true
 
 [cost]
 input = 0.62

--- a/providers/amazon-bedrock/models/deepseek.v3.2.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3.2.toml
@@ -1,16 +1,11 @@
-name = "DeepSeek-V3.2"
-description = "DeepSeek chat model for instruction following, coding, and analysis"
-family = "deepseek"
-release_date = "2026-02-06"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-deepseek-deepseek-v3-2.html
+# https://github.com/aws-samples/bedrock-claude-chatbot/blob/eeb2fa35339081d34ea9caa4e4d39cf1c189770a/agent/chat_agent.py
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default non-thinking mode.
+# Live 2026-09-09: high/omitted returns/omits reasoningContent; maxTokens=81920 accepted.
+# Runtime Converse; US Standard pricing.
+base_model = "deepseek/deepseek-v3.2"
 last_updated = "2026-02-06"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-knowledge = "2024-07"
-tool_call = true
-structured_output = true
-open_weights = true
+reasoning_options = [{ type = "toggle" }]
 
 [cost]
 input = 0.62
@@ -19,7 +14,3 @@ output = 1.85
 [limit]
 context = 163_840
 output = 81_920
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/global.xai.grok-4.6.toml
+++ b/providers/amazon-bedrock/models/global.xai.grok-4.6.toml
@@ -1,4 +1,6 @@
-# Source: AWS Bedrock Grok 4.6 model card — Runtime profiles, pricing, and capabilities.
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html
+# Runtime Converse profile; Global CRIS Standard pricing. Structured outputs are Mantle-only.
+# Effort: additionalModelRequestFields.reasoning.effort = low|medium|high|xhigh, matching the US profile.
 base_model = "xai/grok-4.6"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "Grok 4.6 (Global)"

--- a/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
@@ -3,6 +3,7 @@
 # Live Converse (us-east-1, 2026-09-09): forced toolUse works, but native toolResult continuation fails with a role-alternation error.
 # Tool calling remains disabled because a complete native tool-use round trip is unavailable.
 base_model = "google/gemma-3-12b-it"
+tool_call = false
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
@@ -1,24 +1,13 @@
-name = "Google Gemma 3 12B"
-description = "Open Gemma instruction model for efficient chat and self-hosted deployments"
-family = "gemma"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = false
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-12b-it.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live Converse (us-east-1, 2026-09-09): forced toolUse works, but native toolResult continuation fails with a role-alternation error.
+# Tool calling remains disabled because a complete native tool-use round trip is unavailable.
+base_model = "google/gemma-3-12b-it"
 structured_output = true
-knowledge = "2024-12"
-open_weights = false
 
 [cost]
-input = 0.049999999999999996
-output = 0.09999999999999999
+input = 0.09
+output = 0.29
 
 [limit]
-context = 131072
-output = 8192
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+output = 8_192

--- a/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
@@ -1,24 +1,15 @@
-name = "Google Gemma 3 27B Instruct"
-description = "Open Gemma instruction model for efficient chat and self-hosted deployments"
-family = "gemma"
-attachment = true
-reasoning = false
-tool_call = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-27b-pt.html
+# AWS's card title says PT, but its programmatic ID and discovery name specify IT.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live Converse (us-east-1, 2026-09-09): forced toolUse works, but native toolResult continuation fails with a role-alternation error.
+# Tool calling remains disabled because a complete native tool-use round trip is unavailable.
+base_model = "google/gemma-3-27b-it"
 structured_output = true
-temperature = true
-knowledge = "2025-07"
-release_date = "2025-07-27"
-last_updated = "2025-07-27"
-open_weights = true
 
 [cost]
-input = 0.12
-output = 0.2
+input = 0.23
+output = 0.38
 
 [limit]
 context = 202_752
 output = 8_192
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
@@ -4,6 +4,7 @@
 # Live Converse (us-east-1, 2026-09-09): forced toolUse works, but native toolResult continuation fails with a role-alternation error.
 # Tool calling remains disabled because a complete native tool-use round trip is unavailable.
 base_model = "google/gemma-3-27b-it"
+tool_call = false
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/google.gemma-3-4b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-4b-it.toml
@@ -1,22 +1,12 @@
-name = "Gemma 3 4B IT"
-description = "Open Gemma instruction model for efficient chat and self-hosted deployments"
-family = "gemma"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-open_weights = false
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-4b-it.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live Converse (us-east-1, 2026-09-09): forced toolUse works, but native toolResult continuation fails with a role-alternation error.
+# Tool calling remains disabled because a complete native tool-use round trip is unavailable.
+base_model = "google/gemma-3-4b-it"
 
 [cost]
 input = 0.04
 output = 0.08
 
 [limit]
-context = 128_000
 output = 4_096
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/google.gemma-3-4b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-4b-it.toml
@@ -3,6 +3,7 @@
 # Live Converse (us-east-1, 2026-09-09): forced toolUse works, but native toolResult continuation fails with a role-alternation error.
 # Tool calling remains disabled because a complete native tool-use round trip is unavailable.
 base_model = "google/gemma-3-4b-it"
+tool_call = false
 
 [cost]
 input = 0.04

--- a/providers/amazon-bedrock/models/google.gemma-4-26b-a4b.toml
+++ b/providers/amazon-bedrock/models/google.gemma-4-26b-a4b.toml
@@ -1,0 +1,19 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-4-26b-a4b.html
+# https://github.com/aws-samples/bedrock-claude-chatbot/blob/eeb2fa35339081d34ea9caa4e4d39cf1c189770a/agent/chat_agent.py
+# Effort: reasoning.effort = none|high on Mantle Responses, matching the Gemma 4 31B surface.
+# Live 2026-09-09: high returns reasoning; strict JSON schema and max_output_tokens=32768 accepted.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.13
+output = 0.40
+
+[modalities]
+input = ["text", "image", "video"]
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/google.gemma-4-31b.toml
+++ b/providers/amazon-bedrock/models/google.gemma-4-31b.toml
@@ -1,0 +1,19 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-4-31b.html
+# https://github.com/aws-samples/bedrock-claude-chatbot/blob/eeb2fa35339081d34ea9caa4e4d39cf1c189770a/agent/chat_agent.py
+# Effort: reasoning.effort = none|high on Mantle Responses.
+# Live 2026-09-09: high returns reasoning, none omits it; strict JSON schema and max_output_tokens=32768 accepted.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "google/gemma-4-31b-it"
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.14
+output = 0.40
+
+[modalities]
+input = ["text", "image", "video"]
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/google.gemma-4-e2b.toml
+++ b/providers/amazon-bedrock/models/google.gemma-4-e2b.toml
@@ -1,0 +1,19 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-4-e2b.html
+# Effort: reasoning.effort = none|high on Mantle Responses, matching the Gemma 4 31B surface.
+# AWS recommends high to keep thinking in the reasoning channel.
+# Live 2026-09-09: high returns reasoning; strict JSON schema and max_output_tokens=8192 accepted.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "google/gemma-4-E2B-it"
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.04
+output = 0.08
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
@@ -1,24 +1,10 @@
-name = "MiniMax M2.1"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
-family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
-attachment = false
-reasoning = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-1.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# MiniMax M2.1 has always-on thinking, matching the first-party API.
+base_model = "minimax/MiniMax-M2.1"
 reasoning_options = []
-temperature = true
-tool_call = true
-structured_output = false
-open_weights = true
+structured_output = true
 
 [cost]
 input = 0.30
 output = 1.20
-
-[limit]
-context = 204_800
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
@@ -1,8 +1,10 @@
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-1.html
 # https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
 # MiniMax M2.1 has always-on thinking, matching the first-party API.
+# Live Converse 2026-09-11: reasoningContent returned and outputConfig.textFormat enforced a JSON schema.
 base_model = "minimax/MiniMax-M2.1"
 reasoning_options = []
+interleaved = true
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
@@ -2,9 +2,11 @@
 # https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
 # MiniMax M2.5 has always-on thinking, matching the first-party API.
 # Live 2026-09-09: maxTokens=98304 accepted and reasoningContent returned with no reasoning configuration.
+# Live Converse 2026-09-11: outputConfig.textFormat enforced a JSON schema.
 base_model = "minimax/MiniMax-M2.5"
 last_updated = "2026-03-18"
 reasoning_options = []
+interleaved = true
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
@@ -1,15 +1,11 @@
-name = "MiniMax M2.5"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
-family = "minimax"
-release_date = "2026-03-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# MiniMax M2.5 has always-on thinking, matching the first-party API.
+# Live 2026-09-09: maxTokens=98304 accepted and reasoningContent returned with no reasoning configuration.
+base_model = "minimax/MiniMax-M2.5"
 last_updated = "2026-03-18"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-tool_call = true
-structured_output = false
-open_weights = true
+structured_output = true
 
 [cost]
 input = 0.30
@@ -18,7 +14,3 @@ output = 1.20
 [limit]
 context = 196_608
 output = 98_304
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.toml
@@ -1,8 +1,10 @@
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2.html
 # https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
 # MiniMax M2 has always-on thinking, matching the first-party API.
+# Live Converse 2026-09-11: reasoningContent returned and outputConfig.textFormat enforced a JSON schema.
 base_model = "minimax/MiniMax-M2"
 reasoning_options = []
+interleaved = true
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.toml
@@ -1,15 +1,9 @@
-name = "MiniMax M2"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
-family = "minimax"
-release_date = "2025-10-27"
-last_updated = "2025-10-27"
-attachment = false
-reasoning = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# MiniMax M2 has always-on thinking, matching the first-party API.
+base_model = "minimax/MiniMax-M2"
 reasoning_options = []
-temperature = true
-tool_call = true
-structured_output = false
-open_weights = true
+structured_output = true
 
 [cost]
 input = 0.30
@@ -18,7 +12,3 @@ output = 1.20
 [limit]
 context = 204_608
 output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -1,17 +1,11 @@
-# See https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html
-name = "Kimi K2 Thinking"
-description = "Kimi reasoning model for long-horizon research, planning, and tool use"
-release_date = "2025-12-02"
-family = "kimi-thinking"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html
+# https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model (always-on thinking)
+# Runtime ID; Mantle uses moonshotai.kimi-k2-thinking. US Standard pricing.
+base_model = "moonshotai/kimi-k2-thinking"
 last_updated = "2025-12-02"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-tool_call = true
 structured_output = true
 interleaved = true
-open_weights = true
 
 [cost]
 input = 0.6
@@ -20,7 +14,3 @@ output = 2.5
 [limit]
 context = 262_143
 output = 16_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
+++ b/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
@@ -1,17 +1,15 @@
-# See https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html
-name = "Kimi K2.5"
-description = "Kimi multimodal agent model for visual understanding, coding, and planning"
-family = "kimi"
-release_date = "2026-02-06"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html
+# https://github.com/aws-samples/bedrock-claude-chatbot/blob/eeb2fa35339081d34ea9caa4e4d39cf1c189770a/agent/chat_agent.py
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default non-thinking mode.
+# Live 2026-09-09: high/omitted returns/omits reasoningContent; maxTokens=16384 accepted.
+# Live Converse 2026-09-09: inferenceConfig.temperature accepts both 0 and 1.
+# Runtime Converse; US Standard pricing.
+base_model = "moonshotai/kimi-k2.5"
+release_date = "2026-01-27"
 last_updated = "2026-02-06"
-attachment = false
-reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
-tool_call = true
-structured_output = true
 interleaved = true
-open_weights = true
 
 [cost]
 input = 0.6
@@ -19,8 +17,7 @@ output = 3
 
 [limit]
 context = 262_143
-output = 16_000
+output = 16_384
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-12b-v2.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-12b-v2.toml
@@ -1,23 +1,17 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-12b-v2-vl-bf16.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live 2026-09-09: maxTokens=8192 accepted; reasoning_config=high returned no reasoningContent.
 name = "NVIDIA Nemotron Nano 12B v2 VL BF16"
 base_model = "nvidia/nemotron-nano-12b-v2-vl"
-family = "nemotron"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = false
 
 [cost]
 input = 0.20
 output = 0.60
 
 [limit]
-context = 128_000
-output = 4_096
+output = 8_192
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
@@ -1,24 +1,15 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nemotron-nano-3-30b.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live 2026-09-09: maxTokens=8192 accepted; chat_template_kwargs.enable_thinking had no visible effect.
 name = "NVIDIA Nemotron Nano 3 30B"
 base_model = "nvidia/nemotron-3-nano-30b-a3b"
-family = "nemotron"
-release_date = "2025-12-23"
 last_updated = "2025-12-23"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.06
 output = 0.24
 
 [limit]
-context = 128_000
-output = 4_096
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 8_192

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-9b-v2.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-9b-v2.toml
@@ -1,23 +1,14 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-9b-v2.html
+# Live 2026-09-09: maxTokens=8192 accepted; tested JSON thinking controls had no visible effect.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
 name = "NVIDIA Nemotron Nano 9B v2"
 base_model = "nvidia/nemotron-nano-9b-v2"
-family = "nemotron"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = false
 
 [cost]
 input = 0.06
 output = 0.23
 
 [limit]
-context = 128_000
-output = 4_096
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 8_192

--- a/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
@@ -1,24 +1,14 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nemotron-super-3-120b.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live 2026-09-09: maxTokens=131072 accepted; chat_template_kwargs.enable_thinking had no visible effect.
 name = "NVIDIA Nemotron 3 Super 120B A12B"
 base_model = "nvidia/nemotron-3-super-120b-a12b"
-family = "nemotron"
-release_date = "2026-03-11"
-last_updated = "2026-03-11"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.15
 output = 0.65
 
 [limit]
-context = 262_144
 output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
@@ -1,24 +1,13 @@
-name = "Qwen3 235B A22B 2507"
-description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-235b-a22b-2507.html
+# https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507 (non-thinking Instruct variant)
+# Runtime ID; US Standard pricing.
+base_model = "alibaba/qwen3-235b-a22b-instruct-2507"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-04"
-tool_call = true
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.22
 output = 0.88
 
 [limit]
-context = 262_144
 output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
@@ -1,25 +1,15 @@
-name = "Qwen3 32B (dense)"
-description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html
+# Toggle: additionalModelRequestFields.reasoning_config = low|high (off|on).
+# Live 2026-09-09: high returns reasoningContent, low omits it; maxTokens=16384 accepted.
+# Runtime ID; US Standard pricing. No verified Bedrock reasoning-token budget.
+base_model = "alibaba/qwen3-32b"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-knowledge = "2024-04"
-tool_call = true
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.15
 output = 0.6
 
 [limit]
-context = 16_384
-output = 16_384
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 32_768

--- a/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
@@ -5,6 +5,7 @@
 base_model = "alibaba/qwen3-32b"
 last_updated = "2025-09-18"
 reasoning_options = [{ type = "toggle" }]
+interleaved = true
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
@@ -1,24 +1,13 @@
-name = "Qwen3 Coder 30B A3B Instruct"
-description = "Qwen coding model for software agents, repository edits, and code reasoning"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-30b-a3b-instruct.html
+# Runtime ID; US Standard pricing.
+base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
+release_date = "2025-07-31"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-04"
-tool_call = true
 structured_output = true
-open_weights = false
 
 [cost]
 input = 0.15
 output = 0.6
 
 [limit]
-context = 262_144
 output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
@@ -1,24 +1,13 @@
-name = "Qwen3 Coder 480B A35B Instruct"
-description = "Qwen coding model for software agents, repository edits, and code reasoning"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-480b-a35b-instruct.html
+# AWS Price List: USW2-Qwen3Coder-480B-A35B-{input,output}-tokens (Standard).
+base_model = "alibaba/qwen3-coder-480b-a35b-instruct"
+release_date = "2025-07-23"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-04"
-tool_call = true
 structured_output = true
-open_weights = true
 
 [cost]
-input = 0.22
+input = 0.45
 output = 1.8
 
 [limit]
 context = 131_072
-output = 65_536
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-next.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-next.toml
@@ -1,24 +1,9 @@
-name = "Qwen3 Coder Next"
-description = "Qwen coding model for software agents, repository edits, and code reasoning"
-family = "qwen"
-release_date = "2026-02-06"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html
+# https://huggingface.co/Qwen/Qwen3-Coder-Next (explicitly non-thinking)
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "alibaba/qwen3-coder-next"
 last_updated = "2026-02-06"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [cost]
-input = 0.22
-output = 1.8
-
-[limit]
-context = 131_072
-output = 65_536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+input = 0.50
+output = 1.20

--- a/providers/amazon-bedrock/models/qwen.qwen3-next-80b-a3b.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-next-80b-a3b.toml
@@ -1,23 +1,15 @@
-name = "Qwen/Qwen3-Next-80B-A3B-Instruct"
-description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-next-80b-a3b.html
+# https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct (non-thinking Instruct variant)
+# https://aws.amazon.com/bedrock/pricing/ (US Standard: 0.15/1.20; Mantle has separate SKUs)
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+release_date = "2025-09-11"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = false
 
 [cost]
-input = 0.14
-output = 1.4
+input = 0.15
+output = 1.20
 
 [limit]
-context = 262_000
+context = 262_144
 output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-vl-235b-a22b.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-vl-235b-a22b.toml
@@ -1,23 +1,13 @@
-name = "Qwen/Qwen3-VL-235B-A22B-Instruct"
-description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
-family = "qwen"
-release_date = "2025-10-04"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-vl-235b-a22b.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "alibaba/qwen3-vl-235b-a22b-instruct"
 last_updated = "2025-11-25"
-attachment = true
-reasoning = false
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = false
+structured_output = false
 
 [cost]
-input = 0.3
-output = 1.5
+input = 0.53
+output = 2.66
 
 [limit]
-context = 262_000
+context = 262_144
 output = 262_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-vl-235b-a22b.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-vl-235b-a22b.toml
@@ -1,8 +1,8 @@
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-vl-235b-a22b.html
 # https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live Converse 2026-09-11: outputConfig.textFormat enforced a JSON schema.
 base_model = "alibaba/qwen3-vl-235b-a22b-instruct"
 last_updated = "2025-11-25"
-structured_output = false
 
 [cost]
 input = 0.53

--- a/providers/amazon-bedrock/models/us.deepseek.r1-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.deepseek.r1-v1:0.toml
@@ -1,6 +1,12 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-deepseek.html
+# R1 has always-on reasoning; the API accepts 32,768 output tokens (8,192 recommended).
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-deepseek-deepseek-r1.html
+# Live Converse (us-east-1, 2026-09-09): toolConfig rejected with HTTP 400,
+# "This model doesn't support tool use." with AUTO or omitted toolChoice.
 base_model = "deepseek/deepseek-r1"
 reasoning_options = []
 name = "DeepSeek-R1 (US)"
+tool_call = false
 
 [cost]
 input = 1.35

--- a/providers/amazon-bedrock/models/us.xai.grok-4.6.toml
+++ b/providers/amazon-bedrock/models/us.xai.grok-4.6.toml
@@ -1,4 +1,7 @@
-# Source: AWS Bedrock Grok 4.6 model card — Runtime profiles, pricing, and capabilities.
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html
+# Runtime Converse profile; Geo CRIS Standard pricing. Structured outputs are Mantle-only.
+# Effort: additionalModelRequestFields.reasoning.effort = low|medium|high|xhigh.
+# Live 2026-09-09: nested effort=high returns reasoningContent; maxTokens=500000 accepted.
 base_model = "xai/grok-4.6"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "Grok 4.6 (US)"

--- a/providers/amazon-bedrock/models/xai.grok-4.3.toml
+++ b/providers/amazon-bedrock/models/xai.grok-4.3.toml
@@ -1,3 +1,6 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-3.html
+# Mantle Responses only for this catalog route; US Standard pricing.
+# Effort: reasoning.effort = none|low|medium|high.
 base_model = "xai/grok-4.3"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 last_updated = "2026-06-28"
@@ -8,7 +11,6 @@ output = 2.50
 cache_read = 0.20
 
 [limit]
-context = 1_000_000
 output = 131_072
 
 [modalities]

--- a/providers/amazon-bedrock/models/xai.grok-4.6.toml
+++ b/providers/amazon-bedrock/models/xai.grok-4.6.toml
@@ -1,4 +1,6 @@
 # Source: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html
+# Mantle Responses; US Standard in-Region pricing.
+# Effort: reasoning.effort = low|medium|high|xhigh (always on).
 base_model = "xai/grok-4.6"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 last_updated = "2026-08-18"

--- a/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
@@ -1,25 +1,11 @@
-name = "GLM-4.7-Flash"
-description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
-family = "glm-flash"
-release_date = "2026-01-19"
-last_updated = "2026-01-19"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-tool_call = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-4-7-flash.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default mode, matching GLM-4.7.
+# Live 2026-09-09: high returns reasoningContent; maxTokens=131072 accepted (card's 4K is not the cap).
+base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
-knowledge = "2025-04"
-open_weights = true
 
 [cost]
 input = 0.07
 output = 0.40
-
-[limit]
-context = 200_000
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
@@ -4,6 +4,7 @@
 # Live 2026-09-09: high returns reasoningContent; maxTokens=131072 accepted (card's 4K is not the cap).
 base_model = "zhipuai/glm-4.7-flash"
 reasoning_options = [{ type = "toggle" }]
+interleaved = true
 structured_output = true
 
 [cost]

--- a/providers/amazon-bedrock/models/zai.glm-4.7.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7.toml
@@ -1,28 +1,13 @@
-name = "GLM-4.7"
-description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-tool_call = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-4-7.html
+# https://github.com/danny-avila/LibreChat/issues/11974 (Bedrock Converse request)
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default non-thinking mode.
+# Live 2026-09-09: high/omitted returns/omits reasoningContent; maxTokens=131072 accepted.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "zhipuai/glm-4.7"
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
-knowledge = "2025-04"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+interleaved = true
 
 [cost]
 input = 0.60
 output = 2.20
-
-[limit]
-context = 204_800
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/zai.glm-5.toml
+++ b/providers/amazon-bedrock/models/zai.glm-5.toml
@@ -1,18 +1,12 @@
-name = "GLM-5"
-description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
-release_date = "2026-03-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default mode, matching GLM-4.7.
+# Live 2026-09-09: high returns reasoningContent; maxTokens=131072 accepted.
+base_model = "zhipuai/glm-5"
 last_updated = "2026-03-18"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-tool_call = true
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+interleaved = true
 
 [cost]
 input = 1.00
@@ -20,8 +14,3 @@ output = 3.20
 
 [limit]
 context = 202_752
-output = 101_376
-
-[modalities]
-input = ["text"]
-output = ["text"]


### PR DESCRIPTION
## Summary

Remaining open-model split of #6637, based on current `dev`: DeepSeek, Qwen, xAI, NVIDIA, Google, MiniMax, Z.AI, and Moonshot.

- Audit all 30 existing entries; preserve every existing ID and route.
- Correct confirmed prices, dates, modalities, open-weight facts, limits, and host reasoning controls.
- Convert third-party provider definitions to override-only `base_model` entries.
- Add three live-verified Gemma 4 Mantle Responses models and complete Gemma 3 lab metadata.
- Keep Gemma 3 `tool_call=false`: forced calls can be emitted, but valid native tool-result continuations fail.
- Keep Bedrock DeepSeek R1 `tool_call=false` after explicit API rejection.
- Retain Kimi K2.5’s temperature override after live Converse accepted both `temperature=0` and `temperature=1`.

Unresolved NVIDIA controls remain conservative rather than inventing caller options. New Chat/GovCloud candidates with incomplete controls or client-route support are deferred.

Sources are in leading TOML comments, including AWS model cards and public pricing.

## Validation

- `bun validate`
- All new lab entries contain required capabilities, modalities, context, and output
- `git diff --check`
- No model deletions or route changes
