### PR TITLE
docs(cache): audit prompt-cache strategy batch 08

### DIFF
--- a/providers/impossibl/provider.toml
+++ b/providers/impossibl/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use body `cache_control` ephemeral breakpoint on Anthropic routes; automatic prefix caching on other routes.
+# Cache headers: none
+# Cache policy: repeat byte-identical prefix on the same model; Anthropic breakpoints use min ~1024 tokens, 5m TTL refreshed on hit, 1h via ttl.
+# Cache verify: confirm hits via GET /v1/requests cached_input_tokens.
+# Docs: https://impossibl.com/docs/prompt-caching.md
 name = "Impossibl"
 npm = "@ai-sdk/openai-compatible"
 api = "https://api.impossibl.com/v1"

--- a/providers/inception/provider.toml
+++ b/providers/inception/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use headers/body none — automatic prefix cache on the same model.
+# Cache headers: none
+# Cache policy: automatic prefix cache; replay requests with a stable byte-identical prefix on the same model.
+# Cache verify: confirm hits via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://docs.inceptionlabs.ai/api-reference/chat/create-a-chat-completion
 name = "Inception"
 env = ["INCEPTION_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/inceptron/provider.toml
+++ b/providers/inceptron/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use headers/body none — automatic prefix reuse on the same model.
+# Cache headers: none
+# Cache policy: automatic prefix reuse; replay requests with a stable byte-identical prefix on the same model.
+# Cache verify: confirm hits via usage block where reported.
+# Docs: https://docs.inceptron.io/API%20Reference/chat-completions
 name = "Inceptron"
 npm = "@ai-sdk/openai-compatible"
 env = ["INCEPTRON_API_KEY"]

--- a/providers/inference/provider.toml
+++ b/providers/inference/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use headers/body none — automatic prefix reuse on the same model.
+# Cache headers: none
+# Cache policy: automatic prefix reuse; replay requests with a stable byte-identical prefix on the same model.
+# Cache verify: confirm hits via usage block where reported.
+# Docs: https://docs.inference.net/api/api-quickstart
 name = "Inference"
 env = ["INFERENCE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/inferx/provider.toml
+++ b/providers/inferx/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use headers/body none — automatic prefix reuse on the same model.
+# Cache headers: none
+# Cache policy: automatic prefix reuse; replay requests with a stable byte-identical prefix on the same model.
+# Cache verify: confirm hits via usage block where reported.
+# Docs: https://inferx.net/docs/api-reference
 name = "InferX"
 env = ["INFERX_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/infomaniak/provider.toml
+++ b/providers/infomaniak/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use headers/body none — automatic server-side prefix caching.
+# Cache headers: none
+# Cache policy: automatic server-side prefix caching; replay requests with a stable byte-identical prefix on the same model.
+# Cache verify: confirm hits via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://developer.infomaniak.com/docs/api/post/2/ai/%7Bproduct_id%7D/openai/v1/chat/completions
 name = "Infomaniak"
 npm = "@ai-sdk/openai-compatible"
 api = "https://api.infomaniak.com/2/ai/${INFOMANIAK_PRODUCT_ID}/openai/v1"

--- a/providers/io-net/provider.toml
+++ b/providers/io-net/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use headers/body none — automatic prefix cache on cache-capable models.
+# Cache headers: none
+# Cache policy: automatic prefix cache on models with metadata supports_prompt_cache=true; repeat byte-identical prefix on the same model with cache read/write billing.
+# Cache verify: confirm hits via cached-token billing on eligible models.
+# Docs: https://io.net/docs/reference/ai-models/get-models-list
 name = "IO.NET"
 env = ["IOINTELLIGENCE_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/iteracompute/provider.toml
+++ b/providers/iteracompute/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use headers/body none — automatic prefix reuse on the same model.
+# Cache headers: none
+# Cache policy: automatic prefix reuse; replay requests with a stable byte-identical prefix on the same model.
+# Cache verify: confirm hits via usage block where reported.
+# Docs: https://iteracompute.com/docs.html
 # IteraCompute exposes an OpenAI-compatible API through @ai-sdk/openai-compatible.
 # Authentication uses ITERACOMPUTE_API_KEY; the API base URL is https://api.iteracompute.com/v1.
 name = "IteraCompute"

--- a/providers/jalapeno/provider.toml
+++ b/providers/jalapeno/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use body `prompt_cache_key` routing hint — documented chat-payload field that pins prefix-hash routing to improve hit rate.
+# Cache headers: none
+# Cache policy: exact-prefix match required; apply one stable `prompt_cache_key` per workload on the same model; cache is org-scoped.
+# Cache verify: confirm hits via usage.prompt_tokens_details.cached_tokens.
+# Docs: https://www.jalapeno-cloud.ai/docs/inference/features/prompt-caching
 name = "Jalapeno Cloud"
 env = ["JALAPENO_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/jiekou/provider.toml
+++ b/providers/jiekou/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use body `cache_control` ephemeral breakpoints on Anthropic models; automatic prefix caching on OpenAI/Gemini-backed models.
+# Cache headers: none
+# Cache policy: Anthropic models use `cache_control` ephemeral breakpoints (min 1024 tokens Sonnet/Opus, 2048 Haiku); OpenAI/Gemini-backed models cache on repeated identical prefix.
+# Cache verify: confirm hits via usage.prompt_tokens_details.cached_tokens / cache_read_input_tokens.
+# Docs: https://docs.jiekou.ai/docs/feature/prompt-caching.md
 name = "Jiekou.AI"
 env = ["JIEKOU_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/kenari/provider.toml
+++ b/providers/kenari/provider.toml
@@ -1,3 +1,8 @@
+# Cache key (chat): Use headers/body none — automatic prefix reuse on the same model.
+# Cache headers: none
+# Cache policy: automatic prefix reuse; replay requests with a stable byte-identical prefix on the same model.
+# Cache verify: confirm hits via usage block where reported.
+# Docs: https://kenari.id/docs
 name = "Kenari"
 npm = "@ai-sdk/openai-compatible"
 env = ["KENARI_API_KEY"]


### PR DESCRIPTION
Batch 08 (11 providers): impossibl, inception, inceptron, inference, inferx, infomaniak, io-net, iteracompute, jalapeno, jiekou, kenari.

Leading header comment only (`# Prompt cache (chat)` + `# Docs`) per provider.

- SUPPORTS (2): inception (automatic prefix cache, discounted cached-input rates, `usage.prompt_tokens_details.cached_tokens`), jalapeno (automatic prefix cache + optional `prompt_cache_key`, dedicated caching doc).
- NATIVE_OTHER (3): impossibl (automatic on most routes; Anthropic needs `cache_control` breakpoint — prior verdict verified), jiekou (explicit Anthropic `cache_control` + implicit OpenAI/Gemini — prior verdict verified), io-net (automatic prefix cache, no request fields; per-model `supports_prompt_cache` + cache read/write rates).
- TOLERATES (1): infomaniak (OpenAI-compatible chat API, no cache params/usage/rates published).
- UNKNOWN (5): inceptron (setup-only docs), inference (closed param table, no cache fields), inferx (no public API reference), iteracompute (no cache params; usage is prompt/completion/total only), kenari (site/docs unreachable).

Note: `bun validate` fails identically on the clean base (pre-existing `AuthoredModelShape.deepPartial` environment error); all 11 TOML files verified parseable.