### PR TITLE
docs(cache): document prompt-cache strategy batch 09 (kilo-llmtr)

### DIFF
--- a/providers/llama/provider.toml
+++ b/providers/llama/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic prefix/KV cache — no key required for hits; shared keys route to warm backends.
+# Cache headers: none — Use no cache headers.
+# Cache body: Use body `prompt_cache_key` (replaces deprecated user) — accepted on Chat Completions per the prompt-caching guide; add a stable per-prefix value at scale.
+# Cache policy: stable content first, volatile last; hits surface at usage.prompt_tokens_details.cached_tokens and bill at the reduced cached rate.
+# Docs: https://dev.meta.ai/docs/prompt-caching
 # POST /compat/v1/chat/completions follows Meta's published Chat request
 # schema, which lists no toggle, effort, or reasoning-token-budget field.
 # https://llama.developer.meta.com/docs/api-reference/chat-completions (accessed 2026-06-25)

--- a/providers/llmgateway-providers/provider.toml
+++ b/providers/llmgateway-providers/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): gateway replay plus translation — same endpoint as llmgateway with a provider-pinned catalog.
+# Cache headers: Use headers `x-llmgateway-cache`/`x-no-cache` — HIT signals gateway replay; per-request bypass is available.
+# Cache body: none — Use no body key field; the gateway derives its own key from request params and translates cache_control per upstream.
+# Cache policy: $0 byte-identical replay (opt-in per project, TTL default 60s); stable prefix first; provider-pinned `provider/model-id` on the same endpoint.
+# Docs: https://docs.llmgateway.io/features/caching
 # The provider-pinned LLM Gateway catalog: one entry per upstream provider
 # mapping, addressed as `provider/model-id` — the format the gateway accepts to
 # pin a request to a specific upstream provider. The aggregated, auto-routed

--- a/providers/llmgateway/provider.toml
+++ b/providers/llmgateway/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): gateway replay plus translation — $0 byte-identical replay plus provider cache-control translation/injection (Automatic/Client-managed/Disabled).
+# Cache headers: Use headers `x-llmgateway-cache`/`x-no-cache` — HIT signals gateway replay; per-request bypass is available.
+# Cache body: none — Use no body key field; the gateway derives its own key from request params.
+# Cache policy: opt-in per project, TTL default 60s; stable prefix first; verify via metadata.cached and usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.llmgateway.io/features/caching
 # POST /v1/chat/completions accepts $.reasoning_effort = none|minimal|low|
 # medium|high|xhigh|max. Its raw schema lists $.reasoning.effort = low|medium|
 # high; the two effort paths are mutually exclusive. $.reasoning.max_tokens

--- a/providers/llmtech/provider.toml
+++ b/providers/llmtech/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic prefix cache — documented as automatic only with no key param.
+# Cache headers: none — Use no cache headers.
+# Cache body: none — Use no body key field; no key param is in the request surface.
+# Cache policy: 1584-token blocks with lazy materialization (prefix must repeat ~3x to pay off); system prompt and tools byte-identical in stable order, volatile last; cached prefixes bill at the cached-input rate.
+# Docs: https://llmtech.eu/models/qwen3.8-27b
 name = "LLM Tech"
 env = ["LLMTECH_API_KEY"]
 npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
Batch 09 of the provider prompt-cache audit (11 providers). Header-only changes to each provider.toml:

| provider | verdict | mechanism |
|---|---|---|
| kilo | TOLERATES | OpenAI-compatible passthrough to upstream; per-model cached rates billed, no gateway cache controls (https://kilo.ai/docs/gateway) |
| kimi-for-coding | TOLERATES | OpenAI/Anthropic passthrough; implicit context cache invalidated on model switch, no cache params (https://www.kimi.com/code/docs/en/kimi-code/models.html) |
| klokintegration | TOLERATES | OpenAI-compatible passthrough; no cache controls or cached pricing documented (https://klokintegration.se/docs/ai-api) |
| kosmik | SUPPORTS | automatic prefix cache; usage.cache_read_tokens on chat plus published cache_read rate (https://api.koscompute.com/docs/) |
| kuae-cloud-coding-plan | TOLERATES | OpenAI-compatible passthrough on subscription plan; no cache controls documented (https://docs.mthreads.com/kuaecloud/kuaecloud-doc-online/coding_plan/) |
| lilac | SUPPORTS | automatic prefix cache; repeated prefixes billed at the published cache-read rate (https://docs.getlilac.com/inference/pricing) |
| llama | SUPPORTS | automatic prefix/KV cache, no key required; usage.cached_tokens plus optional prompt_cache_key (https://dev.meta.ai/docs/prompt-caching) |
| llmgateway | NATIVE_OTHER | gateway-level caching (byte-identical $0 gateway cache plus provider cache-control translation/injection), not chat params (https://docs.llmgateway.io/features/caching) |
| llmgateway-providers | NATIVE_OTHER | same gateway-level caching as llmgateway; provider-pinned catalog (https://docs.llmgateway.io/features/caching) |
| llmtech | SUPPORTS | automatic prompt caching in 1584-token blocks; cached prefixes billed at the cached-input rate (https://llmtech.eu/models/qwen3.8-27b) |
| llmtr | TOLERATES | OpenAI-compatible passthrough; per-model cached rates billed, no gateway cache controls documented (https://llmtr.com/docs) |

bun validate passes. Note (out of scope, header-only batch): lilac pricing page lists GLM 5.2 cache-read at $0.17/MTok while the catalog has cache_read = 0.27.