### PR TITLE
docs(providers): prompt cache batch 01

### DIFF
--- a/providers/302ai/provider.toml
+++ b/providers/302ai/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://doc.302.ai/llms.txt
 name = "302.AI"
 env = ["302AI_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/abacus/provider.toml
+++ b/providers/abacus/provider.toml
@@ -1,3 +1,6 @@
+# Prompt caching (chat): RouteLLM gateway routes POST /v1/chat/completions to the selected model with prompt-cache-aware routing; cache is the routed-model automatic prefix cache.
+# To get a hit: reuse the same routed model with an identical stable prefix and matching tools/order; repeat the identical prefix and confirm via the response usage block where reported.
+# Docs: https://abacus.ai/teams/routellm-apis
 name = "Abacus"
 npm = "@ai-sdk/openai-compatible"
 # Reasoning HTTP format (accessed 2026-06-25):

--- a/providers/abliteration-ai/provider.toml
+++ b/providers/abliteration-ai/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic prompt-prefix cache on POST /v1/chat/completions, active by default; cache reads billed at 10% of input rate.
+# Use headers: `x-abliteration-session-id` — include the same opaque affinity value per conversation on any generation endpoint; with both key and header present the header provides the routing hint.
+# Use body: `prompt_cache_key` — top-level string (e.g. `conv_7d2a9f`) for Chat Completions/Responses; stable per-workload value improving reuse as a routing hint.
+# To get a hit: keep same project+model with identical system/developer instructions, message history/order, tools/order, and reasoning/output settings; place stable content first and let the first request begin returning before parallel calls; confirm via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.abliteration.ai/capabilities/prompt-caching.md
 # Reasoning controls for the whole API surface (verified 2026-07-28):
 # https://docs.abliteration.ai/capabilities/thinking
 # Both models reason by default. Effort ladder, least to most:

--- a/providers/above/provider.toml
+++ b/providers/above/provider.toml
@@ -1,3 +1,6 @@
+# Prompt caching (chat): gateway routes POST /v1/messages and POST /v1/chat/completions (alias delegating to messages) to the selected model; cache is the upstream provider automatic prefix cache with the full discount reflected in billing.
+# To get a hit: pin the same model with direct mode and replay a stable prefix with matching tools/order; confirm per response via `x-input-cache-hit-rate` / `x-input-cache-hit-tokens` plus `x-model-used` and `x-cost-usd`.
+# Docs: https://above.dev/docs
 name = "above.dev"
 env = ["ABOVE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/agentrouter/provider.toml
+++ b/providers/agentrouter/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://agentrouter.org/docs/
 name = "AgentRouter"
 env = ["AGENTROUTER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/agnes/provider.toml
+++ b/providers/agnes/provider.toml
@@ -1,3 +1,6 @@
+# Prompt caching (chat): OpenAI-style chat API with automatic prefix cache; cached input billed at 10% of input price.
+# To get a hit: reuse the same model with an identical stable prefix, appending new content last; confirm via cached-input billing.
+# Docs: https://wiki.agnes-ai.com/en/docs/pricing.md
 name = "Agnes AI"
 env = ["AGNES_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/ai-router/provider.toml
+++ b/providers/ai-router/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://ai-router.dev/openai-compatible-api-gateway/
 name = "AI-ROUTER"
 env = ["AI_ROUTER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/aiand/provider.toml
+++ b/providers/aiand/provider.toml
@@ -1,3 +1,6 @@
+# Prompt caching (chat): automatic prefix cache on POST /v1/chat/completions; repeated prefixes reuse cached input with reduced cached-input billing on models offering a cached rate.
+# To get a hit: reuse the same model with an identical stable prefix and matching tools/order plus matching reasoning_effort, with 1024-token minimum in 128-token increments; confirm via usage.prompt_tokens_details.cached_tokens; for streams include `stream_options: { "include_usage": true }` and read the trailing usage event.
+# Docs: https://docs.aiand.com/models/pricing/
 name = "ai&"
 npm = "@ai-sdk/openai-compatible"
 env = ["AIAND_API_KEY"]

--- a/providers/aihubmix/provider.toml
+++ b/providers/aihubmix/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): automatic 1024-token prefix cache on POST /v1/chat/completions; GPT-5.6 series adds key-assisted matching plus explicit breakpoints with 30-minute minimum retention.
+# Use body: `prompt_cache_key` — top-level string with a stable per-workload value (≈15 req/min per key); `prompt_cache_options` — object with `mode: implicit|explicit` and `ttl: 30m` only; `prompt_cache_breakpoint` — object `{"mode": "explicit"}` inside content blocks to pin the stable-prefix boundary (max 4 new writes per request; reads use the longest match of the recent 50).
+# To get a hit: place fixed long instructions/tools first (≥1024 tokens), keep the same key/model with byte-identical prefix incl. tools order, detail, response_format, and reasoning_effort, and append new messages only; confirm via usage.prompt_tokens_details.cached_tokens; GPT-5.6 writes bill 1.25x and reads 0.1x, with 30-minute minimum retention on GPT-5.6 and 5–10 minute quiet-window retention before that (max 1 h).
+# Docs: https://docs.aihubmix.com/cn/api/GPT-Cache.md
 name = "AIHubMix"
 npm = "@aihubmix/ai-sdk-provider"
 # Raw Chat: $.reasoning_effort = "none"|"minimal"|"low"|"medium"|"high"|"xhigh"; aliases are $.reasoning.effort and integer $.reasoning.max_tokens. "none" disables models that permit it. https://docs.aihubmix.com/cn/api/unified-inference (accessed 2026-06-25)

--- a/providers/aixy/provider.toml
+++ b/providers/aixy/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://docs.aixy-gateway.com/api-reference/inference/create-a-chat-completion.md
 name = "Aixy"
 env = ["AIXY_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/aki-io/provider.toml
+++ b/providers/aki-io/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://aki.io/docs/compatibility/openai-api-compatibility/
 name = "AKI.IO"
 env = ["AKI_IO_API_KEY"]
 npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
Documents chat-completions prompt_cache_key strategy for batch 01 (11 providers), leading-comment only.

| provider | verdict | docs URL | evidence |
|---|---|---|---|
| 302ai | UNKNOWN | https://doc.302.ai | relay proxies upstream lab endpoints; no prompt-cache docs retrievable (doc site unfetchable via fetcher) |
| abacus | TOLERATES | https://abacus.ai/help/api | RouteLLM gateway forwards body to routed model; API reference documents no cache/reasoning fields, no extra-field rejection |
| abliteration-ai | SUPPORTS | https://docs.abliteration.ai/capabilities/prompt-caching.md | dedicated prompt-caching page: prompt_cache_key example + x-abliteration-session-id header; automatic prefix cache at 10% input rate |
| above | NATIVE_OTHER | https://above.dev/docs | automatic upstream cache passthrough; request schema has no client key; reports x-input-cache-hit-rate headers |
| agentrouter | UNKNOWN | https://agentrouter.org/docs/opencode.html | community proxy; docs are client setup guides only, no API field reference |
| agnes | UNKNOWN | https://agnes-ai.com/doc | first-party OpenAI-compatible API; no cache docs; error reference lists no extra-field policy |
| ai-router | UNKNOWN | https://ai-router.dev/openai-compatible-api-gateway/ | gateway docs list no cache fields; no extra-field policy found |
| aiand | UNKNOWN | https://docs.aiand.com/api/chat-completions/ | closed param list on own infra, no client key documented; usage carries optional cached_tokens field |
| aihubmix | SUPPORTS | https://docs.aihubmix.com/cn/api/GPT-Cache.md | GPT-Cache doc with verified prompt_cache_key example (cached_tokens 2816 on repeat request) |
| aixy | REJECTS | https://docs.aixy-gateway.com/api-reference/inference/create-a-chat-completion.md | "Advanced fields without a supported translation are rejected explicitly"; prompt_cache_key absent from ChatCompletionRequest schema |
| aki-io | UNKNOWN | https://aki.io/docs/compatibility/openai-api-compatibility/ | narrow documented param list (model/messages/temperature/max_tokens/stream/stop) on EU-hosted models; no cache docs or extra-field policy |

Notes:
- Web search returned no results; all verdicts based on direct primary-docs fetches.
- abacus TOLERATES and abliteration-ai/aihubmix SUPPORTS re-verified against live docs.
- bun validate fails identically on the clean tree (pre-existing generate.ts AuthoredModelShape.deepPartial TypeError, unrelated); all 11 edited TOMLs parse with unchanged keys.