### PR TITLE
feat: add Prism provider

### DIFF
--- a/providers/prism/logo.svg
+++ b/providers/prism/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 630" fill="currentColor">
+  <path d="M2 581 314 45l101 188-276 349Z"/>
+  <path d="m340 580 98-319 190 328Z"/>
+</svg>

--- a/providers/prism/models/prism/deepseek-v4-flash.toml
+++ b/providers/prism/models/prism/deepseek-v4-flash.toml
@@ -1,0 +1,20 @@
+# Sources:
+# https://prisminference.com/pricing
+# https://docs.prisminference.com/models
+# Reasoning: reasoning_effort = none|low|medium|high; none disables reasoning.
+base_model = "deepseek/deepseek-v4-flash"
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 0.14
+output = 0.28
+cache_read = 0.07
+
+[limit]
+input = 1_000_000

--- a/providers/prism/models/prism/deepseek-v4-flash.toml
+++ b/providers/prism/models/prism/deepseek-v4-flash.toml
@@ -1,6 +1,7 @@
 # Sources:
 # https://prisminference.com/pricing
 # https://docs.prisminference.com/models
+# https://docs.prisminference.com/api-reference/chat-completions
 # Reasoning: reasoning_effort = none|low|medium|high; none disables reasoning.
 base_model = "deepseek/deepseek-v4-flash"
 

--- a/providers/prism/models/prism/deepseek-v4.1-flash.toml
+++ b/providers/prism/models/prism/deepseek-v4.1-flash.toml
@@ -1,0 +1,25 @@
+# Sources:
+# https://prisminference.com/pricing
+# https://docs.prisminference.com/models
+# Reasoning: reasoning_effort = none|low|medium|high; none disables reasoning.
+base_model = "deepseek/deepseek-v4.1-flash"
+attachment = false
+
+[interleaved]
+field = "reasoning_content"
+
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high"]
+
+[cost]
+input = 0.30
+output = 1.20
+cache_read = 0.07
+
+[limit]
+input = 1_000_000
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/prism/models/prism/deepseek-v4.1-flash.toml
+++ b/providers/prism/models/prism/deepseek-v4.1-flash.toml
@@ -3,9 +3,7 @@
 # https://docs.prisminference.com/models
 # https://docs.prisminference.com/api-reference/chat-completions
 # Reasoning: reasoning_effort = none|low|medium|high; none disables reasoning.
-# Prism serves this model with text-only input.
 base_model = "deepseek/deepseek-v4.1-flash"
-attachment = false
 
 [interleaved]
 field = "reasoning_content"
@@ -21,7 +19,3 @@ cache_read = 0.07
 
 [limit]
 input = 1_000_000
-
-[modalities]
-input = ["text"]
-output = ["text"]

--- a/providers/prism/models/prism/deepseek-v4.1-flash.toml
+++ b/providers/prism/models/prism/deepseek-v4.1-flash.toml
@@ -1,7 +1,9 @@
 # Sources:
 # https://prisminference.com/pricing
 # https://docs.prisminference.com/models
+# https://docs.prisminference.com/api-reference/chat-completions
 # Reasoning: reasoning_effort = none|low|medium|high; none disables reasoning.
+# Prism serves this model with text-only input.
 base_model = "deepseek/deepseek-v4.1-flash"
 attachment = false
 

--- a/providers/prism/provider.toml
+++ b/providers/prism/provider.toml
@@ -1,3 +1,11 @@
+# Raw HTTP routes are POST `/v1/chat/completions`, `/v1/responses`, and
+# `/v1/messages`. Chat uses `reasoning_effort = none|low|medium|high`, Responses
+# uses `reasoning.effort` with the same values, and Messages uses `thinking.type`
+# set to `enabled` or `disabled` with optional `budget_tokens` when enabled.
+# https://docs.prisminference.com/api-reference/chat-completions
+# https://docs.prisminference.com/api-reference/responses
+# https://docs.prisminference.com/guides/coding-agents
+# https://docs.prisminference.com/openapi.yaml
 name = "Prism"
 npm = "@ai-sdk/openai-compatible"
 env = ["PRISM_API_KEY"]

--- a/providers/prism/provider.toml
+++ b/providers/prism/provider.toml
@@ -1,0 +1,5 @@
+name = "Prism"
+npm = "@ai-sdk/openai-compatible"
+env = ["PRISM_API_KEY"]
+api = "https://api.prisminference.com/v1"
+doc = "https://docs.prisminference.com/models"


### PR DESCRIPTION
## Summary

- add Prism as an OpenAI-compatible inference provider
- document Prism's Chat Completions, Responses, and Anthropic Messages API surfaces
- add DeepSeek V4.1 Flash and DeepSeek V4 Flash with Prism pricing and reasoning controls
- inherit V4.1 image capability while keeping V4 text-only
- add a monochrome Prism provider logo

## Sources and verification

- Model catalog: https://docs.prisminference.com/models
- Live model IDs: https://api.prisminference.com/v1/models
- Pricing: https://prisminference.com/pricing
- Chat Completions: https://docs.prisminference.com/api-reference/chat-completions
- Responses: https://docs.prisminference.com/api-reference/responses
- Anthropic Messages setup: https://docs.prisminference.com/guides/coding-agents
- OpenAPI contract: https://docs.prisminference.com/openapi.yaml

Prism intentionally exposes `reasoning_effort=none|low|medium|high`; `none` disables reasoning and V4.1 maps Prism medium/high to the underlying high/xhigh tiers. Both submitted model IDs are returned verbatim by the live Models API. DeepSeek V4.1 Flash accepts base64 image inputs through Chat Completions, Responses, and Anthropic Messages; remote image URLs are not supported. DeepSeek V4 Flash remains text-only.

This PR remains draft until the V4.1 image-input API and documentation changes are deployed.

## Validation

- `bun validate`