### PR TITLE
fix(amazon-bedrock): correct Gemma catalog

### DIFF
--- a/models/google/gemma-3-12b-it.toml
+++ b/models/google/gemma-3-12b-it.toml
@@ -1,0 +1,25 @@
+# https://ai.google.dev/gemma/docs/core/model_card_3
+# https://blog.google/technology/developers/gemma-3/
+name = "Gemma 3 12B IT"
+description = "Open multimodal Gemma instruction model for multilingual text generation and image understanding"
+family = "gemma"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-08"
+open_weights = true
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/google/gemma-3-12b-it"

--- a/models/google/gemma-3-27b-it.toml
+++ b/models/google/gemma-3-27b-it.toml
@@ -1,0 +1,25 @@
+# https://ai.google.dev/gemma/docs/core/model_card_3
+# https://blog.google/technology/developers/gemma-3/
+name = "Gemma 3 27B IT"
+description = "Largest open Gemma 3 instruction model for multilingual text generation and visual understanding"
+family = "gemma"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-08"
+open_weights = true
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/google/gemma-3-27b-it"

--- a/models/google/gemma-3-4b-it.toml
+++ b/models/google/gemma-3-4b-it.toml
@@ -1,0 +1,25 @@
+# https://ai.google.dev/gemma/docs/core/model_card_3
+# https://blog.google/technology/developers/gemma-3/
+name = "Gemma 3 4B IT"
+description = "Open multimodal Gemma instruction model for efficient text generation and image understanding"
+family = "gemma"
+release_date = "2025-03-12"
+last_updated = "2025-03-12"
+attachment = true
+reasoning = false
+temperature = true
+tool_call = true
+knowledge = "2024-08"
+open_weights = true
+
+[limit]
+context = 131_072
+output = 131_072
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[weights]]
+label = "Hugging Face"
+url = "https://huggingface.co/google/gemma-3-4b-it"

--- a/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-12b-it.toml
@@ -1,24 +1,14 @@
-name = "Google Gemma 3 12B"
-description = "Open Gemma instruction model for efficient chat and self-hosted deployments"
-family = "gemma"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
-reasoning = false
-temperature = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-12b-it.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live Converse (us-east-1, 2026-09-09): forced toolUse works, but native toolResult continuation fails with a role-alternation error.
+# Tool calling remains disabled because a complete native tool-use round trip is unavailable.
+base_model = "google/gemma-3-12b-it"
 tool_call = false
 structured_output = true
-knowledge = "2024-12"
-open_weights = false
 
 [cost]
-input = 0.049999999999999996
-output = 0.09999999999999999
+input = 0.09
+output = 0.29
 
 [limit]
-context = 131072
-output = 8192
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]
+output = 8_192

--- a/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-27b-it.toml
@@ -1,24 +1,16 @@
-name = "Google Gemma 3 27B Instruct"
-description = "Open Gemma instruction model for efficient chat and self-hosted deployments"
-family = "gemma"
-attachment = true
-reasoning = false
-tool_call = true
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-27b-pt.html
+# AWS's card title says PT, but its programmatic ID and discovery name specify IT.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live Converse (us-east-1, 2026-09-09): forced toolUse works, but native toolResult continuation fails with a role-alternation error.
+# Tool calling remains disabled because a complete native tool-use round trip is unavailable.
+base_model = "google/gemma-3-27b-it"
+tool_call = false
 structured_output = true
-temperature = true
-knowledge = "2025-07"
-release_date = "2025-07-27"
-last_updated = "2025-07-27"
-open_weights = true
 
 [cost]
-input = 0.12
-output = 0.2
+input = 0.23
+output = 0.38
 
 [limit]
 context = 202_752
 output = 8_192
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/google.gemma-3-4b-it.toml
+++ b/providers/amazon-bedrock/models/google.gemma-3-4b-it.toml
@@ -1,22 +1,13 @@
-name = "Gemma 3 4B IT"
-description = "Open Gemma instruction model for efficient chat and self-hosted deployments"
-family = "gemma"
-release_date = "2024-12-01"
-last_updated = "2024-12-01"
-attachment = false
-reasoning = false
-temperature = true
-tool_call = true
-open_weights = false
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-4b-it.html
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+# Live Converse (us-east-1, 2026-09-09): forced toolUse works, but native toolResult continuation fails with a role-alternation error.
+# Tool calling remains disabled because a complete native tool-use round trip is unavailable.
+base_model = "google/gemma-3-4b-it"
+tool_call = false
 
 [cost]
 input = 0.04
 output = 0.08
 
 [limit]
-context = 128_000
 output = 4_096
-
-[modalities]
-input = ["text", "image"]
-output = ["text"]

--- a/providers/amazon-bedrock/models/google.gemma-4-26b-a4b.toml
+++ b/providers/amazon-bedrock/models/google.gemma-4-26b-a4b.toml
@@ -1,0 +1,19 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-4-26b-a4b.html
+# https://github.com/aws-samples/bedrock-claude-chatbot/blob/eeb2fa35339081d34ea9caa4e4d39cf1c189770a/agent/chat_agent.py
+# Effort: reasoning.effort = none|high on Mantle Responses, matching the Gemma 4 31B surface.
+# Live 2026-09-09: high returns reasoning; strict JSON schema and max_output_tokens=32768 accepted.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "google/gemma-4-26b-a4b-it"
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.13
+output = 0.40
+
+[modalities]
+input = ["text", "image", "video"]
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/google.gemma-4-31b.toml
+++ b/providers/amazon-bedrock/models/google.gemma-4-31b.toml
@@ -1,0 +1,19 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-4-31b.html
+# https://github.com/aws-samples/bedrock-claude-chatbot/blob/eeb2fa35339081d34ea9caa4e4d39cf1c189770a/agent/chat_agent.py
+# Effort: reasoning.effort = none|high on Mantle Responses.
+# Live 2026-09-09: high returns reasoning, none omits it; strict JSON schema and max_output_tokens=32768 accepted.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "google/gemma-4-31b-it"
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.14
+output = 0.40
+
+[modalities]
+input = ["text", "image", "video"]
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"

--- a/providers/amazon-bedrock/models/google.gemma-4-e2b.toml
+++ b/providers/amazon-bedrock/models/google.gemma-4-e2b.toml
@@ -1,0 +1,19 @@
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-4-e2b.html
+# Effort: reasoning.effort = none|high on Mantle Responses, matching the Gemma 4 31B surface.
+# AWS recommends high to keep thinking in the reasoning channel.
+# Live 2026-09-09: high returns reasoning; strict JSON schema and max_output_tokens=8192 accepted.
+# https://aws.amazon.com/bedrock/pricing/ (US Standard pricing)
+base_model = "google/gemma-4-E2B-it"
+reasoning_options = [{ type = "effort", values = ["none", "high"] }]
+
+[cost]
+input = 0.04
+output = 0.08
+
+[modalities]
+input = ["text", "image", "audio", "video"]
+
+[provider]
+npm = "@ai-sdk/amazon-bedrock/mantle"
+api = "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1"
+shape = "responses"


### PR DESCRIPTION
## Summary

Google/Gemma-only split of #6794, based on current `dev`.

- Add complete provider-agnostic Gemma 3 lab metadata.
- Convert Bedrock Gemma 3 entries to override-only `base_model` files with corrected prices and host limits.
- Keep lab `tool_call = true`, but override Bedrock to false: forced tool calls work, while valid native tool-result continuation fails on all three sizes.
- Add three live-verified Gemma 4 Mantle Responses entries with `none`/`high` reasoning effort and structured JSON support.

Sources and live-check notes are in leading TOML comments.

## Validation

- `bun validate`
- New labs include all required capabilities, modalities, context and output
- `git diff --check`
- No removals or route changes
