### PR TITLE
Add Wallaby provider (wallaby/kimi-k3)

### DIFF
--- a/providers/wallaby/logo.svg
+++ b/providers/wallaby/logo.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 5L6.5 19L10 9L12 15L14 9L17.5 19L21 5" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/providers/wallaby/models/moonshotai/kimi-k3.toml
+++ b/providers/wallaby/models/moonshotai/kimi-k3.toml
@@ -1,0 +1,6 @@
+base_model = "moonshotai/kimi-k3"
+
+[cost]
+input = 2.70
+output = 13.50
+cache_read = 0.27

--- a/providers/wallaby/provider.toml
+++ b/providers/wallaby/provider.toml
@@ -1,0 +1,5 @@
+name = "Wallaby"
+npm = "@ai-sdk/openai-compatible"
+env = ["WALLABY_API_KEY"]
+api = "https://api.wallabytoken.com/v1"
+doc = "https://www.wallabytoken.com/docs"


### PR DESCRIPTION
Adds Wallaby as an OpenAI-compatible provider serving moonshotai/kimi-k3.

- Endpoint: https://api.wallabytoken.com/v1
- Docs: https://www.wallabytoken.com/docs
- Cost: $2.70 input / $13.50 output / $0.27 cached read per 1M tokens (current pricing)

Only overrides cost; all model facts come from base_model moonshotai/kimi-k3.