### PR TITLE
feat(greenpt): add DeepSeek V4.1 Flash

### DIFF
--- a/providers/greenpt/models/deepseek-v4.1-flash.toml
+++ b/providers/greenpt/models/deepseek-v4.1-flash.toml
@@ -1,0 +1,13 @@
+# Cost: GreenPT EUR list prices converted at 1.1616 USD/EUR (ECB, 2026-09-10).
+# Sources: https://docs.greenpt.ai/deepseek-v4-1-flash and https://docs.greenpt.ai/model-cards
+# FX: https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/eurofxref-graph-usd.en.html
+# GreenPT accepts reasoning_effort = none|minimal|low|medium|high.
+# Source: https://docs.greenpt.ai/reasoning
+# Cache writes are not charged: https://docs.greenpt.ai/prompt-caching
+base_model = "deepseek/deepseek-v4.1-flash"
+reasoning_options = [{ type = "effort", values = ["none", "minimal", "low", "medium", "high"] }]
+
+[cost]
+input = 0.255552
+cache_read = 0.0127776
+output = 1.27776


### PR DESCRIPTION
GreenPT now exposes `deepseek-v4.1-flash`, but its models.dev catalog does not list it. Add the provider entry so clients can discover it, following the GreenPT additions in #6618.

Inherit shared metadata from `deepseek/deepseek-v4.1-flash`, including text/image input, tool calling, 1M context and 384,000 maximum output tokens. Set GreenPT's documented `reasoning_effort` values: `none`, `minimal`, `low`, `medium`, `high`.

Convert GreenPT's EUR customer prices to USD per million tokens at the ECB's 2026-09-10 rate of 1.1616 USD/EUR:

| Token class | EUR/MTok | USD/MTok |
|---|---:|---:|
| Input | 0.22 | 0.255552 |
| Cached input | 0.011 | 0.0127776 |
| Output | 1.10 | 1.27776 |

Cache writes are not charged; omit that field, matching existing GreenPT entries. The existing `deepseek-v4-flash-0731` remains a separate model with its own prices.

Validation: `npm run --silent validate` passes. `npm test` in `packages/sdk` passes generation, typechecking and all 23 tests. Resolved-data assertions verify prices, reasoning controls, modalities and inherited limits. GreenPT grows from 39 to 40 models; every existing resolved catalog entry remains identical. Production inference and the inherited maximum output limit were not tested.

Sources:
- GreenPT model ID, prices and reasoning controls: https://docs.greenpt.ai/deepseek-v4-1-flash
- GreenPT multimodal capabilities: https://docs.greenpt.ai/model-cards
- GreenPT reasoning API: https://docs.greenpt.ai/reasoning
- Cache billing: https://docs.greenpt.ai/prompt-caching
- Shared model limits: https://api-docs.deepseek.com/quick_start/pricing/
- EUR/USD conversion: https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/eurofxref-graph-usd.en.html
