### PR TITLE
feat(baseten): add DeepSeek V4.1 Flash

### DIFF
--- a/providers/baseten/models/deepseek-ai/DeepSeek-V4.1-Flash.toml
+++ b/providers/baseten/models/deepseek-ai/DeepSeek-V4.1-Flash.toml
@@ -1,0 +1,25 @@
+# Baseten documents top-level reasoning_effort for DeepSeek V4.1 Flash with
+# values none | low | high (default) | max. Reasoning is enabled by default;
+# reasoning_effort: "none" disables it. Reasoning output is returned in
+# reasoning_content.
+# Baseten serves at most 32k output tokens for this model on Model APIs.
+# https://www.baseten.co/library/deepseek-v41-flash/
+# https://docs.baseten.co/inference/model-apis/overview
+# https://docs.baseten.co/inference/model-apis/reasoning
+base_model = "deepseek/deepseek-v4.1-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "high", "max"]
+
+[cost]
+input = 0.3
+output = 1.2
+cache_read = 0.03
+
+[limit]
+context = 1_048_576
+output = 32_768


### PR DESCRIPTION
### Summary
Adds `deepseek-ai/DeepSeek-V4.1-Flash` to the Baseten provider.

### Specifications
- **Base Model**: `deepseek/deepseek-v4.1-flash`
- **Pricing**:
  - Input: $0.30 / MTok
  - Output: $1.20 / MTok
  - Cache Read: $0.03 / MTok
- **Limits**:
  - Context: 1,048,576 tokens
  - Output: 32,768 tokens (Baseten Model APIs serving output limit of 32k)
- **Reasoning**:
  - Top-level `reasoning_effort`: `none`, `low`, `high` (default), `max`
  - Interleaved wire field: `reasoning_content`
  - Enabled by default

### Sources
- https://www.baseten.co/library/deepseek-v41-flash/
- https://www.baseten.co/resources/changelog/deepseek-v41-flash-available-on-baseten
- https://docs.baseten.co/inference/model-apis/overview
- https://docs.baseten.co/inference/model-apis/reasoning

### Verification
- [x] `bun validate` passes
- [x] `packages/core/test/baseten.test.ts` passes