### PR TITLE
feat(cline-pass): add deepseek-v4.1-flash

### DIFF
--- a/providers/cline-pass/models/cline-pass/deepseek-v4.1-flash.toml
+++ b/providers/cline-pass/models/cline-pass/deepseek-v4.1-flash.toml
@@ -1,17 +1,36 @@
 # ClinePass catalog: https://api.cline.bot/api/v1/ai/cline/recommended-models
-# (accessed 2026-09-11) — `clinePass` entry `cline-pass/deepseek-v4.1-flash`, whose
-# description is "Smarter and more efficient, with 1M context window".
-# Reference pricing is the underlying DeepSeek-V4.1-Flash off-peak rate, the same rate
-# models.dev records for the first-party DeepSeek entry (ClinePass footnotes DeepSeek
-# API pricing for the DeepSeek models): $0.15 / $0.60 / $0.003 per 1M tokens
-# (input / output / cache read); peak rates are $0.30 / $1.20 / $0.006. Reasoning
-# tokens bill at the output rate. Effort levels follow the DeepSeek V4.1 Flash
-# reference (low|high|max).
+# (accessed 2026-09-11) — `clinePass` entry `cline-pass/deepseek-v4.1-flash`. ClinePass
+# serves this Cline-branded slug with the description below; the underlying open-weights
+# model is DeepSeek-V4.1-Flash.
+# Reference pricing is the DeepSeek-V4.1-Flash off-peak rate: $0.15 / $0.60 / $0.003 per
+# 1M tokens (input / output / cache read); peak rates are $0.30 / $1.20 / $0.006.
+# Reasoning tokens bill at the output rate. Effort levels low|high|max follow the
+# DeepSeek V4.1 Flash reference.
 # https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-11)
-base_model = "deepseek/deepseek-v4.1-flash"
 name = "DeepSeek 4.1 Flash"
 description = "Smarter and more efficient, with 1M context window"
-reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+family = "deepseek-flash"
+release_date = "2026-09-10"
+last_updated = "2026-09-10"
+attachment = true
+reasoning = true
+temperature = true
+tool_call = true
+structured_output = true
+open_weights = true
+knowledge = "2025-05"
+
+[limit]
+context = 1_000_000
+output = 384_000
+
+[modalities]
+input = ["text", "image"]
+output = ["text"]
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
 
 [interleaved]
 field = "reasoning_content"

--- a/providers/cline-pass/models/cline-pass/deepseek-v4.1-flash.toml
+++ b/providers/cline-pass/models/cline-pass/deepseek-v4.1-flash.toml
@@ -1,6 +1,7 @@
 # ClinePass catalog: https://api.cline.bot/api/v1/ai/cline/recommended-models
-# (accessed 2026-09-11) — `clinePass` entry `cline-pass/deepseek-v4.1-flash`,
-# "Smarter and more efficient, with 1M context window".
+# (accessed 2026-09-11) — `clinePass` entry `cline-pass/deepseek-v4.1-flash`, whose
+# catalog name is that full slug and whose description is "Smarter and more efficient,
+# with 1M context window".
 # Reference pricing is the underlying DeepSeek-V4.1-Flash off-peak rate, the same rate
 # models.dev records for the first-party DeepSeek entry (ClinePass footnotes DeepSeek
 # API pricing for the DeepSeek models): $0.15 / $0.60 / $0.003 per 1M tokens
@@ -9,7 +10,7 @@
 # reference (low|high|max).
 # https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-11)
 base_model = "deepseek/deepseek-v4.1-flash"
-name = "DeepSeek 4.1 Flash"
+name = "cline-pass/deepseek-v4.1-flash"
 description = "Smarter and more efficient, with 1M context window"
 reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 

--- a/providers/cline-pass/models/cline-pass/deepseek-v4.1-flash.toml
+++ b/providers/cline-pass/models/cline-pass/deepseek-v4.1-flash.toml
@@ -1,0 +1,23 @@
+# ClinePass catalog: https://api.cline.bot/api/v1/ai/cline/recommended-models
+# (accessed 2026-09-11) — `clinePass` entry `cline-pass/deepseek-v4.1-flash`,
+# "Smarter and more efficient, with 1M context window".
+# Reference pricing is the underlying DeepSeek-V4.1-Flash off-peak rate, the same rate
+# models.dev records for the first-party DeepSeek entry (ClinePass footnotes DeepSeek
+# API pricing for the DeepSeek models): $0.15 / $0.60 / $0.003 per 1M tokens
+# (input / output / cache read); peak rates are $0.30 / $1.20 / $0.006. Reasoning
+# tokens bill at the output rate. Effort levels follow the DeepSeek V4.1 Flash
+# reference (low|high|max).
+# https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-11)
+base_model = "deepseek/deepseek-v4.1-flash"
+name = "DeepSeek 4.1 Flash"
+description = "Smarter and more efficient, with 1M context window"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.6
+reasoning = 0.6
+cache_read = 0.003

--- a/providers/cline-pass/models/cline-pass/deepseek-v4.1-flash.toml
+++ b/providers/cline-pass/models/cline-pass/deepseek-v4.1-flash.toml
@@ -1,7 +1,6 @@
 # ClinePass catalog: https://api.cline.bot/api/v1/ai/cline/recommended-models
 # (accessed 2026-09-11) — `clinePass` entry `cline-pass/deepseek-v4.1-flash`, whose
-# catalog name is that full slug and whose description is "Smarter and more efficient,
-# with 1M context window".
+# description is "Smarter and more efficient, with 1M context window".
 # Reference pricing is the underlying DeepSeek-V4.1-Flash off-peak rate, the same rate
 # models.dev records for the first-party DeepSeek entry (ClinePass footnotes DeepSeek
 # API pricing for the DeepSeek models): $0.15 / $0.60 / $0.003 per 1M tokens
@@ -10,7 +9,7 @@
 # reference (low|high|max).
 # https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-11)
 base_model = "deepseek/deepseek-v4.1-flash"
-name = "cline-pass/deepseek-v4.1-flash"
+name = "DeepSeek 4.1 Flash"
 description = "Smarter and more efficient, with 1M context window"
 reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
 


### PR DESCRIPTION
Closes #6861.

`deepseek-v4.1-flash` is available in ClinePass but missing from the provider data.

Adds `providers/cline-pass/models/cline-pass/deepseek-v4.1-flash.toml` as a full standalone entry, same shape as `cline-pass/glm-5.3-flash.toml`:

- model id `cline-pass/deepseek-v4.1-flash` (from the file path), `name = "DeepSeek 4.1 Flash"`, description from the ClinePass catalog
- **no `base_model`**: `base_model = "cline-pass/deepseek-v4.1-flash"` does not resolve — `base_model` is looked up only in `models/<lab>/<model>.toml` (`packages/core/src/generate.ts:161`) and there is no `models/cline-pass/` namespace, so the metadata is inlined instead
- metadata inlined from the DeepSeek V4.1 Flash lab entry: family `deepseek-flash`, 1M context / 384K output, `text+image` input, open weights, release `2026-09-10`
- reasoning effort `low|high|max` + interleaved `reasoning_content`, matching the DeepSeek V4.1 Flash reference and the same-surface peer relay (`opencode-go/deepseek-v4.1-flash`)
- reference pricing = DeepSeek's off-peak V4.1 Flash rate, `$0.15 / $0.60 / $0.003` per 1M tokens (input/output/cache read), the same rate models.dev records for the first-party DeepSeek entry; reasoning tokens bill at the output rate (`reasoning = 0.6`). Peak rates are `$0.30 / $1.20 / $0.006`.

Sources:

- ClinePass catalog: https://api.cline.bot/api/v1/ai/cline/recommended-models (accessed 2026-09-11)
- DeepSeek pricing: https://api-docs.deepseek.com/quick_start/pricing (accessed 2026-09-11)

`bun validate` passes.
