### PR TITLE
fix(amazon-bedrock): correct hosted reasoner catalog

### DIFF
--- a/providers/amazon-bedrock/models/global.xai.grok-4.6.toml
+++ b/providers/amazon-bedrock/models/global.xai.grok-4.6.toml
@@ -1,4 +1,6 @@
-# Source: AWS Bedrock Grok 4.6 model card — Runtime profiles, pricing, and capabilities.
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html
+# Runtime Converse profile; Global CRIS Standard pricing. Structured outputs are Mantle-only.
+# Effort: additionalModelRequestFields.reasoning.effort = low|medium|high|xhigh, matching the US profile.
 base_model = "xai/grok-4.6"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "Grok 4.6 (Global)"

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.1.toml
@@ -1,24 +1,12 @@
-name = "MiniMax M2.1"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
-family = "minimax"
-release_date = "2025-12-23"
-last_updated = "2025-12-23"
-attachment = false
-reasoning = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-1.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# MiniMax M2.1 has always-on thinking, matching the first-party API.
+# Live Converse 2026-09-11: reasoningContent returned and outputConfig.textFormat enforced a JSON schema.
+base_model = "minimax/MiniMax-M2.1"
 reasoning_options = []
-temperature = true
-tool_call = true
-structured_output = false
-open_weights = true
+interleaved = true
+structured_output = true
 
 [cost]
 input = 0.30
 output = 1.20
-
-[limit]
-context = 204_800
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.5.toml
@@ -1,15 +1,13 @@
-name = "MiniMax M2.5"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
-family = "minimax"
-release_date = "2026-03-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# MiniMax M2.5 has always-on thinking, matching the first-party API.
+# Live 2026-09-09: maxTokens=98304 accepted and reasoningContent returned with no reasoning configuration.
+# Live Converse 2026-09-11: outputConfig.textFormat enforced a JSON schema.
+base_model = "minimax/MiniMax-M2.5"
 last_updated = "2026-03-18"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-tool_call = true
-structured_output = false
-open_weights = true
+interleaved = true
+structured_output = true
 
 [cost]
 input = 0.30
@@ -18,7 +16,3 @@ output = 1.20
 [limit]
 context = 196_608
 output = 98_304
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/minimax.minimax-m2.toml
+++ b/providers/amazon-bedrock/models/minimax.minimax-m2.toml
@@ -1,15 +1,11 @@
-name = "MiniMax M2"
-description = "MiniMax model for chat, coding, office work, and agentic tasks"
-family = "minimax"
-release_date = "2025-10-27"
-last_updated = "2025-10-27"
-attachment = false
-reasoning = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# MiniMax M2 has always-on thinking, matching the first-party API.
+# Live Converse 2026-09-11: reasoningContent returned and outputConfig.textFormat enforced a JSON schema.
+base_model = "minimax/MiniMax-M2"
 reasoning_options = []
-temperature = true
-tool_call = true
-structured_output = false
-open_weights = true
+interleaved = true
+structured_output = true
 
 [cost]
 input = 0.30
@@ -18,7 +14,3 @@ output = 1.20
 [limit]
 context = 204_608
 output = 128_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
+++ b/providers/amazon-bedrock/models/moonshot.kimi-k2-thinking.toml
@@ -1,17 +1,11 @@
-# See https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html
-name = "Kimi K2 Thinking"
-description = "Kimi reasoning model for long-horizon research, planning, and tool use"
-release_date = "2025-12-02"
-family = "kimi-thinking"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html
+# https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model (always-on thinking)
+# Runtime ID; Mantle uses moonshotai.kimi-k2-thinking. US Standard pricing.
+base_model = "moonshotai/kimi-k2-thinking"
 last_updated = "2025-12-02"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-tool_call = true
 structured_output = true
 interleaved = true
-open_weights = true
 
 [cost]
 input = 0.6
@@ -20,7 +14,3 @@ output = 2.5
 [limit]
 context = 262_143
 output = 16_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
+++ b/providers/amazon-bedrock/models/moonshotai.kimi-k2.5.toml
@@ -1,17 +1,15 @@
-# See https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html
-name = "Kimi K2.5"
-description = "Kimi multimodal agent model for visual understanding, coding, and planning"
-family = "kimi"
-release_date = "2026-02-06"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html
+# https://github.com/aws-samples/bedrock-claude-chatbot/blob/eeb2fa35339081d34ea9caa4e4d39cf1c189770a/agent/chat_agent.py
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default non-thinking mode.
+# Live 2026-09-09: high/omitted returns/omits reasoningContent; maxTokens=16384 accepted.
+# Live Converse 2026-09-09: inferenceConfig.temperature accepts both 0 and 1.
+# Runtime Converse; US Standard pricing.
+base_model = "moonshotai/kimi-k2.5"
+release_date = "2026-01-27"
 last_updated = "2026-02-06"
-attachment = false
-reasoning = true
-reasoning_options = []
+reasoning_options = [{ type = "toggle" }]
 temperature = true
-tool_call = true
-structured_output = true
 interleaved = true
-open_weights = true
 
 [cost]
 input = 0.6
@@ -19,8 +17,7 @@ output = 3
 
 [limit]
 context = 262_143
-output = 16_000
+output = 16_384
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-12b-v2.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-12b-v2.toml
@@ -1,23 +1,17 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-12b-v2-vl-bf16.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live 2026-09-09: maxTokens=8192 accepted; reasoning_config=high returned no reasoningContent.
 name = "NVIDIA Nemotron Nano 12B v2 VL BF16"
 base_model = "nvidia/nemotron-nano-12b-v2-vl"
-family = "nemotron"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = false
 
 [cost]
 input = 0.20
 output = 0.60
 
 [limit]
-context = 128_000
-output = 4_096
+output = 8_192
 
 [modalities]
 input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
@@ -1,4 +1,5 @@
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nemotron-nano-3-30b.html
+# AWS documents a 256K Bedrock context window; inherit the matching 262,144-token lab context.
 # https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
 # Live 2026-09-09: maxTokens=8192 accepted; chat_template_kwargs.enable_thinking had no visible effect.
 name = "NVIDIA Nemotron Nano 3 30B"

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-3-30b.toml
@@ -1,24 +1,15 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nemotron-nano-3-30b.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live 2026-09-09: maxTokens=8192 accepted; chat_template_kwargs.enable_thinking had no visible effect.
 name = "NVIDIA Nemotron Nano 3 30B"
 base_model = "nvidia/nemotron-3-nano-30b-a3b"
-family = "nemotron"
-release_date = "2025-12-23"
 last_updated = "2025-12-23"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.06
 output = 0.24
 
 [limit]
-context = 128_000
-output = 4_096
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 8_192

--- a/providers/amazon-bedrock/models/nvidia.nemotron-nano-9b-v2.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-nano-9b-v2.toml
@@ -1,23 +1,14 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nvidia-nemotron-nano-9b-v2.html
+# Live 2026-09-09: maxTokens=8192 accepted; tested JSON thinking controls had no visible effect.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
 name = "NVIDIA Nemotron Nano 9B v2"
 base_model = "nvidia/nemotron-nano-9b-v2"
-family = "nemotron"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
 reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = false
 
 [cost]
 input = 0.06
 output = 0.23
 
 [limit]
-context = 128_000
-output = 4_096
-
-[modalities]
-input = ["text"]
-output = ["text"]
+output = 8_192

--- a/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
+++ b/providers/amazon-bedrock/models/nvidia.nemotron-super-3-120b.toml
@@ -1,24 +1,14 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-nvidia-nemotron-super-3-120b.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live 2026-09-09: maxTokens=131072 accepted; chat_template_kwargs.enable_thinking had no visible effect.
 name = "NVIDIA Nemotron 3 Super 120B A12B"
 base_model = "nvidia/nemotron-3-super-120b-a12b"
-family = "nemotron"
-release_date = "2026-03-11"
-last_updated = "2026-03-11"
-attachment = false
-reasoning = true
 reasoning_options = []
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.15
 output = 0.65
 
 [limit]
-context = 262_144
 output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/us.xai.grok-4.6.toml
+++ b/providers/amazon-bedrock/models/us.xai.grok-4.6.toml
@@ -1,4 +1,7 @@
-# Source: AWS Bedrock Grok 4.6 model card — Runtime profiles, pricing, and capabilities.
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html
+# Runtime Converse profile; Geo CRIS Standard pricing. Structured outputs are Mantle-only.
+# Effort: additionalModelRequestFields.reasoning.effort = low|medium|high|xhigh.
+# Live 2026-09-09: nested effort=high returns reasoningContent; maxTokens=500000 accepted.
 base_model = "xai/grok-4.6"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 name = "Grok 4.6 (US)"

--- a/providers/amazon-bedrock/models/xai.grok-4.3.toml
+++ b/providers/amazon-bedrock/models/xai.grok-4.3.toml
@@ -1,3 +1,6 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-3.html
+# Mantle Responses only for this catalog route; US Standard pricing.
+# Effort: reasoning.effort = none|low|medium|high.
 base_model = "xai/grok-4.3"
 reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high"] }]
 last_updated = "2026-06-28"
@@ -8,7 +11,6 @@ output = 2.50
 cache_read = 0.20
 
 [limit]
-context = 1_000_000
 output = 131_072
 
 [modalities]

--- a/providers/amazon-bedrock/models/xai.grok-4.6.toml
+++ b/providers/amazon-bedrock/models/xai.grok-4.6.toml
@@ -1,4 +1,6 @@
 # Source: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-6.html
+# Mantle Responses; US Standard in-Region pricing.
+# Effort: reasoning.effort = low|medium|high|xhigh (always on).
 base_model = "xai/grok-4.6"
 reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh"] }]
 last_updated = "2026-08-18"

--- a/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7-flash.toml
@@ -1,25 +1,12 @@
-name = "GLM-4.7-Flash"
-description = "Efficient GLM model for fast reasoning, coding, and agent workflows"
-family = "glm-flash"
-release_date = "2026-01-19"
-last_updated = "2026-01-19"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-tool_call = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-4-7-flash.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default mode, matching GLM-4.7.
+# Live 2026-09-09: high returns reasoningContent; maxTokens=131072 accepted (card's 4K is not the cap).
+base_model = "zhipuai/glm-4.7-flash"
+reasoning_options = [{ type = "toggle" }]
+interleaved = true
 structured_output = true
-knowledge = "2025-04"
-open_weights = true
 
 [cost]
 input = 0.07
 output = 0.40
-
-[limit]
-context = 200_000
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/zai.glm-4.7.toml
+++ b/providers/amazon-bedrock/models/zai.glm-4.7.toml
@@ -1,28 +1,13 @@
-name = "GLM-4.7"
-description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
-release_date = "2025-12-22"
-last_updated = "2025-12-22"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-tool_call = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-4-7.html
+# https://github.com/danny-avila/LibreChat/issues/11974 (Bedrock Converse request)
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default non-thinking mode.
+# Live 2026-09-09: high/omitted returns/omits reasoningContent; maxTokens=131072 accepted.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "zhipuai/glm-4.7"
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
-knowledge = "2025-04"
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+interleaved = true
 
 [cost]
 input = 0.60
 output = 2.20
-
-[limit]
-context = 204_800
-output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/zai.glm-5.toml
+++ b/providers/amazon-bedrock/models/zai.glm-5.toml
@@ -1,18 +1,12 @@
-name = "GLM-5"
-description = "Flagship GLM model for hybrid reasoning, coding, and agentic engineering"
-family = "glm"
-release_date = "2026-03-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default mode, matching GLM-4.7.
+# Live 2026-09-09: high returns reasoningContent; maxTokens=131072 accepted.
+base_model = "zhipuai/glm-5"
 last_updated = "2026-03-18"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-tool_call = true
+reasoning_options = [{ type = "toggle" }]
 structured_output = true
-open_weights = true
-
-[interleaved]
-field = "reasoning_content"
+interleaved = true
 
 [cost]
 input = 1.00
@@ -20,8 +14,3 @@ output = 3.20
 
 [limit]
 context = 202_752
-output = 101_376
-
-[modalities]
-input = ["text"]
-output = ["text"]


### PR DESCRIPTION
## Summary

xAI/NVIDIA/MiniMax/Z.AI/Moonshot split of #6794, based on current `dev`.

- Correct verified dates, limits, capabilities, prices, and host reasoning controls across 16 entries.
- Mark models interleaved where Bedrock Converse returns `reasoningContent`.
- Confirm MiniMax M2/M2.1/M2.5 structured output and reasoning side channels through live Converse checks.
- Retain Kimi K2.5’s temperature override after live acceptance of both `temperature=0` and `temperature=1`.
- Keep unresolved NVIDIA caller controls conservative rather than inventing options.

Sources and live-check notes are in leading TOML comments.

## Validation

- `bun validate`
- `git diff --check`
- No removals or route changes
