### PR TITLE
docs(providers): prompt cache batch 03

### DIFF
--- a/providers/arcee/provider.toml
+++ b/providers/arcee/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://docs.arcee.ai/api-reference/chat-completion
 name = "Arcee"
 npm = "@ai-sdk/openai-compatible"
 env = ["ARCEE_API_KEY"]

--- a/providers/atomic-chat/provider.toml
+++ b/providers/atomic-chat/provider.toml
@@ -1,3 +1,6 @@
+# Prompt caching (chat): Local OpenAI-compatible server with automatic prefix reuse via the loaded backend KV cache plus automatic TurboQuant KV compression.
+# To get a hit: Replay the same model with a byte-stable shared prefix and append-only turns; keep long system content plus tools first.
+# Docs: https://atomic.chat/blog/guides/what-is-kv-cache
 name = "Atomic Chat"
 env = ["ATOMIC_CHAT_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/auriko/provider.toml
+++ b/providers/auriko/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): Routing gateway with automatic prefix reuse plus explicit per-conversation grouping for OpenAI-family models.
+# Use body: `prompt_cache_key` stable per conversation sharing a prefix; `prompt_cache_retention: "24h"` extends lifetime on gpt-4.1 plus gpt-5 family models.
+# To get a hit: Place reusable system content first with append-only growth, reuse one stable key per shared prefix, confirm via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.auriko.ai/guides/prompt-caching
 name = "Auriko"
 env = ["AURIKO_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/azure-cognitive-services/provider.toml
+++ b/providers/azure-cognitive-services/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): Automatic prefix reuse with keyed grouping plus explicit breakpoints on GPT-5.6 family plus later.
+# Use body: `prompt_cache_key` with one stable value per shared prefix (~15 req/min per prefix plus key); `prompt_cache_options` mode implicit|explicit with ttl 30m; `prompt_cache_breakpoint` pinning the stable-prefix boundary (up to 4 new writes per request, reads consider the recent 50); `prompt_cache_retention` selecting retention on pre-5.6 models.
+# To get a hit: Keep the first 1024 plus tokens identical plus append-only with stable tools order, reuse one key per shared prefix, confirm via usage.prompt_tokens_details.cached_tokens plus cache_write_tokens on Standard deployments.
+# Docs: https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/prompt-caching
 name = "Azure Cognitive Services"
 env = ["AZURE_COGNITIVE_SERVICES_RESOURCE_NAME", "AZURE_COGNITIVE_SERVICES_API_KEY"]
 npm = "@ai-sdk/azure"

--- a/providers/azure/provider.toml
+++ b/providers/azure/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): Automatic prefix reuse with keyed grouping plus explicit breakpoints on GPT-5.6 family plus later.
+# Use body: `prompt_cache_key` with one stable value per shared prefix (~15 req/min per prefix plus key); `prompt_cache_options` mode implicit|explicit with ttl 30m; `prompt_cache_breakpoint` pinning the stable-prefix boundary (up to 4 new writes per request, reads consider the recent 50); `prompt_cache_retention` selecting retention on pre-5.6 models.
+# To get a hit: Keep the first 1024 plus tokens identical plus append-only with stable tools order, reuse one key per shared prefix, confirm via usage.prompt_tokens_details.cached_tokens plus cache_write_tokens on Standard deployments.
+# Docs: https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/prompt-caching
 name = "Azure"
 env = ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"]
 npm = "@ai-sdk/azure"

--- a/providers/bailing/provider.toml
+++ b/providers/bailing/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://alipaytbox.yuque.com/sxs0ba/ling/intro
 name = "Bailing"
 env = ["BAILING_API_TOKEN"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/baseten/provider.toml
+++ b/providers/baseten/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): Automatic KV prefix reuse with discounted cached input tokens plus session-aware routing to the replica holding the shared prefix.
+# Use headers: `x-session-affinity` stable per conversation or agent task across related requests.
+# To get a hit: Keep a stable shared prefix with append-only growth on the same model, reuse one session value per conversation, confirm via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.baseten.co/inference/model-apis/pricing-and-limits
 name = "Baseten"
 npm = "@ai-sdk/openai-compatible"
 # Raw HTTP reasoning controls (sources accessed 2026-06-25):

--- a/providers/berget/provider.toml
+++ b/providers/berget/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://api.berget.ai/
 name = "Berget.AI"
 env = ["BERGET_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/blueclaw/provider.toml
+++ b/providers/blueclaw/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://blueclaw.network/how-it-works.html
 name = "Blue Claw"
 npm = "@ai-sdk/openai-compatible"
 api = "https://openai.blueclaw.network/v1"

--- a/providers/bothub/provider.toml
+++ b/providers/bothub/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://bothub.ru/models
 name = "Bothub"
 env = ["BOTHUB_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/cerebras/provider.toml
+++ b/providers/cerebras/provider.toml
@@ -1,3 +1,7 @@
+# Prompt caching (chat): Automatic prefix reuse in 128-token blocks with 5-minute guaranteed TTL up to 1 hour plus optional keyed routing for conversations sharing a prefix.
+# Use body: `prompt_cache_key` stable per conversation or workflow sharing a prefix, max 1024 chars, with one key per conversation; shared system prompts across many users stay on automatic reuse.
+# To get a hit: Place stable system content plus tools first with exact append-only prefixes, reuse the same key across the conversation, confirm via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://inference-docs.cerebras.ai/capabilities/prompt-caching
 name = "Cerebras"
 env = ["CEREBRAS_API_KEY"]
 npm = "@ai-sdk/cerebras"


### PR DESCRIPTION
Documents prompt-cache (chat) strategy for batch 03 providers. Header-only changes (leading comment block above first key); no schema fields touched. `bun validate` passes.

| Provider | Verdict | Mechanism | Docs |
|---|---|---|---|
| arcee | TOLERATES | Request schema omits prompt_cache_key with no additionalProperties:false, so unknown key is accepted but ignored. | https://docs.arcee.ai/api-reference/chat-completion |
| atomic-chat | UNKNOWN | Local OpenAI-compatible server documents no prompt_cache_key or caching behavior; backend-dependent. | https://github.com/AtomicBot-ai/Atomic-Chat |
| auriko | SUPPORTS | Explicit prompt_cache_key field with OpenAI-compatible passthrough. | https://docs.auriko.ai/api-reference/chat-completions |
| azure | SUPPORTS | Automatic prefix caching plus prompt_cache_key routing hint (retention/breakpoints on newer models). | https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/prompt-caching |
| azure-cognitive-services | SUPPORTS | Same Azure OpenAI prompt-caching surface: automatic prefix caching plus prompt_cache_key. | https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/prompt-caching |
| bailing | UNKNOWN | No prompt_cache_key or prompt-caching behavior documented. | https://alipaytbox.yuque.com/sxs0ba/ling/intro |
| baseten | REJECTS | Strict ChatCompletionRequest (additionalProperties:false) with no prompt_cache_key; unknown key fails validation. | https://docs.baseten.co/reference/inference-api/chat-completions |
| berget | TOLERATES | Schema omits prompt_cache_key but permits extras (additionalProperties:{}), so unknown key is accepted without effect. | https://api.berget.ai/openapi.json |
| blueclaw | UNKNOWN | OpenAI-compatible gateway docs list chat/streaming/tools with no cache param or schema. | https://blueclaw.network/how-it-works.html |
| bothub | UNKNOWN | No prompt_cache_key or prompt-caching behavior documented for the OpenAI-compatible endpoint. | https://bothub.ru/models |
| cerebras | SUPPORTS | Automatic prefix caching plus optional prompt_cache_key routing hint (max 1024 chars, longer values rejected with 400). | https://inference-docs.cerebras.ai/capabilities/prompt-caching |

Verification notes:
- Cerebras prompt_cache_key limit (1024 chars, 400 if longer) confirmed in docs.
- Baseten REJECTS confirmed via OpenAPI (ChatCompletionRequest additionalProperties:false, no prompt_cache_key).
- Berget TOLERATES confirmed via openapi.json (no prompt_cache_key anywhere; ChatCompletionRequest additionalProperties:{}).
- Auriko SUPPORTS confirmed via OpenAPI (explicit prompt_cache_key: "Prompt caching identifier. Supported by OpenAI.").
- Azure SUPPORTS confirmed via MS prompt-caching guide (automatic caching + prompt_cache_key on GPT-5.6+).
