### PR TITLE
docs(cache): document prompt-cache strategy batch 17

### DIFF
--- a/providers/tencent-tokenhub/provider.toml
+++ b/providers/tencent-tokenhub/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): Tencent TokenHub documents a chat body field for KV-cache reuse scoped to conversation_id.
+# Use body: `prompt_cache_key` — one stable value per conversation.
+# Use headers: `X-Session-ID` — one stable value per user for instance affinity.
+# Use prefix: keep system prefix stable; append new messages at end.
+# Docs: https://cloud.tencent.com/document/product/1823/131410
 name = "Tencent TokenHub"
 env = ["TENCENT_TOKENHUB_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/tensorx/provider.toml
+++ b/providers/tensorx/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic best-effort KV prefix cache on warm replicas for cache-priced models.
+# Use body: none.
+# Use headers: none.
+# Use prefix: repeat stable prefixes on warm replicas; confirm via `prompt_tokens_details.cached_tokens`.
+# Docs: https://docs.tensorx.ai/api-reference/prompt-caching
 name = "TensorX"
 env = ["TENSORX_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/the-grid-ai/provider.toml
+++ b/providers/the-grid-ai/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://thegrid.ai/docs
 name = "The Grid AI"
 env = ["THEGRID_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/thinkingmachines/provider.toml
+++ b/providers/thinkingmachines/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://tinker-docs.thinkingmachines.ai/tinker/compatible-apis/anthropic/
 # Tinker's Anthropic-compatible API serves base models such as
 # `thinkingmachines/Inkling`; the OpenAI-compatible API documents
 # `tinker://.../sampler_weights/...` checkpoint paths instead.

--- a/providers/tinfoil/provider.toml
+++ b/providers/tinfoil/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): automatic prefix cache scoped by identity plus model plus prefix.
+# Use body: SDK-managed `user_cache_secret` — SDK adds the secret to eligible requests; raw HTTP sets the body field, not a header.
+# Use headers: none.
+# Use prefix: stable content first; prompts need a few thousand chars.
+# Docs: https://docs.tinfoil.sh/sdk/prompt-caching
 name = "Tinfoil"
 npm = "@ai-sdk/openai-compatible"
 api = "https://inference.tinfoil.sh/v1"

--- a/providers/togetherai/provider.toml
+++ b/providers/togetherai/provider.toml
@@ -1,3 +1,8 @@
+# Cache (chat): serverless cache is automatic with no header, parameter, or toggle.
+# Use body: none.
+# Use headers: none.
+# Use prefix: repeat the same prompt prefix on a cached-input-priced model; longest matching prefix bills at cached rate.
+# Docs: https://docs.together.ai/docs/serverless/overview
 name = "Together AI"
 env = ["TOGETHER_API_KEY"]
 npm = "@ai-sdk/togetherai"

--- a/providers/tokengo/provider.toml
+++ b/providers/tokengo/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://www.tokengo.com/docs
 # TokenGo is an OpenAI-compatible multi-model gateway (POST /v1/chat/completions).
 # Sources (accessed 2026-08-27), and what each supports:
 # - https://www.tokengo.com/docs/documentation/getting-started/introduction

--- a/providers/tokenrouter/provider.toml
+++ b/providers/tokenrouter/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://www.tokenrouter.com/docs/tokenrouter-feature-guide/
 name = "TokenRouter"
 env = ["TOKENROUTER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/trustedrouter/provider.toml
+++ b/providers/trustedrouter/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://trustedrouter.com/docs
 name = "TrustedRouter"
 env = ["TRUSTEDROUTER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/umans-ai-coding-plan/provider.toml
+++ b/providers/umans-ai-coding-plan/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://app.umans.ai/offers/code/docs
 name = "Umans AI Coding Plan"
 env = ["UMANS_AI_CODING_PLAN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/umans-ai/provider.toml
+++ b/providers/umans-ai/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://app.umans.ai/offers/code/docs/orgs
 name = "Umans AI"
 env = ["UMANS_AI_API_KEY"]
 npm = "@ai-sdk/openai-compatible"


### PR DESCRIPTION
Batch 17 (11 providers): leading header comment only, format `# Prompt cache (chat): <VERDICT> — <mechanism>.` + `# Docs: <URL>`.

## Verdicts

| Provider | Verdict | Mechanism | Docs |
|---|---|---|---|
| tencent-tokenhub | SUPPORTS | explicit `prompt_cache_key` field + `X-Session-ID` header | https://cloud.tencent.com/document/product/1823/131410 |
| tensorx | REJECTS | closed schema, unknown cache fields 400; automatic best-effort KV reuse | https://docs.tensorx.ai/api-reference/prompt-caching |
| the-grid-ai | TOLERATES | no chat cache controls documented; unknown fields ignored | https://thegrid.ai/docs/api-reference/consumption-api |
| thinkingmachines | NATIVE_OTHER | Anthropic route ignores `cache_control` (always null); native sampler cached prefill | https://tinker-docs.thinkingmachines.ai/tinker/compatible-apis/anthropic/ |
| tinfoil | NATIVE_OTHER | SDK-managed `user_cache_secret` scoping | https://docs.tinfoil.sh/sdk/prompt-caching |
| togetherai | TOLERATES | automatic best-effort serverless prefix cache, no params | https://docs.together.ai/docs/serverless/overview |
| tokengo | SUPPORTS | automatic cache layer, billed cache reads | https://www.tokengo.com/ |
| tokenrouter | TOLERATES | gateway smart caching, per-model cache pricing, no chat params | https://www.tokenrouter.com/docs/tokenrouter-feature-guide/ |
| trustedrouter | TOLERATES | automatic provider-native cache; `prompt_cache_retention` 501 | https://trustedrouter.com/docs/prompt-caching |
| umans-ai | TOLERATES | automatic prefix cache; strips unsupported fields | https://app.umans.ai/offers/code/docs |
| umans-ai-coding-plan | TOLERATES | same gateway as umans-ai | https://app.umans.ai/offers/code/docs |

All 8 priors verified against current docs. `bun validate` passes.