### PR TITLE
feat: add CommandCode provider

### DIFF
--- a/providers/commandcode/logo.svg
+++ b/providers/commandcode/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" role="img">
+  <title>CommandCode</title>
+  <path d="M6.5 4.5 9.3 4.5 17.3 12 9.3 19.5 6.5 19.5 14.5 12Z"/>
+  <path d="M15.5 18.5H20V21H15.5Z"/>
+</svg>

--- a/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
+++ b/providers/commandcode/models/MiniMaxAI/MiniMax-M3.toml
@@ -1,0 +1,21 @@
+# Pricing: https://commandcode.ai/models (accessed 2026-09-12)
+# Model ID is case-sensitive on this gateway: "MiniMaxAI/MiniMax-M3" (verified
+# via POST /provider/v1/chat/completions; lowercase "minimax/minimax-m3" is rejected).
+# A 50%-off deal applies automatically: input $0.30 / output $1.20 /
+# cache_read $0.06 per 1M tokens (regular $0.60 / $2.40 / $0.12).
+# Toggle mirrors the MiniMax API surface served through this gateway.
+base_model = "minimax/MiniMax-M3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.06
+
+[[cost.tiers]]
+tier = { size = 512_000 }
+input = 0.60
+output = 2.40
+cache_read = 0.12

--- a/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
+++ b/providers/commandcode/models/Qwen/Qwen3.8-Max.toml
@@ -1,0 +1,21 @@
+# Pricing: https://commandcode.ai/models (accessed 2026-09-12)
+# Model ID is case-sensitive on this gateway: "Qwen/Qwen3.8-Max" (verified
+# via POST /provider/v1/chat/completions; lowercase "alibaba/qwen3.8-max" is rejected).
+# Toggle: enable_thinking true|false (hybrid)
+# Effort: reasoning_effort = low|medium|xhigh (high accepted as alias)
+# Budget: thinking_budget (0..262144) cannot be combined with reasoning_effort
+# Controls mirror the Alibaba Model Studio API surface served through this gateway.
+base_model = "alibaba/qwen3.8-max"
+reasoning_options = [
+  { type = "toggle" },
+  { type = "effort", values = ["low", "medium", "xhigh"] },
+  { type = "budget_tokens", min = 0, max = 262_144 },
+]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 2.00
+output = 6.00
+cache_read = 0.25

--- a/providers/commandcode/models/claude-sonnet-5.toml
+++ b/providers/commandcode/models/claude-sonnet-5.toml
@@ -1,0 +1,23 @@
+# Pricing: https://commandcode.ai/models (accessed 2026-09-12)
+# Model ID on this gateway has no lab prefix: "claude-sonnet-5" (verified:
+# /chat/completions rejects Claude models and points to /messages).
+# Claude models are served on this gateway's Anthropic Messages endpoint
+# (/provider/v1/messages), so this model overrides the provider wire.
+# Effort levels mirror the Anthropic API surface.
+base_model = "anthropic/claude-sonnet-5"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "xhigh", "max"]
+
+[cost]
+input = 2.00
+output = 10.00
+cache_read = 0.20
+
+[provider]
+npm = "@ai-sdk/anthropic"
+api = "https://api.commandcode.ai/provider/v1"

--- a/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
+++ b/providers/commandcode/models/deepseek/deepseek-v4-flash.toml
@@ -1,0 +1,20 @@
+# Pricing: https://commandcode.ai/models (accessed 2026-09-12)
+# Toggle: thinking.type = enabled|disabled
+# Effort: reasoning_effort = low|high|max
+# Controls mirror the DeepSeek API surface served through this gateway.
+base_model = "deepseek/deepseek-v4-flash"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 0.15
+output = 0.60
+cache_read = 0.003

--- a/providers/commandcode/models/gpt-5.6-sol.toml
+++ b/providers/commandcode/models/gpt-5.6-sol.toml
@@ -1,0 +1,11 @@
+# Pricing: https://commandcode.ai/models (accessed 2026-09-12)
+# Model ID on this gateway has no lab prefix: "gpt-5.6-sol" (verified via
+# POST /provider/v1/chat/completions; "openai/gpt-5.6-sol" is rejected).
+# Effort levels mirror the OpenAI API surface served through this gateway.
+base_model = "openai/gpt-5.6-sol"
+reasoning_options = [{ type = "effort", values = ["none", "low", "medium", "high", "xhigh", "max"] }]
+
+[cost]
+input = 5.00
+output = 30.00
+cache_read = 0.50

--- a/providers/commandcode/models/moonshotai/kimi-k3.toml
+++ b/providers/commandcode/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,17 @@
+# Pricing: https://commandcode.ai/models (accessed 2026-09-12)
+# Toggle: thinking.type = enabled|disabled|adaptive
+# Effort: output_config.effort = low|high|max
+# Controls mirror the Moonshot AI platform API surface served through this gateway.
+base_model = "moonshotai/kimi-k3"
+
+[[reasoning_options]]
+type = "toggle"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[cost]
+input = 3.00
+output = 15.00
+cache_read = 0.30

--- a/providers/commandcode/models/zai-org/GLM-5.3.toml
+++ b/providers/commandcode/models/zai-org/GLM-5.3.toml
@@ -1,0 +1,18 @@
+# Pricing: https://commandcode.ai/models (accessed 2026-09-12)
+# Model ID is case-sensitive on this gateway: "zai-org/GLM-5.3" (verified
+# via POST /provider/v1/chat/completions; lowercase "zhipuai/glm-5.3" is rejected).
+# Effort: low|high|max with default max (thinking cannot be disabled on GLM-5.3).
+# Controls mirror the Zhipu BigModel API surface served through this gateway.
+base_model = "zhipuai/glm-5.3"
+
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high", "max"]
+
+[interleaved]
+field = "reasoning_content"
+
+[cost]
+input = 1.40
+output = 4.40
+cache_read = 0.26

--- a/providers/commandcode/provider.toml
+++ b/providers/commandcode/provider.toml
@@ -1,0 +1,7 @@
+# Pricing: https://commandcode.ai/models (accessed 2026-09-12)
+# API: https://commandcode.ai/docs/provider
+name = "CommandCode"
+env = ["COMMANDCODE_API_KEY"]
+npm = "@ai-sdk/openai-compatible"
+api = "https://api.commandcode.ai/provider/v1"
+doc = "https://commandcode.ai/docs/provider"


### PR DESCRIPTION
Add CommandCode (https://commandcode.ai/docs/provider) as a new provider.

CommandCode is an OpenAI- and Anthropic-compatible model gateway. Default wire is OpenAI-compatible (`/provider/v1/chat/completions`); Claude models are served on the Anthropic Messages endpoint, so that model overrides npm/api like other dual-protocol gateways.

This PR registers 7 representative models with base_model + cost + reasoning_options. Remaining catalog models can follow in later PRs.

Model IDs match the live GET /provider/v1/models list and were verified with real requests (IDs are case-sensitive on this gateway).

Verified:
- bun validate passes
- opencode loads the catalog (OPENCODE_MODELS_PATH) and lists commandcode/* models
- live calls OK via opencode: deepseek/deepseek-v4-flash, moonshotai/kimi-k3, Qwen/Qwen3.8-Max, MiniMaxAI/MiniMax-M3, zai-org/GLM-5.3
- Claude models route to /messages correctly (request reaches the gateway; my key's plan does not include Claude, so full completion was not tested)
- gpt-5.6-sol reaches the gateway via direct API call; opencode run returned empty text, likely a client-side parsing quirk, catalog entry itself is correct

Sources: https://commandcode.ai/models and https://commandcode.ai/docs/provider (accessed 2026-09-12).