### PR TITLE
fix: Remove PDF input from Bedrock GPT-6 and GPT-5.6 models

### DIFF
--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-luna.toml
@@ -19,3 +19,6 @@ input = 0.40
 output = 1.80
 cache_read = 0.04
 cache_write = 0.50
+
+[modalities]
+input = ["text", "image"]

--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-sol.toml
@@ -19,3 +19,6 @@ input = 8.00
 output = 30.00
 cache_read = 0.80
 cache_write = 10.00
+
+[modalities]
+input = ["text", "image"]

--- a/providers/amazon-bedrock/models/global.openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-5.6-terra.toml
@@ -19,3 +19,6 @@ input = 4.00
 output = 18.00
 cache_read = 0.40
 cache_write = 5.00
+
+[modalities]
+input = ["text", "image"]

--- a/providers/amazon-bedrock/models/global.openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/global.openai.gpt-6-astra.toml
@@ -19,3 +19,6 @@ input = 20.00
 output = 75.00
 cache_read = 2.00
 cache_write = 25.00
+
+[modalities]
+input = ["text", "image"]

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-luna.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-luna.toml
@@ -20,3 +20,6 @@ input = 0.44
 output = 1.98
 cache_read = 0.044
 cache_write = 0.55
+
+[modalities]
+input = ["text", "image"]

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-sol.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-sol.toml
@@ -20,3 +20,6 @@ input = 8.80
 output = 33.00
 cache_read = 0.88
 cache_write = 11.00
+
+[modalities]
+input = ["text", "image"]

--- a/providers/amazon-bedrock/models/us.openai.gpt-5.6-terra.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-5.6-terra.toml
@@ -20,3 +20,6 @@ input = 4.40
 output = 19.80
 cache_read = 0.44
 cache_write = 5.50
+
+[modalities]
+input = ["text", "image"]

--- a/providers/amazon-bedrock/models/us.openai.gpt-6-astra.toml
+++ b/providers/amazon-bedrock/models/us.openai.gpt-6-astra.toml
@@ -19,3 +19,6 @@ input = 22.00
 output = 82.50
 cache_read = 2.20
 cache_write = 27.50
+
+[modalities]
+input = ["text", "image"]


### PR DESCRIPTION
Adding an input modalities override to the Bedrock GPT-6 Astra and all GPT-5.6 model profiles to restrict PDF inputs allowed by the base profiles.

Attempting to pass PDF inputs to any of these models via Converse API results in a `ValidationError`, e.g. for GPT-5.6 Terra: 
> An error occurred (ValidationException) when calling the Converse operation: This model doesn't support documents.

Slightly different one for Astra:
> An error occurred (ValidationException) when calling the Converse operation: This model doesn't support the document field for user messages. Remove document and try again.

