### PR TITLE
opencode-go: declare Anthropic SDK for Qwen models

### DIFF
--- a/providers/opencode-go/models/qwen3.5-plus.toml
+++ b/providers/opencode-go/models/qwen3.5-plus.toml
@@ -25,3 +25,6 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"

--- a/providers/opencode-go/models/qwen3.6-plus.toml
+++ b/providers/opencode-go/models/qwen3.6-plus.toml
@@ -31,3 +31,6 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"

--- a/providers/opencode-go/models/qwen3.7-max.toml
+++ b/providers/opencode-go/models/qwen3.7-max.toml
@@ -23,3 +23,6 @@ output = 65_536
 [modalities]
 input = ["text"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"

--- a/providers/opencode-go/models/qwen3.7-plus.toml
+++ b/providers/opencode-go/models/qwen3.7-plus.toml
@@ -30,3 +30,6 @@ output = 65_536
 [modalities]
 input = ["text", "image", "video"]
 output = ["text"]
+
+[provider]
+npm = "@ai-sdk/anthropic"

--- a/providers/opencode-go/models/qwen3.8-max.toml
+++ b/providers/opencode-go/models/qwen3.8-max.toml
@@ -20,3 +20,6 @@ cache_write = 2.5
 
 [modalities]
 input = ["text", "image", "video"]
+
+[provider]
+npm = "@ai-sdk/anthropic"


### PR DESCRIPTION
## Problem

The OpenCode Go provider TOMLs for the Qwen models omit the per-model `[provider] npm` override, so consumers resolving the API protocol per model (the OpenCode CLI, Zed's new registry fetch in zed-industries/zed#64070) fall back to the provider-level default `@ai-sdk/openai-compatible` — but the gateway actually serves these models through the **Anthropic Messages API**.

Evidence already in the catalog:

- `qwen3.8-max.toml`'s own comments cite the Anthropic messages endpoint (`https://help.aliyun.com/en/model-studio/anthropic-api-messages`) and describe `thinking.type` toggle / `budget_tokens` / `output_config.effort` request fields.
- All five entries use `budget_tokens` reasoning options, an Anthropic-API mechanism.
- The sibling Go entry `qwen3.8-flash.toml` already declares `[provider] npm = "@ai-sdk/anthropic"`.
- The Zen entries `qwen3.5-plus.toml` and `qwen3.6-plus.toml` already declare `[provider] npm = "@ai-sdk/anthropic"`.
- Zed's bundled OpenCode provider likewise maps Qwen to the Anthropic protocol.

## Change

Adds `[provider] npm = "@ai-sdk/anthropic"` to the OpenCode Go entries for `qwen3.5-plus`, `qwen3.6-plus`, `qwen3.7-plus`, `qwen3.7-max`, and `qwen3.8-max`, so the registry alone is authoritative about the protocol instead of requiring consumers to special-case the Qwen family.

`bun validate` passes.

Release Notes:

- n/a (catalog data fix)
