### PR TITLE
Add deepseek-v4-flash and glm-5.3 to AgentRouter provider

### DIFF
--- a/providers/agentrouter/models/deepseek-v4-flash.toml
+++ b/providers/agentrouter/models/deepseek-v4-flash.toml
@@ -1,0 +1,6 @@
+# Catalog and endpoint support: https://agentrouter.org/api/pricing
+# AgentRouter publishes relative token ratios, not USD prices, so cost is intentionally omitted.
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
+base_model = "deepseek/deepseek-v4-flash"
+reasoning_options = [{ type = "toggle" }, { type = "effort", values = ["low", "high", "max"] }]

--- a/providers/agentrouter/models/glm-5.3.toml
+++ b/providers/agentrouter/models/glm-5.3.toml
@@ -1,0 +1,5 @@
+# Catalog and endpoint support: https://agentrouter.org/api/pricing
+# AgentRouter publishes relative token ratios, not USD prices, so cost is intentionally omitted.
+# GLM-5.3 always reasons (thinking cannot be disabled); effort levels low|high|max, default max.
+base_model = "zhipuai/glm-5.3"
+reasoning_options = [{ type = "effort", values = ["low", "high", "max"] }]


### PR DESCRIPTION
AgentRouter serves deepseek-v4-flash and glm-5.3 but the provider entry only had 3 models so neither appeared in opencode. Adds override-only provider files following existing AgentRouter convention.