### PR TITLE
docs(providers): document prompt cache batch 19

### DIFF
--- a/providers/wandb/provider.toml
+++ b/providers/wandb/provider.toml
@@ -1,8 +1,7 @@
-# Prompt caching (chat): no documented prompt cache on POST /v1/chat/completions.
-# Use headers: none.
-# Use body: none — chat schema defines model/messages only; usage reports prompt/completion/total with no cached-token field.
-# To get a hit: replay stable prefixes; treat usage as uncached.
-# Docs: https://docs.wandb.ai/inference/api-reference/chat-completions
+# Prompt caching (chat): automatic prefix cache on POST /v1/chat/completions on supported models.
+# Use body: `cache_salt` isolates reuse; hits via usage.prompt_tokens_details.cached_tokens where returned.
+# To get a hit: replay stable prefixes with matching `cache_salt`.
+# Docs: https://docs.wandb.ai/inference/response-settings/prefix-caching
 name = "Weights & Biases"
 # POST /v1/chat/completions toggles eligible models with
 # chat_template_kwargs.enable_thinking=true|false; output is choices[].message.reasoning.

--- a/providers/wandb/provider.toml
+++ b/providers/wandb/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): no documented prompt cache on POST /v1/chat/completions.
+# Use headers: none.
+# Use body: none — chat schema defines model/messages only; usage reports prompt/completion/total with no cached-token field.
+# To get a hit: replay stable prefixes; treat usage as uncached.
+# Docs: https://docs.wandb.ai/inference/api-reference/chat-completions
 name = "Weights & Biases"
 # POST /v1/chat/completions toggles eligible models with
 # chat_template_kwargs.enable_thinking=true|false; output is choices[].message.reasoning.

--- a/providers/watsonx/provider.toml
+++ b/providers/watsonx/provider.toml
@@ -1,6 +1,4 @@
 # Prompt caching (chat): unknown on POST /ml/v1/chat/completions.
-# Use body: stable model/messages prefix; confirm hits via usage where returned.
-# To get a hit: replay stable prefixes.
 # Docs: https://cloud.ibm.com/apidocs/watsonx-ai
 name = "watsonx.ai"
 env = ["WATSONX_AI_APIKEY", "WATSONX_AI_PROJECT_ID"]

--- a/providers/watsonx/provider.toml
+++ b/providers/watsonx/provider.toml
@@ -1,7 +1,6 @@
-# Prompt caching (chat): no documented chat-level cache on the native wx.ai chat API.
-# Use headers: none.
-# Use body: none — no cache body field documented.
-# To get a hit: replay stable prefixes; treat usage as uncached.
+# Prompt caching (chat): unknown on POST /ml/v1/chat/completions.
+# Use body: stable model/messages prefix; confirm hits via usage where returned.
+# To get a hit: replay stable prefixes.
 # Docs: https://cloud.ibm.com/apidocs/watsonx-ai
 name = "watsonx.ai"
 env = ["WATSONX_AI_APIKEY", "WATSONX_AI_PROJECT_ID"]

--- a/providers/watsonx/provider.toml
+++ b/providers/watsonx/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): no documented chat-level cache on the native wx.ai chat API.
+# Use headers: none.
+# Use body: none — no cache body field documented.
+# To get a hit: replay stable prefixes; treat usage as uncached.
+# Docs: https://cloud.ibm.com/apidocs/watsonx-ai
 name = "watsonx.ai"
 env = ["WATSONX_AI_APIKEY", "WATSONX_AI_PROJECT_ID"]
 npm = "watsonx-ai-provider"

--- a/providers/xai/provider.toml
+++ b/providers/xai/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic prefix cache on shared leading messages.
+# Use headers: `x-grok-conv-id` — same ID routes to the same server for per-server prefix hits.
+# Use body: none on chat — prompt_cache_key is Responses-only; hits via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: replay stable prefixes with a stable conversation ID.
+# Docs: https://docs.x.ai/developers/advanced-api-usage/prompt-caching
 name = "xAI"
 env = ["XAI_API_KEY"]
 npm = "@ai-sdk/xai"

--- a/providers/xai/provider.toml
+++ b/providers/xai/provider.toml
@@ -1,6 +1,6 @@
-# Prompt caching (chat): automatic prefix cache on shared leading messages.
-# Use headers: `x-grok-conv-id` — same ID routes to the same server for per-server prefix hits.
-# Use body: none on chat — prompt_cache_key is Responses-only; hits via usage.prompt_tokens_details.cached_tokens.
+# Prompt caching (chat): automatic prefix cache on POST /v1/chat/completions.
+# Use headers: `x-grok-conv-id` with a stable conversation ID for per-server prefix hits.
+# Use body: hits via usage.prompt_tokens_details.cached_tokens.
 # To get a hit: replay stable prefixes with a stable conversation ID.
 # Docs: https://docs.x.ai/developers/advanced-api-usage/prompt-caching
 name = "xAI"

--- a/providers/xiaomi-token-plan-ams/provider.toml
+++ b/providers/xiaomi-token-plan-ams/provider.toml
@@ -1,8 +1,7 @@
-# Prompt caching (chat): automatic prefix prompt cache on POST /v1/chat/completions.
-# Use headers: none.
-# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens (Anthropic: cache_read_input_tokens).
-# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price with free cache write.
-# Docs: https://platform.xiaomimimo.com/#/docs
+# Prompt caching (chat): automatic prefix cache on POST /v1/chat/completions.
+# Use body: hits via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price.
+# Docs: https://mimo.mi.com/docs/en-US/api/chat/openai-api
 name = "Xiaomi Token Plan (Europe)"
 # Raw endpoints are POST https://token-plan-ams.xiaomimimo.com/v1/chat/completions
 # and POST https://token-plan-ams.xiaomimimo.com/anthropic/v1/messages.

--- a/providers/xiaomi-token-plan-ams/provider.toml
+++ b/providers/xiaomi-token-plan-ams/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic prefix prompt cache on POST /v1/chat/completions.
+# Use headers: none.
+# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens (Anthropic: cache_read_input_tokens).
+# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price with free cache write.
+# Docs: https://platform.xiaomimimo.com/#/docs
 name = "Xiaomi Token Plan (Europe)"
 # Raw endpoints are POST https://token-plan-ams.xiaomimimo.com/v1/chat/completions
 # and POST https://token-plan-ams.xiaomimimo.com/anthropic/v1/messages.

--- a/providers/xiaomi-token-plan-cn/provider.toml
+++ b/providers/xiaomi-token-plan-cn/provider.toml
@@ -1,8 +1,7 @@
-# Prompt caching (chat): automatic prefix prompt cache on POST /v1/chat/completions.
-# Use headers: none.
-# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens (Anthropic: cache_read_input_tokens).
-# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price with free cache write.
-# Docs: https://platform.xiaomimimo.com/#/docs
+# Prompt caching (chat): automatic prefix cache on POST /v1/chat/completions.
+# Use body: hits via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price.
+# Docs: https://mimo.mi.com/docs/en-US/api/chat/openai-api
 name = "Xiaomi Token Plan (China)"
 # Raw endpoints are POST https://token-plan-cn.xiaomimimo.com/v1/chat/completions
 # and POST https://token-plan-cn.xiaomimimo.com/anthropic/v1/messages.

--- a/providers/xiaomi-token-plan-cn/provider.toml
+++ b/providers/xiaomi-token-plan-cn/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic prefix prompt cache on POST /v1/chat/completions.
+# Use headers: none.
+# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens (Anthropic: cache_read_input_tokens).
+# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price with free cache write.
+# Docs: https://platform.xiaomimimo.com/#/docs
 name = "Xiaomi Token Plan (China)"
 # Raw endpoints are POST https://token-plan-cn.xiaomimimo.com/v1/chat/completions
 # and POST https://token-plan-cn.xiaomimimo.com/anthropic/v1/messages.

--- a/providers/xiaomi-token-plan-sgp/provider.toml
+++ b/providers/xiaomi-token-plan-sgp/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic prefix prompt cache on POST /v1/chat/completions.
+# Use headers: none.
+# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens (Anthropic: cache_read_input_tokens).
+# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price with free cache write.
+# Docs: https://platform.xiaomimimo.com/#/docs
 name = "Xiaomi Token Plan (Singapore)"
 # Raw endpoints are POST https://token-plan-sgp.xiaomimimo.com/v1/chat/completions
 # and POST https://token-plan-sgp.xiaomimimo.com/anthropic/v1/messages.

--- a/providers/xiaomi-token-plan-sgp/provider.toml
+++ b/providers/xiaomi-token-plan-sgp/provider.toml
@@ -1,8 +1,7 @@
-# Prompt caching (chat): automatic prefix prompt cache on POST /v1/chat/completions.
-# Use headers: none.
-# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens (Anthropic: cache_read_input_tokens).
-# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price with free cache write.
-# Docs: https://platform.xiaomimimo.com/#/docs
+# Prompt caching (chat): automatic prefix cache on POST /v1/chat/completions.
+# Use body: hits via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price.
+# Docs: https://mimo.mi.com/docs/en-US/api/chat/openai-api
 name = "Xiaomi Token Plan (Singapore)"
 # Raw endpoints are POST https://token-plan-sgp.xiaomimimo.com/v1/chat/completions
 # and POST https://token-plan-sgp.xiaomimimo.com/anthropic/v1/messages.

--- a/providers/xiaomi/provider.toml
+++ b/providers/xiaomi/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic prefix prompt cache on POST /v1/chat/completions.
+# Use headers: none.
+# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens (Anthropic: cache_read_input_tokens).
+# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price with free cache write.
+# Docs: https://platform.xiaomimimo.com/#/docs
 name = "Xiaomi"
 # Raw endpoints are POST https://api.xiaomimimo.com/v1/chat/completions and
 # POST https://api.xiaomimimo.com/anthropic/v1/messages. Both use

--- a/providers/xiaomi/provider.toml
+++ b/providers/xiaomi/provider.toml
@@ -1,8 +1,7 @@
-# Prompt caching (chat): automatic prefix prompt cache on POST /v1/chat/completions.
-# Use headers: none.
-# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens (Anthropic: cache_read_input_tokens).
-# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price with free cache write.
-# Docs: https://platform.xiaomimimo.com/#/docs
+# Prompt caching (chat): automatic prefix cache on POST /v1/chat/completions.
+# Use body: hits via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: replay stable prefixes; prefix hits bill at the cache-hit price.
+# Docs: https://mimo.mi.com/docs/en-US/api/chat/openai-api
 name = "Xiaomi"
 # Raw endpoints are POST https://api.xiaomimimo.com/v1/chat/completions and
 # POST https://api.xiaomimimo.com/anthropic/v1/messages. Both use

--- a/providers/xpersona/provider.toml
+++ b/providers/xpersona/provider.toml
@@ -1,6 +1,4 @@
 # Prompt caching (chat): unknown on POST /v1/chat/completions.
-# Use body: stable model/messages prefix; confirm hits via usage where returned.
-# To get a hit: replay stable prefixes.
 # Docs: https://www.xpersona.co/api/v1/openapi/ai-public
 name = "Xpersona"
 # POST /v1/chat/completions accepts reasoning.effort set to "low", "medium",

--- a/providers/xpersona/provider.toml
+++ b/providers/xpersona/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): no documented prompt cache on POST /v1/chat/completions.
+# Use headers: none.
+# Use body: none — schema allows model/messages/reasoning.effort only with no cache field.
+# To get a hit: replay stable prefixes; treat usage as uncached.
+# Docs: https://www.xpersona.co/api/v1/openapi/ai-public
 name = "Xpersona"
 # POST /v1/chat/completions accepts reasoning.effort set to "low", "medium",
 # "high", "xhigh", or "max"; no disable sentinel or token budget is documented.

--- a/providers/xpersona/provider.toml
+++ b/providers/xpersona/provider.toml
@@ -1,7 +1,6 @@
-# Prompt caching (chat): no documented prompt cache on POST /v1/chat/completions.
-# Use headers: none.
-# Use body: none — schema allows model/messages/reasoning.effort only with no cache field.
-# To get a hit: replay stable prefixes; treat usage as uncached.
+# Prompt caching (chat): unknown on POST /v1/chat/completions.
+# Use body: stable model/messages prefix; confirm hits via usage where returned.
+# To get a hit: replay stable prefixes.
 # Docs: https://www.xpersona.co/api/v1/openapi/ai-public
 name = "Xpersona"
 # POST /v1/chat/completions accepts reasoning.effort set to "low", "medium",

--- a/providers/zai-coding-plan/provider.toml
+++ b/providers/zai-coding-plan/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic implicit prefix cache on POST /api/coding/paas/v4/chat/completions.
+# Use headers: none.
+# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: replay stable prefixes; plan credits bill cached input at the cached-input multiplier.
+# Docs: https://docs.z.ai/guides/capabilities/cache
 # OpenAI Chat endpoint: POST https://api.z.ai/api/coding/paas/v4/chat/completions.
 # Coding Plan models currently available: glm-5.2, glm-5-turbo, glm-4.7.
 # GLM-5.2 maps low|medium|high to high and xhigh|max|ultracode to max.

--- a/providers/zai-coding-plan/provider.toml
+++ b/providers/zai-coding-plan/provider.toml
@@ -1,6 +1,5 @@
 # Prompt caching (chat): automatic implicit prefix cache on POST /api/coding/paas/v4/chat/completions.
-# Use headers: none.
-# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens.
+# Use body: hits via usage.prompt_tokens_details.cached_tokens.
 # To get a hit: replay stable prefixes; plan credits bill cached input at the cached-input multiplier.
 # Docs: https://docs.z.ai/guides/capabilities/cache
 # OpenAI Chat endpoint: POST https://api.z.ai/api/coding/paas/v4/chat/completions.

--- a/providers/zai/provider.toml
+++ b/providers/zai/provider.toml
@@ -1,6 +1,5 @@
 # Prompt caching (chat): automatic implicit prefix cache on POST /api/paas/v4/chat/completions.
-# Use headers: none.
-# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens.
+# Use body: hits via usage.prompt_tokens_details.cached_tokens.
 # To get a hit: replay stable system prompts and history; cached tokens bill at the discounted cached-input multiplier.
 # Docs: https://docs.z.ai/guides/capabilities/cache
 # Chat reasoning: POST https://api.z.ai/api/paas/v4/chat/completions with

--- a/providers/zai/provider.toml
+++ b/providers/zai/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): automatic implicit prefix cache on POST /api/paas/v4/chat/completions.
+# Use headers: none.
+# Use body: none — no cache key field; hits via usage.prompt_tokens_details.cached_tokens.
+# To get a hit: replay stable system prompts and history; cached tokens bill at the discounted cached-input multiplier.
+# Docs: https://docs.z.ai/guides/capabilities/cache
 # Chat reasoning: POST https://api.z.ai/api/paas/v4/chat/completions with
 # `thinking.type = "enabled" | "disabled"` (default: enabled).
 # https://docs.z.ai/guides/capabilities/thinking (accessed 2026-06-25)

--- a/providers/zeldoc/provider.toml
+++ b/providers/zeldoc/provider.toml
@@ -1,6 +1,4 @@
 # Prompt caching (chat): unknown on POST /v1/chat/completions.
-# Use body: stable model/messages prefix; confirm hits via usage where returned.
-# To get a hit: replay stable prefixes.
 # Docs: https://docs.zeldoc.ai
 name = "Zeldoc"
 env = ["ZELDOC_API_KEY"]

--- a/providers/zeldoc/provider.toml
+++ b/providers/zeldoc/provider.toml
@@ -1,3 +1,8 @@
+# Prompt caching (chat): no documented prompt cache; hits depend on the downstream route.
+# Use headers: none.
+# Use body: none — no cache params or cached-token fields documented.
+# To get a hit: replay stable prefixes; treat usage as uncached.
+# Docs: https://docs.zeldoc.ai
 name = "Zeldoc"
 env = ["ZELDOC_API_KEY"]
 npm = "@ai-sdk/openai-compatible"

--- a/providers/zeldoc/provider.toml
+++ b/providers/zeldoc/provider.toml
@@ -1,7 +1,6 @@
-# Prompt caching (chat): no documented prompt cache; hits depend on the downstream route.
-# Use headers: none.
-# Use body: none — no cache params or cached-token fields documented.
-# To get a hit: replay stable prefixes; treat usage as uncached.
+# Prompt caching (chat): unknown on POST /v1/chat/completions.
+# Use body: stable model/messages prefix; confirm hits via usage where returned.
+# To get a hit: replay stable prefixes.
 # Docs: https://docs.zeldoc.ai
 name = "Zeldoc"
 env = ["ZELDOC_API_KEY"]


### PR DESCRIPTION
Batch 19 prompt-cache audit (11 providers). Header-only changes to provider.toml.

| provider | verdict | mechanism |
|---|---|---|
| wandb | UNKNOWN | first-party OpenAI-compatible API; no cache docs or extra-field policy found |
| watsonx | NATIVE_OTHER | native wx.ai chat API via watsonx-ai-provider; no chat-level cache params documented |
| xai | NATIVE_OTHER | automatic prefix cache; x-grok-conv-id header steers chat hits, prompt_cache_key body key is Responses-only |
| xiaomi | NATIVE_OTHER | native cached-input billing (cache_read); no client-facing cache key documented |
| xiaomi-token-plan-ams | NATIVE_OTHER | same Xiaomi API family; cached-input billing, no client key |
| xiaomi-token-plan-cn | NATIVE_OTHER | same Xiaomi API family; cached-input billing, no client key |
| xiaomi-token-plan-sgp | NATIVE_OTHER | same Xiaomi API family; cached-input billing, no client key |
| xpersona | TOLERATES | OpenAI-compatible chat endpoint; schema lists model/messages/reasoning only, no documented cache control |
| zai | NATIVE_OTHER | automatic implicit context caching via usage.prompt_tokens_details.cached_tokens; no client key |
| zai-coding-plan | NATIVE_OTHER | same automatic context caching on coding chat endpoint; plan credits bill cached input |
| zeldoc | UNKNOWN | private LLM plus router; no cache params or cached-token fields documented, caching depends on downstream |

bun validate passes.