### PR TITLE
feat: add Infer provider with Astra and Sol API options

### DIFF
--- a/providers/infer/logo.svg
+++ b/providers/infer/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1254 1254" fill="currentColor">
+  <path d="M393 704 455 538H531L548 446C568 346 656 270 755 270H889L840 424H781C746 424 722 444 715 477L707 538H895Z"/>
+  <path d="m496 714 199-75-77 313H436Z"/>
+</svg>

--- a/providers/infer/models/infer/gpt-5.6-sol:official.toml
+++ b/providers/infer/models/infer/gpt-5.6-sol:official.toml
@@ -1,0 +1,20 @@
+# Source: https://infer.flow7.org/api/public/catalog (2026-09-12 UTC)
+# Exact selector: infer/gpt-5.6-sol:official
+# Responses request reasoning.effort follows the underlying OpenAI model.
+base_model = "openai/gpt-5.6-sol"
+base_model_omit = ["limit.input"]
+name = "GPT-5.6 Sol (Official API)"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 2.5
+output = 12.5
+cache_read = 0.25
+cache_write = 3.125
+
+[limit]
+context = 271999
+output = 128000
+
+[provider]
+shape = "responses"

--- a/providers/infer/models/infer/gpt-6-astra:official.toml
+++ b/providers/infer/models/infer/gpt-6-astra:official.toml
@@ -1,0 +1,20 @@
+# Source: https://infer.flow7.org/api/public/catalog (2026-09-12 UTC)
+# Exact selector: infer/gpt-6-astra:official
+# Responses request reasoning.effort follows the underlying OpenAI model.
+base_model = "openai/gpt-6-astra"
+base_model_omit = ["limit.input"]
+name = "GPT-6 Astra (Official API)"
+reasoning_options = [{ type = "effort", values = ["low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 12.5
+output = 62.5
+cache_read = 1.25
+cache_write = 15.625
+
+[limit]
+context = 271999
+output = 128000
+
+[provider]
+shape = "responses"

--- a/providers/infer/provider.toml
+++ b/providers/infer/provider.toml
@@ -1,0 +1,7 @@
+# Docs: https://infer.flow7.org/docs
+# Public catalog: https://infer.flow7.org/api/public/catalog
+name = "Infer by Flow7"
+npm = "@ai-sdk/openai"
+env = ["INFER_API_KEY"]
+api = "https://infer.flow7.org/v1"
+doc = "https://infer.flow7.org/opencode"


### PR DESCRIPTION
Infer is missing from the provider catalog. This adds Infer by Flow7 with two currently available options, GPT-6 Astra and GPT-5.6 Sol, using their exact API selectors and the Responses API surface.

The entries inherit the underlying OpenAI model metadata and override Infer's current prices and serving limits: 271,999 context tokens and 128,000 output tokens. The model-name suffix matches Infer's `Official API` catalog option. The native effort lists match the OpenAI entries and the same-model relay entries; Infer forwards the Responses `reasoning.effort` field. The provider uses `@ai-sdk/openai`, `INFER_API_KEY`, and a monochrome SVG of Infer's mark.

Sources, checked September 12, 2026 UTC:

- [Infer public catalog](https://infer.flow7.org/api/public/catalog): exact selectors, published USD prices per million tokens, capabilities, and serving limits.
- [Infer API documentation](https://infer.flow7.org/docs#responses): API format and authentication.
- [Infer OpenCode setup](https://infer.flow7.org/opencode): Responses-based provider configuration.
- Existing `providers/openai` and `providers/openrouter` entries for the same models: effort options and underlying model metadata.

Validation: `bun validate` passes for the full catalog, and the staged patch passes Git whitespace checks. The generated Infer entries were checked against the retrieved public catalog. No paid inference request was made for this change. This is a provider-data contribution from Infer's side, not a claim of an official OpenCode partnership.
