### PR TITLE
docs(cache): audit prompt-cache strategy batch 10

### DIFF
--- a/providers/lmstudio/provider.toml
+++ b/providers/lmstudio/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): No documented cache — local server with no cached-token usage or cached-input billing.
+# Cache key (chat): none — closed payload of model/top_p/top_k/messages/temperature/max_tokens/stream/stop/penalties/logit_bias/repeat_penalty/seed; no `prompt_cache_key` field.
+# Cache headers: none
+# Cache policy: no chat cache; to reuse local KV keep same model with identical prefix order.
+# Docs: https://lmstudio.ai/docs/developer/openai-compat/chat-completions
 # Native POST /api/v1/chat: $.reasoning = "off"|"low"|"medium"|"high"|"on".
 # OpenAI POST /v1/responses: $.reasoning.effort (the example uses "low").
 # The published POST /v1/chat/completions payload list has no reasoning field.

--- a/providers/longcat/provider.toml
+++ b/providers/longcat/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): Automatic server-side prefix cache billed as Cached Input vs Uncached Input.
+# Cache key (chat): none — chat body is model/messages/stream/max_tokens/temperature/top_p/thinking; no key field.
+# Cache headers: none
+# Cache policy: automatic; to improve hits keep same model, stable prefix order, identical tools.
+# Docs: https://longcat.chat/platform/docs/api/chat
 name = "LongCat"
 npm = "@ai-sdk/openai-compatible"
 api = "https://api.longcat.chat/openai"

--- a/providers/lucidquery/provider.toml
+++ b/providers/lucidquery/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): No documented chat prefix cache.
+# Cache key (chat): none — request body is model/messages/max_tokens/temperature/stream/stream_options/response_format/tools/tool_choice; no key field.
+# Cache headers: none — response headers are x-request-id plus ratelimit only.
+# Cache policy: no prefix cache; usage is prompt/completion/total tokens only; to improve reuse keep same model with stable prefix order.
+# Docs: https://lucidquery.com/docs
 # POST /v1/chat/completions enables a trace with $.thinking = true; aliases are
 # $.include_reasoning and $.reasoning.enabled = true. The published request
 # schema gives no false value, effort enum, or reasoning-token budget.

--- a/providers/lynkr/provider.toml
+++ b/providers/lynkr/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): No native chat prefix cache — gateway documents semantic cache only.
+# Cache key (chat): none — no documented chat `prompt_cache_key` or `cache_control` field.
+# Cache headers: none
+# Cache policy: no chat prefix cache; to improve reuse keep same model, stable prefix order, identical tools.
+# Docs: https://github.com/Fast-Editor/Lynkr
 name = "Lynkr"
 # Lynkr is a self-hosted gateway: any non-empty API key is accepted locally;
 # provider credentials live in Lynkr's own configuration.

--- a/providers/meganova/provider.toml
+++ b/providers/meganova/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): No documented chat prefix cache.
+# Cache key (chat): none — chat body is messages/model/max_tokens/temperature/top_p/stream; usage prompt_tokens_details null.
+# Cache headers: none
+# Cache policy: no chat prefix cache; to improve reuse keep same model with stable prefix order.
+# Docs: https://docs.meganova.ai/inference-models/text-generation.md
 # POST /v1/chat/completions publishes messages, model, max_tokens, temperature,
 # top_p, and stream; no toggle, effort, or reasoning-token budget is listed.
 # https://docs.meganova.ai/inference-models/text-generation.md (accessed 2026-06-25)

--- a/providers/merge-gateway/provider.toml
+++ b/providers/merge-gateway/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): No gateway-level chat cache — prefix behavior follows the selected vendor route.
+# Cache key (chat): none — no gateway-level chat key field; vendor-native controls apply per route.
+# Cache headers: none
+# Cache policy: vendor-route controls only; to improve reuse keep same vendor route, model, and stable prefix order.
+# Docs: https://docs.merge.dev/merge-gateway/get-started
 # Reasoning request surfaces (sources accessed 2026-07-21):
 # - Reasoning support and controls are vendor-route capabilities. Use the exact
 #   model response from GET /v1/models and inspect

--- a/providers/meta/provider.toml
+++ b/providers/meta/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): Supported — automatic prefix caching on Chat Completions and Responses.
+# Cache key (chat): Use body `prompt_cache_key` to group shared prefixes at scale.
+# Cache headers: none — hits via usage.prompt_tokens_details.cached_tokens (chat) and input_tokens_details.cached_tokens (responses).
+# Cache policy: automatic; stable content first, stable key per shared prefix, never per-user or per-request.
+# Docs: https://dev.meta.ai/docs/prompt-caching.md
 name = "Meta"
 npm = "@ai-sdk/openai"
 env = ["META_MODEL_API_KEY"]

--- a/providers/minimax-cn-coding-plan/provider.toml
+++ b/providers/minimax-cn-coding-plan/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): Explicit — Anthropic-compatible breakpoint cache.
+# Cache key (chat): Use body `cache_control` with type ephemeral; max 4 breakpoints; 5m TTL refreshed on hit.
+# Cache headers: none — hits via usage.cache_read_input_tokens and cache_creation_input_tokens.
+# Cache policy: explicit breakpoints; order tools, system, then messages; keep stable prefix per breakpoint.
+# Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
 name = "MiniMax Token Plan (minimaxi.com)"
 env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"

--- a/providers/minimax-cn/provider.toml
+++ b/providers/minimax-cn/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): Explicit — Anthropic-compatible breakpoint cache.
+# Cache key (chat): Use body `cache_control` with type ephemeral; max 4 breakpoints; 5m TTL refreshed on hit.
+# Cache headers: none — hits via usage.cache_read_input_tokens and cache_creation_input_tokens.
+# Cache policy: explicit breakpoints; order tools, system, then messages; keep stable prefix per breakpoint.
+# Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
 name = "MiniMax (minimaxi.com)"
 env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"

--- a/providers/minimax-coding-plan/provider.toml
+++ b/providers/minimax-coding-plan/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): Explicit — Anthropic-compatible breakpoint cache.
+# Cache key (chat): Use body `cache_control` with type ephemeral; max 4 breakpoints; 5m TTL refreshed on hit.
+# Cache headers: none — hits via usage.cache_read_input_tokens and cache_creation_input_tokens.
+# Cache policy: explicit breakpoints; order tools, system, then messages; keep stable prefix per breakpoint.
+# Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
 name = "MiniMax Token Plan (minimax.io)"
 env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"

--- a/providers/minimax/provider.toml
+++ b/providers/minimax/provider.toml
@@ -1,3 +1,8 @@
+# Prompt cache (chat): Explicit — Anthropic-compatible breakpoint cache.
+# Cache key (chat): Use body `cache_control` with type ephemeral; max 4 breakpoints; 5m TTL refreshed on hit.
+# Cache headers: none — hits via usage.cache_read_input_tokens and cache_creation_input_tokens.
+# Cache policy: explicit breakpoints; order tools, system, then messages; keep stable prefix per breakpoint.
+# Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
 name = "MiniMax (minimax.io)"
 env = ["MINIMAX_API_KEY"]
 npm = "@ai-sdk/anthropic"


### PR DESCRIPTION
Batch 10 (11 providers): lmstudio, longcat, lucidquery, lynkr, meganova, merge-gateway, meta, minimax, minimax-cn, minimax-cn-coding-plan, minimax-coding-plan.

Header-only changes to each provider.toml (leading comment block, sync-safe). Format: `# Prompt cache (chat): <VERDICT> — <mechanism>.` + `# Docs: <URL>`.

| Provider | Verdict | Mechanism | Docs |
|---|---|---|---|
| lmstudio | TOLERATES | no cache params or cached-token usage in published chat payloads; local server ignores OpenAI cache fields | https://lmstudio.ai/docs/developer/openai-compat/chat-completions |
| longcat | SUPPORTS | server-side prefix caching billed at discounted cached-input rate | https://longcat.chat/platform/docs/pricing/longcat-2.0 |
| lucidquery | TOLERATES | chat API publishes no cache params, cached-token usage, or cached-input rates | https://lucidquery.com/docs |
| lynkr | TOLERATES | self-hosted gateway forwards cache fields upstream; no native chat-cache billing | https://github.com/Fast-Editor/Lynkr |
| meganova | TOLERATES | OpenAI-compatible relay publishes no chat cache params; per-model cached-input prices reflect upstream | https://docs.meganova.ai/inference-models/text-generation.md |
| merge-gateway | TOLERATES | routes across vendors, forwards provider-native controls; no gateway-level chat cache | https://docs.merge.dev/merge-gateway/get-started |
| meta | SUPPORTS | automatic prefix caching via usage.prompt_tokens_details.cached_tokens, optional prompt_cache_key | https://dev.meta.ai/docs/prompt-caching.md |
| minimax | NATIVE_OTHER | Anthropic-surface explicit cache_control (cache_read/cache_creation tokens) | https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache |
| minimax-cn | NATIVE_OTHER | same as minimax (shared API, minimaxi.com domain) | https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache |
| minimax-cn-coding-plan | NATIVE_OTHER | same as minimax (token-plan auth, same Anthropic surface) | https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache |
| minimax-coding-plan | NATIVE_OTHER | same as minimax (token-plan auth, same Anthropic surface) | https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache |

Priors verified: meta SUPPORTS (dedicated prompt-caching doc with automatic prefix caching + prompt_cache_key), minimax x4 NATIVE_OTHER (explicit Anthropic cache_control plus passive automatic caching on the OpenAI surface; these four providers are Anthropic-surface configured), lynkr/meganova/merge-gateway TOLERATES (passthrough gateways/relays, no native chat-cache billing).

Notes:
- longcat newly classified SUPPORTS: pricing lists Cached Input at $0.015/M vs $0.75/M uncached (no client cache params; server-side reuse).
- lmstudio/lucidquery classified TOLERATES: OpenAI-compatible with no cache params, cached-token usage, or cached rates in published docs.
- bun validate passes (required bun install in fresh worktree first; initial validate failure was a pre-existing missing-deps issue, reproduced on clean tree).