### PR TITLE
fix: [missing-model] ollama-cloud: deepseek-v4.1-flash

### DIFF
--- a/providers/ollama-cloud/models/deepseek-v4.1-flash.toml
+++ b/providers/ollama-cloud/models/deepseek-v4.1-flash.toml
@@ -1,0 +1,14 @@
+# Toggle: native POST /api/chat and /api/generate use `think = true|false`.
+# Effort: OpenAI POST /v1/chat/completions accepts top-level `reasoning_effort`
+# or `reasoning.effort` with low|high|max (Flash maps requested low -> low).
+# Sources: https://docs.ollama.com/capabilities/thinking, https://docs.ollama.com/openai
+# API-verified context: https://ollama.com/api/show (deepseek_v41.context_length = 1048576)
+base_model = "deepseek/deepseek-v4.1-flash"
+
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[limit]
+context = 1048576


### PR DESCRIPTION
## Summary

- Add Ollama Cloud's currently served `deepseek-v4.1-flash` model
- Inherit shared DeepSeek V4.1 Flash metadata via `base_model = "deepseek/deepseek-v4.1-flash"`
- Record Ollama-specific reasoning controls and the API-verified context window

## Evidence

- Ollama's public model API (`POST https://ollama.com/api/show`) lists the model as active with `completion`, `thinking`, `tools`, and `vision` capabilities
- The API reports a 1,048,576-token context window (`deepseek_v41.context_length = 1048576`)
- The library page (https://ollama.com/library/deepseek-v4.1-flash) confirms text and image input
- Reasoning controls follow the host surface: native `think = true|false` toggle plus `reasoning_effort` with `low|high|max` on the OpenAI-compatible endpoint (Flash maps requested `low` to `low`, unlike Pro)

## Validation

- `bun validate`