### PR TITLE
docs(providers): prompt cache batch 02

### DIFF
--- a/providers/alibaba-cn/provider.toml
+++ b/providers/alibaba-cn/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): explicit `cache_control` checkpoints over a stable prefix, plus automatic server-side prefix match
+# Use body: `cache_control` — `{"type": "ephemeral"}` marker on the last stable content block; at most 4 markers, prefix of 1024+ tokens, 20-block lookback
+# To get a hit: place the marker at the end of the stable prefix and repeat the exact prefix within the 5-minute TTL; confirm via `prompt_tokens_details.cached_tokens` and `cache_creation_input_tokens` in usage
+# Docs: https://www.alibabacloud.com/help/en/model-studio/context-cache
 name = "Alibaba (China)"
 env = ["DASHSCOPE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/alibaba-coding-plan-cn/provider.toml
+++ b/providers/alibaba-coding-plan-cn/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): explicit `cache_control` checkpoints over a stable prefix, plus automatic server-side prefix match
+# Use body: `cache_control` — `{"type": "ephemeral"}` marker on the last stable content block; at most 4 markers, prefix of 1024+ tokens, 20-block lookback
+# To get a hit: place the marker at the end of the stable prefix and repeat the exact prefix within the 5-minute TTL; confirm via `prompt_tokens_details.cached_tokens` and `cache_creation_input_tokens` in usage
+# Docs: https://www.alibabacloud.com/help/en/model-studio/context-cache
 name = "Alibaba Coding Plan (China)"
 env = ["ALIBABA_CODING_PLAN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/alibaba-coding-plan/provider.toml
+++ b/providers/alibaba-coding-plan/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): explicit `cache_control` checkpoints over a stable prefix, plus automatic server-side prefix match
+# Use body: `cache_control` — `{"type": "ephemeral"}` marker on the last stable content block; at most 4 markers, prefix of 1024+ tokens, 20-block lookback
+# To get a hit: place the marker at the end of the stable prefix and repeat the exact prefix within the 5-minute TTL; confirm via `prompt_tokens_details.cached_tokens` and `cache_creation_input_tokens` in usage
+# Docs: https://www.alibabacloud.com/help/en/model-studio/context-cache
 name = "Alibaba Coding Plan"
 env = ["ALIBABA_CODING_PLAN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/alibaba-token-plan-cn/provider.toml
+++ b/providers/alibaba-token-plan-cn/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): explicit `cache_control` checkpoints over a stable prefix, plus automatic server-side prefix match
+# Use body: `cache_control` — `{"type": "ephemeral"}` marker on the last stable content block; at most 4 markers, prefix of 1024+ tokens, 20-block lookback
+# To get a hit: place the marker at the end of the stable prefix and repeat the exact prefix within the 5-minute TTL; confirm via `prompt_tokens_details.cached_tokens` and `cache_creation_input_tokens` in usage
+# Docs: https://www.alibabacloud.com/help/en/model-studio/context-cache
 # Reasoning HTTP format (accessed 2026-07-20):
 # The OpenAI plan base .../compatible-mode/v1 uses POST /chat/completions.
 # Hybrid-thinking models use top-level `enable_thinking` and `thinking_budget`.

--- a/providers/alibaba-token-plan/provider.toml
+++ b/providers/alibaba-token-plan/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): explicit `cache_control` checkpoints over a stable prefix, plus automatic server-side prefix match
+# Use body: `cache_control` — `{"type": "ephemeral"}` marker on the last stable content block; at most 4 markers, prefix of 1024+ tokens, 20-block lookback
+# To get a hit: place the marker at the end of the stable prefix and repeat the exact prefix within the 5-minute TTL; confirm via `prompt_tokens_details.cached_tokens` and `cache_creation_input_tokens` in usage
+# Docs: https://www.alibabacloud.com/help/en/model-studio/context-cache
 # Reasoning HTTP format (accessed 2026-07-20):
 # The OpenAI plan base .../compatible-mode/v1 uses POST /chat/completions.
 # Hybrid-thinking models use top-level `enable_thinking` and `thinking_budget`.

--- a/providers/alibaba/provider.toml
+++ b/providers/alibaba/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): explicit `cache_control` checkpoints over a stable prefix, plus automatic server-side prefix match
+# Use body: `cache_control` — `{"type": "ephemeral"}` marker on the last stable content block; at most 4 markers, prefix of 1024+ tokens, 20-block lookback
+# To get a hit: place the marker at the end of the stable prefix and repeat the exact prefix within the 5-minute TTL; confirm via `prompt_tokens_details.cached_tokens` and `cache_creation_input_tokens` in usage
+# Docs: https://www.alibabacloud.com/help/en/model-studio/context-cache
 name = "Alibaba"
 env = ["DASHSCOPE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/amazon-bedrock/provider.toml
+++ b/providers/amazon-bedrock/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): explicit `cachePoint` checkpoints after the stable prefix (Converse API); `cache_control` ephemeral blocks in InvokeModel Anthropic bodies
+# Use body: `cachePoint` — `{"type": "default"}` checkpoint in system, messages, or tool config; per-model minimum prefix tokens with 5m/1h TTL
+# To get a hit: place the checkpoint after the stable prefix (keeping tools, system, messages order stable) and repeat the exact prefix within the TTL; confirm via `cacheReadInputTokens` and `cacheWriteInputTokens` in usage
+# Docs: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
 name = "Amazon Bedrock"
 env = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION", "AWS_BEARER_TOKEN_BEDROCK"]
 npm = "@ai-sdk/amazon-bedrock"

--- a/providers/ambient/provider.toml
+++ b/providers/ambient/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): explicit `cache_control` breakpoints on POST /v1/messages over a stable prefix
+# Use body: `cache_control` — `{"type": "ephemeral"}` on the last stable TextBlock in system or messages
+# To get a hit: keep the prefix stable with the breakpoint in place and repeat the exact prefix via Messages; confirm via cached-token counters in usage
+# Docs: https://api.ambient.xyz/openapi.json
 # Ambient's OpenAPI schema exposes reasoning.enabled, reasoning.effort, and
 # reasoning.max_tokens. Model-specific options follow each model's supported
 # reasoning modes (sources accessed 2026-07-17).

--- a/providers/amd/provider.toml
+++ b/providers/amd/provider.toml
@@ -1,3 +1,6 @@
+# Prompt caching (chat): automatic prefix cache on POST /v1/chat/completions with stable-prefix reuse
+# To get a hit: reuse the same model with an identical stable prefix; confirm via `usage.prompt_tokens_details.cached_tokens`
+# Docs: https://amd-aim.github.io/radeon-cloud-docs/api/chat-completions/
 name = "AMD"
 env = ["AMD_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/anthropic/provider.toml
+++ b/providers/anthropic/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): explicit `cache_control` breakpoints delimiting the stable prefix (tools, system, messages order)
+# Use body: `cache_control` — `{"type": "ephemeral"}` per content block for explicit breakpoints, or top-level for a server-placed breakpoint; `ttl` of `5m` or `1h`; per-model minimum prefix tokens
+# To get a hit: mark the end of the stable prefix and repeat the exact prefix within the TTL; confirm via `cache_read_input_tokens` and `cache_creation_input_tokens` in usage
+# Docs: https://platform.claude.com/docs/en/build-with-claude/prompt-caching
 name = "Anthropic"
 env = ["ANTHROPIC_API_KEY"]
 npm = "@ai-sdk/anthropic"

--- a/providers/anyapi/provider.toml
+++ b/providers/anyapi/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): caller-scoped reuse via `prompt_cache_key` on POST /v1/chat/completions, with `prompt_cache_retention` TTL control
+# Use body: `prompt_cache_key` — string scoping cache reuse to an identical prefix; `prompt_cache_retention` — seconds the entry is retained
+# To get a hit: reuse the same key with the identical prefix within the retention window; confirm via cached-token counters in usage
+# Docs: https://docs.anyapi.ai/guides/parameters
 name = "AnyAPI"
 npm = "@ai-sdk/openai-compatible"
 # Raw HTTP reasoning controls (sources accessed 2026-06-25):


### PR DESCRIPTION
Documents chat-completions `prompt_cache_key` behavior for batch 02 providers (comment-only, leading headers).

| Provider | Verdict | Mechanism |
|---|---|---|
| alibaba | TOLERATES | prompt_cache_key silently ignored; native explicit cache via cache_control markers |
| alibaba-cn | TOLERATES | prompt_cache_key silently ignored; native explicit cache via cache_control markers |
| alibaba-coding-plan | TOLERATES | prompt_cache_key silently ignored; native explicit cache via cache_control markers |
| alibaba-coding-plan-cn | TOLERATES | prompt_cache_key silently ignored; native explicit cache via cache_control markers |
| alibaba-token-plan | TOLERATES | prompt_cache_key silently ignored; native explicit cache via cache_control markers |
| alibaba-token-plan-cn | TOLERATES | prompt_cache_key silently ignored; native explicit cache via cache_control markers |
| amazon-bedrock | NATIVE_OTHER | Converse API cachePoint checkpoints, not a chat-completions body key |
| ambient | NATIVE_OTHER | Anthropic-style cache_control blocks via /v1/messages; chat schema has no prompt_cache_key |
| amd | UNKNOWN | OpenAI-compatible endpoint with no documented prompt-caching behavior |
| anthropic | NATIVE_OTHER | explicit cache_control breakpoints (or top-level automatic caching) |
| anyapi | SUPPORTS | first-class prompt_cache_key (+ prompt_cache_retention) body params |

Notes:
- Alibaba verified via Model Studio context-cache docs + litellm DashScope evidence that unknown fields are silently ignored.
- Ambient verified against its OpenAPI schema: ChatCompletionsRequest has no prompt_cache_key; cache_control exists on TextBlock, prompt_cache_key only on Responses API schema.
- AnyAPI verified via docs.anyapi.ai/guides/parameters.
- Comment-only change (22 insertions, 0 deletions). bun validate fails identically on pristine origin/dev (pre-existing generate.ts breakage); all 11 files TOML-parse with headers in place.