### PR TITLE
Add GLM-5.3-Flash to NVIDIA (hosted NIM)

### DIFF
--- a/providers/nvidia/models/z-ai/glm-5.3-flash.toml
+++ b/providers/nvidia/models/z-ai/glm-5.3-flash.toml
@@ -1,0 +1,14 @@
+# Hosted NIM: model listed at GET https://integrate.api.nvidia.com/v1/models
+# (verified 2026-09-12). Thinking is always enabled; reasoning budget controlled
+# with top-level `reasoning_effort`: low|high|max, default max.
+# https://docs.nvidia.com/nim/vision-language-models/latest/get-started/advanced/get-started-glm-5-3-flash.html
+base_model = "zhipuai/glm-5.3-flash"
+
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.0
+output = 0.0


### PR DESCRIPTION
Add GLM-5.3-Flash to NVIDIA (hosted NIM)

`z-ai/glm-5.3-flash` is now available on NVIDIA's hosted API — confirmed via
`GET https://integrate.api.nvidia.com/v1/models` (verified 2026-09-12).

Follows the existing pattern of `providers/nvidia/models/z-ai/glm-5.2.toml`:

- `base_model = "zhipuai/glm-5.3-flash"` (model-only metadata already exists)
- Reasoning: thinking is always enabled; budget controlled with top-level
  `reasoning_effort` (low | high, default max) per
  https://docs.nvidia.com/nim/vision-language-models/latest/get-started/advanced/get-started-glm-5-3-flash.html
- `interleaved.field = "reasoning_content"` (OpenAI-compatible surface)
- Cost: free on the hosted catalog tier, matching the glm-5.2 NVIDIA entry
  (0.0 / 0.0)
