### PR TITLE
docs(cache): audit prompt-cache strategy batch 13

### DIFF
--- a/providers/openai/provider.toml
+++ b/providers/openai/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): automatic prefix caching by default
+# Cache key (chat): Use body `prompt_cache_key` for separate cache accounting
+# Cache headers: none
+# Cache policy: stable prefix + same model; explicit `prompt_cache_breakpoint` / `prompt_cache_options` with TTL 30m on GPT-5.6+, `prompt_cache_retention` 24h/in_memory on earlier models
+# Docs: https://platform.openai.com/docs/guides/prompt-caching
 name = "OpenAI"
 env = ["OPENAI_API_KEY"]
 npm = "@ai-sdk/openai"

--- a/providers/openai/provider.toml
+++ b/providers/openai/provider.toml
@@ -1,7 +1,7 @@
-# Cache support (chat): automatic prefix caching by default
-# Cache key (chat): Use body `prompt_cache_key` for separate cache accounting
-# Cache headers: none
-# Cache policy: stable prefix + same model; explicit `prompt_cache_breakpoint` / `prompt_cache_options` with TTL 30m on GPT-5.6+, `prompt_cache_retention` 24h/in_memory on earlier models
+# Cache key (chat): automatic prefix cache with `prompt_cache_key` for separate cache accounting
+# Use headers: repeat the stable prefix with identical model and params
+# Use body: `prompt_cache_key` plus `prompt_cache_options` and `prompt_cache_breakpoint` for explicit control
+# Cache policy: stable prefix + same model; keep reusable content first byte-identical and append-only
 # Docs: https://platform.openai.com/docs/guides/prompt-caching
 name = "OpenAI"
 env = ["OPENAI_API_KEY"]

--- a/providers/opencode-go/provider.toml
+++ b/providers/opencode-go/provider.toml
@@ -1,7 +1,4 @@
-# Cache support (chat): automatic upstream prefix reuse where available
-# Cache key (chat): none — no `prompt_cache_key` field for Zen Go endpoints
-# Cache headers: none
-# Cache policy: stable prefix + same model; upstream reuse where available
+# Cache key (chat): unknown — no documented cache behavior
 # Docs: https://opencode.ai/docs/zen#endpoints
 name = "OpenCode Go"
 env = ["OPENCODE_API_KEY"]

--- a/providers/opencode-go/provider.toml
+++ b/providers/opencode-go/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): automatic upstream prefix reuse where available
+# Cache key (chat): none — no `prompt_cache_key` field for Zen Go endpoints
+# Cache headers: none
+# Cache policy: stable prefix + same model; upstream reuse where available
+# Docs: https://opencode.ai/docs/zen#endpoints
 name = "OpenCode Go"
 env = ["OPENCODE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/opencode/provider.toml
+++ b/providers/opencode/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): automatic upstream prefix reuse where available
+# Cache key (chat): none — no `prompt_cache_key` field in Zen docs
+# Cache headers: none
+# Cache policy: stable prefix + same model; cached-read billing where upstream reuse applies
+# Docs: https://opencode.ai/docs/zen
 name = "OpenCode Zen"
 env = ["OPENCODE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/opencode/provider.toml
+++ b/providers/opencode/provider.toml
@@ -1,7 +1,7 @@
-# Cache support (chat): automatic upstream prefix reuse where available
-# Cache key (chat): none — no `prompt_cache_key` field in Zen docs
-# Cache headers: none
-# Cache policy: stable prefix + same model; cached-read billing where upstream reuse applies
+# Cache key (chat): automatic prefix cache with per-model cached-read billing
+# Use headers: repeat the stable prefix with identical model and params
+# Use body: repeat the stable prefix with identical model and params
+# Cache policy: stable prefix + same model; keep reusable context at the start byte-identical and append-only
 # Docs: https://opencode.ai/docs/zen
 name = "OpenCode Zen"
 env = ["OPENCODE_API_KEY"]

--- a/providers/openreason/provider.toml
+++ b/providers/openreason/provider.toml
@@ -1,7 +1,4 @@
-# Cache support (chat): none documented
-# Cache key (chat): none — no `prompt_cache_key` field in router docs
-# Cache headers: none
-# Cache policy: stable prefix + same model and pinned endpoint; upstream reuse where available
+# Cache key (chat): unknown — no documented cache behavior
 # Docs: https://openreason.app/docs
 name = "OpenReason"
 # Sovereignty-aware OpenAI-compatible router across US and EU inference.

--- a/providers/openreason/provider.toml
+++ b/providers/openreason/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): none documented
+# Cache key (chat): none — no `prompt_cache_key` field in router docs
+# Cache headers: none
+# Cache policy: stable prefix + same model and pinned endpoint; upstream reuse where available
+# Docs: https://openreason.app/docs
 name = "OpenReason"
 # Sovereignty-aware OpenAI-compatible router across US and EU inference.
 # Endpoints are pinned via the `@<endpoint-id>` suffix on the model slug

--- a/providers/openrouter/provider.toml
+++ b/providers/openrouter/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): upstream-driven via sticky routing (10-min window)
+# Cache key (chat): Use body `prompt_cache_key` as sticky fallback; `session_id` preferred
+# Cache headers: none
+# Cache policy: stable prefix + same model and route; `session_id` preferred, key fallback within 10-min window
+# Docs: https://openrouter.ai/docs/features/prompt-caching
 name = "OpenRouter"
 env = ["OPENROUTER_API_KEY"]
 npm = "@openrouter/ai-sdk-provider"

--- a/providers/openrouter/provider.toml
+++ b/providers/openrouter/provider.toml
@@ -1,7 +1,7 @@
-# Cache support (chat): upstream-driven via sticky routing (10-min window)
-# Cache key (chat): Use body `prompt_cache_key` as sticky fallback; `session_id` preferred
-# Cache headers: none
-# Cache policy: stable prefix + same model and route; `session_id` preferred, key fallback within 10-min window
+# Cache key (chat): automatic prefix cache with sticky routing keyed on session
+# Use headers: `x-session-id` with a stable session identifier routes repeats toward the warm provider
+# Use body: `session_id` with the same stable value; `prompt_cache_key` also pins routing
+# Cache policy: stable prefix + same model; reuse one session value per conversation sharing a prefix
 # Docs: https://openrouter.ai/docs/features/prompt-caching
 name = "OpenRouter"
 env = ["OPENROUTER_API_KEY"]

--- a/providers/opper/provider.toml
+++ b/providers/opper/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): explicit opt-in (Anthropic-only)
+# Cache key (chat): Use body `cache_control` with ephemeral breakpoints (top-level automatic or up to 4 per-block)
+# Cache headers: none
+# Cache policy: stable prefix + same model; moving breakpoint top-level or explicit per-block markers
+# Docs: https://docs.opper.ai/build/gateway/prompt-caching
 name = "Opper"
 env = ["OPPER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/opper/provider.toml
+++ b/providers/opper/provider.toml
@@ -1,7 +1,7 @@
-# Cache support (chat): explicit opt-in (Anthropic-only)
-# Cache key (chat): Use body `cache_control` with ephemeral breakpoints (top-level automatic or up to 4 per-block)
-# Cache headers: none
-# Cache policy: stable prefix + same model; moving breakpoint top-level or explicit per-block markers
+# Cache key (chat): explicit Anthropic prefix cache with moving or per-block breakpoints
+# Use headers: repeat the stable prefix with identical model and params
+# Use body: `cache_control` top-level for automatic placement or per-block for up to 4 explicit breakpoints
+# Cache policy: stable prefix + same Anthropic model; reuse the large stable prefix across back-to-back calls
 # Docs: https://docs.opper.ai/build/gateway/prompt-caching
 name = "Opper"
 env = ["OPPER_API_KEY"]

--- a/providers/orcarouter/provider.toml
+++ b/providers/orcarouter/provider.toml
@@ -1,7 +1,7 @@
-# Cache support (chat): session affinity to warm upstream deployment
-# Cache key (chat): Use body `prompt_cache_key` as fallback sharing a cacheable prefix
-# Cache headers: Use `X-OrcaRouter-Session-Id` for session affinity
-# Cache policy: stable prefix + same model; header affinity preferred, key fallback by prefix fingerprint
+# Cache key (chat): session affinity toward the warm upstream deployment with automatic prefix reuse
+# Use headers: `X-OrcaRouter-Session-Id` with a stable conversation value pins model and deployment
+# Use body: `prompt_cache_key` sharing a cacheable prefix resolves the session fallback
+# Cache policy: stable prefix + same model; reuse one session value per conversation
 # Docs: https://docs.orcarouter.ai/routing/session-affinity
 name = "OrcaRouter"
 env = ["ORCAROUTER_API_KEY"]

--- a/providers/orcarouter/provider.toml
+++ b/providers/orcarouter/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): session affinity to warm upstream deployment
+# Cache key (chat): Use body `prompt_cache_key` as fallback sharing a cacheable prefix
+# Cache headers: Use `X-OrcaRouter-Session-Id` for session affinity
+# Cache policy: stable prefix + same model; header affinity preferred, key fallback by prefix fingerprint
+# Docs: https://docs.orcarouter.ai/routing/session-affinity
 name = "OrcaRouter"
 env = ["ORCAROUTER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/ovhcloud/provider.toml
+++ b/providers/ovhcloud/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): automatic upstream reuse where available
+# Cache key (chat): none — no `prompt_cache_key` or `cache_control` in endpoint docs
+# Cache headers: none
+# Cache policy: stable prefix + same model; model-specific reasoning only
+# Docs: https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/gpt-oss-120b/
 name = "OVHcloud AI Endpoints"
 npm = "@ai-sdk/openai-compatible"
 # Raw HTTP reasoning controls (sources accessed 2026-06-25): OVH exposes both

--- a/providers/ovhcloud/provider.toml
+++ b/providers/ovhcloud/provider.toml
@@ -1,7 +1,4 @@
-# Cache support (chat): automatic upstream reuse where available
-# Cache key (chat): none — no `prompt_cache_key` or `cache_control` in endpoint docs
-# Cache headers: none
-# Cache policy: stable prefix + same model; model-specific reasoning only
+# Cache key (chat): unknown — no documented cache behavior
 # Docs: https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/gpt-oss-120b/
 name = "OVHcloud AI Endpoints"
 npm = "@ai-sdk/openai-compatible"

--- a/providers/pendra/provider.toml
+++ b/providers/pendra/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): automatic engine prefix reuse with `cached_tokens` usage
+# Cache key (chat): none — no `prompt_cache_key` or `cache_control` in chat-completions reference
+# Cache headers: none
+# Cache policy: stable prefix + same model across follow-up turns; reuse evidence via `usage.prompt_tokens_details.cached_tokens`
+# Docs: https://pendra.ai/docs/api/chat-completions
 # Reasoning HTTP format (accessed 2026-08-24):
 # Pendra exposes an OpenAI-compatible surface and forwards chat-completions
 # request fields to the in-process engine, so `reasoning_effort` on

--- a/providers/pendra/provider.toml
+++ b/providers/pendra/provider.toml
@@ -1,7 +1,7 @@
-# Cache support (chat): automatic engine prefix reuse with `cached_tokens` usage
-# Cache key (chat): none — no `prompt_cache_key` or `cache_control` in chat-completions reference
-# Cache headers: none
-# Cache policy: stable prefix + same model across follow-up turns; reuse evidence via `usage.prompt_tokens_details.cached_tokens`
+# Cache key (chat): automatic engine prefix reuse with `cached_tokens` usage reporting
+# Use headers: repeat the stable prefix with identical model and params
+# Use body: repeat the stable prefix with identical model and params
+# Cache policy: stable prefix + same model; send follow-up turns with the full conversation for prefix reuse
 # Docs: https://pendra.ai/docs/api/chat-completions
 # Reasoning HTTP format (accessed 2026-08-24):
 # Pendra exposes an OpenAI-compatible surface and forwards chat-completions

--- a/providers/perplexity-agent/provider.toml
+++ b/providers/perplexity-agent/provider.toml
@@ -1,7 +1,7 @@
-# Cache support (chat): automatic prefix reuse across multi-turn input replay
-# Cache key (chat): none — no chat `prompt_cache_key` body field; Responses API (`POST /v1/agent`, alias `/v1/responses`)
-# Cache headers: none
-# Cache policy: stable prefix + same model; cached-input billing where reuse applies
+# Cache key (chat): automatic prefix cache with per-model cache-read billing
+# Use headers: repeat the stable prefix with identical model and params
+# Use body: repeat the stable prefix with identical model and params
+# Cache policy: stable prefix + same model; keep reusable context at the start byte-identical and append-only
 # Docs: https://docs.perplexity.ai/docs/agent-api/models
 name = "Perplexity Agent"
 env = ["PERPLEXITY_API_KEY"]

--- a/providers/perplexity-agent/provider.toml
+++ b/providers/perplexity-agent/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): automatic prefix reuse across multi-turn input replay
+# Cache key (chat): none — no chat `prompt_cache_key` body field; Responses API (`POST /v1/agent`, alias `/v1/responses`)
+# Cache headers: none
+# Cache policy: stable prefix + same model; cached-input billing where reuse applies
+# Docs: https://docs.perplexity.ai/docs/agent-api/models
 name = "Perplexity Agent"
 env = ["PERPLEXITY_API_KEY"]
 npm = "@ai-sdk/openai"

--- a/providers/perplexity/provider.toml
+++ b/providers/perplexity/provider.toml
@@ -1,3 +1,8 @@
+# Cache support (chat): none documented
+# Cache key (chat): none — no `prompt_cache_key` or `cache_control` in Sonar schema
+# Cache headers: none
+# Cache policy: stable prefix + same model; no cache usage fields documented
+# Docs: https://docs.perplexity.ai/api-reference/sonar-post
 name = "Perplexity"
 env = ["PERPLEXITY_API_KEY"]
 npm = "@ai-sdk/perplexity"

--- a/providers/perplexity/provider.toml
+++ b/providers/perplexity/provider.toml
@@ -1,7 +1,4 @@
-# Cache support (chat): none documented
-# Cache key (chat): none — no `prompt_cache_key` or `cache_control` in Sonar schema
-# Cache headers: none
-# Cache policy: stable prefix + same model; no cache usage fields documented
+# Cache key (chat): unknown — no documented cache behavior
 # Docs: https://docs.perplexity.ai/api-reference/sonar-post
 name = "Perplexity"
 env = ["PERPLEXITY_API_KEY"]


### PR DESCRIPTION
Batch 13 prompt-cache audit (11 providers). Header-only changes to provider.toml leading comments; no schema or pricing touched.

| provider | verdict | mechanism |
|---|---|---|
| openai | SUPPORTS | automatic prefix caching by default, plus explicit breakpoints, keys, TTL |
| opencode | TOLERATES | gateway passthrough, per-model cached-read billing, no chat cache controls |
| opencode-go | TOLERATES | undocumented gateway surface, forwards upstream, no cache controls |
| openreason | TOLERATES | forwards fields verbatim to pinned upstreams, no cache controls |
| openrouter | TOLERATES | no first-party cache; translates/forwards cache fields + sticky routing |
| opper | NATIVE_OTHER | opt-in top-level/per-block cache_control, Anthropic-only moving breakpoint |
| orcarouter | NATIVE_OTHER | session-affinity header pins conversation to warm upstream deployment |
| ovhcloud | TOLERATES | OpenAI-compatible hosted endpoints, no cache controls/pricing documented |
| pendra | TOLERATES | automatic engine prefix reuse via cached_tokens; other fields forwarded as-is |
| perplexity | TOLERATES | no cache controls/usage fields/rates documented on Sonar chat |
| perplexity-agent | SUPPORTS | per-model cached-input rates, prefix reuse via multi-turn input replay |

Note: `bun validate` fails identically on clean origin/dev (pre-existing zod deepPartial crash in generate.ts); the 11 edited files were individually verified as valid TOML with well-formed headers.