### PR TITLE
feat(coralbricks): add GLM 5.3 Flash (glm-5.3-flash-fp4)

### DIFF
--- a/providers/coralbricks/models/glm-5.3-flash-fp4.toml
+++ b/providers/coralbricks/models/glm-5.3-flash-fp4.toml
@@ -1,0 +1,14 @@
+base_model = "zhipuai/glm-5.3-flash"
+name = "GLM 5.3 Flash FP4"
+
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+interleaved = true
+
+[limit]
+context = 1_048_576
+output = 131_072
+
+[cost]
+input = 0.15
+output = 0.5
+cache_read = 0


### PR DESCRIPTION
Adds GLM 5.3 Flash (`glm-5.3-flash-fp4`) to the CoralBricks provider, following the existing `glm-5.3-fp4` entry and inheriting the lab baseline from `zhipuai/glm-5.3-flash` (always reasons, effort `low|high|max`, vision).

Live on the CoralBricks gateway, verified in the public `/v1/models` plus a chat smoke and an image-input smoke (`image_tokens` returned):

| field | value |
|---|---|
| context | 1,048,576 (1M) |
| max output | 131,072 |
| input | $0.15 / M |
| output | $0.50 / M |
| cache_read | 0 (cached input is free) |
| reasoning | effort `low` / `high` / `max` |

Our rate matches the lab's list price ($0.15 / $0.50). Single new model TOML, override-only, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)