### PR TITLE
Add lanseq provider

### DIFF
--- a/providers/lanseq/logo.svg
+++ b/providers/lanseq/logo.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Lanseq">
-  <text x="16" y="56" fill="currentColor" font-family="Arial, Helvetica, sans-serif" font-size="52" font-weight="600">Lanseq</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M5 4h4v12h10v4H5V4zm6 4h8v4h-8V8z" fill="currentColor"/>
 </svg>

--- a/providers/lanseq/logo.svg
+++ b/providers/lanseq/logo.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-  <path d="M5 4h4v12h10v4H5z"/>
-  <path d="M12 4h7v4h-7z"/>
+<svg viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Lanseq">
+  <text x="16" y="56" fill="currentColor" font-family="Arial, Helvetica, sans-serif" font-size="52" font-weight="600">Lanseq</text>
 </svg>

--- a/providers/lanseq/logo.svg
+++ b/providers/lanseq/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M5 4h4v12h10v4H5z"/>
+  <path d="M12 4h7v4h-7z"/>
+</svg>

--- a/providers/lanseq/models/qwen3.8-27b-int4.toml
+++ b/providers/lanseq/models/qwen3.8-27b-int4.toml
@@ -1,0 +1,20 @@
+# Lanseq's initial live SKU; serving specifications supplied by the operator.
+# Prices are USD per million tokens.
+# BLOCKED: add reasoning_options only after verifying the public API controls.
+base_model = "alibaba/qwen3.8-27b"
+name = "Qwen3.8-27B INT4"
+description = "Text-only INT4 deployment of Qwen3.8-27B, served by Lanseq"
+attachment = false
+
+[cost]
+input = 0.25
+output = 1.99
+cache_read = 0.045
+
+[limit]
+context = 70_000
+output = 8_192
+
+[modalities]
+input = ["text"]
+output = ["text"]

--- a/providers/lanseq/models/qwen3.8-27b-int4.toml
+++ b/providers/lanseq/models/qwen3.8-27b-int4.toml
@@ -3,10 +3,16 @@ name = "Qwen3.8-27B INT4"
 description = "Text-only INT4 deployment of Qwen3.8-27B served by Lanseq."
 attachment = false
 
+# Verified against the live Lanseq OpenAI-compatible endpoint.
+# Request field: reasoning_effort
+# Accepted values: none, low, medium, xhigh
+# Rejected values include high, minimal, and max.
 reasoning_options = [
   { type = "effort", values = ["none", "low", "medium", "xhigh"] },
 ]
 
+# First-party Lanseq pricing and limits:
+# https://api.172.98.22.239.sslip.io/docs
 [cost]
 input = 0.25
 output = 1.99

--- a/providers/lanseq/models/qwen3.8-27b-int4.toml
+++ b/providers/lanseq/models/qwen3.8-27b-int4.toml
@@ -1,5 +1,5 @@
 # First-party Lanseq deployment documentation:
-# https://api.172.98.22.239.sslip.io/docs
+# https://api.lanseq.cloud/docs
 # Pricing: input = $0.25/M tokens, cache_read = $0.045/M tokens, output = $1.99/M tokens.
 # Limits: context = 70,000 tokens, max output = 8,192 tokens.
 # Reasoning wire control: reasoning_effort = none | low | medium | xhigh.

--- a/providers/lanseq/models/qwen3.8-27b-int4.toml
+++ b/providers/lanseq/models/qwen3.8-27b-int4.toml
@@ -1,5 +1,6 @@
 base_model = "alibaba/qwen3.8-27b"
 name = "Qwen3.8-27B INT4"
+description = "Text-only INT4 deployment of Qwen3.8-27B served by Lanseq."
 attachment = false
 
 reasoning_options = [

--- a/providers/lanseq/models/qwen3.8-27b-int4.toml
+++ b/providers/lanseq/models/qwen3.8-27b-int4.toml
@@ -1,18 +1,18 @@
+# First-party Lanseq deployment documentation:
+# https://api.172.98.22.239.sslip.io/docs
+# Pricing: input = $0.25/M tokens, cache_read = $0.045/M tokens, output = $1.99/M tokens.
+# Limits: context = 70,000 tokens, max output = 8,192 tokens.
+# Reasoning wire control: reasoning_effort = none | low | medium | xhigh.
+
 base_model = "alibaba/qwen3.8-27b"
 name = "Qwen3.8-27B INT4"
 description = "Text-only INT4 deployment of Qwen3.8-27B served by Lanseq."
 attachment = false
 
-# Verified against the live Lanseq OpenAI-compatible endpoint.
-# Request field: reasoning_effort
-# Accepted values: none, low, medium, xhigh
-# Rejected values include high, minimal, and max.
 reasoning_options = [
   { type = "effort", values = ["none", "low", "medium", "xhigh"] },
 ]
 
-# First-party Lanseq pricing and limits:
-# https://api.172.98.22.239.sslip.io/docs
 [cost]
 input = 0.25
 output = 1.99

--- a/providers/lanseq/models/qwen3.8-27b-int4.toml
+++ b/providers/lanseq/models/qwen3.8-27b-int4.toml
@@ -1,10 +1,10 @@
-# Lanseq's initial live SKU; serving specifications supplied by the operator.
-# Prices are USD per million tokens.
-# BLOCKED: add reasoning_options only after verifying the public API controls.
 base_model = "alibaba/qwen3.8-27b"
 name = "Qwen3.8-27B INT4"
-description = "Text-only INT4 deployment of Qwen3.8-27B, served by Lanseq"
 attachment = false
+
+reasoning_options = [
+  { type = "effort", values = ["none", "low", "medium", "xhigh"] },
+]
 
 [cost]
 input = 0.25

--- a/providers/lanseq/provider.toml
+++ b/providers/lanseq/provider.toml
@@ -1,8 +1,5 @@
-# Lanseq is an open-weight multi-model inference provider.
-# Qwen3.8-27B INT4 is the initial live SKU. Additional model SKUs and capacity
-# will be added according to actual demand.
-# BLOCKED: verified public API base URL and model documentation URL are required.
-# api and doc are deliberately omitted rather than filled with invented URLs.
 name = "Lanseq"
 npm = "@ai-sdk/openai-compatible"
 env = ["LANSEQ_API_KEY"]
+api = "https://api.172.98.22.239.sslip.io/v1"
+doc = "https://api.172.98.22.239.sslip.io/docs"

--- a/providers/lanseq/provider.toml
+++ b/providers/lanseq/provider.toml
@@ -1,0 +1,8 @@
+# Lanseq is an open-weight multi-model inference provider.
+# Qwen3.8-27B INT4 is the initial live SKU. Additional model SKUs and capacity
+# will be added according to actual demand.
+# BLOCKED: verified public API base URL and model documentation URL are required.
+# api and doc are deliberately omitted rather than filled with invented URLs.
+name = "Lanseq"
+npm = "@ai-sdk/openai-compatible"
+env = ["LANSEQ_API_KEY"]

--- a/providers/lanseq/provider.toml
+++ b/providers/lanseq/provider.toml
@@ -1,5 +1,5 @@
 name = "Lanseq"
 npm = "@ai-sdk/openai-compatible"
 env = ["LANSEQ_API_KEY"]
-api = "https://api.172.98.22.239.sslip.io/v1"
-doc = "https://api.172.98.22.239.sslip.io/docs"
+api = "https://api.lanseq.cloud/v1"
+doc = "https://api.lanseq.cloud/docs"


### PR DESCRIPTION
Adds Lanseq as an OpenAI-compatible inference provider.

Initial live model:
- Qwen3.8-27B INT4

Lanseq provides an OpenAI-compatible inference API for open-weight models. Additional model SKUs and capacity can be added based on demand.

The initial endpoint has been validated end-to-end through OpenCode using its custom OpenAI-compatible provider path.

API:
https://api.lanseq.cloud/v1

First-party documentation:
https://api.lanseq.cloud/docs

The documentation supports the provider-specific metadata in this PR:
- Pricing: input $0.25 / 1M tokens, cached input $0.045 / 1M tokens, output $1.99 / 1M tokens.
- Limits: 70,000-token context and 8,192-token maximum output.
- Reasoning control: `reasoning_effort` accepts `none`, `low`, `medium`, and `xhigh`.