### PR TITLE
docs(cache): audit prompt-cache strategy batch 14

### DIFF
--- a/providers/pioneer/provider.toml
+++ b/providers/pioneer/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): explicit `cache_control` breakpoints on Claude/Anthropic-style models; automatic server-side prefix match on OpenAI/GPT-family models
+# Use headers: none.
+# Use body: `cache_control` — `{"type": "ephemeral"}` marker on the last stable content block (content-block array, not plain string); up to 4 markers; GPT-family ignores markers
+# To get a hit: send the stable prefix as content blocks with the marker and repeat the exact prefix; verify via `usage.prompt_tokens_details.cached_tokens` (chat) or `cache_read_input_tokens` (messages)
+# Docs: https://docs.pioneer.ai/api-reference/prompt-caching
 name = "Pioneer"
 env = ["PIONEER_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/poe/provider.toml
+++ b/providers/poe/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://creator.poe.com/docs/external-applications/openai-compatible-api
 name = "Poe"
 env = ["POE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/poolside/provider.toml
+++ b/providers/poolside/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://docs.poolside.ai/api/overview
 name = "Poolside"
 env = ["POOLSIDE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/privatemode-ai/provider.toml
+++ b/providers/privatemode-ai/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): per-request `cache_salt` scoping; inactive by default, enable per proxy or per request
+# Use headers: none.
+# Use body: `cache_salt` — string with >=256-bit entropy (via `extra_body`); same salt shares a cache; request value overrides proxy
+# To get a hit: reuse the same salt with an identical prefix; keep salts private (`openssl rand -base64 32`)
+# Docs: https://docs.privatemode.ai/api/prompt-caching/
 name = "Privatemode AI"
 env = ["PRIVATEMODE_API_KEY", "PRIVATEMODE_ENDPOINT"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/qihang-ai/provider.toml
+++ b/providers/qihang-ai/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://www.qhaigc.net/docs/api-reference/chat/openai-style.md
 name = "QiHang"
 npm = "@ai-sdk/openai-compatible"
 api = "https://api.qhaigc.net/v1"

--- a/providers/qiniu-ai/provider.toml
+++ b/providers/qiniu-ai/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://developer.qiniu.com/aitokenapi/13390/chat-completions
 name = "Qiniu"
 env = ["QINIU_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/qvac/provider.toml
+++ b/providers/qvac/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://docs.qvac.tether.io/cli/http-server/
 name = "QVAC"
 env = ["QVAC_API_KEY"]
 npm = "@qvac/ai-sdk-provider"

--- a/providers/regolo-ai/provider.toml
+++ b/providers/regolo-ai/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://docs.regolo.ai/models/families/completions/
 name = "Regolo AI"
 env = ["REGOLO_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/requesty/provider.toml
+++ b/providers/requesty/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): router `requesty.auto_cache` plus pass-through `cache_control` breakpoints; provider caches server-side
+# Use headers: none.
+# Use body: `requesty.auto_cache` — boolean (`true` attempts caching, `false` skips costly writes); `cache_control` — `{"type": "ephemeral"}` breakpoints on Messages API content blocks
+# To get a hit: send the full history with `auto_cache: true` (chat) or place `cache_control` on stable blocks (messages); verify via cache analytics and cached-token counters in usage
+# Docs: https://docs.requesty.ai/features/auto-caching
 name = "Requesty"
 env = ["REQUESTY_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/routing-run/provider.toml
+++ b/providers/routing-run/provider.toml
@@ -1,3 +1,5 @@
+# Prompt caching (chat): unknown.
+# Docs: https://app.routing.run/docs/api/chat-completions
 name = "routing.run"
 env = ["ROUTING_RUN_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/runinfra/provider.toml
+++ b/providers/runinfra/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic prefix cache with session-affinity routing; no parameter required for basic reuse
+# Use headers: `x-session-id` for session affinity (plus `x-parent-session-id` fan-out, `x-session-affinity`/`x-runinfra-session` aliases)
+# Use body: `prompt_cache_key` — string routing identity when no session header (consumed at gateway); `runinfra.sessionId` — session identity taking precedence over headers
+# To get a hit: keep a byte-identical prefix with the same model and pin multi-turn sessions with `x-session-id`; verify via `usage.prompt_tokens_details.cached_tokens`
+# Docs: https://runinfra.ai/docs/cookbook/prompt-caching.md
 # Docs: https://runinfra.ai/docs
 # Per-model pages: https://runinfra.ai/inference-api/<slug>
 # API: OpenAI-compatible chat completions at https://api.runinfra.ai/v1 (/chat/completions, /models)


### PR DESCRIPTION
Batch 14 prompt-cache audit (11 providers). Header-only changes to provider.toml leading comments.

| Provider | Verdict | Mechanism |
|---|---|---|
| pioneer | NATIVE_OTHER | gateway translates unified params to per-upstream native shapes; caching follows the serving upstream |
| poe | TOLERATES | best-effort extra_body passthrough varies by bot; usage.prompt_tokens_details always empty |
| poolside | NATIVE_OTHER | vLLM-backed inference with server-native prefix reuse; no chat cache params or cache billing documented |
| privatemode-ai | NATIVE_OTHER | proprietary cache_salt request field or proxy config; inactive by default, shared per proxy |
| qihang-ai | TOLERATES | OpenAI-compatible relay with no documented cache control; behavior follows the serving upstream |
| qiniu-ai | SUPPORTS | server-side caching billed at published cached-input rates, with explicit-cache tiers on select models |
| qvac | NATIVE_OTHER | local on-device runtime; engine-local KV-cache hits surface via cached_tokens, no chat params or billing |
| regolo-ai | TOLERATES | OpenAI-spec relay with standard params only and no cache feature; behavior follows the serving upstream |
| requesty | TOLERATES | auto_cache and manual cache_control forwarded to the underlying provider; no router-side cache store |
| routing-run | TOLERATES | router with automatic failover and no cache-tier pricing; caching follows the selected upstream provider |
| runinfra | SUPPORTS | automatic prefix cache at ~1/10 input rate with cached_tokens usage and session affinity |

Note: bun validate fails identically on pristine origin/dev (pre-existing generate.ts schema error); all 11 edited TOMLs parse cleanly.