### PR TITLE
fix(amazon-bedrock): correct DeepSeek and Qwen catalog

### DIFF
--- a/providers/amazon-bedrock/models/deepseek.r1-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.r1-v1:0.toml
@@ -1,24 +1,14 @@
-name = "DeepSeek-R1"
-description = "DeepSeek reasoning model for multi-step analysis, math, coding, and tools"
-family = "deepseek-thinking"
-release_date = "2025-01-20"
-last_updated = "2025-05-29"
-attachment = false
-reasoning = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-deepseek-deepseek-r1.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-deepseek.html
+# Runtime accepts 32,768 output tokens; 8,192 is the quality recommendation.
+# R1 has always-on reasoning and no reasoning toggle, effort, or budget parameter.
+# US Standard pricing; use the us.deepseek.r1-v1:0 profile for on-demand Converse.
+# Live US profile (us-east-1, 2026-09-09): toolConfig rejected with HTTP 400,
+# "This model doesn't support tool use." with AUTO or omitted toolChoice.
+base_model = "deepseek/deepseek-r1"
 reasoning_options = []
-temperature = true
-knowledge = "2024-07"
-tool_call = true
-open_weights = false
+tool_call = false
 
 [cost]
 input = 1.35
 output = 5.4
-
-[limit]
-context = 128_000
-output = 32_768
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3-v1:0.toml
@@ -1,16 +1,12 @@
-name = "DeepSeek-V3.1"
-description = "DeepSeek chat model for instruction following, coding, and analysis"
-family = "deepseek"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-deepseek-deepseek-v3-1.html
+# Runtime ID; Mantle uses deepseek.v3.1. Prices are US Standard.
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default mode, matching V3.2.
+# Live 2026-09-09: high returns reasoningContent; maxTokens=81920 accepted (card's 8K is not the cap).
+base_model = "deepseek/deepseek-v3.1"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-knowledge = "2024-07"
-tool_call = true
+reasoning_options = [{ type = "toggle" }]
+interleaved = true
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.58
@@ -19,7 +15,3 @@ output = 1.68
 [limit]
 context = 163_840
 output = 81_920
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/deepseek.v3.2.toml
+++ b/providers/amazon-bedrock/models/deepseek.v3.2.toml
@@ -1,16 +1,12 @@
-name = "DeepSeek-V3.2"
-description = "DeepSeek chat model for instruction following, coding, and analysis"
-family = "deepseek"
-release_date = "2026-02-06"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-deepseek-deepseek-v3-2.html
+# https://github.com/aws-samples/bedrock-claude-chatbot/blob/eeb2fa35339081d34ea9caa4e4d39cf1c189770a/agent/chat_agent.py
+# Toggle: additionalModelRequestFields.reasoning_config = "high"; omit for default non-thinking mode.
+# Live 2026-09-09: high/omitted returns/omits reasoningContent; maxTokens=81920 accepted.
+# Runtime Converse; US Standard pricing.
+base_model = "deepseek/deepseek-v3.2"
 last_updated = "2026-02-06"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-knowledge = "2024-07"
-tool_call = true
-structured_output = true
-open_weights = true
+reasoning_options = [{ type = "toggle" }]
+interleaved = true
 
 [cost]
 input = 0.62
@@ -19,7 +15,3 @@ output = 1.85
 [limit]
 context = 163_840
 output = 81_920
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-235b-a22b-2507-v1:0.toml
@@ -1,24 +1,13 @@
-name = "Qwen3 235B A22B 2507"
-description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-235b-a22b-2507.html
+# https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507 (non-thinking Instruct variant)
+# Runtime ID; US Standard pricing.
+base_model = "alibaba/qwen3-235b-a22b-instruct-2507"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-04"
-tool_call = true
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.22
 output = 0.88
 
 [limit]
-context = 262_144
 output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-32b-v1:0.toml
@@ -1,25 +1,16 @@
-name = "Qwen3 32B (dense)"
-description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-32b.html
+# Toggle: additionalModelRequestFields.reasoning_config = low|high (off|on).
+# Live 2026-09-09: high returns reasoningContent, low omits it; maxTokens=16384 accepted.
+# Runtime ID; US Standard pricing. No verified Bedrock reasoning-token budget.
+base_model = "alibaba/qwen3-32b"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-knowledge = "2024-04"
-tool_call = true
+reasoning_options = [{ type = "toggle" }]
+interleaved = true
 structured_output = true
-open_weights = true
 
 [cost]
 input = 0.15
 output = 0.6
 
 [limit]
-context = 16_384
-output = 16_384
-
-[modalities]
-input = ["text"]
-output = ["text"]
+context = 32_768

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-30b-a3b-v1:0.toml
@@ -1,24 +1,13 @@
-name = "Qwen3 Coder 30B A3B Instruct"
-description = "Qwen coding model for software agents, repository edits, and code reasoning"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-30b-a3b-instruct.html
+# Runtime ID; US Standard pricing.
+base_model = "alibaba/qwen3-coder-30b-a3b-instruct"
+release_date = "2025-07-31"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-04"
-tool_call = true
 structured_output = true
-open_weights = false
 
 [cost]
 input = 0.15
 output = 0.6
 
 [limit]
-context = 262_144
 output = 131_072
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-480b-a35b-v1:0.toml
@@ -1,24 +1,13 @@
-name = "Qwen3 Coder 480B A35B Instruct"
-description = "Qwen coding model for software agents, repository edits, and code reasoning"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-480b-a35b-instruct.html
+# AWS Price List: USW2-Qwen3Coder-480B-A35B-{input,output}-tokens (Standard).
+base_model = "alibaba/qwen3-coder-480b-a35b-instruct"
+release_date = "2025-07-23"
 last_updated = "2025-09-18"
-attachment = false
-reasoning = false
-temperature = true
-knowledge = "2024-04"
-tool_call = true
 structured_output = true
-open_weights = true
 
 [cost]
-input = 0.22
+input = 0.45
 output = 1.8
 
 [limit]
 context = 131_072
-output = 65_536
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-coder-next.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-coder-next.toml
@@ -1,24 +1,9 @@
-name = "Qwen3 Coder Next"
-description = "Qwen coding model for software agents, repository edits, and code reasoning"
-family = "qwen"
-release_date = "2026-02-06"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html
+# https://huggingface.co/Qwen/Qwen3-Coder-Next (explicitly non-thinking)
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "alibaba/qwen3-coder-next"
 last_updated = "2026-02-06"
-attachment = false
-reasoning = true
-reasoning_options = []
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = true
 
 [cost]
-input = 0.22
-output = 1.8
-
-[limit]
-context = 131_072
-output = 65_536
-
-[modalities]
-input = ["text"]
-output = ["text"]
+input = 0.50
+output = 1.20

--- a/providers/amazon-bedrock/models/qwen.qwen3-next-80b-a3b.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-next-80b-a3b.toml
@@ -1,23 +1,15 @@
-name = "Qwen/Qwen3-Next-80B-A3B-Instruct"
-description = "Qwen instruction model for multilingual chat, reasoning, and tool use"
-family = "qwen"
-release_date = "2025-09-18"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-next-80b-a3b.html
+# https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct (non-thinking Instruct variant)
+# https://aws.amazon.com/bedrock/pricing/ (US Standard: 0.15/1.20; Mantle has separate SKUs)
+base_model = "alibaba/qwen3-next-80b-a3b-instruct"
+release_date = "2025-09-11"
 last_updated = "2025-11-25"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
 structured_output = true
-open_weights = false
 
 [cost]
-input = 0.14
-output = 1.4
+input = 0.15
+output = 1.20
 
 [limit]
-context = 262_000
+context = 262_144
 output = 262_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/qwen.qwen3-vl-235b-a22b.toml
+++ b/providers/amazon-bedrock/models/qwen.qwen3-vl-235b-a22b.toml
@@ -1,23 +1,13 @@
-name = "Qwen/Qwen3-VL-235B-A22B-Instruct"
-description = "Qwen vision-language model for visual reasoning, documents, and agent tasks"
-family = "qwen"
-release_date = "2025-10-04"
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-vl-235b-a22b.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live Converse 2026-09-11: outputConfig.textFormat enforced a JSON schema.
+base_model = "alibaba/qwen3-vl-235b-a22b-instruct"
 last_updated = "2025-11-25"
-attachment = true
-reasoning = false
-temperature = true
-tool_call = true
-structured_output = true
-open_weights = false
 
 [cost]
-input = 0.3
-output = 1.5
+input = 0.53
+output = 2.66
 
 [limit]
-context = 262_000
+context = 262_144
 output = 262_000
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/us.deepseek.r1-v1:0.toml
+++ b/providers/amazon-bedrock/models/us.deepseek.r1-v1:0.toml
@@ -1,6 +1,12 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-deepseek.html
+# R1 has always-on reasoning; the API accepts 32,768 output tokens (8,192 recommended).
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-deepseek-deepseek-r1.html
+# Live Converse (us-east-1, 2026-09-09): toolConfig rejected with HTTP 400,
+# "This model doesn't support tool use." with AUTO or omitted toolChoice.
 base_model = "deepseek/deepseek-r1"
 reasoning_options = []
 name = "DeepSeek-R1 (US)"
+tool_call = false
 
 [cost]
 input = 1.35


### PR DESCRIPTION
## Summary

DeepSeek/Qwen-only split of #6794, based on current `dev`.

- Convert 11 Bedrock entries to override-only `base_model` definitions.
- Correct verified prices, limits, dates, structured-output behavior, and reasoning controls.
- Preserve Bedrock DeepSeek R1 `tool_call = false` after the API explicitly rejected tool use.
- Mark DeepSeek V3.1/V3.2 and Qwen 3 32B interleaved when Converse returns `reasoningContent`.
- Confirm Qwen 3 VL structured output through live constrained-JSON output and inherit the lab capability.

Sources and live-check notes are in leading TOML comments.

## Validation

- `bun validate`
- `git diff --check`
- No removals or route changes
