### PR TITLE
docs(cache): document prompt-cache strategy batch 18 (11 providers)

### DIFF
--- a/providers/unorouter/provider.toml
+++ b/providers/unorouter/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): unknown — quickstart + integration guides document model/messages only; no cache key field found after 3 sources.
+# Use headers: unknown — no cache routing header documented.
+# Use body: unknown — chat schema covers model/messages/tools/streaming; stable prefixes route to upstream caches where available.
+# Cache policy: supported upstream prefix reuse; keep shared prefix stable with identical model + route; confirm via usage.prompt_tokens_details.cached_tokens where reported.
+# Docs: https://unorouter.com/en/docs/platform/quickstart
 name = "UnoRouter"
 env = ["UNOROUTER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/unorouter/provider.toml
+++ b/providers/unorouter/provider.toml
@@ -1,7 +1,4 @@
-# Cache key (chat): unknown — quickstart + integration guides document model/messages only; no cache key field found after 3 sources.
-# Use headers: unknown — no cache routing header documented.
-# Use body: unknown — chat schema covers model/messages/tools/streaming; stable prefixes route to upstream caches where available.
-# Cache policy: supported upstream prefix reuse; keep shared prefix stable with identical model + route; confirm via usage.prompt_tokens_details.cached_tokens where reported.
+# Prompt caching (chat): unknown.
 # Docs: https://unorouter.com/en/docs/platform/quickstart
 name = "UnoRouter"
 env = ["UNOROUTER_API_KEY"]

--- a/providers/upstage/provider.toml
+++ b/providers/upstage/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): supported — native Solar prefix cache with per-session key.
+# Use headers: unknown — cache routing via body key; no header control documented.
+# Use body: `prompt_cache_key` — top-level chat field; stable value per session/conversation.
+# Cache policy: place static prefix first, reuse same `prompt_cache_key` within the session; Cached Token billing at published cached rate.
+# Docs: https://console.upstage.ai/api/chat
 name = "Upstage"
 # Raw POST /v1/solar/chat/completions uses top-level reasoning_effort.
 # solar-pro2: "high" enables reasoning; omission disables it. solar-pro3:

--- a/providers/upstage/provider.toml
+++ b/providers/upstage/provider.toml
@@ -1,7 +1,6 @@
-# Cache key (chat): supported — native Solar prefix cache with per-session key.
-# Use headers: unknown — cache routing via body key; no header control documented.
+# Prompt caching (chat): supported — native Solar prefix cache with per-session key.
 # Use body: `prompt_cache_key` — top-level chat field; stable value per session/conversation.
-# Cache policy: place static prefix first, reuse same `prompt_cache_key` within the session; Cached Token billing at published cached rate.
+# To get a hit: place static prefix first, reuse same `prompt_cache_key` within the session; Cached Token billing at published cached rate.
 # Docs: https://console.upstage.ai/api/chat
 name = "Upstage"
 # Raw POST /v1/solar/chat/completions uses top-level reasoning_effort.

--- a/providers/v0/provider.toml
+++ b/providers/v0/provider.toml
@@ -1,7 +1,4 @@
-# Cache key (chat): unknown — Model API + v2 chats API define chat with model/messages/system/modelConfiguration; no cache key field found after 3 sources.
-# Use headers: unknown — no cache routing header documented.
-# Use body: unknown — chat accepts documented model/messages fields only; keep payload to documented fields.
-# Cache policy: supported prefix stability; generation lives on the native v2 chats API; keep shared prefix stable with stable inputs.
+# Prompt caching (chat): unknown.
 # Docs: https://v0.dev/docs/api/model
 name = "v0"
 env = ["V0_API_KEY"]

--- a/providers/v0/provider.toml
+++ b/providers/v0/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): unknown — Model API + v2 chats API define chat with model/messages/system/modelConfiguration; no cache key field found after 3 sources.
+# Use headers: unknown — no cache routing header documented.
+# Use body: unknown — chat accepts documented model/messages fields only; keep payload to documented fields.
+# Cache policy: supported prefix stability; generation lives on the native v2 chats API; keep shared prefix stable with stable inputs.
+# Docs: https://v0.dev/docs/api/model
 name = "v0"
 env = ["V0_API_KEY"]
 npm = "@ai-sdk/vercel"

--- a/providers/vancine/provider.toml
+++ b/providers/vancine/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): unknown — chat table lists model/messages/max_tokens/stream/temperature; no cache key field found after 3 sources.
+# Use headers: unknown — no cache routing header documented.
+# Use body: unknown — chat schema covers documented model/messages fields; keep payload to documented fields.
+# Cache policy: supported upstream reuse pattern; keep shared prefix stable for upstream prefix reuse where available.
+# Docs: https://vancine.com/docs/chat
 name = "Vancine"
 npm = "@ai-sdk/openai-compatible"
 env = ["VANCINE_API_KEY"]

--- a/providers/vancine/provider.toml
+++ b/providers/vancine/provider.toml
@@ -1,7 +1,4 @@
-# Cache key (chat): unknown — chat table lists model/messages/max_tokens/stream/temperature; no cache key field found after 3 sources.
-# Use headers: unknown — no cache routing header documented.
-# Use body: unknown — chat schema covers documented model/messages fields; keep payload to documented fields.
-# Cache policy: supported upstream reuse pattern; keep shared prefix stable for upstream prefix reuse where available.
+# Prompt caching (chat): unknown.
 # Docs: https://vancine.com/docs/chat
 name = "Vancine"
 npm = "@ai-sdk/openai-compatible"

--- a/providers/venice/provider.toml
+++ b/providers/venice/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): supported — automatic prefix cache for all models.
+# Use headers: unknown — cache control via body fields.
+# Use body: `prompt_cache_key` routing hint for all models; `cache_control` ephemeral markers for Claude.
+# Cache policy: reuse a stable `prompt_cache_key`, add Claude `cache_control` breakpoints, confirm via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.venice.ai/guides/features/prompt-caching
 name = "Venice AI"
 env = ["VENICE_API_KEY"]
 npm = "venice-ai-sdk-provider"

--- a/providers/venice/provider.toml
+++ b/providers/venice/provider.toml
@@ -1,7 +1,6 @@
-# Cache key (chat): supported — automatic prefix cache for all models.
-# Use headers: unknown — cache control via body fields.
+# Prompt caching (chat): supported — automatic prefix cache for all models.
 # Use body: `prompt_cache_key` routing hint for all models; `cache_control` ephemeral markers for Claude.
-# Cache policy: reuse a stable `prompt_cache_key`, add Claude `cache_control` breakpoints, confirm via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: reuse a stable `prompt_cache_key`, add Claude `cache_control` breakpoints, confirm via usage.prompt_tokens_details.cached_tokens.
 # Docs: https://docs.venice.ai/guides/features/prompt-caching
 name = "Venice AI"
 env = ["VENICE_API_KEY"]

--- a/providers/vercel/provider.toml
+++ b/providers/vercel/provider.toml
@@ -1,7 +1,7 @@
-# Cache key (chat): supported — automatic gateway caching with implicit upstream reuse.
+# Prompt caching (chat): supported — automatic gateway caching with implicit upstream reuse.
 # Use headers: supported affinity for sticky routing; include session affinity header for locality.
 # Use body: `providerOptions.gateway` with caching='auto' (plus cache_ttl / cache_anchor_items on Responses).
-# Cache policy: enable gateway caching='auto', keep prefix stable, pin provider route where needed; confirm via cached-token usage.
+# To get a hit: enable gateway caching='auto', keep prefix stable, pin provider route where needed; confirm via cached-token usage.
 # Docs: https://vercel.com/docs/ai-gateway/models-and-providers/automatic-caching
 name = "Vercel AI Gateway"
 env = ["AI_GATEWAY_API_KEY"]

--- a/providers/vercel/provider.toml
+++ b/providers/vercel/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): supported — automatic gateway caching with implicit upstream reuse.
+# Use headers: supported affinity for sticky routing; include session affinity header for locality.
+# Use body: `providerOptions.gateway` with caching='auto' (plus cache_ttl / cache_anchor_items on Responses).
+# Cache policy: enable gateway caching='auto', keep prefix stable, pin provider route where needed; confirm via cached-token usage.
+# Docs: https://vercel.com/docs/ai-gateway/models-and-providers/automatic-caching
 name = "Vercel AI Gateway"
 env = ["AI_GATEWAY_API_KEY"]
 npm = "@ai-sdk/gateway"

--- a/providers/vivgrid/provider.toml
+++ b/providers/vivgrid/provider.toml
@@ -1,7 +1,5 @@
-# Cache key (chat): supported — automatic implicit cache with Cached Token billing.
-# Use headers: unknown — no cache routing header documented.
-# Use body: unknown — schema lists model/messages/tools/reasoning_effort; hits bill at Cached Input rate with no extra key step.
-# Cache policy: keep shared prefix stable for implicit reuse; confirm via Cached Input billing on model pages.
+# Prompt caching (chat): supported — automatic implicit cache with Cached Token billing.
+# To get a hit: keep shared prefix stable for implicit reuse; confirm via Cached Input billing on model pages.
 # Docs: https://docs.vivgrid.com/models
 name = "Vivgrid"
 env = ["VIVGRID_API_KEY"]

--- a/providers/vivgrid/provider.toml
+++ b/providers/vivgrid/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): supported — automatic implicit cache with Cached Token billing.
+# Use headers: unknown — no cache routing header documented.
+# Use body: unknown — schema lists model/messages/tools/reasoning_effort; hits bill at Cached Input rate with no extra key step.
+# Cache policy: keep shared prefix stable for implicit reuse; confirm via Cached Input billing on model pages.
+# Docs: https://docs.vivgrid.com/models
 name = "Vivgrid"
 env = ["VIVGRID_API_KEY"]
 api = "https://api.vivgrid.com/v1"

--- a/providers/volcengine-coding-plan/provider.toml
+++ b/providers/volcengine-coding-plan/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): supported via separate Context API — `context_id` from ContextCreate, applied on ContextChatCompletions.
+# Use headers: unknown — cache routing via body `context_id`.
+# Use body: `context_id` on ContextChatCompletions; Responses caching with previous_response_id plus caching enabled.
+# Cache policy: call ContextCreate once, reuse `context_id` across turns with stable prefix; confirm via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.byteplus.com/en/docs/ModelArk/1346559
 name = "Volcengine Ark Coding Plan"
 env = ["ARK_CODING_PLAN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/volcengine-coding-plan/provider.toml
+++ b/providers/volcengine-coding-plan/provider.toml
@@ -1,7 +1,6 @@
-# Cache key (chat): supported via separate Context API — `context_id` from ContextCreate, applied on ContextChatCompletions.
-# Use headers: unknown — cache routing via body `context_id`.
+# Prompt caching (chat): supported via separate Context API — `context_id` from ContextCreate, applied on ContextChatCompletions.
 # Use body: `context_id` on ContextChatCompletions; Responses caching with previous_response_id plus caching enabled.
-# Cache policy: call ContextCreate once, reuse `context_id` across turns with stable prefix; confirm via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: call ContextCreate once, reuse `context_id` across turns with stable prefix; confirm via usage.prompt_tokens_details.cached_tokens.
 # Docs: https://docs.byteplus.com/en/docs/ModelArk/1346559
 name = "Volcengine Ark Coding Plan"
 env = ["ARK_CODING_PLAN_API_KEY"]

--- a/providers/volcengine/provider.toml
+++ b/providers/volcengine/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): supported via separate Context API — `context_id` from ContextCreate, applied on ContextChatCompletions.
+# Use headers: unknown — cache routing via body `context_id`.
+# Use body: `context_id` on ContextChatCompletions; Responses caching with previous_response_id plus caching enabled.
+# Cache policy: call ContextCreate once, reuse `context_id` across turns with stable prefix; confirm via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.byteplus.com/en/docs/ModelArk/1346559
 name = "Volcengine Ark"
 env = ["ARK_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/volcengine/provider.toml
+++ b/providers/volcengine/provider.toml
@@ -1,7 +1,6 @@
-# Cache key (chat): supported via separate Context API — `context_id` from ContextCreate, applied on ContextChatCompletions.
-# Use headers: unknown — cache routing via body `context_id`.
+# Prompt caching (chat): supported via separate Context API — `context_id` from ContextCreate, applied on ContextChatCompletions.
 # Use body: `context_id` on ContextChatCompletions; Responses caching with previous_response_id plus caching enabled.
-# Cache policy: call ContextCreate once, reuse `context_id` across turns with stable prefix; confirm via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: call ContextCreate once, reuse `context_id` across turns with stable prefix; confirm via usage.prompt_tokens_details.cached_tokens.
 # Docs: https://docs.byteplus.com/en/docs/ModelArk/1346559
 name = "Volcengine Ark"
 env = ["ARK_API_KEY"]

--- a/providers/vultr/provider.toml
+++ b/providers/vultr/provider.toml
@@ -1,7 +1,4 @@
-# Cache key (chat): unknown — request tables list model/messages/tools with prompt/completion/total usage; no cache key field found after 3 sources.
-# Use headers: unknown — no cache routing header documented.
-# Use body: unknown — keep payload to documented chat fields.
-# Cache policy: supported prefix stability; keep shared prefix stable with identical model + params; treat usage as uncached where no cached-token field is reported.
+# Prompt caching (chat): unknown.
 # Docs: https://docs.vultr.com/products/compute/serverless-inference/management/usage/chat
 name = "Vultr"
 # POST /v1/chat/completions documents no reasoning request field or control.

--- a/providers/vultr/provider.toml
+++ b/providers/vultr/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): unknown — request tables list model/messages/tools with prompt/completion/total usage; no cache key field found after 3 sources.
+# Use headers: unknown — no cache routing header documented.
+# Use body: unknown — keep payload to documented chat fields.
+# Cache policy: supported prefix stability; keep shared prefix stable with identical model + params; treat usage as uncached where no cached-token field is reported.
+# Docs: https://docs.vultr.com/products/compute/serverless-inference/management/usage/chat
 name = "Vultr"
 # POST /v1/chat/completions documents no reasoning request field or control.
 # Responses may contain choices[].message.reasoning; a -normalize model suffix

--- a/providers/wafer.ai/provider.toml
+++ b/providers/wafer.ai/provider.toml
@@ -1,7 +1,5 @@
-# Cache key (chat): supported — automatic server-side prefix cache with Cache-rate billing.
-# Use headers: unknown — hits are automatic with no header flag.
-# Use body: unknown — chat table defines model/messages/sampling only; keep payload to documented fields.
-# Cache policy: keep shared prefix stable; repeated prefixes bill at the Cache rate; confirm via model-card Cache pricing.
+# Prompt caching (chat): supported — automatic server-side prefix cache with Cache-rate billing.
+# To get a hit: keep shared prefix stable; repeated prefixes bill at the Cache rate; confirm via model-card Cache pricing.
 # Docs: https://docs.wafer.ai/serverless/api-reference
 name = "Wafer"
 # POST /v1/chat/completions normalizes thinking.type="enabled"|"disabled",

--- a/providers/wafer.ai/provider.toml
+++ b/providers/wafer.ai/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): supported — automatic server-side prefix cache with Cache-rate billing.
+# Use headers: unknown — hits are automatic with no header flag.
+# Use body: unknown — chat table defines model/messages/sampling only; keep payload to documented fields.
+# Cache policy: keep shared prefix stable; repeated prefixes bill at the Cache rate; confirm via model-card Cache pricing.
+# Docs: https://docs.wafer.ai/serverless/api-reference
 name = "Wafer"
 # POST /v1/chat/completions normalizes thinking.type="enabled"|"disabled",
 # reasoning_effort="none"|"low"|"medium"|"high"|"max", and


### PR DESCRIPTION
Batch 18 prompt-cache audit. Leading header comment only (2 lines per file, no other changes). `bun validate` passes.

| Provider | Verdict | Mechanism |
| --- | --- | --- |
| unorouter | TOLERATES | no cache params documented; unknown fields forwarded upstream |
| upstage | NATIVE_OTHER | implicit prefix cache with prompt_cache_key routing hint on native Solar endpoint |
| v0 | TOLERATES | no cache controls on the chat surface; generation lives on the native v2 chats API |
| vancine | TOLERATES | OpenAI-compatible relay; no cache params documented |
| venice | SUPPORTS | prompt_cache_key routing plus cache_control markers; cached_tokens in usage |
| vercel | NATIVE_OTHER | gateway providerOptions caching auto plus implicit upstream caching; no chat-level cache params |
| vivgrid | NATIVE_OTHER | cached-token billing with implicit upstream caching; chat usage exposes no cache fields |
| volcengine | REJECTS | chat endpoint accepts no cache params; caching requires the separate Context API with context_id |
| volcengine-coding-plan | REJECTS | same as volcengine (coding endpoint variant) |
| vultr | REJECTS | strict chat schema defines no cache fields; usage carries no cached-token accounting |
| wafer.ai | REJECTS | unsupported params return request errors; chat table defines no cache fields |

Docs URLs are in each file header.