### PR TITLE
feat(ollama-cloud): add deepseek-v4-pro:0813 model

### DIFF
--- a/providers/ollama-cloud/models/deepseek-v4-pro:0813.toml
+++ b/providers/ollama-cloud/models/deepseek-v4-pro:0813.toml
@@ -1,0 +1,14 @@
+# Toggle: native POST /api/chat and /api/generate use `think = true|false`.
+# Effort: OpenAI POST /v1/chat/completions accepts top-level `reasoning_effort`
+# or `reasoning.effort` with high|max (DeepSeek V4 maps low/medium -> high).
+# Sources: https://docs.ollama.com/capabilities/thinking, https://docs.ollama.com/openai
+# API-verified context: https://ollama.com/api/show (deepseek4.context_length = 1048576)
+# Output: Ollama has no separate output cap; deepseek4 peers on this host
+# (deepseek-v4-flash:0731, deepseek-v4-pro) serve output = 1048576.
+base_model = "deepseek/deepseek-v4-pro-0813"
+
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["high", "max"] }]
+
+[limit]
+context = 1048576
+output = 1048576


### PR DESCRIPTION
## Context

Ollama Cloud has been serving `deepseek-v4-pro:0813` (the 0813 snapshot of DeepSeek V4 Pro, listed by `GET /v1/models` since 2026-08-13). The lab metadata already exists on `dev` at [deepseek-v4-pro-0813.toml](https://github.com/anomalyco/models.dev/blob/dev/models/deepseek/deepseek-v4-pro-0813.toml); this PR adds the missing provider entry so the model surfaces under `ollama-cloud` in the generated catalog.

Confirmed live on the Ollama Cloud API:

```fish
$ curl -s https://ollama.com/v1/models | jq -r '.data[] | .id' | grep deepseek
deepseek-v4.1-flash
deepseek-v4-flash:0731
deepseek-v4-pro:0813

$ curl -s https://ollama.com/api/show -d '{"model":"deepseek-v4-pro:0813"}' | jq '.'
{
  "capabilities": ["completion", "tools", "thinking"],
  "details": {
    "parent_model": "deepseek-v4-pro:0813",
    "family": "deepseek4",
    "parameter_size": "1650497936906",
    "quantization_level": "FP8"
  },
  "model_info": {
    "deepseek4.context_length": 1048576,
    "general.architecture": "deepseek4"
  },
  "modified_at": "2026-08-13T08:00:00-07:00"
}
```

## What changed

- Added `providers/ollama-cloud/models/deepseek-v4-pro:0813.toml`, a `base_model`-factored provider entry that inherits provider-agnostic facts from the existing lab metadata and only declares host-specific overrides.

## Critical Changes

- **New model on `ollama-cloud`:** `deepseek-v4-pro:0813` now resolves in the generated catalog with `limit.context = 1_048_576` / `limit.output = 1_048_576` and `reasoning_options` of `toggle` + `effort: ["high", "max"]`.
- **Override-only:** the provider file uses `base_model = "deepseek/deepseek-v4-pro-0813"` and restates only `reasoning_options` and `[limit]` (real deltas vs. the lab's 1M/384K limits). `name`, `description`, `family`, dates, capabilities, modalities, `open_weights`, `license`, and `weights` are inherited from the lab entry.
- **Reasoning controls:** `toggle` + `effort: ["high", "max"]` matches the DeepSeek V4 family on this provider (see [deepseek-v4-flash:0731.toml](https://github.com/anomalyco/models.dev/blob/dev/providers/ollama-cloud/models/deepseek-v4-flash:0731.toml) and [deepseek-v4-pro.toml](https://github.com/anomalyco/models.dev/blob/dev/providers/ollama-cloud/models/deepseek-v4-pro.toml)) and the AGENTS.md DeepSeek V4 guidance (`toggle` + `high`/`max`, not L/M/H). Wire path documented in the leading comment per the ollama-cloud convention (see #3985).
- **Context override rationale:** the lab's `1_000_000` is a rounded figure; Ollama Cloud's `/api/show` exposes the real `deepseek4.context_length = 1_048_576`.
- **`limit.output = 1_048_576`:** Ollama publishes no separate output cap for this model. The same-host deepseek4 peers (`deepseek-v4-flash:0731`, `deepseek-v4-pro`) both serve `output = 1048576`, so this follows the established ollama-cloud convention (#1586) rather than the lab's `384_000`.
- **No `[interleaved]`:** Ollama's OpenAI-compatible endpoint returns the reasoning trace in `message.reasoning` (verified in [ollama/ollama `openai/openai.go`](https://github.com/ollama/ollama/blob/main/openai/openai.go)), which is not a schema-supported interleaved field. The earlier `deepseek-v4-pro` entry on this provider had `[interleaved]` removed for the same reason (see 3a5867834).

## Expected behavior

- `bun validate` passes (exit 0).
- Resolved provider model:
  - `id`: `deepseek-v4-pro:0813`
  - `name`: `DeepSeek V4 Pro 0813` (inherited from lab)
  - `limit`: `{ context: 1048576, output: 1048576 }`
  - `reasoning_options`: `[{ type: "toggle" }, { type: "effort", values: ["high", "max"] }]`
  - All other fields inherited from `models/deepseek/deepseek-v4-pro-0813.toml`.

## Relationship to #5109 and #6742

Both open PRs add the same file. This PR is a corrected alternative — happy to defer to the maintainers on which to land.

1. **#5109** uses a full inline definition. Per AGENTS.md, non-lab hosts must use `base_model` when the lab model is nameable, and the lab metadata already exists. The automated review flagged this as a violation on that PR.
2. **#6742** uses `base_model` correctly but bundles this file into a catalog-wide `[cost]` change. No other `ollama-cloud` model on `dev` currently has a `[cost]` block, so adding one only here would be inconsistent. This PR stays scoped to the missing model; if #6742 lands first, the cost block can be added there.