### PR TITLE
docs(cache): batch 20 prompt-cache strategy

### DIFF
--- a/providers/zenifra/provider.toml
+++ b/providers/zenifra/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): unknown; docs describe OpenAI-compatible chat on `alibaba/qwen3.6-35b-a3b` with console cost tracking.
+# Use headers: Authorization Bearer key created in the console, with per-key budgets scoping spend.
+# Use body: model with messages; same-model stable prefixes favor reuse.
+# To get a hit: replay identical stable prefixes on the same model; confirm via console usage and response usage where reported.
+# Docs: https://docs.zenifra.com/en/docs/ai
 name = "Zenifra"
 env = ["ZENIFRA_AI_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/zenmux/provider.toml
+++ b/providers/zenmux/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): explicit breakpoint cache via body `cache_control` markers plus automatic prefix cache across routed models.
+# Use headers: cache activity surfaces in ZenMux Logs token details as `input_cache_read` and `input_cache_write`.
+# Use body: `cache_control` with `type: ephemeral` on stable blocks; tools, system, then messages order; up to 4 breakpoints.
+# To get a hit: place stable content first with `cache_control` on each reusable segment; minima 1024 Claude Sonnet/Opus, 2048 Haiku 3.5, 256 Qwen; reuse within the 5m TTL.
+# Docs: https://docs.zenmux.ai/guide/advanced/prompt-cache.html
 # OpenAI POST /api/v1/chat/completions: `reasoning_effort`, or `reasoning`
 # with `effort`, `max_tokens`, and `enabled`.
 # Anthropic POST /api/anthropic/v1/messages: `thinking.type` enabled|disabled;

--- a/providers/zhipuai-coding-plan/provider.toml
+++ b/providers/zhipuai-coding-plan/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic implicit prefix cache on the coding chat endpoint with Cached Input credit deduction.
+# Use headers: standard Bearer auth on POST /api/coding/paas/v4/chat/completions; Cached Input deduction visible in billing detail.
+# Use body: model with messages; stable system prompt first with chat history appended.
+# To get a hit: replay identical system prompts and stable prefixes; Cached Input deduction confirms reuse.
+# Docs: https://docs.bigmodel.cn/cn/coding-plan/overview
 # OpenAI Chat endpoint: POST https://open.bigmodel.cn/api/coding/paas/v4/chat/completions.
 # GLM-5.2 maps low|medium|high to high and xhigh|max|ultracode to max.
 # https://docs.bigmodel.cn/cn/coding-plan/latest-model (accessed 2026-06-25)

--- a/providers/zhipuai/provider.toml
+++ b/providers/zhipuai/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic implicit context cache; repeated system prompts and conversation history reuse prior compute at a discount.
+# Use headers: standard Bearer auth on POST /api/paas/v4/chat/completions; cache outcomes surface in `usage.prompt_tokens_details.cached_tokens`.
+# Use body: model with messages; stable system prompt first with history appended.
+# To get a hit: replay identical system prompts and stable prefixes; confirm via `usage.prompt_tokens_details.cached_tokens`.
+# Docs: https://docs.bigmodel.cn/cn/guide/capabilities/cache
 # Chat reasoning: POST https://open.bigmodel.cn/api/paas/v4/chat/completions with
 # `thinking.type = "enabled" | "disabled"` (default: enabled).
 # https://docs.bigmodel.cn/cn/guide/capabilities/thinking (accessed 2026-06-25)


### PR DESCRIPTION
Batch 20 prompt-cache audit (4 providers). Header-only changes to provider.toml.

| provider | verdict | mechanism | docs |
| --- | --- | --- | --- |
| zenifra | UNKNOWN | no cache params documented for OpenAI-compatible chat | https://docs.zenifra.com/en/docs/ai |
| zenmux | NATIVE_OTHER | cache_control explicit plus automatic implicit; chat prompt_cache_key unsupported | https://docs.zenmux.ai/guide/advanced/prompt-cache.html |
| zhipuai | AUTOMATIC | implicit context caching, no params; usage.prompt_tokens_details.cached_tokens | https://docs.bigmodel.cn/cn/guide/capabilities/cache |
| zhipuai-coding-plan | AUTOMATIC | implicit context caching via coding endpoint; Cached Input deduction | https://docs.bigmodel.cn/cn/coding-plan/overview |

Validation: bun validate passes. Only leading header comments edited.