### PR TITLE
docs(cache): batch 12 prompt-cache chat strategy headers

### DIFF
--- a/providers/nano-gpt/provider.toml
+++ b/providers/nano-gpt/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): implicit auto-cache by default on supporting routes; explicit Claude controls plus `caching: true` routing to a cache-capable provider.
+# Use headers: `anthropic-beta`, `x-prompt-caching-cut-after`.
+# Use body: `caching`, `promptCaching`/`prompt_caching`, inline `cache_control` with `ttl`, `cutAfterMessageIndex`, `stickyprovider`.
+# Prefix: place stable content first and keep prefixes byte-identical; hits in `cache_read_input_tokens` and `prompt_tokens_details.cached_tokens`.
+# Docs: https://docs.nano-gpt.com/api-reference/miscellaneous/prompt-caching
 name = "NanoGPT"
 env = ["NANO_GPT_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/nano-gpt/provider.toml
+++ b/providers/nano-gpt/provider.toml
@@ -1,7 +1,7 @@
-# Cache (chat): implicit auto-cache by default on supporting routes; explicit Claude controls plus `caching: true` routing to a cache-capable provider.
-# Use headers: `anthropic-beta`, `x-prompt-caching-cut-after`.
-# Use body: `caching`, `promptCaching`/`prompt_caching`, inline `cache_control` with `ttl`, `cutAfterMessageIndex`, `stickyprovider`.
-# Prefix: place stable content first and keep prefixes byte-identical; hits in `cache_read_input_tokens` and `prompt_tokens_details.cached_tokens`.
+# Cache key (chat): implicit auto-cache on supporting routes plus `caching: true` routing to a cache-capable provider (sticky by default; `stickyprovider: false` opts out; `:caching`/`:cache`/`:cached` model suffix)
+# Use headers: `anthropic-beta: prompt-caching-2024-07-31` (add `extended-cache-ttl-2025-04-11` for 1h TTL); `x-prompt-caching-cut-after: N` sets the last cached message index
+# Use body: `promptCaching`/`prompt_caching`/`cache_control` helper (`enabled`, `ttl` 5m/1h, `cutAfterMessageIndex`, `stickyProvider`, `explicitCacheControl`); inline `cache_control: {"type": "ephemeral"}` blocks (max 4 per request, Claude models)
+# Cache policy: stable prefix + same model; keep static content first byte-identical; Claude minimums 1024-4096 tokens; verify via `usage.cache_read_input_tokens` and `prompt_tokens_details.cached_tokens`
 # Docs: https://docs.nano-gpt.com/api-reference/miscellaneous/prompt-caching
 name = "NanoGPT"
 env = ["NANO_GPT_API_KEY"]

--- a/providers/nearai/provider.toml
+++ b/providers/nearai/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic engine prefix reuse on TEE-hosted models with no API changes required.
+# Use headers: none.
+# Use body: none.
+# Prefix: place stable content first and keep prefixes byte-identical; hits in `usage.prompt_tokens_details.cached_tokens`.
+# Docs: https://docs.near.ai/cloud/guides/prompt-caching
 name = "NEAR AI Cloud"
 npm = "@ai-sdk/openai-compatible"
 # Gateway and direct TEE hosts use the same POST `/v1/chat/completions` API.

--- a/providers/nearai/provider.toml
+++ b/providers/nearai/provider.toml
@@ -1,7 +1,7 @@
-# Cache (chat): automatic engine prefix reuse on TEE-hosted models with no API changes required.
-# Use headers: none.
-# Use body: none.
-# Prefix: place stable content first and keep prefixes byte-identical; hits in `usage.prompt_tokens_details.cached_tokens`.
+# Cache key (chat): automatic prefix cache on TEE-hosted models with per-model input_cache_read billing
+# Use headers: repeat the stable prefix with identical model and params
+# Use body: repeat the stable prefix with identical model and params
+# Cache policy: stable prefix + same model; put system prompt and reference docs first byte-identical; verify via `usage.prompt_tokens_details.cached_tokens`
 # Docs: https://docs.near.ai/cloud/guides/prompt-caching
 name = "NEAR AI Cloud"
 npm = "@ai-sdk/openai-compatible"

--- a/providers/nebius/provider.toml
+++ b/providers/nebius/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic server-side prefix reuse with no request cache controls.
+# Use headers: none.
+# Use body: none.
+# Prefix: keep stable prefixes first with dynamic content last; hits in `usage.prompt_tokens_details.cached_tokens`.
+# Docs: https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion
 name = "Nebius Token Factory"
 env = ["NEBIUS_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/nebius/provider.toml
+++ b/providers/nebius/provider.toml
@@ -1,8 +1,5 @@
-# Cache (chat): automatic server-side prefix reuse with no request cache controls.
-# Use headers: none.
-# Use body: none.
-# Prefix: keep stable prefixes first with dynamic content last; hits in `usage.prompt_tokens_details.cached_tokens`.
-# Docs: https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion
+# Cache key (chat): unknown — no documented chat cache controls; KV cache appears only as internal serving infra and observability metrics
+# Docs: https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion; https://docs.tokenfactory.nebius.com/ai-models-inference/overview; https://docs.tokenfactory.nebius.com/ai-models-inference/observability
 name = "Nebius Token Factory"
 env = ["NEBIUS_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/neon/provider.toml
+++ b/providers/neon/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): no cache fields on unified chat; explicit caching lives on the native Anthropic route.
+# Use headers: none (chat); `anthropic-beta`/`anthropic-version` forwarded on the native Anthropic route.
+# Use body: none (chat); `cache_control` markers on the native Anthropic route.
+# Prefix: keep stable prefixes first for upstream reuse where available; verify via native route usage fields.
+# Docs: https://neon.com/docs/ai-gateway/chat-completions
 name = "Neon"
 npm = "@ai-sdk/openai-compatible"
 # Unified Chat is POST `/v1/chat/completions`. Native routes are POST

--- a/providers/neon/provider.toml
+++ b/providers/neon/provider.toml
@@ -1,8 +1,8 @@
-# Cache (chat): no cache fields on unified chat; explicit caching lives on the native Anthropic route.
-# Use headers: none (chat); `anthropic-beta`/`anthropic-version` forwarded on the native Anthropic route.
-# Use body: none (chat); `cache_control` markers on the native Anthropic route.
-# Prefix: keep stable prefixes first for upstream reuse where available; verify via native route usage fields.
-# Docs: https://neon.com/docs/ai-gateway/chat-completions
+# Cache key (chat): explicit `cache_control` breakpoints via the native Anthropic Messages route
+# Use headers: `anthropic-version` plus `anthropic-beta` forwarded to Anthropic on the native route
+# Use body: `cache_control: {"type": "ephemeral"}` on native system/message content blocks
+# Cache policy: stable prefix + same Claude model; verify via native `usage.cache_creation_input_tokens` and `cache_read_input_tokens`
+# Docs: https://neon.com/docs/ai-gateway/anthropic-messages
 name = "Neon"
 npm = "@ai-sdk/openai-compatible"
 # Unified Chat is POST `/v1/chat/completions`. Native routes are POST

--- a/providers/neosmith/provider.toml
+++ b/providers/neosmith/provider.toml
@@ -1,8 +1,5 @@
-# Cache (chat): no documented chat cache controls; cache-read rates published as a billing ceiling in model costs.
-# Use headers: none.
-# Use body: none.
-# Prefix: keep stable prefixes first with dynamic content last.
-# Docs: https://neosmith.ai/docs
+# Cache key (chat): unknown — docs cover endpoints, SKUs, and auth only; no cache fields or cache behavior documented
+# Docs: https://neosmith.ai/docs; https://neosmith.ai/features/evaluation; https://models.dev/providers/neosmith
 name = "NeoSmith"
 
 env = ["NEOSMITH_API_KEY"]

--- a/providers/neosmith/provider.toml
+++ b/providers/neosmith/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): no documented chat cache controls; cache-read rates published as a billing ceiling in model costs.
+# Use headers: none.
+# Use body: none.
+# Prefix: keep stable prefixes first with dynamic content last.
+# Docs: https://neosmith.ai/docs
 name = "NeoSmith"
 
 env = ["NEOSMITH_API_KEY"]

--- a/providers/neuralwatt/provider.toml
+++ b/providers/neuralwatt/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic vLLM prefix reuse with no request fields.
+# Use headers: none.
+# Use body: none.
+# Prefix: keep stable byte-identical prefixes first; hits in `usage.prompt_tokens_details.cached_tokens` at reduced energy cost.
+# Docs: https://portal.neuralwatt.com/docs/api/chat-completions
 name = "Neuralwatt"
 env = ["NEURALWATT_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/neuralwatt/provider.toml
+++ b/providers/neuralwatt/provider.toml
@@ -1,7 +1,7 @@
-# Cache (chat): automatic vLLM prefix reuse with no request fields.
-# Use headers: none.
-# Use body: none.
-# Prefix: keep stable byte-identical prefixes first; hits in `usage.prompt_tokens_details.cached_tokens` at reduced energy cost.
+# Cache key (chat): automatic vLLM prefix cache with `prompt_tokens_details.cached_tokens` reporting and reduced energy cost on cached tokens
+# Use headers: repeat the stable prefix with identical model and params
+# Use body: repeat the stable prefix with identical model and params
+# Cache policy: stable prefix + same model; hits grow across follow-up turns sharing system prompt and history
 # Docs: https://portal.neuralwatt.com/docs/api/chat-completions
 name = "Neuralwatt"
 env = ["NEURALWATT_API_KEY"]

--- a/providers/nova/provider.toml
+++ b/providers/nova/provider.toml
@@ -1,8 +1,5 @@
-# Cache (chat): no documented cache controls on the OpenAI-compatible chat API.
-# Use headers: none.
-# Use body: none.
-# Prefix: keep stable prefixes first; Bedrock-style `cachePoint` is a separate API surface.
-# Docs: https://nova.amazon.com/dev/documentation
+# Cache key (chat): unknown — no cache controls documented on the direct OpenAI-compatible chat API; `cachePoint` is Bedrock-only
+# Docs: https://nova.amazon.com/dev/documentation; https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html; https://docs.langchain.com/oss/python/integrations/chat/amazon_nova
 name = "Nova"
 env = ["NOVA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/nova/provider.toml
+++ b/providers/nova/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): no documented cache controls on the OpenAI-compatible chat API.
+# Use headers: none.
+# Use body: none.
+# Prefix: keep stable prefixes first; Bedrock-style `cachePoint` is a separate API surface.
+# Docs: https://nova.amazon.com/dev/documentation
 name = "Nova"
 env = ["NOVA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/novita-ai/provider.toml
+++ b/providers/novita-ai/provider.toml
@@ -1,7 +1,7 @@
-# Cache (chat): automatic engine-level prompt cache on supported models with no request changes.
-# Use headers: none.
-# Use body: none.
-# Prefix: repeat identical prompts and keep stable prefixes; hits in `usage.prompt_tokens_details.cached_tokens`.
+# Cache key (chat): automatic engine prompt cache on supported models (`support_prompt_cache`) with cache-token billing
+# Use headers: repeat the stable prefix with identical model and params
+# Use body: repeat the identical prompt with identical model and params; no request changes required
+# Cache policy: stable prefix + same model; repeated template and system prompts hit; verify via `usage.prompt_tokens_details.cached_tokens`
 # Docs: https://novita.ai/docs/guides/llm-prompt-cache.md
 name = "NovitaAI"
 env = ["NOVITA_API_KEY"]

--- a/providers/novita-ai/provider.toml
+++ b/providers/novita-ai/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic engine-level prompt cache on supported models with no request changes.
+# Use headers: none.
+# Use body: none.
+# Prefix: repeat identical prompts and keep stable prefixes; hits in `usage.prompt_tokens_details.cached_tokens`.
+# Docs: https://novita.ai/docs/guides/llm-prompt-cache.md
 name = "NovitaAI"
 env = ["NOVITA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/nvidia/provider.toml
+++ b/providers/nvidia/provider.toml
@@ -1,8 +1,5 @@
-# Cache (chat): no chat cache controls; per-model NIM `ChatRequest` sets `additionalProperties: false` (closed; e.g. meta/llama-3.3-70b-instruct).
-# Use headers: none.
-# Use body: none.
-# Prefix: no documented prefix-reuse behavior on the chat API; keep requests within the closed per-model schema.
-# Docs: https://docs.api.nvidia.com/nim/reference/llm-apis
+# Cache key (chat): unknown — no cache controls on the hosted chat API; prefix caching is a self-hosted NIM deployment flag, not a request field
+# Docs: https://docs.api.nvidia.com/nim/reference/llm-apis; https://docs.nvidia.com/nim/large-language-models/1.13.0/kv-cache-reuse.html; https://docs.nvidia.com/nim/large-language-models/2.0.4/reference/advanced-configuration.html
 name = "Nvidia"
 env = ["NVIDIA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/nvidia/provider.toml
+++ b/providers/nvidia/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): no chat cache controls; per-model NIM `ChatRequest` sets `additionalProperties: false` (closed; e.g. meta/llama-3.3-70b-instruct).
+# Use headers: none.
+# Use body: none.
+# Prefix: no documented prefix-reuse behavior on the chat API; keep requests within the closed per-model schema.
+# Docs: https://docs.api.nvidia.com/nim/reference/llm-apis
 name = "Nvidia"
 env = ["NVIDIA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/ofox/provider.toml
+++ b/providers/ofox/provider.toml
@@ -1,7 +1,7 @@
-# Cache (chat): automatic implicit reuse on chat; explicit controls live on native routes.
-# Use headers: none (chat).
-# Use body: none (chat); `cache_control` on the Anthropic Messages route and `cachedContents` for Gemini explicit caching.
-# Prefix: place long static content first and keep prefixes identical; monitor `usage` cache fields and console stats.
+# Cache key (chat): automatic implicit prefix reuse on chat plus explicit `cache_control` on the Anthropic native route and `cachedContents` on the Gemini native route
+# Use headers: repeat the stable prefix with identical model and params
+# Use body: `cache_control: {"type": "ephemeral"}` on Anthropic Messages content blocks; `cachedContent` handle reference (created via `cachedContents`) on Gemini generateContent
+# Cache policy: stable prefix + same model; put long static content first byte-identical; verify via `usage` cache fields and console usage stats
 # Docs: https://ofox.ai/docs/develop/advanced/prompt-caching
 name = "Ofox"
 env = ["OFOX_API_KEY"]

--- a/providers/ofox/provider.toml
+++ b/providers/ofox/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic implicit reuse on chat; explicit controls live on native routes.
+# Use headers: none (chat).
+# Use body: none (chat); `cache_control` on the Anthropic Messages route and `cachedContents` for Gemini explicit caching.
+# Prefix: place long static content first and keep prefixes identical; monitor `usage` cache fields and console stats.
+# Docs: https://ofox.ai/docs/develop/advanced/prompt-caching
 name = "Ofox"
 env = ["OFOX_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/ollama-cloud/provider.toml
+++ b/providers/ollama-cloud/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic server-side KV reuse with no request cache fields.
+# Use headers: none.
+# Use body: none.
+# Prefix: keep stable prefixes first with dynamic content last.
+# Docs: https://docs.ollama.com/openai
 name = "Ollama Cloud"
 env = ["OLLAMA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/ollama-cloud/provider.toml
+++ b/providers/ollama-cloud/provider.toml
@@ -1,8 +1,5 @@
-# Cache (chat): automatic server-side KV reuse with no request cache fields.
-# Use headers: none.
-# Use body: none.
-# Prefix: keep stable prefixes first with dynamic content last.
-# Docs: https://docs.ollama.com/openai
+# Cache key (chat): unknown — no cache request fields on the OpenAI-compatible chat API; backend reuse is implicit and unreported
+# Docs: https://docs.ollama.com/openai; https://docs.ollama.com/cloud; https://github.com/ollama/ollama/issues/16714
 name = "Ollama Cloud"
 env = ["OLLAMA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
Batch 12 (11 providers): documents prompt-cache strategy on the chat completions endpoint via leading header comments only.

| Provider | Verdict | Mechanism |
| --- | --- | --- |
| nano-gpt | NATIVE_OTHER | implicit auto-cache + proprietary top-level caching/prompt_caching controls |
| nearai | TOLERATES | accepts cache hints w/o 400, may silently drop; auto prefix reuse on self-hosted routes |
| nebius | TOLERATES | generic chat schema permits additional properties; no explicit chat cache controls |
| neon | TOLERATES | unified chat is OpenAI-passthrough; explicit caching only on native Anthropic route |
| neosmith | TOLERATES | no documented cache fields on chat; cache-read billing server-side |
| neuralwatt | NATIVE_OTHER | automatic vLLM prefix cache, no request fields; cached_tokens + discounted reads |
| nova | TOLERATES | no documented cache fields on the OpenAI-compatible chat API |
| novita-ai | NATIVE_OTHER | automatic engine-level prompt cache on supported models; cached_tokens in usage |
| nvidia | REJECTS | per-model closed NIM schema rejects unknown fields with 400 |
| ofox | NATIVE_OTHER | automatic implicit caching + passthrough; explicit Gemini cachedContents |
| ollama-cloud | TOLERATES | no cache fields, unknown fields ignored; server-side KV reuse automatic |

Priors verified: nvidia REJECTS, nano-gpt/ofox NATIVE_OTHER, nearai/nebius/neon TOLERATES.
bun validate: pass.