### PR TITLE
docs(cache): audit batch 15 prompt-cache headers

### DIFF
--- a/providers/sakana/provider.toml
+++ b/providers/sakana/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): Automatic server-side reuse of prompt prefixes shared between internal orchestration calls; no client cache control.
+# Use headers: none.
+# Use body: none. Chat and Responses field tables define no `prompt_cache_key` or `cache_control`.
+# To get a hit: Resend stable context unchanged so internal calls share a prefix; confirm via usage.input_tokens_details.cached_tokens, billed at the discounted cached-input rate.
+# Docs: https://console.sakana.ai/models
 name = "Sakana AI"
 env = ["SAKANA_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/salad-cloud/provider.toml
+++ b/providers/salad-cloud/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown — no cache mechanism documented.
+# Docs: https://docs.salad.com/ai-gateway/explanation/overview
 name = "SaladCloud AI Gateway"
 env = ["SALAD_CLOUD_API_KEY"]
 npm = "@saladtechnologies-oss/ai-sdk-provider"

--- a/providers/sap-ai-core/provider.toml
+++ b/providers/sap-ai-core/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): Explicit ephemeral `cache_control` breakpoints on prompt-templating content blocks (Orchestration V2; Claude/Nova families); OpenAI/Gemini-backed models cache implicitly with no configuration.
+# Use headers: none.
+# Use body: `cache_control` (`{"type": "ephemeral"}` default 5-minute TTL, `"ttl": "1h"` on select Claude models).
+# To get a hit: Mark the breakpoint at the end of the stable prefix with enough cached tokens; keep shared content byte-identical and append-only.
+# Docs: https://help.sap.com/docs/sap-ai-core/generative-ai/prompt-caching
 name = "SAP AI Core"
 env = ["AICORE_SERVICE_KEY"]
 npm = "@jerome-benoit/sap-ai-provider-v2"

--- a/providers/sarvam/provider.toml
+++ b/providers/sarvam/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown — no cache mechanism documented.
+# Docs: https://docs.sarvam.ai/api-reference-docs/chat/chat-completions
 name = "Sarvam AI"
 env = ["SARVAM_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/scaleway/provider.toml
+++ b/providers/scaleway/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): Automatic token caching with no client control; Serverless persists the prefix cache automatically (50-90% hits on recurring prefixes, discounted cached-input billing); Dedicated input cache included in price.
+# Use headers: none.
+# Use body: none. The chat schema exposes no `prompt_cache_key` or cache control field.
+# To get a hit: Keep recurring prefixes (system prompt, conversation start) stable and append-only; monitor cached-token consumption in Cockpit.
+# Docs: https://www.scaleway.com/en/docs/generative-apis/faq/
 name = "Scaleway"
 npm = "@ai-sdk/openai-compatible"
 api = "https://api.scaleway.ai/v1"

--- a/providers/scnet-token-plan/provider.toml
+++ b/providers/scnet-token-plan/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown — no cache mechanism documented.
+# Docs: https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/tools/opencode.html
 # SCNet documents its OpenAI-compatible endpoint and OpenCode integration here:
 # https://www.scnet.cn/ac/openapi/doc/2.0/moduleapi/tools/opencode.html
 # Token Plan model catalog (accessed 2026-08-16):

--- a/providers/scx-ai/provider.toml
+++ b/providers/scx-ai/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown — no cache mechanism documented.
+# Docs: https://platform.scx.ai/docs
 name = "SCX.ai"
 env = ["SCX_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/sensenova/provider.toml
+++ b/providers/sensenova/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): Automatic server-side prefix reuse with no chat-level cache control; cache hits are reported per request.
+# Use headers: none.
+# Use body: none. Chat examples document model/messages/max_tokens only, with no cache params.
+# To get a hit: Keep shared prefixes stable and append-only; confirm via usage.prompt_tokens_details.cached_tokens, billed at the cache-read rate.
+# Docs: https://github.com/OpenSenseNova/SenseNova6.7/blob/main/API.md
 name = "SenseNova (China)"
 npm = "@ai-sdk/openai-compatible"
 env = ["SENSENOVA_API_KEY"]

--- a/providers/siliconflow-cn/provider.toml
+++ b/providers/siliconflow-cn/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): Automatic best-effort prefix cache with no client control; eligible repeated input is billed at the model Cache Read rate, but repeated text alone does not guarantee a hit.
+# Use headers: none.
+# Use body: none. The chat schema defines no `prompt_cache_key` or `cache_control` field.
+# To get a hit: Keep system instructions and stable context byte-identical first and append new content last; measure effective cost per task.
+# Docs: https://www.siliconflow.com/blog/siliconflow-prompt-caching-api-costs
 name = "SiliconFlow (China)"
 env = ["SILICONFLOW_CN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/siliconflow/provider.toml
+++ b/providers/siliconflow/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): Automatic best-effort prefix cache with no client control; eligible repeated input is billed at the model Cache Read rate, but repeated text alone does not guarantee a hit.
+# Use headers: none.
+# Use body: none. The chat schema defines no `prompt_cache_key` or `cache_control` field.
+# To get a hit: Keep system instructions and stable context byte-identical first and append new content last; measure effective cost per task.
+# Docs: https://www.siliconflow.com/blog/siliconflow-prompt-caching-api-costs
 name = "SiliconFlow"
 env = ["SILICONFLOW_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/snowflake-cortex/provider.toml
+++ b/providers/snowflake-cortex/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): OpenAI models cache implicitly from 1024+ tokens with no request changes; Claude models cache explicitly with `cache_control` ephemeral breakpoints (max 4, 5-minute TTL).
+# Use headers: none.
+# Use body: `prompt_cache_key` routes OpenAI-model requests sharing a prefix (Supported for OpenAI, Ignored for Claude/Other); `cache_control` on Claude content blocks.
+# To get a hit: Keep the first 1024+ tokens byte-identical and append-only on one model; reuse one `prompt_cache_key` per shared OpenAI prefix; confirm via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api
 name = "Snowflake Cortex"
 npm = "@ai-sdk/openai-compatible"
 api = "https://${SNOWFLAKE_ACCOUNT}.snowflakecomputing.com/api/v2/cortex/v1"


### PR DESCRIPTION
Batch 15 prompt-cache audit (11 providers). Leading header comment only; no schema/data changes.