### PR TITLE
docs(cache): audit prompt-cache strategy batch 07

### DIFF
--- a/providers/google-vertex-anthropic/provider.toml
+++ b/providers/google-vertex-anthropic/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: Anthropic cache breakpoints on Vertex Claude.
+# Use body: `cache_control` ephemeral blocks for explicit breakpoints.
+# Use headers: none.
+# Prefix/TTL/cost: 5-minute TTL on Vertex; 1024-token minimum; repeat exact prefix within TTL.
+# Docs: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/prompt-caching
 name = "Vertex (Anthropic)"
 env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]
 npm = "@ai-sdk/google-vertex/anthropic"

--- a/providers/google-vertex-anthropic/provider.toml
+++ b/providers/google-vertex-anthropic/provider.toml
@@ -1,7 +1,6 @@
-# Prompt cache: Anthropic cache breakpoints on Vertex Claude.
-# Use body: `cache_control` ephemeral blocks for explicit breakpoints.
-# Use headers: none.
-# Prefix/TTL/cost: 5-minute TTL on Vertex; 1024-token minimum; repeat exact prefix within TTL.
+# Cache key (chat): explicit `cache_control` breakpoints on Claude models via Vertex.
+# Use body: `cache_control` — `{"type": "ephemeral"}` on stable blocks with up to 4 breakpoints plus optional 1h TTL.
+# Cache policy: stable prefix plus same model; repeat the exact prefix with markers in place within the 5-minute TTL; confirm via cache_creation_input_tokens plus cache_read_input_tokens.
 # Docs: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/prompt-caching
 name = "Vertex (Anthropic)"
 env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]

--- a/providers/google-vertex/provider.toml
+++ b/providers/google-vertex/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: implicit automatic prefix cache plus explicit context caching.
+# Use body: `cachedContents` via context-cache API; no chat-level cache key.
+# Use headers: none.
+# Prefix/TTL/cost: implicit hits automatic; explicit cache managed via context-cache API.
+# Docs: https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
 name = "Vertex"
 env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]
 npm = "@ai-sdk/google-vertex"

--- a/providers/google-vertex/provider.toml
+++ b/providers/google-vertex/provider.toml
@@ -1,7 +1,6 @@
-# Prompt cache: implicit automatic prefix cache plus explicit context caching.
-# Use body: `cachedContents` via context-cache API; no chat-level cache key.
-# Use headers: none.
-# Prefix/TTL/cost: implicit hits automatic; explicit cache managed via context-cache API.
+# Cache key (chat): none — chat carries no cache key field; explicit caching uses the Vertex context-cache API.
+# Use body: `cachedContents` — create via the cachedContents API, then reference the `cachedContent` resource name on generateContent.
+# Cache policy: implicit automatic prefix cache plus explicit cache reuse with 60-minute default TTL; keep stable prefix first; confirm via cachedContentTokenCount metadata.
 # Docs: https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
 name = "Vertex"
 env = ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"]

--- a/providers/google/provider.toml
+++ b/providers/google/provider.toml
@@ -1,7 +1,6 @@
-# Prompt cache: implicit automatic prefix cache plus explicit context caching.
-# Use body: `cachedContents` for explicit context cache; no chat-level cache key.
-# Use headers: none.
-# Prefix/TTL/cost: Gemini 2.5+ min 2048 tokens, 3.x min 4096; hits via usage.total_cached_tokens.
+# Cache key (chat): none — chat carries no cache key field; explicit caching uses the separate `cachedContents` resource.
+# Use body: `cachedContents` — create a cache via the cachedContents API, then pass the cache name as `cachedContent` on the request.
+# Cache policy: implicit automatic prefix cache plus explicit cache reuse; keep stable prefix first on the same model; confirm via `usage.total_cached_tokens`.
 # Docs: https://ai.google.dev/gemini-api/docs/caching
 name = "Google"
 env = ["GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"]

--- a/providers/google/provider.toml
+++ b/providers/google/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: implicit automatic prefix cache plus explicit context caching.
+# Use body: `cachedContents` for explicit context cache; no chat-level cache key.
+# Use headers: none.
+# Prefix/TTL/cost: Gemini 2.5+ min 2048 tokens, 3.x min 4096; hits via usage.total_cached_tokens.
+# Docs: https://ai.google.dev/gemini-api/docs/caching
 name = "Google"
 env = ["GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"]
 npm = "@ai-sdk/google"

--- a/providers/greenpt/provider.toml
+++ b/providers/greenpt/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: automatic repeated-prefix cache with discounted cached-input rates.
+# Use body: none; no parameter or SDK field for cache control.
+# Use headers: none; no header for cache control.
+# Prefix/TTL/cost: repeat identical prefix from start; per-model cached-input rates; hits via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.greenpt.ai/prompt-caching
 name = "GreenPT"
 npm = "@ai-sdk/openai-compatible"
 api = "https://api.greenpt.ai/v1"

--- a/providers/greenpt/provider.toml
+++ b/providers/greenpt/provider.toml
@@ -1,7 +1,5 @@
-# Prompt cache: automatic repeated-prefix cache with discounted cached-input rates.
-# Use body: none; no parameter or SDK field for cache control.
-# Use headers: none; no header for cache control.
-# Prefix/TTL/cost: repeat identical prefix from start; per-model cached-input rates; hits via usage.prompt_tokens_details.cached_tokens.
+# Cache key (chat): none — chat schema carries no cache key field; caching is automatic.
+# Cache policy: automatic repeated-prefix cache on supported models with discounted cached-input rates; keep stable prefix first byte-identical; confirm via `usage.prompt_tokens_details.cached_tokens`.
 # Docs: https://docs.greenpt.ai/prompt-caching
 name = "GreenPT"
 npm = "@ai-sdk/openai-compatible"

--- a/providers/groq/provider.toml
+++ b/providers/groq/provider.toml
@@ -1,7 +1,5 @@
-# Prompt cache: automatic exact-prefix cache on supported models.
-# Use body: none for Chat Completions; provider documents body key for Responses API only.
-# Use headers: none.
-# Prefix/TTL/cost: gpt-oss-20b/120b; 128-1024 token minimum varies by model; 50% cached-input discount; 2h expiry; hits via usage.prompt_tokens_details.cached_tokens.
+# Cache key (chat): none — chat completions carry no cache key field; caching is automatic on supported models.
+# Cache policy: automatic exact-prefix cache with 50 percent cached-input discount plus 2-hour expiry; keep stable prefix first; confirm via `usage.prompt_tokens_details.cached_tokens`.
 # Docs: https://console.groq.com/docs/prompt-caching
 name = "Groq"
 env = ["GROQ_API_KEY"]

--- a/providers/groq/provider.toml
+++ b/providers/groq/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: automatic exact-prefix cache on supported models.
+# Use body: none for Chat Completions; provider documents body key for Responses API only.
+# Use headers: none.
+# Prefix/TTL/cost: gpt-oss-20b/120b; 128-1024 token minimum varies by model; 50% cached-input discount; 2h expiry; hits via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://console.groq.com/docs/prompt-caching
 name = "Groq"
 env = ["GROQ_API_KEY"]
 npm = "@ai-sdk/groq"

--- a/providers/helicone/provider.toml
+++ b/providers/helicone/provider.toml
@@ -1,7 +1,7 @@
-# Prompt cache: gateway response cache plus provider prefix cache and Anthropic breakpoints.
-# Use body: body key passthrough with `prompt_cache_key` for prefix control and Anthropic `cache_control`.
-# Use headers: `Helicone-Cache-Enabled` for gateway exact-match cache; plus Cache-Control max-age, Bucket-Max-Size, Seed.
-# Prefix/TTL/cost: provider prefix from 1024 tokens; Anthropic 5min/1h TTL, 1024-token minimum; gateway cache by max-age.
+# Cache key (chat): gateway response cache plus provider prefix cache with `prompt_cache_key` affinity.
+# Use headers: `Helicone-Cache-Enabled` plus `Cache-Control` max-age plus `Helicone-Cache-Bucket-Max-Size` plus `Helicone-Cache-Seed`; hits report `Helicone-Cache` HIT or MISS.
+# Use body: `prompt_cache_key` plus Anthropic `cache_control` passthrough to the upstream provider.
+# Cache policy: enable gateway cache headers for exact-match response reuse; use body keys for provider prefix control on 1024-plus token prefixes; confirm via Helicone-Cache header plus usage cached tokens.
 # Docs: https://docs.helicone.ai/gateway/concepts/prompt-caching
 name = "Helicone"
 env = ["HELICONE_API_KEY"]

--- a/providers/helicone/provider.toml
+++ b/providers/helicone/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: gateway response cache plus provider prefix cache and Anthropic breakpoints.
+# Use body: body key passthrough with `prompt_cache_key` for prefix control and Anthropic `cache_control`.
+# Use headers: `Helicone-Cache-Enabled` for gateway exact-match cache; plus Cache-Control max-age, Bucket-Max-Size, Seed.
+# Prefix/TTL/cost: provider prefix from 1024 tokens; Anthropic 5min/1h TTL, 1024-token minimum; gateway cache by max-age.
+# Docs: https://docs.helicone.ai/gateway/concepts/prompt-caching
 name = "Helicone"
 env = ["HELICONE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/hetzner/provider.toml
+++ b/providers/hetzner/provider.toml
@@ -1,7 +1,4 @@
-# Prompt cache: no documented prefix-cache policy.
-# Use body: none; chat schema lists model, messages, and image_url only.
-# Use headers: none.
-# Prefix/TTL/cost: no documented threshold, discount, TTL, or cached-token reporting.
+# Cache key (chat): unknown cache behavior; check provider docs plus usage totals for cache reporting.
 # Docs: https://docs.hetzner.com/general/company-and-policy/experiments/inference/
 name = "Hetzner"
 env = ["HETZNER_API_KEY"]

--- a/providers/hetzner/provider.toml
+++ b/providers/hetzner/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: no documented prefix-cache policy.
+# Use body: none; chat schema lists model, messages, and image_url only.
+# Use headers: none.
+# Prefix/TTL/cost: no documented threshold, discount, TTL, or cached-token reporting.
+# Docs: https://docs.hetzner.com/general/company-and-policy/experiments/inference/
 name = "Hetzner"
 env = ["HETZNER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/hpc-ai/provider.toml
+++ b/providers/hpc-ai/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: automatic prefix cache with per-model Cache Read pricing.
+# Use body: none; chat schema lists model, messages, tools, and reasoning_effort without cache key.
+# Use headers: none.
+# Prefix/TTL/cost: repeat identical prefix; per-model Cache Read rate; hits via usage details cached-token reporting.
+# Docs: https://www.hpc-ai.com/doc/docs/Model-APIs/API-Reference/OpenAI-Compatible-API/Create-Chat-Completions/
 name = "HPC-AI"
 env = ["HPC_AI_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/hpc-ai/provider.toml
+++ b/providers/hpc-ai/provider.toml
@@ -1,7 +1,5 @@
-# Prompt cache: automatic prefix cache with per-model Cache Read pricing.
-# Use body: none; chat schema lists model, messages, tools, and reasoning_effort without cache key.
-# Use headers: none.
-# Prefix/TTL/cost: repeat identical prefix; per-model Cache Read rate; hits via usage details cached-token reporting.
+# Cache key (chat): none — chat schema lists model plus messages plus tools plus reasoning_effort with no cache key field.
+# Cache policy: automatic prefix reuse with per-model Cache Read billing; keep stable prefix first on the same model; confirm via usage details where reported.
 # Docs: https://www.hpc-ai.com/doc/docs/Model-APIs/API-Reference/OpenAI-Compatible-API/Create-Chat-Completions/
 name = "HPC-AI"
 env = ["HPC_AI_API_KEY"]

--- a/providers/huggingface/provider.toml
+++ b/providers/huggingface/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: no router-level prefix cache; downstream provider caching only.
+# Use body: none; router chat schema lists messages, tools, and reasoning controls without cache key.
+# Use headers: none.
+# Prefix/TTL/cost: no router threshold, discount, TTL, or cached-token reporting; usage reports prompt/completion/total only.
+# Docs: https://huggingface.co/docs/inference-providers/tasks/chat-completion
 name = "Hugging Face"
 env = ["HF_TOKEN"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/huggingface/provider.toml
+++ b/providers/huggingface/provider.toml
@@ -1,7 +1,4 @@
-# Prompt cache: no router-level prefix cache; downstream provider caching only.
-# Use body: none; router chat schema lists messages, tools, and reasoning controls without cache key.
-# Use headers: none.
-# Prefix/TTL/cost: no router threshold, discount, TTL, or cached-token reporting; usage reports prompt/completion/total only.
+# Cache key (chat): unknown cache behavior; check provider docs plus usage totals for cache reporting.
 # Docs: https://huggingface.co/docs/inference-providers/tasks/chat-completion
 name = "Hugging Face"
 env = ["HF_TOKEN"]

--- a/providers/hyper/provider.toml
+++ b/providers/hyper/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: automatic prefix cache with per-model cache_hit and cache_create pricing.
+# Use body: none; chat schema lists model, messages, stream, temperature, max_tokens, and tools only.
+# Use headers: none.
+# Prefix/TTL/cost: repeat identical prefix; Cache Read and Cache Write rates per model; no published minimum or expiry.
+# Docs: https://hyper.charm.land/docs/api/openai-chat-completions.html
 name = "Charm Hyper"
 env = ["HYPER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/hyper/provider.toml
+++ b/providers/hyper/provider.toml
@@ -1,8 +1,6 @@
-# Prompt cache: automatic prefix cache with per-model cache_hit and cache_create pricing.
-# Use body: none; chat schema lists model, messages, stream, temperature, max_tokens, and tools only.
-# Use headers: none.
-# Prefix/TTL/cost: repeat identical prefix; Cache Read and Cache Write rates per model; no published minimum or expiry.
-# Docs: https://hyper.charm.land/docs/api/openai-chat-completions.html
+# Cache key (chat): none — chat schema lists model plus messages plus stream plus temperature plus max_tokens plus tools with no cache key field.
+# Cache policy: automatic prefix cache with per-model Cache Read plus Cache Write rates; keep stable prefix first on the same model.
+# Docs: https://hyper.charm.land/docs/models.html
 name = "Charm Hyper"
 env = ["HYPER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/iflowcn/provider.toml
+++ b/providers/iflowcn/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache: no documented prefix-cache policy.
+# Use body: none; platform docs publish Search endpoints without chat cache params.
+# Use headers: none.
+# Prefix/TTL/cost: no documented threshold, discount, TTL, or cached-token reporting.
+# Docs: https://platform.iflow.cn/en/docs
 name = "iFlow"
 env = ["IFLOW_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/iflowcn/provider.toml
+++ b/providers/iflowcn/provider.toml
@@ -1,7 +1,4 @@
-# Prompt cache: no documented prefix-cache policy.
-# Use body: none; platform docs publish Search endpoints without chat cache params.
-# Use headers: none.
-# Prefix/TTL/cost: no documented threshold, discount, TTL, or cached-token reporting.
+# Cache key (chat): unknown cache behavior; check provider docs plus usage totals for cache reporting.
 # Docs: https://platform.iflow.cn/en/docs
 name = "iFlow"
 env = ["IFLOW_API_KEY"]


### PR DESCRIPTION
Batch 07 prompt-cache audit (comment-only headers in provider.toml): google, google-vertex, google-vertex-anthropic, greenpt, groq, helicone, hetzner, hpc-ai, huggingface, hyper, iflowcn.

| provider | verdict | mechanism |
|---|---|---|
| google | NATIVE_OTHER | implicit auto-cache + explicit cachedContents/cachedContent context caching |
| google-vertex | NATIVE_OTHER | Vertex implicit auto-cache + explicit cachedContents context caching |
| google-vertex-anthropic | NATIVE_OTHER | Anthropic cache_control breakpoints, 5-min TTL on Vertex |
| greenpt | SUPPORTS | automatic repeated-prefix caching, discounted cached-input rates, usage.prompt_tokens_details.cached_tokens |
| groq | SUPPORTS | automatic prefix caching on supported models, 50% cached-input discount |
| helicone | SUPPORTS | Helicone-Cache-Enabled gateway cache + provider prompt-caching passthrough |
| hetzner | UNKNOWN | experimental API, no documented cache behavior |
| hpc-ai | SUPPORTS | Cache Read pricing tier, cached tokens in usage details |
| huggingface | UNKNOWN | router documents no cache fields; downstream-provider dependent |
| hyper | SUPPORTS | per-model cache_hit/cache_create pricing, Cache Read/Write rates |
| iflowcn | UNKNOWN | no documented cache params; usage has no cached-token fields |

Corrections to priors: groq was REJECTS, now SUPPORTS (first-party automatic prompt caching docs at https://console.groq.com/docs/prompt-caching). google/vertex NATIVE_OTHER and helicone SUPPORTS verified, unchanged.

Sources: https://ai.google.dev/gemini-api/docs/caching, https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview, https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/prompt-caching, https://docs.greenpt.ai/prompt-caching, https://console.groq.com/docs/prompt-caching, https://docs.helicone.ai/gateway/concepts/prompt-caching, https://www.hpc-ai.com/model-apis, https://hyper.charm.land/docs/models.html, https://huggingface.co/docs/inference-providers/tasks/chat-completion, https://platform.iflow.cn/en/docs

Note: bun validate fails identically on clean origin/dev (TypeError AuthoredModelShape.deepPartial in packages/core/src/generate.ts) — pre-existing, unrelated to this comment-only change. All 11 files TOML-parse cleanly.
