### PR TITLE
docs(cache): prompt-cache strategy batch 05

### DIFF
--- a/providers/crusoe/provider.toml
+++ b/providers/crusoe/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): none — MemoryAlloy cluster-wide KV cache with cache-aware routing is automatic; the chat API defines no cache request field
+# Use headers: none
+# Use body: none
+# Cache policy: repeat identical prefixes on the same model so requests route to warm nodes; no client control or retention window documented
+# Docs: https://docs.crusoecloud.com/serverless-inference/overview
 name = "Crusoe"
 env = ["CRUSOE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/databricks/provider.toml
+++ b/providers/databricks/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): body `cache_control` breakpoints on Databricks-hosted Claude models — `{"type": "ephemeral"}` on stable text/reasoning/image/tool content
+# Use headers: none
+# Use body: `cache_control` — `{"type": "ephemeral"}` marker on content blocks in `messages.content` and `tools`; Claude-hosted models only
+# Cache policy: keep identical prefixes on the same model with breakpoints set; reuse reports `cache_read_input_tokens`, writes report `cache_creation_input_tokens`
+# Docs: https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models
 name = "Databricks"
 npm = "@ai-sdk/openai-compatible"
 # Raw Chat is POST `/serving-endpoints/{model}/invocations`: GPT/Gemini 3 use

--- a/providers/deepinfra/provider.toml
+++ b/providers/deepinfra/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): body `prompt_cache_key` — stable per-session string scoping reuse to an identical prefix on the same model; supported models only
+# Use headers: none
+# Use body: `prompt_cache_key` plus `prompt_cache_options` (`mode: explicit`, `ttl: 5m|1h`) to retain the prefix; `prompt_cache_breakpoint` (`mode: explicit`) on a content part ends the retained prefix
+# Cache policy: automatic prefix match plus guaranteed retention windows — keep stable content first with a byte-identical prefix; the first request carrying `ttl` writes the window, reuse omits `ttl` and bills the cache-read rate (`prompt_tokens_details.cached_tokens`/`cache_write_tokens`)
+# Docs: https://docs.deepinfra.com/chat/prompt-caching
 # Reasoning HTTP format (accessed 2026-06-25):
 # OpenAI Chat: POST https://api.deepinfra.com/v1/openai/chat/completions
 # (also POST /v1/chat/completions). Toggle: reasoning.enabled = true|false;

--- a/providers/deepseek/provider.toml
+++ b/providers/deepseek/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): none — on-disk context caching is automatic and enabled by default with no request cache field
+# Use headers: none
+# Use body: none
+# Cache policy: fully match a persisted cache-prefix unit (request-boundary, common-prefix, or fixed-interval unit at 64-token granularity) from the first token; best-effort with no code changes — verify via usage `prompt_cache_hit_tokens` versus `prompt_cache_miss_tokens`
+# Docs: https://api-docs.deepseek.com/guides/kv_cache
 name = "DeepSeek"
 env = ["DEEPSEEK_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/digitalocean/provider.toml
+++ b/providers/digitalocean/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): automatic prefix match on the same model; `X-Model-Affinity` pins router sessions — body `cache_control` on Anthropic routes, `prompt_cache_retention` on OpenAI models (1024+ tokens)
+# Use headers: `X-Model-Affinity` — stable per-session value pinning multi-turn turns to one model for reuse; `none` opts out where supported
+# Use body: `cache_control` ephemeral breakpoints for Anthropic models; `prompt_cache_retention` (`in_memory`|`24h`) for OpenAI models
+# Cache policy: keep an exact token-prefix match with static content first; reuse reports `prompt_tokens_details.cached_tokens` and `cache_read_input_tokens` at the discounted rate
+# Docs: https://docs.digitalocean.com/products/inference/how-to/use-prompt-caching/
 name = "DigitalOcean"
 env = ["DIGITALOCEAN_ACCESS_TOKEN"]
 npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
Batch 05 of prompt-cache audit: documents chat prompt-cache strategy in the leading header comment of 11 provider.toml files. Comment-only change; no keys touched.

| provider | verdict | mechanism |
|---|---|---|
| crossmodel | TOLERATES | OpenAI-compatible gateway, no documented cache control; usage reports cached_tokens |
| crusoe | NATIVE_OTHER | automatic server-side prefix caching via MemoryAlloy cache-aware routing; no prompt_cache_key |
| daoxe | TOLERATES | OpenAI-compatible gateway, no documented cache control |
| databricks | NATIVE_OTHER | Anthropic-style cache_control breakpoints on Claude-hosted models; no prompt_cache_key |
| deepinfra | SUPPORTS | explicit prompt_cache_key plus automatic prefix caching with prompt_cache_retention |
| deepseek | NATIVE_OTHER | automatic on-disk context caching, enabled by default; usage reports prompt_cache_hit_tokens |
| digitalocean | NATIVE_OTHER | automatic prefix caching for open models, Anthropic cache_control, OpenAI prompt_cache_retention |
| dinference | TOLERATES | OpenAI-compatible API, no documented cache control |
| drun | TOLERATES | OpenAI-compatible API, no documented cache control |
| ebcloud | TOLERATES | OpenAI-compatible model API, no documented cache control |
| echo | TOLERATES | narrow OpenAI-compatible text API, no documented cache control; usage carries no cache fields |

Docs URLs are in each header as # Docs. Note: bun validate fails identically on clean origin/dev (pre-existing AuthoredModelShape.deepPartial TypeError in packages/core/src/generate.ts), unrelated to this change.